### PR TITLE
feat(surveyor): backfill entity links on new entity creation (#25)

### DIFF
--- a/src/alfred/surveyor/config.py
+++ b/src/alfred/surveyor/config.py
@@ -83,6 +83,12 @@ class EntityLinkConfig:
     """
     threshold: float = 0.75
     max_per_record: int = 5
+    # When a new entity record (matter/person/org/project) is created, run
+    # a reverse scan across the vault and add it to matching records'
+    # related_<type> frontmatter. Without this, brand-new matters show up
+    # as structurally disconnected until the next clustering pass happens
+    # to co-cluster them with something.
+    backfill_enabled: bool = True
 
 
 @dataclass

--- a/src/alfred/surveyor/daemon.py
+++ b/src/alfred/surveyor/daemon.py
@@ -126,7 +126,17 @@ class Daemon:
                 except Exception:
                     pass
 
-        await self._cluster_and_label(all_records)
+        # Entity records that appeared for the FIRST TIME (diff.new, not
+        # diff.changed) trigger the backfill pass on the next
+        # _cluster_and_label call.
+        from .labeler import ENTITY_RECORD_TYPES
+        new_entity_paths = [
+            p for p in diff.new
+            if all_records.get(p) is not None
+            and all_records[p].record_type in ENTITY_RECORD_TYPES
+        ]
+
+        await self._cluster_and_label(all_records, newly_added_entity_paths=new_entity_paths)
         self.state.save()
         log.info("daemon.startup_sync_complete", files=len(hashes))
 
@@ -181,12 +191,35 @@ class Daemon:
                 except Exception:
                     pass
 
-        # Stage 3 + 4: Cluster and label
-        await self._cluster_and_label(all_records)
+        # Entity records that are genuinely NEW (not just changed) drive
+        # the Stage-7 backfill pass — a renamed or edited matter
+        # shouldn't re-spray related_matters across 3000 events.
+        from .labeler import ENTITY_RECORD_TYPES
+        new_entity_paths = [
+            p for p in diff.new
+            if all_records.get(p) is not None
+            and all_records[p].record_type in ENTITY_RECORD_TYPES
+        ]
+
+        # Stage 3 + 4 + 5 + 6 + 7: Cluster, label, entity-link, noise-link, backfill
+        await self._cluster_and_label(all_records, newly_added_entity_paths=new_entity_paths)
         self.state.save()
 
-    async def _cluster_and_label(self, records: dict[str, VaultRecord]) -> None:
-        """Run clustering then label changed clusters."""
+    async def _cluster_and_label(
+        self,
+        records: dict[str, VaultRecord],
+        newly_added_entity_paths: list[str] | None = None,
+    ) -> None:
+        """Run clustering then label changed clusters.
+
+        If `newly_added_entity_paths` is supplied and entity_link.backfill_enabled
+        is true, a Stage-7 backfill pass runs after cluster + noise linking:
+        for each new entity, scan every non-entity record in the vault and
+        write the link when similarity is above threshold. This is the
+        path that gives brand-new matters / persons / orgs / projects an
+        immediate structural footprint instead of waiting for the next
+        clustering pass to co-cluster them with something.
+        """
         # Get all embeddings for clustering
         embedding_data = self.embedder.get_all_embeddings()
         if embedding_data is None:
@@ -295,6 +328,17 @@ class Daemon:
         if noise_paths:
             self._link_noise_points_to_entities(
                 noise_paths, records, paths, vectors,
+            )
+
+        # Stage 7: backfill links FROM every non-entity record in the vault
+        # TO each newly-created entity. This is the complement of the cluster
+        # + noise passes, which link FROM a record TO nearby entities — here
+        # we link FROM a new entity OUT to every record it's close to, so a
+        # matter added at 3pm has its related-* footprint by 3:01pm rather
+        # than waiting for the next cluster membership shift.
+        if newly_added_entity_paths and self.cfg.entity_link.backfill_enabled:
+            self._backfill_new_entities(
+                newly_added_entity_paths, records, paths, vectors,
             )
 
     def _link_entities_in_clusters(
@@ -493,6 +537,90 @@ class Daemon:
             log.info(
                 "daemon.noise_linking_complete",
                 noise_processed=noise_processed,
+                links_added=total_added,
+                threshold=threshold,
+                max_per_record=max_per,
+            )
+
+    def _backfill_new_entities(
+        self,
+        new_entity_paths: list[str],
+        records: dict[str, "VaultRecord"],
+        all_paths: list[str],
+        all_vectors,
+    ) -> None:
+        """Reverse-direction scan for newly-created entity records.
+
+        For each new entity E, walk every non-entity record R in the vault.
+        If cos(E, R) >= threshold, append E's path to R's related_<E.type>
+        frontmatter (up to max_per_record per field).
+
+        This is the complement of the cluster/noise passes — they link FROM
+        each record TO its nearest entities; this pass links FROM a new
+        entity OUTWARDS to every record it's close to, so the new entity
+        has a structural footprint immediately on creation.
+
+        Cost: |new_entities| × |non_entity_records| numpy dot products.
+        A new matter on David's ~3500-record vault = ~3500 dot products
+        = sub-second.
+        """
+        import numpy as np
+        from .labeler import ENTITY_RECORD_TYPES
+
+        path_to_vec: dict[str, "np.ndarray"] = {}
+        for p, v in zip(all_paths, all_vectors):
+            path_to_vec[p] = np.asarray(v, dtype=np.float32)
+
+        writer_methods = {
+            "matter": self.writer.write_related_matters,
+            "person": self.writer.write_related_persons,
+            "org": self.writer.write_related_orgs,
+            "project": self.writer.write_related_projects,
+        }
+
+        threshold = self.cfg.entity_link.threshold
+        max_per = self.cfg.entity_link.max_per_record
+
+        total_added = 0
+        entities_processed = 0
+        for entity_path in new_entity_paths:
+            entity_record = records.get(entity_path)
+            if entity_record is None:
+                continue
+            entity_type = entity_record.record_type
+            if entity_type not in ENTITY_RECORD_TYPES:
+                continue
+            entity_vec = path_to_vec.get(entity_path)
+            if entity_vec is None:
+                continue
+
+            entities_processed += 1
+            method = writer_methods[entity_type]
+
+            # For each non-entity record in the vault, check similarity.
+            # Entity→entity self-type suppressed (same rule as noise
+            # linking): a new matter doesn't get added to another matter's
+            # related_matters list.
+            for other_path, other_record in records.items():
+                if other_path == entity_path:
+                    continue
+                if other_record.record_type == entity_type:
+                    continue  # self-type suppression
+                other_vec = path_to_vec.get(other_path)
+                if other_vec is None:
+                    continue
+                sim = float(np.dot(entity_vec, other_vec))
+                if sim < threshold:
+                    continue
+                # Write ONE entity at a time so each target record's
+                # max_per_record cap is respected independently.
+                added = method(other_path, [entity_path], max_total=max_per)
+                total_added += added
+
+        if entities_processed > 0:
+            log.info(
+                "daemon.entity_backfill_complete",
+                entities_processed=entities_processed,
                 links_added=total_added,
                 threshold=threshold,
                 max_per_record=max_per,

--- a/tests/surveyor/test_daemon_backfill.py
+++ b/tests/surveyor/test_daemon_backfill.py
@@ -1,0 +1,246 @@
+"""Tests for daemon._backfill_new_entities — reverse-direction entity linking."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import frontmatter
+
+from alfred.surveyor.config import (
+    ClusteringConfig,
+    EntityLinkConfig,
+    HdbscanConfig,
+    LabelerConfig,
+    LeidenConfig,
+    LoggingConfig,
+    MilvusConfig,
+    OllamaConfig,
+    OpenRouterConfig,
+    PipelineConfig,
+    StateConfig,
+    VaultConfig,
+    WatcherConfig,
+)
+from alfred.surveyor.daemon import Daemon
+from alfred.surveyor.parser import VaultRecord
+from alfred.surveyor.state import PipelineState
+from alfred.surveyor.writer import VaultWriter
+
+
+def _cfg(vault, state_path, threshold=0.75, max_per=5, backfill=True) -> PipelineConfig:
+    return PipelineConfig(
+        vault=VaultConfig(path=vault),
+        watcher=WatcherConfig(),
+        ollama=OllamaConfig(),
+        milvus=MilvusConfig(uri=str(state_path.parent / "milvus.db")),
+        clustering=ClusteringConfig(hdbscan=HdbscanConfig(), leiden=LeidenConfig()),
+        openrouter=OpenRouterConfig(api_key="x"),
+        labeler=LabelerConfig(),
+        state=StateConfig(path=str(state_path)),
+        logging=LoggingConfig(),
+        entity_link=EntityLinkConfig(
+            threshold=threshold, max_per_record=max_per, backfill_enabled=backfill
+        ),
+    )
+
+
+def _write(vault: Path, rel: str, rt: str) -> None:
+    full = vault / rel
+    full.parent.mkdir(parents=True, exist_ok=True)
+    full.write_text(f"---\ntype: {rt}\nname: x\n---\n\nbody\n", encoding="utf-8")
+
+
+def _record(rel: str, rt: str) -> VaultRecord:
+    return VaultRecord(rel_path=rel, frontmatter={"type": rt, "name": "x"}, body="", record_type=rt)
+
+
+def _norm(v):
+    a = np.asarray(v, dtype=np.float32)
+    n = float(np.linalg.norm(a))
+    return (a / n).tolist() if n > 0 else a.tolist()
+
+
+@pytest.fixture
+def daemon_and_vault(tmp_path):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    state_path = tmp_path / "state.json"
+    daemon = Daemon.__new__(Daemon)
+    daemon.cfg = _cfg(vault, state_path)
+    daemon.state = PipelineState(state_path=daemon.cfg.state.path)
+    daemon.writer = VaultWriter(vault_path=vault, state=daemon.state)
+    daemon.embedder = MagicMock()
+    daemon.watcher = MagicMock()
+    daemon.clusterer = MagicMock()
+    daemon.labeler = MagicMock()
+    daemon._shutdown_requested = False
+    return daemon, vault
+
+
+def test_new_matter_links_to_nearby_events(daemon_and_vault):
+    """A brand-new matter with high similarity to 2 events gets written
+    into both events' related_matters."""
+    daemon, vault = daemon_and_vault
+    _write(vault, "matter/new.md", "matter")
+    _write(vault, "event/a.md", "event")
+    _write(vault, "event/b.md", "event")
+    _write(vault, "event/far.md", "event")
+
+    records = {
+        "matter/new.md": _record("matter/new.md", "matter"),
+        "event/a.md": _record("event/a.md", "event"),
+        "event/b.md": _record("event/b.md", "event"),
+        "event/far.md": _record("event/far.md", "event"),
+    }
+
+    m_vec = _norm([1.0, 0.0, 0.0])
+    a_vec = _norm([0.95, 0.312, 0.0])  # sim ≈ 0.95
+    b_vec = _norm([0.85, 0.52, 0.0])    # sim ≈ 0.85
+    far_vec = _norm([0.3, 0.95, 0.0])   # sim ≈ 0.30 below threshold
+    paths = list(records.keys())
+    vectors = np.asarray([m_vec, a_vec, b_vec, far_vec], dtype=np.float32)
+
+    daemon._backfill_new_entities(
+        new_entity_paths=["matter/new.md"],
+        records=records,
+        all_paths=paths,
+        all_vectors=vectors,
+    )
+
+    assert frontmatter.load(vault / "event/a.md").metadata["related_matters"] == ["matter/new.md"]
+    assert frontmatter.load(vault / "event/b.md").metadata["related_matters"] == ["matter/new.md"]
+    assert "related_matters" not in frontmatter.load(vault / "event/far.md").metadata
+
+
+def test_backfill_skips_same_type_targets(daemon_and_vault):
+    """A new matter should NOT be added to another matter's related_matters."""
+    daemon, vault = daemon_and_vault
+    _write(vault, "matter/new.md", "matter")
+    _write(vault, "matter/existing.md", "matter")
+    _write(vault, "event/e.md", "event")
+
+    records = {
+        "matter/new.md": _record("matter/new.md", "matter"),
+        "matter/existing.md": _record("matter/existing.md", "matter"),
+        "event/e.md": _record("event/e.md", "event"),
+    }
+
+    v = _norm([1.0, 0.0])  # all three share vector → sim = 1.0
+    paths = list(records.keys())
+    vectors = np.asarray([v] * 3, dtype=np.float32)
+
+    daemon._backfill_new_entities(
+        new_entity_paths=["matter/new.md"],
+        records=records,
+        all_paths=paths,
+        all_vectors=vectors,
+    )
+
+    # Cross-type: event got the matter link
+    assert frontmatter.load(vault / "event/e.md").metadata["related_matters"] == ["matter/new.md"]
+    # Same-type: existing matter did NOT get related_matters populated
+    assert "related_matters" not in frontmatter.load(vault / "matter/existing.md").metadata
+
+
+def test_backfill_respects_threshold(daemon_and_vault):
+    daemon, vault = daemon_and_vault
+    _write(vault, "matter/new.md", "matter")
+    _write(vault, "event/e.md", "event")
+
+    records = {
+        "matter/new.md": _record("matter/new.md", "matter"),
+        "event/e.md": _record("event/e.md", "event"),
+    }
+
+    m_vec = _norm([1.0, 0.0])
+    e_vec = _norm([0.5, 0.87])  # sim ≈ 0.5 — below default 0.75
+    paths = list(records.keys())
+    vectors = np.asarray([m_vec, e_vec], dtype=np.float32)
+
+    daemon._backfill_new_entities(
+        new_entity_paths=["matter/new.md"],
+        records=records,
+        all_paths=paths,
+        all_vectors=vectors,
+    )
+
+    assert "related_matters" not in frontmatter.load(vault / "event/e.md").metadata
+
+
+def test_backfill_all_four_entity_types(daemon_and_vault):
+    """Each entity type gets written to its own field."""
+    daemon, vault = daemon_and_vault
+    for rel, rt in [
+        ("matter/m.md", "matter"),
+        ("person/p.md", "person"),
+        ("org/o.md", "org"),
+        ("project/x.md", "project"),
+        ("event/e.md", "event"),
+    ]:
+        _write(vault, rel, rt)
+    records = {rel: _record(rel, rt) for rel, rt in [
+        ("matter/m.md", "matter"),
+        ("person/p.md", "person"),
+        ("org/o.md", "org"),
+        ("project/x.md", "project"),
+        ("event/e.md", "event"),
+    ]}
+    v = _norm([1.0, 0.0])
+    paths = list(records.keys())
+    vectors = np.asarray([v] * 5, dtype=np.float32)
+
+    daemon._backfill_new_entities(
+        new_entity_paths=["matter/m.md", "person/p.md", "org/o.md", "project/x.md"],
+        records=records,
+        all_paths=paths,
+        all_vectors=vectors,
+    )
+
+    md = frontmatter.load(vault / "event/e.md").metadata
+    assert md["related_matters"] == ["matter/m.md"]
+    assert md["related_persons"] == ["person/p.md"]
+    assert md["related_orgs"] == ["org/o.md"]
+    assert md["related_projects"] == ["project/x.md"]
+
+
+def test_backfill_caps_max_per_record(tmp_path):
+    """If many existing matters already saturate related_matters on event,
+    a new matter with lower sim should NOT push out existing ones
+    (writer._append_to_list_field caps by truncation at the tail of the
+    append list — existing entries preserved)."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    state_path = tmp_path / "state.json"
+    daemon = Daemon.__new__(Daemon)
+    daemon.cfg = _cfg(vault, state_path, threshold=0.0, max_per=2)
+    daemon.state = PipelineState(state_path=daemon.cfg.state.path)
+    daemon.writer = VaultWriter(vault_path=vault, state=daemon.state)
+
+    _write(vault, "event/e.md", "event")
+    _write(vault, "matter/a.md", "matter")
+    _write(vault, "matter/b.md", "matter")
+    _write(vault, "matter/c.md", "matter")
+
+    records = {
+        "event/e.md": _record("event/e.md", "event"),
+        "matter/a.md": _record("matter/a.md", "matter"),
+        "matter/b.md": _record("matter/b.md", "matter"),
+        "matter/c.md": _record("matter/c.md", "matter"),
+    }
+
+    v = _norm([1.0, 0.0])
+    paths = list(records.keys())
+    vectors = np.asarray([v] * 4, dtype=np.float32)
+
+    # Backfill in sequence
+    daemon._backfill_new_entities(
+        new_entity_paths=["matter/a.md", "matter/b.md", "matter/c.md"],
+        records=records,
+        all_paths=paths,
+        all_vectors=vectors,
+    )
+
+    md = frontmatter.load(vault / "event/e.md").metadata
+    assert md["related_matters"] == ["matter/a.md", "matter/b.md"]  # capped at 2

--- a/tests/surveyor/test_daemon_startup_sync.py
+++ b/tests/surveyor/test_daemon_startup_sync.py
@@ -146,7 +146,7 @@ async def test_startup_sync_saves_state_after_embed_phase(tmp_path):
 
     daemon.state.save = _traced_save
 
-    async def _trace_label(_records):
+    async def _trace_label(_records, newly_added_entity_paths=None):
         save_order.append("cluster_and_label")
 
     daemon._cluster_and_label = _trace_label


### PR DESCRIPTION
## Summary

Closes the "new matter shows up with no structural footprint" gap. Previously, creating a new matter at 3pm meant waiting for the next re-clustering to happen to co-cluster it with related events. This PR adds an immediate reverse-direction pass: walk every non-entity record in the vault, link to the new entity above threshold.

Runs inside `_cluster_and_label` as Stage 7, gated on `entity_link.backfill_enabled` (default true). Triggered from `_tick` (steady-state inflow) and `_startup_sync` (post-restart with new entities added while surveyor was down).

Only `diff.new` triggers backfill — `diff.changed` (renames, body edits) doesn't re-spray links. Same config knobs and same same-type suppression rule as #24.

## Test plan
- [x] 5 unit tests for `_backfill_new_entities` covering happy path / same-type suppression / below-threshold / 4-types / max_per cap.
- [x] Full surveyor suite (57 tests) green.
- [ ] Deploy via ALFRED_SHA bump. On David: create a throwaway test matter (`matter/test-backfill.md`) → within one tick, expect `daemon.entity_backfill_complete entities_processed=1 links_added=N` and event records with `related_matters: [matter/test-backfill.md]`.

## Closes
#25