### PR TITLE
perf(surveyor): idempotent startup sync + mid-label checkpointing

### DIFF
--- a/src/alfred/surveyor/daemon.py
+++ b/src/alfred/surveyor/daemon.py
@@ -20,6 +20,12 @@ from .writer import VaultWriter
 log = structlog.get_logger()
 
 LOOP_INTERVAL = 5.0  # seconds
+# How often to persist state during the labeling pass. Each label +
+# suggest_relationships call costs 1-2 LLM round-trips; checkpointing
+# every N clusters means a mid-pass kill loses at most this many
+# clusters of work. 10 is a good balance — ~5s of extra disk I/O per
+# full 200-cluster pass, minimal in the big picture.
+LABEL_CHECKPOINT_EVERY = 10
 
 
 class Daemon:
@@ -51,9 +57,11 @@ class Daemon:
         log.info("daemon.starting")
         self.state.load()
 
-        # Initial sync if no state exists
-        if not self.state.files:
-            await self._initial_sync()
+        # Always run a startup sync — this reconciles any drift between the
+        # vault on disk and persisted state (files added while surveyor was
+        # down never fire watcher events). compute_diff makes this cheap —
+        # only truly-new-or-changed files get re-embedded.
+        await self._startup_sync()
 
         # Start filesystem watcher
         self.watcher.start()
@@ -65,20 +73,53 @@ class Daemon:
         finally:
             await self.shutdown()
 
-    async def _initial_sync(self) -> None:
-        """Full scan → embed all → cluster → label."""
-        log.info("daemon.initial_sync_start")
+    async def _startup_sync(self) -> None:
+        """Reconcile full vault against persisted state on boot.
+
+        Runs a full filesystem rescan, diffs against state.files, and
+        embeds only what's actually new or changed. Deleted files are
+        purged. Unlike the prior `_initial_sync`, this path is idempotent:
+        a partially-complete previous run (e.g. killed mid-labeling by
+        alfred-update.timer) resumes cleanly instead of redoing everything
+        from scratch.
+
+        Also handles drift for tenants whose state file is intact but
+        stale (files added to the vault while surveyor was down — the
+        watcher only fires inotify events after startup, so those files
+        are otherwise invisible to `_tick`).
+        """
+        log.info("daemon.startup_sync_start")
 
         hashes = self.watcher.full_scan()
-        for rel, md5 in hashes.items():
-            self.state.update_file(rel, md5)
+        diff = self.state.compute_diff(hashes)
 
-        all_paths = list(hashes.keys())
-        records = await self.embedder.process_diff(all_paths, [], [])
+        log.info(
+            "daemon.startup_sync_diff",
+            on_disk=len(hashes),
+            in_state=len(self.state.files),
+            new=len(diff.new),
+            changed=len(diff.changed),
+            deleted=len(diff.deleted),
+        )
 
-        # Need all records for clustering — parse any we didn't get from embedder
+        # Update state md5s for new/changed files BEFORE embedding.
+        for rel in diff.new + diff.changed:
+            if rel in hashes:
+                self.state.update_file(rel, hashes[rel])
+
+        # Embed only the delta. On a cold start this is everything; on a
+        # resumed-after-restart case this is often zero or a handful.
+        records = await self.embedder.process_diff(diff.new, diff.changed, diff.deleted)
+
+        # Checkpoint here so the ~2min (cloud) / ~30min (local) embed work
+        # survives even if the labeling pass crashes or gets killed.
+        self.state.save()
+        log.info("daemon.startup_embed_checkpoint", embedded=len(records))
+
+        # Parse records that weren't freshly embedded so clustering sees
+        # the full vault in memory.
         all_records = dict(records)
-        for rel in all_paths:
+        for rel in hashes:
             if rel not in all_records:
                 try:
                     all_records[rel] = parse_file(self.cfg.vault.path, rel)
@@ -87,7 +128,7 @@ class Daemon:
 
         await self._cluster_and_label(all_records)
         self.state.save()
-        log.info("daemon.initial_sync_complete", files=len(hashes))
+        log.info("daemon.startup_sync_complete", files=len(hashes))
 
     async def _tick(self) -> None:
         """One iteration of the main loop."""
@@ -178,6 +219,11 @@ class Daemon:
         from datetime import datetime, timezone
 
         semaphore = asyncio.Semaphore(self.cfg.labeler.max_concurrent)
