### PR TITLE
fix(surveyor): paginate get_all_embeddings via query_iterator

### DIFF
--- a/src/alfred/surveyor/embedder.py
+++ b/src/alfred/surveyor/embedder.py
@@ -551,29 +551,47 @@ class Embedder:
             }],
         )
 
+    # Page size for pulling all embeddings out of Milvus.
+    #
+    # Milvus Lite's `segcore` has an internal result-size cap on how many
+    # rows a single `query()` can return. The hard ceiling is ~16,384, but
+    # in practice the cap trips well before that once rows carry a fat
+    # payload like a 768-dim embedding vector — we've seen
+    # `query results exceed the limit size at ... SegmentInterface.cpp:116`
+    # crash the surveyor daemon on David's vault at ~12k entity rows with
+    # `limit=16_000`. 2,000 rows per page is comfortably under the cap
+    # across observed payload shapes and still keeps total round-trips
+    # reasonable (a 20k-row vault = 10 pages).
+    _GET_ALL_PAGE_SIZE = 2_000
+
     def get_all_embeddings(self) -> tuple[list[str], np.ndarray] | None:
         """Retrieve all embeddings from Milvus as (paths, matrix).
 
+        Paginates via `query_iterator` so arbitrarily large collections
+        don't trip Milvus Lite's `segcore` per-query result-size cap.
         Returns None if collection is empty.
         """
-        PAGE_SIZE = 16_000  # Milvus caps query limit at 16,384
         all_results: list[dict] = []
-        offset = 0
-
-        while True:
-            page = self.milvus.query(
-                collection_name=self.collection_name,
-                filter="",
-                output_fields=["id", "embedding"],
-                limit=PAGE_SIZE,
-                offset=offset,
-            )
-            if not page:
-                break
-            all_results.extend(page)
-            if len(page) < PAGE_SIZE:
-                break
-            offset += PAGE_SIZE
+        iterator = self.milvus.query_iterator(
+            collection_name=self.collection_name,
+            batch_size=self._GET_ALL_PAGE_SIZE,
+            filter="",
+            output_fields=["id", "embedding"],
+        )
+        try:
+            while True:
+                page = iterator.next()
+                if not page:
+                    break
+                all_results.extend(page)
+        finally:
+            # query_iterator holds a server-side cursor; closing is
+            # mandatory to release it (esp. on milvus-lite where the
+            # cursor is a process-local resource).
+            try:
+                iterator.close()
+            except Exception:
+                pass
 
         if not all_results:
             return None

