### PR TITLE
Drop thread type, add closed status to conversation

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -53,8 +53,8 @@ Four specialized workers maintain the vault continuously:
 
 Each worker has **scope enforcement** — the Curator can create and edit but not delete; the Janitor can edit and delete but not create; the Distiller can only create learning-type records. This prevents any single worker from having unconstrained write access.
 
-20 record types across three categories:
-- **Operational**: project, task, session, conversation, input, note, process, run, event, thread
+19 record types across three categories:
+- **Operational**: project, task, session, conversation, input, note, process, run, event
 - **Entity**: person, org, location, account, asset
 - **Epistemic**: assumption, decision, constraint, contradiction, synthesis
 

--- a/docs/Semantic-Layer.md
+++ b/docs/Semantic-Layer.md
@@ -73,11 +73,11 @@ See [Surveyor](Surveyor) for pipeline details.
 
 ## Record Types
 
-20 record types across three categories:
+19 record types across three categories:
 
 | Category | Types |
 |----------|-------|
-| **Operational** | project, task, session, conversation, input, note, process, run, event, thread |
+| **Operational** | project, task, session, conversation, input, note, process, run, event |
 | **Entity** | person, org, location, account, asset |
 | **Epistemic** | assumption, decision, constraint, contradiction, synthesis |
 

--- a/docs/Vault-Schema.md
+++ b/docs/Vault-Schema.md
@@ -1,6 +1,6 @@
 # Vault Schema
 
-Alfred organizes vault records into 20 entity types plus 5 learning types. All records are Markdown files with YAML frontmatter and are linked together with Obsidian `[[wikilinks]]`.
+Alfred organizes vault records into 19 entity types plus 5 learning types. All records are Markdown files with YAML frontmatter and are linked together with Obsidian `[[wikilinks]]`.
 
 ## Record Types
 
@@ -17,7 +17,6 @@ Alfred organizes vault records into 20 entity types plus 5 learning types. All r
 | `process` | `process/` | Repeatable workflow or procedure | status, owner |
 | `run` | `run/` | Instance of a process execution | status, process, project |
 | `event` | `event/` | Scheduled or past event | status, date, location, participants |
-| `thread` | `thread/` | Discussion thread | status, project |
 
 ### Entity Records
 
@@ -47,7 +46,8 @@ Each record type has a defined set of valid statuses:
 |-------|---------------|
 | project | `active`, `paused`, `completed`, `abandoned`, `proposed` |
 | task | `todo`, `in-progress`, `done`, `blocked`, `cancelled` |
-| session, conversation, run | `active`, `completed` |
+| session, run | `active`, `completed` |
+| conversation | `active`, `waiting`, `resolved`, `closed`, `archived` |
 | person, org, location, account, asset | `active`, `inactive` |
 | assumption, constraint | `active`, `retired`, `superseded` |
 | decision | `final`, `draft`, `superseded`, `reversed` |
@@ -57,7 +57,7 @@ Each record type has a defined set of valid statuses:
 ## Required Fields
 
 Every record must have:
-- `type` — the record type (one of the 20 types above)
+- `type` — the record type (one of the 19 types above)
 - `name` (or type-specific name field like `subject` for decisions) — the record title
 - `status` — current status
 - `created` — ISO date of creation

--- a/src/alfred/_bundled/scaffold/CLAUDE.md
+++ b/src/alfred/_bundled/scaffold/CLAUDE.md
@@ -10,7 +10,7 @@ There are no build steps, tests, or linting commands. The vault is edited direct
 
 ## Architecture
 
-### Record Types (20 types, all markdown + YAML frontmatter)
+### Record Types (19 types, all markdown + YAML frontmatter)
 
 Every file is a **record** with a `type` frontmatter property. The core types are: `project`, `task`, `session`, `conversation`, `input`, `person`, `org`, `location`, `note`, `decision`, `process`, `run`, `event`.
 
@@ -33,7 +33,7 @@ Each type has a **template** in `_templates/` defining its frontmatter schema an
 - `_templates/` — Record type templates (one per type)
 - `_bases/` — Base view definitions (`.base` files with YAML filters/sorts)
 - `view/` — Views (Home, CRM, Task Manager) combining base views + Alfred dynamic sections
-- `project/`, `task/`, `person/`, `org/`, `location/`, `conversation/`, `process/`, `account/`, `asset/`, `event/`, `note/`, `run/`, `input/`, `session/`, `thread/` — Entity records by type
+- `project/`, `task/`, `person/`, `org/`, `location/`, `conversation/`, `process/`, `account/`, `asset/`, `event/`, `note/`, `run/`, `input/`, `session/` — Entity records by type
 - `assumption/`, `constraint/`, `contradiction/`, `decision/`, `synthesis/` — Epistemic (learn) records
 - `YYYY/MM/DD/` — Date-organized temporal content:
   - `inbox/` — Inbound items (emails, voice memos)
