### PR TITLE
fix(ctrl-api): handle Composio connected_account.updated webhooks (unblocks INITIATED→ACTIVE)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,18 @@ OPENROUTER_API_KEY=
 # Composio API key — third-party tool/integration connections.
 COMPOSIO_API_KEY=
 
+# Composio webhook signing secret — OPTIONAL. Configure the webhook on
+# Composio's dashboard pointing at
+#   https://${DOMAIN}/api/v1/composio/webhook
+# and paste the signing secret here. When set, ctrl-api enforces HMAC
+# verification (Standard-Webhooks scheme: webhook-id / webhook-timestamp /
+# webhook-signature headers; also tolerates `x-composio-signature` /
+# `sha256=<hex>` as a fallback). When unset, ctrl-api accepts unsigned
+# webhooks with a loud WARN — strictly so the connected_account.updated
+# → ACTIVE flip still unblocks onboarding on tenants that haven't rotated
+# in a secret yet. Set this in production.
+COMPOSIO_WEBHOOK_SECRET=
+
 # ════════════════════════════════════════════════════════════════════
 # USER MUST FILL — optional. Leave blank to disable the feature.
 # ════════════════════════════════════════════════════════════════════

--- a/packages/ctrl/src/api/routes/composioWebhook.ts
+++ b/packages/ctrl/src/api/routes/composioWebhook.ts
@@ -1,0 +1,476 @@
+// Composio inbound webhook receiver — flips a local ComposioConnection row
+// from INITIATED → ACTIVE the moment Composio confirms the OAuth exchange.
+//
+// The incident this fixes
+// -----------------------
+// On joe.alfred.black (2026-05-27) Composio finished authenticating Gmail
+// on their side, but our local ComposioConnection row stuck at status=
+// INITIATED for ~36 minutes. The existing 1-minute reconciler
+// (`reconcileComposioAutoConfigJob` → `buildPendingRowsWhere`, web side)
+// only acts on rows that already have status="ACTIVE" — chicken-and-egg.
+// Composio HAD attempted a webhook, and ctrl-api logged the inbound as
+//
+//     POST /api/v1/composio/webhook 401 0ms
+//
+// — the 401 was the global auth middleware seeing no Bearer header and
+// rejecting before any route lookup, because no route was registered.
+// This file is that route.
+//
+// What it does
+// ------------
+// On a `connected_account.updated` event with `data.status === "ACTIVE"`,
+// POST to the web side's internal /webhook/composio/finalize endpoint with
+// `Authorization: Bearer ${AAS_API_KEY}` (the shared secret already in
+// both containers). Web flips the Prisma row's `status` from INITIATED to
+// ACTIVE; the existing 1-min reconciler then picks it up on its next tick
+// and runs the actual auto-config side-effects. We do NOT touch
+// autoConfigState — that's the reconciler's lane.
+//
+// Why ctrl-api and not web
+// ------------------------
+// ctrl-api owns the public webhook surface for this platform (the Caddy
+// `@public_webhooks` matcher routes /api/v1/webhooks/* + /api/v1/channels/*
+// through to ctrl-api on :3100). web-1 sits behind Wasp auth middleware.
+// Putting the webhook landing here keeps the "public, HMAC-only" pattern
+// consistent with the Paperclip heartbeat, Vexa, and the Plane steward
+// hook. The state write *does* live in web-db, so we hop one container
+// over via the AAS_API_KEY-secured internal endpoint. This avoids giving
+// ctrl-api a Prisma client just for a single field-flip.
+//
+// Auth model
+// ----------
+// Two layers stacked, in order:
+//
+//   1. **Composio HMAC** (preferred). Two schemes supported:
+//      - **Standard Webhooks** (Composio's documented scheme today —
+//        `webhook-id` / `webhook-timestamp` / `webhook-signature`
+//        headers, signing string `<id>.<ts>.<body>`, HMAC-SHA-256,
+//        base64, signature header value is `v1,<b64>` (possibly
+//        multiple comma-separated versions).
+//      - **Simple SHA-256 over raw body** in `x-composio-signature`
+//        as `sha256=<hex>` — older / alternative scheme, accept too.
+//      Either secret bytes come from `COMPOSIO_WEBHOOK_SECRET`.
+//
+//   2. **Unsigned fallback** (deploy-friendly). If
+//      `COMPOSIO_WEBHOOK_SECRET` is unset, accept anyway with a loud
+//      `WARN` log. The 5 live tenants today have NO secret configured;
+//      this fallback unblocks them immediately. Sir can rotate in the
+//      secret via Composio's webhook config UI later.
+//
+// Event shape tolerance
+// ---------------------
+// We accept both the V3 envelope (`{ metadata: { event_type, ... }, data:
+// {...} }`) and the older flat shape (`{ type, data: {...} }`). The
+// canonical signal we care about is `connected_account.updated` (or any
+// event_type containing `connected_account` plus a state-change marker)
+// with `data.status === "ACTIVE"`. Anything else → 200 no-op so Composio
+// doesn't retry on events we don't care about.
+//
+// 200 vs 4xx policy
+// -----------------
+// Composio retries on non-2xx. Therefore:
+//   * unknown connectionId          → 200 (the row was deleted on our side)
+//   * already-ACTIVE row            → 200 (idempotent no-op)
+//   * unknown event type            → 200 (we don't care)
+//   * malformed body                → 200 + WARN (don't trigger retries on
+//                                       a body shape we don't understand)
+//   * bad signature (when secret IS set) → 401 (genuine auth failure)
+//   * web-side flip failed          → 502 (transient; do retry)
+
+import crypto from "node:crypto";
+import { addRoute } from "../server.js";
+import { sendJson } from "../errors.js";
+
+// Web-internal URL for the row flip. Same compose-network reach as
+// apikeys/proxy.ts uses for ctrl-api (`http://ctrl-api:3100`). The web
+// container is reachable at `http://web:3000` on the compose network.
+const WEB_BASE_URL = process.env.WEB_BASE_URL ?? "http://web:3000";
+const WEB_FINALIZE_PATH = "/webhook/composio/finalize";
+const WEB_TIMEOUT_MS = 15_000;
+
+// ── signature verification ─────────────────────────────────────────────────
+
+interface VerifyResult {
+  ok: boolean;
+  /** Human-readable reason; used in the WARN log when unsigned-fallback fires. */
+  reason: string;
+}
+
+/** Composio's Standard-Webhooks scheme:
+ *
+ *   webhook-id:        <ulid-ish string>
+ *   webhook-timestamp: <unix-seconds>
+ *   webhook-signature: v1,<base64-hmac>  (or "v1,<sig1> v1,<sig2>" with
+ *                                          multiple signatures separated by
+ *                                          spaces during key rotation)
+ *
+ * signing string:  `${id}.${ts}.${rawBody}`
+ * algorithm:       HMAC-SHA-256, base64-encoded
+ *
+ * Implementation cross-references:
+ *  - https://docs.composio.dev (webhook verification page) — quoted in the
+ *    PR body.
+ *  - The Standard Webhooks spec (standardwebhooks.com) is the umbrella;
+ *    Composio is svix-compatible.
+ */
+function verifyStandardWebhooks(
+  rawBody: Buffer,
+  headers: Record<string, string | string[] | undefined>,
+  secret: string,
+): boolean {
+  const id = headerString(headers["webhook-id"]);
+  const ts = headerString(headers["webhook-timestamp"]);
+  const sig = headerString(headers["webhook-signature"]);
+  if (!id || !ts || !sig) return false;
+
+  // The secret arrives base64-prefixed-with-"whsec_" in some
+  // implementations; tolerate that.
+  const secretBytes = secret.startsWith("whsec_")
+    ? Buffer.from(secret.slice("whsec_".length), "base64")
+    : Buffer.from(secret, "utf-8");
+
+  const signed = Buffer.concat([
+    Buffer.from(`${id}.${ts}.`, "utf-8"),
+    rawBody,
+  ]);
+  const expected = crypto
+    .createHmac("sha256", secretBytes)
+    .update(signed)
+    .digest("base64");
+
+  // Header is space-separated "v1,<sig> v1,<sig2> ..." — any match wins.
+  for (const part of sig.split(" ")) {
+    const eq = part.indexOf(",");
+    if (eq < 0) continue;
+    const version = part.slice(0, eq).trim();
+    const received = part.slice(eq + 1).trim();
+    if (version !== "v1") continue;
+    if (constantTimeStringEq(expected, received)) return true;
+  }
+  return false;
+}
+
+/** Alternative scheme some Composio deployments emit (also matches the
+ * shape mentioned in the joe-incident triage): a single header
+ *
+ *   x-composio-signature: sha256=<hex>
+ *
+ * over the raw body keyed on the shared secret. Provided as a defensive
+ * fallback so we don't 401 a real Composio webhook just because their
+ * docs and their actual emission don't match. */
+function verifyXComposioSignature(
+  rawBody: Buffer,
+  headers: Record<string, string | string[] | undefined>,
+  secret: string,
+): boolean {
+  const sig = headerString(headers["x-composio-signature"]);
+  if (!sig) return false;
+  const hex = sig.startsWith("sha256=") ? sig.slice("sha256=".length) : sig;
+  if (!/^[0-9a-fA-F]+$/.test(hex) || hex.length === 0) return false;
+  let received: Buffer;
+  try {
+    received = Buffer.from(hex, "hex");
+  } catch {
+    return false;
+  }
+  const expected = crypto
+    .createHmac("sha256", secret)
+    .update(rawBody)
+    .digest();
+  if (expected.length !== received.length) return false;
+  try {
+    return crypto.timingSafeEqual(expected, received);
+  } catch {
+    return false;
+  }
+}
+
+function verifyComposioWebhook(
+  rawBody: Buffer,
+  headers: Record<string, string | string[] | undefined>,
+  secret: string,
+): VerifyResult {
+  // Accept either scheme. A real Composio webhook only carries one of
+  // them; both being absent means "no signature presented" — distinguish
+  // that from "signature presented but wrong" so the log line is honest.
+  const hasStandard = headerString(headers["webhook-signature"]) !== null;
+  const hasXSig = headerString(headers["x-composio-signature"]) !== null;
+  if (!hasStandard && !hasXSig) {
+    return { ok: false, reason: "no signature headers present" };
+  }
+  if (hasStandard && verifyStandardWebhooks(rawBody, headers, secret)) {
+    return { ok: true, reason: "standard-webhooks signature verified" };
+  }
+  if (hasXSig && verifyXComposioSignature(rawBody, headers, secret)) {
+    return { ok: true, reason: "x-composio-signature verified" };
+  }
+  return { ok: false, reason: "signature did not validate against COMPOSIO_WEBHOOK_SECRET" };
+}
+
+function headerString(h: string | string[] | undefined): string | null {
+  if (!h) return null;
+  const v = Array.isArray(h) ? h[0] : h;
+  if (typeof v !== "string" || v.length === 0) return null;
+  return v;
+}
+
+/** Timing-safe compare of two string-as-bytes views. */
+function constantTimeStringEq(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  try {
+    return crypto.timingSafeEqual(ab, bb);
+  } catch {
+    return false;
+  }
+}
+
+// ── event shape tolerance ──────────────────────────────────────────────────
+
+interface NormalisedEvent {
+  /** "connected_account.updated", "connected_account.created", etc. */
+  type: string;
+  /** Composio's connected_account id ("ca_..."). May be empty if the payload
+   * version omits it — caller should bail on the empty case. */
+  connectionId: string;
+  /** "ACTIVE" | "FAILED" | "INITIATED" | ... */
+  status: string;
+}
+
+/** Parse the event-type slug + connection id + status out of either the
+ * V3 envelope or the older flat shape. Returns null if the payload doesn't
+ * look like a connected_account event we can act on. */
+function normaliseEvent(payload: unknown): NormalisedEvent | null {
+  if (typeof payload !== "object" || payload === null) return null;
+  const p = payload as Record<string, unknown>;
+
+  // Event type: V3 puts it at metadata.event_type or metadata.trigger_slug;
+  // older shape uses top-level `type`.
+  let type = "";
+  const meta = p.metadata;
+  if (typeof meta === "object" && meta !== null) {
+    const m = meta as Record<string, unknown>;
+    if (typeof m.event_type === "string") type = m.event_type;
+    else if (typeof m.trigger_slug === "string") type = m.trigger_slug;
+  }
+  if (!type && typeof p.type === "string") type = p.type;
+  type = type.toLowerCase();
+
+  // Connection id: V3 puts it at metadata.connected_account_id; older shape
+  // nests it at data.id, sometimes data.connected_account_id, sometimes
+  // data.connectionId.
+  let connectionId = "";
+  if (typeof meta === "object" && meta !== null) {
+    const m = meta as Record<string, unknown>;
+    if (typeof m.connected_account_id === "string")
+      connectionId = m.connected_account_id;
+  }
+  const data = p.data;
+  if (!connectionId && typeof data === "object" && data !== null) {
+    const d = data as Record<string, unknown>;
+    if (typeof d.id === "string") connectionId = d.id;
+    else if (typeof d.connected_account_id === "string")
+      connectionId = d.connected_account_id;
+    else if (typeof d.connectionId === "string") connectionId = d.connectionId;
+  }
+
+  // Status: data.status (or data.state for older payloads).
+  let status = "";
+  if (typeof data === "object" && data !== null) {
+    const d = data as Record<string, unknown>;
+    if (typeof d.status === "string") status = d.status;
+    else if (typeof d.state === "string") status = d.state;
+  }
+  status = status.toUpperCase();
+
+  if (!type) return null;
+  return { type, connectionId, status };
+}
+
+/** Is this an event we care about? We act on connected-account state
+ * changes to ACTIVE. Anything else → no-op (200). */
+function isConnectedAccountActivation(ev: NormalisedEvent): boolean {
+  if (ev.status !== "ACTIVE") return false;
+  // Tolerate both "connected_account.updated" (current) and
+  // "connected_account.created" / "connection.created" (legacy slugs).
+  return /connected[_-]?account|connection/.test(ev.type);
+}
+
+// ── web-side flip ──────────────────────────────────────────────────────────
+
+interface FlipResult {
+  ok: boolean;
+  /** HTTP status from the web endpoint (or 0 on transport failure). */
+  status: number;
+  detail: string;
+}
+
+/** POST {connectionId} to web's /webhook/composio/finalize. The web endpoint
+ * validates the `Authorization: Bearer ${AAS_API_KEY}` and idempotently sets
+ * status=ACTIVE on the matching ComposioConnection row. */
+async function flipRowOnWeb(connectionId: string): Promise<FlipResult> {
+  const apiKey = process.env.AAS_API_KEY ?? "";
+  if (!apiKey) {
+    return {
+      ok: false,
+      status: 0,
+      detail: "AAS_API_KEY is not set on ctrl-api; cannot reach web internal endpoint",
+    };
+  }
+  const url = `${WEB_BASE_URL.replace(/\/$/, "")}${WEB_FINALIZE_PATH}`;
+  let resp: Response;
+  try {
+    resp = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ connectionId, status: "ACTIVE" }),
+      signal: AbortSignal.timeout(WEB_TIMEOUT_MS),
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      status: 0,
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  }
+  if (!resp.ok) {
+    let text = "";
+    try {
+      text = await resp.text();
+    } catch {
+      /* swallow */
+    }
+    return {
+      ok: false,
+      status: resp.status,
+      detail: text.slice(0, 500),
+    };
+  }
+  return { ok: true, status: resp.status, detail: "" };
+}
+
+// Exported for tests so they can stub the network seam without touching
+// globalThis.fetch. NOT part of the HTTP surface.
+export const _composioWebhookInternals = {
+  verifyComposioWebhook,
+  normaliseEvent,
+  isConnectedAccountActivation,
+  flipRowOnWeb,
+};
+
+// ── route ──────────────────────────────────────────────────────────────────
+
+export function registerComposioWebhookRoutes(): void {
+  addRoute("POST", "/api/v1/composio/webhook", async ({ req, res, body }) => {
+    // server.ts hands us the raw Buffer because the path is in the
+    // isRawBody allowlist. Defensive fallback: if for any reason it's
+    // not a Buffer, re-serialise — HMAC-over-the-canonical-bytes is
+    // what matters for the standard-webhooks scheme.
+    const rawBody: Buffer = Buffer.isBuffer(body)
+      ? body
+      : Buffer.from(typeof body === "string" ? body : JSON.stringify(body ?? {}), "utf-8");
+
+    const secret = process.env.COMPOSIO_WEBHOOK_SECRET ?? "";
+    const headers = req.headers ?? {};
+
+    // ── signature gate ────────────────────────────────────────────────────
+    if (secret) {
+      const v = verifyComposioWebhook(rawBody, headers, secret);
+      if (!v.ok) {
+        // Genuine auth failure — return 401 so Composio's retry surface
+        // shows the misconfiguration. Do NOT echo the secret-derived
+        // detail to the client.
+        console.warn(
+          `[composio-webhook] signature rejected: ${v.reason}`,
+        );
+        sendJson(res, 401, {
+          error: {
+            code: "AUTH_FAILED",
+            message: "Composio webhook signature did not validate",
+          },
+        });
+        return;
+      }
+    } else {
+      // The 5 live tenants today have no COMPOSIO_WEBHOOK_SECRET set.
+      // Refusing here would re-break the very thing this PR fixes. Loud-
+      // log so the operator can see exactly what landed unsigned.
+      console.warn(
+        "[composio-webhook] COMPOSIO_WEBHOOK_SECRET is not set on this tenant — accepting unsigned webhook. Rotate a secret in via Composio's webhook config UI to enable HMAC enforcement.",
+      );
+    }
+
+    // ── parse body ────────────────────────────────────────────────────────
+    let payload: unknown;
+    try {
+      payload = JSON.parse(rawBody.toString("utf-8"));
+    } catch (err) {
+      // 200 + WARN — see the file-header policy block. Composio retries on
+      // non-2xx, and we don't want retries on a body shape we can't parse.
+      console.warn(
+        `[composio-webhook] body was not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      sendJson(res, 200, { ok: true, noop: "unparseable body" });
+      return;
+    }
+
+    // ── dispatch ──────────────────────────────────────────────────────────
+    const ev = normaliseEvent(payload);
+    if (!ev) {
+      console.warn("[composio-webhook] payload did not match any known event shape");
+      sendJson(res, 200, { ok: true, noop: "unrecognised event shape" });
+      return;
+    }
+    if (!isConnectedAccountActivation(ev)) {
+      // Other events (deletion, failure, refresh, …) deferred to a later
+      // PR per task scope. Today: just connected_account.updated → ACTIVE.
+      sendJson(res, 200, {
+        ok: true,
+        noop: "event not actionable",
+        event_type: ev.type,
+        event_status: ev.status,
+      });
+      return;
+    }
+    if (!ev.connectionId) {
+      console.warn(
+        `[composio-webhook] ${ev.type} event missing connectionId — cannot flip a row`,
+      );
+      sendJson(res, 200, { ok: true, noop: "missing connectionId" });
+      return;
+    }
+
+    // Flip the row on the web side. The web endpoint is idempotent — if
+    // the row is already ACTIVE it returns 200 with `noop: true` and we
+    // surface that downstream so retries don't churn the row's
+    // updated_at.
+    const flip = await flipRowOnWeb(ev.connectionId);
+    if (!flip.ok) {
+      console.error(
+        `[composio-webhook] web-side flip failed for ${ev.connectionId}: ` +
+          `status=${flip.status} detail=${flip.detail}`,
+      );
+      // Transport / web-side failures should be retried by Composio — 502.
+      sendJson(res, 502, {
+        error: {
+          code: "WEB_FLIP_FAILED",
+          message: flip.detail || "Failed to flip ComposioConnection.status on web",
+        },
+      });
+      return;
+    }
+
+    console.info(
+      `[composio-webhook] flipped ${ev.connectionId} → ACTIVE (event ${ev.type})`,
+    );
+    sendJson(res, 200, {
+      ok: true,
+      connection_id: ev.connectionId,
+      flipped_to: "ACTIVE",
+    });
+  });
+}

--- a/packages/ctrl/src/api/server.ts
+++ b/packages/ctrl/src/api/server.ts
@@ -57,6 +57,7 @@ import { registerSmsRoutes } from "./routes/sms.js";
 import { registerVoiceRoutes } from "./routes/voice.js";
 import { registerOmiChannelRoutes } from "./routes/channels_omi.js";
 import { registerPaperclipChannelRoutes } from "./routes/channels_paperclip.js";
+import { registerComposioWebhookRoutes } from "./routes/composioWebhook.js";
 import { registerAlfredJournalRoutes } from "./routes/alfredJournal.js";
 import { registerAlfredDeliverRoutes } from "./routes/alfredDeliver.js";
 
@@ -173,6 +174,7 @@ export function createApiServer(): http.Server {
   registerVoiceRoutes();
   registerOmiChannelRoutes();
   registerPaperclipChannelRoutes();
+  registerComposioWebhookRoutes();
   // The one-Alfred continuity layer — alfred_journal + principal mapping
   // (the persistence + lookup surface) plus alfred-deliver (the unified
   // outbound delivery endpoint). Sir-facing UX invariant: there is only
@@ -223,7 +225,13 @@ export function createApiServer(): http.Server {
         // Paperclip heartbeat is HMAC-validated (X-Paperclip-Signature over
         // <ts>.<raw-body>), not bearer-authed. Lane V's Caddy
         // @public_webhooks matcher passes /api/v1/channels/paperclip/* through.
-        pathname === "/api/v1/channels/paperclip/heartbeat";
+        pathname === "/api/v1/channels/paperclip/heartbeat" ||
+        // Composio webhook is HMAC-validated against COMPOSIO_WEBHOOK_SECRET
+        // (Standard-Webhooks scheme on `webhook-signature` / older shape on
+        // `x-composio-signature`). Composio cannot send a Bearer header so
+        // the global auth gate must not pre-empt the HMAC check. See
+        // routes/composioWebhook.ts for the full auth model.
+        pathname === "/api/v1/composio/webhook";
       if (!isPublic) {
         // Pass method+pathname so the scoped-token path can check the
         // route allowlist (see auth.ts VOICE_BRIDGE_ALLOWLIST). The master
@@ -255,7 +263,10 @@ export function createApiServer(): http.Server {
       const isRawBody =
         pathname === "/api/v1/plane/webhook" ||
         pathname === "/api/v1/webhooks/plane/steward" ||
-        pathname === "/api/v1/webhooks/vexa";
+        pathname === "/api/v1/webhooks/vexa" ||
+        // Composio's Standard-Webhooks scheme signs the raw body, so the
+        // handler must see the exact bytes — see routes/composioWebhook.ts.
+        pathname === "/api/v1/composio/webhook";
       const query = new URLSearchParams(qIdx >= 0 ? url.slice(qIdx + 1) : "");
 
       const matched = matchRoute(method, pathname);

--- a/packages/ctrl/tests/composioWebhook.test.ts
+++ b/packages/ctrl/tests/composioWebhook.test.ts
@@ -1,0 +1,459 @@
+// Composio webhook handler — fix/composio-webhook-handler.
+//
+// What's under test
+// -----------------
+// POST /api/v1/composio/webhook — public, HMAC-validated, flips a local
+// ComposioConnection row's `status` from INITIATED → ACTIVE by hopping to
+// the web-side internal endpoint /webhook/composio/finalize. See
+// packages/ctrl/src/api/routes/composioWebhook.ts for the design notes.
+//
+// We test through matchRoute + a handleError shim — same pattern as
+// channels_paperclip.test.ts. The web-side hop is stubbed at the fetch
+// boundary so the assertions cover the ctrl-api auth + dispatch surface
+// only.
+//
+// Coverage:
+//   1.  unknown event type → 200 no-op (no web call)
+//   2.  connected_account.updated with non-ACTIVE status → 200 no-op
+//   3.  connected_account.updated + ACTIVE → 200, web-flip called once
+//   4.  same event when row is already ACTIVE → 200 idempotent (web noop)
+//   5.  unknown connectionId → 200 no-op
+//   6.  unparseable body → 200 no-op
+//   7.  v3 envelope `{ metadata: { event_type, connected_account_id }, data:
+//       { status } }` shape also routed correctly
+//   8.  SECRET set + bad standard-webhooks signature → 401
+//   9.  SECRET set + missing both signature headers → 401
+//  10.  SECRET unset + no signature → 200 + WARN (deploy-friendly fallback)
+//  11.  SECRET set + valid x-composio-signature → 200 (alt scheme)
+//  12.  web-side flip returns 500 → 502 (transient; Composio will retry)
+//
+// Privacy: public repo. No real secrets in this file.
+
+import { describe, it, before, beforeEach, after } from "node:test";
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ServerResponse } from "node:http";
+
+// ── env setup ──────────────────────────────────────────────────────────────
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "composio-webhook-"));
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.VAULT_PATH = path.join(tmp, "vault");
+process.env.STATE_DB_PATH = path.join(tmp, "alfred-state.db");
+process.env.SQLITE_VEC_PATH = "";
+process.env.DOMAIN = "test.alfred.black";
+process.env.AAS_API_KEY = "test-aas-api-key";
+// Web URL the handler will POST to — stubbed at fetch boundary below.
+process.env.WEB_BASE_URL = "http://web-stub:3000";
+delete process.env.COMPOSIO_WEBHOOK_SECRET;
+
+// ── fetch mock ─────────────────────────────────────────────────────────────
+//
+// One upstream to intercept: POST http://web-stub:3000/webhook/composio/finalize.
+// Tests assert on this call ledger to verify the ctrl-api → web hop fired
+// (or didn't) for each scenario.
+
+const originalFetch = globalThis.fetch;
+
+interface WebCall {
+  url: string;
+  method: string;
+  authorization: string;
+  body: any;
+}
+const webCalls: WebCall[] = [];
+let webResponseStatus = 200;
+let webResponseBody: any = { ok: true };
+
+function makeJsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+globalThis.fetch = (async (input: any, init?: any) => {
+  const url = typeof input === "string" ? input : (input?.url ?? String(input));
+  const method = (init?.method ?? "GET").toUpperCase();
+  if (url.endsWith("/webhook/composio/finalize") && method === "POST") {
+    const headers = init?.headers ?? {};
+    const authorization = headers.Authorization ?? headers.authorization ?? "";
+    let body: any = null;
+    try {
+      body = JSON.parse(String(init?.body ?? "null"));
+    } catch {
+      body = null;
+    }
+    webCalls.push({ url, method, authorization, body });
+    return makeJsonResponse(webResponseBody, webResponseStatus);
+  }
+  throw new Error(`unexpected fetch in composioWebhook test: ${method} ${url}`);
+}) as typeof fetch;
+
+// ── module imports (after env + fetch are set) ─────────────────────────────
+
+const { matchRoute } = await import("../src/api/server.js");
+const { handleError } = await import("../src/api/errors.js");
+const { registerComposioWebhookRoutes } = await import(
+  "../src/api/routes/composioWebhook.js"
+);
+registerComposioWebhookRoutes();
+
+async function invokeRoute(
+  method: string,
+  p: string,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Promise<{ status: number; payload: any }> {
+  const m = matchRoute(method, p);
+  assert.ok(m, `${method} ${p} must be registered`);
+  let status = 0;
+  let payload: any;
+  const res = {
+    statusCode: 0,
+    setHeader() {},
+    writeHead(c: number) {
+      status = c;
+      return res;
+    },
+    end(j?: string) {
+      payload = j ? JSON.parse(j) : undefined;
+    },
+  } as unknown as ServerResponse;
+  try {
+    await m!.handler({
+      req: { method, url: p, headers } as any,
+      res,
+      params: m!.params,
+      body,
+      query: new URLSearchParams(),
+    });
+  } catch (err) {
+    handleError(res, err);
+  }
+  return { status, payload };
+}
+
+// ── signing helpers ────────────────────────────────────────────────────────
+
+const SECRET = "test-composio-secret-do-not-use-in-prod";
+
+/** Sign a body the way Composio's Standard-Webhooks scheme does:
+ * `${id}.${ts}.${rawBody}` HMAC-SHA-256, base64. */
+function signStandardWebhooks(
+  rawBody: Buffer,
+  opts: { id?: string; ts?: number; secret?: string } = {},
+): { id: string; ts: string; sig: string } {
+  const id = opts.id ?? "msg_test_01HK7";
+  const ts = String(opts.ts ?? Math.floor(Date.now() / 1000));
+  const secret = opts.secret ?? SECRET;
+  const signed = Buffer.concat([
+    Buffer.from(`${id}.${ts}.`, "utf-8"),
+    rawBody,
+  ]);
+  const sig = crypto.createHmac("sha256", secret).update(signed).digest("base64");
+  return { id, ts, sig: `v1,${sig}` };
+}
+
+/** Sign a body the alt-scheme way: x-composio-signature: sha256=<hex>. */
+function signXComposio(
+  rawBody: Buffer,
+  opts: { secret?: string } = {},
+): string {
+  const secret = opts.secret ?? SECRET;
+  const hex = crypto.createHmac("sha256", secret).update(rawBody).digest("hex");
+  return `sha256=${hex}`;
+}
+
+// ── event-shape helpers ────────────────────────────────────────────────────
+
+function buildActiveEvent(connectionId: string): any {
+  return {
+    type: "connected_account.updated",
+    data: {
+      id: connectionId,
+      status: "ACTIVE",
+      toolkit: { slug: "gmail" },
+      user_id: "user_xyz",
+    },
+  };
+}
+
+function buildV3ActiveEvent(connectionId: string): any {
+  return {
+    metadata: {
+      event_type: "connected_account.updated",
+      connected_account_id: connectionId,
+    },
+    data: { status: "ACTIVE", toolkit: { slug: "gmail" } },
+  };
+}
+
+function buildBody(payload: any): Buffer {
+  return Buffer.from(JSON.stringify(payload), "utf-8");
+}
+
+// ── tests ──────────────────────────────────────────────────────────────────
+
+describe("/api/v1/composio/webhook — connected_account.updated → ACTIVE flip", () => {
+  beforeEach(() => {
+    webCalls.length = 0;
+    webResponseStatus = 200;
+    webResponseBody = { ok: true };
+    delete process.env.COMPOSIO_WEBHOOK_SECRET;
+  });
+
+  after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("200 no-op when the event type is not connected_account.* (unsigned fallback)", async () => {
+    const body = buildBody({
+      type: "trigger.fired",
+      data: { id: "ca_xyz", status: "ACTIVE" },
+    });
+    const r = await invokeRoute(
+      "POST",
+      "/api/v1/composio/webhook",
+      body,
+      { "content-type": "application/json" },
+    );
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.ok, true);
+    assert.equal(webCalls.length, 0, "must not hop to web for unrelated events");
+  });
+
+  it("200 no-op when status is not ACTIVE (e.g. INITIATED)", async () => {
+    const body = buildBody({
+      type: "connected_account.updated",
+      data: { id: "ca_xyz", status: "INITIATED" },
+    });
+    const r = await invokeRoute(
+      "POST",
+      "/api/v1/composio/webhook",
+      body,
+      { "content-type": "application/json" },
+    );
+    assert.equal(r.status, 200);
+    assert.equal(webCalls.length, 0);
+  });
+
+  it("200 + flips row when connected_account.updated + ACTIVE (unsigned fallback)", async () => {
+    const body = buildBody(buildActiveEvent("ca_active_001"));
+    const r = await invokeRoute(
+      "POST",
+      "/api/v1/composio/webhook",
+      body,
+      { "content-type": "application/json" },
+    );
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.ok, true);
+    assert.equal(r.payload.connection_id, "ca_active_001");
+    assert.equal(r.payload.flipped_to, "ACTIVE");
+    assert.equal(webCalls.length, 1);
+    assert.equal(
+      webCalls[0].url,
+      "http://web-stub:3000/webhook/composio/finalize",
+    );
+    assert.equal(webCalls[0].authorization, "Bearer test-aas-api-key");
+    assert.equal(webCalls[0].body.connectionId, "ca_active_001");
+    assert.equal(webCalls[0].body.status, "ACTIVE");
+  });
+
+  it("200 + idempotent when the row is already ACTIVE (web returns noop:true)", async () => {
+    // The web side is the source of truth for idempotency; we just need to
+    // confirm ctrl-api forwards the call and surfaces a 200.
+    webResponseBody = { ok: true, noop: true, status: "ACTIVE" };
+    const body = buildBody(buildActiveEvent("ca_already_active"));
+    const r = await invokeRoute(
+      "POST",
+      "/api/v1/composio/webhook",
+      body,
+      { "content-type": "application/json" },
+    );
+    assert.equal(r.status, 200);
+    assert.equal(webCalls.length, 1);
+  });
+
+  it("200 no-op when the connectionId is unknown on web (web returns 200 noop:not found)", async () => {
+    // ctrl-api itself doesn't know about row existence — it forwards. The
+    // web side returns 200 + noop:"not found" and ctrl-api passes through a
+    // 200 to Composio (so they don't retry).
+    webResponseStatus = 200;
+    webResponseBody = { ok: true, noop: "not found" };
+    const body = buildBody(buildActiveEvent("ca_does_not_exist"));
+    const r = await invokeRoute(
+      "POST",
+      "/api/v1/composio/webhook",
+      body,
+      { "content-type": "application/json" },
+    );
+    assert.equal(r.status, 200);
+    assert.equal(webCalls.length, 1);
+  });
+
+  it("200 no-op on unparseable body (don't trigger Composio retries on garbage)", async () => {
+    const body = Buffer.from("this is not JSON{{{", "utf-8");
+    const r = await invokeRoute(
+      "POST",
+      "/api/v1/composio/webhook",
+      body,
+      { "content-type": "application/json" },
+    );
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.ok, true);
+    assert.equal(webCalls.length, 0);
+  });
+
+  it("V3 envelope { metadata, data } is also routed", async () => {
+    const body = buildBody(buildV3ActiveEvent("ca_v3_envelope"));
+    const r = await invokeRoute(
+      "POST",
+      "/api/v1/composio/webhook",
+      body,
+      { "content-type": "application/json" },
+    );
+    assert.equal(r.status, 200);
+    assert.equal(webCalls.length, 1);
+    assert.equal(webCalls[0].body.connectionId, "ca_v3_envelope");
+  });
+
+  describe("HMAC enforcement (COMPOSIO_WEBHOOK_SECRET set)", () => {
+    beforeEach(() => {
+      process.env.COMPOSIO_WEBHOOK_SECRET = SECRET;
+    });
+
+    it("200 when standard-webhooks signature validates", async () => {
+      const raw = buildBody(buildActiveEvent("ca_signed_ok"));
+      const { id, ts, sig } = signStandardWebhooks(raw);
+      const r = await invokeRoute(
+        "POST",
+        "/api/v1/composio/webhook",
+        raw,
+        {
+          "content-type": "application/json",
+          "webhook-id": id,
+          "webhook-timestamp": ts,
+          "webhook-signature": sig,
+        },
+      );
+      assert.equal(r.status, 200);
+      assert.equal(webCalls.length, 1);
+      assert.equal(webCalls[0].body.connectionId, "ca_signed_ok");
+    });
+
+    it("401 when standard-webhooks signature is wrong", async () => {
+      const raw = buildBody(buildActiveEvent("ca_bad_sig"));
+      const { id, ts } = signStandardWebhooks(raw, { secret: "wrong-secret" });
+      const sig = "v1," + Buffer.from("garbage").toString("base64");
+      const r = await invokeRoute(
+        "POST",
+        "/api/v1/composio/webhook",
+        raw,
+        {
+          "content-type": "application/json",
+          "webhook-id": id,
+          "webhook-timestamp": ts,
+          "webhook-signature": sig,
+        },
+      );
+      assert.equal(r.status, 401);
+      assert.equal(r.payload.error.code, "AUTH_FAILED");
+      assert.equal(webCalls.length, 0, "no web hop on auth failure");
+    });
+
+    it("401 when neither signature header is present and secret IS set", async () => {
+      const raw = buildBody(buildActiveEvent("ca_no_sig"));
+      const r = await invokeRoute(
+        "POST",
+        "/api/v1/composio/webhook",
+        raw,
+        { "content-type": "application/json" },
+      );
+      assert.equal(r.status, 401);
+      assert.equal(r.payload.error.code, "AUTH_FAILED");
+    });
+
+    it("200 when alt-scheme x-composio-signature validates", async () => {
+      const raw = buildBody(buildActiveEvent("ca_xsig_ok"));
+      const xsig = signXComposio(raw);
+      const r = await invokeRoute(
+        "POST",
+        "/api/v1/composio/webhook",
+        raw,
+        {
+          "content-type": "application/json",
+          "x-composio-signature": xsig,
+        },
+      );
+      assert.equal(r.status, 200);
+      assert.equal(webCalls.length, 1);
+    });
+
+    it("401 when alt-scheme x-composio-signature is wrong", async () => {
+      const raw = buildBody(buildActiveEvent("ca_xsig_bad"));
+      const xsig = signXComposio(raw, { secret: "wrong-secret" });
+      const r = await invokeRoute(
+        "POST",
+        "/api/v1/composio/webhook",
+        raw,
+        {
+          "content-type": "application/json",
+          "x-composio-signature": xsig,
+        },
+      );
+      assert.equal(r.status, 401);
+      assert.equal(webCalls.length, 0);
+    });
+  });
+
+  describe("unsigned-fallback (COMPOSIO_WEBHOOK_SECRET unset)", () => {
+    it("200 + WARN log when no signature is presented and no secret is configured", async () => {
+      // Capture console.warn to assert the fallback fired.
+      const warnings: string[] = [];
+      const orig = console.warn;
+      console.warn = (...args: unknown[]) => {
+        warnings.push(args.map((a) => String(a)).join(" "));
+      };
+      try {
+        const raw = buildBody(buildActiveEvent("ca_unsigned_ok"));
+        const r = await invokeRoute(
+          "POST",
+          "/api/v1/composio/webhook",
+          raw,
+          { "content-type": "application/json" },
+        );
+        assert.equal(r.status, 200);
+        assert.equal(webCalls.length, 1);
+        assert.ok(
+          warnings.some((w) =>
+            w.includes("COMPOSIO_WEBHOOK_SECRET is not set"),
+          ),
+          "expected WARN about missing COMPOSIO_WEBHOOK_SECRET",
+        );
+      } finally {
+        console.warn = orig;
+      }
+    });
+  });
+
+  describe("web-side failure surface", () => {
+    it("502 when the web /webhook/composio/finalize endpoint returns 500", async () => {
+      webResponseStatus = 500;
+      webResponseBody = { error: { code: "INTERNAL_ERROR", message: "boom" } };
+      const raw = buildBody(buildActiveEvent("ca_web_500"));
+      const r = await invokeRoute(
+        "POST",
+        "/api/v1/composio/webhook",
+        raw,
+        { "content-type": "application/json" },
+      );
+      assert.equal(r.status, 502);
+      assert.equal(r.payload.error.code, "WEB_FLIP_FAILED");
+      assert.equal(webCalls.length, 1);
+    });
+  });
+});

--- a/packages/web/main.wasp
+++ b/packages/web/main.wasp
@@ -482,6 +482,20 @@ api userApiProxy {
   httpRoute: (ALL, "/user-api")
 }
 
+// Composio webhook finalize hop. Internal endpoint called by ctrl-api after
+// it receives + verifies a Composio `connected_account.updated → ACTIVE`
+// webhook. Auth is shared-secret AAS_API_KEY (same secret ctrl-api ↔ web
+// already use for the proxy hop in the opposite direction). Flips the
+// ComposioConnection row's `status` to ACTIVE so the existing 1-min
+// reconciler picks it up on its next tick. See
+// packages/ctrl/src/api/routes/composioWebhook.ts for the rationale.
+api finalizeComposioWebhook {
+  fn: import { finalizeComposioWebhook } from "@src/integrations/composioWebhookFinalize",
+  entities: [ComposioConnection],
+  middlewareConfigFn: import { finalizeComposioWebhookMiddleware } from "@src/integrations/composioWebhookFinalize",
+  httpRoute: (POST, "/webhook/composio/finalize")
+}
+
 // Dashboard queries and actions (proxy to tenant API)
 query getDashboardData {
   fn: import { getDashboardData } from "@src/dashboard/operations",

--- a/packages/web/src/integrations/composioWebhookFinalize.ts
+++ b/packages/web/src/integrations/composioWebhookFinalize.ts
@@ -1,0 +1,181 @@
+/**
+ * Composio webhook → ComposioConnection status flip (internal endpoint).
+ *
+ * What this is
+ * ------------
+ * The Wasp `api` `finalizeComposioWebhook` (POST /webhook/composio/finalize)
+ * is the web-side landing for ctrl-api's Composio webhook handler. ctrl-api
+ * receives + HMAC-validates Composio's `connected_account.updated → ACTIVE`
+ * webhook, then POSTs `{connectionId, status}` here so the row can flip on
+ * the SaaS DB.
+ *
+ * See packages/ctrl/src/api/routes/composioWebhook.ts for the inbound side
+ * and the joe-incident rationale.
+ *
+ * Auth
+ * ----
+ * Shared secret `AAS_API_KEY` — the same secret used in the other direction
+ * (web → ctrl-api). The middleware swaps out Wasp's default authMiddleware
+ * (which expects a session cookie) for a Bearer-token check against
+ * `process.env.AAS_API_KEY`. The endpoint is NOT user-facing; it's
+ * compose-network-only and never crosses the Caddy public surface.
+ *
+ * Why this isn't an action
+ * ------------------------
+ * Wasp actions require an authenticated user (`context.user`). This endpoint
+ * is service-to-service — there is no user session. Hence the `api`
+ * declaration with custom middleware, mirroring how `userApiProxy` handles
+ * its own bearer-token auth.
+ *
+ * Idempotency
+ * -----------
+ * A second call for an already-ACTIVE row returns 200 with `noop: true` and
+ * does NOT touch `updatedAt`. We do NOT touch `autoConfigState` — the
+ * existing reconcileComposioAutoConfigJob picks that up within 60 seconds
+ * once it sees status="ACTIVE".
+ *
+ * Unknown connectionId
+ * --------------------
+ * Composio may fire `connected_account.updated` events for a connection the
+ * user deleted on our side. Return 200 with `noop: "not found"` so neither
+ * Composio nor ctrl-api treats it as a retryable failure.
+ */
+
+import type { MiddlewareConfigFn } from "wasp/server";
+import { markStatusActive } from "./connectionRepo";
+
+// Wasp generates a typed FinalizeComposioWebhook<...> from main.wasp, but
+// since this file ships in the same commit as the api declaration, the
+// generated type is not available at editor-time on the first build. We
+// fall back to the loose `(req, res, context) => Promise<void>` shape that
+// every other Wasp api fn uses (see apikeys/proxy.ts:userApiProxy for the
+// canonical pattern).
+
+const AAS_API_KEY = process.env.AAS_API_KEY ?? "";
+
+// ── middleware ─────────────────────────────────────────────────────────────
+//
+// Same pattern as apikeys/proxy.ts:apiProxyMiddleware — strip Wasp's default
+// authMiddleware so we can do our own service-token check here.
+
+export const finalizeComposioWebhookMiddleware: MiddlewareConfigFn = (
+  middlewareConfig,
+) => {
+  middlewareConfig.delete("authMiddleware");
+  return middlewareConfig;
+};
+
+// ── handler ────────────────────────────────────────────────────────────────
+
+interface FinalizePayload {
+  connectionId: string;
+  status?: string;
+}
+
+function parsePayload(raw: unknown): FinalizePayload | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const b = raw as Record<string, unknown>;
+  if (typeof b.connectionId !== "string" || b.connectionId.length === 0) {
+    return null;
+  }
+  return {
+    connectionId: b.connectionId,
+    status: typeof b.status === "string" ? b.status : "ACTIVE",
+  };
+}
+
+export const finalizeComposioWebhook = async (
+  req: any,
+  res: any,
+  context: any,
+): Promise<void> => {
+  // Service-token auth. The middleware above has already stripped Wasp's
+  // user-session check, so this is the only gate.
+  if (!AAS_API_KEY) {
+    console.error(
+      "[finalizeComposioWebhook] AAS_API_KEY is not set on the web container — refusing",
+    );
+    res.status(500).json({
+      error: { code: "NOT_CONFIGURED", message: "AAS_API_KEY is not set" },
+    });
+    return;
+  }
+  const auth = req.headers.authorization ?? "";
+  if (!auth.startsWith("Bearer ") || auth.slice(7) !== AAS_API_KEY) {
+    res.status(401).json({
+      error: { code: "UNAUTHORIZED", message: "Bearer AAS_API_KEY required" },
+    });
+    return;
+  }
+
+  const payload = parsePayload(req.body);
+  if (!payload) {
+    res.status(400).json({
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Body must be { connectionId: string, status?: string }",
+      },
+    });
+    return;
+  }
+
+  const targetStatus = (payload.status ?? "ACTIVE").toUpperCase();
+  if (targetStatus !== "ACTIVE") {
+    // Defensive — this endpoint only handles the INITIATED → ACTIVE flip
+    // today. Other lifecycle events (FAILED, deletion, …) are scoped out of
+    // this PR. Refuse loudly so a future caller doesn't accidentally write
+    // a different status here.
+    res.status(400).json({
+      error: {
+        code: "UNSUPPORTED_STATUS",
+        message: `finalize endpoint only sets status=ACTIVE (got ${payload.status})`,
+      },
+    });
+    return;
+  }
+
+  const delegate = context.entities.ComposioConnection;
+  const existing = await delegate.findUnique({
+    where: { connectionId: payload.connectionId },
+  });
+  if (!existing) {
+    // Composio fired an event for a connection that no longer exists on our
+    // side. 200 — don't trigger ctrl-api / Composio retries.
+    console.info(
+      `[finalizeComposioWebhook] no row for connectionId=${payload.connectionId} — noop`,
+    );
+    res.status(200).json({ ok: true, noop: "not found" });
+    return;
+  }
+
+  if (existing.status === "ACTIVE") {
+    // Idempotent — already in the target state. Skip the update so we don't
+    // churn updatedAt on every Composio retry.
+    res.status(200).json({
+      ok: true,
+      noop: true,
+      connectionId: payload.connectionId,
+      status: "ACTIVE",
+    });
+    return;
+  }
+
+  // Use the shared markStatusActive helper introduced in #72 (the reconciler
+  // INITIATED-row widening PR) — same code path the safety-net reconciler
+  // takes, so the webhook fast-path and the polling slow-path produce
+  // byte-identical row state. The helper only writes `status` +
+  // `lastSyncedAt`; `autoConfigState` stays untouched and the existing
+  // 1-min reconciler drives auto-config from there.
+  await markStatusActive(delegate, existing.userId, payload.connectionId);
+  console.info(
+    `[finalizeComposioWebhook] flipped ${existing.toolkit}/${payload.connectionId} ` +
+      `${existing.status} → ACTIVE (reconciler will pick up within 60s)`,
+  );
+
+  res.status(200).json({
+    ok: true,
+    connectionId: payload.connectionId,
+    previous_status: existing.status,
+    status: "ACTIVE",
+  });
+};


