### PR TITLE
perf(surveyor): batch cloud embeddings + drop per-call throttle

### DIFF
--- a/src/alfred/surveyor/embedder.py
+++ b/src/alfred/surveyor/embedder.py
@@ -21,8 +21,20 @@ log = structlog.get_logger()
 # Retry config
 MAX_RETRIES = 5
 RETRY_BASE_DELAY = 2.0
-# Throttle between sequential embedding requests (seconds)
-EMBED_THROTTLE = 0.2
+# Throttle between sequential embedding requests (seconds). Applied only when
+# hitting local Ollama (unbounded local compute wants pacing to avoid
+# thrashing the GPU/CPU). Cloud APIs don't need it — their own rate limits
+# protect the backend, and inter-request sleep just wastes wall time.
+EMBED_THROTTLE_LOCAL = 0.2
+EMBED_THROTTLE_CLOUD = 0.0
+
+# Maximum number of inputs per batched embeddings request. OpenAI's
+# embeddings API accepts up to 2048 per call; other OpenAI-compatible
+# providers vary. Conservative default trades some batch size for
+# compatibility across endpoints. Local Ollama's /api/embeddings does NOT
+# support batching — `_embed_batch` falls back to sequential on the local
+# path regardless of this value.
+EMBED_BATCH_SIZE = 256
 
 # Chunking config — nomic-embed-text has an 8192-token context window.
 # Token-per-char ratio varies by language and content: ~4 for English prose,
@@ -188,6 +200,113 @@ class Embedder:
         if self._http is not None and not self._http.is_closed:
             await self._http.aclose()
 
+    @property
+    def _is_cloud(self) -> bool:
+        """True when embedding calls target an OpenAI-compatible endpoint
+        (api_key is set). False for native Ollama."""
+        return bool(self.api_key)
+
+    @property
+    def _throttle_seconds(self) -> float:
+        return EMBED_THROTTLE_CLOUD if self._is_cloud else EMBED_THROTTLE_LOCAL
+
+    async def _embed_batch(self, texts: list[str]) -> list[list[float] | None]:
+        """Embed a list of texts in a single API call when on cloud, otherwise
+        sequential fallback.
+
+        Returns a list of same length as `texts`, with None entries where a
+        specific text failed (mirrors `_embed_single`'s None-on-failure). The
+        caller maps these back to their source chunks/documents.
+
+        - **Cloud path (api_key set)**: one POST with `input: [text1, text2, ...]`.
+          Response's `data` array comes back in index order. Handles
+          context-length errors by halving the batch and retrying (a single
+          oversized text in the batch would fail the whole batch; splitting
+          isolates the offender so others still succeed).
+        - **Local Ollama path**: Ollama's /api/embeddings does not support
+          multi-input batching, so we fall back to sequential `_embed_single`
+          calls with throttling — preserves prior behaviour.
+        """
+        if not texts:
+            return []
+
+        if not self._is_cloud:
+            out: list[list[float] | None] = []
+            for idx, t in enumerate(texts):
+                emb = await self._embed_single(t)
+                out.append(emb)
+                if idx < len(texts) - 1 and self._throttle_seconds > 0:
+                    await asyncio.sleep(self._throttle_seconds)
+            return out
+
+        # Cloud path: single batched request
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        body = {"model": self.model, "input": texts}
+        client = await self._ensure_http()
+
+        for attempt in range(MAX_RETRIES):
+            try:
+                resp = await client.post(
+                    self.embed_url,
+                    json=body,
+                    headers=headers,
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                items = data.get("data") or []
+                # Providers return items with a `index` field that we MUST use
+                # to reassemble ordering — don't rely on response order.
+                result: list[list[float] | None] = [None] * len(texts)
+                for item in items:
+                    idx = item.get("index", 0)
+                    emb = item.get("embedding")
+                    if emb is not None and 0 <= idx < len(texts):
+                        result[idx] = emb
+                log.debug(
+                    "embedder.batch_success",
+                    batch_size=len(texts),
+                    returned=sum(1 for v in result if v is not None),
+                )
+                return result
+            except (httpx.ConnectError, httpx.TimeoutException, httpx.HTTPStatusError) as e:
+                detail = ""
+                if isinstance(e, httpx.HTTPStatusError):
+                    detail = e.response.text[:400]
+                # If the batch failed because ONE input is oversized, splitting
+                # the batch isolates the offender so the rest succeed.
+                if "exceeds the context length" in detail or "maximum context" in detail:
+                    if len(texts) == 1:
+                        log.warning(
+                            "embedder.embed_skipped_oversized",
+                            detail=detail[:200],
+                            batch_path="cloud",
+                        )
+                        return [None]
+                    mid = len(texts) // 2
+                    log.info(
+                        "embedder.batch_split_on_oversized",
+                        batch_size=len(texts),
+                        halves=(mid, len(texts) - mid),
+                    )
+                    left = await self._embed_batch(texts[:mid])
+                    right = await self._embed_batch(texts[mid:])
+                    return left + right
+                delay = RETRY_BASE_DELAY * (2 ** attempt)
+                log.warning(
+                    "embedder.batch_retry",
+                    attempt=attempt + 1,
+                    error=str(e)[:200],
+                    detail=detail[:200],
+                    delay=delay,
+                    batch_size=len(texts),
+                )
+                await asyncio.sleep(delay)
+        log.error("embedder.batch_failed", max_retries=MAX_RETRIES, batch_size=len(texts))
+        return [None] * len(texts)
+
     async def _embed_single(self, text: str) -> list[float] | None:
         """Call embedding API once for a single chunk, with retry.
 
@@ -237,6 +356,10 @@ class Embedder:
         document-level vector. This preserves whole-document semantics without
         losing content (vs. truncation) and keeps the downstream clustering
         interface unchanged (one vector per document).
+
+        - Cloud path: all chunks submitted in a single `_embed_batch` call.
+        - Local Ollama: falls back to sequential `_embed_single` (with
+          throttling inside `_embed_batch`).
         """
         chunks = _chunk_text(text)
         if len(chunks) == 1:
@@ -248,16 +371,13 @@ class Embedder:
             num_chunks=len(chunks),
         )
 
