### PR TITLE
feat(channels,voice-bridge): SMS + voice allowlists in /channels Phone card

### DIFF
--- a/packages/ctrl/src/api/routes/sms.ts
+++ b/packages/ctrl/src/api/routes/sms.ts
@@ -74,6 +74,8 @@ interface SmsStatus {
   phone_number: string | null;
   account_sid_masked: string | null;
   allowed_users: string; // comma-separated E.164; "" if unset
+  /** When true, SMS_ALLOW_ALL_USERS is on — anyone can text the number. */
+  allow_all: boolean;
 }
 
 // ── vault-cli helpers (mirror of telegram.ts / slack.ts) ──────────────────
@@ -210,8 +212,23 @@ const SMS_ENV_KEYS = [
   "TWILIO_AUTH_TOKEN",
   "TWILIO_PHONE_NUMBER",
   "SMS_ALLOWED_USERS",
+  "SMS_ALLOW_ALL_USERS",
+  // Hermes' SMS adapter refuses to start without SMS_WEBHOOK_URL set and
+  // defaults SMS_WEBHOOK_HOST to 127.0.0.1 (unreachable from other compose
+  // containers — Caddy → hermes:8080 would 502). We write both alongside
+  // the Twilio credentials so a fresh install never hits the "saved creds
+  // but no inbound replies" trap; ${DOMAIN} comes from the compose .env.
+  "SMS_WEBHOOK_URL",
+  "SMS_WEBHOOK_HOST",
 ] as const;
 type SmsEnvKey = (typeof SMS_ENV_KEYS)[number];
+
+/** Public URL Hermes' SMS adapter validates X-Twilio-Signature against.
+ *  Reads ${DOMAIN} so this works on every alfred-black host without code edits. */
+function smsWebhookUrl(): string {
+  const dom = (process.env.DOMAIN || "").trim();
+  return dom ? `https://sms.${dom}/webhooks/twilio` : "";
+}
 
 async function readProfileEnv(): Promise<Record<string, string>> {
   const raw = await dockerExec(HERMES_CONTAINER, [
@@ -512,6 +529,7 @@ export function registerSmsRoutes(): void {
     const token = envMap.TWILIO_AUTH_TOKEN ?? "";
     const phone = envMap.TWILIO_PHONE_NUMBER ?? "";
     const allowed = envMap.SMS_ALLOWED_USERS ?? "";
+    const allowAll = (envMap.SMS_ALLOW_ALL_USERS ?? "").toLowerCase() === "true";
     const configured = Boolean(sid && token && phone);
 
     if (envErr) {
@@ -522,6 +540,7 @@ export function registerSmsRoutes(): void {
         phone_number: null,
         account_sid_masked: null,
         allowed_users: "",
+        allow_all: false,
       } satisfies SmsStatus);
       return;
     }
@@ -533,6 +552,7 @@ export function registerSmsRoutes(): void {
         phone_number: null,
         account_sid_masked: null,
         allowed_users: "",
+        allow_all: false,
       } satisfies SmsStatus);
       return;
     }
@@ -549,6 +569,7 @@ export function registerSmsRoutes(): void {
         phone_number: phone,
         account_sid_masked: maskAccountSid(sid),
         allowed_users: allowed,
+        allow_all: allowAll,
       } satisfies SmsStatus);
       return;
     }
@@ -560,7 +581,37 @@ export function registerSmsRoutes(): void {
       phone_number: phone,
       account_sid_masked: maskAccountSid(sid),
       allowed_users: allowed,
+      allow_all: allowAll,
     } satisfies SmsStatus);
