### PR TITLE
feat(surveyor): structured entity-link writeback (#23)

### DIFF
--- a/src/alfred/surveyor/config.py
+++ b/src/alfred/surveyor/config.py
@@ -69,6 +69,17 @@ class LabelerConfig:
 
 
 @dataclass
+class EntityLinkConfig:
+    """Structured entity-link writeback — when a cluster contains entity
+    records (matter/person/org/project), non-entity members with cosine
+    similarity above threshold get the entity's vault path written into
+    a typed frontmatter field (related_matters / related_persons / etc).
+    """
+    threshold: float = 0.75
+    max_per_record: int = 5
+
+
+@dataclass
 class StateConfig:
     path: str = "./data/state.json"
 
@@ -90,6 +101,7 @@ class PipelineConfig:
     labeler: LabelerConfig
     state: StateConfig
     logging: LoggingConfig
+    entity_link: EntityLinkConfig = field(default_factory=EntityLinkConfig)
 
 
 _ENV_PATTERN = re.compile(r"\$\{(\w+)\}")
@@ -160,6 +172,7 @@ def load_config(config_path: str | Path) -> PipelineConfig:
         labeler=_build_dataclass(LabelerConfig, raw.get("labeler")),
         state=_build_dataclass(StateConfig, raw.get("state")),
         logging=_build_dataclass(LoggingConfig, raw.get("logging")),
+        entity_link=_build_dataclass(EntityLinkConfig, raw.get("entity_link")),
     )
 
 
@@ -177,4 +190,5 @@ def load_from_unified(raw: dict) -> PipelineConfig:
         labeler=_build_dataclass(LabelerConfig, tool.get("labeler")),
         state=_build_dataclass(StateConfig, tool.get("state")),
         logging=_build_dataclass(LoggingConfig, raw.get("logging")),
+        entity_link=_build_dataclass(EntityLinkConfig, tool.get("entity_link")),
     )

--- a/src/alfred/surveyor/daemon.py
+++ b/src/alfred/surveyor/daemon.py
@@ -200,3 +200,111 @@ class Daemon:
                     self.writer.write_relationships(source, [rel])
 
         log.info("daemon.labeling_complete", clusters_processed=len(all_changed))
+
+        # Stage 5: structured entity-link writeback. For each cluster whose
+        # membership changed, walk non-entity members and add typed
+        # frontmatter links (related_matters / related_persons / related_orgs
+        # / related_projects) to any entity member of the same cluster whose
+        # cosine similarity is above the configured threshold.
+        self._link_entities_in_clusters(
+            all_changed, cluster_members, records, paths, vectors,
+        )
+
+    def _link_entities_in_clusters(
+        self,
+        changed_cluster_ids: set[int],
+        cluster_members: dict[int, list[str]],
+        records: dict[str, "VaultRecord"],
+        all_paths: list[str],
+        all_vectors,
+    ) -> None:
+        """Write structured entity-link frontmatter for records whose cluster
+        contains entity records (matter/person/org/project).
+
+        For each non-entity member of a changed cluster, compute cosine
+        similarity against each entity member. Above threshold → add the
+        entity's vault path to the appropriate typed frontmatter field.
+
+        Requires numpy; surveyor already imports it for embedding work.
+        """
+        import numpy as np
+        from .labeler import ENTITY_RECORD_TYPES
+
+        # Build path → vector lookup once (all_paths + all_vectors come from
+        # embedder.get_all_embeddings()).
+        path_to_vec: dict[str, "np.ndarray"] = {}
+        for p, v in zip(all_paths, all_vectors):
+            path_to_vec[p] = np.asarray(v, dtype=np.float32)
+
+        # Entity type → frontmatter field name → writer method.
+        # Kept local to avoid polluting module namespace.
+        writer_methods = {
+            "matter": self.writer.write_related_matters,
+            "person": self.writer.write_related_persons,
+            "org": self.writer.write_related_orgs,
+            "project": self.writer.write_related_projects,
+        }
+
+        threshold = self.cfg.entity_link.threshold
+        max_per = self.cfg.entity_link.max_per_record
+
+        total_added = 0
+        clusters_processed = 0
+        for cid in changed_cluster_ids:
+            members = cluster_members.get(cid, [])
+            if len(members) < 2:
+                continue
+
+            # Partition: entities by type, regulars separately
+            entities_by_type: dict[str, list[str]] = {}
+            regulars: list[str] = []
+            for path in members:
+                record = records.get(path)
+                if record is None:
+                    continue
+                if record.record_type in ENTITY_RECORD_TYPES:
+                    entities_by_type.setdefault(record.record_type, []).append(path)
+                else:
+                    regulars.append(path)
+
+            if not entities_by_type or not regulars:
+                continue
+            clusters_processed += 1
+
+            for reg_path in regulars:
+                reg_vec = path_to_vec.get(reg_path)
+                if reg_vec is None:
+                    continue
+
+                for entity_type, entity_paths in entities_by_type.items():
+                    # Compute cos(reg_path, each entity), keep those above
+                    # threshold, sort by similarity desc, cap at max_per.
+                    scored: list[tuple[str, float]] = []
+                    for e_path in entity_paths:
+                        e_vec = path_to_vec.get(e_path)
+                        if e_vec is None:
+                            continue
+                        # Vectors are already L2-normalised in the embedder,
+                        # so dot product == cosine similarity.
+                        sim = float(np.dot(reg_vec, e_vec))
+                        if sim >= threshold:
+                            scored.append((e_path, sim))
+
+                    if not scored:
+                        continue
+
+                    scored.sort(key=lambda x: x[1], reverse=True)
+                    to_write = [p for p, _ in scored[:max_per]]
+
+                    method = writer_methods[entity_type]
+                    added = method(reg_path, to_write, max_total=max_per)
+                    total_added += added
+
+        if clusters_processed > 0:
+            log.info(
+                "daemon.entity_linking_complete",
+                clusters_processed=clusters_processed,
+                links_added=total_added,
+                threshold=threshold,
+                max_per_record=max_per,
+            )

