### PR TITLE
fix(hermes): teach the Slack adapter about HTML attachments

### DIFF
--- a/packages/hermes/Dockerfile
+++ b/packages/hermes/Dockerfile
@@ -98,6 +98,57 @@ RUN pip install --no-cache-dir \
     && hermes --version || true
 
 # =============================================================================
+# Patch: teach the Slack adapter (and base SUPPORTED_DOCUMENT_TYPES) about
+# HTML attachments. Upstream Hermes drops .html/.htm uploads silently —
+# they're not in the whitelist at gateway/platforms/base.py:SUPPORTED_DOCUMENT_TYPES,
+# so the Slack adapter's else-branch hits `continue` and the file never
+# reaches the agent. Same gap on Telegram & Discord adapters by inheritance.
+#
+# Two edits, applied in-place to the pip-installed copy of the gateway
+# package:
+#   1. base.py — add .html/.htm with text/html mime
+#   2. slack.py — add .html/.htm to TEXT_INJECT_EXTENSIONS so small HTML
+#                 (≤100KB) gets inlined as text rather than just attached
+#
+# The patch is idempotent + verifies post-edit (the `grep -q` lines fail
+# the build if the needle drifts between Hermes releases). When we bump
+# HERMES_REF, those greps will catch any upstream rename and we can
+# either re-author the patch or drop it (if upstream finally accepts HTML).
+#
+# Sir 2026-05-26 — local-only durable fix for an upstream Hermes bug.
+RUN set -eux \
+ && python3 -c "$(cat <<'PY'
+import pathlib, sys
+def patch(path, needle, insertion, label):
+    p = pathlib.Path(path)
+    src = p.read_text()
+    if '\".html\"' in src and '\".htm\"' in src:
+        print(f'{label}: already patched, skipping')
+        return
+    if needle not in src:
+        print(f'{label}: NEEDLE_NOT_FOUND in {path}; Hermes upstream may have moved this hunk', file=sys.stderr)
+        sys.exit(2)
+    p.write_text(src.replace(needle, insertion, 1))
+    print(f'{label}: patched')
+
+patch(
+    '/usr/local/lib/python3.12/site-packages/gateway/platforms/base.py',
+    '    \".zip\": \"application/zip\",',
+    '    \".html\": \"text/html\",\n    \".htm\": \"text/html\",\n    \".zip\": \"application/zip\",',
+    'base.py:SUPPORTED_DOCUMENT_TYPES',
+)
+patch(
+    '/usr/local/lib/python3.12/site-packages/gateway/platforms/slack.py',
+    '                        \".yaml\", \".yml\", \".toml\", \".ini\", \".cfg\",',
+    '                        \".yaml\", \".yml\", \".toml\", \".ini\", \".cfg\",\n                        \".html\", \".htm\",',
+    'slack.py:TEXT_INJECT_EXTENSIONS',
+)
+PY
+)" \
+ && grep -q '"\.html": "text/html"' /usr/local/lib/python3.12/site-packages/gateway/platforms/base.py \
+ && grep -q '"\.html", "\.htm"' /usr/local/lib/python3.12/site-packages/gateway/platforms/slack.py
+
+# =============================================================================
 # Bake the hermes-lcm plugin (lossless cross-session context engine).
 # =============================================================================
 # The `stephenschoettler/hermes-lcm` plugin enables Hermes' LCM context engine


### PR DESCRIPTION
Sir DM'd Alfred an HTML file via Slack 2026-05-26 — the file never reached the agent and there was no error on either side. Root cause: upstream Hermes silently drops `.html` / `.htm` uploads.

## Root cause

`/usr/local/lib/python3.12/site-packages/gateway/platforms/base.py:815` (inside the upstream `hermes-agent` package):

```python
SUPPORTED_DOCUMENT_TYPES = {
    ".pdf": "application/pdf",
    ".md":  "text/markdown",
    ".txt": "text/plain",
    ".csv": "text/csv",
    ".log": "text/plain",
    ".json": "application/json",
    ".xml":  "application/xml",
    ".yaml": ".yml": ".toml": ".ini": ".cfg":
    ".zip": ".docx": ".xlsx": ".pptx":
    # no .html / .htm
}
```

`gateway/platforms/slack.py:~2119`:

```python
if ext not in SUPPORTED_DOCUMENT_TYPES:
    continue  # Skip unsupported file types silently
```

HTML extension → not in the whitelist → `continue` → no log line, no warning, no attachment for the agent.

## Fix

Build-time patch inside `packages/hermes/Dockerfile`, right after the `pip install hermes-agent`:

1. `base.py` — add `.html` / `.htm` to `SUPPORTED_DOCUMENT_TYPES` with `text/html` mime
2. `slack.py` — add `.html` / `.htm` to `TEXT_INJECT_EXTENSIONS` so HTML ≤100 KB inlines as text into the prompt instead of just being attached as a media URL

```dockerfile
RUN set -eux \
 && python3 -c "$(cat <<'PY'
import pathlib, sys
def patch(path, needle, insertion, label):
    p = pathlib.Path(path)
    src = p.read_text()
    if '\".html\"' in src and '\".htm\"' in src:
        print(f'{label}: already patched, skipping'); return
    if needle not in src:
        print(f'{label}: NEEDLE_NOT_FOUND', file=sys.stderr); sys.exit(2)
    p.write_text(src.replace(needle, insertion, 1))
    print(f'{label}: patched')
...
PY
)" \
 && grep -q '\"\.html\": \"text/html\"' ...base.py \
 && grep -q '\"\.html\", \"\.htm\"' ...slack.py
```

The patch is:

- **Idempotent** — re-applies cleanly across rebuilds with the same HERMES_REF.
- **Tripwire'd** — when we bump HERMES_REF, the `grep -q` lines fail the build if the upstream needle moved. We re-author the patch (or drop it if upstream finally accepts HTML).
- **Build-time, not runtime** — no init hook, no monkey-patch at boot. The image just ships correct.

Same fix benefits Telegram/Discord adapters too, since they share `SUPPORTED_DOCUMENT_TYPES`. The TEXT_INJECT_EXTENSIONS edit is Slack-specific.

## Verification

Ran the patch script in a throwaway container off the current `:latest` image:

```
base.py: patched
slack.py: patched
--- POST-PATCH base.py ---
828:    \".html\": \"text/html\",
829:    \".htm\": \"text/html\",
--- POST-PATCH slack.py ---
2142:                    TEXT_INJECT_EXTENSIONS = {
2145:                        \".html\", \".htm\",
2147:                    if ext in TEXT_INJECT_EXTENSIONS and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
```

Hot-patched `home.alfred.black` already so the bug is unblocked while CI rebuilds. Once CI ships `:latest`, a `docker compose pull hermes && up -d --no-deps hermes` on each tenant makes it durable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)