### PR TITLE
feat: archive agent sessions instead of deleting them

### DIFF
--- a/src/alfred/curator/backends/openclaw.py
+++ b/src/alfred/curator/backends/openclaw.py
@@ -7,6 +7,7 @@ import json as _json
 import os
 import shutil
 import tempfile
+import time
 import uuid
 from pathlib import Path
 
@@ -18,19 +19,34 @@ log = get_logger(__name__)
 
 
 def _clear_agent_sessions(agent_id: str) -> None:
-    """Remove all session files for an agent so each invocation starts fresh.
+    """Archive existing session files for an agent so each invocation starts fresh.
 
-    OpenClaw ties each agent to a single session file.  Concurrent or
+    OpenClaw ties each agent to a single session file. Concurrent or
     back-to-back invocations will deadlock on the session lock unless we
-    wipe the session state between runs.
+    move the session state out of the way between runs.
+
+    We *archive* rather than delete because the per-call token-usage records
+    written into these session jsonls (input/output/cacheRead/cacheWrite/cost)
+    are the only audit trail for these stateless one-shot agents — wiping them
+    eliminates fleet-wide cost observability. Files are moved into
+    ``<sessions_dir>/_archive/<run-stamp>/`` instead of unlinked. Operators can
+    prune ``_archive/`` manually for now; a future change can add a retention
+    policy.
     """
     sessions_dir = Path.home() / ".openclaw" / "agents" / agent_id / "sessions"
     if not sessions_dir.exists():
         return
+    run_stamp = f"{time.strftime('%Y%m%dT%H%M%S')}-{uuid.uuid4().hex[:8]}"
+    archive_root = sessions_dir / "_archive" / run_stamp
     for f in sessions_dir.iterdir():
+        # Don't recurse into the archive directory itself.
+        if f.name == "_archive":
+            continue
         try:
-            f.unlink(missing_ok=True)
+            archive_root.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(f), str(archive_root / f.name))
         except Exception:
+            # Match prior contract: a failed move must never block a new run.
             pass
 
 

--- a/src/alfred/distiller/backends/openclaw.py
+++ b/src/alfred/distiller/backends/openclaw.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 import shutil
+import time
 import uuid
 from pathlib import Path
 
@@ -16,14 +17,30 @@ log = get_logger(__name__)
 
 
 def _clear_agent_sessions(agent_id: str) -> None:
-    """Remove all session files for an agent to avoid lock contention."""
+    """Archive existing session files for an agent to avoid lock contention.
+
+    We *archive* rather than delete because the per-call token-usage records
+    written into these session jsonls (input/output/cacheRead/cacheWrite/cost)
+    are the only audit trail for these stateless one-shot agents — wiping them
+    eliminates fleet-wide cost observability. Files are moved into
+    ``<sessions_dir>/_archive/<run-stamp>/`` instead of unlinked. Operators can
+    prune ``_archive/`` manually for now; a future change can add a retention
+    policy.
+    """
     sessions_dir = Path.home() / ".openclaw" / "agents" / agent_id / "sessions"
     if not sessions_dir.exists():
         return
+    run_stamp = f"{time.strftime('%Y%m%dT%H%M%S')}-{uuid.uuid4().hex[:8]}"
+    archive_root = sessions_dir / "_archive" / run_stamp
     for f in sessions_dir.iterdir():
+        # Don't recurse into the archive directory itself.
+        if f.name == "_archive":
+            continue
         try:
-            f.unlink(missing_ok=True)
+            archive_root.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(f), str(archive_root / f.name))
         except Exception:
+            # Match prior contract: a failed move must never block a new run.
             pass
 
 

--- a/src/alfred/janitor/backends/openclaw.py
+++ b/src/alfred/janitor/backends/openclaw.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 import shutil
+import time
 import uuid
 from pathlib import Path
 
@@ -16,14 +17,30 @@ log = get_logger(__name__)
 
 
 def _clear_agent_sessions(agent_id: str) -> None:
-    """Remove all session files for an agent to avoid lock contention."""
+    """Archive existing session files for an agent to avoid lock contention.
+
+    We *archive* rather than delete because the per-call token-usage records
+    written into these session jsonls (input/output/cacheRead/cacheWrite/cost)
+    are the only audit trail for these stateless one-shot agents — wiping them
+    eliminates fleet-wide cost observability. Files are moved into
+    ``<sessions_dir>/_archive/<run-stamp>/`` instead of unlinked. Operators can
+    prune ``_archive/`` manually for now; a future change can add a retention
+    policy.
+    """
     sessions_dir = Path.home() / ".openclaw" / "agents" / agent_id / "sessions"
     if not sessions_dir.exists():
         return
+    run_stamp = f"{time.strftime('%Y%m%dT%H%M%S')}-{uuid.uuid4().hex[:8]}"
+    archive_root = sessions_dir / "_archive" / run_stamp
     for f in sessions_dir.iterdir():
+        # Don't recurse into the archive directory itself.
+        if f.name == "_archive":
+            continue
         try:
-            f.unlink(missing_ok=True)
+            archive_root.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(f), str(archive_root / f.name))
         except Exception:
+            # Match prior contract: a failed move must never block a new run.
             pass
 
 

--- a/tests/test_archive_agent_sessions.py
+++ b/tests/test_archive_agent_sessions.py
@@ -1,0 +1,122 @@
+"""Tests for the archive-instead-of-delete behaviour of `_clear_agent_sessions`.
+
+The vault-worker daemons (curator, janitor, distiller) used to wipe their
+OpenClaw session directories between runs to avoid session-lock deadlock.
+Side effect: every per-call token-usage record (input/output/cacheRead/
+cacheWrite/cost — written by openclaw to the jsonl) was permanently destroyed
+before anyone could aggregate it, killing fleet-wide cost observability.
+
+The fix moves session files into ``<sessions_dir>/_archive/<run-stamp>/``
+instead of unlinking them. These tests exercise that path against a fake
+``$HOME`` so we don't touch the real openclaw state.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from alfred.curator.backends.openclaw import (
+    _clear_agent_sessions as curator_clear,
+)
+from alfred.distiller.backends.openclaw import (
+    _clear_agent_sessions as distiller_clear,
+)
+from alfred.janitor.backends.openclaw import (
+    _clear_agent_sessions as janitor_clear,
+)
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect Path.home() into a tmp dir for the duration of the test."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # On some platforms Path.home() consults pwd before $HOME — patch it too.
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    return tmp_path
+
+
+def _seed_session_files(home: Path, agent_id: str) -> Path:
+    """Create a sessions dir with a representative jsonl + lock + sessions.json."""
+    sessions_dir = home / ".openclaw" / "agents" / agent_id / "sessions"
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    (sessions_dir / "curator-abc123.jsonl").write_text(
+        '{"role":"assistant","usage":{"input":42,"output":7,"cost":0.0001}}\n'
+    )
+    (sessions_dir / "curator-abc123.jsonl.lock").write_text("")
+    (sessions_dir / "sessions.json").write_text("{}")
+    return sessions_dir
+
+
+@pytest.mark.parametrize(
+    "clear_fn,agent_id",
+    [
+        (curator_clear, "curator-test"),
+        (janitor_clear, "janitor-test"),
+        (distiller_clear, "distiller-test"),
+    ],
+)
+def test_clear_agent_sessions_archives_instead_of_deleting(
+    clear_fn,
+    agent_id: str,
+    fake_home: Path,
+) -> None:
+    sessions_dir = _seed_session_files(fake_home, agent_id)
+
+    # Sanity: files are in place pre-clear.
+    assert (sessions_dir / "curator-abc123.jsonl").exists()
+    assert (sessions_dir / "curator-abc123.jsonl.lock").exists()
+    assert (sessions_dir / "sessions.json").exists()
+
+    clear_fn(agent_id)
+
+    # Top-level files have been moved out of sessions_dir...
+    assert not (sessions_dir / "curator-abc123.jsonl").exists()
+    assert not (sessions_dir / "curator-abc123.jsonl.lock").exists()
+    assert not (sessions_dir / "sessions.json").exists()
+
+    # ...and into a single timestamped folder under _archive/.
+    archive_root = sessions_dir / "_archive"
+    assert archive_root.exists() and archive_root.is_dir()
+    stamps = list(archive_root.iterdir())
+    assert len(stamps) == 1, f"expected one archive folder, got {stamps}"
+    archived_files = sorted(p.name for p in stamps[0].iterdir())
+    assert archived_files == sorted(
+        ["curator-abc123.jsonl", "curator-abc123.jsonl.lock", "sessions.json"]
+    )
+
+    # The original jsonl payload survives the move — the whole point of the change.
+    payload = (stamps[0] / "curator-abc123.jsonl").read_text()
+    assert '"input":42' in payload
+    assert '"cost":0.0001' in payload
+
+
+def test_clear_agent_sessions_is_noop_when_dir_missing(fake_home: Path) -> None:
+    # No sessions dir for this agent — should not raise, should not create anything.
+    curator_clear("nonexistent-agent")
+    assert not (fake_home / ".openclaw" / "agents" / "nonexistent-agent").exists()
+
+
+def test_clear_agent_sessions_does_not_recurse_into_archive(fake_home: Path) -> None:
+    """Two back-to-back invocations must not re-archive the prior _archive/ folder."""
+    sessions_dir = _seed_session_files(fake_home, "curator-test")
+
+    curator_clear("curator-test")
+    first_run_archives = sorted(p.name for p in (sessions_dir / "_archive").iterdir())
+    assert len(first_run_archives) == 1
+
+    # Seed a second run's worth of files.
+    (sessions_dir / "curator-xyz999.jsonl").write_text(
+        '{"role":"assistant","usage":{"input":1,"output":1}}\n'
+    )
+
+    curator_clear("curator-test")
+
+    # _archive/ must still be only two stamps deep — the previous archive folder
+    # was NOT moved into a nested archive.
+    second_run_archives = sorted(p.name for p in (sessions_dir / "_archive").iterdir())
+    assert len(second_run_archives) == 2, second_run_archives
+    # And no _archive sub-folder should have been treated as a session file.
+    for stamp in second_run_archives:
+        for entry in (sessions_dir / "_archive" / stamp).iterdir():
+            assert entry.name != "_archive"


