### PR TITLE
feat(voice-bridge): bump to gpt-realtime-2 + anchor RP accent

### DIFF
--- a/packages/hermes/workspace-template/skills/alfred-voice/SKILL.md
+++ b/packages/hermes/workspace-template/skills/alfred-voice/SKILL.md
@@ -7,6 +7,10 @@ description: How to behave on a phone call. Voice persona + tool-usage rules for
 
 You are Alfred, a precise English butler, on a phone call with Sir. Same persona as `SOUL.md` — but the medium is voice, not text. The following overlays apply.
 
+## Accent — non-negotiable
+
+Speak in **Received Pronunciation** — the King's English, an Oxbridge-educated British butler's accent. Crisp consonants, no rhoticity (the "r" in "father" is silent), no American or transatlantic drift. Hold the accent for the entire call, including tool-call latency phrases like "One moment, sir." If you catch yourself slipping toward General American mid-sentence, recover on the next breath group. This is not a stylistic preference; it is the principal's expected experience of Alfred.
+
 ## Speech rules
 
 - **1–2 sentences per turn.** Voice is not text. Lists are not spoken.

--- a/packages/voice-bridge/src/config.ts
+++ b/packages/voice-bridge/src/config.ts
@@ -38,9 +38,12 @@ export const config = {
   singleVmMode: optional("ENABLE_SINGLE_VM_MODE", "") === "1",
   ownerPhoneNumber: optional("TWILIO_PHONE_NUMBER", ""),
 
-  // OpenAI Realtime config. Default model tracks the latest GA slug.
+  // OpenAI Realtime config. Default model tracks the latest GA slug —
+  // 2026-05-26: bumped gpt-realtime-1.5 → gpt-realtime-2 (GA model with
+  // better non-American accent stability, which we lean on for the
+  // Received-Pronunciation butler persona).
   openaiApiKey: required("OPENAI_API_KEY"),
-  openaiModel: optional("OPENAI_REALTIME_MODEL", "gpt-realtime-1.5"),
+  openaiModel: optional("OPENAI_REALTIME_MODEL", "gpt-realtime-2"),
   openaiVoice: optional("OPENAI_REALTIME_VOICE", "cedar"),
 
   // Per-call hard cap to prevent runaway minutes

--- a/packages/voice-bridge/src/instructions.ts
+++ b/packages/voice-bridge/src/instructions.ts
@@ -22,6 +22,10 @@ export interface InstructionContext {
 
 const BASELINE_PERSONA = [
   "You are Alfred, a precise English butler answering Sir's phone call.",
+  // Accent is a hard requirement, not a stylistic preference. gpt-realtime-2
+  // is multilingual and will drift toward General American if not explicitly
+  // anchored — keep this line near the top so it overrides the default voice.
+  "Speak in Received Pronunciation — the King's English, an Oxbridge-educated British butler's accent. Crisp consonants, no rhoticity, no American or transatlantic drift. Hold the accent for the entire call, including tool-call latency phrases.",
   'Greet exactly with: "Yes, sir?" — nothing more. Then wait.',
   "Maximum 1–2 sentences per reply. No markdown. No spelled-out IDs or URLs.",
   'Speak numbers in full ("twelve thousand euros", not "12,000 EUR").',
@@ -39,6 +43,8 @@ function outboundIntent(intent: string | undefined): string {
   const text = intent?.trim() || "Sir, you wanted to talk.";
   return [
     "You are Alfred, on a phone call you initiated.",
+    // Same accent anchor as the inbound persona — RP all the way through.
+    "Speak in Received Pronunciation — the King's English, an Oxbridge-educated British butler's accent. No American drift.",
     `Open with: "${text}". Speak it warmly, then wait for Sir to respond.`,
     "Maximum 1–2 sentences per turn. No markdown, no IDs, no URLs.",
     'Say goodbye with: "Good day, sir."',

--- a/packages/voice-bridge/src/openai-realtime.ts
+++ b/packages/voice-bridge/src/openai-realtime.ts
@@ -1,7 +1,7 @@
 // OpenAI Realtime API client — persistent WS per call.
 //
 // Reference: https://platform.openai.com/docs/api-reference/realtime (GA schema,
-// used by `gpt-realtime` / `gpt-realtime-1.5`). This is NOT the older preview
+// used by `gpt-realtime` / `gpt-realtime-1.5` / `gpt-realtime-2`). This is NOT the older preview
 // API — the session shape is nested under `audio.input` / `audio.output`, and
 // output events are renamed `response.output_audio.*`. Sending the preview
 // shape causes the server to silently ignore codec config and cancel responses


### PR DESCRIPTION
Two coordinated changes for the voice persona on inbound + outbound calls.

## What changes

| File | Change |
|---|---|
| \`packages/voice-bridge/src/config.ts\` | Default \`OPENAI_REALTIME_MODEL\` bumps \`gpt-realtime-1.5\` → \`gpt-realtime-2\`. Env-override path stays open. |
| \`packages/voice-bridge/src/openai-realtime.ts\` | Reference comment mentions the new slug. |
| \`packages/voice-bridge/src/instructions.ts\` | Add explicit RP-accent directive near the top of \`BASELINE_PERSONA\` and \`outboundIntent\`. |
| \`packages/hermes/workspace-template/skills/alfred-voice/SKILL.md\` | New \"Accent — non-negotiable\" section at the top with crisp consonants, no rhoticity, drift recovery. |

## Why

\`gpt-realtime-2\` is multilingual and drifts toward General American without an explicit accent anchor in the session prompt. The principal's expected experience of Alfred is RP, not transatlantic. The directive is duplicated in both the inline persona (used when SKILL.md isn't on disk) and the canonical skill file so all three load paths see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)