--- a/tests/surveyor/test_embedder_get_all.py
+++ b/tests/surveyor/test_embedder_get_all.py
@@ -1,0 +1,131 @@
+"""Tests for Embedder.get_all_embeddings pagination.
+
+The surveyor daemon crash-looped on David's vault (12,372 entities) because
+`get_all_embeddings()` issued a single `milvus.query(limit=16_000)` and tripped
+milvus-lite's segcore per-query result-size cap:
+
+    pymilvus.exceptions.MilvusException:
+        query results exceed the limit size at ... SegmentInterface.cpp:116
+
+The fix switches to `query_iterator` with a smaller page size, stitching
+batches into a single result. These tests exercise that path via a fake
+iterator so we don't need a real Milvus instance.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from alfred.surveyor.embedder import Embedder, _encode_id
+
+
+def _stub_embedder() -> Embedder:
+    """Bare-bones Embedder without real Milvus/HTTP setup."""
+    e = Embedder.__new__(Embedder)
+    e.collection_name = "vault"
+    e.milvus = MagicMock()
+    return e
+
+
+def _fake_iterator(pages: list[list[dict]]) -> MagicMock:
+    """Build a fake query_iterator that yields the given pages, then empty."""
+    it = MagicMock()
+    # next() returns each page then an empty list to signal exhaustion.
+    # The real API also returns [] once exhausted, so a plain side_effect
+    # with a trailing [] matches production behaviour.
+    it.next.side_effect = list(pages) + [[]]
+    it.close = MagicMock()
+    return it
+
+
+def _make_rows(n: int, offset: int = 0, dim: int = 4) -> list[dict]:
+    """Build n fake Milvus rows with encoded IDs and dummy vectors."""
+    rows: list[dict] = []
+    for i in range(n):
+        idx = offset + i
+        rows.append({
+            "id": _encode_id(f"entity/e-{idx}.md"),
+            "embedding": [float(idx)] * dim,
+        })
+    return rows
+
+
+def test_get_all_embeddings_concatenates_pages() -> None:
+    """Iterator returns [2000, 2000, 372] → we see 4,372 stitched rows."""
+    e = _stub_embedder()
+    page1 = _make_rows(2000, offset=0)
+    page2 = _make_rows(2000, offset=2000)
+    page3 = _make_rows(372, offset=4000)
+    e.milvus.query_iterator = MagicMock(
+        return_value=_fake_iterator([page1, page2, page3])
+    )
+
+    result = e.get_all_embeddings()
+    assert result is not None
+    paths, vectors = result
+
+    assert len(paths) == 4372
+    assert vectors.shape == (4372, 4)
+    # Ordering is preserved (important: clusterer maps paths[i] ↔ vectors[i])
+    assert paths[0] == "entity/e-0.md"
+    assert paths[1999] == "entity/e-1999.md"
+    assert paths[2000] == "entity/e-2000.md"
+    assert paths[4371] == "entity/e-4371.md"
+    assert vectors.dtype == np.float32
+    # Iterator cursor is always closed (server-side resource)
+    e.milvus.query_iterator.return_value.close.assert_called_once()
+
+
+def test_get_all_embeddings_empty_collection_returns_none() -> None:
+    """Empty collection (iterator yields nothing) → None, not ([], array([]))."""
+    e = _stub_embedder()
+    e.milvus.query_iterator = MagicMock(return_value=_fake_iterator([]))
+
+    assert e.get_all_embeddings() is None
+
+
+def test_get_all_embeddings_single_page_under_batch_size() -> None:
+    """Collection smaller than batch_size still works and decodes IDs."""
+    e = _stub_embedder()
+    rows = _make_rows(17, offset=0)
+    e.milvus.query_iterator = MagicMock(return_value=_fake_iterator([rows]))
+
+    result = e.get_all_embeddings()
+    assert result is not None
+    paths, vectors = result
+    assert len(paths) == 17
+    assert vectors.shape == (17, 4)
+    assert paths[0] == "entity/e-0.md"
+
+
+def test_get_all_embeddings_decodes_url_encoded_ids() -> None:
+    """Milvus stores URL-encoded IDs; caller expects vault-relative paths."""
+    e = _stub_embedder()
+    # A path that definitely gets percent-encoded: spaces, apostrophes.
+    raw_path = "matter/Acme's Big Deal.md"
+    rows = [{
+        "id": _encode_id(raw_path),
+        "embedding": [0.1, 0.2, 0.3, 0.4],
+    }]
+    e.milvus.query_iterator = MagicMock(return_value=_fake_iterator([rows]))
+
+    result = e.get_all_embeddings()
+    assert result is not None
+    paths, _ = result
+    assert paths == [raw_path]
+
+
+def test_get_all_embeddings_closes_iterator_on_exception() -> None:
+    """If iteration blows up mid-way, the iterator cursor still gets closed."""
+    e = _stub_embedder()
+    it = MagicMock()
+    it.next.side_effect = RuntimeError("segcore boom")
+    it.close = MagicMock()
+    e.milvus.query_iterator = MagicMock(return_value=it)
+
+    try:
+        e.get_all_embeddings()
+    except RuntimeError:
+        pass
+    it.close.assert_called_once()


### PR DESCRIPTION
## Summary

David's surveyor daemon was crash-looping on vault reindex with:

```
pymilvus.exceptions.MilvusException: (code=2000, message= => query results exceed the limit size at SegmentInterface.cpp:116 : segcore error)
```

`get_all_embeddings()` was paginating with `limit=16_000`, which sits above Milvus Lite's internal segcore per-query result-size cap once rows carry a 768-dim embedding payload. At 12,372 entities, David tipped over; Miguel (~67) and Rapali (~166) were fine.

Switches to pymilvus' `query_iterator` with `batch_size=2_000`. That's the idiomatic "read the whole collection" primitive and handles the cap internally.

- Empty-collection path (`return None`) preserved.
- Caller contract (`list[str], np.ndarray` with `float32` dtype, same ordering) preserved.
- Iterator cursor is always closed (including exceptional paths).

## Test plan

- [x] `pytest tests/surveyor/test_embedder_get_all.py -v` — new file, 5 tests green.
- [x] `pytest tests/ -v` — full suite 68/68 passing.
- [ ] Post-merge: rebuild `ssdavidai00/alfred-worker:latest`, roll out to david/miguel/rapali, tail `docker compose logs alfred` for a clean `daemon.entity_linking_complete` tick with no MilvusException.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)