+        results = await self._embed_batch(chunks)
         vectors: list[list[float]] = []
-        for idx, chunk in enumerate(chunks):
-            emb = await self._embed_single(chunk)
+        for idx, emb in enumerate(results):
             if emb is None:
                 log.warning("embedder.chunk_failed", chunk_idx=idx, num_chunks=len(chunks))
                 continue
             vectors.append(emb)
-            # Throttle between chunks of the same document to reduce Ollama pressure
-            if idx < len(chunks) - 1:
-                await asyncio.sleep(EMBED_THROTTLE)
 
         if not vectors:
             return None
@@ -273,51 +393,23 @@ class Embedder:
     async def process_diff(
         self, new_paths: list[str], changed_paths: list[str], deleted_paths: list[str]
     ) -> dict[str, VaultRecord]:
-        """Embed new/changed files, delete removed ones. Returns parsed records."""
+        """Embed new/changed files, delete removed ones. Returns parsed records.
+
+        On the cloud path (api_key set), this batches across documents AND
+        across chunks so a full re-embed of 3,000+ files can complete in
+        seconds instead of an hour. On the local Ollama path, preserves the
+        old one-file-at-a-time behavior since Ollama's /api/embeddings
+        doesn't accept batched inputs anyway.
+        """
         records: dict[str, VaultRecord] = {}
-
-        # Upsert new + changed
         to_embed = new_paths + changed_paths
-        for rel_path in to_embed:
-            try:
-                record = parse_file(self.vault_path, rel_path)
-            except Exception as e:
-                log.warning("embedder.parse_error", path=rel_path, error=str(e))
-                continue
 
-            text = build_embedding_text(record)
-            if not text.strip():
-                log.debug("embedder.empty_text", path=rel_path)
-                continue
+        if self._is_cloud:
+            await self._process_diff_cloud(to_embed, records)
+        else:
+            await self._process_diff_local(to_embed, records)
 
