### PR TITLE
perf(surveyor): parallelise cluster labeling pass

### DIFF
--- a/src/alfred/surveyor/config.py
+++ b/src/alfred/surveyor/config.py
@@ -66,6 +66,12 @@ class LabelerConfig:
     max_files_per_cluster_context: int = 20
     body_preview_chars: int = 200
     min_cluster_size_to_label: int = 2
+    # Max LLM calls in flight during the cluster-labeling pass. Each cluster
+    # fires 2 sequential calls (label_cluster + suggest_relationships), and
+    # we fan out across clusters. 8 keeps well under OpenRouter's default
+    # rate limits for the fast-tier models while shortening full-vault
+    # labeling from tens of minutes to single digits.
+    max_concurrent: int = 8
 
 
 @dataclass

--- a/src/alfred/surveyor/daemon.py
+++ b/src/alfred/surveyor/daemon.py
@@ -170,36 +170,57 @@ class Daemon:
                 continue
             cluster_members.setdefault(cid, []).append(path)
 
-        for cid in all_changed:
+        # Clusters are independent — their label calls and relationship
+        # suggestions don't share state. Fan them out through an asyncio
+        # semaphore so we can keep up to `max_concurrent` LLM calls in
+        # flight instead of serialising 208 × 2 calls at ~5-10s each.
+        from .state import ClusterState
+        from datetime import datetime, timezone
+
+        semaphore = asyncio.Semaphore(self.cfg.labeler.max_concurrent)
+
+        async def _process_cluster(cid: int) -> None:
             members = cluster_members.get(cid, [])
             if len(members) < self.cfg.labeler.min_cluster_size_to_label:
-                continue
+                return
 
-            # Label the cluster
-            tags = await self.labeler.label_cluster(cid, members, records)
-            if tags:
-                # Write tags to all members
-                for path in members:
-                    self.writer.write_alfred_tags(path, tags)
+            async with semaphore:
+                tags = await self.labeler.label_cluster(cid, members, records)
+                if tags:
+                    for path in members:
+                        self.writer.write_alfred_tags(path, tags)
+                    cluster_key = f"semantic_{cid}"
+                    self.state.clusters[cluster_key] = ClusterState(
+                        label=tags,
+                        member_files=members,
+                        last_labeled=datetime.now(timezone.utc).isoformat(),
+                    )
 
-                # Update cluster state
-                cluster_key = f"semantic_{cid}"
-                from .state import ClusterState
-                from datetime import datetime, timezone
-                self.state.clusters[cluster_key] = ClusterState(
-                    label=tags,
-                    member_files=members,
-                    last_labeled=datetime.now(timezone.utc).isoformat(),
+                rels = await self.labeler.suggest_relationships(
+                    cid, members, records
                 )
+                for rel in rels:
+                    source = rel.get("source", "")
+                    if source in records:
+                        self.writer.write_relationships(source, [rel])
 
-            # Suggest relationships
-            rels = await self.labeler.suggest_relationships(cid, members, records)
-            for rel in rels:
-                source = rel.get("source", "")
-                if source in records:
-                    self.writer.write_relationships(source, [rel])
+        # gather() with return_exceptions=True keeps the pass running even
+        # if one cluster's LLM call blows up — we'd rather log and keep
+        # labeling the rest than abort the whole surveyor tick.
+        results = await asyncio.gather(
+            *(_process_cluster(cid) for cid in all_changed),
+            return_exceptions=True,
+        )
+        failures = [r for r in results if isinstance(r, Exception)]
+        for err in failures:
+            log.warning("daemon.cluster_label_error", error=str(err)[:200])
 
-        log.info("daemon.labeling_complete", clusters_processed=len(all_changed))
+        log.info(
+            "daemon.labeling_complete",
+            clusters_processed=len(all_changed),
+            failed=len(failures),
+            concurrency=self.cfg.labeler.max_concurrent,
+        )
 
         # Stage 5: structured entity-link writeback. For each cluster whose
         # membership changed, walk non-entity members and add typed


### PR DESCRIPTION
## Summary

`daemon._cluster_and_label` walked clusters sequentially with two LLM calls each (label + suggest_relationships). On David's vault that's 208 × 2 ≈ 416 serialised calls at ~5-10s each = **45-70 min wall time** for the labeling pass. Clusters are independent, writes go to disjoint files, no shared state on the label path — trivially parallelizable.

New behaviour: wrap the cluster loop in `asyncio.gather(…)` with a semaphore capped at `labeler.max_concurrent` (default 8). OpenRouter handles the fan-out fine; local Ollama queues server-side.

Expected impact on David: full-vault labeling drops from ~45min → **~5-8min**.

`gather(return_exceptions=True)` keeps the pass running if one cluster's call throws — we log the failure and continue instead of aborting the tick. `daemon.labeling_complete` now includes `failed` + `concurrency` for observability.

## Config
```yaml
surveyor:
  labeler:
    max_concurrent: 8   # default; bump higher on dedicated cloud keys
```

## Test plan
- [x] Full surveyor test suite (40 tests) green.
- [ ] Deploy via ALFRED_SHA bump. On David restart with empty state, confirm `labeling_complete` fires within ~10 min of `embedder.cloud_batch_done`, followed by `entity_linking_complete`.
- [ ] No regression on local-Ollama tenants (Miguel/Rapali): Ollama should absorb 8 parallel embedding-adjacent load; watch for 503 / queue-overflow events.

## Follow-ups
- Monitor OpenRouter rate-limit 429s at concurrency=8; dial down if needed.
- Could also overlap `label_cluster` and `suggest_relationships` within a single cluster for another ~2x, but starting conservative — 8-way cross-cluster parallelism is the high-order win.