### PR TITLE
feat(surveyor): link noise-point records to nearest entities (#24)

### DIFF
--- a/src/alfred/surveyor/daemon.py
+++ b/src/alfred/surveyor/daemon.py
@@ -286,6 +286,17 @@ class Daemon:
             all_changed, cluster_members, records, paths, vectors,
         )
 
+        # Stage 6: noise-point entity linking. HDBSCAN assigns cluster id -1
+        # to records that don't fit any cluster. Those records still deserve
+        # related_* frontmatter — we just can't infer it from cluster
+        # co-membership. Instead, compare each noise point directly against
+        # every entity record in the vault and link above threshold.
+        noise_paths = [p for p, cid in result.semantic.items() if cid == -1]
+        if noise_paths:
+            self._link_noise_points_to_entities(
+                noise_paths, records, paths, vectors,
+            )
+
     def _link_entities_in_clusters(
         self,
         changed_cluster_ids: set[int],
@@ -380,6 +391,108 @@ class Daemon:
             log.info(
                 "daemon.entity_linking_complete",
                 clusters_processed=clusters_processed,
+                links_added=total_added,
+                threshold=threshold,
+                max_per_record=max_per,
+            )
+
+    def _link_noise_points_to_entities(
+        self,
+        noise_paths: list[str],
+        records: dict[str, "VaultRecord"],
+        all_paths: list[str],
+        all_vectors,
+    ) -> None:
+        """Write related_* frontmatter for records that HDBSCAN assigned to
+        noise (cluster id -1).
+
+        These records aren't members of any cluster, so
+        `_link_entities_in_clusters` never touches them — they'd stay
+        unlinked forever. Instead, compare each noise point's embedding
+        directly against every matter/person/org/project record in the
+        vault and write the same typed frontmatter fields above threshold.
+
+        Entity records that are themselves noise points are excluded as
+        link *targets* (we don't want matter→matter self-links); they're
+        still included as *sources* (their own related_* fields get
+        populated if they sit alone in cluster-noise).
+        """
+        import numpy as np
+        from .labeler import ENTITY_RECORD_TYPES
+
+        path_to_vec: dict[str, "np.ndarray"] = {}
+        for p, v in zip(all_paths, all_vectors):
+            path_to_vec[p] = np.asarray(v, dtype=np.float32)
+
+        # Collect entity paths by type from the FULL vault, not just cluster
+        # members — we want to be able to link to an entity even when that
+        # entity lives in a different cluster (or noise) from the source.
+        all_entities_by_type: dict[str, list[str]] = {}
+        for path, record in records.items():
+            if record.record_type in ENTITY_RECORD_TYPES:
+                all_entities_by_type.setdefault(record.record_type, []).append(path)
+
+        if not all_entities_by_type:
+            return
+
+        writer_methods = {
+            "matter": self.writer.write_related_matters,
+            "person": self.writer.write_related_persons,
+            "org": self.writer.write_related_orgs,
+            "project": self.writer.write_related_projects,
+        }
+
+        threshold = self.cfg.entity_link.threshold
+        max_per = self.cfg.entity_link.max_per_record
+
+        total_added = 0
+        noise_processed = 0
+        for np_path in noise_paths:
+            record = records.get(np_path)
+            if record is None:
+                continue
+            np_vec = path_to_vec.get(np_path)
+            if np_vec is None:
+                continue
+
+            # Determine this noise point's own record_type so we can skip
+            # linking an entity to itself (and so matter→matter / person→
+            # person self-links don't propagate through).
+            src_type = record.record_type
+            noise_processed += 1
+
+            for entity_type, entity_paths in all_entities_by_type.items():
+                scored: list[tuple[str, float]] = []
+                for e_path in entity_paths:
+                    if e_path == np_path:
+                        continue  # self-link
+                    # Also skip cross-type self-reference (e.g. linking a
+                    # matter TO another matter via related_matters): the
+                    # source was itself an entity of the same type, so that
+                    # field shouldn't be used as a graph link for peers.
+                    if src_type == entity_type:
+                        continue
+                    e_vec = path_to_vec.get(e_path)
+                    if e_vec is None:
+                        continue
+                    sim = float(np.dot(np_vec, e_vec))
+                    if sim >= threshold:
+                        scored.append((e_path, sim))
+
+                if not scored:
+                    continue
+
+                scored.sort(key=lambda x: x[1], reverse=True)
+                to_write = [p for p, _ in scored[:max_per]]
+
+                method = writer_methods[entity_type]
+                added = method(np_path, to_write, max_total=max_per)
+                total_added += added
+
+        if noise_processed > 0:
+            log.info(
+                "daemon.noise_linking_complete",
+                noise_processed=noise_processed,
                 links_added=total_added,
                 threshold=threshold,
                 max_per_record=max_per,

--- a/tests/surveyor/test_daemon_noise_linking.py
+++ b/tests/surveyor/test_daemon_noise_linking.py
@@ -1,0 +1,257 @@
+"""Tests for daemon._link_noise_points_to_entities."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import frontmatter
+
+from alfred.surveyor.config import (
+    ClusteringConfig,
+    EntityLinkConfig,
+    HdbscanConfig,
+    LabelerConfig,
+    LeidenConfig,
+    LoggingConfig,
+    MilvusConfig,
+    OllamaConfig,
+    OpenRouterConfig,
+    PipelineConfig,
+    StateConfig,
+    VaultConfig,
+    WatcherConfig,
+)
+from alfred.surveyor.daemon import Daemon
+from alfred.surveyor.parser import VaultRecord
+from alfred.surveyor.state import PipelineState
+from alfred.surveyor.writer import VaultWriter
+
+
+def _cfg(vault: Path, state_path: Path, threshold: float = 0.75, max_per: int = 5) -> PipelineConfig:
+    return PipelineConfig(
+        vault=VaultConfig(path=vault),
+        watcher=WatcherConfig(),
+        ollama=OllamaConfig(),
+        milvus=MilvusConfig(uri=str(state_path.parent / "milvus.db")),
+        clustering=ClusteringConfig(hdbscan=HdbscanConfig(), leiden=LeidenConfig()),
+        openrouter=OpenRouterConfig(api_key="x"),
+        labeler=LabelerConfig(),
+        state=StateConfig(path=str(state_path)),
+        logging=LoggingConfig(),
+        entity_link=EntityLinkConfig(threshold=threshold, max_per_record=max_per),
+    )
+
+
+def _write(vault: Path, rel: str, rt: str) -> None:
+    full = vault / rel
+    full.parent.mkdir(parents=True, exist_ok=True)
+    full.write_text(f"---\ntype: {rt}\nname: x\n---\n\nbody\n", encoding="utf-8")
+
+
+def _record(rel: str, rt: str) -> VaultRecord:
+    return VaultRecord(rel_path=rel, frontmatter={"type": rt, "name": "x"}, body="", record_type=rt)
+
+
+def _norm(v: list[float]) -> list[float]:
+    a = np.asarray(v, dtype=np.float32)
+    n = float(np.linalg.norm(a))
+    return (a / n).tolist() if n > 0 else a.tolist()
+
+
+@pytest.fixture
+def daemon_and_vault(tmp_path):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    state_path = tmp_path / "state.json"
+
+    daemon = Daemon.__new__(Daemon)
+    daemon.cfg = _cfg(vault, state_path)
+    daemon.state = PipelineState(state_path=daemon.cfg.state.path)
+    daemon.writer = VaultWriter(vault_path=vault, state=daemon.state)
+    daemon.embedder = MagicMock()
+    daemon.watcher = MagicMock()
+    daemon.clusterer = MagicMock()
+    daemon.labeler = MagicMock()
+    daemon._shutdown_requested = False
+    return daemon, vault
+
+
+def test_noise_point_event_links_to_matter_above_threshold(daemon_and_vault):
+    """A noise-point event record with high similarity to an entity gets linked."""
+    daemon, vault = daemon_and_vault
+    _write(vault, "matter/primary.md", "matter")
+    _write(vault, "event/lonely.md", "event")
+    daemon.state.update_file("matter/primary.md", "h1")
+    daemon.state.update_file("event/lonely.md", "h2")
+
+    records = {
+        "matter/primary.md": _record("matter/primary.md", "matter"),
+        "event/lonely.md": _record("event/lonely.md", "event"),
+    }
+
+    matter_vec = _norm([1.0, 0.0, 0.0])
+    event_vec = _norm([0.95, 0.312, 0.0])  # sim ≈ 0.95
+    paths = ["matter/primary.md", "event/lonely.md"]
+    vectors = np.asarray([matter_vec, event_vec], dtype=np.float32)
+
+    daemon._link_noise_points_to_entities(
+        noise_paths=["event/lonely.md"],
+        records=records,
+        all_paths=paths,
+        all_vectors=vectors,
+    )
+
+    md = frontmatter.load(vault / "event/lonely.md").metadata
+    assert md.get("related_matters") == ["matter/primary.md"]
+
+
+def test_noise_event_below_threshold_not_linked(daemon_and_vault):
+    daemon, vault = daemon_and_vault
+    _write(vault, "matter/m.md", "matter")
+    _write(vault, "event/e.md", "event")
+    records = {
+        "matter/m.md": _record("matter/m.md", "matter"),
+        "event/e.md": _record("event/e.md", "event"),
+    }
+    matter_vec = _norm([1.0, 0.0, 0.0])
+    event_vec = _norm([0.3, 0.95, 0.0])  # sim ≈ 0.3 — below default 0.75
+    paths = list(records.keys())
+    vectors = np.asarray([matter_vec, event_vec], dtype=np.float32)
+
+    daemon._link_noise_points_to_entities(
+        noise_paths=["event/e.md"],
+        records=records,
+        all_paths=paths,
+        all_vectors=vectors,
+    )
+
+    md = frontmatter.load(vault / "event/e.md").metadata
+    assert "related_matters" not in md
+
+
+def test_noise_point_all_four_entity_types(daemon_and_vault):
+    """One noise event linked to each entity type in one pass."""
+    daemon, vault = daemon_and_vault
+    for rel, rt in [
+        ("matter/m.md", "matter"),
+        ("person/p.md", "person"),
+        ("org/o.md", "org"),
+        ("project/x.md", "project"),
+        ("event/e.md", "event"),
+    ]:
+        _write(vault, rel, rt)
+    records = {rel: _record(rel, rt) for rel, rt in [
+        ("matter/m.md", "matter"),
+        ("person/p.md", "person"),
+        ("org/o.md", "org"),
+        ("project/x.md", "project"),
+        ("event/e.md", "event"),
+    ]}
+
+    # All five share the same vector → sim ≈ 1.0 for all entity comparisons
+    v = _norm([1.0, 0.0])
+    paths = list(records.keys())
+    vectors = np.asarray([v] * 5, dtype=np.float32)
+
+    daemon._link_noise_points_to_entities(
+        noise_paths=["event/e.md"],
+        records=records,
+        all_paths=paths,
+        all_vectors=vectors,
+    )
+
+    md = frontmatter.load(vault / "event/e.md").metadata
+    assert md.get("related_matters") == ["matter/m.md"]
+    assert md.get("related_persons") == ["person/p.md"]
+    assert md.get("related_orgs") == ["org/o.md"]
+    assert md.get("related_projects") == ["project/x.md"]
+
+
+def test_noise_entity_source_skips_same_type_targets(daemon_and_vault):
+    """If the noise source is a matter, don't populate its related_matters
+    (that would create matter→matter chains). Other types still allowed.
+    """
+    daemon, vault = daemon_and_vault
+    _write(vault, "matter/src.md", "matter")
+    _write(vault, "matter/other.md", "matter")
+    _write(vault, "person/p.md", "person")
+    records = {
+        "matter/src.md": _record("matter/src.md", "matter"),
+        "matter/other.md": _record("matter/other.md", "matter"),
+        "person/p.md": _record("person/p.md", "person"),
+    }
+
+    v = _norm([1.0, 0.0])
+    paths = list(records.keys())
+    vectors = np.asarray([v] * 3, dtype=np.float32)
+
+    daemon._link_noise_points_to_entities(
+        noise_paths=["matter/src.md"],
+        records=records,
+        all_paths=paths,
+        all_vectors=vectors,
+    )
+
+    md = frontmatter.load(vault / "matter/src.md").metadata
+    # No matter→matter self-type linkage
+    assert "related_matters" not in md
+    # Cross-type still works
+    assert md.get("related_persons") == ["person/p.md"]
+
+
+def test_noise_point_sorted_by_similarity(daemon_and_vault):
+    daemon, vault = daemon_and_vault
+    for rel in ["matter/close.md", "matter/less.md", "matter/distant.md", "event/e.md"]:
+        _write(vault, rel, rel.split("/")[0])
+    records = {
+        "matter/close.md": _record("matter/close.md", "matter"),
+        "matter/less.md": _record("matter/less.md", "matter"),
+        "matter/distant.md": _record("matter/distant.md", "matter"),
+        "event/e.md": _record("event/e.md", "event"),
+    }
+
+    e_vec = _norm([1.0, 0.0, 0.0])
+    close_vec = _norm([0.95, 0.312, 0.0])   # ~0.95
+    less_vec = _norm([0.8, 0.6, 0.0])        # ~0.80
+    distant_vec = _norm([0.3, 0.95, 0.0])    # ~0.30 below threshold
+    paths = list(records.keys())
+    vectors = np.asarray([close_vec, less_vec, distant_vec, e_vec], dtype=np.float32)
+
+    daemon._link_noise_points_to_entities(
+        noise_paths=["event/e.md"],
+        records=records,
+        all_paths=paths,
+        all_vectors=vectors,
+    )
+
+    md = frontmatter.load(vault / "event/e.md").metadata
+    # Close first, then less-close. Distant below threshold.
+    assert md["related_matters"] == ["matter/close.md", "matter/less.md"]
+
+
+def test_noise_point_no_entities_is_noop(daemon_and_vault):
+    daemon, vault = daemon_and_vault
+    _write(vault, "event/a.md", "event")
+    _write(vault, "event/b.md", "event")
+    records = {
+        "event/a.md": _record("event/a.md", "event"),
+        "event/b.md": _record("event/b.md", "event"),
+    }
+    v = _norm([1.0, 0.0])
+    paths = list(records.keys())
+    vectors = np.asarray([v, v], dtype=np.float32)
+
+    daemon._link_noise_points_to_entities(
+        noise_paths=list(records.keys()),
+        records=records,
+        all_paths=paths,
+        all_vectors=vectors,
+    )
+
+    # No entity records → no writes
+    for p in records:
+        md = frontmatter.load(vault / p).metadata
+        assert "related_matters" not in md
+        assert "related_persons" not in md


### PR DESCRIPTION
## Summary

Finishes the coverage gap left by #23. Under the cluster-based linker, any record HDBSCAN labelled "noise" (cluster id -1) was skipped — these records got `alfred_tags` from #22 but never received structured `related_*` frontmatter. New `_link_noise_points_to_entities` runs after the cluster pass and does direct cosine comparisons against every entity record in the vault.

Same config knobs as #23 (`entity_link.threshold`, `entity_link.max_per_record`). Same VaultWriter methods. Same in-memory vectors from `get_all_embeddings()` — no extra Milvus queries, no LLM calls.

Same-type self-link suppression: a matter as a source doesn't populate `related_matters`. Cross-type is the only axis (matter ↔ person, event ↔ matter, etc.).

## Test plan
- [x] 6 unit tests (threshold, sort, self-type suppression, all-four-types, happy-path, noop).
- [x] 52 surveyor tests green.
- [ ] Deploy via ALFRED_SHA bump. On David: expect `daemon.noise_linking_complete noise_processed=N links_added=M` after `daemon.entity_linking_complete`. Confirm noise-point events under `/event/` get `related_*` fields.

## Closes
#24