### PR TITLE
fix(hermes): teach the Slack adapter about HTML attachments

### DIFF
--- a/packages/hermes/Dockerfile
+++ b/packages/hermes/Dockerfile
@@ -104,49 +104,16 @@ RUN pip install --no-cache-dir \
 # so the Slack adapter's else-branch hits `continue` and the file never
 # reaches the agent. Same gap on Telegram & Discord adapters by inheritance.
 #
-# Two edits, applied in-place to the pip-installed copy of the gateway
-# package:
-#   1. base.py — add .html/.htm with text/html mime
-#   2. slack.py — add .html/.htm to TEXT_INJECT_EXTENSIONS so small HTML
-#                 (≤100KB) gets inlined as text rather than just attached
-#
-# The patch is idempotent + verifies post-edit (the `grep -q` lines fail
-# the build if the needle drifts between Hermes releases). When we bump
-# HERMES_REF, those greps will catch any upstream rename and we can
-# either re-author the patch or drop it (if upstream finally accepts HTML).
+# See patch_upstream_hermes.py for the full rationale; the script is
+# idempotent and tripwire'd so a future HERMES_REF bump that moves the
+# upstream needle fails the build loudly.
 #
 # Sir 2026-05-26 — local-only durable fix for an upstream Hermes bug.
-RUN set -eux \
- && python3 -c "$(cat <<'PY'
-import pathlib, sys
-def patch(path, needle, insertion, label):
-    p = pathlib.Path(path)
-    src = p.read_text()
-    if '\".html\"' in src and '\".htm\"' in src:
-        print(f'{label}: already patched, skipping')
-        return
-    if needle not in src:
-        print(f'{label}: NEEDLE_NOT_FOUND in {path}; Hermes upstream may have moved this hunk', file=sys.stderr)
-        sys.exit(2)
-    p.write_text(src.replace(needle, insertion, 1))
-    print(f'{label}: patched')
-
-patch(
-    '/usr/local/lib/python3.12/site-packages/gateway/platforms/base.py',
-    '    \".zip\": \"application/zip\",',
-    '    \".html\": \"text/html\",\n    \".htm\": \"text/html\",\n    \".zip\": \"application/zip\",',
-    'base.py:SUPPORTED_DOCUMENT_TYPES',
-)
-patch(
-    '/usr/local/lib/python3.12/site-packages/gateway/platforms/slack.py',
-    '                        \".yaml\", \".yml\", \".toml\", \".ini\", \".cfg\",',
-    '                        \".yaml\", \".yml\", \".toml\", \".ini\", \".cfg\",\n                        \".html\", \".htm\",',
-    'slack.py:TEXT_INJECT_EXTENSIONS',
-)
-PY
-)" \
+COPY patch_upstream_hermes.py /tmp/patch_upstream_hermes.py
+RUN python3 /tmp/patch_upstream_hermes.py \
  && grep -q '"\.html": "text/html"' /usr/local/lib/python3.12/site-packages/gateway/platforms/base.py \
- && grep -q '"\.html", "\.htm"' /usr/local/lib/python3.12/site-packages/gateway/platforms/slack.py
+ && grep -q '"\.html", "\.htm"' /usr/local/lib/python3.12/site-packages/gateway/platforms/slack.py \
+ && rm /tmp/patch_upstream_hermes.py
 
 # =============================================================================
 # Bake the hermes-lcm plugin (lossless cross-session context engine).

