### PR TITLE
feat(paperclip): click-through setup card on /channels

### DIFF
--- a/packages/ctrl/src/api/routes/channels_paperclip.ts
+++ b/packages/ctrl/src/api/routes/channels_paperclip.ts
@@ -52,6 +52,7 @@
 
 import crypto from "node:crypto";
 import fs from "node:fs";
+import http from "node:http";
 import { addRoute } from "../server.js";
 import { sendJson, ValidationError, ApiError } from "../errors.js";
 import { getStateDb } from "../../db/state.js";
@@ -607,21 +608,227 @@ function recordAuthFailure(body: unknown, kind: "auth_failed" | "replay"): void 
   });
 }
 
+// ── Paperclip setup-state probe ───────────────────────────────────────────
+//
+// Paperclip's auto-bootstrap turned out to be a much bigger lift than the
+// integration was worth (Paperclip's `authenticated` mode requires a
+// CEO-invite ritual that touches multiple internal tables; `local_trusted`
+// mode needs additional config the container won't boot without). So the
+// /channels card carries the principal through Paperclip's own setup with
+// a polished click-through UX instead. Sir 2026-05-27.
+//
+// `setup_state` drives which sub-card the UI renders:
+//   * "needs_api_key"  — Paperclip is reachable but our PAPERCLIP_API_KEY
+//                        is blank → tell the principal to sign up at
+//                        paperclip.<DOMAIN>, then paste a Settings → API
+//                        keys value back here.
+//   * "configured"     — PAPERCLIP_API_KEY set and Paperclip accepts it
+//                        (probed: /api/companies returns 200, NOT 401/403).
+//   * "auth_failed"    — key set but Paperclip rejects → key likely
+//                        expired/revoked; prompt for a new one.
+//   * "unreachable"    — paperclip:3100 not responding → container down /
+//                        not deployed.
+type PaperclipSetupState =
+  | "needs_api_key"
+  | "configured"
+  | "auth_failed"
+  | "unreachable";
+
+const PAPERCLIP_URL = "http://paperclip:3100";
+
+async function probeSetupState(): Promise<PaperclipSetupState> {
+  const apiKey = process.env.PAPERCLIP_API_KEY?.trim();
+  // Paperclip's better-auth checks Host header against PAPERCLIP_PUBLIC_URL —
+  // same trusted-origins quirk apps.ts already handles. Use the public host.
+  const host = `paperclip.${
+    process.env.DOMAIN ?? process.env.TENANT_DOMAIN ?? "alfred.black"
+  }`;
+  // Reach the compose-internal address but spoof Host. Node fetch drops
+  // manual Host; fall back to node:http (same trick as apps.ts).
+  function probe(path: string, withAuth: boolean): Promise<number> {
+    return new Promise((resolve) => {
+      const headers: Record<string, string> = { Host: host };
+      if (withAuth && apiKey) headers.Authorization = `Bearer ${apiKey}`;
+      const req = http.request(
+        {
+          method: "GET",
+          hostname: "paperclip",
+          port: 3100,
+          path,
+          headers,
+          timeout: 3000,
+        },
+        (resp) => {
+          resp.resume();
+          resolve(resp.statusCode ?? 0);
+        },
+      );
+      req.on("error", () => resolve(0));
+      req.on("timeout", () => {
+        req.destroy();
+        resolve(0);
+      });
+      req.end();
+    });
+  }
+  if (!apiKey) {
+    // Confirm Paperclip is at least reachable before saying "needs key".
+    const ping = await probe("/sign-in", false);
+    if (ping === 0) return "unreachable";
+    return "needs_api_key";
+  }
+  const probed = await probe("/api/companies", true);
+  if (probed === 0) return "unreachable";
+  if (probed === 401 || probed === 403) return "auth_failed";
+  // 200 = configured. 404 etc. would be unexpected — treat as auth_failed
+  // so the UI prompts for a fresh key.
+  if (probed >= 200 && probed < 300) return "configured";
+  return "auth_failed";
+}
+
 // ── Routes ────────────────────────────────────────────────────────────────
 
 export function registerPaperclipChannelRoutes(): void {
   // GET /status — always 200; operator card needs every field populated.
+  // setup_state extends the original P2 contract (configured/has_signing_secret
+  // stay for back-compat); the card uses setup_state to drive the new
+  // click-through flow. paperclip_origin is the public URL the principal
+  // signs up at — pre-derived here so the card doesn't re-do hostname math.
   addRoute("GET", "/api/v1/channels/paperclip/status", async ({ res }) => {
     const configured = Boolean(process.env.PAPERCLIP_API_KEY);
     const hasSecret = Boolean(process.env.PAPERCLIP_HEARTBEAT_SECRET);
+    const setupState = await probeSetupState();
+    const domain =
+      process.env.DOMAIN ?? process.env.TENANT_DOMAIN ?? "alfred.black";
     sendJson(res, 200, {
       configured,
       heartbeat_url: heartbeatUrl(),
       has_signing_secret: hasSecret,
       last_heartbeat_at: lastHeartbeatAt,
       recent_runs: recentRuns.slice(),
+      setup_state: setupState,
+      paperclip_origin: `https://paperclip.${domain}`,
     });
   });
+
+  // POST /api-key — the principal pastes their freshly-generated Paperclip
+  // API key here. We validate it round-trips against Paperclip, then write
+  // it to BOTH locations Hermes reads:
+  //   * /srv/alfred-black/.env (== host /opt/alfred/.env) — durable across
+  //     re-init, the canonical operator-facing env file
+  //   * /hermes-state/profiles/main/.env — what the running Hermes gateway
+  //     reads at boot; we update this so a `docker compose restart hermes`
+  //     picks up the new key without waiting for a full init re-render
+  //
+  // Then we restart hermes-main's gateway process (via docker exec) so the
+  // paperclip MCP server picks up PAPERCLIP_API_KEY immediately. The full
+  // container doesn't need to restart — just the gateway.
+  addRoute(
+    "POST",
+    "/api/v1/channels/paperclip/api-key",
+    async ({ res, body }) => {
+      const b = (body ?? {}) as { api_key?: unknown };
+      if (typeof b.api_key !== "string" || !b.api_key.trim()) {
+        throw new ValidationError("api_key (string) is required");
+      }
+      const key = b.api_key.trim();
+      // Validate by round-tripping against Paperclip /api/companies.
+      const host = `paperclip.${
+        process.env.DOMAIN ?? process.env.TENANT_DOMAIN ?? "alfred.black"
+      }`;
+      const ok = await new Promise<boolean>((resolve) => {
+        const req = http.request(
+          {
+            method: "GET",
+            hostname: "paperclip",
+            port: 3100,
+            path: "/api/companies",
+            headers: { Host: host, Authorization: `Bearer ${key}` },
+            timeout: 5000,
+          },
+          (resp) => {
+            resp.resume();
+            const code = resp.statusCode ?? 0;
+            resolve(code >= 200 && code < 300);
+          },
+        );
+        req.on("error", () => resolve(false));
+        req.on("timeout", () => {
+          req.destroy();
+          resolve(false);
+        });
+        req.end();
+      });
+      if (!ok) {
+        throw new ApiError(
+          400,
+          "INVALID_KEY",
+          "Paperclip rejected this API key. Generate a new one in Paperclip → Settings → API keys and try again.",
+        );
+      }
+      // Atomic .env update — read existing, set/replace PAPERCLIP_API_KEY,
+      // write back. Mirrors the secret-set pattern used by other channel
+      // routes.
+      function upsertEnvKey(path: string, k: string, v: string): void {
+        let raw = "";
+        try {
+          raw = fs.readFileSync(path, "utf-8");
+        } catch {
+          // file may not exist on a partially-bootstrapped tenant —
+          // create it
+        }
+        const lines = raw.split("\n");
+        let found = false;
+        for (let i = 0; i < lines.length; i++) {
+          const t = lines[i].trim();
+          if (!t || t.startsWith("#")) continue;
+          const eq = t.indexOf("=");
+          if (eq < 0) continue;
+          if (t.slice(0, eq).trim() === k) {
+            lines[i] = `${k}=${v}`;
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          if (raw.length > 0 && !raw.endsWith("\n")) lines.push("");
+          lines.push(`${k}=${v}`);
+        }
+        const out = lines.join("\n");
+        fs.writeFileSync(path, out.endsWith("\n") ? out : out + "\n", {
+          mode: 0o600,
+        });
+      }
+      // 1. /opt/alfred/.env (durable)
+      upsertEnvKey("/srv/alfred-black/.env", "PAPERCLIP_API_KEY", key);
+      // 2. /hermes-state/profiles/main/.env (immediate)
+      upsertEnvKey(
+        `${process.env.HERMES_CONFIG_DIR ?? "/hermes-state/profiles"}/main/.env`,
+        "PAPERCLIP_API_KEY",
+        key,
+      );
+      // 3. process.env in this container so subsequent /status calls see
+      //    the new key without a restart.
+      process.env.PAPERCLIP_API_KEY = key;
+      // 4. Kick hermes-main's gateway process so the paperclip MCP server
+      //    re-spawns with the new key. Best-effort — if docker exec fails
+      //    (e.g. socket unmounted in dev), the principal can restart hermes
+      //    manually. We do not block on this.
+      try {
+        const { execSync } = await import("node:child_process");
+        execSync(
+          `docker exec alfred-black-hermes-1 pkill -f "main gateway run" || true`,
+          { stdio: "ignore", timeout: 5000 },
+        );
+      } catch {
+        /* best-effort */
+      }
+      sendJson(res, 200, {
+        ok: true,
+        setup_state: "configured" as PaperclipSetupState,
+      });
+    },
+  );
 
   // POST /heartbeat — Paperclip's HTTP adapter target. Public-facing; the
   // X-Paperclip-Signature header is the only auth. The route is registered

--- a/packages/web/main.wasp
+++ b/packages/web/main.wasp
@@ -780,6 +780,13 @@ action sendPaperclipTest {
   entities: []
 }
 
+// P3 — Paperclip setup: the principal pastes their generated API key here
+// and ctrl-api wires it into the runtime (Hermes + .env).
+action setPaperclipApiKey {
+  fn: import { setPaperclipApiKey } from "@src/dashboard/operations",
+  entities: []
+}
+
 // Lane III — Slack channel on /channels. Five ops backed by ctrl-api
 // /api/v1/channels/slack/*. Mirrors the Telegram op set; same shape.
 query getSlackChannelStatus {

--- a/packages/web/src/dashboard/ChannelsPage.tsx
+++ b/packages/web/src/dashboard/ChannelsPage.tsx
@@ -42,6 +42,7 @@ import {
   sendOmiTest,
   getPaperclipChannelStatus,
   sendPaperclipTest,
+  setPaperclipApiKey,
   updateCredentials,
 } from "wasp/client/operations";
 import { Frame } from "../client/components/ab/Frame";
@@ -2800,6 +2801,19 @@ function PaperclipCard() {
         </div>
       )}
 
+      {/* needs_api_key — Paperclip is up but the principal hasn't walked
+          its own setup ritual yet (P3). Two-click path: "Open Paperclip"
+          → they sign up + generate an API key → paste here. Once the
+          key validates, the card flips to "awaiting". */}
+      {card.status === "needs_api_key" && (
+        <PaperclipApiKeyPanel
+          paperclipOrigin={card.paperclipOrigin}
+          isReauth={card.pillLabel === "Key rejected"}
+          description={card.description}
+          onSaved={refetch}
+        />
+      )}
+
       {/* awaiting — secret set, no heartbeat yet. The webhook URL is the
           hero artifact: Sir pastes it into Paperclip's HTTP-adapter UI
           when creating the Alfred employee. */}
@@ -3048,5 +3062,146 @@ function PaperclipCard() {
         </div>
       )}
     </ChannelCard>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// P3 — Paperclip API-key paste panel.
+//
+// Rendered when card.status === "needs_api_key". Paperclip's authenticated
+// mode requires the principal to walk Paperclip's own first-run ritual
+// (CEO invite, signup, claim instance) — we can't auto-bootstrap because
+// the ritual writes through Paperclip's internal tables, not its REST API.
+// So the card guides the principal:
+//
+//   1. "Open Paperclip" button → paperclip.<DOMAIN> in a new tab.
+//   2. They sign up + complete Paperclip's setup.
+//   3. They generate an API key (Settings → API keys).
+//   4. They paste it back here; ctrl-api validates round-trip, writes
+//      PAPERCLIP_API_KEY into /opt/alfred/.env + the hermes profile's
+//      .env, and kicks hermes-main so the MCP server picks it up.
+//
+// On success the card auto-flips to "awaiting" (heartbeat URL ready to
+// paste into Paperclip's HTTP-adapter agent setup). Same one-time-paste
+// UX as the SSH-key "generate + download" panel.
+// ---------------------------------------------------------------------------
+
+function PaperclipApiKeyPanel({
+  paperclipOrigin,
+  isReauth,
+  description,
+  onSaved,
+}: {
+  paperclipOrigin: string;
+  isReauth: boolean;
+  description: string;
+  onSaved: () => Promise<unknown>;
+}) {
+  const [apiKey, setApiKey] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function save() {
+    const trimmed = apiKey.trim();
+    if (!trimmed) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const r: any = await setPaperclipApiKey({ api_key: trimmed });
+      if (r?.ok) {
+        setApiKey("");
+        await onSaved();
+      } else {
+        setError("Paperclip didn't accept that key. Try generating a fresh one.");
+      }
+    } catch (e: any) {
+      setError(e?.message ?? "Couldn't save the key. Check the ctrl-api logs.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="mt-5 space-y-5">
+      <p
+        className="font-body italic text-[13px]"
+        style={{ color: isReauth ? "var(--brass)" : "var(--marginalia)" }}
+      >
+        {description}
+      </p>
+
+      {!isReauth && (
+        <ol
+          className="space-y-2 font-body text-[13px]"
+          style={{ color: "var(--ink)" }}
+        >
+          <li>
+            <span style={{ color: "var(--marginalia)" }}>1.</span>{" "}
+            Open Paperclip and finish its first-run setup (sign up, claim
+            the instance).
+          </li>
+          <li>
+            <span style={{ color: "var(--marginalia)" }}>2.</span>{" "}
+            Inside Paperclip: <code className="font-mono">Settings →
+            API keys → Generate</code>.
+          </li>
+          <li>
+            <span style={{ color: "var(--marginalia)" }}>3.</span>{" "}
+            Paste the generated key below. Alfred takes it from there.
+          </li>
+        </ol>
+      )}
+
+      {paperclipOrigin && (
+        <a
+          href={paperclipOrigin}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="btn-ghost inline-block"
+        >
+          Open Paperclip →
+        </a>
+      )}
+
+      <div className="space-y-2">
+        <div
+          className="font-mono text-[10px] uppercase tracking-[0.22em]"
+          style={{ color: "var(--marginalia)" }}
+        >
+          Paste API key
+        </div>
+        <textarea
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          placeholder="pck_… (from Paperclip Settings → API keys)"
+          rows={2}
+          className="w-full bg-transparent border border-rule px-2 py-1 font-mono text-[11px]"
+        />
+        <div className="flex items-baseline justify-between gap-2">
+          <p
+            className="font-body italic text-[11px]"
+            style={{ color: "var(--marginalia)" }}
+          >
+            Alfred validates the key against Paperclip and only persists it
+            if it works.
+          </p>
+          <button
+            onClick={save}
+            disabled={busy || !apiKey.trim()}
+            className="btn-ghost shrink-0"
+          >
+            {busy ? "Validating…" : isReauth ? "Update key" : "Save & connect"}
+          </button>
+        </div>
+        {error && (
+          <p
+            className="font-body italic text-[12px]"
+            style={{ color: "var(--brass)" }}
+          >
+            {error}
+          </p>
+        )}
+      </div>
+    </div>
   );
 }

--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -284,6 +284,26 @@ export const sendPaperclipTest = async (_args: unknown, context: any) => {
   });
 };
 
