### PR TITLE
feat(ctrl,caddy): make AgentMail webhook publicly reachable

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -36,10 +36,27 @@
 
 	# Public webhook paths → ctrl-api directly. Exact prefixes only;
 	# anything else on the apex falls through to the SPA below.
+	#
+	# /api/v1/channels/email/inbound is included so AgentMail can POST
+	# inbound emails to alfred-black directly. AgentMail does not sign
+	# its webhooks (per their docs), so the handler validates a
+	# shared-secret `?token=` query param against AGENTMAIL_WEBHOOK_TOKEN
+	# baked into the URL configured in the AgentMail console.
 	@public_webhooks {
-		path /api/v1/streams/omi/* /api/v1/plane/webhook /api/v1/webhooks/plane/steward /api/v1/webhooks/vexa /api/v1/webhooks/in/*
+		path /api/v1/streams/omi/* /api/v1/plane/webhook /api/v1/webhooks/plane/steward /api/v1/webhooks/vexa /api/v1/webhooks/in/* /api/v1/channels/email/inbound
 	}
 	handle @public_webhooks {
+		reverse_proxy ctrl-api:3100
+	}
+
+	# Legacy AgentMail URL — the old SaaS exposed `/webhooks/agentmail`
+	# (which proxied to the tenant ctrl-api over Tailscale). On alfred-black
+	# we still see this URL in existing AgentMail console configurations,
+	# so we transparently rewrite it to the canonical endpoint. The
+	# ?token=... query string is preserved automatically by uri replace.
+	@legacy_agentmail_webhook path /webhooks/agentmail
+	handle @legacy_agentmail_webhook {
+		uri replace /webhooks/agentmail /api/v1/channels/email/inbound
 		reverse_proxy ctrl-api:3100
 	}
 

--- a/packages/ctrl/src/api/routes/channelsEmail.ts
+++ b/packages/ctrl/src/api/routes/channelsEmail.ts
@@ -1,15 +1,31 @@
 // Email channel inbound handler.
 //
-// Called by the SaaS webhook receiver at
-// packages/saas/app/src/server/agentmailReceiver.ts when an inbound email
-// comes from an authorized sender. We start a one-shot Hermes run with the
-// email pre-loaded as the run input plus an envelope of metadata
-// (from/to/cc/subject/thread_id/message_id), so the main agent can read,
-// reason, and reply via /api/v1/email/reply.
+// alfred-black ingress shape (post-SaaS-retirement):
+//
+//   AgentMail (their cloud, alfred@agent.szabostuban.com)
+//      |  POST https://home.alfred.black/api/v1/channels/email/inbound?token=<SECRET>
+//      v
+//   Caddy apex (@public_webhooks matcher)
+//      |  reverse_proxy ctrl-api:3100
+//      v
+//   ctrl-api  ← this handler
+//      |  POST /v1/runs (Hermes main profile)
+//      v
+//   Hermes  → alfred-email-channel skill → reply via /api/v1/email/reply
+//
+// Auth: AgentMail does not sign its webhooks (no header documented), so we
+// gate on a shared-secret `?token=` baked into the URL configured in the
+// AgentMail console. The path itself is marked public in server.ts so the
+// master AAS_API_KEY isn't required.
+//
+// Filters (matched against Hermes' native email adapter behaviour):
+//   - drop emails from noreply@ / mailer-daemon@ / no-reply@ / bounce@
+//   - drop Auto-Submitted (RFC 3834), Precedence: bulk|list|junk,
+//     List-Unsubscribe — RFC-flagged automated mail
+//   - drop self-loops (from == AGENTMAIL_INBOX_ADDRESS)
 //
 // Fire-and-forget: we respond 202 immediately and let the run proceed in
-// the background. Failures to start are logged; the message is still safe
-// because the SaaS receiver also buffers a StreamEvent fallback.
+// the background. Failures to start are logged.
 //
 // Phase 2: calls Hermes `POST /v1/runs` natively against the Hermes API
 // server's canonical port (the hermes-shim was retired in issue #40). The
@@ -94,11 +110,116 @@ function buildChannelPrompt(message: any): string {
   ].join("\n");
 }
 
+// Match RFC 2822 local-parts (case-insensitive) that indicate an automated
+// sender — Hermes' native email adapter drops these silently. The address
+// is parsed by `extractLocalPart`, so we match on local-part alone.
+const AUTOMATED_LOCAL_PARTS = new Set([
+  "noreply",
+  "no-reply",
+  "no_reply",
+  "donotreply",
+  "do-not-reply",
+  "do_not_reply",
+  "mailer-daemon",
+  "mailerdaemon",
+  "postmaster",
+  "bounce",
+  "bounces",
+  "notification",
+  "notifications",
+]);
+
+function extractLocalPart(addr: string): string {
+  // Accept either `user@host` or `Display Name <user@host>` shapes.
+  const m = addr.match(/<([^>]+)>/);
+  const email = (m ? m[1] : addr).trim().toLowerCase();
+  const at = email.indexOf("@");
+  return at > 0 ? email.slice(0, at) : email;
+}
+
+function isAutomatedSender(from: string): boolean {
+  if (!from) return false;
+  return AUTOMATED_LOCAL_PARTS.has(extractLocalPart(from));
+}
+
+function hasBulkHeader(headers: Record<string, string> | undefined): boolean {
+  if (!headers || typeof headers !== "object") return false;
+  // Normalize header lookup (RFC headers are case-insensitive).
+  const lower: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) {
+    if (typeof v === "string") lower[k.toLowerCase()] = v;
+  }
+  // RFC 3834 Auto-Submitted: anything other than "no" means automated.
+  const autoSub = (lower["auto-submitted"] || "").toLowerCase();
+  if (autoSub && autoSub !== "no") return true;
+  // Precedence: bulk | list | junk
+  const prec = (lower["precedence"] || "").toLowerCase();
+  if (prec === "bulk" || prec === "list" || prec === "junk") return true;
+  // List-Unsubscribe present at all → mailing list
+  if (lower["list-unsubscribe"]) return true;
+  return false;
+}
+
+function isSelfLoop(from: string): boolean {
+  const ourAddr = (process.env.AGENTMAIL_INBOX_ADDRESS || "").trim().toLowerCase();
+  if (!ourAddr) return false;
+  // Compare local-part@host of the from-address against ours.
+  const m = from.match(/<([^>]+)>/);
+  const fromEmail = (m ? m[1] : from).trim().toLowerCase();
+  return fromEmail === ourAddr;
+}
+
 export function registerChannelsEmailRoutes(): void {
-  addRoute("POST", "/api/v1/channels/email/inbound", async ({ res, body }) => {
-    const b = (body ?? {}) as { message?: any; event_id?: string };
+  addRoute("POST", "/api/v1/channels/email/inbound", async ({ res, body, query }) => {
+    // Shared-secret token: AgentMail doesn't sign its webhooks, so the public
+    // path is gated by a `?token=` query param we configure in their console.
+    // When AGENTMAIL_WEBHOOK_TOKEN is unset, the endpoint reverts to internal-
+    // only (refuses every call) — fail closed.
+    const expected = (process.env.AGENTMAIL_WEBHOOK_TOKEN || "").trim();
+    const provided = (query.get("token") || "").trim();
+    if (!expected) {
+      console.warn(
+        "[channels-email] AGENTMAIL_WEBHOOK_TOKEN unset — rejecting inbound (fail-closed)",
+      );
+      sendJson(res, 403, { error: { code: "WEBHOOK_TOKEN_NOT_CONFIGURED" } });
+      return;
+    }
+    if (!provided || provided !== expected) {
+      console.warn("[channels-email] webhook token mismatch — rejecting");
+      sendJson(res, 401, { error: { code: "INVALID_WEBHOOK_TOKEN" } });
+      return;
+    }
+
+    const b = (body ?? {}) as {
+      message?: any;
+      event_id?: string;
+    };
     if (!b.message || typeof b.message !== "object") {
       throw new ValidationError("`message` required");
+    }
+
+    // Resolve from-address (AgentMail emits `from_` as a single-element array).
+    const fromAddr: string = Array.isArray(b.message.from_)
+      ? String(b.message.from_[0] ?? "")
+      : String(b.message.from ?? b.message.from_ ?? "");
+
+    // Filter 1: automated/noreply senders. Silent drop, 202 to keep AgentMail happy.
+    if (isAutomatedSender(fromAddr)) {
+      console.log(`[channels-email] drop automated sender: ${fromAddr}`);
+      sendJson(res, 202, { accepted: false, reason: "automated_sender" });
+      return;
+    }
+    // Filter 2: bulk/list mail via RFC headers.
+    if (hasBulkHeader(b.message.headers)) {
+      console.log(`[channels-email] drop bulk/list mail from: ${fromAddr}`);
+      sendJson(res, 202, { accepted: false, reason: "bulk_or_list" });
+      return;
+    }
+    // Filter 3: self-loop (Alfred's own outbound landing back in the inbox).
+    if (isSelfLoop(fromAddr)) {
+      console.log(`[channels-email] drop self-loop from: ${fromAddr}`);
+      sendJson(res, 202, { accepted: false, reason: "self_loop" });
+      return;
     }
 
     const token = getGatewayToken();
@@ -112,9 +233,9 @@ export function registerChannelsEmailRoutes(): void {
 
     // Fire-and-forget Hermes run on the main profile. We intentionally don't
     // await the response — the run takes tens of seconds to minutes and
-    // AgentMail has a 5s webhook budget upstream (already satisfied — SaaS
-    // 204'd before this point). `session_id` correlates the run to the email
-    // thread so a follow-up reply on the same thread chains the conversation.
+    // AgentMail has a 5s webhook budget upstream. `session_id` correlates the
+    // run to the email thread so a follow-up reply on the same thread chains
+    // the conversation.
     const sessionId = `email-${b.message?.thread_id ?? b.message?.message_id ?? b.event_id ?? Date.now()}`;
     const run = fetch(`${HERMES_GATEWAY_URL}/v1/runs`, {
       method: "POST",

--- a/packages/ctrl/src/api/routes/credentials.ts
+++ b/packages/ctrl/src/api/routes/credentials.ts
@@ -108,6 +108,17 @@ const KNOWN_CREDENTIALS: CredentialDef[] = [
     description: "Shared secret between ctrl-api/voice-bridge and the SaaS internal Twilio endpoints (Bearer auth). Generated at provision time.",
     used_by: ["ctrl-api phone routes", "voice-bridge", "SaaS internal endpoints"],
   },
+  // AgentMail webhook secret. AgentMail does not sign its webhooks, so the
+  // public `/api/v1/channels/email/inbound` endpoint validates a shared
+  // `?token=` query param against this value. Bake the token into the URL
+  // configured in the AgentMail console. Rotate by setting a new value here
+  // and updating the console — old value stops accepting immediately.
+  {
+    key: "AGENTMAIL_WEBHOOK_TOKEN",
+    label: "AgentMail webhook token",
+    description: "Shared secret for inbound AgentMail webhook delivery. The agentmail.to console webhook URL must include ?token=<this value>. Generate with `openssl rand -hex 32` and update both places.",
+    used_by: ["ctrl-api /api/v1/channels/email/inbound"],
+  },
 ];
 
 /** Protected keys that cannot be modified via this endpoint. */

--- a/packages/ctrl/src/api/server.ts
+++ b/packages/ctrl/src/api/server.ts
@@ -206,12 +206,18 @@ export function createApiServer(): http.Server {
 
       // Public routes that authenticate via their own mechanism (e.g. webhook token,
       // HMAC signature).
+      //
+      // /api/v1/channels/email/inbound is the AgentMail webhook target. AgentMail
+      // does not sign its webhook payloads (their docs cover REST + webhooks but no
+      // signature scheme), so the handler enforces a shared-secret `?token=` query
+      // param against AGENTMAIL_WEBHOOK_TOKEN — same model as OMI's inbound stream.
       const isPublic =
         pathname.startsWith("/api/v1/streams/omi/") ||
         pathname === "/api/v1/plane/webhook" ||
         pathname === "/api/v1/webhooks/plane/steward" ||
         pathname === "/api/v1/webhooks/vexa" ||
-        pathname.startsWith("/api/v1/webhooks/in/");
+        pathname.startsWith("/api/v1/webhooks/in/") ||
+        pathname === "/api/v1/channels/email/inbound";
       if (!isPublic) {
         // Pass method+pathname so the scoped-token path can check the
         // route allowlist (see auth.ts VOICE_BRIDGE_ALLOWLIST). The master


### PR DESCRIPTION
Three coordinated changes so inbound mail to `alfred@<domain>` lands directly on the alfred-black VM without going through any SaaS layer.

## What changes

| File | Change |
|---|---|
| `caddy/Caddyfile` | Add `/api/v1/channels/email/inbound` to `@public_webhooks`; preserve legacy `/webhooks/agentmail` via a `uri replace` rewrite |
| `packages/ctrl/src/api/server.ts` | Add the path to `isPublic` (master `AAS_API_KEY` not required) |
| `packages/ctrl/src/api/routes/channelsEmail.ts` | Validate `?token=` against `AGENTMAIL_WEBHOOK_TOKEN` (fail-closed when unset). Add noreply/bulk/self-loop filters that mirror Hermes' native email adapter |
| `packages/ctrl/src/api/routes/credentials.ts` | Add `AGENTMAIL_WEBHOOK_TOKEN` to `KNOWN_CREDENTIALS` so it's rotatable via `PATCH /admin/credentials` |

## Filters added (parity with Hermes native)

- noreply / no-reply / mailer-daemon / postmaster / bounce sender drop
- RFC 3834 `Auto-Submitted` ≠ `no`; `Precedence: bulk|list|junk`; `List-Unsubscribe` present → drop
- self-loop drop (from == `AGENTMAIL_INBOX_ADDRESS`)

All drops return 202 (silently consume the webhook so AgentMail doesn't retry) and log the reason.

## Why not Hermes-native email instead

AgentMail is API+webhook only — no IMAP/SMTP — so Hermes' native email adapter can't drive it. Switching to a real IMAP provider would also strip the `alfred_journal` cross-channel continuity that already lists `'email'` as a known channel; email replies would lose memory of Telegram conversations. ~30 lines of glue is cheaper than that regression.

## Deploy plan after merge

1. CI builds + pushes `ssdavidai00/alfred-ctrl-api:latest`.
2. On home.alfred.black: rsync the new `caddy/Caddyfile`, set `AGENTMAIL_WEBHOOK_TOKEN=$(openssl rand -hex 32)` in `/opt/alfred/.env`.
3. `docker compose pull ctrl-api caddy && docker compose up -d --force-recreate --no-deps ctrl-api caddy`.
4. Update the AgentMail console webhook URL to include `?token=<the value>` (or keep the existing `/webhooks/agentmail` URL with the token appended — both work via the Caddy rewrite).
5. Send a test email to `alfred@agent.szabostuban.com`. ctrl-api logs should show `[channels-email] accepted` and the Hermes `main` profile should start an `email-<thread_id>` session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)