### PR TITLE
feat(ctrl,web): /channels Phone card — surface OPENAI_API_KEY inline

### DIFF
--- a/packages/ctrl/src/api/routes/credentials.ts
+++ b/packages/ctrl/src/api/routes/credentials.ts
@@ -29,8 +29,8 @@ const KNOWN_CREDENTIALS: CredentialDef[] = [
   {
     key: "OPENAI_API_KEY",
     label: "OpenAI",
-    description: "GPT-4, GPT-4o, and other OpenAI models",
-    used_by: ["OpenClaw agents (if model requires it)"],
+    description: "GPT-4, GPT-4o, gpt-realtime. Required for voice calls — voice-bridge uses gpt-realtime over the Twilio Media Streams socket.",
+    used_by: ["voice-bridge (gpt-realtime)", "Hermes agents (if model requires it)"],
   },
   {
     key: "XAI_API_KEY",
@@ -247,25 +247,40 @@ export function registerCredentialRoutes(): void {
     // instead of waiting up to an hour for the cache to expire.
     invalidateModelCatalogCache();
 
+    // Choose which services to recreate based on which credentials changed.
+    // Every credential rotation needs openclaw/hermes + alfred picked up
+    // (their env is the LLM provider keys). OPENAI_API_KEY ALSO drives
+    // voice-bridge — without this, setting the key via the /channels Phone
+    // card surfaces "saved" but the container keeps crash-looping until the
+    // next manual restart.
+    const changedKeys = new Set(Object.keys(updates));
+    const services = ["openclaw", "alfred"];
+    if (changedKeys.has("OPENAI_API_KEY")) {
+      services.push("voice-bridge");
+    }
+
     // Respond immediately, then restart only the containers that need
     // the new API keys. CRITICAL: ctrl-api also uses env_file: .env,
     // so `docker compose up -d` would recreate ALL containers including
     // ctrl-api itself — causing a 502 cascade. Instead, selectively
-    // recreate only openclaw and alfred using --no-deps to prevent
-    // Docker Compose from also recreating their dependencies (ctrl-api).
+    // recreate using --no-deps to prevent Docker Compose from also
+    // recreating dependencies (ctrl-api).
     sendJson(res, 200, {
       message: "Credentials updated. Services are restarting (may take ~30s).",
-      restarted: ["openclaw", "alfred"],
+      restarted: services,
     });
 
-    // Fire-and-forget: recreate only openclaw and alfred with new env.
-    // --no-deps prevents Docker from touching ctrl-api or temporal.
-    // Sequential: openclaw must be healthy before alfred can start.
-    dockerComposeCmd(["up", "-d", "--no-deps", "--force-recreate", "openclaw"]).then(() =>
-      dockerComposeCmd(["up", "-d", "--no-deps", "--force-recreate", "alfred"])
-    ).catch((err) => {
-      console.error("Background container restart failed:", err);
-    });
+    // Fire-and-forget: recreate each service sequentially so we don't
+    // contend with health-checks. Sequential = openclaw → alfred → (voice).
+    (async () => {
+      for (const svc of services) {
+        try {
+          await dockerComposeCmd(["up", "-d", "--no-deps", "--force-recreate", svc]);
+        } catch (err) {
+          console.error(`Background restart of ${svc} failed:`, err);
+        }
+      }
+    })();
   });
 
   // POST /api/v1/admin/vault/refresh — pull every secret out of Vaultwarden,

--- a/packages/ctrl/src/api/routes/voice.ts
+++ b/packages/ctrl/src/api/routes/voice.ts
@@ -3,23 +3,25 @@
 //   GET /api/v1/channels/voice/status
 //
 // A read-only status endpoint for the Phase-2 voice card. There is NO
-// PUT / DELETE / test on this surface — voice doesn't have its own
-// credentials, it reuses the SMS configuration (specifically
-// TWILIO_PHONE_NUMBER from the hermes-main per-profile .env). The whole
-// point of the route is to tell the dashboard whether the voice-bridge
-// container is deployed-and-healthy on this VM, so the redesigned
-// /channels card knows whether to show "Voice not deployed yet" or
-// "Voice connected, calling number +1…".
+// PUT / DELETE / test on this surface — voice's only operator-facing
+// setting (OPENAI_API_KEY) is set via PATCH /api/v1/admin/credentials,
+// the same path every other credential takes. The status endpoint
+// surfaces `openai_key_set` so the UI can render an inline input when
+// it's missing instead of pointing the operator at /study.
 //
-// Resolution table (frozen contract from the Phase-2 spec):
+// Resolution table:
 //
-//   compose_service_exists=false                           → state="unconfigured"
-//   compose_service_exists=true  && !configured           → state="unconfigured"
-//   compose_service_exists=true  && configured && healthy → state="configured_running"
-//   compose_service_exists=true  && configured && starting → state="configured_starting"
-//   compose_service_exists=true  && configured && unhealthy → state="error"
+//   compose_service_exists=false                                          → state="unconfigured"
+//   compose_service_exists=true  && !configured                          → state="unconfigured"
+//   compose_service_exists=true  && configured && !openai_key_set        → state="unconfigured"  (UI shows the OpenAI input)
+//   compose_service_exists=true  && configured && openai_key_set && healthy   → state="configured_running"
+//   compose_service_exists=true  && configured && openai_key_set && starting  → state="configured_starting"
+//   compose_service_exists=true  && configured && openai_key_set && unhealthy → state="error"
 //
 // `configured`     = TWILIO_PHONE_NUMBER is set in the hermes-main /.env.
+// `openai_key_set` = OPENAI_API_KEY is set in the compose /.env (the file
+//                    PATCH /admin/credentials writes; voice-bridge reads it
+//                    via env_file).
 // `calling_number` = the value of TWILIO_PHONE_NUMBER (reuses SMS).
 //
 // FAIL-SOFT POLICY: /status MUST NOT 5xx — the dashboard polls it. On any
@@ -29,9 +31,11 @@
 // merged the compose change yet), so it MUST resolve to state="unconfigured"
 // with error=null.
 
+import fs from "node:fs";
+
 import { addRoute } from "../server.js";
 import { sendJson } from "../errors.js";
-import { dockerExec, dockerComposeCmd } from "../helpers.js";
+import { dockerExec, dockerComposeCmd, COMPOSE_DIR } from "../helpers.js";
 
 // Hermes-main per-profile .env path INSIDE the hermes runtime container.
 // Mirrors the SMS / Telegram routes — `HERMES_HOME=/hermes-state` is the
@@ -56,6 +60,10 @@ interface VoiceStatus {
   error: string | null;
   calling_number: string | null;
   compose_service_exists: boolean;
+  /** True when OPENAI_API_KEY is set in the compose-level .env (read by
+   *  voice-bridge via env_file). The UI surfaces an inline input when this
+   *  is false so the operator can paste the key without leaving /channels. */
+  openai_key_set: boolean;
 }
 
 // ── Compose probe ─────────────────────────────────────────────────────────
@@ -180,6 +188,42 @@ async function readProfileEnvKey(key: string): Promise<string> {
   return "";
 }
 
+// ── Compose-level .env reader (the file PATCH /admin/credentials writes) ──
+//
+// voice-bridge reads OPENAI_API_KEY through compose's `env_file: .env`, so
+// the file at COMPOSE_DIR/.env is the source of truth — NOT process.env on
+// ctrl-api (which only refreshes when ctrl-api itself is recreated). Read
+// the file directly so we see PATCH writes on the next /status poll without
+// a ctrl-api restart.
+
+function readComposeEnvKey(key: string): string {
+  const path = `${COMPOSE_DIR}/.env`;
+  let raw: string;
+  try {
+    raw = fs.readFileSync(path, "utf-8");
+  } catch {
+    return "";
+  }
+  for (const line of raw.split("\n")) {
+    const t = line.replace(/^﻿/, "");
+    if (!t || t.trimStart().startsWith("#")) continue;
+    const eq = t.indexOf("=");
+    if (eq <= 0) continue;
+    const k = t.slice(0, eq).trim();
+    if (k !== key) continue;
+    let v = t.slice(eq + 1);
+    if (v.endsWith("\r")) v = v.slice(0, -1);
+    if (
+      (v.startsWith('"') && v.endsWith('"')) ||
+      (v.startsWith("'") && v.endsWith("'"))
+    ) {
+      v = v.slice(1, -1);
+    }
+    return v.trim();
+  }
+  return "";
+}
+
 // ── Container logs tail (for state="error" details) ───────────────────────
 
 async function tailVoiceBridgeLogs(): Promise<string> {
@@ -203,6 +247,9 @@ export function registerVoiceRoutes(): void {
   // GET /status — fail-soft. NEVER 5xx (dashboard polls it).
   addRoute("GET", "/api/v1/channels/voice/status", async ({ res }) => {
     const probe = await probeComposeService();
+    // OPENAI_API_KEY is required for voice-bridge to talk to gpt-realtime.
+    // Read it eagerly so every return path can include the flag.
+    const openaiKeySet = readComposeEnvKey("OPENAI_API_KEY").length > 0;
 
     // Case 1: voice-bridge service isn't deployed on this VM yet. This is
     // the "Phase-2 orchestrator hasn't merged the compose change" state —
@@ -214,6 +261,7 @@ export function registerVoiceRoutes(): void {
         error: null,
         calling_number: null,
         compose_service_exists: false,
+        openai_key_set: openaiKeySet,
       } satisfies VoiceStatus);
       return;
     }
@@ -227,6 +275,7 @@ export function registerVoiceRoutes(): void {
         error: probe.error,
         calling_number: null,
         compose_service_exists: false,
+        openai_key_set: openaiKeySet,
       } satisfies VoiceStatus);
       return;
     }
@@ -243,11 +292,30 @@ export function registerVoiceRoutes(): void {
         error: null,
         calling_number: null,
         compose_service_exists: true,
+        openai_key_set: openaiKeySet,
       } satisfies VoiceStatus);
       return;
     }
 
