### PR TITLE
feat(hermes-mcp): 6th MCP server — runtime delegation + scheduling

### DIFF
--- a/packages/ctrl/src/api/routes/hermes.ts
+++ b/packages/ctrl/src/api/routes/hermes.ts
@@ -348,6 +348,278 @@ export function registerHermesRoutes(): void {
       prime_enabled: primeEnabled,
     });
   });
+
+  // ─── 6th-MCP-server routes (#256 — hermes-mcp): runs / models / cron ───
+  //
+  // The voice agent (OpenAI Realtime via voice-bridge) gets a 6th MCP server
+  // — `hermes` — that surfaces the runtime itself: schedule reminders,
+  // delegate background work, list active runs, inspect models. The other 5
+  // MCP servers act on Sir's world; this one acts on Alfred-the-runtime.
+  //
+  // Two transports under the hood:
+  //   * HTTP — runs / models. Calls hermes:18789 (main) or :18790 (workers).
+  //     API key is profile-scoped, read from /hermes-state/profiles/<p>/.env
+  //     at call time (no caching — a hermes rebuild rotates the key without
+  //     bouncing ctrl-api).
+  //   * docker exec — cron. Hermes' /v1/* HTTP API doesn't expose cron;
+  //     the `hermes cron {list,create,remove}` CLI is the contract surface.
+  //
+  // Auth at the ingress is the same AAS_API_KEY bearer the rest of
+  // /api/v1/* requires; mcp-server proxies through here exactly like the
+  // alfred / sure / plane / vaultwarden / execute MCP apps do.
+  // See packages/mcp-server/src/tools/hermes.ts for the tool defs and
+  // packages/hermes/workspace-template/skills/alfred-hermes-operations/
+  // SKILL.md for the agent-facing contract.
+
+  type Profile = "main" | "workers";
+  const HERMES_MAIN_API_URL =
+    process.env.HERMES_GATEWAY_URL ?? "http://hermes:18789";
+  const HERMES_WORKERS_API_URL =
+    process.env.HERMES_WORKERS_GATEWAY_URL ?? "http://hermes:18790";
+
+  function parseProfile(raw: unknown, fallback: Profile): Profile {
+    return raw === "main" || raw === "workers" ? raw : fallback;
+  }
+  function profileBaseUrl(p: Profile): string {
+    return p === "workers" ? HERMES_WORKERS_API_URL : HERMES_MAIN_API_URL;
+  }
+
+  /** Read API_SERVER_KEY for the given Hermes profile out of its .env. */
+  function readHermesApiKey(p: Profile): string | null {
+    const envPath = `${HERMES_CONFIG_DIR}/${p}/.env`;
+    let raw: string;
+    try {
+      raw = fs.readFileSync(envPath, "utf-8");
+    } catch {
+      return null;
+    }
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const eq = trimmed.indexOf("=");
+      if (eq < 0) continue;
+      if (trimmed.slice(0, eq).trim() === "API_SERVER_KEY") {
+        return trimmed.slice(eq + 1).trim();
+      }
+    }
+    return null;
+  }
+
+  async function hermesHttp(
+    profile: Profile,
+    method: "GET" | "POST",
+    path: string,
+    body?: unknown,
+  ): Promise<{ status: number; data: unknown }> {
+    const key = readHermesApiKey(profile);
+    if (!key) {
+      return {
+        status: 500,
+        data: {
+          error: "HERMES_KEY_MISSING",
+          detail: `Hermes API key not found at ${HERMES_CONFIG_DIR}/${profile}/.env — has hermes-init run?`,
+        },
+      };
+    }
+    const url = `${profileBaseUrl(profile)}${path}`;
+    const init: RequestInit & { signal: AbortSignal } = {
+      method,
+      headers: {
+        Authorization: `Bearer ${key}`,
+        "Content-Type": "application/json",
+      },
+      signal: AbortSignal.timeout(15_000),
+    };
+    if (body !== undefined && method === "POST") {
+      init.body = JSON.stringify(body);
+    }
+    let resp: Response;
+    try {
+      resp = await fetch(url, init);
+    } catch (err: any) {
+      return {
+        status: 502,
+        data: {
+          error: "HERMES_UNREACHABLE",
+          detail: `${url}: ${err?.message ?? String(err)}`,
+        },
+      };
+    }
+    const text = await resp.text();
+    let data: unknown;
+    try {
+      data = text ? JSON.parse(text) : null;
+    } catch {
+      data = text;
+    }
+    return { status: resp.status, data };
+  }
+
+  function tryJsonParse(text: string): {
+    json?: unknown;
+    raw?: string;
+  } {
+    const trimmed = text.trim();
+    if (!trimmed) return { json: null };
+    if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+      try {
+        return { json: JSON.parse(trimmed) };
+      } catch {
+        /* fall through to raw */
+      }
+    }
+    return { raw: text };
+  }
+
+  // GET /api/v1/hermes/models?profile=main|workers
+  // Returns the OpenAI-API `/v1/models` shape (Hermes treats profiles as
+  // "models" for compat with OpenAI SDKs).
+  addRoute("GET", "/api/v1/hermes/models", async ({ res, query }) => {
+    const profile = parseProfile(query.get("profile"), "main");
+    const out = await hermesHttp(profile, "GET", "/v1/models");
+    sendJson(res, out.status, out.data ?? {});
+  });
+
+  // POST /api/v1/hermes/runs
+  //   body: { prompt, profile?, model?, return_via?, session_id? }
+  // Forwards to Hermes `POST /v1/runs`. `return_via:{channel,chat_id?}` gets
+  // appended to the prompt as a trailing instruction so the run knows where
+  // to deliver its result (Hermes' API has no native parameter for this).
+  addRoute("POST", "/api/v1/hermes/runs", async ({ res, body }) => {
+    const b = (body as Record<string, unknown>) || {};
+    const prompt = b.prompt;
+    if (typeof prompt !== "string" || !prompt.trim()) {
+      sendJson(res, 400, { error: "prompt (string) is required" });
+      return;
+    }
+    const profile = parseProfile(b.profile, "workers");
+    const model = typeof b.model === "string" ? b.model : undefined;
+    const sessionId =
+      typeof b.session_id === "string" ? b.session_id : undefined;
+
+    let finalPrompt = prompt.trim();
+    const rv = b.return_via;
+    if (rv && typeof rv === "object" && !Array.isArray(rv)) {
+      const ch = (rv as any).channel;
+      const cid = (rv as any).chat_id;
+      if (typeof ch === "string" && ch) {
+        const where = typeof cid === "string" && cid ? `${ch}:${cid}` : ch;
+        finalPrompt =
+          `${finalPrompt}\n\nWhen complete, deliver the result via the ${where} channel.`;
+      }
+    }
+
+    const hermesBody: Record<string, unknown> = { input: finalPrompt };
+    if (model) hermesBody.model = model;
+    if (sessionId) hermesBody.session_id = sessionId;
+
+    const out = await hermesHttp(profile, "POST", "/v1/runs", hermesBody);
+    const payload =
+      out.data && typeof out.data === "object"
+        ? (out.data as Record<string, unknown>)
+        : {};
+    sendJson(res, out.status, { profile, ...payload });
+  });
+
+  // POST /api/v1/hermes/runs/:id/stop?profile=
+  addRoute(
+    "POST",
+    "/api/v1/hermes/runs/:id/stop",
+    async ({ res, params, query }) => {
+      const profile = parseProfile(query.get("profile"), "workers");
+      const out = await hermesHttp(
+        profile,
+        "POST",
+        `/v1/runs/${encodeURIComponent(params.id)}/stop`,
+      );
+      sendJson(res, out.status, out.data ?? {});
+    },
+  );
+
+  // GET /api/v1/hermes/cron?profile=main
+  addRoute("GET", "/api/v1/hermes/cron", async ({ res, query }) => {
+    const profile = parseProfile(query.get("profile"), "main");
+    const stdout = await dockerExec(HERMES_CONTAINER, [
+      ...HERMES_CMD,
+      "--profile",
+      profile,
+      "cron",
+      "list",
+    ]);
+    const parsed = tryJsonParse(stdout);
+    sendJson(res, 200, { profile, ...parsed });
+  });
+
+  // POST /api/v1/hermes/cron
+  //   body: { prompt, when, channel?, chat_id?, profile? }
+  //   `when` is ISO-8601 OR a 5-field cron expression — Hermes accepts both.
+  addRoute("POST", "/api/v1/hermes/cron", async ({ res, body }) => {
+    const b = (body as Record<string, unknown>) || {};
+    const prompt = b.prompt;
+    const when = b.when;
+    if (typeof prompt !== "string" || !prompt.trim()) {
+      sendJson(res, 400, { error: "prompt (string) is required" });
+      return;
+    }
+    if (typeof when !== "string" || !when.trim()) {
+      sendJson(res, 400, {
+        error:
+          "when (string — ISO-8601 timestamp or cron expression) is required",
+      });
+      return;
+    }
+    const profile = parseProfile(b.profile, "main");
+    const channel = typeof b.channel === "string" ? b.channel : undefined;
+    const chatId = typeof b.chat_id === "string" ? b.chat_id : undefined;
+
+    // Mark the prompt so a fired job knows the delivery target. Hermes
+    // cron forwards the prompt verbatim to the profile's run pipeline;
+    // the gateway adapters then route on the [scheduled→…] marker.
+    const finalPrompt = channel
+      ? `${prompt.trim()}\n\n[scheduled→${channel}${chatId ? `:${chatId}` : ""}]`
+      : prompt.trim();
+
+    const args = [
+      ...HERMES_CMD,
+      "--profile",
+      profile,
+      "cron",
+      "create",
+      "--when",
+      when,
+      "--prompt",
+      finalPrompt,
+    ];
+    if (channel) args.push("--channel", channel);
+    if (chatId) args.push("--chat-id", chatId);
+
+    const stdout = await dockerExec(HERMES_CONTAINER, args);
+    const parsed = tryJsonParse(stdout);
+    sendJson(res, 201, {
+      profile,
+      when,
+      channel: channel ?? null,
+      ...parsed,
+    });
+  });
+
+  // DELETE /api/v1/hermes/cron/:id?profile=main
+  addRoute(
+    "DELETE",
+    "/api/v1/hermes/cron/:id",
+    async ({ res, params, query }) => {
+      const profile = parseProfile(query.get("profile"), "main");
+      const stdout = await dockerExec(HERMES_CONTAINER, [
+        ...HERMES_CMD,
+        "--profile",
+        profile,
+        "cron",
+        "remove",
+        params.id,
+      ]);
+      sendJson(res, 200, { profile, ok: true, output: stdout.trim() });
+    },
+  );
 }
 
 // -----------------------------------------------------------------------------