--- a/src/alfred/surveyor/writer.py
+++ b/src/alfred/surveyor/writer.py
@@ -42,6 +42,124 @@ class VaultWriter:
         self._write_atomic(full_path, rel_path, post)
         log.info("writer.tags_written", path=rel_path, tags=tags)
 
+    def _append_to_list_field(
+        self,
+        rel_path: str,
+        field: str,
+        new_paths: list[str],
+        max_total: int | None = None,
+    ) -> int:
+        """Append entries to a frontmatter list field (e.g. `related_matters`)
+        without removing existing entries. Returns the number of new entries
+        added. Idempotent — re-calling with the same paths is a no-op.
+
+        Invariants:
+          - Never remove a human-authored or previously-written entry.
+          - Dedupe against existing entries (exact string match).
+          - Preserve original ordering; append new entries at the end.
+          - If `max_total` is set, cap final list length (drop from the
+            TAIL of new entries, not existing ones).
+        """
+        if not new_paths:
+            return 0
+
+        full_path = self.vault_path / rel_path
+        if not full_path.exists():
+            log.warning("writer.file_not_found", path=rel_path)
+            return 0
+
+        try:
+            raw = full_path.read_text(encoding="utf-8")
+            post = frontmatter.loads(raw)
+        except Exception as e:
+            log.warning("writer.parse_error", path=rel_path, error=str(e))
+            return 0
+
+        existing = post.metadata.get(field, [])
+        if not isinstance(existing, list):
+            # Respect unexpected scalar values — treat as a single entry
+            existing = [str(existing)] if existing else []
+        existing_set = set(existing)
+
+        to_add: list[str] = []
+        for p in new_paths:
+            if p in existing_set:
+                continue
+            to_add.append(p)
+            existing_set.add(p)
+
+        if not to_add:
+            return 0
+
+        merged = existing + to_add
+        if max_total is not None and len(merged) > max_total:
+            # Trim from the tail so human-authored + earlier machine entries
+            # are preserved. The assumption: callers already ranked
+            # `new_paths` by similarity, so earliest=best.
+            merged = merged[:max_total]
+
+        # "added" = net new entries actually retained after cap.
+        added_kept = max(0, len(merged) - len(existing))
+
+        post.metadata[field] = merged
+        self._write_atomic(full_path, rel_path, post)
+        log.info(
+            "writer.entity_links_written",
+            path=rel_path,
+            field=field,
+            added=added_kept,
+            total=len(merged),
+        )
+        return added_kept
+
+    def write_related_matters(
+        self,
+        rel_path: str,
+        matter_paths: list[str],
+        max_total: int | None = None,
+    ) -> int:
+        """Append matter vault paths to `related_matters` frontmatter.
+
+        Respects existing entries (both human-authored and previously
+        machine-written). Returns count of newly-added entries.
+        """
+        return self._append_to_list_field(
+            rel_path, "related_matters", matter_paths, max_total
+        )
+
+    def write_related_persons(
+        self,
+        rel_path: str,
+        person_paths: list[str],
+        max_total: int | None = None,
+    ) -> int:
+        """Append person vault paths to `related_persons` frontmatter."""
+        return self._append_to_list_field(
+            rel_path, "related_persons", person_paths, max_total
+        )
+
+    def write_related_orgs(
+        self,
+        rel_path: str,
+        org_paths: list[str],
+        max_total: int | None = None,
+    ) -> int:
+        """Append org vault paths to `related_orgs` frontmatter."""
+        return self._append_to_list_field(
+            rel_path, "related_orgs", org_paths, max_total
+        )
+
+    def write_related_projects(
+        self,
+        rel_path: str,
+        project_paths: list[str],
+        max_total: int | None = None,
+    ) -> int:
+        """Append project vault paths to `related_projects` frontmatter."""
+        return self._append_to_list_field(
+            rel_path, "related_projects", project_paths, max_total
+        )
+
     def write_relationships(self, rel_path: str, new_rels: list[dict]) -> None:
         """Append machine-generated relationships (only those with confidence < 1.0).
 

--- a/tests/surveyor/test_daemon_entity_link.py
+++ b/tests/surveyor/test_daemon_entity_link.py
@@ -1,0 +1,264 @@
+"""Tests for daemon._link_entities_in_clusters."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import frontmatter
+
+from alfred.surveyor.config import (
+    ClusteringConfig,
+    EntityLinkConfig,
+    HdbscanConfig,
+    LabelerConfig,
+    LeidenConfig,
+    LoggingConfig,
+    MilvusConfig,
+    OllamaConfig,
+    OpenRouterConfig,
+    PipelineConfig,
+    StateConfig,
+    VaultConfig,
+    WatcherConfig,
+)
+from alfred.surveyor.daemon import Daemon
+from alfred.surveyor.parser import VaultRecord
+from alfred.surveyor.state import PipelineState
+from alfred.surveyor.writer import VaultWriter
+
+
+def _make_config(vault: Path, state_path: Path, threshold: float = 0.75, max_per: int = 5) -> PipelineConfig:
+    return PipelineConfig(
+        vault=VaultConfig(path=vault),
+        watcher=WatcherConfig(),
+        ollama=OllamaConfig(),
+        milvus=MilvusConfig(uri=str(state_path.parent / "milvus.db")),
+        clustering=ClusteringConfig(hdbscan=HdbscanConfig(), leiden=LeidenConfig()),
+        openrouter=OpenRouterConfig(api_key="x"),
+        labeler=LabelerConfig(),
+        state=StateConfig(path=str(state_path)),
+        logging=LoggingConfig(),
+        entity_link=EntityLinkConfig(threshold=threshold, max_per_record=max_per),
+    )
+
+
+def _write(vault: Path, rel: str, record_type: str, name: str = "x") -> None:
+    full = vault / rel
+    full.parent.mkdir(parents=True, exist_ok=True)
+    full.write_text(
+        f"---\ntype: {record_type}\nname: {name}\n---\n\nbody\n",
+        encoding="utf-8",
+    )
+
+
+def _record(rel: str, rt: str) -> VaultRecord:
+    return VaultRecord(rel_path=rel, frontmatter={"type": rt, "name": "x"}, body="", record_type=rt)
+
+
+def _normalise(vec: list[float]) -> list[float]:
+    a = np.asarray(vec, dtype=np.float32)
+    n = float(np.linalg.norm(a))
+    return (a / n).tolist() if n > 0 else a.tolist()
+
+
+@pytest.fixture
+def daemon_and_vault(tmp_path):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    state_path = tmp_path / "state.json"
+    cfg = _make_config(vault, state_path)
+
+    # Stub daemon — we only need writer + cfg + state for the test.
+    daemon = Daemon.__new__(Daemon)
+    daemon.cfg = cfg
+    daemon.state = PipelineState(state_path=cfg.state.path)
+    daemon.writer = VaultWriter(vault_path=vault, state=daemon.state)
+    daemon.embedder = MagicMock()
+    daemon.watcher = MagicMock()
+    daemon.clusterer = MagicMock()
+    daemon.labeler = MagicMock()
+    daemon._shutdown_requested = False
+    return daemon, vault
+
+
+def test_links_events_to_matter_above_threshold(daemon_and_vault):
+    daemon, vault = daemon_and_vault
+    # Create vault records
+    _write(vault, "matter/erste.md", "matter")
+    _write(vault, "event/a.md", "event")
+    _write(vault, "event/b.md", "event")
+    daemon.state.update_file("matter/erste.md", "h1")
+    daemon.state.update_file("event/a.md", "h2")
+    daemon.state.update_file("event/b.md", "h3")
+
+    records = {
+        "matter/erste.md": _record("matter/erste.md", "matter"),
+        "event/a.md": _record("event/a.md", "event"),
+        "event/b.md": _record("event/b.md", "event"),
+    }
+    # Unit-norm vectors; matter is "baseline"; event/a is 0.9 similar; event/b is 0.3 similar.
+    matter_vec = _normalise([1.0, 0.0, 0.0, 0.0])
+    a_vec = _normalise([0.9, 0.436, 0.0, 0.0])  # cos ≈ 0.9
+    b_vec = _normalise([0.3, 0.95, 0.0, 0.0])   # cos ≈ 0.3
+
+    paths = ["matter/erste.md", "event/a.md", "event/b.md"]
+    vectors = np.asarray([matter_vec, a_vec, b_vec], dtype=np.float32)
+    cluster_members = {0: paths[:]}
+
+    daemon._link_entities_in_clusters(
+        changed_cluster_ids={0},
+        cluster_members=cluster_members,
+        records=records,
+        all_paths=paths,
+        all_vectors=vectors,
+    )
+
+    # event/a (sim 0.9) should be linked, event/b (sim 0.3) should NOT be linked
+    a_md = frontmatter.load(vault / "event/a.md").metadata
+    b_md = frontmatter.load(vault / "event/b.md").metadata
+    assert a_md.get("related_matters") == ["matter/erste.md"]
+    assert "related_matters" not in b_md
+
+
+def test_separates_entity_types_into_own_fields(daemon_and_vault):
+    daemon, vault = daemon_and_vault
+    _write(vault, "matter/m.md", "matter")
+    _write(vault, "person/p.md", "person")
+    _write(vault, "org/o.md", "org")
+    _write(vault, "project/x.md", "project")
+    _write(vault, "event/e.md", "event")
+    for p in ["matter/m.md", "person/p.md", "org/o.md", "project/x.md", "event/e.md"]:
+        daemon.state.update_file(p, "h")
+
+    records = {
+        "matter/m.md": _record("matter/m.md", "matter"),
+        "person/p.md": _record("person/p.md", "person"),
+        "org/o.md": _record("org/o.md", "org"),
+        "project/x.md": _record("project/x.md", "project"),
+        "event/e.md": _record("event/e.md", "event"),
+    }
+    # All 5 same vector so all sims = 1.0
+    v = _normalise([1.0, 0.0])
+    paths = list(records.keys())
+    vectors = np.asarray([v] * 5, dtype=np.float32)
+    cluster_members = {7: paths[:]}
+
+    daemon._link_entities_in_clusters(
+        changed_cluster_ids={7},
+        cluster_members=cluster_members,
+        records=records,
+        all_paths=paths,
+        all_vectors=vectors,
+    )
+
+    e_md = frontmatter.load(vault / "event/e.md").metadata
+    assert e_md.get("related_matters") == ["matter/m.md"]
+    assert e_md.get("related_persons") == ["person/p.md"]
+    assert e_md.get("related_orgs") == ["org/o.md"]
+    assert e_md.get("related_projects") == ["project/x.md"]
+
+
+def test_cluster_without_entities_noop(daemon_and_vault):
+    daemon, vault = daemon_and_vault
+    _write(vault, "event/a.md", "event")
+    _write(vault, "event/b.md", "event")
+    records = {
+        "event/a.md": _record("event/a.md", "event"),
+        "event/b.md": _record("event/b.md", "event"),
+    }
+    v = _normalise([1.0])
+    daemon._link_entities_in_clusters(
+        changed_cluster_ids={0},
+        cluster_members={0: list(records.keys())},
+        records=records,
+        all_paths=list(records.keys()),
+        all_vectors=np.asarray([v, v], dtype=np.float32),
+    )
+    # No writes
+    assert "related_matters" not in frontmatter.load(vault / "event/a.md").metadata
+    assert "related_matters" not in frontmatter.load(vault / "event/b.md").metadata
+
+
+def test_multiple_matters_ranked_by_similarity(daemon_and_vault):
+    daemon, vault = daemon_and_vault
+    _write(vault, "matter/close.md", "matter")
+    _write(vault, "matter/less-close.md", "matter")
+    _write(vault, "matter/distant.md", "matter")
+    _write(vault, "event/e.md", "event")
+    for p in ["matter/close.md", "matter/less-close.md", "matter/distant.md", "event/e.md"]:
+        daemon.state.update_file(p, "h")
+
+    records = {
+        "matter/close.md": _record("matter/close.md", "matter"),
+        "matter/less-close.md": _record("matter/less-close.md", "matter"),
+        "matter/distant.md": _record("matter/distant.md", "matter"),
+        "event/e.md": _record("event/e.md", "event"),
+    }
+    # event/e most similar to close (0.95), less to less-close (0.8), distant (0.3 — below threshold)
+    e_vec = _normalise([1.0, 0.0, 0.0])
+    close_vec = _normalise([0.95, 0.312, 0.0])
+    less_vec = _normalise([0.8, 0.6, 0.0])
+    distant_vec = _normalise([0.3, 0.95, 0.0])
+    paths = list(records.keys())
+    vectors = np.asarray([close_vec, less_vec, distant_vec, e_vec], dtype=np.float32)
+
+    daemon._link_entities_in_clusters(
+        changed_cluster_ids={0},
+        cluster_members={0: paths[:]},
+        records=records,
+        all_paths=paths,
+        all_vectors=vectors,
+    )
+
+    e_md = frontmatter.load(vault / "event/e.md").metadata
+    # Distant is below threshold (0.75); close + less-close both above
+    # Order by similarity desc: close first, then less-close.
+    assert e_md["related_matters"] == ["matter/close.md", "matter/less-close.md"]
+
+
+def test_respects_max_per_record(tmp_path):
+    # Shrink max_per_record to 2, expect only top 2 similarity hits
+    vault = tmp_path / "vault"
+    vault.mkdir(exist_ok=True)
+    state_path = tmp_path / "state.json"
+    cfg = _make_config(vault, state_path, threshold=0.0, max_per=2)
+    daemon = Daemon.__new__(Daemon)
+    daemon.cfg = cfg
+    daemon.state = PipelineState(state_path=cfg.state.path)
+    daemon.writer = VaultWriter(vault_path=vault, state=daemon.state)
+
+    _write(vault, "event/e.md", "event")
+    matter_paths = []
+    for i in range(5):
+        _write(vault, f"matter/m{i}.md", "matter")
+        matter_paths.append(f"matter/m{i}.md")
+        daemon.state.update_file(f"matter/m{i}.md", "h")
+    daemon.state.update_file("event/e.md", "h")
+
+    records = {p: _record(p, "matter") for p in matter_paths}
+    records["event/e.md"] = _record("event/e.md", "event")
+
+    e_vec = _normalise([1.0, 0.0, 0.0, 0.0])
+    # Decreasing similarity
+    matter_vecs = [
+        _normalise([1.0, 0.01, 0.0, 0.0]),    # 0.99
+        _normalise([0.9, 0.2, 0.0, 0.0]),     # ≈0.97
+        _normalise([0.8, 0.4, 0.0, 0.0]),     # ≈0.89
+        _normalise([0.6, 0.6, 0.0, 0.0]),     # ≈0.71
+        _normalise([0.4, 0.8, 0.0, 0.0]),     # ≈0.45
+    ]
+    paths = matter_paths + ["event/e.md"]
+    vectors = np.asarray(matter_vecs + [e_vec], dtype=np.float32)
+
+    daemon._link_entities_in_clusters(
+        changed_cluster_ids={0},
+        cluster_members={0: paths[:]},
+        records=records,
+        all_paths=paths,
+        all_vectors=vectors,
+    )
+
+    e_md = frontmatter.load(vault / "event/e.md").metadata
+    assert e_md["related_matters"] == ["matter/m0.md", "matter/m1.md"]

