### PR TITLE
feat: /channels Terminal card is now self-contained (no redirect)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -391,10 +391,15 @@ services:
       # stack reads. ${COMPOSE_DIR_HOST} defaults to /opt/alfred (the merged
       # single-VM layout); override in .env for a different host path.
       - ${COMPOSE_DIR_HOST:-/opt/alfred}:/srv/alfred-black
-      # Host's authorized_keys, read-only, so GET /api/v1/system/ssh-info
-      # can surface the operator-installed pubkey on the /channels Terminal
-      # card. Sir #8, 2026-05-24.
-      - /root/.ssh/authorized_keys:/root/.ssh/authorized_keys:ro
+      # Host's authorized_keys, READ-WRITE — GET /api/v1/system/ssh-info
+      # surfaces the operator-installed pubkey on the /channels Terminal
+      # card (Sir #8, 2026-05-24); POST/DELETE /api/v1/system/ssh-keys
+      # let the operator add/revoke keys from the same card (Sir self-
+      # contained-card rework, 2026-05-26). RW is intentional and safe:
+      # ctrl-api is already the trust-root for the VM (docker socket,
+      # vault writes, secret rotation); the bootstrap line is locked at
+      # the API layer to prevent UI lockout.
+      - /root/.ssh/authorized_keys:/root/.ssh/authorized_keys
     env_file:
       - .env
     environment:

--- a/packages/ctrl/Dockerfile
+++ b/packages/ctrl/Dockerfile
@@ -75,6 +75,7 @@ RUN apt-get update \
        ca-certificates \
        python3 \
        python3-yaml \
+       openssh-client \
        docker.io \
   && rm -rf /var/lib/apt/lists/* \
   && case "${TARGETARCH}" in \

--- a/packages/ctrl/src/api/routes/system.ts
+++ b/packages/ctrl/src/api/routes/system.ts
@@ -2,67 +2,363 @@
 // names) for in-app cards that need to display "how to connect" without
 // hard-coding host/key info in the SPA.
 //
-// Today's only consumer is the /channels Terminal card (Sir #8) — it shows
-// the operator the SSH command to reach the VM and offers the operator's
-// own pubkey for download.
+// Consumers today:
+//   * /channels Terminal card (Sir #8, then self-contained rework Sir
+//     2026-05-26): GET /ssh-info (status string) + GET /ssh-keys (full
+//     list with fingerprints), POST /ssh-keys (add a pubkey OR generate
+//     a fresh ed25519 keypair on the VM), POST /ssh-keys/revoke (drop
+//     a non-bootstrap line by fingerprint).
+//
+// The pubkey store is the VM's own /root/.ssh/authorized_keys, bind-
+// mounted RW into this container. That file is the source of truth —
+// no shadow state in state.db.
+
 import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import crypto from "node:crypto";
+import { execFileSync } from "node:child_process";
 import { addRoute } from "../server.js";
-import { sendJson } from "../errors.js";
+import {
+  sendJson,
+  ValidationError,
+  NotFoundError,
+  ConflictError,
+  ExecError,
+} from "../errors.js";
 
 const HERMES_CONTAINER = "alfred-black-hermes-1";
 const HERMES_EXEC_CMD = `docker exec -it ${HERMES_CONTAINER} hermes`;
 const DEFAULT_AUTHORIZED_KEYS = "/root/.ssh/authorized_keys";
 
-/**
- * Pick the first usable line from an SSH `authorized_keys` file:
- *   - skip blank lines and lines whose first non-whitespace char is `#`,
- *   - return null if nothing usable remains.
- *
- * That's "the operator key installed at bootstrap" — cloud-init writes it
- * as the first non-comment line; subsequent lines are operator-managed.
- */
-function firstAuthorizedKey(raw: string): string | null {
-  for (const line of raw.split(/\r?\n/)) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) continue;
-    return trimmed;
-  }
-  return null;
+function keysPath(): string {
+  return process.env.AUTHORIZED_KEYS_PATH || DEFAULT_AUTHORIZED_KEYS;
 }
 
