### PR TITLE
fix(paperclip): paperclipCardCore.test.ts typecheck-clean (cast via unknown)

### DIFF
--- a/packages/web/src/dashboard/paperclipCardCore.test.ts
+++ b/packages/web/src/dashboard/paperclipCardCore.test.ts
@@ -175,19 +175,23 @@ test("derive: null status (no data yet) → missing_secret with empty fields", (
 });
 
 test("derive: malformed recent_runs entry is dropped or normalised", () => {
+  // The runtime normaliser must survive garbage from the wire — null entries,
+  // strings instead of objects, unknown status enums, non-numeric durations.
+  // Tests must cast through `unknown` because the statically-typed shape
+  // forbids this on purpose; the *whole point* is that the runtime defends
+  // against an API that has drifted.
   const card = derivePaperclipCardState(
     {
       ...BASE,
       has_signing_secret: true,
       last_heartbeat_at: isoMinutesAgo(1),
-      // @ts-expect-error — intentionally mixed shape for the runtime normaliser
       recent_runs: [
         null,
         "not-an-object",
         { run_id: "ok", paperclip_agent_id: "a", task_id: "t", ts: "", status: "ok", duration_ms: 100 },
-        // bad status string → normalises to "ok"
+        // bad status string → normalises to "ok"; non-numeric duration → 0
         { run_id: "bs", paperclip_agent_id: "a", task_id: "t2", ts: "", status: "blew_up", duration_ms: "fast" },
-      ],
+      ] as unknown as PaperclipStatus["recent_runs"],
     },
     FROZEN_NOW,
   );


### PR DESCRIPTION
Hot-fix for build-web failure on #68 — TS2578 unused-@ts-expect-error + TS2322 type errors in the malformed-runs test. Cast through unknown instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