### PR DESCRIPTION
## The joe.alfred.black incident (2026-05-27)

Composio finished authenticating Gmail on their side, but our local
`ComposioConnection` row stuck at `status=INITIATED` for ~36 minutes —
blocking the rest of onboarding. ctrl-api logged the inbound webhook as

```
POST /api/v1/composio/webhook 401 0ms
```

**Root cause**: there was NO route registered at that path. The 401 was the
global auth middleware seeing no `Authorization: Bearer` header and
rejecting before any route lookup. Composio signs webhooks via HMAC
headers, not bearer tokens — they never had a chance to be admitted.

The existing 1-minute `reconcileComposioAutoConfigJob` only acted on rows
with local `status='ACTIVE'`. The row was INITIATED. Chicken-and-egg.
(#72 fixed the reconciler side by polling Composio for INITIATED rows; this
PR is the fast-path complement.)

## The fix

A real handler at `POST /api/v1/composio/webhook` in ctrl-api. Two-layer
auth:

1. **Composio HMAC** (preferred). Both signature schemes supported:
   - **Standard Webhooks** (Composio's documented scheme — headers
     `webhook-id` / `webhook-timestamp` / `webhook-signature`, signing
     `${id}.${ts}.${body}` HMAC-SHA-256 base64, header value
     `v1,<b64>` possibly space-separated for key rotation).
   - **`x-composio-signature: sha256=<hex>` over raw body** — defensive
     fallback for deployments that emit that shape.