+  });
+
+  // PUT /allowlist — set SMS_ALLOWED_USERS + SMS_ALLOW_ALL_USERS without
+  // re-validating credentials. Lets the UI toggle inbound-sender policy
+  // independently from a credential rotation.
+  addRoute("PUT", "/api/v1/channels/sms/allowlist", async ({ res, body }) => {
+    const b = (body ?? {}) as Record<string, unknown>;
+    const allowAll = b.allow_all === true;
+    let allowedUsers: string | null = null;
+    if (!allowAll) {
+      const raw = typeof b.allowed_users === "string" ? b.allowed_users.trim() : "";
+      if (raw) {
+        const parts = raw.split(",").map((s) => s.trim()).filter(Boolean);
+        for (const p of parts) {
+          if (!E164_RE.test(p)) {
+            throw new ValidationError(
+              `allowed_users must be comma-separated E.164 numbers — "${p}" is not`,
+            );
+          }
+        }
+        allowedUsers = parts.join(",");
+      }
+    }
+    await writeProfileEnvKeys({
+      SMS_ALLOWED_USERS: allowedUsers,
+      SMS_ALLOW_ALL_USERS: allowAll ? "true" : null,
+    });
+    restartHermes();
+    sendJson(res, 200, { ok: true, allow_all: allowAll, allowed_users: allowedUsers ?? "" });
   });
 
   // PUT /credentials — validate against Twilio + vault upsert (3 items) +
@@ -625,6 +676,14 @@ export function registerSmsRoutes(): void {
       TWILIO_ACCOUNT_SID: sid,
       TWILIO_AUTH_TOKEN: token,
       TWILIO_PHONE_NUMBER: phone,
+      // Persist the two webhook bind variables alongside credentials so the
+      // SMS adapter doesn't silently refuse to start (SMS_WEBHOOK_URL is
+      // mandatory) or bind to 127.0.0.1 (the SMS_WEBHOOK_HOST default,
+      // unreachable from sibling compose containers — Caddy → hermes:8080
+      // would 502). Idempotent: existing operator-set values still take
+      // precedence because writeProfileEnvKeys is a merge, not a replace.
+      SMS_WEBHOOK_URL: smsWebhookUrl() || null,
+      SMS_WEBHOOK_HOST: "0.0.0.0",
     };
     if (typeof b.allowed_users === "string") {
       updates.SMS_ALLOWED_USERS = allowedUsers;

--- a/packages/ctrl/src/api/routes/voice.ts
+++ b/packages/ctrl/src/api/routes/voice.ts
@@ -64,6 +64,10 @@ interface VoiceStatus {
    *  voice-bridge via env_file). The UI surfaces an inline input when this
    *  is false so the operator can paste the key without leaving /channels. */
   openai_key_set: boolean;
+  /** Comma-separated E.164 numbers allowed to call Alfred. "" when unset. */
+  allowed_callers: string;
+  /** When true, VOICE_ALLOW_ALL_CALLERS is on — anyone can call the Twilio number. */
+  allow_all: boolean;
 }
 
 // ── Compose probe ─────────────────────────────────────────────────────────
@@ -224,6 +228,26 @@ function readComposeEnvKey(key: string): string {
   return "";
 }
 
+// ── Voice allowlist reader ────────────────────────────────────────────────
+//
+// VOICE_ALLOWED_CALLERS / VOICE_ALLOW_ALL_CALLERS live in the compose .env
+// alongside the other voice-bridge env. The bridge reads them via env_file:
+// the TwiML responder (packages/voice-bridge/src/twiml.ts) checks the caller
+// `From` field against the allowlist and rejects disallowed callers with
+// <Reject reason="busy"/>. ctrl-api keeps a read-side view here so the
+// /channels Phone card can surface the current setting.
+
+function readVoiceAllowlist(): {
+  allowed_callers: string;
+  allow_all: boolean;
+} {
+  const allowed = readComposeEnvKey("VOICE_ALLOWED_CALLERS").trim();
+  const allowAll =
+    readComposeEnvKey("VOICE_ALLOW_ALL_CALLERS").trim().toLowerCase() ===
+    "true";
+  return { allowed_callers: allowed, allow_all: allowAll };
+}
+
 // ── Container logs tail (for state="error" details) ───────────────────────
 
 async function tailVoiceBridgeLogs(): Promise<string> {
@@ -250,6 +274,7 @@ export function registerVoiceRoutes(): void {
     // OPENAI_API_KEY is required for voice-bridge to talk to gpt-realtime.
     // Read it eagerly so every return path can include the flag.
     const openaiKeySet = readComposeEnvKey("OPENAI_API_KEY").length > 0;
+    const allowlist = readVoiceAllowlist();
 
     // Case 1: voice-bridge service isn't deployed on this VM yet. This is
     // the "Phase-2 orchestrator hasn't merged the compose change" state —
@@ -262,6 +287,8 @@ export function registerVoiceRoutes(): void {
         calling_number: null,
         compose_service_exists: false,
         openai_key_set: openaiKeySet,
+        allowed_callers: allowlist.allowed_callers,
+        allow_all: allowlist.allow_all,
       } satisfies VoiceStatus);
       return;
     }