--- a/packages/hermes/workspace-template/skills/alfred-hermes-operations/SKILL.md
+++ b/packages/hermes/workspace-template/skills/alfred-hermes-operations/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: alfred-hermes-operations
+description: Schedule reminders, delegate background work to Alfred-the-text-agent, list scheduled jobs, and inspect Hermes runtime — anything that's about Alfred-the-runtime rather than Sir's vault/calendar/finances. Use whenever Sir asks "remind me…", "research X then tell me…", "what reminders do I have set?", or wants to fire-and-forget a long task on text-mode while you stay on the phone with him.
+version: "1.0"
+metadata:
+  openclaw:
+    emoji: "🧠"
+---
+
+# 🧠 Alfred — Hermes Operations
+
+Hermes is the runtime Sir's Alfred lives in. The other MCP servers act on Sir's *world* (vault / finances / projects / secrets / third-party apps). This one acts on **the Alfred runtime itself**: scheduling, delegation, model selection, run inspection.
+
+Two Hermes profiles run side-by-side. `main` handles Sir's user-facing channels (Telegram, Slack, email, voice). `workers` runs background tasks. Every tool in this skill takes an optional `profile` parameter with a sensible default — **never specify it unless Sir tells you to**.
+
+## When to reach for this server (vs the others)
+
+- **Sir asks for a reminder** — *"remind me tomorrow at 6 a.m. about X"*, *"every weekday morning, send me a brief about my day"* → `hermes__schedule_prompt`. Never try to set a reminder by writing to the vault or by spawning a long-running run; cron is the right primitive.
+- **Sir asks for background work** — *"research these VAT rules and email me a summary tonight"*, *"prepare the presentation deck and let me know when it's done"* → `hermes__run` with `return_via`. The work runs in `workers` while you stay on the phone or close out the conversation.
+- **Sir asks what's scheduled** — *"what reminders do I have set?"*, *"is the morning brief still running?"* → `hermes__list_scheduled`.
+- **Sir asks to cancel** — *"cancel that 6 a.m. reminder"* → `hermes__cancel_scheduled` (confirm the job_id from `list_scheduled` first; never cancel by guessing).
+- **Sir asks about model availability** — *"what model are you running?"*, *"can I use Opus for this?"* → `hermes__list_models`.
+
+## When NOT to reach for this server
+
+- **Vault edits** (update a task, mark a matter done, write a note) — use the `alfred__*` server.
+- **Calendar / email / Composio apps** — use `execute__*`.
+- **Sure / Plane / Vaultwarden** — use the corresponding `<server>__*`.
+- **An immediate one-line answer that doesn't need delegation** — just do it on the call, don't fire a `run`.
+
+## Worked examples
+
+### Reminder
+> Sir: *"Remind me tomorrow at 6 a.m. about the Makerspace prep."*
+
+```js
+hermes__schedule_prompt({
+  prompt: "Sir, here is your morning reminder: review the Makerspace session-1 prep and finalise the presentation.",
+  when: "2026-05-27T06:00:00+02:00",
+  channel: "telegram",
+})
+```
+
+**Always include the timezone offset.** Sir is in Budapest (+02:00 in summer, +01:00 in winter — check the current date if you're unsure). A naked timestamp is interpreted as UTC and the reminder fires two hours late.
+
+The prompt should be **Sir-facing** — write what the user receives, not "remind sir about X" (that gets handed to a model that would then send "Reminding Sir about X" instead of the actual reminder).
+
+### Background research
+> Sir: *"Research the new Hungarian VAT rules and email me a one-page summary tonight."*
+
+```js
+hermes__run({
+  prompt: "Research the current Hungarian VAT changes for 2026 — focus on changes affecting small companies and EVs. Produce a one-page summary in plain prose (no markdown bullets) covering: (1) what changed, (2) effective dates, (3) action items for Szabó-Stubán Kft. Email the summary to Sir at david@szabostuban.com.",
+  profile: "workers",
+  return_via: { channel: "email", chat_id: "david@szabostuban.com" },
+})
+```
+
+Two rules for the prompt:
+1. **Self-contained.** The spawned run has no shared context with this conversation — every fact it needs (company name, recipient, format, deadline) must be in the prompt.
+2. **End-state oriented.** Tell it what the finished deliverable looks like, not a sequence of steps.
+
+### Recurring brief
+> Sir: *"Every weekday morning, send me a quick brief about my day."*
+
+```js
+hermes__schedule_prompt({
+  prompt: "Sir, your morning brief: read today's calendar, the overnight Telegram digest, and the top three open matters; write a 3–4 sentence summary covering what is on Sir's plate today and which item to start with.",
+  when: "0 7 * * 1-5",
+  channel: "telegram",
+})
+```
+
+5-field cron expression — fires at 07:00 every weekday in Hermes' configured timezone.
+
+### Cancel
+> Sir: *"Cancel that 6 a.m. reminder I set earlier."*
+
+First confirm what's there:
+
+```js
+hermes__list_scheduled({})
+```
+
+…then cancel by the id:
+
+```js
+hermes__cancel_scheduled({ job_id: "cron-abc123" })
+```
+
+Never cancel a job whose prompt you can't preview to Sir; if the list returns more than one matching reminder, ask Sir which.
+
+## Output etiquette
+
+- After `hermes__schedule_prompt` succeeds: *"Done, sir — the reminder is set for tomorrow at six."* (One sentence. No job_id, no timezone offset, no internals.)
+- After `hermes__run` returns: *"I've kicked that off, sir. You'll have the summary by email by this evening."*
+- If a tool returns an error: surface the gist plainly. Don't invent a reason — the error body says what failed.
+
+## Things to never do
+
+- **Never fabricate confirmation.** If a tool 5xx'd or didn't return success, do NOT tell Sir the reminder was set.
+- **Never use UTC for Sir's `when`.** Sir is in Budapest. The voice agent must spell out the offset.
+- **Never spawn a `run` to do something the other MCP servers can do in one call.** A `hermes__run` is delegation to a *separate* text agent — it costs an LLM round-trip on the workers profile, and the result lands in some other channel later. Use it for genuine multi-step work, not for "list my open tasks".
+- **Never recurse.** Do not fire a `run` whose prompt itself asks the spawned agent to fire more runs — Hermes has a `max_spawn_depth: 1` for a reason.

--- a/packages/mcp-server/src/bin/stdio-app.ts
+++ b/packages/mcp-server/src/bin/stdio-app.ts
@@ -9,7 +9,7 @@
 // Invoke as:
 //   node dist/bin/stdio-app.js <appId>
 //
-// Where <appId> ∈ SUPPORTED_APPS = {alfred, sure, plane, vaultwarden, execute}.
+// Where <appId> ∈ SUPPORTED_APPS = {alfred, sure, plane, vaultwarden, execute, hermes}.
 //
 // Environment:
 //   CTRL_API_URL   — base URL for ctrl-api (default: http://ctrl-api:3100)

--- a/packages/mcp-server/src/tools/hermes.ts
+++ b/packages/mcp-server/src/tools/hermes.ts
@@ -1,0 +1,207 @@
+// Hermes MCP tool catalogue (the 6th MCP server, alongside alfred / sure /
+// plane / vaultwarden / execute).
+//
+// Sir's design (2026-05-26): the voice agent has 5 MCP servers for Sir's
+// world (vault / finances / projects / secrets / third-party apps); it
+// needs a 6th for the runtime itself — scheduling, delegation, model
+// selection. The other 5 MCP servers all proxy through ctrl-api; this
+// one follows the same pattern. ctrl-api's `/api/v1/hermes/*` routes
+// (added in packages/ctrl/src/api/routes/hermes.ts) are the backend.
+//
+// Two transports under the hood (transparent to the tool caller):
+//   * HTTP — runs / models / health. ctrl-api fetches hermes:18789 (main)
+//     or :18790 (workers) with the per-profile API key.
+//   * docker exec — cron. Hermes' /v1/* HTTP API doesn't expose cron;
+//     the `hermes cron {list,create,remove}` CLI is the contract.
+//
+// Profile model: every tool accepts an optional `profile: "main" | "workers"`
+// with sensible defaults — agents don't normally specify it. Defaults:
+//   run / stop_run    → workers   (background, won't compete with main chat)
+//   schedule          → main      (fires into a user-facing channel)
+//   health / models   → main      (workers is symmetric; main is canonical)
+//
+// Descriptions are written for the model on the other end of the connector —
+// what to call, when to call it, what NOT to do. See
+// packages/hermes/workspace-template/skills/alfred-hermes-operations/SKILL.md
+// for the higher-level skill that teaches the agent when to reach for this
+// server vs the other five.
+
+import { z } from "zod";
+import type { ToolDef } from "./types.js";
+
+// Shared profile schema fragment (kept identical across all 7 tools so the
+// model learns one rule). Hermes' two profiles bind separate API ports +
+// have separate cron stores, so a tool call MUST pick one even when the
+// default is fine.
+const ProfileSchema = z
+  .enum(["main", "workers"])
+  .optional()
+  .describe(
+    "Hermes profile to target. `main` runs Sir's user-facing channels (Telegram/Slack/email/voice); `workers` runs background tasks. Omit to use the tool's sensible default: run/stop_run default to `workers`, schedule defaults to `main`, health/models default to `main`.",
+  );
+
+export const ALL_HERMES_TOOLS: ToolDef[] = [
+  // ─── Runtime calls (HTTP path) ─────────────────────────────────────────
+
+  {
+    name: "run",
+    description:
+      "Spawn a Hermes run with a prompt and optional return-channel. Use this to **delegate background work to Alfred-the-text-agent** — research, long-form composition, multi-step tool chains — instead of doing it inside a phone call where the model is voice-tuned and time-bound. Returns immediately with a `run_id`; the run executes asynchronously and (if `return_via` is set) posts its result back via the named channel when complete. Defaults to the `workers` profile so it doesn't compete with Sir's live chat sessions on `main`. **When to call:** Sir says \"research X and email me the summary\" / \"figure out Y and tell me when you're done\" / \"prepare Z by tonight\". **When NOT to call:** Sir wants an immediate answer on this call (just use the other MCP tools directly). Set `return_via.channel` to one of `telegram` / `slack` / `email` / `voice`; `chat_id` is optional and defaults to Sir's primary on that channel. Pre-reqs: write a clear, self-contained prompt — the spawned run won't have your conversation context unless you put it in `prompt`.",
+    inputSchema: z.object({
+      prompt: z
+        .string()
+        .min(1)
+        .describe(
+          "The full task. Make it self-contained — the spawned run has no shared context with you. Include all relevant facts (deadlines, recipients, formats) in the prompt itself.",
+        ),
+      profile: ProfileSchema,
+      model: z
+        .string()
+        .optional()
+        .describe(
+          "Override the profile's default model (e.g. `claude-opus-4-5` for research; `claude-haiku-4-5` for cheap routing). Omit to use the profile's configured default.",
+        ),
+      return_via: z
+        .object({
+          channel: z
+            .enum(["telegram", "slack", "voice", "email"])
+            .describe(
+              "Where to deliver the run's result on completion. The run picks up this channel from the prompt's trailing instruction.",
+            ),
+          chat_id: z
+            .string()
+            .optional()
+            .describe(
+              "Channel-specific recipient ID. Optional — defaults to Sir's primary on that channel.",
+            ),
+        })
+        .optional()
+        .describe(
+          "Where to deliver the result. Omit for fire-and-forget (Sir will need to call `list_scheduled` to see the run later).",
+        ),
+      session_id: z
+        .string()
+        .optional()
+        .describe(
+          "Attach this run to an existing Hermes session for continuity. Rare — most voice-initiated runs should be fresh sessions.",
+        ),
+    }),
+    buildRequest: (args) => ({
+      method: "POST",
+      path: "/api/v1/hermes/runs",
+      body: args,
+    }),
+  },
+
+  {
+    name: "stop_run",
+    description:
+      "Stop a Hermes run by ID. Use when Sir says \"cancel the X you were doing\" or when a run has clearly stalled. Returns 200 even if the run had already completed (idempotent). Defaults to the `workers` profile (matches where `run` defaults to). **DON'T USE this to kill a run mid-progress unless Sir asks** — stopping a run loses its in-flight tool calls and any partial results.",
+    inputSchema: z.object({
+      run_id: z
+        .string()
+        .min(1)
+        .describe("The `run_id` returned by a prior `run` call."),
+      profile: ProfileSchema,
+    }),
+    buildRequest: ({ run_id, profile }) => ({
+      method: "POST",
+      path: `/api/v1/hermes/runs/${encodeURIComponent(run_id)}/stop`,
+      query: profile ? { profile } : undefined,
+    }),
+  },
+
+  {
+    name: "health",
+    description:
+      "Liveness probe for a Hermes profile. Returns `{status, platform}`. Use rarely — only when Sir asks \"is Alfred up?\" or \"is the workers thread running?\". For routine status, just try the operation Sir asked for; a 502/503 from any other tool already tells you Hermes is down. Defaults to `main`.",
+    inputSchema: z.object({ profile: ProfileSchema }),
+    buildRequest: ({ profile }) => ({
+      method: "GET",
+      path: "/api/v1/hermes/health",
+      query: profile ? { profile } : undefined,
+    }),
+  },
+
+  {
+    name: "list_models",
+    description:
+      "List the models Hermes' profile-as-model registry exposes (OpenAI-API shape — Hermes presents each profile as a `model`). Use this when Sir asks \"what models do you have access to?\" or when you want to pass a specific `model` override to `run`. Defaults to `main`. Cheap, idempotent.",
+    inputSchema: z.object({ profile: ProfileSchema }),
+    buildRequest: ({ profile }) => ({
+      method: "GET",
+      path: "/api/v1/hermes/models",
+      query: profile ? { profile } : undefined,
+    }),
+  },
+
+  // ─── Cron / scheduling (CLI-shell path under the hood) ────────────────
+
+  {
+    name: "schedule_prompt",
+    description:
+      "Schedule a prompt to fire later — either once at a specific time, or on a recurring cron schedule. **This is how Sir gets a reminder at 6 a.m.** When the schedule fires, Hermes runs the prompt and delivers the result through the named channel (Telegram by default). **When to call:** Sir says \"remind me at X\" / \"send me a Y at Z\" / \"every morning at 7\". **Time formats:** ISO-8601 (`2026-05-27T06:00:00+02:00`) for a one-shot, or a 5-field cron expression (`0 7 * * *` for every morning at 07:00). Always include the timezone offset for ISO timestamps — Sir is in Budapest (+02:00 summer / +01:00 winter), do NOT default to UTC. **The prompt is what the agent will be asked to do when the schedule fires** — make it self-contained and end-user friendly (\"Sir, here is your morning reminder about X\"), not a system-flavoured note. Defaults to the `main` profile so the result lands in a user-facing channel. Returns the new `job_id`.",
+    inputSchema: z.object({
+      prompt: z
+        .string()
+        .min(1)
+        .describe(
+          "The user-facing text Hermes will deliver when the schedule fires. Write it as Sir's-eye-view: 'Sir, here is your reminder to prep the Makerspace session', NOT 'remind sir about X'.",
+        ),
+      when: z
+        .string()
+        .min(1)
+        .describe(
+          "ISO-8601 timestamp (with timezone offset) for a one-shot, or a 5-field cron expression for recurrence. Examples: '2026-05-27T06:00:00+02:00' fires tomorrow at 6 a.m. Budapest time. '0 7 * * 1-5' fires every weekday at 07:00. NEVER use a naked timestamp without offset — Sir is not in UTC.",
+        ),
+      channel: z
+        .enum(["telegram", "slack", "voice", "email"])
+        .optional()
+        .describe(
+          "Where to deliver the fired prompt. Defaults to `telegram` (Sir's primary async channel). Use `voice` for time-critical reminders Sir said he needs by phone, NOT for routine notifications (calls are disruptive).",
+        ),
+      chat_id: z
+        .string()
+        .optional()
+        .describe(
+          "Channel-specific recipient ID. Optional — defaults to Sir's primary on that channel.",
+        ),
+      profile: ProfileSchema,
+    }),
+    buildRequest: (args) => ({
+      method: "POST",
+      path: "/api/v1/hermes/cron",
+      body: args,
+    }),
+  },
+
+  {
+    name: "list_scheduled",
+    description:
+      "List currently-scheduled prompts (cron jobs) for a profile. Use when Sir asks \"what reminders do I have set?\" or \"what's coming up?\" or before scheduling a new one (so you don't double-book). Returns a list of jobs with their `id`, `prompt`, `when` (cron spec or next-fire ISO), and `channel`. Defaults to `main`. Cheap, idempotent.",
+    inputSchema: z.object({ profile: ProfileSchema }),
+    buildRequest: ({ profile }) => ({
+      method: "GET",
+      path: "/api/v1/hermes/cron",
+      query: profile ? { profile } : undefined,
+    }),
+  },
+
+  {
+    name: "cancel_scheduled",
+    description:
+      "Cancel a scheduled prompt by `job_id`. Use when Sir says \"cancel that reminder\" or \"never mind, I don't need the X anymore\". Always confirm with Sir before cancelling unless he EXPLICITLY said to. Idempotent — cancelling an already-removed job returns 200 with `ok: true`. Defaults to `main`.",
+    inputSchema: z.object({
+      job_id: z
+        .string()
+        .min(1)
+        .describe("The job's id from a prior `schedule_prompt` or `list_scheduled` call."),
+      profile: ProfileSchema,
+    }),
+    buildRequest: ({ job_id, profile }) => ({
+      method: "DELETE",
+      path: `/api/v1/hermes/cron/${encodeURIComponent(job_id)}`,
+      query: profile ? { profile } : undefined,
+    }),
+  },
+];

--- a/packages/mcp-server/src/tools/registry.ts
+++ b/packages/mcp-server/src/tools/registry.ts
@@ -8,8 +8,18 @@ import { ALL_PLANE_TOOLS } from "./plane.js";
 import { ALL_ALFRED_TOOLS } from "./alfred.js";
 import { ALL_VAULTWARDEN_TOOLS } from "./vaultwarden.js";
 import { ALL_EXECUTE_TOOLS } from "./execute.js";
+import { ALL_HERMES_TOOLS } from "./hermes.js";
 
-export type AppId = "sure" | "plane" | "alfred" | "vaultwarden" | "execute";
+// `hermes` — 6th MCP server (added 2026-05-26). Surfaces the Hermes runtime
+// itself (scheduling, run delegation, model selection) so the voice agent
+// can schedule reminders and delegate background work.
+export type AppId =
+  | "sure"
+  | "plane"
+  | "alfred"
+  | "vaultwarden"
+  | "execute"
+  | "hermes";
 
 export const SUPPORTED_APPS: ReadonlySet<AppId> = new Set([
   "sure",
@@ -17,6 +27,7 @@ export const SUPPORTED_APPS: ReadonlySet<AppId> = new Set([
   "alfred",
   "vaultwarden",
   "execute",
+  "hermes",
 ]);
 
 export function isAppId(value: string): value is AppId {
@@ -29,6 +40,7 @@ const REGISTRY: Record<AppId, ToolDef[]> = {
   alfred: ALL_ALFRED_TOOLS,
   vaultwarden: ALL_VAULTWARDEN_TOOLS,
   execute: ALL_EXECUTE_TOOLS,
+  hermes: ALL_HERMES_TOOLS,
 };
 
 export function getToolsForApp(app: AppId): ToolDef[] {

--- a/packages/voice-bridge/src/mcp-clients.ts
+++ b/packages/voice-bridge/src/mcp-clients.ts
@@ -28,7 +28,10 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { config } from "./config.js";
 
-const APPS = ["alfred", "sure", "plane", "vaultwarden", "execute"] as const;
+// 6 servers: the original 5 (Sir's world) + hermes (the runtime itself — added
+// 2026-05-26 so the voice agent can schedule reminders + delegate background
+// work, not just act on the vault/finances/etc.).
+const APPS = ["alfred", "sure", "plane", "vaultwarden", "execute", "hermes"] as const;
 type App = (typeof APPS)[number];
 
 /** Separator we use to prefix MCP tool names. Two underscores so it never


### PR DESCRIPTION
## Sir's design (2026-05-26)

The voice agent had 5 MCP servers covering Sir's world (vault / finances /
projects / secrets / third-party apps), but **nothing** covering the
Alfred runtime itself. The 7-minute Telegram-aware call today exposed
the gap: Sir asked for a 6 a.m. reminder, the agent fabricated a
confirmation because no scheduling tool was on its surface.

This PR adds the missing 6th MCP server: `hermes`.

## 7 tools

| Tool | Purpose | Default profile |
|---|---|---|
| `hermes__run` | Delegate background work to Alfred-the-text-agent | workers |
| `hermes__stop_run` | Cancel an in-flight run | workers |
| `hermes__health` | Liveness probe | main |
| `hermes__list_models` | Model registry inspection | main |
| `hermes__schedule_prompt` | Cron-based reminder / recurring delivery | main |
| `hermes__list_scheduled` | List current cron jobs | main |
| `hermes__cancel_scheduled` | Cancel a scheduled job | main |

Every tool accepts an optional `profile: "main" | "workers"` — agents
normally don't specify it.

## Architecture

Two transports inside ctrl-api (transparent to the tool caller):
- **HTTP** — runs / models / health → `hermes:18789` (main) or `:18790` (workers).
- **docker exec** — cron → `hermes cron {list,create,remove}` inside the
  hermes container. Hermes' `/v1/*` HTTP API doesn't expose cron; the
  CLI is the contract (probed live to confirm).

mcp-server side is the same proxy pattern the other 5 apps use — every
ToolDef forwards to `/api/v1/hermes/*` on ctrl-api. Auto-registers via
`SUPPORTED_APPS` so OAuth, Caddy routing (`mcp.{DOMAIN}/hermes/mcp`),
and approval-secret-bypass all work without further wiring.

## Skill

`packages/hermes/workspace-template/skills/alfred-hermes-operations/SKILL.md`
teaches the voice agent **when to reach for this server**, worked
examples (one-shot reminder, recurring cron, background research with
return-via, cancel-with-confirmation), and what NOT to do ("never
fabricate confirmation", "never use UTC for Sir's when", "never recurse
runs").

## Stack

This branch was cut off main. Companion ctrl-api routes already
committed on the same branch (see `packages/ctrl/src/api/routes/hermes.ts`
diff in commit 49c75e04). The deploy/manual-2026-05-26 lane adds the
1-line `VOICE_OPS_SKILLS += alfred-hermes-operations` to phone.ts so
the new skill ships in the voice-context primer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)