### PR TITLE
fix(curator): reduce default max_concurrent from 4 to 2 to prevent OOM

### DIFF
--- a/src/alfred/curator/config.py
+++ b/src/alfred/curator/config.py
@@ -95,7 +95,13 @@ class WatcherConfig:
     poll_interval: int = 5
     debounce_seconds: int = 10
     rescan_interval: int = 60
-    max_concurrent: int = 4  # number of inbox files to process in parallel
+    max_concurrent: int = 2  # number of inbox files to process in parallel
+    # Reduced from 4 to 2 to prevent openclaw-workers OOM on bulk uploads.
+    # Each concurrent curator session holds ~1-1.5GB of heap in openclaw-workers
+    # (agent context + transcript + 4-stage pipeline state). At 4 concurrent,
+    # a 10-file bulk upload spikes workers to 4-5GB and crashes the V8 heap.
+    # At 2 concurrent: ~3GB peak, ~9 min for 10 files. Safe + predictable.
+    # Tune per-tenant via config.yaml: curator.watcher.max_concurrent
 
 
 @dataclass


### PR DESCRIPTION
## Summary

- Change `WatcherConfig.max_concurrent` default from `4` → `2`
- Prevents openclaw-workers OOM crash during bulk inbox uploads

## Context

Each concurrent curator session holds ~1-1.5GB of openclaw-workers heap (agent context + transcript + 4-stage pipeline state). At the old default of 4, a 10-file bulk upload reliably pushes workers past the V8 heap limit.

## Observed on David's tenant

Uploaded 34 VTT transcripts (~100KB each) to the inbox:
- With `max_concurrent=4`: workers mem 80% → 83% → 86% → 98% → OOM
- With `max_concurrent=2`: workers mem flat at ~77% (~3GB / 6GB heap), zero restarts

## Trade-off

Bulk-upload throughput for 10 files:
- Old (4 concurrent): ~5 min
- New (2 concurrent): ~9 min

Acceptable cost for stability. Tenants with beefier workers can override via `curator.watcher.max_concurrent` in `config.yaml`.

## Test plan

- [x] Applied to david, miguel, rapali tenants manually — workers stable
- [x] Confirmed `daemon.startup_scan files=X max_concurrent=2` in curator logs
- [ ] New tenants pick up the new default on next `alfred-worker` image bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)