@@ -276,6 +303,8 @@ export function registerVoiceRoutes(): void {
         calling_number: null,
         compose_service_exists: false,
         openai_key_set: openaiKeySet,
+        allowed_callers: allowlist.allowed_callers,
+        allow_all: allowlist.allow_all,
       } satisfies VoiceStatus);
       return;
     }
@@ -293,6 +322,8 @@ export function registerVoiceRoutes(): void {
         calling_number: null,
         compose_service_exists: true,
         openai_key_set: openaiKeySet,
+        allowed_callers: allowlist.allowed_callers,
+        allow_all: allowlist.allow_all,
       } satisfies VoiceStatus);
       return;
     }
@@ -311,6 +342,8 @@ export function registerVoiceRoutes(): void {
         calling_number: phone,
         compose_service_exists: true,
         openai_key_set: false,
+        allowed_callers: allowlist.allowed_callers,
+        allow_all: allowlist.allow_all,
       } satisfies VoiceStatus);
       return;
     }
@@ -349,6 +382,63 @@ export function registerVoiceRoutes(): void {
       calling_number: phone,
       compose_service_exists: true,
       openai_key_set: true,
+      allowed_callers: allowlist.allowed_callers,
+      allow_all: allowlist.allow_all,
     } satisfies VoiceStatus);
+  });
+
+  // PUT /allowlist — set VOICE_ALLOWED_CALLERS + VOICE_ALLOW_ALL_CALLERS in
+  // the compose .env (the file voice-bridge reads via env_file). voice-bridge
+  // is recreated so the new env is picked up. The TwiML responder enforces
+  // the allowlist on every inbound call.
+  addRoute("PUT", "/api/v1/channels/voice/allowlist", async ({ res, body }) => {
+    const b = (body ?? {}) as Record<string, unknown>;
+    const allowAll = b.allow_all === true;
+    let allowedCallers: string | null = null;
+    const E164 = /^\+[1-9]\d{1,14}$/;
+    if (!allowAll) {
+      const raw =
+        typeof b.allowed_callers === "string" ? b.allowed_callers.trim() : "";
+      if (raw) {
+        const parts = raw
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean);
+        for (const p of parts) {
+          if (!E164.test(p)) {
+            throw new Error(
+              `allowed_callers must be comma-separated E.164 numbers — "${p}" is not`,
+            );
+          }
+        }
+        allowedCallers = parts.join(",");
+      }
+    }
+
+    // Write directly to COMPOSE_DIR/.env via the credentials.ts merge writer.
+    // We import the helper lazily to avoid a top-level dep cycle.
+    const { patchEnv } = await import("./credentials.js");
+    patchEnv({
+      VOICE_ALLOWED_CALLERS: allowedCallers,
+      VOICE_ALLOW_ALL_CALLERS: allowAll ? "true" : null,
+    });
+
+    // Recreate voice-bridge so the new env lands. `--no-deps --force-recreate`
+    // limits the blast radius to the one container.
+    dockerComposeCmd([
+      "up",
+      "-d",
+      "--no-deps",
+      "--force-recreate",
+      VOICE_COMPOSE_SERVICE,
+    ]).catch((err) => {
+      console.error("[voice/allowlist] recreate failed:", err);
+    });
+
+    sendJson(res, 200, {
+      ok: true,
+      allow_all: allowAll,
+      allowed_callers: allowedCallers ?? "",
+    });
   });
 }

