### PR TITLE
fix: make curator prompt model-agnostic

### DIFF
--- a/src/alfred/_bundled/skills/vault-curator/prompts/stage1_analyze.md
+++ b/src/alfred/_bundled/skills/vault-curator/prompts/stage1_analyze.md
@@ -15,14 +15,12 @@ You must do exactly TWO things:
 
 ### Single document (default)
 
-If the inbox file contains one document (an email, a conversation, a note), create a single rich note:
+If the inbox file contains one document (an email, a conversation, a note), create a single rich note.
 
-```bash
-cat <<'BODY' | alfred vault create note "<Descriptive Title>" \
-  --set status=active \
-  --set 'description="<1-2 sentence summary>"' \
-  --set 'project="[[project/Project Name]]"' \
-  --body-stdin
+**Step 1:** Use the **Write** tool to create a temporary file with the note body:
+
+Write to `/tmp/note-body.md`:
+```markdown
 # <Descriptive Title>
 
 ## Context
@@ -40,7 +38,12 @@ cat <<'BODY' | alfred vault create note "<Descriptive Title>" \
 <Any tasks, follow-ups, or next steps identified>
 
 ![[related.base#All]]
-BODY
+```
+
+**Step 2:** Use the **Bash** tool to create the vault record:
+
+```bash
+alfred vault create note "<Descriptive Title>" --set status=active --set 'description="<1-2 sentence summary>"' --set 'project="[[project/Project Name]]"' --body-stdin < /tmp/note-body.md
 ```
 
 ### Batched items (emails, messages, etc.)
@@ -52,14 +55,10 @@ If the inbox file contains **multiple items** (indicated by headers like "## Ema
 - **Tasks/action items**: Create individual task records for anything actionable.
 - **Noise** (login codes, automated alerts, marketing spam): Skip entirely — don't create records.
 
-**For batched service emails, the note should look like:**
+**For batched service emails, follow the same two-step pattern:**
 
-```bash
-cat <<'BODY' | alfred vault create note "GitHub Activity Summary" \
-  --set status=active \
-  --set 'description="Summary of GitHub activity: repos, collaborators, CI/CD patterns"' \
-  --set subtype=reference \
-  --body-stdin
+**Step 1:** Write to `/tmp/note-body.md`:
+```markdown
 # GitHub Activity Summary
 
 ## Repositories
@@ -75,7 +74,11 @@ cat <<'BODY' | alfred vault create note "GitHub Activity Summary" \
 <CI/CD activity, PR review patterns, etc.>
 
 ![[related.base#All]]
-BODY
+```
+
+**Step 2:** Run:
+```bash
+alfred vault create note "GitHub Activity Summary" --set status=active --set 'description="Summary of GitHub activity: repos, collaborators, CI/CD patterns"' --set subtype=reference --body-stdin < /tmp/note-body.md
 ```
 
 **Create at least one note per inbox file.** Even for pure noise, create a brief note acknowledging the source (e.g., "20 marketing emails from stan.store — no actionable content").
@@ -89,30 +92,34 @@ BODY
 
 ---
 
-## Task 2: Write the Entity Manifest to a File
+## Task 2: Write the Entity Manifest
 
-**CRITICAL: You MUST write the entity manifest JSON file.** This is not optional. The pipeline reads this file to create entity records. If you skip writing the file, no entities will be created and the extraction is lost.
+**CRITICAL: You MUST produce the entity manifest JSON.** This is not optional. The pipeline reads this to create entity records.
 
-After creating the note, write a JSON file listing entities that are **directly relevant to the vault owner** (see Relevance filter below).
+After creating the note, produce a JSON object listing entities that are **directly relevant to the vault owner** (see Relevance filter below). Even if you find zero entities, you MUST still produce: `{{"entities": []}}`
 
-**Write the JSON to this exact file path:** `{manifest_path}`
+Do NOT create these entities in the vault — just list them in the JSON. The pipeline will create them automatically.
 
-Do NOT create these entities in the vault — just list them in the JSON file. The pipeline will create them automatically.
+**Primary method:** Use the **Write** tool to write the JSON to this exact file path: `{manifest_path}`
 
-**Execute this command — do not just display it.** Even if you find zero entities, you MUST still write the file with an empty array: `{{"entities": []}}`
+**Fallback:** If the Write tool is unavailable or fails, include the JSON in your response inside a fenced code block marked `json`, like this:
 
-Write the file using a bash command like this:
+````
+```json
+{{"entities": [...]}}
+```
+````
 
-```bash
-cat > {manifest_path} <<'MANIFEST_EOF'
+**Example manifest content:**
+
+```json
 {{"entities": [
   {{"type": "person", "name": "John Smith", "description": "CTO at Acme Corp, discussed API integration", "fields": {{"org": "\"[[org/Acme Corp]]\"", "role": "CTO", "status": "active"}}}},
   {{"type": "org", "name": "Acme Corp", "description": "Client company, enterprise SaaS vendor", "fields": {{"org_type": "client", "status": "active"}}}},
   {{"type": "project", "name": "Acme API Integration", "description": "Integrate Acme's REST API with internal dashboard", "fields": {{"client": "\"[[org/Acme Corp]]\"", "status": "active"}}}},
   {{"type": "task", "name": "Send Acme API credentials", "description": "John to send staging API keys by Friday", "fields": {{"status": "todo", "project": "\"[[project/Acme API Integration]]\""}}}},
   {{"type": "decision", "name": "Use REST over GraphQL for Acme", "description": "Decided to use REST API due to better documentation", "fields": {{"status": "final", "confidence": "high"}}}}
-]}}
-MANIFEST_EOF
+]}}"
 ```
 
 **Entity extraction rules:**
@@ -170,10 +177,11 @@ Use this profile to determine what is relevant to the vault owner. Only extract 
 ## Important Rules
 
 - **Write everything in English.** Translate if the source is in another language. Keep proper nouns in original form.
-- **Use `alfred vault` commands for vault records.** The only direct filesystem write allowed is the entity manifest JSON to the specified `/tmp/` path.
-- **Do NOT create entity records** — only create the note. Write the entity manifest JSON to the specified file path.
+- **Use `alfred vault` commands for vault records.** Use the Write tool for the temporary note body file and the entity manifest JSON.
+- **Do NOT create entity records** — only create the note. The entity manifest JSON is for the pipeline to process.
 - **Do NOT move the inbox file** — the system handles this after processing.
 - **Prefer precision over recall** — only extract entities the vault owner directly interacts with. When in doubt, leave it out.
+- **Always produce the entity manifest** — even if empty. Use Write tool to write to the specified path, OR include it in your response as a ```json code block.
 
 ---
 

