### PR TITLE
fix(hermes): pin max_tokens=8192 on every profile's openrouter model

### DIFF
--- a/packages/hermes/hermes-config.yaml.njk
+++ b/packages/hermes/hermes-config.yaml.njk
@@ -64,6 +64,22 @@ model:
 {%- endif %}
   provider: "openrouter"
   base_url: "https://openrouter.ai/api/v1"
+  # Per-request output-token ceiling.
+  #
+  # OpenRouter's affordability gate reserves `max_tokens × upstream-output
+  # cost` before billing. With the default (unset → model max ≈ 65 536) on
+  # gpt-5.5, the reservation exceeds the typical $50–100 credit floor and
+  # OpenRouter returns 402 ("can only afford N tokens of 65 536 requested")
+  # before the request ever runs. 8 192 is well above any chore or chat
+  # turn's real need, and small enough to stay under the reserve gate.
+  #
+  # When a profile is later flipped to `provider: openai-codex` this value
+  # is harmless — run_agent translates it via `_max_tokens_param()` into
+  # `max_completion_tokens` for direct-OpenAI / Codex endpoints.
+  #
+  # Sir 2026-05-27 — see joe.alfred.black cdsk incident: tool routing died
+  # on this exact gate while the OpenRouter key still had $46 of credit.
+  max_tokens: 8192
 
 # =============================================================================
 # Agent behaviour


### PR DESCRIPTION
## Why

OpenRouter's affordability gate reserves `max_tokens × upstream-output cost` before billing each request. With `max_tokens` unset, hermes lets the SDK fall through to the model's max (≈ 65,536 on `gpt-5.5`), which makes the per-request reserve exceed the typical \$50–100 credit floor. OpenRouter then returns:

```
HTTP 402: This request requires more credits, or fewer max_tokens.
You requested up to 65536 tokens, but can only afford N.
```

…before the request ever runs.

This is the gate that:
- broke rj.alfred.black's 05:00 UTC morning briefing today (body written as the 402 string)
- killed joe.alfred.black's cdsk MCP tool routing today
- intermittently 402'd home.alfred.black's heavy LLM calls earlier this morning

…all while the shared OpenRouter key still had ~\$46 of credit. It's not a balance issue, it's a per-request reserve-shape issue.

## The fix

One line per branch in `hermes-config.yaml.njk` — set `max_tokens: 8192` on all three profiles' `model:` block. 8,192 is well above any real chore or chat turn need (this morning's heaviest `extract_facts_opus` emitted 5 output tokens) and small enough to stay under OpenRouter's gate.

When a profile is later flipped to `provider: openai-codex` (home + rj's workers + heavy are already there) the value is harmless: `run_agent._max_tokens_param()` translates it into `max_completion_tokens` for direct-OpenAI / Codex endpoints.

## Verification

Already proven live on joe (all 4 profiles) and rj (main on openrouter) via a hot config-yaml patch:
- 0 × HTTP 402 in 30+ minutes after the cap was in place
- A 200-tool gpt-5.5 routing call cost \$0.018 with most of the prompt cache-hit

Render-preserve tests (10/10) still pass.

## Rollout

1. Merge → CI builds `ssdavidai00/alfred-black-hermes:latest`.
2. On each tenant: `docker compose pull hermes && docker compose up -d hermes`.
3. Tenants that already have a manually edited `config.yaml` keep their values — `config.yaml` is operator-owned per `render_hermes.py:342-355`. New tenants get the safe default from this template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)