### PR TITLE
Add semantic drift monitor with CLI and security hardening

### DIFF
--- a/INITIAL_SECURITY_REVIEW.md
+++ b/INITIAL_SECURITY_REVIEW.md
@@ -1,0 +1,87 @@
+# Semantic Drift Monitor Security Review
+
+**Date:** 2026-02-24  
+**Project:** `alfred`  
+**Scope:** Surveyor semantic drift monitor (`drift.py`, `drift_cli.py`, daemon integration)
+
+## Summary
+
+This review documents issues identified during adversarial/security analysis of the Semantic Drift Monitor implementation, the remediation executed, and remaining concerns.
+
+## Remediated Issues
+
+### 1. Drift artifact corruption could crash Surveyor (availability risk)
+
+- **Issue:** malformed snapshot/report JSON could raise unhandled exceptions and break drift processing, with potential pipeline impact.
+- **Remediation:**
+  - unreadable/corrupt snapshots are now skipped with warning logs.
+  - invalid report JSON now returns controlled validation errors.
+  - daemon wraps drift processing in `try/except` to prevent pipeline failure.
+- **References:**
+  - `src/alfred/surveyor/drift.py`
+  - `src/alfred/surveyor/daemon.py`
+
+### 2. `alfred drift show` accepted absolute paths (path confinement issue)
+
+- **Issue:** report lookup previously allowed absolute paths, enabling reads outside `data/semantic_drift`.
+- **Remediation:**
+  - report input is now constrained to filename-only.
+  - absolute paths and traversal-style inputs are rejected.
+  - resolved path is verified to remain within `data/semantic_drift`.
+- **References:**
+  - `src/alfred/surveyor/drift.py`
+  - `src/alfred/surveyor/drift_cli.py`
+
+### 3. Non-atomic snapshot/report writes (corruption risk)
+
+- **Issue:** direct writes to final files could leave partial JSON on interruption.
+- **Remediation:**
+  - writes now use temp file + atomic `os.replace`.
+- **References:**
+  - `src/alfred/surveyor/drift.py`
+
+### 4. Unbounded report growth (storage/DoS risk)
+
+- **Issue:** snapshots had retention; reports did not.
+- **Remediation:**
+  - added report pruning with same retention cap as snapshots.
+- **References:**
+  - `src/alfred/surveyor/drift.py`
+
+### 5. Missing validation for drift config bounds
+
+- **Issue:** invalid threshold/retention values could produce unstable behavior.
+- **Remediation:**
+  - `similarity_threshold` normalized to `[0.0, 1.0]`.
+  - `snapshot_retention` normalized to integer `>= 1`.
+- **References:**
+  - `src/alfred/surveyor/drift.py`
+
+## Remaining Concerns
+
+### 1. Local write access can still induce churn before pruning
+
+- A user/process with local write access could create many valid drift artifacts between runs.
+- Retention limits steady-state footprint but does not fully prevent short-window file churn.
+
+### 2. No cryptographic integrity/authentication on drift artifacts
+
+- Drift snapshots/reports are trusted as local JSON.
+- Tampering is detectable only by behavior/anomalies, not by signatures or checksums.
+
+### 3. Drift artifacts include vault topology metadata
+
+- Stored member lists and labels may be sensitive in some environments.
+- File-permission and data-governance posture depends on host OS/user configuration.
+
+## Verification Performed
+
+- Static review of drift code paths and CLI input handling.
+- Compile validation:
+  - `python -m compileall src/alfred/surveyor/drift.py src/alfred/surveyor/daemon.py src/alfred/surveyor/drift_cli.py`
+
+## Recommended Next Hardening Steps
+
+1. Add optional artifact integrity checks (hash or signature).
+2. Add filesystem permission checks/warnings for `data/semantic_*` directories.
+3. Add tests for corrupted JSON recovery and path-confinement behavior.

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -29,6 +29,14 @@ logging:
   level: "INFO"
   dir: "./data"
 
+features:
+  semantic_drift_monitor: false
+
+semantic_drift:
+  snapshot_retention: 10
+  similarity_threshold: 0.5
+  warn_on_high_drift: true
+
 curator:
   inbox_dir: "inbox"
   processed_dir: "inbox/processed"

