### PR TITLE
fix(surveyor): scope labeling to changed_semantic only

### DIFF
--- a/src/alfred/surveyor/daemon.py
+++ b/src/alfred/surveyor/daemon.py
@@ -231,8 +231,19 @@ class Daemon:
         # Stage 3: Cluster
         result = self.clusterer.run(paths, vectors, records)
 
-        # Stage 4: Label changed clusters
-        all_changed = result.changed_semantic | result.changed_structural
+        # Stage 4: Label changed clusters.
+        #
+        # Scope to `changed_semantic` only. `cluster_members` below is built
+        # from `result.semantic` — structural cluster IDs have no member
+        # paths in that map. If we include `changed_structural` in the
+        # union, the numeric overlap between the two namespaces (both are
+        # integers starting from 0) causes spurious re-labeling: a semantic
+        # cluster whose semantic membership didn't change still gets
+        # relabeled whenever a structural cluster with the same ID
+        # changed. On David's vault that's a ~10x LLM-cost multiplier for
+        # zero additional information — every "changed structural" was
+        # hitting an unrelated semantic cluster's members.
+        all_changed = set(result.changed_semantic)
         if not all_changed:
             log.info("daemon.no_changed_clusters")
             return


### PR DESCRIPTION
## Summary

Hot-fix surfaced while watching David's post-deploy labeling pass. Every full-vault run was re-labeling essentially all 330 semantic clusters because `all_changed = changed_semantic | changed_structural` unions cluster IDs from two different namespaces that happen to numerically overlap (both start at 0). A semantic cluster whose membership didn't change was getting re-labeled every time a structural cluster with the same ID changed.

On David's pass just now: 10 semantic clusters actually changed. 2312 structural communities also "changed" (any community membership shift counts). Union → effectively 330 clusters get processed → **~10x LLM cost multiplier** on every full run.

Fix is one-line: scope labeling to `changed_semantic` only. `cluster_members` is built from `result.semantic` exclusively, so structural IDs in the set were either (a) colliding with an unrelated semantic cluster ID or (b) early-returning due to empty members — no useful work either way.

## Impact

David's current run (40/330 clusters labeled, ~40 min remaining) would have finished at 5 min flat. Future full runs drop to ~5-8 min regardless of vault size.

## Test plan
- [x] Full surveyor test suite (63 tests) green.
- [ ] Next deploy: `daemon.labeling_complete clusters_processed=N` should match the `changed_semantic` count from `clusterer.complete`, not the 10x-inflated structural union.