### PR DESCRIPTION
## Problem

The vault-worker daemons (`curator`, `janitor`, `distiller`) call OpenClaw via a wrapper that maintains a per-agent session jsonl. To avoid session-lock deadlock between back-to-back invocations, each backend wipes the session dir on every run via `_clear_agent_sessions()`.

Side effect: every per-call token-usage record (input/output/cacheRead/cacheWrite/cost — written by openclaw to the jsonl) is **permanently destroyed** before anyone can aggregate it.

## Operational impact

Fleet-wide cost observability gap. We discovered this while building token-usage reporting on alfred-platform's tenant `david`: there is no audit trail for the spend driven by these stateless one-shot agents because `_clear_agent_sessions` truncates the only file that records it. Across the fleet that's three daemons × N runs/hour × every tenant, blind.

## Fix

Replace the unlink loop with an archive-instead-of-delete. Files (`*.jsonl`, `*.jsonl.lock`, `sessions.json`) are moved into `<sessions_dir>/_archive/<run-stamp>/` instead of unlinked, where `<run-stamp>` = `YYYYMMDDTHHMMSS` plus an 8-char uuid suffix to avoid collisions when invocations within the same second run twice.

- Same lock-contention guarantee — the live `sessions/` dir is empty on the next run, just as before.
- Each move is wrapped in `try/except` so a failed move never blocks a new run (preserves the prior contract).
- The `_archive/` folder itself is skipped on subsequent runs, so we don't recursively re-archive stale archives.

All three backends (`curator`, `janitor`, `distiller`) carry their own copy of `_clear_agent_sessions` and were updated symmetrically. Dedup is out of scope for this PR.

## Why no retention policy here

Keeping the change minimal. Operators can prune `_archive/` manually for now; a future PR can add a config-driven retention policy (e.g. delete archive folders older than N days, or keep only the last K runs).

## Test plan

- [x] Existing tests pass: `PYTHONPATH=src pytest tests/ -x -q` → 73 passed (was 68; +5 new).
- [x] New unit test `tests/test_archive_agent_sessions.py` covers all three backends:
  - Pre-creates a fake session jsonl + lock + sessions.json under a tmp `$HOME`.
  - Calls `_clear_agent_sessions`.
  - Asserts the files are gone from `sessions_dir/` and present in `sessions_dir/_archive/<stamp>/`.
  - Asserts the original jsonl payload (with the simulated `usage:{...}` block) survives the move.
  - Verifies no-op when sessions dir is missing.
  - Verifies `_archive/` itself is not re-archived on subsequent runs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>