--- a/docs/CLI-Commands.md
+++ b/docs/CLI-Commands.md
@@ -81,8 +81,13 @@ The curator also runs as part of `alfred up`. For standalone use, it watches the
 | Command | Description |
 |---------|-------------|
 | `alfred surveyor` | Run full embed/cluster/label/write pipeline |
+| `alfred drift status` | Show latest semantic drift summary |
+| `alfred drift history` | List available semantic drift reports |
+| `alfred drift show <timestamp>` | Print a drift report JSON payload |
 
 The surveyor runs its 4-stage pipeline once and exits. As part of `alfred up`, it runs as a daemon with configurable intervals.
+
+`alfred drift ...` commands are available only when `features.semantic_drift_monitor` is enabled.
 
 ## Temporal (Kinetic Layer)
 

--- a/docs/Surveyor.md
+++ b/docs/Surveyor.md
@@ -197,6 +197,14 @@ All configuration lives in `config.yaml` under the `surveyor` section.
 ### Full Example
 
 ```yaml
+features:
+  semantic_drift_monitor: false
+
+semantic_drift:
+  snapshot_retention: 10
+  similarity_threshold: 0.5
+  warn_on_high_drift: true
+
 surveyor:
   watcher:
     debounce_seconds: 30
@@ -266,6 +274,12 @@ surveyor:
 **State:**
 - `path`: State persistence file location (default: `./data/surveyor_state.json`)
 
+**Semantic Drift Monitor (optional):**
+- `features.semantic_drift_monitor`: Enable snapshot + drift comparison layer (default: false)
+- `semantic_drift.snapshot_retention`: Number of snapshots to retain (default: 10)
+- `semantic_drift.similarity_threshold`: Threshold for split/merge and new/dissolved heuristics (default: 0.5)
+- `semantic_drift.warn_on_high_drift`: Log warning when churn exceeds threshold (default: true)
+
 ## Usage
 
 ### Run Once
@@ -318,6 +332,8 @@ Surveyor maintains several data files:
 - `data/surveyor_state.json`: File hashes, cluster assignments, labeling history
 - `data/surveyor.log`: Processing logs
 - `data/vault_audit.log`: Append-only log of all vault mutations
+- `data/semantic_snapshots/*.json`: Cluster snapshots per run (when enabled)
+- `data/semantic_drift/*.log`: Drift reports between consecutive snapshots (when enabled)
 
 State files can be deleted to force full re-processing. The vault itself is always the source of truth.
 

--- a/src/alfred/_bundled/config.yaml.example
+++ b/src/alfred/_bundled/config.yaml.example
@@ -29,6 +29,14 @@ logging:
   level: "INFO"
   dir: "./data"
 
+features:
+  semantic_drift_monitor: false
+
+semantic_drift:
+  snapshot_retention: 10
+  similarity_threshold: 0.5
+  warn_on_high_drift: true
+
 curator:
   inbox_dir: "inbox"
   processed_dir: "inbox/processed"

--- a/src/alfred/cli.py
+++ b/src/alfred/cli.py
@@ -485,6 +485,30 @@ def cmd_surveyor(args: argparse.Namespace) -> None:
         print("\nStopped.")
 
 
+def cmd_drift(args: argparse.Namespace) -> None:
+    raw = _load_unified_config(args.config)
+
+    if "surveyor" not in raw:
+        print("Surveyor is not configured in this config file.")
+        return
+
+    from alfred.surveyor.config import load_from_unified
+    from alfred.surveyor import drift_cli as dcli
+
+    config = load_from_unified(raw)
+    subcmd = getattr(args, "drift_cmd", None)
+    if subcmd == "status":
+        dcli.cmd_status(config)
+    elif subcmd == "history":
+        dcli.cmd_history(config, limit=args.limit)
+    elif subcmd == "show":
+        dcli.cmd_show(config, args.timestamp)
+    else:
+        print("Usage: alfred drift {status|history|show}")
+        print("Run `alfred drift --help` for details.")
+        sys.exit(1)
+
+
 # --- Argument parser ---
 
 def build_parser() -> argparse.ArgumentParser:
@@ -623,6 +647,15 @@ def build_parser() -> argparse.ArgumentParser:
     # surveyor
     sub.add_parser("surveyor", help="Start surveyor pipeline")
 
+    # drift
+    drift = sub.add_parser("drift", help="Surveyor semantic drift monitor")
+    drift_sub = drift.add_subparsers(dest="drift_cmd")
+    drift_sub.add_parser("status", help="Show latest drift report summary")
+    drift_history = drift_sub.add_parser("history", help="List available drift reports")
+    drift_history.add_argument("--limit", type=int, default=10)
+    drift_show = drift_sub.add_parser("show", help="Show a drift report by timestamp or filename")
+    drift_show.add_argument("timestamp", help="Report timestamp or filename (e.g. 20260224T120000Z)")
+
     # tui
     sub.add_parser("tui", help="Launch interactive Ink TUI dashboard (requires Node.js)")
 
@@ -653,6 +686,7 @@ def main() -> None:
         "process": cmd_process,
         "temporal": cmd_temporal,
         "surveyor": cmd_surveyor,
+        "drift": cmd_drift,
         "tui": cmd_tui,
     }
 

--- a/src/alfred/quickstart.py
+++ b/src/alfred/quickstart.py
@@ -266,6 +266,14 @@ def run_quickstart() -> None:
             "level": "INFO",
             "dir": "./data",
         },
+        "features": {
+            "semantic_drift_monitor": False,
+        },
+        "semantic_drift": {
+            "snapshot_retention": 10,
+            "similarity_threshold": 0.5,
+            "warn_on_high_drift": True,
+        },
         "curator": {
             "inbox_dir": "inbox",
             "processed_dir": "inbox/processed",

--- a/src/alfred/surveyor/config.py
+++ b/src/alfred/surveyor/config.py
@@ -80,6 +80,18 @@ class LoggingConfig:
 
 
 @dataclass
+class FeatureFlags:
+    semantic_drift_monitor: bool = False
+
+
+@dataclass
+class SemanticDriftConfig:
+    snapshot_retention: int = 10
+    similarity_threshold: float = 0.5
+    warn_on_high_drift: bool = True
+
+
+@dataclass
 class PipelineConfig:
     vault: VaultConfig
     watcher: WatcherConfig
@@ -90,6 +102,8 @@ class PipelineConfig:
     labeler: LabelerConfig
     state: StateConfig
     logging: LoggingConfig
+    features: FeatureFlags = field(default_factory=FeatureFlags)
+    semantic_drift: SemanticDriftConfig = field(default_factory=SemanticDriftConfig)
 
 
 _ENV_PATTERN = re.compile(r"\$\{(\w+)\}")
@@ -160,6 +174,8 @@ def load_config(config_path: str | Path) -> PipelineConfig:
         labeler=_build_dataclass(LabelerConfig, raw.get("labeler")),
         state=_build_dataclass(StateConfig, raw.get("state")),
         logging=_build_dataclass(LoggingConfig, raw.get("logging")),
+        features=_build_dataclass(FeatureFlags, raw.get("features")),
+        semantic_drift=_build_dataclass(SemanticDriftConfig, raw.get("semantic_drift")),
     )
 
 
@@ -177,4 +193,6 @@ def load_from_unified(raw: dict) -> PipelineConfig:
         labeler=_build_dataclass(LabelerConfig, tool.get("labeler")),
         state=_build_dataclass(StateConfig, tool.get("state")),
         logging=_build_dataclass(LoggingConfig, raw.get("logging")),
+        features=_build_dataclass(FeatureFlags, raw.get("features")),
+        semantic_drift=_build_dataclass(SemanticDriftConfig, raw.get("semantic_drift")),
     )

--- a/src/alfred/surveyor/daemon.py
+++ b/src/alfred/surveyor/daemon.py
@@ -9,6 +9,7 @@ import structlog
 
 from .clusterer import Clusterer
 from .config import PipelineConfig
+from .drift import DriftMonitor
 from .embedder import Embedder
 from .labeler import Labeler
 from .parser import parse_file, VaultRecord
@@ -33,6 +34,11 @@ class Daemon:
         self.clusterer = Clusterer(cfg.clustering, self.state)
         self.labeler = Labeler(cfg.openrouter, cfg.labeler)
         self.writer = VaultWriter(cfg.vault.path, self.state)
+        self.drift = DriftMonitor(
+            data_dir=Path(cfg.state.path).resolve().parent,
+            config=cfg.semantic_drift,
+            enabled=cfg.features.semantic_drift_monitor,
+        )
 
     def request_shutdown(self) -> None:
         log.info("daemon.shutdown_requested")
@@ -161,42 +167,50 @@ class Daemon:
         all_changed = result.changed_semantic | result.changed_structural
         if not all_changed:
             log.info("daemon.no_changed_clusters")
-            return
+        else:
+            # Build cluster membership map (semantic)
+            cluster_members: dict[int, list[str]] = {}
+            for path, cid in result.semantic.items():
+                if cid == -1:
+                    continue
+                cluster_members.setdefault(cid, []).append(path)
 
-        # Build cluster membership map (semantic)
-        cluster_members: dict[int, list[str]] = {}
-        for path, cid in result.semantic.items():
-            if cid == -1:
-                continue
-            cluster_members.setdefault(cid, []).append(path)
+            for cid in all_changed:
+                members = cluster_members.get(cid, [])
+                if len(members) < self.cfg.labeler.min_cluster_size_to_label:
+                    continue
 
-        for cid in all_changed:
-            members = cluster_members.get(cid, [])
-            if len(members) < self.cfg.labeler.min_cluster_size_to_label:
-                continue
+                # Label the cluster
+                tags = await self.labeler.label_cluster(cid, members, records)
+                if tags:
+                    # Write tags to all members
+                    for path in members:
+                        self.writer.write_alfred_tags(path, tags)
 
-            # Label the cluster
-            tags = await self.labeler.label_cluster(cid, members, records)
-            if tags:
-                # Write tags to all members
-                for path in members:
-                    self.writer.write_alfred_tags(path, tags)
+                    # Update cluster state
+                    cluster_key = f"semantic_{cid}"
+                    from .state import ClusterState
+                    from datetime import datetime, timezone
+                    self.state.clusters[cluster_key] = ClusterState(
+                        label=tags,
+                        member_files=members,
+                        last_labeled=datetime.now(timezone.utc).isoformat(),
+                    )
 
-                # Update cluster state
-                cluster_key = f"semantic_{cid}"
-                from surveyor.state import ClusterState
-                from datetime import datetime, timezone
-                self.state.clusters[cluster_key] = ClusterState(
-                    label=tags,
-                    member_files=members,
-                    last_labeled=datetime.now(timezone.utc).isoformat(),
-                )
+                # Suggest relationships
+                rels = await self.labeler.suggest_relationships(cid, members, records)
+                for rel in rels:
+                    source = rel.get("source", "")
+                    if source in records:
+                        self.writer.write_relationships(source, [rel])
 
-            # Suggest relationships
-            rels = await self.labeler.suggest_relationships(cid, members, records)
-            for rel in rels:
-                source = rel.get("source", "")
-                if source in records:
-                    self.writer.write_relationships(source, [rel])
+        try:
+            self.drift.process(
+                state=self.state,
+                model_backend="openai-compatible" if self.cfg.ollama.api_key else "ollama",
+                embedding_model=self.cfg.ollama.model,
+            )
+        except Exception as e:
+            log.warning("daemon.drift_monitor_failed", error=str(e))
 
         log.info("daemon.labeling_complete", clusters_processed=len(all_changed))

--- a/src/alfred/surveyor/drift.py
+++ b/src/alfred/surveyor/drift.py
@@ -1,0 +1,361 @@
+"""Semantic drift snapshots and comparison logic for Surveyor."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+import structlog
+
+from .config import SemanticDriftConfig
+from .state import PipelineState
+
+log = structlog.get_logger()
+
+
+@dataclass
+class SnapshotCluster:
+    label: str
+    members: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ClusterSnapshot:
+    timestamp: str
+    model_backend: str
+    embedding_model: str
+    total_records: int
+    clusters: dict[str, SnapshotCluster] = field(default_factory=dict)
+
+
+class DriftMonitor:
+    """Persists snapshots and computes drift reports between consecutive runs."""
+
+    def __init__(self, data_dir: Path, config: SemanticDriftConfig, enabled: bool) -> None:
+        self.data_dir = data_dir
+        self.config = config
+        self.enabled = enabled
+        self.snapshot_dir = self.data_dir / "semantic_snapshots"
+        self.report_dir = self.data_dir / "semantic_drift"
+        self.similarity_threshold = self._normalize_threshold(config.similarity_threshold)
+        self.retention = self._normalize_retention(config.snapshot_retention)
+
+    def process(self, state: PipelineState, model_backend: str, embedding_model: str) -> dict | None:
+        if not self.enabled:
+            return None
+
+        previous = self.load_latest_snapshot()
+        current = self._build_snapshot(state, model_backend, embedding_model)
+        self._write_snapshot(current)
+        self._prune_snapshots()
+
+        if previous is None:
+            log.info("drift.initial_snapshot_written")
+            return None
+
+        report = self._compare(previous, current)
+        self._write_report(report)
+
+        if self.config.warn_on_high_drift and report["overall_churn"] >= self.similarity_threshold:
+            log.warning(
+                "drift.high_churn_detected",
+                overall_churn=round(report["overall_churn"], 4),
+                threshold=self.similarity_threshold,
+            )
+        else:
+            log.info("drift.report_written", overall_churn=round(report["overall_churn"], 4))
+
+        return report
+
+    def list_snapshots(self) -> list[Path]:
+        if not self.snapshot_dir.exists():
+            return []
+        return sorted(self.snapshot_dir.glob("*.json"))
+
+    def load_latest_snapshot(self) -> ClusterSnapshot | None:
+        snapshots = self.list_snapshots()
+        for path in reversed(snapshots):
+            snapshot = self._read_snapshot(path)
+            if snapshot is not None:
+                return snapshot
+        return None
+
+    def list_reports(self) -> list[Path]:
+        if not self.report_dir.exists():
+            return []
+        return sorted(self.report_dir.glob("*.log"))
+
+    def load_latest_report(self) -> dict | None:
+        reports = self.list_reports()
+        for path in reversed(reports):
+            try:
+                return self.load_report(path.name)
+            except (FileNotFoundError, ValueError):
+                continue
+        return None
+
+    def load_report(self, timestamp: str) -> dict:
+        report_path = self._resolve_report_path(timestamp)
+        try:
+            with open(report_path, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            raise ValueError(f"Invalid drift report format: {report_path.name}") from e
+
+    def _build_snapshot(self, state: PipelineState, model_backend: str, embedding_model: str) -> ClusterSnapshot:
+        semantic_members: dict[int, list[str]] = {}
+        for rel_path, file_state in state.files.items():
+            if file_state.semantic_cluster_id == -1:
+                continue
+            semantic_members.setdefault(file_state.semantic_cluster_id, []).append(rel_path)
+
+        clusters: dict[str, SnapshotCluster] = {}
+        for cluster_id, members in semantic_members.items():
+            key = f"cluster_{cluster_id}"
+            cluster_state = state.clusters.get(f"semantic_{cluster_id}")
+            label = key
+            if cluster_state and cluster_state.label:
+                label = " / ".join(cluster_state.label)
+            clusters[key] = SnapshotCluster(label=label, members=sorted(members))
+
+        return ClusterSnapshot(
+            timestamp=self._iso_now(),
+            model_backend=model_backend,
+            embedding_model=embedding_model,
+            total_records=len(state.files),
+            clusters=clusters,
+        )
+
+    def _write_snapshot(self, snapshot: ClusterSnapshot) -> Path:
+        self.snapshot_dir.mkdir(parents=True, exist_ok=True)
+        path = self.snapshot_dir / f"{self._filename_timestamp()}.json"
+        payload = asdict(snapshot)
+        tmp_path = path.with_suffix(".tmp")
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2)
+        os.replace(tmp_path, path)
+        return path
+
+    def _read_snapshot(self, path: Path) -> ClusterSnapshot | None:
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                raw = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            log.warning("drift.snapshot_unreadable", path=str(path))
+            return None
+        clusters = {
+            cid: SnapshotCluster(label=cdata.get("label", cid), members=cdata.get("members", []))
+            for cid, cdata in raw.get("clusters", {}).items()
+        }
+        return ClusterSnapshot(
+            timestamp=raw.get("timestamp", ""),
+            model_backend=raw.get("model_backend", ""),
+            embedding_model=raw.get("embedding_model", ""),
+            total_records=int(raw.get("total_records", 0)),
+            clusters=clusters,
+        )
+
+    def _prune_snapshots(self) -> None:
+        snapshots = self.list_snapshots()
+        while len(snapshots) > self.retention:
+            oldest = snapshots.pop(0)
+            try:
+                oldest.unlink(missing_ok=True)
+            except OSError:
+                break
+
+    def _compare(self, previous: ClusterSnapshot, current: ClusterSnapshot) -> dict:
+        prev_sets = {cid: set(cluster.members) for cid, cluster in previous.clusters.items()}
+        curr_sets = {cid: set(cluster.members) for cid, cluster in current.clusters.items()}
+        prev_ids = list(prev_sets.keys())
+        curr_ids = list(curr_sets.keys())
+
+        jaccard: dict[tuple[str, str], float] = {}
+        for prev_id in prev_ids:
+            for curr_id in curr_ids:
+                score = self._jaccard(prev_sets[prev_id], curr_sets[curr_id])
+                jaccard[(prev_id, curr_id)] = score
+
+        threshold = self.similarity_threshold
+        new_clusters = [cid for cid in curr_ids if max((jaccard[(pid, cid)] for pid in prev_ids), default=0.0) < threshold]
+        dissolved_clusters = [pid for pid in prev_ids if max((jaccard[(pid, cid)] for cid in curr_ids), default=0.0) < threshold]
+
+        split_events: list[dict] = []
+        for prev_id in prev_ids:
+            matches = [(curr_id, jaccard[(prev_id, curr_id)]) for curr_id in curr_ids if jaccard[(prev_id, curr_id)] >= threshold]
+            if len(matches) >= 2:
+                split_events.append(
+                    {
+                        "previous_cluster": prev_id,
+                        "current_clusters": [cid for cid, _ in matches],
+                        "combined_similarity": round(sum(score for _, score in matches), 4),
+                    }
+                )
+
+        merge_events: list[dict] = []
+        for curr_id in curr_ids:
+            matches = [(prev_id, jaccard[(prev_id, curr_id)]) for prev_id in prev_ids if jaccard[(prev_id, curr_id)] >= threshold]
+            if len(matches) >= 2:
+                merge_events.append(
+                    {
+                        "current_cluster": curr_id,
+                        "previous_clusters": [pid for pid, _ in matches],
+                        "combined_similarity": round(sum(score for _, score in matches), 4),
+                    }
+                )
+
+        per_cluster: list[dict] = []
+        for curr_id in curr_ids:
+            best_prev, best_score = self._best_prev(curr_id, prev_ids, jaccard)
+            membership_change = 1.0 - best_score
+            split_likelihood = 0.0
+            if best_prev:
+                split_likelihood = min(
+                    1.0,
+                    sum(jaccard[(best_prev, other_curr)] for other_curr in curr_ids if other_curr != curr_id),
+                )
+            merge_likelihood = min(
+                1.0,
+                sum(jaccard[(prev_id, curr_id)] for prev_id in prev_ids if prev_id != best_prev),
+            )
+            per_cluster.append(
+                {
+                    "cluster_id": curr_id,
+                    "label": current.clusters[curr_id].label,
+                    "best_previous_cluster": best_prev,
+                    "best_previous_label": previous.clusters[best_prev].label if best_prev else "",
+                    "jaccard_similarity": round(best_score, 4),
+                    "membership_change": round(membership_change, 4),
+                    "split_likelihood": round(split_likelihood, 4),
+                    "merge_likelihood": round(merge_likelihood, 4),
+                }
+            )
+
+        per_cluster.sort(key=lambda item: item["membership_change"], reverse=True)
+        most_unstable = per_cluster[0] if per_cluster else None
+
+        prev_assignments = self._member_to_cluster(prev_sets)
+        curr_assignments = self._member_to_cluster(curr_sets)
+        members_union = set(prev_assignments.keys()) | set(curr_assignments.keys())
+        moved = sum(1 for member in members_union if prev_assignments.get(member) != curr_assignments.get(member))
+        overall_churn = (moved / len(members_union)) if members_union else 0.0
+
+        return {
+            "timestamp": self._iso_now(),
+            "previous_snapshot_timestamp": previous.timestamp,
+            "current_snapshot_timestamp": current.timestamp,
+            "previous_model_backend": previous.model_backend,
+            "current_model_backend": current.model_backend,
+            "previous_embedding_model": previous.embedding_model,
+            "current_embedding_model": current.embedding_model,
+            "cluster_count_delta": len(curr_ids) - len(prev_ids),
+            "previous_cluster_count": len(prev_ids),
+            "current_cluster_count": len(curr_ids),
+            "new_clusters": new_clusters,
+            "dissolved_clusters": dissolved_clusters,
+            "overall_churn": round(overall_churn, 4),
+            "split_events": split_events,
+            "merge_events": merge_events,
+            "most_unstable_cluster": {
+                "cluster_id": most_unstable["cluster_id"],
+                "label": most_unstable["label"],
+                "membership_change": most_unstable["membership_change"],
+            } if most_unstable else None,
+            "per_cluster_metrics": per_cluster,
+        }
+
+    def _write_report(self, report: dict) -> Path:
+        self.report_dir.mkdir(parents=True, exist_ok=True)
+        path = self.report_dir / f"{self._filename_timestamp()}.log"
+        tmp_path = path.with_suffix(".tmp")
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2)
+        os.replace(tmp_path, path)
+        self._prune_reports()
+        return path
+
+    def _resolve_report_path(self, timestamp: str) -> Path:
+        candidate = Path(timestamp.strip())
+        if candidate.is_absolute() or candidate.name != str(candidate):
+            raise FileNotFoundError("Report path must be a filename in data/semantic_drift.")
+
+        if candidate.suffix != ".log":
+            candidate = candidate.with_suffix(".log")
+        candidate = self.report_dir / candidate.name
+
+        try:
+            candidate.resolve().relative_to(self.report_dir.resolve())
+        except ValueError as e:
+            raise FileNotFoundError("Report path must stay within data/semantic_drift.") from e
+
+        if not candidate.exists():
+            raise FileNotFoundError(f"Drift report not found: {timestamp}")
+        return candidate
+
+    def _prune_reports(self) -> None:
+        reports = self.list_reports()
+        while len(reports) > self.retention:
+            oldest = reports.pop(0)
+            try:
+                oldest.unlink(missing_ok=True)
+            except OSError:
+                break
+
+    @staticmethod
+    def _member_to_cluster(clusters: dict[str, set[str]]) -> dict[str, str]:
+        out: dict[str, str] = {}
+        for cluster_id, members in clusters.items():
+            for member in members:
+                out[member] = cluster_id
+        return out
+
+    @staticmethod
+    def _jaccard(a: set[str], b: set[str]) -> float:
+        if not a and not b:
+            return 1.0
+        union = a | b
+        if not union:
+            return 0.0
+        return len(a & b) / len(union)
+
+    @staticmethod
+    def _best_prev(curr_id: str, prev_ids: list[str], scores: dict[tuple[str, str], float]) -> tuple[str, float]:
+        best_prev = ""
+        best_score = 0.0
+        for prev_id in prev_ids:
+            score = scores[(prev_id, curr_id)]
+            if score > best_score:
+                best_prev = prev_id
+                best_score = score
+        return best_prev, best_score
+
+    @staticmethod
+    def _iso_now() -> str:
+        return datetime.now(timezone.utc).isoformat()
+
+    @staticmethod
+    def _filename_timestamp() -> str:
+        return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+
+    @staticmethod
+    def _normalize_threshold(value: float) -> float:
+        try:
+            parsed = float(value)
+        except (TypeError, ValueError):
+            return 0.5
+        if parsed < 0.0:
+            return 0.0
+        if parsed > 1.0:
+            return 1.0
+        return parsed
+
+    @staticmethod
+    def _normalize_retention(value: int) -> int:
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return 10
+        return max(1, parsed)

--- a/src/alfred/surveyor/drift_cli.py
+++ b/src/alfred/surveyor/drift_cli.py
@@ -1,0 +1,86 @@
+"""CLI handlers for semantic drift monitor."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .config import PipelineConfig
+from .drift import DriftMonitor
+
+
+def _monitor_from_config(config: PipelineConfig) -> DriftMonitor:
+    return DriftMonitor(
+        data_dir=Path(config.state.path).resolve().parent,
+        config=config.semantic_drift,
+        enabled=config.features.semantic_drift_monitor,
+    )
+
+
+def cmd_status(config: PipelineConfig) -> None:
+    if not config.features.semantic_drift_monitor:
+        print("Semantic drift monitor is disabled. Enable `features.semantic_drift_monitor` in config.yaml.")
+        return
+
+    monitor = _monitor_from_config(config)
+    latest = monitor.load_latest_report()
+    if latest is None:
+        print("No drift report found yet. Run `alfred surveyor` to generate snapshots.")
+        return
+
+    print("Semantic Drift Status")
+    print(f"Compared clusters: {latest['previous_cluster_count']} -> {latest['current_cluster_count']}")
+    print(f"Cluster delta: {latest['cluster_count_delta']}")
+    print(f"New clusters: {len(latest.get('new_clusters', []))}")
+    print(f"Dissolved clusters: {len(latest.get('dissolved_clusters', []))}")
+    print(f"Overall churn: {round(latest.get('overall_churn', 0.0) * 100, 2)}%")
+
+    unstable = latest.get("most_unstable_cluster")
+    if unstable:
+        print(
+            "Most unstable: "
+            f"{unstable.get('label', unstable.get('cluster_id', 'unknown'))} "
+            f"({round(float(unstable.get('membership_change', 0.0)) * 100, 2)}% change)"
+        )
+
+    if latest.get("current_model_backend") != latest.get("previous_model_backend"):
+        print(
+            "Warning: model backend changed "
+            f"({latest.get('previous_model_backend')} -> {latest.get('current_model_backend')})"
+        )
+    if latest.get("current_embedding_model") != latest.get("previous_embedding_model"):
+        print(
+            "Warning: embedding model changed "
+            f"({latest.get('previous_embedding_model')} -> {latest.get('current_embedding_model')})"
+        )
+
+
+def cmd_history(config: PipelineConfig, limit: int = 10) -> None:
+    if not config.features.semantic_drift_monitor:
+        print("Semantic drift monitor is disabled. Enable `features.semantic_drift_monitor` in config.yaml.")
+        return
+
+    monitor = _monitor_from_config(config)
+    reports = monitor.list_reports()
+    if not reports:
+        print("No drift history found.")
+        return
+
+    print("Semantic Drift History")
+    for path in reports[-max(1, limit):]:
+        print(path.name)
+
+
+def cmd_show(config: PipelineConfig, timestamp: str) -> None:
+    if not config.features.semantic_drift_monitor:
+        print("Semantic drift monitor is disabled. Enable `features.semantic_drift_monitor` in config.yaml.")
+        return
+
+    monitor = _monitor_from_config(config)
+    try:
+        report = monitor.load_report(timestamp)
+    except (FileNotFoundError, ValueError) as e:
+        print(str(e))
+        return
+
+    import json
+    print(json.dumps(report, indent=2))


### PR DESCRIPTION
This PR introduces an optional **Semantic Drift Monitor** for Surveyor, along with a focused round of security and robustness hardening.

The drift monitor adds temporal awareness to Surveyor’s clustering output by comparing cluster structure across runs. It does not alter clustering behavior or writeback logic. It is fully optional and disabled by default.

The security fixes address availability, path confinement, atomic writes, retention, and config validation.

---

## What’s Included

### 1. Semantic Drift Monitor (Optional)

**New module:**

- `drift.py`
  - Persists cluster snapshots to JSON
  - Compares latest two snapshots
  - Computes:
    - Jaccard similarity
    - Membership churn
    - New clusters
    - Dissolved clusters
    - Split/merge heuristics
  - Writes drift reports to JSON payloads in `.log` files

**Surveyor integration:**

- Drift runs **after** clustering and labeling
- No changes to clustering logic
- No changes to writeback behavior
- Fully non-blocking
- Wrapped in `try/except` to prevent pipeline failure

**CLI additions:**

- `alfred drift status`
- `alfred drift history [--limit N]`
- `alfred drift show <timestamp|filename>`

**Configuration:**

```yaml
features:
  semantic_drift_monitor: false

semantic_drift:
  snapshot_retention: 10
  similarity_threshold: 0.5
  warn_on_high_drift: true