--- a/tests/surveyor/test_writer_entity_links.py
+++ b/tests/surveyor/test_writer_entity_links.py
@@ -1,0 +1,139 @@
+"""Tests for surveyor writer — structured entity-link writeback."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import frontmatter
+import pytest
+
+from alfred.surveyor.state import PipelineState
+from alfred.surveyor.writer import VaultWriter
+
+
+@pytest.fixture
+def vault_with_record(tmp_path: Path):
+    """Build a real tiny vault + PipelineState + VaultWriter."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "event").mkdir()
+    ev = vault / "event" / "test-event.md"
+    ev.write_text(
+        "---\ntype: event\nname: Test Event\nstatus: active\n---\n\nEvent body.\n",
+        encoding="utf-8",
+    )
+    state = PipelineState(state_path=tmp_path / "state.json")
+    state.update_file("event/test-event.md", "hash-placeholder")
+    writer = VaultWriter(vault_path=vault, state=state)
+    return vault, state, writer, "event/test-event.md"
+
+
+def _read_metadata(vault: Path, rel: str) -> dict:
+    with open(vault / rel, encoding="utf-8") as f:
+        return frontmatter.load(f).metadata
+
+
+def test_write_related_matters_new_record(vault_with_record):
+    _, _, writer, rel = vault_with_record
+    added = writer.write_related_matters(rel, ["matter/erste.md", "matter/nova.md"])
+    assert added == 2
+    md = _read_metadata(writer.vault_path, rel)
+    assert md["related_matters"] == ["matter/erste.md", "matter/nova.md"]
+
+
+def test_write_related_matters_dedupes(vault_with_record):
+    _, _, writer, rel = vault_with_record
+    writer.write_related_matters(rel, ["matter/a.md"])
+    added = writer.write_related_matters(rel, ["matter/a.md", "matter/b.md"])
+    assert added == 1  # only matter/b.md is new
+    md = _read_metadata(writer.vault_path, rel)
+    assert md["related_matters"] == ["matter/a.md", "matter/b.md"]
+
+
+def test_write_related_matters_preserves_existing_human_entries(vault_with_record, tmp_path):
+    vault, state, writer, rel = vault_with_record
+    # Human-authored existing entry
+    (vault / rel).write_text(
+        "---\ntype: event\nname: X\nrelated_matters: [matter/human-added.md]\n---\n\nBody.\n",
+        encoding="utf-8",
+    )
+    state.update_file(rel, "new-hash")
+    added = writer.write_related_matters(rel, ["matter/machine-added.md"])
+    assert added == 1
+    md = _read_metadata(vault, rel)
+    assert md["related_matters"] == ["matter/human-added.md", "matter/machine-added.md"]
+
+
+def test_write_related_matters_caps_at_max_total(vault_with_record):
+    _, _, writer, rel = vault_with_record
+    paths = [f"matter/{i}.md" for i in range(10)]
+    added = writer.write_related_matters(rel, paths, max_total=3)
+    assert added == 3
+    md = _read_metadata(writer.vault_path, rel)
+    # First 3 are kept; callers rank before passing so earliest = best
+    assert md["related_matters"] == ["matter/0.md", "matter/1.md", "matter/2.md"]
+
+
+def test_write_related_persons_separate_field(vault_with_record):
+    _, _, writer, rel = vault_with_record
+    writer.write_related_matters(rel, ["matter/a.md"])
+    writer.write_related_persons(rel, ["person/b.md"])
+    md = _read_metadata(writer.vault_path, rel)
+    assert md["related_matters"] == ["matter/a.md"]
+    assert md["related_persons"] == ["person/b.md"]
+
+
+def test_write_related_orgs_and_projects_separate_fields(vault_with_record):
+    _, _, writer, rel = vault_with_record
+    writer.write_related_orgs(rel, ["org/x.md"])
+    writer.write_related_projects(rel, ["project/y.md"])
+    md = _read_metadata(writer.vault_path, rel)
+    assert md["related_orgs"] == ["org/x.md"]
+    assert md["related_projects"] == ["project/y.md"]
+
+
+def test_empty_list_is_noop(vault_with_record):
+    _, _, writer, rel = vault_with_record
+    added = writer.write_related_matters(rel, [])
+    assert added == 0
+    md = _read_metadata(writer.vault_path, rel)
+    assert "related_matters" not in md
+
+
+def test_nonexistent_file_is_noop(tmp_path):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    state = PipelineState(state_path=tmp_path / "state.json")
+    writer = VaultWriter(vault_path=vault, state=state)
+    added = writer.write_related_matters("event/missing.md", ["matter/a.md"])
+    assert added == 0
+
+
+def test_existing_scalar_value_handled(vault_with_record):
+    """Some vault records have a scalar (string) value in the field by mistake —
+    upgrade it to a list on next write rather than crashing.
+    """
+    vault, state, writer, rel = vault_with_record
+    (vault / rel).write_text(
+        "---\ntype: event\nrelated_matters: matter/old-scalar.md\n---\n\nBody.\n",
+        encoding="utf-8",
+    )
+    state.update_file(rel, "hash-b")
+    added = writer.write_related_matters(rel, ["matter/new.md"])
+    assert added == 1
+    md = _read_metadata(vault, rel)
+    assert md["related_matters"] == ["matter/old-scalar.md", "matter/new.md"]
+
+
+def test_multiple_fields_independent(vault_with_record):
+    """All four fields can coexist on the same record without interference."""
+    _, _, writer, rel = vault_with_record
+    writer.write_related_matters(rel, ["matter/a.md"])
+    writer.write_related_persons(rel, ["person/p.md"])
+    writer.write_related_orgs(rel, ["org/o.md"])
+    writer.write_related_projects(rel, ["project/x.md"])
+    md = _read_metadata(writer.vault_path, rel)
+    assert md["related_matters"] == ["matter/a.md"]
+    assert md["related_persons"] == ["person/p.md"]
+    assert md["related_orgs"] == ["org/o.md"]
+    assert md["related_projects"] == ["project/x.md"]


