### PR TITLE
Fix curator reprocessing loop: mark_processed on failure

### DIFF
--- a/src/alfred/curator/daemon.py
+++ b/src/alfred/curator/daemon.py
@@ -251,6 +251,13 @@ async def run(config: CuratorConfig, skills_dir: Path) -> None:
                     await _process_file(inbox_file, backend, skill_text, config, state_mgr)
                 except Exception:
                     log.exception("daemon.process_error", file=inbox_file.name)
+                    # Always move to processed — even on failure — to prevent
+                    # infinite reprocessing loops.  The error is logged above.
+                    if inbox_file.exists():
+                        try:
+                            mark_processed(inbox_file, config.vault.processed_path)
+                        except Exception:
+                            log.exception("daemon.mark_processed_fallback_failed", file=inbox_file.name)
                 finally:
                     _processing.discard(str(inbox_file))
     finally:


### PR DESCRIPTION
When _process_file throws, the file stays in inbox forever causing an infinite loop. The except handler now calls mark_processed() as a fallback.

This is the upstream counterpart to alfred-platform PR #110 (wrapper exit code fix).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>