-            embedding = await self._get_embedding(text)
-            if embedding is None:
-                continue
-
-            # Throttle between requests to reduce Ollama pressure
-            await asyncio.sleep(EMBED_THROTTLE)
-
-            # Milvus Lite's upsert/insert internally runs a filter-based
-            # DELETE on the primary key. That parser chokes on IDs with
-            # apostrophes, spaces, or tokens like "Road" (real example from
-            # tenant vaults: "constraint/Fixed Rental Period for Parents'
-            # Road Trip.md"). URL-encode the ID so Milvus only ever sees
-            # safe chars. _decode_id reverses this in get_all_embeddings.
-            encoded_id = _encode_id(rel_path)
-            self.milvus.upsert(
-                collection_name=self.collection_name,
-                data=[{
-                    "id": encoded_id,
-                    "embedding": embedding,
-                    "record_type": record.record_type,
-                    "name": record.frontmatter.get("name", rel_path),
-                }],
-            )
-            self.state.mark_embedded(rel_path)
-            records[rel_path] = record
-            log.debug("embedder.upserted", path=rel_path)
-
-        # Delete removed
+        # Delete removed (same path on both)
         for rel_path in deleted_paths:
             try:
                 encoded_id = _encode_id(rel_path)
@@ -334,8 +426,130 @@ class Embedder:
             "embedder.diff_processed",
             upserted=len(to_embed),
             deleted=len(deleted_paths),
+            path=("cloud" if self._is_cloud else "local"),
         )
         return records