--- a/packages/voice-bridge/src/twiml.ts
+++ b/packages/voice-bridge/src/twiml.ts
@@ -106,6 +106,44 @@ function renderTwiml(opts: {
   );
 }
 
+/**
+ * TwiML body that hangs up disallowed callers immediately. Twilio plays a
+ * busy signal then ends the call — no audio frames consumed, no Realtime
+ * session opened, no OpenAI cost. The /channels Phone card surfaces both
+ * the allowlist and the open/closed toggle so the operator can flip it.
+ */
+function renderRejectTwiml(): string {
+  return (
+    '<?xml version="1.0" encoding="UTF-8"?>\n' +
+    "<Response>\n" +
+    "  <Reject reason=\"busy\"/>\n" +
+    "</Response>\n"
+  );
+}
+
+/**
+ * Caller-allowlist check. Default policy: OPEN — anyone can call. Lock down
+ * by setting VOICE_ALLOWED_CALLERS to a comma-separated E.164 list (and
+ * leaving VOICE_ALLOW_ALL_CALLERS unset or "false"). Matches `From` exactly;
+ * loose matching would let attackers spoof a prefix.
+ */
+function isCallerAllowed(from: string): boolean {
+  const allowAll = (process.env.VOICE_ALLOW_ALL_CALLERS || "").trim().toLowerCase() === "true";
+  if (allowAll) return true;
+  const list = (process.env.VOICE_ALLOWED_CALLERS || "").trim();
+  if (!list) {
+    // Default-open: if neither env var is set, accept all callers. Matches
+    // the SMS adapter's behaviour and avoids "set up everything but voice
+    // mysteriously rejects every call" UX surprise.
+    return true;
+  }
+  const allowed = new Set(list.split(",").map((s) => s.trim()).filter(Boolean));
+  // Strip the display-name shape (`"Name" <+E164>`) if Twilio ever sends one.
+  const m = from.match(/<([^>]+)>/);
+  const normalised = (m ? m[1] : from).trim();
+  return allowed.has(normalised);
+}
+
 function readBody(req: IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
@@ -226,6 +264,19 @@ export async function handleTwimlInbound(
     To: params.get("To") ?? "",
     CallSid: params.get("CallSid") ?? "",
   };
+
+  // Caller allowlist — VOICE_ALLOWED_CALLERS / VOICE_ALLOW_ALL_CALLERS in the
+  // compose .env, set via /channels Phone card → PUT /api/v1/channels/voice/allowlist.
+  // Default policy: OPEN. Disallowed callers get a <Reject> and never reach
+  // gpt-realtime, so they cost zero OpenAI credits.
+  if (!isCallerAllowed(callParams.From)) {
+    console.log(
+      `[twiml] reject disallowed caller from=${callParams.From} sid=${callParams.CallSid}`,
+    );
+    res.writeHead(200, { "Content-Type": "application/xml; charset=utf-8" });
+    res.end(renderRejectTwiml());
+    return;
+  }
 
   // Build the wss URL. Twilio strips query strings from <Stream url=...>,
   // so the sig must travel inside <Parameter>, not the URL.

--- a/packages/web/main.wasp
+++ b/packages/web/main.wasp
@@ -800,12 +800,30 @@ query getSmsAuthorizedUsers {
   entities: []
 }
 
+// Lane III (SMS allowlist, 2026-05-26) — Open / Allowlist toggle on the
+// Phone card. Wraps ctrl-api PUT /api/v1/channels/sms/allowlist
+// ({ allow_all, allowed_users }), which writes the values into the
+// hermes-main .env and bounces the container.
+action setSmsAllowlist {
+  fn: import { setSmsAllowlist } from "@src/dashboard/operations",
+  entities: []
+}
+
 // Lane III (voice) — read-only voice channel status. Backed by ctrl-api
 // /api/v1/channels/voice/status (Lane I). Voice has no operator-facing
 // settings (reuses Twilio creds from SMS), so this query is the only
 // Wasp op the VoiceSection card needs.
 query getVoiceChannelStatus {
   fn: import { getVoiceChannelStatus } from "@src/dashboard/operations",
+  entities: []
+}
+
+// Lane III (voice allowlist, 2026-05-26) — Open / Allowlist toggle on the
+// Phone card. Wraps ctrl-api PUT /api/v1/channels/voice/allowlist
+// ({ allow_all, allowed_callers }), which writes VOICE_ALLOW_ALL_CALLERS /
+// VOICE_ALLOWED_CALLERS into the compose .env and recreates voice-bridge.
+action setVoiceAllowlist {
+  fn: import { setVoiceAllowlist } from "@src/dashboard/operations",
   entities: []
 }
 

--- a/packages/web/src/dashboard/ChannelsPage.tsx
+++ b/packages/web/src/dashboard/ChannelsPage.tsx
@@ -29,9 +29,11 @@ import {
   disconnectSlack,
   getSmsChannelStatus,
   setSmsCredentials,
+  setSmsAllowlist,
   sendSmsTest,
   disconnectSms,
   getVoiceChannelStatus,
+  setVoiceAllowlist,
   getOmiChannelStatus,
   setOmiGroqKey,
   disconnectOmiGroqKey,
@@ -1301,6 +1303,198 @@ function SectionDivider({ label }: { label: string }) {
   );
 }
 
+// ---------------------------------------------------------------------------
+// AllowlistEditor — shared Open / Allowlist toggle (2026-05-26).
+//
+// Used by both SmsSection (allowed_users) and VoiceSection (allowed_callers).
+// The two channels have identical UX shape — radio toggle + CSV input — so
+// they share one component. The differences are: the kind label
+// ("texters" vs "callers"), the field name on the wire, and which Wasp
+// action gets called on save. Everything else (E.164 hint, count line,
+// save-disabled-when-empty-in-restrict-mode) is shared.
+//
+// Visual style matches the rest of /channels: var(--ink) / var(--marginalia)
+// / var(--brass), monospace labels in uppercase letterspaced caps, italic
+// body for descriptive lines.
+// ---------------------------------------------------------------------------
+
+interface AllowlistEditorProps {
+  /** Initial state from /status — "" means no allowlist saved yet. */
+  initialAllowAll: boolean;
+  initialEntries: string;
+  /** Singular subject ("texter" / "caller") used in the muted-italic copy. */
+  subjectSingular: string;
+  /** Verb used in the muted-italic open-mode line ("text" / "call"). */
+  verbOpen: string;
+  /** Async save callback — receives the final shape; the editor handles UI state. */
+  onSave: (next: {
+    allow_all: boolean;
+    entries: string;
+  }) => Promise<unknown>;
+}
+
+function AllowlistEditor({
+  initialAllowAll,
+  initialEntries,
+  subjectSingular,
+  verbOpen,
+  onSave,
+}: AllowlistEditorProps) {
+  // The radio's source of truth is local state, seeded from status. We
+  // intentionally do NOT keep this in sync with status after first mount —
+  // mid-edit, the operator's choice wins until they hit Save.
+  const [mode, setMode] = useState<"open" | "allowlist">(
+    initialAllowAll ? "open" : "allowlist",
+  );
+  const [entries, setEntries] = useState<string>(initialEntries);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [savedFlash, setSavedFlash] = useState(false);
+
+  const trimmed = entries.trim();
+  const count = trimmed
+    ? trimmed
+        .split(",")
+        .map((p) => p.trim())
+        .filter(Boolean).length
+    : 0;
+  const canSave =
+    !busy && (mode === "open" || (mode === "allowlist" && count > 0));
+
+  async function handleSave() {
+    if (!canSave) return;
+    setBusy(true);
+    setErr(null);
+    try {
+      await onSave({
+        allow_all: mode === "open",
+        entries: mode === "open" ? "" : trimmed,
+      });
+      setSavedFlash(true);
+      setTimeout(() => setSavedFlash(false), 1800);
+    } catch (e: any) {
+      setErr(
+        e?.message ??
+          e?.data?.error ??
+          "Couldn't save the allowlist. Check the format and try again.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="space-y-2 border-l border-rule/40 pl-3">
+      <div
+        className="font-mono text-[10px] uppercase tracking-[0.22em]"
+        style={{ color: "var(--marginalia)" }}
+      >
+        Who can {verbOpen} Alfred
+      </div>
+
+      {/* Radio toggle — two mutually exclusive modes. */}
+      <div className="flex flex-wrap gap-4 items-baseline">
+        <label className="flex items-baseline gap-2 cursor-pointer">
+          <input
+            type="radio"
+            name={`allowlist-mode-${subjectSingular}`}
+            checked={mode === "open"}
+            onChange={() => setMode("open")}
+            disabled={busy}
+          />
+          <span
+            className="font-mono text-[12px]"
+            style={{ color: "var(--ink)" }}
+          >
+            Open
+          </span>
+        </label>
+        <label className="flex items-baseline gap-2 cursor-pointer">
+          <input
+            type="radio"
+            name={`allowlist-mode-${subjectSingular}`}
+            checked={mode === "allowlist"}
+            onChange={() => setMode("allowlist")}
+            disabled={busy}
+          />
+          <span
+            className="font-mono text-[12px]"
+            style={{ color: "var(--ink)" }}
+          >
+            Allowlist
+          </span>
+        </label>
+      </div>
+
+      {/* Status line — what the persisted state says, before the editor. */}
+      {mode === "open" ? (
+        <p
+          className="font-body italic text-[12px]"
+          style={{ color: "var(--marginalia)" }}
+        >
+          Open — anyone can {verbOpen} Alfred.
+        </p>
+      ) : (
+        <p
+          className="font-body italic text-[12px]"
+          style={{ color: "var(--marginalia)" }}
+        >
+          {count === 0
+            ? `No ${subjectSingular}s yet — paste E.164 numbers below.`
+            : `Allowlist: ${count} ${subjectSingular}${count === 1 ? "" : "s"}.`}
+        </p>
+      )}
+
+      <input
+        type="text"
+        value={entries}
+        onChange={(e) => setEntries(e.target.value)}
+        placeholder="+15551234567, +442345..."
+        disabled={mode === "open" || busy}
+        className="w-full bg-transparent border px-2 py-1 font-mono text-[11px]"
+        style={{
+          borderColor: "var(--rule)",
+          color: "var(--ink)",
+          opacity: mode === "open" ? 0.4 : 1,
+        }}
+      />
+
+      <div className="flex flex-wrap gap-3 items-baseline">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={!canSave}
+          className="font-mono text-[10px] uppercase tracking-[0.22em] px-2 py-1 border"
+          style={{
+            borderColor: "var(--ink)",
+            color: "var(--ink)",
+            opacity: canSave ? 1 : 0.5,
+          }}
+        >
+          {busy ? "saving..." : "save"}
+        </button>
+        {savedFlash && (
+          <span
+            className="font-body italic text-[12px]"
+            style={{ color: "var(--marginalia)" }}
+          >
+            ✓ Saved.
+          </span>
+        )}
+      </div>
+
+      {err && (
+        <p
+          className="font-body italic text-[12px]"
+          style={{ color: "var(--brass)" }}
+        >
+          {err}
+        </p>
+      )}
+    </div>
+  );
+}
+
 function SmsSection() {
   const { data: statusData, refetch } = useQuery(
     getSmsChannelStatus,
@@ -1569,30 +1763,23 @@ function SmsSection() {
             </p>
           )}
 
-          {/* Allowed-senders panel — fold-out, sourced from status */}
-          <div className="space-y-2 border-l border-rule/40 pl-3">
-            <div
-              className="font-mono text-[10px] uppercase tracking-[0.22em]"
-              style={{ color: "var(--marginalia)" }}
-            >
-              Allowed senders
-            </div>
-            {status?.allowed_users ? (
-              <p
-                className="font-mono text-[12px]"
-                style={{ color: "var(--ink)" }}
-              >
-                {status.allowed_users}
-              </p>
-            ) : (
-              <p
-                className="font-body italic text-[12px]"
-                style={{ color: "var(--marginalia)" }}
-              >
-                Anyone may text {card.phoneNumber ?? "the bot"}.
-              </p>
-            )}
-          </div>
+          {/* Allowlist editor — Open / Allowlist toggle backed by
+              setSmsAllowlist (2026-05-26). Re-mounts on status change so
+              the initial seed is always the persisted server state. */}
+          <AllowlistEditor
+            key={`sms-${status?.allow_all ? "open" : "list"}-${status?.allowed_users ?? ""}`}
+            initialAllowAll={status?.allow_all ?? true}
+            initialEntries={status?.allowed_users ?? ""}
+            subjectSingular="texter"
+            verbOpen="text"
+            onSave={async ({ allow_all, entries }) => {
+              await setSmsAllowlist({
+                allow_all,
+                allowed_users: entries,
+              });
+              refetch();
+            }}
+          />
 
           <div className="flex flex-wrap gap-3 items-baseline pt-1">
             <button
@@ -1817,6 +2004,27 @@ function VoiceSection() {
         >
           Calling number: {card.callingNumber}
         </p>
+      )}
+
+      {/* Allowlist editor — show as long as voice is past the unconfigured
+          stage (i.e. compose service exists + SMS creds are set). We render
+          it even in needs-openai-key state so the operator can lock down
+          the bridge before pasting the key. */}
+      {card.state !== "unconfigured" && (
+        <AllowlistEditor
+          key={`voice-${status?.allow_all ? "open" : "list"}-${status?.allowed_callers ?? ""}`}
+          initialAllowAll={status?.allow_all ?? true}
+          initialEntries={status?.allowed_callers ?? ""}
+          subjectSingular="caller"
+          verbOpen="call"
+          onSave={async ({ allow_all, entries }) => {
+            await setVoiceAllowlist({
+              allow_all,
+              allowed_callers: entries,
+            });
+            refetch();
+          }}
+        />
       )}
     </div>
   );

--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -308,6 +308,29 @@ export const getVoiceChannelStatus = async (
   });
 };
 
