### PR TITLE
fix(surveyor): coerce list-shaped `type:` frontmatter to scalar

### DIFF
--- a/src/alfred/surveyor/parser.py
+++ b/src/alfred/surveyor/parser.py
@@ -39,6 +39,30 @@ def extract_wikilinks(text: str) -> list[str]:
     return WIKILINK_RE.findall(text)
 
 
+def _coerce_record_type(raw) -> str:
+    """Normalise a `type:` frontmatter value into a scalar string.
+
+    Curator-generated records have occasionally been written with a one-element
+    YAML block-list (`type:\n- contradiction`) instead of a scalar — pyyaml
+    parses that as a Python `list`, and Milvus's VARCHAR `record_type` field
+    rejects it with a schema-mismatch error that crashes the entire surveyor
+    subprocess. Coerce defensively so a single malformed record can never
+    stop the embed pipeline.
+    """
+    if raw is None:
+        return "unknown"
+    if isinstance(raw, str):
+        return raw
+    if isinstance(raw, list):
+        # Take the first non-empty string; fall back to "unknown".
+        for item in raw:
+            if isinstance(item, str) and item.strip():
+                return item.strip()
+        return "unknown"
+    # Any other scalar (int/float/bool) — stringify so Milvus accepts it.
+    return str(raw)
+
+
 def parse_file(vault_path: Path, rel_path: str) -> VaultRecord:
     """Parse a vault markdown file into a VaultRecord."""
     full_path = vault_path / rel_path
@@ -47,7 +71,7 @@ def parse_file(vault_path: Path, rel_path: str) -> VaultRecord:
 
     fm = dict(post.metadata)
     body = post.content
-    record_type = fm.get("type", "unknown")
+    record_type = _coerce_record_type(fm.get("type"))
 
     # Extract wikilinks from the entire raw text (both frontmatter and body)
     wikilinks = extract_wikilinks(raw_text)

--- a/tests/surveyor/test_parser_coerce.py
+++ b/tests/surveyor/test_parser_coerce.py
@@ -1,0 +1,43 @@
+"""Tests for parser._coerce_record_type — defends the surveyor embed path
+against malformed `type:` frontmatter (e.g. one-element YAML block lists).
+"""
+from __future__ import annotations
+
+from alfred.surveyor.parser import _coerce_record_type
+
+
+def test_scalar_string_passes_through() -> None:
+    assert _coerce_record_type("matter") == "matter"
+
+
+def test_none_falls_back_to_unknown() -> None:
+    assert _coerce_record_type(None) == "unknown"
+
+
+def test_single_element_list_takes_first() -> None:
+    # This is the Miguel crash case: curator emitted `type:\n- contradiction`
+    assert _coerce_record_type(["contradiction"]) == "contradiction"
+
+
+def test_multi_element_list_takes_first_non_empty() -> None:
+    assert _coerce_record_type(["", "note", "extra"]) == "note"
+
+
+def test_empty_list_falls_back_to_unknown() -> None:
+    assert _coerce_record_type([]) == "unknown"
+
+
+def test_list_of_all_non_strings_falls_back_to_unknown() -> None:
+    assert _coerce_record_type([None, 42, {"k": "v"}]) == "unknown"
+
+
+def test_int_coerced_to_str() -> None:
+    assert _coerce_record_type(42) == "42"
+
+
+def test_bool_coerced_to_str() -> None:
+    assert _coerce_record_type(True) == "True"
+
+
+def test_whitespace_stripped_from_list_item() -> None:
+    assert _coerce_record_type(["  matter  "]) == "matter"


### PR DESCRIPTION
## Summary

Miguel's tenant hit a surveyor crash-loop after today's image bump:

```
RPC error: [upsert_rows], DataNotMatchException: The Input data type is inconsistent
with defined schema, {record_type} field should be a varchar, but got a {<class 'list'>}
instead.
```

Root cause: one vault file (`contradiction/Retool integration betas may be gated by functional query-saving instability.md`) had its frontmatter written as a YAML block-list:

```yaml
type:
- contradiction
```

pyyaml parses that as `["contradiction"]`. The surveyor's `parse_file` returned `record_type=["contradiction"]`, Milvus's VARCHAR schema rejected the upsert, and the surveyor subprocess exited 1. The in-container process supervisor restarts surveyor, but because `state.save()` only fires at the end of `_initial_sync`, no state ever gets persisted → next restart starts over from scratch → hits the same poison file 12 min later. 3 of 5 supervised restarts had burned before we caught it.

## Fix

`parser._coerce_record_type` normalises the value defensively:
- `None` → `"unknown"` (previous default)
- `list` → first non-empty string element, else `"unknown"`
- `int`/`float`/`bool` → `str(value)`
- `str` → unchanged (most common path)

One malformed record can no longer take down the whole embed pipeline.

## Scope

- David + Rapali vaults scanned clean (0 list-typed records).
- Miguel has exactly 1 offender; this fix unblocks him even before the vault file is cleaned up.
- Curator occasionally emits list-form type values — a parser-side defence is the right abstraction level, since the malformed shape shouldn't ever propagate past parsing.

## Test plan
- [x] 9 new unit tests for `_coerce_record_type` covering scalar, None, list (1 element / multi / empty / all-non-string), int, bool, whitespace-trim.
- [x] Full surveyor test suite (40 tests) still passes.
- [ ] Deploy via ALFRED_SHA bump; confirm Miguel's surveyor completes `initial_sync_complete` instead of exiting 1. Sequential Ollama embed at ~110 calls/min → ~20-30min to finish.