### PR TITLE
Remove thread scaffold, add LINK002 body-entity link promotion

### DIFF
--- a/src/alfred/janitor/autofix.py
+++ b/src/alfred/janitor/autofix.py
@@ -1,6 +1,6 @@
 """Stage 1: Deterministic autofix — pure Python fixes without LLM.
 
-Handles issue codes: FM001, FM002, FM003, FM004 (direct fixes)
+Handles issue codes: FM001, FM002, FM003, FM004, LINK002 (direct fixes)
 and DIR001, ORPHAN001, DUP001 (flag with janitor_note).
 """
 
@@ -234,6 +234,9 @@ def _apply_fix(
     if code == IssueCode.DUPLICATE_NAME:
         return _flag_issue(issue, rel_path, vault_path, session_path)
 
+    if code == IssueCode.UNLINKED_BODY_ENTITY:
+        return _fix_unlinked_body_entity(issue, rel_path, vault_path, session_path)
+
     # Issue codes handled by later stages (LINK001, STUB001) or not autofix-able
     return "skipped"
 
@@ -388,6 +391,67 @@ def _fix_invalid_field_type(
         return "fixed"
     except VaultError as e:
         log.warning("autofix.fm004_failed", file=rel_path, error=str(e))
+        return "skipped"
+
+
+def _fix_unlinked_body_entity(
+    issue: Issue,
+    rel_path: str,
+    vault_path: Path,
+    session_path: str,
+) -> str:
+    """LINK002: Promote body entity wikilinks to related: frontmatter.
+
+    Obsidian Bases' file.hasLink(this.file) only checks frontmatter links.
+    Entity wikilinks in body text won't appear in base view tables unless
+    they're also in a frontmatter field (related:, relationships:, etc.).
+    """
+    try:
+        record = vault_read(vault_path, rel_path)
+        fm = record["frontmatter"]
+    except VaultError:
+        return "skipped"
+
+    # Parse the missing links from the issue detail
+    if not issue.detail:
+        return "skipped"
+
+    missing_links = [link.strip() for link in issue.detail.split(",")]
+    if not missing_links:
+        return "skipped"
+
+    # Get current related: array
+    related = fm.get("related", [])
+    if not isinstance(related, list):
+        related = [related] if related else []
+
+    # Extract existing link targets from related: to avoid duplicates
+    import re
+    existing = set()
+    for item in related:
+        if isinstance(item, str):
+            m = re.search(r"\[\[([^\]|]+)", item)
+            if m:
+                existing.add(m.group(1))
+
+    # Add missing links
+    added = 0
+    for link in missing_links:
+        if link not in existing:
+            related.append(f"[[{link}]]")
+            existing.add(link)
+            added += 1
+
+    if added == 0:
+        return "skipped"
+
+    try:
+        vault_edit(vault_path, rel_path, set_fields={"related": related})
+        log_mutation(session_path, "edit", rel_path)
+        log.info("autofix.link002_fixed", file=rel_path, added=added)
+        return "fixed"
+    except VaultError as e:
+        log.warning("autofix.link002_failed", file=rel_path, error=str(e))
         return "skipped"
 
 

--- a/src/alfred/janitor/issues.py
+++ b/src/alfred/janitor/issues.py
@@ -25,6 +25,7 @@ class IssueCode(str, Enum):
     WRONG_DIRECTORY = "DIR001"
     # Links
     BROKEN_WIKILINK = "LINK001"
+    UNLINKED_BODY_ENTITY = "LINK002"
     # Orphan
     ORPHANED_RECORD = "ORPHAN001"
     # Stub
@@ -47,6 +48,7 @@ SEVERITY_MAP: dict[IssueCode, Severity] = {
     IssueCode.INVALID_FIELD_TYPE: Severity.WARNING,
     IssueCode.WRONG_DIRECTORY: Severity.WARNING,
     IssueCode.BROKEN_WIKILINK: Severity.CRITICAL,
+    IssueCode.UNLINKED_BODY_ENTITY: Severity.WARNING,
     IssueCode.ORPHANED_RECORD: Severity.WARNING,
     IssueCode.STUB_RECORD: Severity.INFO,
     IssueCode.DUPLICATE_NAME: Severity.INFO,

--- a/src/alfred/janitor/scanner.py
+++ b/src/alfred/janitor/scanner.py
@@ -23,6 +23,12 @@ from .utils import compute_md5, get_logger
 log = get_logger(__name__)
 
 
+def _frontmatter_text(fm: dict) -> str:
+    """Serialize frontmatter dict to a string for wikilink extraction."""
+    import yaml
+    return yaml.dump(fm, default_flow_style=False, allow_unicode=True)
+
+
 def _build_stem_index(vault_path: Path, ignore_dirs: set[str]) -> dict[str, set[str]]:
     """Map stem names to file relative paths for wikilink resolution.
 
@@ -258,6 +264,37 @@ def _check_record(
                 message=f"Broken wikilink: [[{target}]]",
                 suggested_fix="Fix target path or create missing record",
             ))
+
+    # LINK002: Entity wikilinks in body but not in any frontmatter field
+    # Obsidian Bases' file.hasLink(this.file) only checks frontmatter links,
+    # so body-only entity links won't appear in base view tables.
+    _entity_dirs = set(TYPE_DIRECTORY.values())
+    fm_text = _frontmatter_text(record.frontmatter)
+    fm_link_targets = set(extract_wikilinks(fm_text))
+    body_links = set(extract_wikilinks(record.body))
+    missing_from_fm = []
+    for link in body_links - fm_link_targets:
+        if "/" not in link:
+            continue
+        link_dir = link.split("/", 1)[0]
+        if link_dir not in _entity_dirs:
+            continue
+        # Skip self-references
+        rel_no_ext = rel_path[:-3] if rel_path.endswith(".md") else rel_path
+        if link == rel_no_ext:
+            continue
+        # Only flag if the target actually exists
+        if stem_index.get(link):
+            missing_from_fm.append(link)
+    if missing_from_fm:
+        issues.append(Issue(
+            code=IssueCode.UNLINKED_BODY_ENTITY,
+            severity=Severity.WARNING,
+            file=rel_path,
+            message=f"{len(missing_from_fm)} entity link(s) in body but not in frontmatter",
+            detail=", ".join(sorted(missing_from_fm)[:5]),
+            suggested_fix="Add to related: frontmatter array",
+        ))
 
     # ORPHAN001: Orphaned record (no inbound links)
     exempt_dirs = set(config.sweep.orphan_exempt_dirs)

--- a/src/alfred/quickstart.py
+++ b/src/alfred/quickstart.py
@@ -22,7 +22,7 @@ ENTITY_DIRS = [
     "inbox", "inbox/processed",
     "account", "asset", "conversation", "note",
     "decision", "assumption", "constraint", "contradiction", "synthesis",
-    "event", "task", "session", "run", "input", "thread", "view",
+    "event", "task", "session", "run", "input", "view",
 ]
 
 


### PR DESCRIPTION
## Summary

Aligns the Alfred scaffold and janitor with lessons learned from the v1→v2 vault migration (3,088 records migrated).

**Three changes:**

### 1. Remove `thread/` scaffold directory and quickstart entry
The `drop-thread-type` branch removed `thread` from `KNOWN_TYPES` and `STATUS_BY_TYPE` but left the scaffold directory and quickstart `ENTITY_DIRS` entry. This completes that removal.

### 2. Add LINK002: Unlinked Body Entity detection (scanner)
New janitor scanner check that detects entity wikilinks (`[[person/X]]`, `[[project/Y]]`, etc.) present in body text but absent from all frontmatter fields.

**Why this matters:** Obsidian Bases' `file.hasLink(this.file)` filter — used by every base view definition — only checks **frontmatter** links, not body text. If a session file mentions `[[person/David]]` in its body but has `related: []` in frontmatter, that session won't appear in David's person page Sessions table.

During migration, 2,156 files had this exact problem — entity links in body, empty `related: []` — causing every base view table to appear empty.

### 3. Add LINK002 autofix (autofix)
Deterministic fix: promotes missing body entity links to the `related:` frontmatter array. Skips self-references, duplicates, and links to non-existent files.

## Files changed

| File | Change |
|------|--------|
| `scaffold/thread/.gitkeep` | Deleted |
| `quickstart.py` | Remove `thread` from `ENTITY_DIRS` |
| `janitor/issues.py` | Add `UNLINKED_BODY_ENTITY = "LINK002"` + severity mapping |
| `janitor/scanner.py` | Add LINK002 check in `_check_record()` + `_frontmatter_text()` helper |
| `janitor/autofix.py` | Add `_fix_unlinked_body_entity()` handler |

## Test plan

- [ ] Verify `alfred quickstart` no longer creates `thread/` directory
- [ ] Run `alfred janitor scan` on a vault with body-only entity links — should report LINK002
- [ ] Run `alfred janitor fix` — should promote links to `related:` frontmatter
- [ ] Verify base view tables populate correctly after fix
- [ ] Verify no false positives: links already in `relationships:`, `participants:`, `owner:`, etc. should NOT be flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)