+// Lane III (voice allowlist, 2026-05-26) — Open / Allowlist toggle backed by
+// ctrl-api PUT /api/v1/channels/voice/allowlist. Body:
+//   { allow_all?: boolean, allowed_callers?: string }
+// Returns: { ok, allow_all, allowed_callers }. ctrl-api validates each entry
+// of `allowed_callers` as E.164 and rejects with 400 on bad input.
+export const setVoiceAllowlist = async (
+  args: { allow_all?: boolean; allowed_callers?: string },
+  context: any,
+) => {
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    method: "PUT",
+    path: "/api/v1/channels/voice/allowlist",
+    body: {
+      allow_all: args?.allow_all === true,
+      allowed_callers:
+        typeof args?.allowed_callers === "string"
+          ? args.allowed_callers.trim()
+          : "",
+    },
+  });
+};
+
 export const setSmsCredentials = async (
   args: {
     account_sid: string;
@@ -336,6 +359,28 @@ export const setSmsCredentials = async (
       auth_token: args.auth_token.trim(),
       phone_number: args.phone_number.trim(),
       allowed_users: args.allowed_users?.trim() ?? "",
+    },
+  });
+};
+
+// Lane III (SMS allowlist, 2026-05-26) — Open / Allowlist toggle backed by
+// ctrl-api PUT /api/v1/channels/sms/allowlist. Body:
+//   { allow_all?: boolean, allowed_users?: string }
+// Returns: { ok, allow_all, allowed_users }. ctrl-api validates each entry
+// of `allowed_users` as E.164 and rejects with 400 on bad input — we let
+// that surface to the caller verbatim (same as the credentials endpoint).
+export const setSmsAllowlist = async (
+  args: { allow_all?: boolean; allowed_users?: string },
+  context: any,
+) => {
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    method: "PUT",
+    path: "/api/v1/channels/sms/allowlist",
+    body: {
+      allow_all: args?.allow_all === true,
+      allowed_users:
+        typeof args?.allowed_users === "string" ? args.allowed_users.trim() : "",
     },
   });
 };