### PR DESCRIPTION
Closes #23. Part of epic #21.

## Change

New daemon pass after cluster labeling writes typed entity-link frontmatter onto non-entity records in clusters that contain entities:

```yaml
related_matters: [matter/erste.md, matter/nova.md]
related_persons: [person/jazmin.md]
related_orgs: [org/erste-bank.md]
related_projects: [project/makerspace.md]
```

Only writes when cosine similarity ≥ threshold (default 0.75). Caps each field per-record (default 5). Respects human-authored entries — never removes.

## Code

- `writer.py` — 4 new methods + private `_append_to_list_field` helper, mirrors existing `write_alfred_tags` pattern (atomic, dedupe, pending_write tracking).
- `daemon.py` — new `_link_entities_in_clusters` pass reuses embeddings from Milvus (via `get_all_embeddings()`), zero additional LLM calls.
- `config.py` — new `EntityLinkConfig` (threshold + max_per_record), wired through both `load_config` and `load_from_unified`.

## Tests

25 tests across test_labeler.py (from #22), test_writer_entity_links.py (new), test_daemon_entity_link.py (new). All pass.

## Rollout

After merge: bump ALFRED_SHA in alfred-platform/packages/openclaw/VERSION. Build CI passes ALFRED_SHA to alfred-worker image build (fixed in ssdavidai/alfred-platform#503), so tenants pick up the code on next rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)