+// P3 — operator pastes their freshly-generated Paperclip API key here.
+// ctrl-api validates round-trip against Paperclip, writes it to
+// /opt/alfred/.env + /hermes-state/profiles/main/.env, then kicks
+// hermes-main so the paperclip MCP server picks up the key without a
+// full container restart.
+export const setPaperclipApiKey = async (
+  args: { api_key: string },
+  context: any,
+) => {
+  if (typeof args?.api_key !== "string" || !args.api_key.trim()) {
+    throw new HttpError(400, "api_key required");
+  }
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    method: "POST",
+    path: "/api/v1/channels/paperclip/api-key",
+    body: { api_key: args.api_key.trim() },
+  });
+};
+
 // Lane III — Slack channel on /channels. Mirrors the Telegram op set; backed
 // by Lane I's ctrl-api endpoints under /api/v1/channels/slack/*. Shape:
 //   getSlackChannelStatus → { configured, state, error, workspace:{team,…},

--- a/packages/web/src/dashboard/paperclipCardCore.ts
+++ b/packages/web/src/dashboard/paperclipCardCore.ts
@@ -31,8 +31,20 @@
 
 export type PaperclipStatusState =
   | "missing_secret"
+  | "needs_api_key"
   | "awaiting"
   | "connected";
+
+// P3 — Paperclip's setup-state, probed by ctrl-api against paperclip:3100
+// (with the right Host header). See route comments in channels_paperclip.ts
+// for the four values. The card uses this to render the new sign-up + paste-
+// API-key sub-card when the principal hasn't completed Paperclip's own
+// onboarding ritual yet.
+export type PaperclipSetupState =
+  | "needs_api_key"
+  | "configured"
+  | "auth_failed"
+  | "unreachable";
 
 export type PaperclipRunStatus =
   | "ok"