+        # Checkpoint state every N clusters so a mid-pass SIGKILL (e.g. the
+        # tenant's alfred-update.timer recreating the container every 15
+        # min) loses at most `LABEL_CHECKPOINT_EVERY` clusters of labeling
+        # work, not the whole pass.
+        processed_counter = {"count": 0}
 
         async def _process_cluster(cid: int) -> None:
             members = cluster_members.get(cid, [])
@@ -203,6 +249,15 @@ class Daemon:
                     source = rel.get("source", "")
                     if source in records:
                         self.writer.write_relationships(source, [rel])
+
+                processed_counter["count"] += 1
+                if processed_counter["count"] % LABEL_CHECKPOINT_EVERY == 0:
+                    self.state.save()
+                    log.info(
+                        "daemon.label_checkpoint",
+                        completed=processed_counter["count"],
+                        total=len(all_changed),
+                    )
 
         # gather() with return_exceptions=True keeps the pass running even
         # if one cluster's LLM call blows up — we'd rather log and keep

--- a/tests/surveyor/test_daemon_startup_sync.py
+++ b/tests/surveyor/test_daemon_startup_sync.py
@@ -1,0 +1,160 @@
+"""Tests for daemon._startup_sync — drift detection + idempotent resume."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from alfred.surveyor.daemon import Daemon
+from alfred.surveyor.state import PipelineState, FileState
+
+
+def _make_daemon(tmp_path: Path) -> Daemon:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "event").mkdir()
+
+    daemon = Daemon.__new__(Daemon)
+    daemon._shutdown_requested = False
+    daemon.cfg = MagicMock()
+    daemon.cfg.vault.path = vault
+    daemon.cfg.labeler.max_concurrent = 8
+    daemon.cfg.labeler.min_cluster_size_to_label = 2
+    daemon.state = PipelineState(state_path=tmp_path / "state.json")
+    daemon.watcher = MagicMock()
+    daemon.embedder = MagicMock()
+    daemon.embedder.process_diff = AsyncMock(return_value={})
+    daemon.clusterer = MagicMock()
+    daemon.labeler = MagicMock()
+    daemon.writer = MagicMock()
+    # Bypass cluster_and_label — tested separately
+    daemon._cluster_and_label = AsyncMock()
+    return daemon
+
+
+@pytest.mark.asyncio
+async def test_startup_sync_cold_start_embeds_everything(tmp_path):
+    """No prior state → every on-disk file is 'new' and goes through embedder."""
+    daemon = _make_daemon(tmp_path)
+    vault = daemon.cfg.vault.path
+    (vault / "event" / "a.md").write_text("---\ntype: event\n---\nbody\n")
+    (vault / "event" / "b.md").write_text("---\ntype: event\n---\nbody\n")
+
+    daemon.watcher.full_scan.return_value = {
+        "event/a.md": "md5-a",
+        "event/b.md": "md5-b",
+    }
+
+    await daemon._startup_sync()
+
+    call = daemon.embedder.process_diff.await_args
+    # positional args: (new, changed, deleted)
+    new_paths, changed_paths, deleted_paths = call.args
+    assert sorted(new_paths) == ["event/a.md", "event/b.md"]
+    assert changed_paths == []
+    assert deleted_paths == []
+
+
+@pytest.mark.asyncio
+async def test_startup_sync_picks_up_drift(tmp_path):
+    """Files on disk but absent from state (Rapali's drift) are detected as new."""
+    daemon = _make_daemon(tmp_path)
+    vault = daemon.cfg.vault.path
+    (vault / "event" / "existing.md").write_text("x")
+    (vault / "event" / "drifted.md").write_text("x")
+    # State knows only about existing.md
+    daemon.state.update_file("event/existing.md", "md5-existing")
+
+    daemon.watcher.full_scan.return_value = {
+        "event/existing.md": "md5-existing",
+        "event/drifted.md": "md5-drifted",
+    }
+
+    await daemon._startup_sync()
+
+    new_paths, changed_paths, deleted_paths = daemon.embedder.process_diff.await_args.args
+    assert new_paths == ["event/drifted.md"]
+    assert changed_paths == []
+    assert deleted_paths == []
+
+
+@pytest.mark.asyncio
+async def test_startup_sync_is_idempotent_when_state_matches_disk(tmp_path):
+    """Resume case: state already matches disk → no re-embed fires."""
+    daemon = _make_daemon(tmp_path)
+    vault = daemon.cfg.vault.path
+    (vault / "event" / "a.md").write_text("x")
+    daemon.state.update_file("event/a.md", "md5-a")
+
+    daemon.watcher.full_scan.return_value = {"event/a.md": "md5-a"}
+
+    await daemon._startup_sync()
+
+    new_paths, changed_paths, deleted_paths = daemon.embedder.process_diff.await_args.args
+    assert new_paths == []
+    assert changed_paths == []
+    assert deleted_paths == []
+
+
+@pytest.mark.asyncio
+async def test_startup_sync_detects_changed_md5(tmp_path):
+    """File modified while surveyor was down → reported as changed."""
+    daemon = _make_daemon(tmp_path)
+    vault = daemon.cfg.vault.path
+    (vault / "event" / "a.md").write_text("x")
+    daemon.state.update_file("event/a.md", "md5-old")
+
+    daemon.watcher.full_scan.return_value = {"event/a.md": "md5-new"}
+
+    await daemon._startup_sync()
+
+    new_paths, changed_paths, deleted_paths = daemon.embedder.process_diff.await_args.args
+    assert new_paths == []
+    assert changed_paths == ["event/a.md"]
+    assert deleted_paths == []
+
+
+@pytest.mark.asyncio
+async def test_startup_sync_detects_deleted_files(tmp_path):
+    """File in state but no longer on disk → reported as deleted."""
+    daemon = _make_daemon(tmp_path)
+    daemon.state.update_file("event/was_here.md", "md5")
+
+    # Nothing on disk now
+    daemon.watcher.full_scan.return_value = {}
+
+    await daemon._startup_sync()
+
+    new_paths, changed_paths, deleted_paths = daemon.embedder.process_diff.await_args.args
+    assert new_paths == []
+    assert changed_paths == []
+    assert deleted_paths == ["event/was_here.md"]
+
+
+@pytest.mark.asyncio
+async def test_startup_sync_saves_state_after_embed_phase(tmp_path):
+    """Checkpoint: state.save() called BEFORE labeling so embed work
+    survives a crash in _cluster_and_label."""
+    daemon = _make_daemon(tmp_path)
+    save_order: list[str] = []
+    original_save = daemon.state.save
+
+    def _traced_save():
+        save_order.append("save")
+        return original_save()
+
+    daemon.state.save = _traced_save
+
+    async def _trace_label(_records):
+        save_order.append("cluster_and_label")
+
+    daemon._cluster_and_label = _trace_label
+    daemon.watcher.full_scan.return_value = {}
+
+    await daemon._startup_sync()
+
+    # Two saves total: one after embed, one after labeling.
+    assert save_order.count("save") == 2
+    # The pre-labeling save must happen before _cluster_and_label runs.
+    assert save_order.index("save") < save_order.index("cluster_and_label")


### PR DESCRIPTION
## Summary

Two bugs surfaced today while shipping the surveyor v2 patches:

1. **Every 15 min each tenant pulls images and recreates containers** via `alfred-update.timer` (systemd unit on the VPS). Any in-progress surveyor pass is killed mid-work.
2. **State is saved only at the end of `_initial_sync`** — so every interruption meant losing the entire embed + label pass and restarting from scratch. On David that's ~45min of wasted LLM calls per restart.

Plus: **Rapali had 81 vault files in drift** (on disk, never indexed) because `_initial_sync` only runs when state.files is empty, and the filesystem watcher only sees events for files changed AFTER it starts.

## Changes

1. **`_startup_sync` replaces `_initial_sync`**. Always runs on boot. Uses `state.compute_diff` to embed only genuinely-new-or-changed files. Resume case is zero-cost; drift case is auto-resolved.

2. **Checkpoint state.save() between embed and labeling** — the ~2min cloud / ~30min local embed work survives a labeling-phase crash.

3. **Checkpoint every `LABEL_CHECKPOINT_EVERY=10` clusters** inside the labeling loop — a SIGKILL mid-pass loses at most 10 clusters of LLM work.

## Test plan
- [x] 6 new unit tests for startup_sync (cold / drift / resume / changed-md5 / deleted / save-ordering).
- [x] Full suite green (46 tests).
- [ ] Deploy via ALFRED_SHA bump.
- [ ] David: next `alfred-update.timer` tick should restart into `daemon.startup_sync_diff new=0 changed=0 deleted=0` and skip right to labeling — the previous run's tags + state resume cleanly.
- [ ] Rapali: next restart should emit `daemon.startup_sync_diff new=81 …` and pick up the drift files automatically.

## Notes on scope

The dedup-against-Milvus idea mentioned in planning turned out to be redundant once `_startup_sync` uses `compute_diff` — the daemon level already decides "new/changed/deleted" correctly, and `process_diff` just sees the delta. Keeping one source of truth.