-export function registerSystemRoutes(): void {
-  addRoute("GET", "/api/v1/system/ssh-info", async ({ res }) => {
-    // Host comes from the env the rest of ctrl-api uses for apex URL
-    // construction (see apps.ts). `localhost` is the safe fallback — never
-    // crash because the operator hasn't set DOMAIN yet.
-    const host = process.env.DOMAIN || process.env.TENANT_DOMAIN || "localhost";
+// ---------------------------------------------------------------------------
+// Pubkey parsing
+// ---------------------------------------------------------------------------
+//
+// An OpenSSH `authorized_keys` line looks like:
+//   <type> <base64-blob> <comment?>
+// where <type> is ssh-ed25519 / ssh-rsa / ecdsa-sha2-nistpXXX /
+// sk-ssh-ed25519@openssh.com. Authorized-keys options (command="...",
+// from="...", no-pty, …) appear BEFORE <type> when present; cloud-init
+// doesn't use them and we don't accept them in user-supplied input
+// because they're a privilege-escalation surface in a UI textarea.
+// Existing options on lines we read back are tolerated by parsing
+// from-the-end (matching the rightmost type token).
 
-    // AUTHORIZED_KEYS_PATH lets tests fake the file; production reads the
-    // real /root/.ssh/authorized_keys mounted into the container.
-    const keysPath = process.env.AUTHORIZED_KEYS_PATH || DEFAULT_AUTHORIZED_KEYS;
+const PUBKEY_LINE_RE =
+  /(?:^|\s)(ssh-ed25519|ssh-rsa|ecdsa-sha2-nistp(?:256|384|521)|sk-ssh-ed25519@openssh\.com)\s+([A-Za-z0-9+/=]{20,})(?:\s+(.+))?\s*$/;
 
-    let pubkey: string | null = null;
-    let error: string | undefined;
+// Stricter form: ONLY <type> <blob> <comment?> — used to validate user
+// input (no leading options allowed).
+const PUBKEY_INPUT_RE =
+  /^(ssh-ed25519|ssh-rsa|ecdsa-sha2-nistp(?:256|384|521)|sk-ssh-ed25519@openssh\.com)\s+([A-Za-z0-9+/=]{20,})(?:\s+(.+))?$/;
+
+interface ParsedKey {
+  /** Trimmed full line as it appears on disk. */
+  raw: string;
+  type: string;
+  /** Base64 blob (no whitespace). */
+  blob: string;
+  /** Optional comment; "" if none. */
+  comment: string;
+  /** OpenSSH-style SHA256 fingerprint: "SHA256:<b64-no-pad>". */
+  fingerprint: string;
+}
+
+function fingerprintForBlob(blobB64: string): string {
+  const buf = Buffer.from(blobB64, "base64");
+  const sha = crypto.createHash("sha256").update(buf).digest("base64");
+  return "SHA256:" + sha.replace(/=+$/, "");
+}
+
+function parseLine(line: string, strict = false): ParsedKey | null {
+  const t = line.trim();
+  if (!t || t.startsWith("#")) return null;
+  const m = (strict ? PUBKEY_INPUT_RE : PUBKEY_LINE_RE).exec(t);
+  if (!m) return null;
+  const [, type, blob, comment] = m;
+  // Validate the blob is real base64 of a reasonable length.
+  let buf: Buffer;
+  try {
+    buf = Buffer.from(blob, "base64");
+  } catch {
+    return null;
+  }
+  if (buf.length < 32) return null;
+  return {
+    raw: t,
+    type,
+    blob,
+    comment: (comment ?? "").trim(),
+    fingerprint: fingerprintForBlob(blob),
+  };
+}
+
+interface InstalledKey extends ParsedKey {
+  /** True for the FIRST usable key in the file — the bootstrap key the
+   *  operator was provisioned with. The UI refuses to revoke it. */
+  bootstrap: boolean;
+}
+
+function parseAuthorizedKeys(raw: string): InstalledKey[] {
+  const lines = raw.split(/\r?\n/);
+  const parsed: ParsedKey[] = [];
+  for (const line of lines) {
+    const k = parseLine(line);
+    if (k) parsed.push(k);
+  }
+  return parsed.map((k, i) => ({ ...k, bootstrap: i === 0 }));
+}
+
+// ---------------------------------------------------------------------------
+// File IO
+// ---------------------------------------------------------------------------
+
+function readAuthorized(): string {
+  try {
+    return fs.readFileSync(keysPath(), "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return "";
+    throw err;
+  }
+}
+
+/**
+ * Atomic-ish write: stage to a sibling tmp file (same mount → same FS so
+ * rename(2) is atomic), then rename over the target. The bind mount is
+ * a bind mount of a single file, so writeFile+rename keeps the inode the
+ * same from the host's perspective.
+ *
+ * If the file is bind-mounted from the host, we cannot rename onto it
+ * directly across the mount boundary — Docker bind-mounts a single file
+ * by inode and rename(2) fails with EBUSY. Fall back to a direct write
+ * in that case.
+ */
+function writeAuthorizedKeys(content: string): void {
+  const p = keysPath();
+  const dir = path.dirname(p);
+  const tmp = path.join(dir, `.authorized_keys.tmp.${process.pid}`);
+  try {
+    fs.writeFileSync(tmp, content, { mode: 0o600 });
+    fs.renameSync(tmp, p);
+  } catch (err) {
+    // Bind-mounted single file: rename onto it fails (EBUSY / EXDEV).
+    // Direct write is fine — the file already exists, we just truncate.
     try {
-      const raw = fs.readFileSync(keysPath, "utf8");
-      pubkey = firstAuthorizedKey(raw);
-      if (pubkey === null) error = "no_authorized_keys";
+      fs.rmSync(tmp, { force: true });
     } catch {
-      // Missing or unreadable — the card still needs host/user/exec, so
-      // surface a soft error rather than 500ing the whole request.
-      error = "no_authorized_keys";
+      /* ignore */
     }
+    if (
+      (err as NodeJS.ErrnoException).code === "EBUSY" ||
+      (err as NodeJS.ErrnoException).code === "EXDEV" ||
+      (err as NodeJS.ErrnoException).code === "EINVAL"
+    ) {
+      fs.writeFileSync(p, content, { mode: 0o600 });
+      return;
+    }
+    throw err;
+  }
+}
 
+// ---------------------------------------------------------------------------
+// ssh-keygen wrapper
+// ---------------------------------------------------------------------------
+
+interface GeneratedKey {
+  pubkey: string;
+  privateKey: string;
+  fingerprint: string;
+}
+
+function generateEd25519(comment: string): GeneratedKey {
+  if (comment.length > 80 || /[\r\n]/.test(comment)) {
+    throw new ValidationError("comment must be ≤80 chars and single-line");
+  }
+  const safeComment = comment.trim() || `alfred-generated-${Date.now()}`;
+  const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "alfred-ssh-"));
+  const privPath = path.join(tmpdir, "k");
+  const pubPath = `${privPath}.pub`;
+  try {
+    try {
+      execFileSync(
+        "ssh-keygen",
+        ["-q", "-t", "ed25519", "-N", "", "-C", safeComment, "-f", privPath],
+        { stdio: ["ignore", "pipe", "pipe"] },
+      );
+    } catch (err) {
+      const stderr = (err as { stderr?: Buffer }).stderr?.toString() ?? "";
+      throw new ExecError(`ssh-keygen failed: ${(err as Error).message}`, stderr);
+    }
+    const priv = fs.readFileSync(privPath, "utf8");
+    const pub = fs.readFileSync(pubPath, "utf8").trim();
+    const parsed = parseLine(pub, true);
+    if (!parsed) throw new ExecError("ssh-keygen produced an unparseable pubkey", pub);
+    return { pubkey: pub, privateKey: priv, fingerprint: parsed.fingerprint };
+  } finally {
+    fs.rmSync(tmpdir, { recursive: true, force: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Routes
+// ---------------------------------------------------------------------------
+
+export function registerSystemRoutes(): void {
+  // Sir #8 — unchanged shape (TerminalCard.deriveTerminalCardState reads
+  // .pubkey/.host/.user/.port/.hermes_exec). New /ssh-keys provides the
+  // full list; this route is kept for back-compat.
+  addRoute("GET", "/api/v1/system/ssh-info", async ({ res }) => {
+    const host = process.env.DOMAIN || process.env.TENANT_DOMAIN || "localhost";
+    const parsed = parseAuthorizedKeys(readAuthorized());
+    const firstPubkey = parsed[0]?.raw ?? null;
     const body: Record<string, unknown> = {
       host,
       port: 22,
       user: "root",
-      pubkey,
+      pubkey: firstPubkey,
       container: HERMES_CONTAINER,
       exec_command: HERMES_EXEC_CMD,
     };
-    if (error) body.error = error;
-
+    if (!firstPubkey) body.error = "no_authorized_keys";
     sendJson(res, 200, body);
+  });
+
+  // GET /ssh-keys — full list with fingerprints + bootstrap flag.
+  //
+  // Returns:
+  //   { host, port, user, container, exec_command,
+  //     keys: [{ fingerprint, type, comment, bootstrap }, …] }
+  //
+  // Bootstrap is true for the FIRST usable line in authorized_keys; the
+  // UI uses it to refuse "Revoke" on that row (prevent self-lockout).
+  addRoute("GET", "/api/v1/system/ssh-keys", async ({ res }) => {
+    const host = process.env.DOMAIN || process.env.TENANT_DOMAIN || "localhost";
+    const parsed = parseAuthorizedKeys(readAuthorized());
+    const keys = parsed.map((k) => ({
+      fingerprint: k.fingerprint,
+      type: k.type,
+      comment: k.comment,
+      bootstrap: k.bootstrap,
+    }));
+    sendJson(res, 200, {
+      host,
+      port: 22,
+      user: "root",
+      container: HERMES_CONTAINER,
+      exec_command: HERMES_EXEC_CMD,
+      keys,
+    });
+  });
+
+  // POST /ssh-keys — append a pubkey (or generate one).
+  //
+  // Body shapes:
+  //   { pubkey: "ssh-ed25519 AAAA… comment" }
+  //   { generate: true, comment?: "laptop" }
+  //
+  // Returns 201 { ok, fingerprint, type, comment, private_key? } —
+  // private_key is ONLY present on generate, and the server never
+  // persists it.
+  //
+  // Errors:
+  //   400 — malformed/missing input
+  //   409 — same blob (fingerprint match) already in authorized_keys
+  addRoute("POST", "/api/v1/system/ssh-keys", async ({ res, body }) => {
+    const b = (body ?? {}) as {
+      pubkey?: unknown;
+      generate?: unknown;
+      comment?: unknown;
+    };
+    const wantGenerate = b.generate === true;
+    let added: ParsedKey;
+    let privateKey: string | null = null;
+
+    if (wantGenerate) {
+      const comment = typeof b.comment === "string" ? b.comment : "";
+      const gen = generateEd25519(comment);
+      const parsed = parseLine(gen.pubkey, true);
+      if (!parsed) throw new ExecError("generated pubkey did not parse");
+      added = parsed;
+      privateKey = gen.privateKey;
+    } else if (typeof b.pubkey === "string") {
+      const parsed = parseLine(b.pubkey, true);
+      if (!parsed) {
+        throw new ValidationError(
+          "pubkey must be an OpenSSH-format line: <type> <base64-blob> [comment]. " +
+            "Authorized-keys options (command=, from=, …) are not accepted.",
+        );
+      }
+      added = parsed;
+    } else {
+      throw new ValidationError(
+        "either 'pubkey' (string) or 'generate' (true) is required",
+      );
+    }
+
+    // Idempotency: same blob already installed → 409 (the existing entry
+    // wins; the user can revoke + re-add if they need a different comment).
+    const existing = parseAuthorizedKeys(readAuthorized());
+    if (existing.some((k) => k.blob === added.blob)) {
+      throw new ConflictError(`key already installed (${added.fingerprint})`);
+    }
+
+    const raw = readAuthorized();
+    const sep = raw.length === 0 || raw.endsWith("\n") ? "" : "\n";
+    writeAuthorizedKeys(`${raw}${sep}${added.raw}\n`);
+
+    const payload: Record<string, unknown> = {
+      ok: true,
+      fingerprint: added.fingerprint,
+      type: added.type,
+      comment: added.comment,
+    };
+    if (privateKey) payload.private_key = privateKey;
+    sendJson(res, 201, payload);
+  });
+
+  // POST /ssh-keys/revoke — drop a non-bootstrap key by fingerprint.
+  //
+  // POST (not DELETE-with-path) because SHA256 fingerprints contain `/`
+  // and `+`, which need URL-encoding in a path param and trip the
+  // [^/]+ matcher in our router. Body-carried fingerprint avoids that.
+  //
+  // Refuses to revoke the bootstrap (first) key — sole guard against
+  // accidentally locking yourself out from the UI.
+  addRoute("POST", "/api/v1/system/ssh-keys/revoke", async ({ res, body }) => {
+    const b = (body ?? {}) as { fingerprint?: unknown };
+    if (typeof b.fingerprint !== "string" || !b.fingerprint.trim()) {
+      throw new ValidationError("fingerprint (string) is required");
+    }
+    const target = b.fingerprint.trim();
+    const raw = readAuthorized();
+    const parsed = parseAuthorizedKeys(raw);
+    const hit = parsed.find((k) => k.fingerprint === target);
+    if (!hit) throw new NotFoundError(`no key with fingerprint ${target}`);
+    if (hit.bootstrap) {
+      throw new ConflictError(
+        "refusing to revoke the bootstrap key (first line of authorized_keys); " +
+          "add another key first, then revoke this one over SSH directly",
+      );
+    }
+
+    // Rewrite the file, dropping only the matched line. Preserve comments
+    // and blank lines — the operator might have organised the file with
+    // section headers.
+    const out = raw
+      .split(/\r?\n/)
+      .filter((line) => {
+        const k = parseLine(line);
+        return !k || k.fingerprint !== target;
+      })
+      .join("\n");
+    const normalised = out.endsWith("\n") || out === "" ? out : out + "\n";
+    writeAuthorizedKeys(normalised);
+
+    sendJson(res, 200, { ok: true, revoked: target });
   });
 }

--- a/packages/ctrl/tests/ssh_keys.test.ts
+++ b/packages/ctrl/tests/ssh_keys.test.ts
@@ -1,0 +1,266 @@
+// Self-contained Terminal card (Sir 2026-05-26): the /channels card now
+// manages SSH keys from the card itself instead of redirecting to /study.
+// These tests pin the contract of /api/v1/system/ssh-keys —
+// list / add (paste OR generate) / revoke — including the bootstrap-key
+// lockout that prevents the operator from locking themselves out.
+import { describe, it, before, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import type { ServerResponse } from "node:http";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "ssh-keys-"));
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.VAULT_PATH = path.join(tmp, "vault");
+process.env.STATE_DB_PATH = path.join(tmp, "state.db");
+process.env.SQLITE_VEC_PATH = "";
+process.env.DOMAIN = "test.alfred.black";
+
+const fakeKeysPath = path.join(tmp, "authorized_keys");
+process.env.AUTHORIZED_KEYS_PATH = fakeKeysPath;
+
+const { matchRoute } = await import("../src/api/server.js");
+const { handleError } = await import("../src/api/errors.js");
+const { registerSystemRoutes } = await import("../src/api/routes/system.js");
+registerSystemRoutes();
+
+// Mimic the server.ts dispatch loop's try/catch so thrown ApiErrors land
+// as JSON envelopes rather than bubbling up into the test runner.
+async function call(
+  method: string,
+  p: string,
+  body?: unknown,
+): Promise<{ status: number; payload: any }> {
+  const m = matchRoute(method, p);
+  assert.ok(m, `${method} ${p} must be registered`);
+  let status = 0;
+  let payload: any;
+  const res = {
+    writeHead(c: number) {
+      status = c;
+      return res;
+    },
+    end(j?: string) {
+      payload = j ? JSON.parse(j) : undefined;
+    },
+  } as unknown as ServerResponse;
+  try {
+    await m!.handler({
+      req: { url: p } as any,
+      res,
+      params: m!.params,
+      body,
+      query: new URLSearchParams(),
+    });
+  } catch (err) {
+    handleError(res, err);
+  }
+  return { status, payload };
+}
+
+// A small set of real, parseable ed25519 lines. We pre-generate them with
+// `ssh-keygen` and inline the strings so the tests don't shell out.
+const KEY_A =
+  "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINFqANq7VfvBmpiTtbBgaPnq9o5OmBKvIvE7XHL+vIot key-A@laptop";
+const KEY_B =
+  "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBO+VYO9rVjkPmRY/68XLPL3lT8eK6vDP1cP6OSlfFLM key-B@phone";
+const KEY_C =
+  "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPLpJ6OG0nQwx5KaH52SI+SqVH9Yfp5gXc2zMs+ZqMRT key-C@desktop";
+
+function seed(content: string) {
+  fs.writeFileSync(fakeKeysPath, content);
+}
+
+describe("/api/v1/system/ssh-keys — Terminal card self-contained CRUD (Sir 2026-05-26)", () => {
+  beforeEach(() => {
+    try {
+      fs.unlinkSync(fakeKeysPath);
+    } catch {}
+  });
+
+  describe("GET /ssh-keys", () => {
+    it("returns host/port/user/container/exec_command + keys[] with bootstrap flag", async () => {
+      seed([KEY_A, KEY_B].join("\n") + "\n");
+      const { status, payload } = await call("GET", "/api/v1/system/ssh-keys");
+      assert.equal(status, 200);
+      assert.equal(payload.host, "test.alfred.black");
+      assert.equal(payload.port, 22);
+      assert.equal(payload.user, "root");
+      assert.equal(payload.container, "alfred-black-hermes-1");
+      assert.equal(payload.exec_command, "docker exec -it alfred-black-hermes-1 hermes");
+      assert.equal(payload.keys.length, 2);
+      assert.equal(payload.keys[0].bootstrap, true, "first key is bootstrap");
+      assert.equal(payload.keys[1].bootstrap, false, "second key is not bootstrap");
+      assert.equal(payload.keys[0].type, "ssh-ed25519");
+      assert.match(payload.keys[0].fingerprint, /^SHA256:[A-Za-z0-9+/]+$/);
+      assert.equal(payload.keys[0].comment, "key-A@laptop");
+    });
+
+    it("returns empty keys[] when the file is missing (no 500)", async () => {
+      const { status, payload } = await call("GET", "/api/v1/system/ssh-keys");
+      assert.equal(status, 200);
+      assert.deepEqual(payload.keys, []);
+    });
+
+    it("skips comments and blank lines", async () => {
+      seed(["# header", "", "  # indented", KEY_A, "", KEY_B].join("\n") + "\n");
+      const { payload } = await call("GET", "/api/v1/system/ssh-keys");
+      assert.equal(payload.keys.length, 2);
+    });
+  });
+
+  describe("POST /ssh-keys — paste-an-existing-pubkey path", () => {
+    it("appends the key + returns 201 with fingerprint+type+comment", async () => {
+      const { status, payload } = await call("POST", "/api/v1/system/ssh-keys", {
+        pubkey: KEY_A,
+      });
+      assert.equal(status, 201);
+      assert.equal(payload.ok, true);
+      assert.equal(payload.type, "ssh-ed25519");
+      assert.equal(payload.comment, "key-A@laptop");
+      assert.match(payload.fingerprint, /^SHA256:/);
+      assert.ok(!payload.private_key, "no private_key on paste path");
+
+      const onDisk = fs.readFileSync(fakeKeysPath, "utf8");
+      assert.ok(onDisk.includes(KEY_A));
+    });
+
+    it("rejects a malformed pubkey with 400", async () => {
+      const { status, payload } = await call("POST", "/api/v1/system/ssh-keys", {
+        pubkey: "this is not a pubkey",
+      });
+      assert.equal(status, 400);
+      assert.equal(payload.error.code, "VALIDATION_ERROR");
+    });
+
+    it("rejects authorized_keys options (command=, from=, …) — privilege-surface", async () => {
+      const { status } = await call("POST", "/api/v1/system/ssh-keys", {
+        pubkey: `command="/usr/bin/echo no" ${KEY_A}`,
+      });
+      assert.equal(status, 400, "options must be rejected on user input");
+    });
+
+    it("409s when the same blob is already installed (by fingerprint)", async () => {
+      seed(KEY_A + "\n");
+      // re-paste the same key, even with a different trailing comment
+      const variant = KEY_A.replace(/\s+\S+$/, " different-comment");
+      const { status, payload } = await call("POST", "/api/v1/system/ssh-keys", {
+        pubkey: variant,
+      });
+      assert.equal(status, 409);
+      assert.equal(payload.error.code, "CONFLICT");
+    });
+
+    it("rejects body with neither pubkey nor generate", async () => {
+      const { status } = await call("POST", "/api/v1/system/ssh-keys", {});
+      assert.equal(status, 400);
+    });
+  });
+
+  describe("POST /ssh-keys — server-side generate path", () => {
+    it("generates an ed25519 keypair, returns private_key once, appends pubkey", async function (t) {
+      // Skip if ssh-keygen isn't on PATH (some CI minimal images).
+      try {
+        execFileSync("ssh-keygen", ["-?"], { stdio: ["ignore", "pipe", "pipe"] });
+      } catch {
+        t.skip("ssh-keygen not on PATH");
+        return;
+      }
+      const { status, payload } = await call("POST", "/api/v1/system/ssh-keys", {
+        generate: true,
+        comment: "test-host",
+      });
+      assert.equal(status, 201);
+      assert.equal(payload.type, "ssh-ed25519");
+      assert.match(payload.fingerprint, /^SHA256:/);
+      assert.ok(payload.private_key, "private_key must be returned on generate");
+      assert.match(payload.private_key, /BEGIN OPENSSH PRIVATE KEY/);
+
+      const onDisk = fs.readFileSync(fakeKeysPath, "utf8");
+      assert.match(onDisk, /^ssh-ed25519 /m);
+      assert.ok(
+        !onDisk.includes(payload.private_key),
+        "private key must NEVER touch authorized_keys",
+      );
+    });
+  });
+
+  describe("POST /ssh-keys/revoke", () => {
+    it("removes the requested key by fingerprint", async () => {
+      seed([KEY_A, KEY_B, KEY_C].join("\n") + "\n");
+      const list = await call("GET", "/api/v1/system/ssh-keys");
+      const targetFp = list.payload.keys[1].fingerprint; // KEY_B
+      const { status, payload } = await call(
+        "POST",
+        "/api/v1/system/ssh-keys/revoke",
+        { fingerprint: targetFp },
+      );
+      assert.equal(status, 200);
+      assert.equal(payload.revoked, targetFp);
+
+      const after = await call("GET", "/api/v1/system/ssh-keys");
+      assert.equal(after.payload.keys.length, 2);
+      assert.ok(
+        !after.payload.keys.some((k: any) => k.fingerprint === targetFp),
+        "the revoked key must be gone",
+      );
+    });
+
+    it("refuses to revoke the bootstrap (first) key — 409", async () => {
+      seed([KEY_A, KEY_B].join("\n") + "\n");
+      const list = await call("GET", "/api/v1/system/ssh-keys");
+      const bootstrapFp = list.payload.keys[0].fingerprint;
+      const { status, payload } = await call(
+        "POST",
+        "/api/v1/system/ssh-keys/revoke",
+        { fingerprint: bootstrapFp },
+      );
+      assert.equal(status, 409);
+      assert.equal(payload.error.code, "CONFLICT");
+
+      // bootstrap key still on disk
+      const after = await call("GET", "/api/v1/system/ssh-keys");
+      assert.equal(after.payload.keys.length, 2);
+      assert.equal(after.payload.keys[0].fingerprint, bootstrapFp);
+    });
+
+    it("404s when the fingerprint isn't installed", async () => {
+      seed(KEY_A + "\n");
+      const { status, payload } = await call(
+        "POST",
+        "/api/v1/system/ssh-keys/revoke",
+        { fingerprint: "SHA256:totallyfakefingerprint" },
+      );
+      assert.equal(status, 404);
+      assert.equal(payload.error.code, "NOT_FOUND");
+    });
+
+    it("rejects missing fingerprint with 400", async () => {
+      seed(KEY_A + "\n");
+      const { status } = await call("POST", "/api/v1/system/ssh-keys/revoke", {});
+      assert.equal(status, 400);
+    });
+  });
+
+  describe("end-to-end: add → list → revoke roundtrip", () => {
+    it("starting empty, adding a key, then revoking it leaves the file empty", async () => {
+      seed(KEY_A + "\n"); // bootstrap
+      const add = await call("POST", "/api/v1/system/ssh-keys", { pubkey: KEY_B });
+      assert.equal(add.status, 201);
+
+      const mid = await call("GET", "/api/v1/system/ssh-keys");
+      assert.equal(mid.payload.keys.length, 2);
+
+      const revoke = await call("POST", "/api/v1/system/ssh-keys/revoke", {
+        fingerprint: add.payload.fingerprint,
+      });
+      assert.equal(revoke.status, 200);
+
+      const final = await call("GET", "/api/v1/system/ssh-keys");
+      assert.equal(final.payload.keys.length, 1);
+      assert.equal(final.payload.keys[0].bootstrap, true);
+    });
+  });
+});

--- a/packages/web/main.wasp
+++ b/packages/web/main.wasp
@@ -718,6 +718,25 @@ query getSshInfo {
   entities: []
 }
 
+// Self-contained Terminal card (Sir 2026-05-26): list + add (generate or
+// paste) + revoke SSH keys, all from the /channels card itself. ctrl-api
+// owns the file (the host's authorized_keys, bind-mounted RW); the
+// bootstrap key is locked from the UI side.
+query listSshKeys {
+  fn: import { listSshKeys } from "@src/dashboard/operations",
+  entities: []
+}
+
+action addSshKey {
+  fn: import { addSshKey } from "@src/dashboard/operations",
+  entities: []
+}
+
+action revokeSshKey {
+  fn: import { revokeSshKey } from "@src/dashboard/operations",
+  entities: []
+}
+
 // Lane III — Telegram channel on /channels. Five ops, all proxied to
 // ctrl-api under /api/v1/channels/telegram/* (Lane I owns the backend).
 // `pairTelegramChat` was removed 2026-05-25 — see operations.ts.

--- a/packages/web/src/dashboard/ChannelsPage.tsx
+++ b/packages/web/src/dashboard/ChannelsPage.tsx
@@ -16,7 +16,9 @@ import {
   removeAuthorizedNumber,
   getVexaAutoJoin,
   setVexaAutoJoin,
-  getSshInfo,
+  listSshKeys,
+  addSshKey,
+  revokeSshKey,
   getTelegramChannelStatus,
   setTelegramBotToken,
   sendTelegramTest,
@@ -42,8 +44,10 @@ import {
 } from "wasp/client/operations";
 import { Frame } from "../client/components/ab/Frame";
 import {
-  deriveTerminalCardState,
-  type SshInfo,
+  deriveTerminalCardStateV2,
+  isProbablyValidPubkey,
+  toKeyRows,
+  type SshKeys,
 } from "./terminalCardCore";
 import {
   deriveTelegramCardState,
@@ -107,10 +111,9 @@ export default function ChannelsPage() {
     undefined,
     { retry: false },
   );
-  // Sir #8 — SSH info for the Terminal card. ctrl-api returns nulls
-  // when SSH isn't provisioned yet; the card renders an empty state
-  // in that case.
-  const { data: sshData } = useQuery(getSshInfo, undefined, { retry: false });
+  // (TerminalCard pulls its own data via listSshKeys — see below. Sir
+  // 2026-05-26: getSshInfo is no longer the Terminal card's primary
+  // source, but is kept as an exported query for any other consumers.)
   const email = (emailData as EmailChannelStatus | undefined) ?? {
     configured: false,
     inbox_address: null,
@@ -121,13 +124,6 @@ export default function ChannelsPage() {
     ? phone.authorizedNumbers
     : [];
   const vexaEnabled: boolean = Boolean((vexaData as any)?.enabled);
-  const ssh: SshInfo = (sshData as SshInfo | undefined) ?? {
-    hostname: null,
-    port: null,
-    user: null,
-    pubkey: null,
-    hermes_exec: null,
-  };
 
   // Email-form state (F57).
   const [emailKey, setEmailKey] = useState("");
@@ -392,8 +388,10 @@ export default function ChannelsPage() {
           <TelegramCard />
 
           {/* Sir #8 — Terminal: SSH straight into the VM + `docker exec`
-              into Hermes for the chattiest, lowest-latency door. */}
-          <TerminalCard ssh={ssh} />
+              into Hermes for the chattiest, lowest-latency door. Sir
+              2026-05-26: card is fully self-contained — generate / paste /
+              revoke keys inline, no redirect to /study. */}
+          <TerminalCard />
         </div>
       </section>
     </Frame>
@@ -401,87 +399,74 @@ export default function ChannelsPage() {
 }
 
 // ---------------------------------------------------------------------------
-// Sir #8 — Terminal card (state derivation lives in terminalCardCore)
+// Sir #8 — Terminal card. Self-contained as of 2026-05-26: connect-commands
+// always shown, add-key (generate or paste) + revoke-key happen inline,
+// no redirect to /study. Backed by ctrl-api /api/v1/system/ssh-keys.
+// State derivation lives in terminalCardCore (pure, unit-tested).
 // ---------------------------------------------------------------------------
 
-export function TerminalCard({ ssh }: { ssh: SshInfo }) {
-  const { ready, sshTarget, hermesExec } = deriveTerminalCardState(ssh);
+const EMPTY_SSH_KEYS: SshKeys = {
+  host: "",
+  port: 22,
+  user: "root",
+  container: "alfred-black-hermes-1",
+  exec_command: "docker exec -it alfred-black-hermes-1 hermes",
+  keys: [],
+};
+
+export function TerminalCard() {
+  const { data: keysData, refetch } = useQuery(listSshKeys, undefined, {
+    retry: false,
+  });
+  const data: SshKeys = (keysData as SshKeys | undefined) ?? EMPTY_SSH_KEYS;
+  const view = deriveTerminalCardStateV2(data);
+  const rows = toKeyRows(data.keys);
 
   return (
     <ChannelCard
       name="Terminal"
-      address={ready ? sshTarget : "Set up your SSH key first"}
+      address={view.sshTarget || "Connect once your VM has a domain"}
       note="The shortest path: SSH in and talk to Hermes directly."
-      status={ready ? "active" : "available"}
+      status={view.status}
     >
-      {ready ? (
-        <div className="mt-5 space-y-5">
-          <PubkeyBlock pubkey={ssh.pubkey!} />
-          <ConnectBlock hermesExec={hermesExec} />
-          <p
-            className="font-body italic text-[12px]"
-            style={{ color: "var(--marginalia)" }}
-          >
-            Add the key above to your <code>~/.ssh/authorized_keys</code>{" "}
-            (already done if you provisioned this VM), then SSH in and run
-            the command above to talk to Alfred directly.
-          </p>
-        </div>
-      ) : (
-        <div className="mt-5">
-          <p
-            className="font-body italic text-[13px]"
-            style={{ color: "var(--marginalia)" }}
-          >
-            No SSH key on file for this instance yet. Set one up in{" "}
-            <Link to="/study#credentials" className="btn-link">
-              Study › Credentials
-            </Link>
-            , then come back — the card will fill in automatically.
-          </p>
-        </div>
-      )}
+      <div className="mt-5 space-y-6">
+        <CommandRow
+          label="SSH in"
+          command={view.sshCommand}
+          hint="From your laptop, once the key below is on this VM."
+        />
+        <CommandRow
+          label="Then talk to Alfred"
+          command={view.hermesExec}
+          hint="Run inside the VM — drops you into Hermes' chat REPL."
+        />
+
+        <KeyList rows={rows} onRevoke={refetch} />
+
+        <AddKeyBlock
+          keygenCommand={view.sshKeygenCommand}
+          onAdded={refetch}
+        />
+      </div>
     </ChannelCard>
   );
 }
 
-function PubkeyBlock({ pubkey }: { pubkey: string }) {
-  // The href is rebuilt every render but it's tiny (< 4KB) and React only
-  // re-mounts the anchor when the pubkey changes, so this is cheap. The
-  // Blob URL is leaked on unmount, which is fine for a card-sized control.
-  const href =
-    typeof window !== "undefined" && typeof Blob !== "undefined"
-      ? URL.createObjectURL(new Blob([pubkey], { type: "text/plain" }))
-      : "";
-  return (
-    <div>
-      <div
-        className="font-mono text-[10px] uppercase tracking-[0.22em] mb-2"
-        style={{ color: "var(--marginalia)" }}
-      >
-        Public key
-      </div>
-      <pre
-        className="font-mono text-[11px] border border-rule p-3 whitespace-pre-wrap break-all max-h-32 overflow-y-auto"
-        style={{ color: "var(--ink)" }}
-      >
-        {pubkey}
-      </pre>
-      <a
-        href={href}
-        download="alfred-ssh-key.pub"
-        className="btn-ghost mt-2 inline-block"
-      >
-        Download key
-      </a>
-    </div>
-  );
-}
-
-function ConnectBlock({ hermesExec }: { hermesExec: string }) {
+// One-line copyable command block. Used for both SSH + docker exec.
+function CommandRow({
+  label,
+  command,
+  hint,
+}: {
+  label: string;
+  command: string;
+  hint?: string;
+}) {
   const [copied, setCopied] = useState(false);
+  const disabled = !command;
   const copy = () => {
-    navigator.clipboard?.writeText(hermesExec);
+    if (disabled) return;
+    navigator.clipboard?.writeText(command);
     setCopied(true);
     setTimeout(() => setCopied(false), 1500);
   };
@@ -491,19 +476,337 @@ function ConnectBlock({ hermesExec }: { hermesExec: string }) {
         className="font-mono text-[10px] uppercase tracking-[0.22em] mb-2"
         style={{ color: "var(--marginalia)" }}
       >
-        Connect to Alfred
+        {label}
       </div>
       <div className="flex items-center gap-2">
         <code
           className="flex-1 font-mono text-[12px] border border-rule p-2 truncate"
           style={{ color: "var(--ink)" }}
         >
-          {hermesExec}
+          {command || "—"}
         </code>
-        <button onClick={copy} className="btn-ghost">
+        <button onClick={copy} disabled={disabled} className="btn-ghost">
           {copied ? "Copied" : "Copy"}
         </button>
       </div>
+      {hint && (
+        <p
+          className="font-body italic text-[11px] mt-1"
+          style={{ color: "var(--marginalia)" }}
+        >
+          {hint}
+        </p>
+      )}
+    </div>
+  );
+}
+
+// Installed-keys list. Bootstrap rows render with a 🔒 and no Revoke.
+function KeyList({
+  rows,
+  onRevoke,
+}: {
+  rows: ReturnType<typeof toKeyRows>;
+  onRevoke: () => Promise<unknown>;
+}) {
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function doRevoke(fingerprint: string) {
+    setBusy(fingerprint);
+    setError(null);
+    try {
+      await revokeSshKey({ fingerprint });
+      await onRevoke();
+    } catch (e: any) {
+      setError(e?.message || "Failed to revoke key");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div>
+      <div
+        className="font-mono text-[10px] uppercase tracking-[0.22em] mb-2"
+        style={{ color: "var(--marginalia)" }}
+      >
+        Keys on this VM
+      </div>
+      {rows.length === 0 ? (
+        <p
+          className="font-body italic text-[13px]"
+          style={{ color: "var(--marginalia)" }}
+        >
+          None yet. Add one below — generate a fresh keypair or paste your
+          existing public key.
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {rows.map((r) => (
+            <li
+              key={r.fingerprint}
+              className="grid grid-cols-[auto_1fr_auto] gap-3 items-baseline border border-rule p-2"
+            >
+              <span className="font-mono text-[10px]" style={{ color: "var(--marginalia)" }}>
+                {r.type.replace(/^ssh-/, "")}
+              </span>
+              <div className="min-w-0">
+                <code className="block font-mono text-[11px] truncate" style={{ color: "var(--ink)" }}>
+                  {r.fingerprint}
+                </code>
+                <span
+                  className="block font-body italic text-[11px] truncate"
+                  style={{ color: "var(--marginalia)" }}
+                >
+                  {r.comment}
+                </span>
+              </div>
+              {r.bootstrap ? (
+                <span
+                  className="font-mono text-[10px] uppercase tracking-[0.18em]"
+                  style={{ color: "var(--marginalia)" }}
+                  title={r.lockReason}
+                >
+                  Bootstrap · locked
+                </span>
+              ) : (
+                <button
+                  onClick={() => doRevoke(r.fingerprint)}
+                  disabled={busy === r.fingerprint}
+                  className="btn-link"
+                >
+                  {busy === r.fingerprint ? "Revoking…" : "Revoke"}
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+      {error && (
+        <p
+          className="font-body italic text-[11px] mt-2"
+          style={{ color: "var(--brass)" }}
+        >
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+// Add-a-key block: Generate OR paste-your-own. The generate path opens
+// a modal-ish reveal in-card with a one-time download of the private
+// key; the paste path is plain validate + POST.
+function AddKeyBlock({
+  keygenCommand,
+  onAdded,
+}: {
+  keygenCommand: string;
+  onAdded: () => Promise<unknown>;
+}) {
+  const [busy, setBusy] = useState<"none" | "generate" | "paste">("none");
+  const [error, setError] = useState<string | null>(null);
+  const [pasted, setPasted] = useState("");
+  const [comment, setComment] = useState("");
+  const [generated, setGenerated] = useState<{
+    privateKey: string;
+    fingerprint: string;
+  } | null>(null);
+
+  const pasteIsValid = isProbablyValidPubkey(pasted);
+
+  async function doGenerate() {
+    setBusy("generate");
+    setError(null);
+    try {
+      const res: any = await addSshKey({
+        generate: true,
+        comment: comment.trim() || undefined,
+      });
+      if (!res?.private_key) {
+        throw new Error("Server returned no private key");
+      }
+      setGenerated({ privateKey: res.private_key, fingerprint: res.fingerprint });
+      setComment("");
+      await onAdded();
+    } catch (e: any) {
+      setError(e?.message || "Failed to generate key");
+    } finally {
+      setBusy("none");
+    }
+  }
+
+  async function doPaste() {
+    setBusy("paste");
+    setError(null);
+    try {
+      await addSshKey({ pubkey: pasted });
+      setPasted("");
+      await onAdded();
+    } catch (e: any) {
+      setError(e?.message || "Failed to add key");
+    } finally {
+      setBusy("none");
+    }
+  }
+
+  // After a successful generate, show the one-time private-key reveal
+  // INSTEAD of the form. The user dismisses it; we don't retain.
+  if (generated) {
+    return (
+      <GeneratedKeyReveal
+        privateKey={generated.privateKey}
+        fingerprint={generated.fingerprint}
+        onDismiss={() => setGenerated(null)}
+      />
+    );
+  }
+
+  return (
+    <div>
+      <div
+        className="font-mono text-[10px] uppercase tracking-[0.22em] mb-2"
+        style={{ color: "var(--marginalia)" }}
+      >
+        Add a key
+      </div>
+
+      {/* Generate path */}
+      <div className="space-y-2 mb-4">
+        <div className="flex gap-2 items-baseline">
+          <input
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+            placeholder="Label (optional, e.g. 'laptop')"
+            className="flex-1 bg-transparent border border-rule px-2 py-1 font-mono text-[12px]"
+          />
+          <button
+            onClick={doGenerate}
+            disabled={busy !== "none"}
+            className="btn-ghost"
+          >
+            {busy === "generate" ? "Generating…" : "Generate new key"}
+          </button>
+        </div>
+        <p
+          className="font-body italic text-[11px]"
+          style={{ color: "var(--marginalia)" }}
+        >
+          Creates an ed25519 keypair on this VM. You'll get one chance to
+          download the private half — we don't keep it.
+        </p>
+      </div>
+
+      {/* Or paste path */}
+      <div
+        className="font-mono text-[10px] uppercase tracking-[0.18em] mb-2 mt-4"
+        style={{ color: "var(--marginalia)" }}
+      >
+        — or paste an existing public key —
+      </div>
+      <div className="space-y-2">
+        <textarea
+          value={pasted}
+          onChange={(e) => setPasted(e.target.value)}
+          placeholder="ssh-ed25519 AAAAC3Nz... user@laptop"
+          rows={3}
+          className="w-full bg-transparent border border-rule px-2 py-1 font-mono text-[11px]"
+        />
+        <div className="flex items-baseline justify-between gap-2">
+          <p
+            className="font-body italic text-[11px]"
+            style={{ color: "var(--marginalia)" }}
+          >
+            Or run on your laptop first:{" "}
+            <code className="font-mono">{keygenCommand}</code>
+          </p>
+          <button
+            onClick={doPaste}
+            disabled={busy !== "none" || !pasted.trim() || !pasteIsValid}
+            className="btn-ghost shrink-0"
+          >
+            {busy === "paste" ? "Adding…" : "Add this key"}
+          </button>
+        </div>
+        {pasted.trim() && !pasteIsValid && (
+          <p
+            className="font-body italic text-[11px]"
+            style={{ color: "var(--brass)" }}
+          >
+            That doesn't look like an OpenSSH public-key line.
+          </p>
+        )}
+      </div>
+
+      {error && (
+        <p
+          className="font-body italic text-[12px] mt-3"
+          style={{ color: "var(--brass)" }}
+        >
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+// One-time reveal of a freshly-generated private key. Dismissed → gone
+// from the UI; the server never stored it. Browsers may keep the Blob
+// URL in memory until the tab closes, which is acceptable here (single-
+// owner VM, single-tab session).
+function GeneratedKeyReveal({
+  privateKey,
+  fingerprint,
+  onDismiss,
+}: {
+  privateKey: string;
+  fingerprint: string;
+  onDismiss: () => void;
+}) {
+  const href =
+    typeof window !== "undefined" && typeof Blob !== "undefined"
+      ? URL.createObjectURL(
+          new Blob([privateKey], { type: "application/x-pem-file" }),
+        )
+      : "";
+  const filename = `alfred-${fingerprint.replace(/^SHA256:/, "").slice(0, 10)}`;
+  return (
+    <div className="border border-rule p-4 space-y-3">
+      <div
+        className="font-mono text-[10px] uppercase tracking-[0.22em]"
+        style={{ color: "var(--brass)" }}
+      >
+        Your new private key — download now
+      </div>
+      <p
+        className="font-body italic text-[12px]"
+        style={{ color: "var(--marginalia)" }}
+      >
+        This will not be shown again. Save the file, then{" "}
+        <code className="font-mono">chmod 600 ~/Downloads/{filename}</code>{" "}
+        and use it with <code className="font-mono">ssh -i &lt;path&gt;</code>.
+      </p>
+      <pre
+        className="font-mono text-[10px] border border-rule p-3 whitespace-pre-wrap break-all max-h-40 overflow-y-auto"
+        style={{ color: "var(--ink)" }}
+      >
+        {privateKey}
+      </pre>
+      <div className="flex items-baseline gap-3">
+        <a href={href} download={filename} className="btn-ghost">
+          Download {filename}
+        </a>
+        <button onClick={onDismiss} className="btn-link">
+          I've saved it — dismiss
+        </button>
+      </div>
+      <p
+        className="font-body text-[11px]"
+        style={{ color: "var(--marginalia)" }}
+      >
+        Fingerprint: <code className="font-mono">{fingerprint}</code>
+      </p>
     </div>
   );
 }

--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -134,6 +134,58 @@ export const getSshInfo = async (_args: unknown, context: any) => {
   return proxyToTenant(instance, { path: "/api/v1/system/ssh-info" });
 };
 
+// Self-contained Terminal card (Sir 2026-05-26). Three ops, all proxied
+// to ctrl-api under /api/v1/system/ssh-keys.
+//
+//   listSshKeys   → { host, port, user, container, exec_command,
+//                     keys: [{ fingerprint, type, comment, bootstrap }] }
+//   addSshKey     → { pubkey?: string }            BYO pubkey path
+//                  | { generate: true, comment? }  server-side keygen
+//                  → 201 { ok, fingerprint, type, comment, private_key? }
+//                  private_key only on generate, NEVER stored
+//   revokeSshKey  → { fingerprint }
+//                  → 200 { ok, revoked }
+//                  refused (409) if fingerprint is the bootstrap key
+export const listSshKeys = async (_args: unknown, context: any) => {
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, { path: "/api/v1/system/ssh-keys" });
+};
+
+export const addSshKey = async (
+  args: { pubkey?: string; generate?: boolean; comment?: string },
+  context: any,
+) => {
+  const instance = await getUserInstance(context);
+  const body: Record<string, unknown> = {};
+  if (args?.generate) body.generate = true;
+  if (typeof args?.pubkey === "string" && args.pubkey.trim()) {
+    body.pubkey = args.pubkey.trim();
+  }
+  if (typeof args?.comment === "string" && args.comment.trim()) {
+    body.comment = args.comment.trim();
+  }
+  return proxyToTenant(instance, {
+    method: "POST",
+    path: "/api/v1/system/ssh-keys",
+    body,
+  });
+};
+
+export const revokeSshKey = async (
+  args: { fingerprint: string },
+  context: any,
+) => {
+  if (typeof args?.fingerprint !== "string" || !args.fingerprint.trim()) {
+    throw new HttpError(400, "fingerprint required");
+  }
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    method: "POST",
+    path: "/api/v1/system/ssh-keys/revoke",
+    body: { fingerprint: args.fingerprint.trim() },
+  });
+};
+
 // Lane III — Telegram channel on /channels. Backed by Lane I's ctrl-api
 // endpoints under /api/v1/channels/telegram/*. Shape:
 //   getTelegramChannelStatus → { configured, bot_handle, state, error,

--- a/packages/web/src/dashboard/terminalCardCore.ts
+++ b/packages/web/src/dashboard/terminalCardCore.ts
@@ -1,6 +1,10 @@
 // terminalCardCore — pure shape derivation for the /channels Terminal
-// card (Sir #8). Import-free (no React/Wasp) so it unit-tests under
-// node:test the same way hermesHealthCore / apiKeysCore do.
+// card. Import-free (no React/Wasp) so it unit-tests under node:test
+// alongside hermesHealthCore / apiKeysCore.
+//
+// The card now uses /api/v1/system/ssh-keys (rich list — used by the
+// self-contained card UX) as its primary source. /ssh-info stays for
+// back-compat (legacy SshInfo shape).
 
 export interface SshInfo {
   hostname: string | null;
@@ -8,6 +12,22 @@ export interface SshInfo {
   user: string | null;
   pubkey: string | null;
   hermes_exec: string | null;
+}
+
+export interface InstalledSshKey {
+  fingerprint: string;
+  type: string;
+  comment: string;
+  bootstrap: boolean;
+}
+
+export interface SshKeys {
+  host: string;
+  port: number;
+  user: string;
+  container: string;
+  exec_command: string;
+  keys: InstalledSshKey[];
 }
 
 // Fallback when ctrl-api hasn't backfilled hermes_exec yet — the Hermes
@@ -29,4 +49,73 @@ export function deriveTerminalCardState(ssh: SshInfo): TerminalCardState {
       : ssh.hostname || "";
   const hermesExec = ssh.hermes_exec || DEFAULT_HERMES_EXEC;
   return { ready, sshTarget, hermesExec };
+}
+
+// Self-contained card derivation (Sir 2026-05-26): SshKeys → the strings
+// the card actually renders. `status` follows the cross-card convention:
+//   * active     — at least one key on file (we can SSH in)
+//   * available  — file is parsable but empty (fresh VM, no bootstrap)
+export interface TerminalCardStateV2 {
+  status: "active" | "available";
+  sshTarget: string;
+  hermesExec: string;
+  sshCommand: string;
+  /** Canonical `ssh-keygen` line the card surfaces under "First time?". */
+  sshKeygenCommand: string;
+  hasBootstrap: boolean;
+  installedCount: number;
+}
+
+export function deriveTerminalCardStateV2(data: SshKeys): TerminalCardStateV2 {
+  const sshTarget =
+    data.user && data.host
+      ? `${data.user}@${data.host}${data.port && data.port !== 22 ? ` -p ${data.port}` : ""}`
+      : data.host || "";
+  const sshCommand = sshTarget ? `ssh ${sshTarget}` : "";
+  const hermesExec = data.exec_command || DEFAULT_HERMES_EXEC;
+  // Comment ties the key on the user's disk back to the tenant.
+  const comment = data.host ? `alfred-${data.host}` : "alfred";
+  const sshKeygenCommand = `ssh-keygen -t ed25519 -C '${comment}'`;
+  const hasBootstrap = data.keys.some((k) => k.bootstrap);
+  const installedCount = data.keys.length;
+  return {
+    status: installedCount > 0 ? "active" : "available",
+    sshTarget,
+    hermesExec,
+    sshCommand,
+    sshKeygenCommand,
+    hasBootstrap,
+    installedCount,
+  };
+}
+
+/** A line for the keys list. Bootstrap rows render with a 🔒 + no
+ *  Revoke button; everything else gets a Revoke link. */
+export interface KeyRowDisplay {
+  fingerprint: string;
+  type: string;
+  comment: string;
+  bootstrap: boolean;
+  /** Tooltip / aria-label text — explains why bootstrap is locked. */
+  lockReason?: string;
+}
+
+export function toKeyRows(keys: InstalledSshKey[]): KeyRowDisplay[] {
+  return keys.map((k) => ({
+    fingerprint: k.fingerprint,
+    type: k.type,
+    comment: k.comment || "(no comment)",
+    bootstrap: k.bootstrap,
+    lockReason: k.bootstrap
+      ? "Bootstrap key — installed when the VM was provisioned. Revoke it over SSH directly if you really mean to."
+      : undefined,
+  }));
+}
+
+/** Strict client-side validation for a pasted pubkey. Mirrors the
+ *  server's PUBKEY_INPUT_RE so we 400 early without a round-trip. */
+export function isProbablyValidPubkey(s: string): boolean {
+  return /^(ssh-ed25519|ssh-rsa|ecdsa-sha2-nistp(?:256|384|521)|sk-ssh-ed25519@openssh\.com)\s+[A-Za-z0-9+/=]{20,}(?:\s+\S.*)?$/.test(
+    s.trim(),
+  );
 }


### PR DESCRIPTION
Sir 2026-05-26 — the Terminal card's empty state pointed at `/study › credentials`, which doesn't actually have an SSH setup UI; that turned the card into a dead end. The card now does the job itself.

## Before / after

**Before** — empty state was a paragraph telling the user to leave the page and "set one up in Study › Credentials". Study › Credentials has no SSH UI. Dead end.

**After** — connect commands always visible, an installed-keys list with inline revoke, and an "Add a key" block that either generates a fresh ed25519 keypair on the VM (one-time private-key download) or accepts a pasted public key.

```
┌─ Terminal ─────────────────  Connected ─┐
│ root@home.alfred.black                  │
│ The shortest path: SSH in...            │
│                                         │
│ SSH IN                                  │
│  $ ssh root@home.alfred.black    [Copy] │
│ THEN TALK TO ALFRED                     │
│  $ docker exec -it ...hermes-1 hermes   │
│                                  [Copy] │
│                                         │
│ KEYS ON THIS VM                         │
│  ed25519  SHA256:…  david@mac           │
│                          Bootstrap·🔒   │
│  ed25519  SHA256:…  laptop              │
│                              [Revoke]   │
│                                         │
│ ADD A KEY                               │
│  [ label (optional) ]  [ Generate ]     │
│  Creates an ed25519 keypair on this VM. │
│  You'll get one chance to download…     │
│  — or paste an existing public key —    │
│  [ ssh-ed25519 AAAAC3… user@laptop  ]   │
│  Or run on your laptop first:           │
│   ssh-keygen -t ed25519 -C 'alfred-…'   │
│                            [Add this k] │
└─────────────────────────────────────────┘
```

## Backend (ctrl-api)

Three new routes under `/api/v1/system/`:

| Method | Path | Body | Returns |
|---|---|---|---|
| GET    | `/ssh-keys` | – | `{host, port, user, container, exec_command, keys:[{fingerprint, type, comment, bootstrap}]}` |
| POST   | `/ssh-keys` | `{pubkey}` *or* `{generate:true, comment?}` | `201 {ok, fingerprint, type, comment, private_key?}` |
| POST   | `/ssh-keys/revoke` | `{fingerprint}` | `200 {ok, revoked}` |

Backed by `/root/.ssh/authorized_keys` (now bind-mounted **RW** into ctrl-api; `ssh-keygen` baked into the image via `openssh-client`).

- The **first usable line is the "bootstrap" key** — the API refuses to revoke it, so the operator can't lock themselves out from the UI. Revoke that one over SSH directly.
- `generate=true` creates the keypair in a `mkdtemp` dir, appends pubkey to `authorized_keys`, returns the private key **once** (never persisted on the server).
- Pasted pubkeys are validated against the strict OpenSSH shape; `authorized_keys` options (`command="…"`, `from="…"`, …) are **rejected on user input** as a privilege-escalation surface.
- Idempotent on blob — same key 409s rather than double-adding.
- Atomic write (sibling tmp + rename, with EBUSY fallback for Docker's bind-mounted-single-file case).
- `/api/v1/system/ssh-info` is unchanged in shape.

## Frontend (Wasp + React)

Three new operations (`listSshKeys` / `addSshKey` / `revokeSshKey`) proxied to the routes above. TerminalCard rewritten to surface always-visible connect rows, an installed-keys list with bootstrap lockout, and an Add-a-key block with the dual Generate / Paste paths and a one-time private-key reveal pane after generate.

`terminalCardCore` gets a v2 derivation + a pasted-pubkey client validator that mirrors ctrl-api's server regex so we 400 early without a round-trip. The v1 `deriveTerminalCardState` is kept exported for any other consumer.

## Tests

- Existing `GET /ssh-info` tests still pass (4/4).
- New `tests/ssh_keys.test.ts` pins the full CRUD: list shape, bootstrap flag, paste path (incl. malformed reject, options reject, duplicate 409), generate path (skipped where ssh-keygen isn't on PATH), revoke (incl. bootstrap lockout, unknown-fingerprint 404, missing-field 400), and a round-trip add → list → revoke. **13/13 green here, 1 skip when ssh-keygen is absent.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)