--- a/packages/web/src/dashboard/smsCardCore.test.ts
+++ b/packages/web/src/dashboard/smsCardCore.test.ts
@@ -33,6 +33,7 @@ const BASE: SmsStatus = {
   phone_number: null,
   account_sid_masked: null,
   allowed_users: "",
+  allow_all: true,
 };
 
 test("derive: unconfigured → setup state with available pill", () => {

--- a/packages/web/src/dashboard/smsCardCore.ts
+++ b/packages/web/src/dashboard/smsCardCore.ts
@@ -22,6 +22,8 @@ export interface SmsStatus {
   account_sid_masked: string | null;
   /** Comma-separated allowlist of E.164 numbers permitted to text the bot. */
   allowed_users: string;
+  /** True when any sender is allowed (default-open policy, no env var set). */
+  allow_all: boolean;
 }
 
 export interface SmsCardState {
@@ -43,6 +45,7 @@ const NULL_STATUS: SmsStatus = {
   phone_number: null,
   account_sid_masked: null,
   allowed_users: "",
+  allow_all: true,
 };
 
 /**

--- a/packages/web/src/dashboard/voiceCardCore.test.ts
+++ b/packages/web/src/dashboard/voiceCardCore.test.ts
@@ -37,6 +37,8 @@ const BASE: VoiceStatus = {
   calling_number: null,
   compose_service_exists: false,
   openai_key_set: false,
+  allowed_callers: "",
+  allow_all: true,
 };
 
 test("derive: unconfigured + compose missing → 'Voice not deployed' card", () => {

--- a/packages/web/src/dashboard/voiceCardCore.ts
+++ b/packages/web/src/dashboard/voiceCardCore.ts
@@ -39,6 +39,10 @@ export interface VoiceStatus {
   compose_service_exists: boolean;
   /** True when OPENAI_API_KEY is set in the compose .env. */
   openai_key_set: boolean;
+  /** Comma-separated E.164 numbers permitted to call the bridge. "" if unset. */
+  allowed_callers: string;
+  /** True when any caller is allowed (default-open policy, no env vars set). */
+  allow_all: boolean;
 }
 
 export interface VoiceCardState {
@@ -60,6 +64,8 @@ const NULL_STATUS: VoiceStatus = {
   calling_number: null,
   compose_service_exists: false,
   openai_key_set: false,
+  allowed_callers: "",
+  allow_all: true,
 };
 
 export function deriveVoiceCardState(args: {


### PR DESCRIPTION
Solves two related problems:
1. **SMS persistence bug.** Sir's UI save earlier set TWILIO_* but missed SMS_WEBHOOK_URL + SMS_WEBHOOK_HOST. Hermes' SMS adapter refused to start, no :8080 listener, Caddy 502s. We now persist both alongside credentials so fresh installs never repeat that.
2. **Operator-facing allowlist controls.** SMS + Voice each get a Phone-card section with an Open / Allowlist radio + CSV input + Save. SMS writes through Hermes per-profile .env. Voice writes through compose .env, voice-bridge enforces in /twiml/inbound via `<Reject reason='busy'/>` for disallowed callers (no Realtime session opened, zero OpenAI cost on rejection).

Default policy is OPEN for both — sane for a fresh install.

## Files
- `ctrl/src/api/routes/sms.ts` — persistence fix + PUT /allowlist
- `ctrl/src/api/routes/voice.ts` — VoiceStatus shape + PUT /allowlist
- `voice-bridge/src/twiml.ts` — caller-allowlist enforcement
- `web/main.wasp` — two new actions
- `web/src/dashboard/operations.ts` — proxy wrappers
- `web/src/dashboard/{sms,voice}CardCore.ts` + tests — schema + fixtures
- `web/src/dashboard/ChannelsPage.tsx` — shared AllowlistEditor + wiring

11/11 + 11/11 unit tests pass. esbuild clean. The only TS errors are the two `wasp/client/operations` missing-member ones that disappear after wasp regenerates the SDK from main.wasp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)