--- a/packages/hermes/patch_upstream_hermes.py
+++ b/packages/hermes/patch_upstream_hermes.py
@@ -1,0 +1,89 @@
+"""In-place patch of the pip-installed Hermes gateway package, applied at
+image-build time inside packages/hermes/Dockerfile.
+
+Why this exists
+---------------
+Upstream NousResearch/hermes-agent silently drops HTML attachments on
+Slack (and any other channel that inherits SUPPORTED_DOCUMENT_TYPES from
+gateway/platforms/base.py). The Slack adapter's else-branch hits
+``continue`` when the file extension isn't in the whitelist, which means
+.html / .htm uploads never reach the agent — no error to the sender, no
+log line above DEBUG, no attachment for the LLM.
+
+This script teaches the whitelist about HTML, AND adds .html/.htm to
+slack.py's TEXT_INJECT_EXTENSIONS so a small HTML attachment (<=100 KB)
+is inlined into the prompt as text rather than just being attached as a
+media URL — the most useful default for things like saved emails or
+articles.
+
+Same gap exists for Telegram/Discord adapters by inheritance from
+base.py — the base.py edit fixes all of them. TEXT_INJECT_EXTENSIONS is
+Slack-specific.
+
+Idempotent + tripwire'd
+-----------------------
+Each edit checks for ".html" before patching and exits 0 if already
+done. If a future HERMES_REF bump moves the upstream needles, the script
+exits 2 — the Dockerfile then fails the build loudly rather than
+silently baking an unpatched image. When that happens, re-author the
+patch against the new shape, or drop the script entirely if upstream
+finally accepts HTML.
+
+Sir 2026-05-26 — local-only durable fix for an upstream Hermes bug.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+
+BASE_PY = "/usr/local/lib/python3.12/site-packages/gateway/platforms/base.py"
+SLACK_PY = "/usr/local/lib/python3.12/site-packages/gateway/platforms/slack.py"
+
+
+def patch(path: str, needle: str, replacement: str, label: str) -> None:
+    p = pathlib.Path(path)
+    src = p.read_text()
+    if '".html"' in src and '".htm"' in src:
+        print(f"{label}: already patched, skipping")
+        return
+    if needle not in src:
+        print(
+            f"{label}: NEEDLE_NOT_FOUND in {path} — upstream Hermes "
+            f"may have moved this hunk; re-author the patch.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    p.write_text(src.replace(needle, replacement, 1))
+    print(f"{label}: patched")
+
+
+def main() -> None:
+    # base.py — add .html / .htm right before .zip in SUPPORTED_DOCUMENT_TYPES.
+    patch(
+        BASE_PY,
+        '    ".zip": "application/zip",',
+        (
+            '    ".html": "text/html",\n'
+            '    ".htm": "text/html",\n'
+            '    ".zip": "application/zip",'
+        ),
+        "base.py:SUPPORTED_DOCUMENT_TYPES",
+    )
+
+    # slack.py — add .html / .htm to TEXT_INJECT_EXTENSIONS so HTML <=100KB
+    # inlines as text into the prompt.
+    patch(
+        SLACK_PY,
+        '                        ".yaml", ".yml", ".toml", ".ini", ".cfg",',
+        (
+            '                        ".yaml", ".yml", ".toml", ".ini", ".cfg",\n'
+            '                        ".html", ".htm",'
+        ),
+        "slack.py:TEXT_INJECT_EXTENSIONS",
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Sir DM'd Alfred an HTML file via Slack 2026-05-26 — file never reached the agent, no error on either side. Root cause: upstream Hermes silently drops `.html` / `.htm` uploads.

Re-do of #61 (which hit a Dockerfile-parser bug on the inlined Python heredoc — `RUN python3 -c "$(cat <<PY ...)"` confused BuildKit). This version moves the patch to its own file + `COPY + RUN`, which both passes the parser and reads cleaner.

## What it does

Build-time edit of the pip-installed Hermes gateway package:

1. `base.py` — add `.html` / `.htm` to `SUPPORTED_DOCUMENT_TYPES` with `text/html` mime. Same fix benefits Telegram / Discord by inheritance.
2. `slack.py` — add `.html` / `.htm` to `TEXT_INJECT_EXTENSIONS` so HTML ≤100 KB inlines as text into the prompt instead of just attaching as a media URL.

Logic lives in `packages/hermes/patch_upstream_hermes.py` (self-documented). Invoked as:

```dockerfile
COPY patch_upstream_hermes.py /tmp/patch_upstream_hermes.py
RUN python3 /tmp/patch_upstream_hermes.py \
 && grep -q '"\.html": "text/html"' .../base.py \
 && grep -q '"\.html", "\.htm"' .../slack.py \
 && rm /tmp/patch_upstream_hermes.py
```

The script is **idempotent** (skips if already patched) and **tripwire'd**: if a future HERMES_REF bump moves either upstream needle, the script exits 2 and the build fails — so we can't silently ship an unpatched image.

## Verification

Earlier validated the patch logic in a throwaway container off the current `:latest` image (it patched `.html` / `.htm` into both files at the expected positions). `home.alfred.black` already hot-patched by the same logic; this PR makes it durable across `docker compose pull`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)