@@ -43,6 +43,6 @@ Each type has a **template** in `_templates/` defining its frontmatter schema an
 ### Key Conventions
 
 - **Linking:** Records reference each other via `[[wikilinks]]` in frontmatter (e.g., `project: "[[project/My Project]]"`). The graph connects everything.
-- **Status values vary by type:** tasks use `todo|active|blocked|done|cancelled`; projects use `active|paused|completed|abandoned|proposed`; inputs use `unprocessed|processed|deferred`; conversations use `active|waiting|resolved|archived`.
+- **Status values vary by type:** tasks use `todo|active|blocked|done|cancelled`; projects use `active|paused|completed|abandoned|proposed`; inputs use `unprocessed|processed|deferred`; conversations use `active|waiting|resolved|closed|archived`.
 - **Session folders** are the unit of work. Human work: `YYYY/MM/DD/{person}/HHMM_{slug}/`. Alfred work: `YYYY/MM/DD/alfred/HHMM_{slug}/`. Provenance is the folder path. Sessions are created automatically by the session tracker worker.
 - **Base views use `this.file` pattern** — project pages, person pages, and views all embed the same base definitions; the `file.hasLink(this.file)` filter makes each page show only its own related records.

--- a/src/alfred/vault/schema.py
+++ b/src/alfred/vault/schema.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 # --- Known record types and their valid statuses ---
 
 KNOWN_TYPES: set[str] = {
-    "project", "task", "session", "thread", "input", "person", "org",
+    "project", "task", "session", "input", "person", "org",
     "location", "note", "decision", "process", "run", "event",
     "account", "asset", "conversation", "assumption", "constraint",
     "contradiction", "synthesis",
@@ -19,7 +19,6 @@ STATUS_BY_TYPE: dict[str, set[str]] = {
     "project": {"active", "paused", "completed", "abandoned", "proposed"},
     "task": {"todo", "active", "blocked", "done", "cancelled"},
     "session": {"active", "completed"},
-    "thread": {"active", "waiting", "closed"},
     "input": {"unprocessed", "processed", "deferred"},
     "person": {"active", "inactive"},
     "org": {"active", "inactive"},
@@ -31,7 +30,7 @@ STATUS_BY_TYPE: dict[str, set[str]] = {
     "event": set(),  # no status constraint
     "account": {"active", "suspended", "closed", "pending"},
     "asset": {"active", "retired", "maintenance", "disposed"},
-    "conversation": {"active", "waiting", "resolved", "archived"},
+    "conversation": {"active", "waiting", "resolved", "closed", "archived"},
     "assumption": {"active", "challenged", "invalidated", "confirmed"},
     "constraint": {"active", "expired", "waived", "superseded"},
     "contradiction": {"unresolved", "resolved", "accepted"},
@@ -57,7 +56,7 @@ TYPE_DIRECTORY: dict[str, str] = {
     "constraint": "constraint",
     "contradiction": "contradiction",
     "synthesis": "synthesis",
-    # session, thread, input have flexible placement
+    # session, input have flexible placement
 }
 
 # Fields that should be lists


### PR DESCRIPTION
## Summary

- **Remove `thread` type** from the canonical schema (20 → 19 record types). Thread was effectively deprecated: janitor autofix already maps `thread → conversation`, there was no template or base file, and no active thread records in any known vault.
- **Add `closed` to conversation statuses** — full lifecycle is now: `active → waiting → resolved → closed → archived`
- **Update all documentation** — Semantic-Layer.md, Vault-Schema.md, Architecture.md, scaffold CLAUDE.md

## Files changed

| File | Change |
|------|--------|
| `src/alfred/vault/schema.py` | Remove thread from `KNOWN_TYPES`, `STATUS_BY_TYPE`, `TYPE_DIRECTORY`; add `closed` to conversation statuses |
| `docs/Semantic-Layer.md` | 20 → 19 types, remove thread from operational list |
| `docs/Vault-Schema.md` | Remove thread row, update type count, split conversation out of session/run status group |
| `docs/Architecture.md` | 20 → 19 types, remove thread from operational list |
| `src/alfred/_bundled/scaffold/CLAUDE.md` | 20 → 19 types, remove thread/ from directory list, update conversation statuses |

## Notes

- `janitor/autofix.py` keeps the `"thread": "conversation"` mapping in `_TYPE_CORRECTIONS` for backwards compatibility — any old thread records encountered will still auto-convert
- The `conversation.md` template's `external_id` comment ("Source system's thread/conversation ID") is natural language, not a type reference — left as-is

## Test plan

- [ ] Verify `alfred vault create conversation test` still works
- [ ] Verify janitor autofix still converts old `type: thread` records to conversation
- [ ] Verify no scaffold references to thread/ remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)