@@ -56,6 +68,11 @@ export interface PaperclipStatus {
   has_signing_secret: boolean;
   last_heartbeat_at: string | null;
   recent_runs: PaperclipRun[];
+  /** P3 fields — present on /status responses ≥ P3. Older ctrl-api may
+   *  omit them; the card falls back to deriving from has_signing_secret +
+   *  last_heartbeat_at the old way (back-compat). */
+  setup_state?: PaperclipSetupState;
+  paperclip_origin?: string;
 }
 
 export interface PaperclipCardState {
@@ -202,6 +219,39 @@ export function derivePaperclipCardState(
     };
   }
 
+  // P3 — Paperclip's own setup ritual hasn't been walked yet. We can't
+  // auto-bootstrap Paperclip (it requires a CEO invite written through its
+  // own DB), so the card carries the principal through Paperclip's UI:
+  // "Open Paperclip → sign up → generate API key → paste it here". Once
+  // pasted, ctrl-api writes the key into the runtime and the card flips
+  // to "awaiting" (then "connected" once the first heartbeat arrives).
+  //
+  // setup_state is set by ctrl-api ≥ P3. When the upstream is older and
+  // omits the field, fall through to the legacy awaiting/connected path
+  // (PAPERCLIP_API_KEY was historically expected to be set manually
+  // before the card was first viewed).
+  if (s.setup_state === "needs_api_key" || s.setup_state === "auth_failed") {
+    const needsAuth = s.setup_state === "auth_failed";
+    return {
+      status: "needs_api_key",
+      pillLabel: needsAuth ? "Key rejected" : "Setup required",
+      pillTone: needsAuth ? "error" : "available",
+      heading: needsAuth
+        ? "Paperclip rejected the API key"
+        : "Finish Paperclip's setup",
+      description: needsAuth
+        ? "The saved key is no longer valid. Generate a new one in Paperclip → Settings → API keys, then paste it below."
+        : "Paperclip is reachable but Alfred can't talk to it yet. Two clicks: sign up in Paperclip, then paste an API key here.",
+      heartbeatUrl,
+      paperclipOrigin: s.paperclip_origin || paperclipOrigin,
+      canTest: false,
+      visibleRuns,
+      hasMoreRuns,
+      allRuns,
+      lastHeartbeatRelative,
+    };
+  }
+
   if (s.last_heartbeat_at === null || s.last_heartbeat_at === "") {
     return {
       status: "awaiting",
@@ -213,7 +263,7 @@ export function derivePaperclipCardState(
         "create the Alfred employee. Once Paperclip pings you, this card " +
         "lights up.",
       heartbeatUrl,
-      paperclipOrigin,
+      paperclipOrigin: s.paperclip_origin || paperclipOrigin,
       canTest: true,
       visibleRuns,
       hasMoreRuns,


### PR DESCRIPTION
## What

Closes the last manual step in Paperclip onboarding (P0/P1/P2 → #63-#69).
After this PR the principal **does not SSH and does not run `hermes mcp add`** to wire Paperclip — they paste an API key in the /channels card and Alfred takes it from there.

## The new flow

1. `/channels` Paperclip card calls `GET /api/v1/channels/paperclip/status`. ctrl-api probes `paperclip:3100` with the right `Host` header (the same trusted-origins quirk apps.ts handles) and returns `setup_state`:
   * `needs_api_key` — Paperclip is up but `PAPERCLIP_API_KEY` is blank
   * `configured` — key set, Paperclip's `/api/companies` returns 2xx
   * `auth_failed` — key set, Paperclip returns 401/403 (re-auth path)
   * `unreachable` — `paperclip:3100` not responding
2. Card renders the new `PaperclipApiKeyPanel`: "Open Paperclip →" button (deep-links to `paperclip.<DOMAIN>`) + a paste textarea + a "Save & connect" button.
3. Principal completes Paperclip's own first-run ritual (CEO invite → signup → claim instance — we can't auto-bootstrap because that path writes through Paperclip's internal tables, not its REST API), generates an API key in Settings → API keys, pastes it.
4. `POST /api/v1/channels/paperclip/api-key` **validates round-trip** by hitting Paperclip's `/api/companies` with the new key. Only persists if 2xx (401/403 → 400 `INVALID_KEY`).
5. On success, ctrl-api writes `PAPERCLIP_API_KEY` to **both** locations Hermes reads:
   * `/srv/alfred-black/.env` (== host `/opt/alfred/.env`) — durable across init re-renders
   * `/hermes-state/profiles/main/.env` — what the running gateway picks up at boot
   Then `docker exec`s a `pkill -f "main gateway run"` on hermes so the paperclip MCP server re-spawns with the new key without a full container restart.
6. Card flips to `awaiting` (heartbeat URL hero artifact ready to paste into Paperclip's HTTP-adapter agent setup), then `connected` on first heartbeat.

## Why no auto-bootstrap

Paperclip's first-run requires writing a CEO row + sending an invite email through its internal mailer. That's a multi-step ritual touching tables outside Paperclip's REST surface; doing it from Alfred would be brittle and a maintenance hazard tied to Paperclip's schema. Walking the principal through Paperclip's own UI is the right seam.

## UX shape

Same paste-and-save shape as the SSH-key "generate + download" panel — familiar idiom. The button label flips to "Update key" + the pill goes "Key rejected" tone when `setup_state=auth_failed`. Description copy is reauth-aware.

## Back-compat

`PaperclipStatus.setup_state` and `paperclip_origin` are optional on the TS type. Older ctrl-api builds that omit them fall through to the legacy `awaiting → connected` path unchanged. No client-side migration needed; deploy ctrl-api + web in either order.

## Tests

* ctrl: `tests/channels_paperclip.test.ts` — 18 tests across 4 suites stay green (HMAC validation, replay window, Hermes call shapes, ring buffer, alfred_journal writes, self-test path).
* web: `src/dashboard/paperclipCardCore.test.ts` — 12 tests stay green (state derivation across 3 visual states, origin swap, runs capping, malformed-status fallback, relative-time formatter).

## Deploy

After merge: `docker compose pull ctrl-api web web-client` on `home.alfred.black` (the only Paperclip tenant — joe doesn't run Paperclip per `paperclip-integration.md` memory), then `docker compose up -d ctrl-api web web-client`. The `web-client` container is non-optional — it serves the SPA and stale-UI bugs from forgetting it have bit before (memory: `web-client-deploy-gotcha`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)