### PR TITLE
fix(paperclip): probe /sign-in (200) not / (403)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1259,11 +1259,12 @@ services:
   # — unlike Sure/Plane — there is NO separate paperclip-db sidecar.
   # All state lives in the paperclip_data volume.
   #
-  # Healthcheck: Paperclip's docs do not document /api/health (verified
-  # 2026-05-26 at docs.paperclip.ing + github.com/paperclipai/paperclip),
-  # so we probe the web UI root with wget. If a future Paperclip release
-  # ships /api/health, switch to `curl -fsS http://127.0.0.1:3100/api/health`
-  # for a tighter liveness signal.
+  # Healthcheck: Paperclip's docs do not document /api/health and the web
+  # root (/) returns 403 to unauthenticated visits (better-auth rejects
+  # before the React shell renders). The unauthed entry page /sign-in
+  # returns 200 and is the right "is the app up?" probe (verified
+  # 2026-05-26). If a future Paperclip release ships /api/health, switch
+  # to `curl -fsS http://127.0.0.1:3100/api/health` for a tighter signal.
   paperclip:
     image: ghcr.io/paperclipai/paperclip@sha256:711d29717855abbd84d0e576a0a07daff8e9007a229fb8220d8203d492e886e4
     restart: unless-stopped
@@ -1279,7 +1280,7 @@ services:
     volumes:
       - paperclip_data:/paperclip
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3100/ >/dev/null 2>&1 || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3100/sign-in >/dev/null 2>&1 || exit 1"]
       interval: 15s
       timeout: 5s
       retries: 30

--- a/packages/ctrl/src/api/routes/apps.ts
+++ b/packages/ctrl/src/api/routes/apps.ts
@@ -73,16 +73,21 @@ export function registerAppsRoutes(): void {
 
     // Paperclip — the company simulation (paperclip.ing). Alfred runs as
     // a "managed employee" here; the principal sees companies / employees
-    // / issues / boards. Always-on per Sir 2026-05-26. Healthcheck probes
-    // the web UI root because Paperclip's docs don't document /api/health
-    // yet — same fallback Lane V uses for the container healthcheck.
+    // / issues / boards. Always-on per Sir 2026-05-26.
+    //
+    // Health probe: /sign-in (Paperclip's unauthenticated entry page,
+    // returns 200). The web-root '/' returns 403 — better-auth rejects
+    // unauthed visits before the React shell renders — which would
+    // misread as 'down' even on a perfectly healthy box. /sign-in is the
+    // semantic 'is the app up?' probe (verified 2026-05-26 against
+    // ghcr.io/paperclipai/paperclip@sha256:711d29717..).
     checks.push(
       (async (): Promise<InstalledApp> => ({
         id: "paperclip",
         name: "Paperclip",
         url: `https://paperclip.${domain}`,
         icon: "/app-icons/paperclip.svg",
-        status: await checkHealth("http://paperclip:3100/"),
+        status: await checkHealth("http://paperclip:3100/sign-in"),
       }))(),
     );
 


### PR DESCRIPTION
Followup to #63. After deploying P0 to home.alfred.black, the container shows healthy but ctrl-api's /apps probe reports paperclip as 'down'. Reason: Paperclip's `/` returns 403 (better-auth rejects unauthed visits before the React shell renders), and ctrl-api's `fetch(...).ok` correctly interprets that as not-up. The docker healthcheck happened to pass because `wget -qO-` without `-S` exits 0 on certain 4xx responses — a less strict probe that misled us.

`/sign-in` is the unauthenticated entry page; returns 200 unauth, verified against the deployed image. Both probes now use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)