-    // Configured — pivot on container Health / State.
+    // Configured-but-no-OpenAI-key: voice-bridge will crash-loop on
+    // "OPENAI_API_KEY env var is required". Don't report this as an "error"
+    // (operator-facing error semantically means "I tried, something broke")
+    // — report it as `unconfigured` with openai_key_set=false. The UI
+    // surfaces an inline input so the key can be pasted without leaving
+    // /channels.
+    if (!openaiKeySet) {
+      sendJson(res, 200, {
+        configured: true,
+        state: "unconfigured",
+        error: null,
+        calling_number: phone,
+        compose_service_exists: true,
+        openai_key_set: false,
+      } satisfies VoiceStatus);
+      return;
+    }
+
+    // Configured + OpenAI key set — pivot on container Health / State.
     const health = (probe.row?.Health ?? "").toLowerCase();
     const state = (probe.row?.State ?? "").toLowerCase();
 
@@ -280,6 +348,7 @@ export function registerVoiceRoutes(): void {
       error,
       calling_number: phone,
       compose_service_exists: true,
+      openai_key_set: true,
     } satisfies VoiceStatus);
   });
 }

--- a/packages/web/src/dashboard/ChannelsPage.tsx
+++ b/packages/web/src/dashboard/ChannelsPage.tsx
@@ -4,7 +4,7 @@
 // data from the existing Wasp ops; Slack/Telegram are "Soon" placeholders.
 // Sir #8 — also surfaces a "Terminal" card with SSH info + the
 // `docker exec ... hermes` command for direct shell access.
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { Link } from "react-router-dom";
 import {
   useQuery,
@@ -1665,13 +1665,50 @@ function SmsSection() {
 // ---------------------------------------------------------------------------
 
 function VoiceSection() {
-  const { data: statusData } = useQuery(
+  const { data: statusData, refetch } = useQuery(
     getVoiceChannelStatus,
     undefined,
     { retry: false },
   );
   const status = (statusData as VoiceStatus | undefined) ?? null;
   const card = deriveVoiceCardState({ status });
+
+  // OpenAI-key inline form. Same shape as OmiCard's needs_groq_key flow:
+  // password input + Save → PATCH /admin/credentials → ctrl-api restarts
+  // voice-bridge → /status flips to configured_running on next poll.
+  const [openaiKey, setOpenaiKey] = useState("");
+  const [showKey, setShowKey] = useState(false);
+  const [saveBusy, setSaveBusy] = useState(false);
+  const [saveErr, setSaveErr] = useState<string | null>(null);
+
+  const saveOpenaiKey = useCallback(async () => {
+    const v = openaiKey.trim();
+    if (!v) return;
+    setSaveBusy(true);
+    setSaveErr(null);
+    try {
+      const resp = await fetch("/api/v1/admin/credentials", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ OPENAI_API_KEY: v }),
+        credentials: "include",
+      });
+      if (!resp.ok) {
+        const j = await resp.json().catch(() => ({}));
+        throw new Error(
+          (j as { error?: string }).error || `HTTP ${resp.status}`,
+        );
+      }
+      setOpenaiKey("");
+      // voice-bridge needs ~30s to restart with the new env; let the poll
+      // catch the new state on its own cadence.
+      setTimeout(() => refetch(), 2_000);
+    } catch (e) {
+      setSaveErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaveBusy(false);
+    }
+  }, [openaiKey, refetch]);
 
   const pillColor =
     card.pill === "active"
@@ -1710,6 +1747,73 @@ function VoiceSection() {
       >
         {card.description}
       </p>
+
+      {card.needsOpenaiKey && (
+        <div className="mt-2 space-y-2">
+          <div className="flex items-center gap-2">
+            <input
+              type={showKey ? "text" : "password"}
+              placeholder="sk-..."
+              value={openaiKey}
+              onChange={(e) => setOpenaiKey(e.target.value)}
+              autoComplete="off"
+              spellCheck={false}
+              disabled={saveBusy}
+              className="flex-1 rounded-sm border bg-transparent px-2 py-1 font-mono text-[12px]"
+              style={{
+                borderColor: "var(--rule)",
+                color: "var(--ink)",
+              }}
+            />
+            <button
+              type="button"
+              onClick={() => setShowKey((s) => !s)}
+              className="font-mono text-[10px] uppercase tracking-[0.22em]"
+              style={{ color: "var(--marginalia)" }}
+              disabled={saveBusy}
+            >
+              {showKey ? "hide" : "show"}
+            </button>
+            <button
+              type="button"
+              onClick={saveOpenaiKey}
+              disabled={saveBusy || !openaiKey.trim()}
+              className="font-mono text-[10px] uppercase tracking-[0.22em] px-2 py-1 border"
+              style={{
+                borderColor: "var(--ink)",
+                color: "var(--ink)",
+                opacity: saveBusy || !openaiKey.trim() ? 0.5 : 1,
+              }}
+            >
+              {saveBusy ? "saving..." : "save"}
+            </button>
+          </div>
+          {saveErr && (
+            <p
+              className="font-mono text-[11px]"
+              style={{ color: "var(--brass)" }}
+            >
+              {saveErr}
+            </p>
+          )}
+          <p
+            className="font-body italic text-[12px]"
+            style={{ color: "var(--marginalia)" }}
+          >
+            Get a key at{" "}
+            <a
+              href="https://platform.openai.com/api-keys"
+              target="_blank"
+              rel="noreferrer"
+              className="underline"
+              style={{ color: "var(--marginalia)" }}
+            >
+              platform.openai.com/api-keys
+            </a>
+            . After saving, the voice bridge restarts (~30s).
+          </p>
+        </div>
+      )}
 
       {card.state === "configured_running" && card.callingNumber && (
         <p

--- a/packages/web/src/dashboard/voiceCardCore.test.ts
+++ b/packages/web/src/dashboard/voiceCardCore.test.ts
@@ -36,6 +36,7 @@ const BASE: VoiceStatus = {
   error: null,
   calling_number: null,
   compose_service_exists: false,
+  openai_key_set: false,
 };
 
 test("derive: unconfigured + compose missing → 'Voice not deployed' card", () => {
@@ -48,15 +49,55 @@ test("derive: unconfigured + compose missing → 'Voice not deployed' card", () 
   assert.equal(s.callingNumber, null);
 });
 
-test("derive: unconfigured + compose present → 'Set up SMS first' card", () => {
+test("derive: unconfigured + compose present + no Twilio → 'Set up SMS first' card", () => {
   const s = deriveVoiceCardState({
     status: { ...BASE, compose_service_exists: true },
   });
   assert.equal(s.state, "unconfigured");
   assert.equal(s.pill, "available");
   assert.equal(s.needsSmsFirst, true);
+  assert.equal(s.needsOpenaiKey, false);
   assert.match(s.heading, /SMS first/i);
   assert.match(s.description, /reuse.*Twilio/i);
+});
+
+test("derive: configured + no OpenAI key → 'Add your OpenAI key' inline form", () => {
+  // The scenario this PR is built for: voice-bridge is deployed AND has
+  // a Twilio number, but the OpenAI key (gpt-realtime) isn't set yet.
+  // The card must render needsOpenaiKey=true so the inline input shows.
+  const s = deriveVoiceCardState({
+    status: {
+      ...BASE,
+      configured: true,
+      compose_service_exists: true,
+      calling_number: "+15550100",
+      openai_key_set: false,
+    },
+  });
+  assert.equal(s.state, "unconfigured");
+  assert.equal(s.pill, "available");
+  assert.equal(s.needsSmsFirst, false);
+  assert.equal(s.needsOpenaiKey, true);
+  assert.match(s.heading, /OpenAI key/i);
+  assert.match(s.description, /gpt-realtime/);
+  assert.equal(s.callingNumber, "+1 555 0100");
+});
+
+test("derive: configured + OpenAI key set + running → needsOpenaiKey=false", () => {
+  // Anti-regression: once the key is set and voice-bridge is running, the
+  // input MUST go away.
+  const s = deriveVoiceCardState({
+    status: {
+      ...BASE,
+      configured: true,
+      compose_service_exists: true,
+      state: "configured_running",
+      calling_number: "+15550100",
+      openai_key_set: true,
+    },
+  });
+  assert.equal(s.state, "configured_running");
+  assert.equal(s.needsOpenaiKey, false);
 });
 
 test("derive: configured_starting → spinner copy + starting pill", () => {

--- a/packages/web/src/dashboard/voiceCardCore.ts
+++ b/packages/web/src/dashboard/voiceCardCore.ts
@@ -3,10 +3,14 @@
 // derived states unit-test under node:test.
 //
 // Phase 2 (voice-bridge promotion, 2026-05-25): voice is a real compose
-// service alongside the SMS adapter. The card is **read-only** because
-// voice reuses the Twilio credentials configured by the SMS section
-// above — the card's job is to surface deploy-readiness, not configure
-// anything.
+// service alongside the SMS adapter.
+//
+// 2026-05-26 (OPENAI_API_KEY inline): voice has ONE operator-facing
+// setting after all — OPENAI_API_KEY drives gpt-realtime on the Twilio
+// Media Streams socket. When `openai_key_set=false` the card surfaces an
+// inline password input (same shape as OmiCard's needs_groq_key state),
+// so the operator can paste the key without context-switching to
+// /study#credentials. Twilio credentials still reuse the SMS section.
 //
 // The states map 1:1 to ctrl-api's GET /api/v1/channels/voice/status
 // `state` field. Lane I owns the endpoint; this derivation is the only
@@ -33,6 +37,8 @@ export interface VoiceStatus {
   calling_number: string | null;
   /** True when the voice-bridge compose service is present on this VM. */
   compose_service_exists: boolean;
+  /** True when OPENAI_API_KEY is set in the compose .env. */
+  openai_key_set: boolean;
 }
 
 export interface VoiceCardState {
@@ -43,6 +49,8 @@ export interface VoiceCardState {
   pill: "active" | "available" | "starting" | "error";
   /** True when the operator needs to set up SMS first (voice reuses Twilio creds). */
   needsSmsFirst: boolean;
+  /** True when OPENAI_API_KEY is missing — UI shows the inline paste box. */
+  needsOpenaiKey: boolean;
 }
 
 const NULL_STATUS: VoiceStatus = {
@@ -51,6 +59,7 @@ const NULL_STATUS: VoiceStatus = {
   error: null,
   calling_number: null,
   compose_service_exists: false,
+  openai_key_set: false,
 };
 
 export function deriveVoiceCardState(args: {
@@ -69,6 +78,7 @@ export function deriveVoiceCardState(args: {
         callingNumber: status.calling_number,
         pill: "starting",
         needsSmsFirst: false,
+        needsOpenaiKey: false,
       };
 
     case "configured_running":
@@ -81,6 +91,7 @@ export function deriveVoiceCardState(args: {
         callingNumber: formatPhoneNumber(status.calling_number) || null,
         pill: "active",
         needsSmsFirst: false,
+        needsOpenaiKey: false,
       };
 
     case "error":
@@ -93,15 +104,29 @@ export function deriveVoiceCardState(args: {
         callingNumber: status.calling_number,
         pill: "error",
         needsSmsFirst: false,
+        needsOpenaiKey: false,
       };
 
     case "unconfigured":
     default:
-      // Two unconfigured shapes:
-      //   • compose_service_exists=false → voice-bridge not deployed yet
-      //   • compose_service_exists=true  → service present, waiting for
-      //     SMS creds (voice reuses them; no extra UI to surface).
-      if (status.compose_service_exists) {
+      // Three unconfigured shapes (resolved by ctrl-api in this order):
+      //   • compose_service_exists=false   → voice-bridge not deployed yet
+      //   • compose_service_exists=true  && !configured            → SMS not set up
+      //   • compose_service_exists=true  && configured && !openai → operator owes us the OpenAI key
+      if (!status.compose_service_exists) {
+        return {
+          state: "unconfigured",
+          heading: "Voice not deployed",
+          description:
+            "Voice calls are powered by a separate bridge service. It hasn't " +
+            "been deployed to this VM yet — re-run `docker compose up -d`.",
+          callingNumber: null,
+          pill: "available",
+          needsSmsFirst: false,
+          needsOpenaiKey: false,
+        };
+      }
+      if (!status.configured) {
         return {
           state: "unconfigured",
           heading: "Set up SMS first",
@@ -111,17 +136,21 @@ export function deriveVoiceCardState(args: {
           callingNumber: null,
           pill: "available",
           needsSmsFirst: true,
+          needsOpenaiKey: false,
         };
       }
+      // Configured + deployed, missing OpenAI key — the inline-input case.
       return {
         state: "unconfigured",
-        heading: "Voice not deployed",
+        heading: "Add your OpenAI key",
         description:
-          "Voice calls are powered by a separate bridge service. It hasn't " +
-          "been deployed to this VM yet — re-run `docker compose up -d`.",
-        callingNumber: null,
+          "Voice calls route audio through gpt-realtime, so the voice bridge " +
+          "needs an OpenAI API key. Paste yours below — it's stored in this " +
+          "VM's .env and never leaves the box.",
+        callingNumber: formatPhoneNumber(status.calling_number) || null,
         pill: "available",
         needsSmsFirst: false,
+        needsOpenaiKey: !status.openai_key_set,
       };
   }
 }


### PR DESCRIPTION
Voice-bridge crash-loops on missing \`OPENAI_API_KEY\`, but the /channels Phone card reports \"Picking up the new credentials\" forever — the operator has no inline way to set the key without context-switching to \`/study#credentials\`.

Same shape as OmiCard's \`needs_groq_key\` inline input.

## Changes
| File | What |
|---|---|
| \`packages/ctrl/src/api/routes/voice.ts\` | Read \`OPENAI_API_KEY\` from compose .env, thread \`openai_key_set: boolean\` through \`VoiceStatus\`. Configured-but-no-OpenAI now resolves to \`state=\"unconfigured\"\` (not the misleading \"starting\"). |
| \`packages/ctrl/src/api/routes/credentials.ts\` | When \`OPENAI_API_KEY\` is in PATCH body, restart \`voice-bridge\` alongside openclaw/alfred. Generalised the restart list. |
| \`packages/web/src/dashboard/voiceCardCore.ts\` | Add \`needsOpenaiKey\` to \`VoiceCardState\`; split unconfigured into 3 sub-cases (not-deployed / no-Twilio / no-OpenAI). |
| \`packages/web/src/dashboard/ChannelsPage.tsx\` | Inline password input + show/hide + Save on \`card.needsOpenaiKey\`. Save → PATCH /admin/credentials → wait 2s → refetch. |
| \`packages/web/src/dashboard/voiceCardCore.test.ts\` | +2 cases pinning the new branch. 11/11 pass. |

## After deploy
- home.alfred.black voice-bridge is currently crash-looping; the operator can paste an OpenAI key inline on /channels and the bridge stops crashing.
- Also fixes rj/miguel/zsolt (same crash-loop) — they just need the key paste once each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)