### PR TITLE
fix(reconciler): pick up INITIATED rows that Composio already confirms ACTIVE

### DIFF
--- a/packages/web/src/integrations/connectionRepo.ts
+++ b/packages/web/src/integrations/connectionRepo.ts
@@ -100,6 +100,34 @@ export async function markAutoConfigRunning(
 }
 
 /**
+ * Flip a row's `status` from whatever it was (typically `INITIATED`) to
+ * `ACTIVE`. Used by the reconciler when Composio's API confirms the
+ * connection is live but the inbound webhook never flipped our row.
+ *
+ * Intentionally narrow: this only writes `status` + `lastSyncedAt`, never
+ * touches `autoConfigState`. The reconciler still drives the auto-config
+ * lifecycle (running → configured | error) through the existing helpers.
+ */
+export async function markStatusActive(
+  delegate: Delegate,
+  userId: string,
+  connectionId: string,
+): Promise<void> {
+  const existing = await delegate.findUnique({
+    where: { connectionId },
+  });
+  if (!existing || existing.userId !== userId) return;
+  if (existing.status === "ACTIVE") return; // already there — no-op
+  await delegate.update({
+    where: { connectionId },
+    data: {
+      status: "ACTIVE",
+      lastSyncedAt: new Date(),
+    },
+  });
+}
+
+/**
  * Apply the auto-config result returned by the tenant's ctrl-api to the
  * SaaS row. Result shape is whatever integrations.ts:/auto-config returned
  * — see the inline `summary` object there.

--- a/packages/web/src/integrations/reconcileCore.test.ts
+++ b/packages/web/src/integrations/reconcileCore.test.ts
@@ -22,9 +22,18 @@ import assert from "node:assert/strict";
 import {
   buildPendingRowsWhere,
   reconcileBatch,
+  type ComposioConnectionSnapshot,
   type PendingRow,
   type ReconcileDeps,
 } from "./reconcileCore";
+
+// Stub that should never be called in tests whose row is already ACTIVE.
+// Wrapped in a factory so each test can assert independently whether it was
+// invoked. Tests that exercise the INITIATED→ACTIVE lift path supply their
+// own stub instead.
+function neverFetchComposio(): ComposioConnectionSnapshot {
+  throw new Error("fetchComposioConnection must not be called for ACTIVE rows");
+}
 
 // ---------------------------------------------------------------------------
 // Fakes
@@ -78,6 +87,9 @@ function makeRow(overrides: Partial<PendingRow> & {
     userId: overrides.userId ?? "user-david",
     connectionId: overrides.connectionId,
     toolkit: overrides.toolkit,
+    // Default ACTIVE so the existing tests preserve their prior semantics.
+    // INITIATED→ACTIVE coverage lives in its own block below.
+    status: overrides.status ?? "ACTIVE",
     autoConfigState: overrides.autoConfigState ?? "pending",
     lastSyncedAt: overrides.lastSyncedAt ?? new Date(0),
     // Single-VM: no per-user instance — the reconciler always hits the one
@@ -121,6 +133,7 @@ test("reconcileBatch: fires auto-config on a pending ACTIVE row and flips it to 
         actions_count: 12,
       };
     },
+    fetchComposioConnection: async () => neverFetchComposio(),
   };
 
   const summary = await reconcileBatch(
@@ -165,6 +178,7 @@ test("reconcileBatch: marks the row 'error' when the tenant call rejects", async
     fetchAutoConfig: async () => {
       throw new Error("tenant auto-config returned 502: bad gateway");
     },
+    fetchComposioConnection: async () => neverFetchComposio(),
   };
 
   const summary = await reconcileBatch(
@@ -222,6 +236,7 @@ test("reconcileBatch: respects the per-tick concurrency cap", async () => {
       inFlight--;
       return { stream_created: "x", actions_count: 0 };
     },
+    fetchComposioConnection: async () => neverFetchComposio(),
   };
 
   const rows = ids.map((i) =>
@@ -242,7 +257,9 @@ test("reconcileBatch: respects the per-tick concurrency cap", async () => {
 
 test("buildPendingRowsWhere: includes pending rows unconditionally", () => {
   const where = buildPendingRowsWhere(new Date("2026-04-29T10:00:00Z"), 5 * 60 * 1000);
-  assert.strictEqual(where.status, "ACTIVE");
+  // The reconciler now picks up ACTIVE + INITIATED rows (the latter so the
+  // safety net can catch webhooks that never fired).
+  assert.deepStrictEqual(where.status, { in: ["ACTIVE", "INITIATED"] });
   assert.ok(Array.isArray(where.OR));
   const pendingPredicate = where.OR.find((p: any) => p.autoConfigState === "pending");
   assert.ok(pendingPredicate, "must include `autoConfigState: pending`");
@@ -250,6 +267,16 @@ test("buildPendingRowsWhere: includes pending rows unconditionally", () => {
     Object.keys(pendingPredicate).length,
     1,
     "pending predicate should NOT carry a lastSyncedAt filter",
+  );
+});
+
+test("buildPendingRowsWhere: status filter accepts both ACTIVE and INITIATED", () => {
+  const where = buildPendingRowsWhere(new Date("2026-05-27T10:00:00Z"), 5 * 60 * 1000);
+  assert.ok(where.status?.in, "status must be an `in` filter, not an equality");
+  assert.ok(where.status.in.includes("ACTIVE"), "ACTIVE must remain in the filter");
+  assert.ok(
+    where.status.in.includes("INITIATED"),
+    "INITIATED must be in the filter so the safety net picks up rows where the webhook never fired (joe.alfred.black, 2026-05-27)",
   );
 });
 
@@ -265,4 +292,243 @@ test("buildPendingRowsWhere: error rows must be older than the backoff window", 
     expectedCutoff.getTime(),
     "error rows touched within the backoff window stay out of this tick",
   );
+});
+
+// ---------------------------------------------------------------------------
+// INITIATED → ACTIVE safety net
+//
+// Regression coverage for the joe.alfred.black incident (2026-05-27): the
+// inbound Composio webhook failed to flip the local row from INITIATED to
+// ACTIVE for 36 minutes while Composio's API was reporting ACTIVE the whole
+// time. The reconciler now consults Composio directly for INITIATED rows
+// and lifts the local row before continuing with auto-config.
+// ---------------------------------------------------------------------------
+
+test("reconcileBatch: INITIATED + Composio ACTIVE → lifts row to ACTIVE + fires auto-config", async () => {
+  const fakeRows: FakeRow[] = [{
+    connectionId: "ca_gmail_joe",
+    userId: "user-david",
+    toolkit: "gmail",
+    status: "INITIATED",                       // ← stuck — webhook never fired
+    autoConfigState: "pending",
+    autoConfigError: null,
+    autoConfiguredAt: null,
+    streamsCreated: 0,
+    toolsEnabled: 0,
+    skillName: null,
+    lastSyncedAt: new Date(0),
+  }];
+  const delegate = makeFakeDelegate(fakeRows);
+  const composioCalls: string[] = [];
+  const autoConfigCalls: string[] = [];
+
+  const deps: ReconcileDeps = {
+    delegate,
+    fetchComposioConnection: async (connectionId) => {
+      composioCalls.push(connectionId);
+      return { status: "ACTIVE" };             // Composio confirms truth
+    },
+    fetchAutoConfig: async (_instance, connectionId) => {
+      autoConfigCalls.push(connectionId);
+      return {
+        stream_created: "composio-gmail-gmail-fetch-emails",
+        skill_generated: "/skills/alfred-composio-gmail",
+        actions_count: 7,
+      };
+    },
+  };
+
+  const summary = await reconcileBatch(
+    [makeRow({ connectionId: "ca_gmail_joe", toolkit: "gmail", status: "INITIATED" })],
+    deps,
+  );
+
+  assert.deepStrictEqual(summary, {
+    attempted: 1,
+    configured: 1,
+    errored: 0,
+    skipped: 0,
+  });
+  assert.deepStrictEqual(composioCalls, ["ca_gmail_joe"], "Composio API queried once");
+  assert.deepStrictEqual(autoConfigCalls, ["ca_gmail_joe"], "auto-config fired exactly once");
+  const updated = delegate.rows.get("ca_gmail_joe")!;
+  assert.strictEqual(updated.status, "ACTIVE", "row lifted to ACTIVE");
+  assert.strictEqual(updated.autoConfigState, "configured");
+  assert.strictEqual(updated.toolsEnabled, 7);
+});
+
+test("reconcileBatch: INITIATED + Composio still INITIATED → skip, no autoconfig, no error", async () => {
+  const fakeRows: FakeRow[] = [{
+    connectionId: "ca_drive_joe",
+    userId: "user-david",
+    toolkit: "googledrive",
+    status: "INITIATED",
+    autoConfigState: "pending",
+    autoConfigError: null,
+    autoConfiguredAt: null,
+    streamsCreated: 0,
+    toolsEnabled: 0,
+    skillName: null,
+    lastSyncedAt: new Date(0),
+  }];
+  const delegate = makeFakeDelegate(fakeRows);
+  let autoConfigCalled = false;
+
+  const deps: ReconcileDeps = {
+    delegate,
+    fetchComposioConnection: async () => ({ status: "INITIATED" }),
+    fetchAutoConfig: async () => {
+      autoConfigCalled = true;
+      return {};
+    },
+  };
+
+  const summary = await reconcileBatch(
+    [makeRow({ connectionId: "ca_drive_joe", toolkit: "googledrive", status: "INITIATED" })],
+    deps,
+  );
+
+  assert.deepStrictEqual(summary, {
+    attempted: 1,
+    configured: 0,
+    errored: 0,
+    skipped: 1,
+  });
+  assert.strictEqual(autoConfigCalled, false, "auto-config must NOT fire while Composio is still INITIATED");
+  const row = delegate.rows.get("ca_drive_joe")!;
+  assert.strictEqual(row.status, "INITIATED", "row stays INITIATED");
+  assert.strictEqual(row.autoConfigState, "pending", "autoConfigState stays pending (no error mark)");
+  assert.strictEqual(row.autoConfigError, null, "no error string recorded — Composio simply hasn't completed OAuth yet");
+});
+
+test("reconcileBatch: INITIATED + Composio FAILED → skip, leave local row alone", async () => {
+  const fakeRows: FakeRow[] = [{
+    connectionId: "ca_calendar_joe",
+    userId: "user-david",
+    toolkit: "googlecalendar",
+    status: "INITIATED",
+    autoConfigState: "pending",
+    autoConfigError: null,
+    autoConfiguredAt: null,
+    streamsCreated: 0,
+    toolsEnabled: 0,
+    skillName: null,
+    lastSyncedAt: new Date(0),
+  }];
+  const delegate = makeFakeDelegate(fakeRows);
+  let autoConfigCalled = false;
+
+  const deps: ReconcileDeps = {
+    delegate,
+    fetchComposioConnection: async () => ({ status: "FAILED" }),
+    fetchAutoConfig: async () => {
+      autoConfigCalled = true;
+      return {};
+    },
+  };
+
+  const summary = await reconcileBatch(
+    [makeRow({ connectionId: "ca_calendar_joe", toolkit: "googlecalendar", status: "INITIATED" })],
+    deps,
+  );
+
+  assert.deepStrictEqual(summary, {
+    attempted: 1,
+    configured: 0,
+    errored: 0,
+    skipped: 1,
+  });
+  assert.strictEqual(autoConfigCalled, false);
+  const row = delegate.rows.get("ca_calendar_joe")!;
+  assert.strictEqual(row.status, "INITIATED", "do not mirror Composio's FAILED — the principal may retry OAuth");
+  assert.strictEqual(row.autoConfigState, "pending", "no error mark — the failure is on Composio's side");
+  assert.strictEqual(row.autoConfigError, null);
+});
+
+test("reconcileBatch: INITIATED + Composio returns null (transport/404) → skip cleanly", async () => {
+  const fakeRows: FakeRow[] = [{
+    connectionId: "ca_slack_joe",
+    userId: "user-david",
+    toolkit: "slack",
+    status: "INITIATED",
+    autoConfigState: "pending",
+    autoConfigError: null,
+    autoConfiguredAt: null,
+    streamsCreated: 0,
+    toolsEnabled: 0,
+    skillName: null,
+    lastSyncedAt: new Date(0),
+  }];
+  const delegate = makeFakeDelegate(fakeRows);
+  let autoConfigCalled = false;
+
+  const deps: ReconcileDeps = {
+    delegate,
+    fetchComposioConnection: async () => null,        // 404, network error, etc.
+    fetchAutoConfig: async () => {
+      autoConfigCalled = true;
+      return {};
+    },
+  };
+
+  const summary = await reconcileBatch(
+    [makeRow({ connectionId: "ca_slack_joe", toolkit: "slack", status: "INITIATED" })],
+    deps,
+  );
+
+  assert.strictEqual(summary.skipped, 1);
+  assert.strictEqual(summary.configured, 0);
+  assert.strictEqual(summary.errored, 0);
+  assert.strictEqual(autoConfigCalled, false);
+  const row = delegate.rows.get("ca_slack_joe")!;
+  assert.strictEqual(row.status, "INITIATED");
+  assert.strictEqual(row.autoConfigState, "pending");
+});
+
+test("reconcileBatch: ACTIVE row does NOT query Composio (cost-flat regression guard)", async () => {
+  // This is the existing common path. We re-pin it explicitly to lock in
+  // the invariant that the safety-net fetch only runs for INITIATED rows.
+  const fakeRows: FakeRow[] = [{
+    connectionId: "ca_gmail_active",
+    userId: "user-david",
+    toolkit: "gmail",
+    status: "ACTIVE",
+    autoConfigState: "pending",
+    autoConfigError: null,
+    autoConfiguredAt: null,
+    streamsCreated: 0,
+    toolsEnabled: 0,
+    skillName: null,
+    lastSyncedAt: new Date(0),
+  }];
+  const delegate = makeFakeDelegate(fakeRows);
+  let composioCalled = false;
+
+  const deps: ReconcileDeps = {
+    delegate,
+    fetchComposioConnection: async () => {
+      composioCalled = true;
+      return { status: "ACTIVE" };
+    },
+    fetchAutoConfig: async () => ({
+      stream_created: "composio-gmail-gmail-fetch-emails",
+      skill_generated: "/skills/alfred-composio-gmail",
+      actions_count: 4,
+    }),
+  };
+
+  const summary = await reconcileBatch(
+    [makeRow({ connectionId: "ca_gmail_active", toolkit: "gmail" })],
+    deps,
+  );
+
+  assert.strictEqual(summary.configured, 1);
+  assert.strictEqual(
+    composioCalled,
+    false,
+    "ACTIVE rows must NOT spend a Composio API call per tick — keeps the common-case cost flat",
+  );
+  const row = delegate.rows.get("ca_gmail_active")!;
+  assert.strictEqual(row.status, "ACTIVE");
+  assert.strictEqual(row.autoConfigState, "configured");
 });

--- a/packages/web/src/integrations/reconcileCore.ts
+++ b/packages/web/src/integrations/reconcileCore.ts
@@ -14,6 +14,7 @@ import {
   applyAutoConfigResult,
   markAutoConfigError,
   markAutoConfigRunning,
+  markStatusActive,
 } from "./connectionRepo";
 
 // Per-tick concurrency cap. We don't want to flood any one tenant with
@@ -32,11 +33,32 @@ export interface PendingRow {
   userId: string;
   connectionId: string;
   toolkit: string;
+  /**
+   * The local mirror of Composio's connection status. Historically the
+   * reconciler only looked at rows whose status was already `ACTIVE`, but
+   * the inbound webhook can silently fail to flip the row from `INITIATED`
+   * (see the joe.alfred.black incident, 2026-05-27 — Gmail sat at
+   * INITIATED for 36 minutes while Composio reported ACTIVE). The
+   * reconciler now picks up `INITIATED` rows too and resolves their
+   * status from Composio's API as ground truth.
+   */
+  status: string;
   autoConfigState: string;
   lastSyncedAt: Date;
   user: {
     id: string;
   };
