### PR TITLE
fix(hermes): bake openai SDK Codex response.output=None patch

### DIFF
--- a/packages/hermes/Dockerfile
+++ b/packages/hermes/Dockerfile
@@ -116,6 +116,25 @@ RUN python3 /tmp/patch_upstream_hermes.py \
  && rm /tmp/patch_upstream_hermes.py
 
 # =============================================================================
+# Patch: handle response.output=None in the openai SDK's streaming parser.
+# 2026-05-27 OpenAI changed Codex's streaming shape — response snapshots
+# during response.output_item.added now carry output=None instead of [].
+# The SDK's parse_response() crashes with 'NoneType' object is not
+# iterable at openai/lib/_parsing/_responses.py:61, taking down every
+# Hermes-main turn using openai-codex. One-line fix: `for output in
+# (response.output or []):`. See patch_openai_sdk.py for the full
+# rationale; the script is idempotent and tripwire'd so a future openai
+# SDK bump that moves or fixes this line fails the build loudly.
+#
+# Sir 2026-05-27 — local-only durable fix for an upstream openai SDK
+# bug exposed by an OpenAI backend contract change.
+COPY packages/hermes/patch_openai_sdk.py /tmp/patch_openai_sdk.py
+RUN python3 /tmp/patch_openai_sdk.py \
+ && grep -q 'for output in (response.output or \[\]):' \
+        /usr/local/lib/python3.12/site-packages/openai/lib/_parsing/_responses.py \
+ && rm /tmp/patch_openai_sdk.py
+
+# =============================================================================
 # Bake the hermes-lcm plugin (lossless cross-session context engine).
 # =============================================================================
 # The `stephenschoettler/hermes-lcm` plugin enables Hermes' LCM context engine

--- a/packages/hermes/patch_openai_sdk.py
+++ b/packages/hermes/patch_openai_sdk.py
@@ -1,0 +1,67 @@
+"""In-place patch of the pip-installed openai Python SDK, applied at
+image-build time inside packages/hermes/Dockerfile.
+
+Why this exists
+---------------
+2026-05-27 OpenAI changed the streaming response shape on their Codex
+backend (`https://chatgpt.com/backend-api/codex/responses`). During the
+`response.output_item.added` event, the snapshot the SDK accumulates now
+carries `output: None` instead of `output: []`. The SDK's response parser
+at `openai/lib/_parsing/_responses.py:61` then crashes with:
+
+    for output in response.output:
+    TypeError: 'NoneType' object is not iterable
+
+…and every Hermes-main turn using `openai-codex` provider fails with
+"Non-retryable client error: 'NoneType' object is not iterable". The
+agent has no fallback configured, so the user gets a 36-char error
+message on every channel.
+
+Hermes' own code in `run_agent.py:7142` already knows how to backfill an
+empty `final_response.output` from the streamed event items + collected
+text deltas — the SDK just needs to stop crashing in the snapshot
+accumulator before that backfill can run.
+
+This patch is one line: `for output in (response.output or []):`.
+Idempotent (skips if already patched) + tripwire'd (fails the build if a
+future openai SDK bump moves the line — at which point we re-author or
+drop the patch).
+
+Sir 2026-05-27 — local-only durable fix for an upstream openai SDK bug
+exposed by an OpenAI backend change.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+
+RESPONSES_PY = (
+    "/usr/local/lib/python3.12/site-packages/openai/lib/_parsing/_responses.py"
+)
+NEEDLE = "    for output in response.output:"
+REPLACEMENT = "    for output in (response.output or []):"
+SENTINEL = "(response.output or [])"
+
+
+def main() -> None:
+    p = pathlib.Path(RESPONSES_PY)
+    src = p.read_text()
+    if SENTINEL in src:
+        print(f"openai/_parsing/_responses.py: already patched, skipping")
+        return
+    if NEEDLE not in src:
+        print(
+            "openai/_parsing/_responses.py: NEEDLE_NOT_FOUND — openai SDK may "
+            "have moved or fixed this. Re-author the patch (or drop it if "
+            "fixed upstream).",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    p.write_text(src.replace(NEEDLE, REPLACEMENT, 1))
+    print("openai/_parsing/_responses.py: patched")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**OpenAI silently broke their own Codex streaming API tonight (2026-05-27 ~03:16 UTC).** During `response.output_item.added` events the response snapshot now carries `output: None` instead of `output: []`. The openai Python SDK 2.24.0's parser at `_parsing/_responses.py:61` does `for output in response.output:` and crashes with `'NoneType' object is not iterable`. Every Hermes-main turn using `openai-codex` provider failed; Sir saw a 36-char error message on every channel.

## Reproduced minimally

```python
from openai import OpenAI
client = OpenAI(api_key=token, base_url="https://chatgpt.com/backend-api/codex")
with client.responses.stream(model="gpt-5.5", instructions="...", input=[...], store=False) as stream:
    for event in stream: pass   # crashes here
# TypeError: 'NoneType' object is not iterable
#   at openai/lib/_parsing/_responses.py:61
```

## Fix

One-line edit in the SDK's response parser:

```python
-    for output in response.output:
+    for output in (response.output or []):
```

Hermes' own `run_agent.py:7142` already knows how to backfill an empty `final_response.output` from streamed event items + collected text deltas — the SDK just needs to stop crashing in the snapshot accumulator before that runs.

## Layout (mirrors the HTML-attachment patch from #62)

- `packages/hermes/patch_openai_sdk.py` — self-documented Python script. Idempotent (skips if already patched) + tripwire'd (exits 2 if the upstream needle moves, failing the build loudly).
- `packages/hermes/Dockerfile` — `COPY + RUN` right after the existing Hermes patch, with a post-condition `grep -q` that fails the build if the patched line isn't present.

## Verified

- Dry-run against current `ssdavidai00/alfred-black-hermes:latest`: patch applies cleanly, idempotent second-run skips.
- Hot-patch applied to home.alfred.black already (sed + pyc drop + hermes-main restart). Live since 03:40 UTC; no NoneType errors since.

## Not in scope

- Upstream issue at `openai/openai-python` — Sir's call: local-only durable fix is sufficient. Will revisit if the contract change persists in future SDK releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)