--- a/src/alfred/curator/pipeline.py
+++ b/src/alfred/curator/pipeline.py
@@ -76,24 +76,21 @@ def _load_user_profile(vault_path: Path) -> str:
     return "(no user profile available — use your best judgement about relevance)"
 
 
-def _parse_entity_manifest(stdout: str) -> list[dict]:
-    """Extract the JSON entity manifest from LLM stdout.
+def _extract_entities_from_text(text: str) -> list[dict] | None:
+    """Find a JSON object with an "entities" array anywhere in text.
 
-    Looks for a JSON object containing an "entities" array.
+    Uses brace-depth tracking to handle nested objects.
     """
-    # Try to find a JSON block with {"entities": [...]}
-    # Search for the pattern in the full output
-    for match in re.finditer(r'\{[^{}]*"entities"\s*:\s*\[', stdout):
+    for match in re.finditer(r'\{[^{}]*"entities"\s*:\s*\[', text):
         start = match.start()
-        # Find the matching closing brace by tracking nesting
         depth = 0
-        for i in range(start, len(stdout)):
-            if stdout[i] == '{':
+        for i in range(start, len(text)):
+            if text[i] == '{':
                 depth += 1
-            elif stdout[i] == '}':
+            elif text[i] == '}':
                 depth -= 1
                 if depth == 0:
-                    candidate = stdout[start:i + 1]
+                    candidate = text[start:i + 1]
                     try:
                         data = json.loads(candidate)
                         if isinstance(data.get("entities"), list):
@@ -101,8 +98,35 @@ def _parse_entity_manifest(stdout: str) -> list[dict]:
                     except json.JSONDecodeError:
                         continue
                     break
+    return None
 
-    # Fallback: try to parse the entire stdout as JSON
+
+def _parse_entity_manifest(stdout: str) -> list[dict]:
+    """Extract the JSON entity manifest from LLM stdout.
+
+    Searches in order:
+    1. Markdown fenced code blocks (```json ... ```)
+    2. Raw JSON with {"entities": [...]} anywhere in output
+    3. Entire stdout as JSON
+    """
+    if not stdout or '"entities"' not in stdout:
+        log.warning("pipeline.manifest_parse_failed", stdout_len=len(stdout))
+        return []
+
+    # Tier 1: Extract from markdown code blocks (```json ... ```)
+    for block_match in re.finditer(r'```(?:json)?\s*\n(.*?)\n```', stdout, re.DOTALL):
+        block = block_match.group(1).strip()
+        if '"entities"' in block:
+            result = _extract_entities_from_text(block)
+            if result is not None:
+                return result
+
+    # Tier 2: Find JSON with "entities" anywhere in the raw output
+    result = _extract_entities_from_text(stdout)
+    if result is not None:
+        return result
+
+    # Tier 3: Try to parse the entire stdout as JSON
     try:
         data = json.loads(stdout.strip())
         if isinstance(data.get("entities"), list):


### PR DESCRIPTION
## Summary

The curator Stage 1 prompt used bash heredoc patterns that only Claude follows. Non-Claude models (GPT-5.4-nano, Grok 4.1 Fast) can use OpenClaw tools but don't generate heredoc-style Bash commands.

### Prompt changes (`stage1_analyze.md`)
- **Note creation:** Two-step pattern — Write tool creates `/tmp/note-body.md`, then simple `alfred vault create note ... --body-stdin < /tmp/note-body.md`
- **Manifest:** Write tool writes JSON to the manifest path directly (not `cat > path <<'EOF'`)
- **Fallback instruction:** Model told to include JSON in a ` ```json ` code block if Write tool fails

### Parser changes (`pipeline.py`)
- `_parse_entity_manifest` now checks markdown code blocks (` ```json ... ``` `) before raw JSON search
- Extracted shared `_extract_entities_from_text` helper
- Early return if `"entities"` not in output at all

Companion PR in alfred-platform: openclaw-wrapper extraction improvements.

Fixes ssdavidai/alfred-platform#241

## Test plan
- [ ] Deploy updated alfred-worker image, test with GPT-5.4-nano on miguel's tenant
- [ ] Verify vault notes are created via `alfred vault create`
- [ ] Verify manifest JSON is parsed from Write tool output or response text
- [ ] No regression with Claude models

🤖 Generated with [Claude Code](https://claude.com/claude-code)