2. **Unsigned fallback**. When `COMPOSIO_WEBHOOK_SECRET` is unset, accept
   with a loud `WARN` log. The 5 live tenants today have NO secret
   configured; this is what unblocks them immediately. Sir can rotate
   a secret in via Composio's webhook config UI later.

## Architecture

ctrl-api owns the public webhook surface (Caddy routes `/api/v1/*` to it).
State lives in web-db Postgres. ctrl-api validates HMAC then POSTs to a
new internal Wasp api endpoint `POST /webhook/composio/finalize` on the
web container with `Authorization: Bearer ${AAS_API_KEY}` (the same
shared secret used in the proxy hop the other direction). web uses
`markStatusActive` (added by #72) to flip the row — byte-identical code
path to the polling reconciler so fast-path and slow-path produce the
same state.

The existing 1-min reconciler is **unchanged** — it's the safety net;
this is the fast path. Both wanted.

## 200-vs-4xx policy

Composio retries on non-2xx, so:
- Unknown connectionId → 200 (row was deleted on our side)
- Already-ACTIVE row → 200 (idempotent)
- Unknown event type → 200 (we don't care)
- Malformed body → 200 + WARN
- Bad signature **when SECRET is set** → 401 (genuine auth failure)
- Web-side transport failure → 502 (transient; do retry)

## Scope

This PR handles only `connected_account.updated → status: ACTIVE`. Failure
/ deletion events are deferred — the joe incident was strictly the
activation flip.

## Tests

14 tests in `packages/ctrl/tests/composioWebhook.test.ts` cover:
- `connected_account.updated` with status ACTIVE flips a row
- Idempotent when row is already ACTIVE
- Unknown connectionId → 200
- Bad signature (with SECRET set) → 401
- Missing signature (with SECRET set) → 401
- Missing secret + missing signature → 200 + WARN (deploy-friendly)
- Wrong event type → 200 no-op
- V3 envelope (`{metadata, data}`) routed
- Both HMAC schemes (standard-webhooks + x-composio-signature)
- web-side 500 → 502

All pass under `node --test`.

## Deploy plan

After merge + `build-ctrl-api.yml` ships the image, deploy to all 5
tenants (home, rj, joe, zsolt, miguel) via
`docker compose pull ctrl-api && docker compose up -d ctrl-api`. No secret
is rotated in by this PR — every tenant runs with the unsigned fallback
until Sir adds `COMPOSIO_WEBHOOK_SECRET` per-tenant via Composio's webhook
config UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)