+
+    async def _process_diff_local(
+        self, to_embed: list[str], records: dict[str, VaultRecord]
+    ) -> None:
+        """Original one-at-a-time embed loop for local Ollama."""
+        for rel_path in to_embed:
+            try:
+                record = parse_file(self.vault_path, rel_path)
+            except Exception as e:
+                log.warning("embedder.parse_error", path=rel_path, error=str(e))
+                continue
+
+            text = build_embedding_text(record)
+            if not text.strip():
+                log.debug("embedder.empty_text", path=rel_path)
+                continue
+
+            embedding = await self._get_embedding(text)
+            if embedding is None:
+                continue
+
+            if self._throttle_seconds > 0:
+                await asyncio.sleep(self._throttle_seconds)
+
+            self._milvus_upsert(rel_path, record, embedding)
+            self.state.mark_embedded(rel_path)
+            records[rel_path] = record
+            log.debug("embedder.upserted", path=rel_path)
+
+    async def _process_diff_cloud(
+        self, to_embed: list[str], records: dict[str, VaultRecord]
+    ) -> None:
+        """Batched embed loop for cloud providers.
+
+        Fold every document's chunks into a single flat input list, submit in
+        batches of `EMBED_BATCH_SIZE`, then reassemble per-document by
+        pooling (mean + L2-normalise) the chunks belonging to each document.
+        One batch of 256 inputs runs in ~1-2s end-to-end vs ~256 sequential
+        calls at ~200ms each (~50s) — a 30-50x speedup on cold re-embed.
+        """
+        # Stage 1: parse all files, build chunks, track owner per chunk.
+        all_chunks: list[str] = []
+        # chunk index → rel_path (so we can reassemble after batch returns)
+        chunk_owner: list[str] = []
+        # rel_path → (record, chunk_indices) so we can map back
+        per_doc_chunks: dict[str, list[int]] = {}
+        per_doc_record: dict[str, VaultRecord] = {}
+
+        for rel_path in to_embed:
+            try:
+                record = parse_file(self.vault_path, rel_path)
+            except Exception as e:
+                log.warning("embedder.parse_error", path=rel_path, error=str(e))
+                continue
+            text = build_embedding_text(record)
+            if not text.strip():
+                log.debug("embedder.empty_text", path=rel_path)
+                continue
+            chunks = _chunk_text(text)
+            if not chunks:
+                continue
+            per_doc_record[rel_path] = record
+            per_doc_chunks[rel_path] = []
+            for chunk in chunks:
+                idx = len(all_chunks)
+                all_chunks.append(chunk)
+                chunk_owner.append(rel_path)
+                per_doc_chunks[rel_path].append(idx)
+
+        if not all_chunks:
+            return
+
+        # Stage 2: embed all chunks in batches.
+        chunk_embeddings: list[list[float] | None] = [None] * len(all_chunks)
+        for start in range(0, len(all_chunks), EMBED_BATCH_SIZE):
+            batch = all_chunks[start : start + EMBED_BATCH_SIZE]
+            result = await self._embed_batch(batch)
+            for i, emb in enumerate(result):
+                chunk_embeddings[start + i] = emb
+
+        # Stage 3: pool per-document + upsert.
+        for rel_path, indices in per_doc_chunks.items():
+            vectors = [chunk_embeddings[i] for i in indices if chunk_embeddings[i] is not None]
+            if not vectors:
+                log.warning("embedder.doc_all_chunks_failed", path=rel_path)
+                continue
+            arr = np.array(vectors, dtype=np.float32)
+            pooled = arr.mean(axis=0)
+            norm = float(np.linalg.norm(pooled))
+            if norm > 0.0:
+                pooled = pooled / norm
+            record = per_doc_record[rel_path]
+            self._milvus_upsert(rel_path, record, pooled.tolist())
+            self.state.mark_embedded(rel_path)
+            records[rel_path] = record
+        log.info(
+            "embedder.cloud_batch_done",
+            docs=len(per_doc_record),
+            chunks=len(all_chunks),
+            batches=(len(all_chunks) + EMBED_BATCH_SIZE - 1) // EMBED_BATCH_SIZE,
+        )
+
+    def _milvus_upsert(self, rel_path: str, record: VaultRecord, embedding: list[float]) -> None:
+        """Write one embedding to Milvus with URL-encoded ID.
+
+        Milvus Lite's internal upsert runs a filter-expression DELETE under
+        the hood (`id == '<path>'`). File paths with apostrophes, spaces, or
+        tokens the expression parser treats specially crash with
+        "near 'X': syntax error". URL-encoding guarantees the ID only
+        contains safe chars.
+        """
+        encoded_id = _encode_id(rel_path)
+        self.milvus.upsert(
+            collection_name=self.collection_name,
+            data=[{
+                "id": encoded_id,
+                "embedding": embedding,
+                "record_type": record.record_type,
+                "name": record.frontmatter.get("name", rel_path),
+            }],
+        )
 
     def get_all_embeddings(self) -> tuple[list[str], np.ndarray] | None:
         """Retrieve all embeddings from Milvus as (paths, matrix).

--- a/tests/surveyor/test_embedder_batching.py
+++ b/tests/surveyor/test_embedder_batching.py
@@ -1,0 +1,114 @@
+"""Tests for embedder cloud-batching + throttle removal."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from alfred.surveyor.embedder import Embedder
+
+
+def _stub_embedder(api_key: str | None = "sk-test") -> Embedder:
+    """Minimal Embedder instance without Milvus/HTTP setup."""
+    e = Embedder.__new__(Embedder)
+    e.api_key = api_key
+    e.model = "openai/text-embedding-3-small"
+    e.embedding_dims = 1536
+    e.embed_url = "https://openrouter.ai/api/v1/embeddings"
+    e._http = None
+    return e
+
+
+class _FakeResponse:
+    def __init__(self, json_data: dict, status_code: int = 200) -> None:
+        self._json = json_data
+        self.status_code = status_code
+        self.text = ""
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("err", request=None, response=self)  # type: ignore[arg-type]
+
+    def json(self) -> dict:
+        return self._json
+
+
+def test_throttle_zero_on_cloud() -> None:
+    e = _stub_embedder(api_key="sk-test")
+    assert e._is_cloud is True
+    assert e._throttle_seconds == 0.0
+
+
+def test_throttle_nonzero_on_local() -> None:
+    e = _stub_embedder(api_key=None)
+    assert e._is_cloud is False
+    assert e._throttle_seconds > 0.0
+
+
+@pytest.mark.asyncio
+async def test_embed_batch_cloud_single_request_for_many_inputs() -> None:
+    """Cloud path should issue ONE POST for a list of many texts."""
+    e = _stub_embedder(api_key="sk-test")
+    # Fake client returning an embeddings-shaped response
+    fake_json = {
+        "data": [
+            {"index": 0, "embedding": [0.1, 0.2]},
+            {"index": 1, "embedding": [0.3, 0.4]},
+            {"index": 2, "embedding": [0.5, 0.6]},
+        ]
+    }
+    client = MagicMock()
+    client.post = AsyncMock(return_value=_FakeResponse(fake_json))
+    client.is_closed = False
+    e._http = client
+
+    result = await e._embed_batch(["a", "b", "c"])
+    assert result == [[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]
+    assert client.post.await_count == 1  # single batched request
+
+
+@pytest.mark.asyncio
+async def test_embed_batch_uses_provider_index_for_ordering() -> None:
+    """Reassembly must use `index` field, not response order."""
+    e = _stub_embedder(api_key="sk-test")
+    # Provider returns items out of order
+    fake_json = {
+        "data": [
+            {"index": 2, "embedding": [2.0]},
+            {"index": 0, "embedding": [0.0]},
+            {"index": 1, "embedding": [1.0]},
+        ]
+    }
+    client = MagicMock()
+    client.post = AsyncMock(return_value=_FakeResponse(fake_json))
+    client.is_closed = False
+    e._http = client
+
+    result = await e._embed_batch(["x", "y", "z"])
+    assert result == [[0.0], [1.0], [2.0]]
+
+
+@pytest.mark.asyncio
+async def test_embed_batch_empty_input_returns_empty() -> None:
+    e = _stub_embedder(api_key="sk-test")
+    result = await e._embed_batch([])
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_embed_batch_local_falls_back_sequentially() -> None:
+    """Local Ollama path has no batch endpoint — should call _embed_single per text."""
+    e = _stub_embedder(api_key=None)
+    e._embed_single = AsyncMock(side_effect=[[0.1], [0.2], [0.3]])
+
+    import alfred.surveyor.embedder as emb_mod
+    original = emb_mod.EMBED_THROTTLE_LOCAL
+    emb_mod.EMBED_THROTTLE_LOCAL = 0.0  # speed up tests
+    try:
+        result = await e._embed_batch(["a", "b", "c"])
+    finally:
+        emb_mod.EMBED_THROTTLE_LOCAL = original
+
+    assert result == [[0.1], [0.2], [0.3]]
+    assert e._embed_single.await_count == 3


### PR DESCRIPTION
## Summary

- Cloud embedding path now issues **one POST for up to 256 inputs** (folds every document's chunks into a flat list, batches, then pools per-document). Previously: one POST per chunk, sequential.
- Throttle between requests removed on the cloud path (was 0.2s — pure wall-time waste, cloud APIs rate-limit themselves). Local Ollama path keeps the 0.2s throttle since Ollama's `/api/embeddings` has no batch endpoint.
- Oversized single inputs isolated via batch-halving (preserves old per-chunk skip-on-context-overflow behaviour).

## Impact

On David's ~2.7k-record vault, a full re-embed currently takes ~30 min on the cloud path (each chunk = one request × ~200ms each). With batching + no throttle this should finish in roughly 1 min.

No behavioural change on local Ollama path — same sequential loop, same throttle, same chunking/pooling semantics.

## Test plan
- [x] `pytest tests/surveyor/` — 31/31 pass (6 new tests in `test_embedder_batching.py` + 25 existing)
- [ ] Deploy via alfred-platform ALFRED_SHA bump; verify David finishes a full re-embed in under 2 min (the surveyor `entity_linking_complete` event appears much sooner).
- [ ] Confirm no regression on local-Ollama tenants (Miguel/Rapali) — surveyor.embed throughput unchanged.