+}
+
+/**
+ * Subset of the Composio `GET /api/v3/connected_accounts/{id}` response
+ * the reconciler needs. We only consume `status`; keeping the shape narrow
+ * makes the test stub trivial. `null` means "Composio replied with 404 or
+ * a transport error" — the reconciler treats those the same as "not yet
+ * ACTIVE" and lets the next tick try again.
+ */
+export interface ComposioConnectionSnapshot {
+  status: string;
 }
 
 export interface ReconcileDeps {
@@ -45,6 +67,16 @@ export interface ReconcileDeps {
     instance: PendingRowInstance,
     connectionId: string,
   ) => Promise<any>;
+  /**
+   * Fetch the live connection state from Composio. Only called for rows
+   * whose local status is `INITIATED` — the common ACTIVE case stays at
+   * one Composio fetch per tick (the auto-config call itself). Return
+   * `null` if Composio rejects the request or the network call fails; the
+   * reconciler will skip the row and retry on the next tick.
+   */
+  fetchComposioConnection: (
+    connectionId: string,
+  ) => Promise<ComposioConnectionSnapshot | null>;
   concurrency?: number;
 }
 
@@ -95,6 +127,60 @@ export async function reconcileOne(
   // gate — go straight to marking the row running and firing auto-config.
   const instance: PendingRowInstance = {};
 
+  // ───────────────────────────────────────────────────────────────────────
+  // INITIATED safety net.
+  //
+  // The inbound Composio webhook is supposed to flip the local row from
+  // INITIATED → ACTIVE the moment OAuth completes. When it doesn't (handler
+  // missing, request lost, header-validation throw, …) the row stays at
+  // INITIATED forever and the principal sees "still connecting…" while
+  // Composio shows the account as live.
+  //
+  // For rows the SaaS still has at INITIATED we ask Composio directly: if
+  // their API reports ACTIVE we flip the local row and continue with
+  // auto-config exactly as we would have if the webhook had fired. For
+  // anything else (still INITIATED, FAILED, EXPIRED, …) we leave the row
+  // alone and let the next tick try again. We do not mark `error`: the
+  // failure is on Composio's side, not the tenant's.
+  // ───────────────────────────────────────────────────────────────────────
+  if (row.status === "INITIATED") {
+    let snapshot: ComposioConnectionSnapshot | null;
+    try {
+      snapshot = await deps.fetchComposioConnection(row.connectionId);
+    } catch (err: any) {
+      console.info(
+        `[reconcileComposioAutoConfig] composio-status fetch failed for ${row.toolkit}/${row.connectionId} (will retry next tick): ${err?.message ?? err}`,
+      );
+      return { outcome: "skipped" };
+    }
+    if (!snapshot) {
+      console.info(
+        `[reconcileComposioAutoConfig] composio reports no row for ${row.toolkit}/${row.connectionId} (404 or transport error) — will retry next tick`,
+      );
+      return { outcome: "skipped" };
+    }
+    if (snapshot.status !== "ACTIVE") {
+      console.info(
+        `[reconcileComposioAutoConfig] ${row.toolkit}/${row.connectionId} still ${snapshot.status} on Composio's side — leaving local row at INITIATED`,
+      );
+      return { outcome: "skipped" };
+    }
+    // Composio's truth says ACTIVE. Flip the local row, then fall through
+    // to the existing auto-config path.
+    try {
+      await markStatusActive(deps.delegate, row.userId, row.connectionId);
+      console.info(
+        `[reconcileComposioAutoConfig] lifted ${row.toolkit}/${row.connectionId}: INITIATED → ACTIVE per Composio API`,
+      );
+    } catch (err: any) {
+      console.error(
+        `[reconcileComposioAutoConfig] markStatusActive failed for ${row.toolkit}/${row.connectionId}: ${err?.message ?? err}`,
+      );
+      // Treat as a skip — next tick will retry the lift.
+      return { outcome: "skipped" };
+    }
+  }
+
   try {
     await markAutoConfigRunning(deps.delegate, row.userId, row.connectionId);
   } catch (err) {
@@ -136,8 +222,11 @@ export async function reconcileOne(
  * reconciliation. Exported so the test can mirror the production query
  * predicate against the same fake-row inputs.
  *
- * - `status: "ACTIVE"` — Composio's truth. The reconciler only touches
- *   connections Composio reports as live.
+ * - `status in {ACTIVE, INITIATED}` — ACTIVE is the common case; INITIATED
+ *   covers the joe.alfred.black incident where the inbound webhook failed
+ *   to flip the row and Composio's API was the only source of truth.
+ *   `reconcileOne` consults Composio for INITIATED rows and lifts them
+ *   in-band before continuing to auto-config.
  * - `autoConfigState in {pending, error}` — `configured` rows are done,
  *   `running` rows are mid-flight from another caller.
  * - `error` rows additionally must be older than `errorBackoffMs` so we
@@ -146,7 +235,7 @@ export async function reconcileOne(
 export function buildPendingRowsWhere(now: Date, errorBackoffMs: number): any {
   const cutoff = new Date(now.getTime() - errorBackoffMs);
   return {
-    status: "ACTIVE",
+    status: { in: ["ACTIVE", "INITIATED"] },
     OR: [
       { autoConfigState: "pending" },
       {

--- a/packages/web/src/integrations/reconcileWorker.ts
+++ b/packages/web/src/integrations/reconcileWorker.ts
@@ -17,7 +17,7 @@
  *
  *   This job runs on a 1-minute cron (see main.wasp). For every
  *   ComposioConnection where:
- *     - Composio's truth is `status: ACTIVE`, AND
+ *     - Our SaaS row is `status in ('ACTIVE','INITIATED')`, AND
  *     - Our SaaS row is `autoConfigState in ('pending','error')`, AND
  *     - We haven't bounced off this row too recently (backoff for `error` rows),
  *   the reconciler calls the tenant ctrl-api's auto-config endpoint and
@@ -25,10 +25,19 @@
  *   `autoConfigIntegration` and `finalizeComposioConnections`. The job is
  *   idempotent — re-running it on a `configured` row is a no-op (filtered
  *   out by the autoConfigState predicate).
+ *
+ *   Webhook safety net (joe.alfred.black, 2026-05-27): for INITIATED rows
+ *   the reconciler ALSO queries Composio's API directly. If Composio
+ *   reports the connection as ACTIVE, the reconciler flips the local row
+ *   in-band and continues with auto-config exactly as it would after a
+ *   working webhook. If Composio reports anything else the row is left
+ *   alone (no error mark — the failure is upstream of us). The ACTIVE
+ *   common case spends zero Composio API calls per tick.
  */
 import {
   buildPendingRowsWhere,
   reconcileBatch,
+  type ComposioConnectionSnapshot,
   type PendingRow,
   type PendingRowInstance,
 } from "./reconcileCore";
@@ -36,6 +45,13 @@ import {
 // Single-VM: the auto-config reconciler always calls the one local ctrl-api.
 const CTRL_API_URL = process.env.CTRL_API_URL ?? "http://ctrl-api:3100";
 const CTRL_API_KEY = process.env.AAS_API_KEY ?? "";
+
+// Composio's REST API. Only consulted for rows whose local status is
+// INITIATED — the common ACTIVE-path stays at one outbound call per tick
+// (the tenant auto-config invocation itself).
+const COMPOSIO_API_V3 = "https://backend.composio.dev/api/v3";
+const COMPOSIO_API_KEY = process.env.COMPOSIO_API_KEY ?? "";
+const COMPOSIO_FETCH_TIMEOUT_MS = 10_000;
 
 // Don't re-fire on rows we just bounced off — Composio's OAuth handshake
 // can take seconds to settle into ACTIVE, and a tenant ctrl-api outage
@@ -64,9 +80,12 @@ export async function reconcileComposioAutoConfigJob(
     console.log('[WASP_DISABLE_JOBS] skipping reconcileComposioAutoConfigJob');
     return { attempted: 0, configured: 0, errored: 0, skipped: 0 };
   }
-  // Pull ACTIVE rows that need auto-config. Errored rows wait out the
-  // ERROR_BACKOFF_MS window via lastSyncedAt; pending rows go through
-  // immediately.
+  // Pull rows that need auto-config. `buildPendingRowsWhere` includes both
+  // ACTIVE rows and INITIATED rows — the latter so `reconcileOne` can
+  // catch the joe.alfred.black case where the inbound webhook never flipped
+  // the local row and Composio's API was the only source of truth.
+  // Errored rows wait out the ERROR_BACKOFF_MS window via lastSyncedAt;
+  // pending rows go through immediately.
   const rows: PendingRow[] = await context.entities.ComposioConnection.findMany({
     where: buildPendingRowsWhere(new Date(), ERROR_BACKOFF_MS),
     include: {
@@ -83,7 +102,61 @@ export async function reconcileComposioAutoConfigJob(
   return reconcileBatch(rows, {
     delegate: context.entities.ComposioConnection,
     fetchAutoConfig: callTenantAutoConfig,
+    fetchComposioConnection: fetchComposioConnection,
   });
+}
+
+/**
+ * GET `/api/v3/connected_accounts/{id}` on Composio's backend. Returns a
+ * narrow snapshot (status only — that's all the reconciler consumes), or
+ * `null` if the API rejects the request or the call fails for any reason.
+ *
+ * Errors are returned as `null` rather than thrown so the reconciler can
+ * cleanly skip the row without marking it `error` — the failure is in
+ * SaaS↔Composio land, not tenant↔ctrl-api land.
+ */
+async function fetchComposioConnection(
+  connectionId: string,
+): Promise<ComposioConnectionSnapshot | null> {
+  if (!COMPOSIO_API_KEY) {
+    console.error(
+      "[reconcileComposioAutoConfig] COMPOSIO_API_KEY is not set in the web container — cannot resolve INITIATED rows",
+    );
+    return null;
+  }
+  const url = `${COMPOSIO_API_V3}/connected_accounts/${encodeURIComponent(connectionId)}`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), COMPOSIO_FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      method: "GET",
+      headers: { "x-api-key": COMPOSIO_API_KEY },
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      // 404 / 403 / 5xx all collapse to null — the reconciler will retry
+      // next tick. Log to INFO so a busy tenant doesn't spam error logs.
+      console.info(
+        `[reconcileComposioAutoConfig] composio /connected_accounts/${connectionId} returned ${response.status}`,
+      );
+      return null;
+    }
+    const body = (await response.json()) as { status?: unknown };
+    if (typeof body?.status !== "string") {
+      console.info(
+        `[reconcileComposioAutoConfig] composio /connected_accounts/${connectionId} response had no string 'status' field`,
+      );
+      return null;
+    }
+    return { status: body.status };
+  } catch (err: any) {
+    console.info(
+      `[reconcileComposioAutoConfig] composio fetch for ${connectionId} failed: ${err?.message ?? err}`,
+    );
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 /**


### PR DESCRIPTION
## The incident

On 2026-05-27, joe.alfred.black's Gmail connection sat in `INITIATED` for **36 minutes** while Composio's API reported it as `ACTIVE` the whole time. The user clicked the OAuth button, granted scopes, was redirected back successfully — and then the dashboard showed "still connecting…" forever.

Root cause: the inbound Composio webhook had no handler on ctrl-api, so the `INITIATED → ACTIVE` flip in `ComposioConnection` never happened. The 1-minute reconciler `reconcileComposioAutoConfigJob` was supposed to be the safety net — but `buildPendingRowsWhere` in `packages/web/src/integrations/reconcileCore.ts` requires `status: "ACTIVE"`, so it skipped the row too. Chicken-and-egg.

## The fix

Widen the reconciler so Composio's API is the source of truth for `INITIATED` rows:

1. **`buildPendingRowsWhere`** now filters `status IN ('ACTIVE', 'INITIATED')` (was `status: "ACTIVE"`).
2. **`reconcileOne`** gets a new preamble: when `row.status === "INITIATED"`, it queries `GET /api/v3/connected_accounts/{id}` on Composio's backend.
   - Composio says `ACTIVE` → flip the local row via the new `markStatusActive` helper, then continue with the existing auto-config flow exactly as before.
   - Composio says anything else (`INITIATED`, `FAILED`, `EXPIRED`, network error, 404) → leave the row alone. No error mark, no auto-config call, no progress. Log at INFO.
3. **`ReconcileDeps`** gains `fetchComposioConnection` — same injection pattern as `fetchAutoConfig`, so the test can stub it.
4. The production `fetchComposioConnection` in `reconcileWorker.ts` uses `COMPOSIO_API_KEY` (already in every tenant's web-container env) and `x-api-key` auth. Errors collapse to `null` so the reconciler skips cleanly rather than marking the row errored — the failure is in SaaS↔Composio land, not tenant↔ctrl-api land.
5. **Cost stays flat in the common case** — ACTIVE rows take ZERO additional Composio API calls per tick. The preamble runs only for INITIATED rows.

## Coordination

Coordinated with the new ctrl-api `POST /api/v1/composio/webhook` handler (Agent A's PR). That handler is the **fast path** — flips the row inside the OAuth round-trip. This PR is the **polling safety net** — catches whatever the webhook missed. Both are wanted; they're not redundant.

## Tests

`packages/web/src/integrations/reconcileCore.test.ts`:

- **Existing 3 cases preserved** (ACTIVE pending → configured, tenant 5xx → error, concurrency cap=2) — regression guard for the common path.
- **`buildPendingRowsWhere` status filter** is now the `{in: [...]}` shape with both ACTIVE and INITIATED.
- **INITIATED + Composio ACTIVE** → row flipped to ACTIVE, auto-config called exactly once.
- **INITIATED + Composio INITIATED** → row stays INITIATED, auto-config NOT called, no error mark.
- **INITIATED + Composio FAILED** → row stays INITIATED, auto-config NOT called, no error mark.
- **INITIATED + Composio null** (404/transport) → skip cleanly, no error.
- **ACTIVE row does NOT query Composio** — explicit regression guard for cost-flatness.

All 11 tests pass under `tsx --test`.

## Deploy

CI's `build-web.yml` will rebuild `ssdavidai00/alfred-web:latest` on merge. After that I'll roll it to home, rj, joe, zsolt, miguel via `docker compose pull web && docker compose up -d web`. The reconcile cron runs every minute, so any stuck `INITIATED` row clears within ~120 s — the verification is "next OAuth click on any tenant lands in ACTIVE without manual intervention".

🤖 Generated with [Claude Code](https://claude.com/claude-code)