### PR TITLE
fix(composio-webhook): use X-AAS-API-Key (Wasp auth rejects Bearer service tokens)

### DIFF
--- a/packages/ctrl/src/api/routes/composioWebhook.ts
+++ b/packages/ctrl/src/api/routes/composioWebhook.ts
@@ -321,10 +321,21 @@ async function flipRowOnWeb(connectionId: string): Promise<FlipResult> {
   const url = `${WEB_BASE_URL.replace(/\/$/, "")}${WEB_FINALIZE_PATH}`;
   let resp: Response;
   try {
+    // IMPORTANT: do NOT send `Authorization: Bearer ...` here. Wasp's
+    // global `auth` middleware sits in front of every `api` route and
+    // tries to validate any Bearer token as a Wasp user session token —
+    // a service-side key gets rejected with `{"message":"Invalid
+    // credentials"}` BEFORE the route's own middlewareConfigFn can run.
+    // (Confirmed live: bundle wires `[auth, ...customMiddleware]` for
+    // every api route. The middlewareConfigFn `.delete("authMiddleware")`
+    // only affects the express-global hook, not the per-route shim.)
+    // Wasp's auth middleware passes through when the Authorization
+    // header is absent / non-Bearer, so we ship the secret on a custom
+    // header that the web handler picks up on its own.
     resp = await fetch(url, {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${apiKey}`,
+        "X-AAS-API-Key": apiKey,
         "Content-Type": "application/json",
       },
       body: JSON.stringify({ connectionId, status: "ACTIVE" }),

--- a/packages/ctrl/tests/composioWebhook.test.ts
+++ b/packages/ctrl/tests/composioWebhook.test.ts
@@ -61,7 +61,7 @@ const originalFetch = globalThis.fetch;
 interface WebCall {
   url: string;
   method: string;
-  authorization: string;
+  aasApiKey: string;
   body: any;
 }
 const webCalls: WebCall[] = [];
@@ -80,14 +80,19 @@ globalThis.fetch = (async (input: any, init?: any) => {
   const method = (init?.method ?? "GET").toUpperCase();
   if (url.endsWith("/webhook/composio/finalize") && method === "POST") {
     const headers = init?.headers ?? {};
-    const authorization = headers.Authorization ?? headers.authorization ?? "";
+    // ctrl-api ships the AAS key on `X-AAS-API-Key` — see comment in
+    // composioWebhook.ts:flipRowOnWeb for why this isn't `Authorization`.
+    const aasApiKey =
+      headers["X-AAS-API-Key"] ??
+      headers["x-aas-api-key"] ??
+      "";
     let body: any = null;
     try {
       body = JSON.parse(String(init?.body ?? "null"));
     } catch {
       body = null;
     }
-    webCalls.push({ url, method, authorization, body });
+    webCalls.push({ url, method, aasApiKey, body });
     return makeJsonResponse(webResponseBody, webResponseStatus);
   }
   throw new Error(`unexpected fetch in composioWebhook test: ${method} ${url}`);
@@ -258,7 +263,7 @@ describe("/api/v1/composio/webhook — connected_account.updated → ACTIVE flip
       webCalls[0].url,
       "http://web-stub:3000/webhook/composio/finalize",
     );
-    assert.equal(webCalls[0].authorization, "Bearer test-aas-api-key");
+    assert.equal(webCalls[0].aasApiKey, "test-aas-api-key");
     assert.equal(webCalls[0].body.connectionId, "ca_active_001");
     assert.equal(webCalls[0].body.status, "ACTIVE");
   });

--- a/packages/web/src/integrations/composioWebhookFinalize.ts
+++ b/packages/web/src/integrations/composioWebhookFinalize.ts
@@ -15,10 +15,19 @@
  * Auth
  * ----
  * Shared secret `AAS_API_KEY` — the same secret used in the other direction
- * (web → ctrl-api). The middleware swaps out Wasp's default authMiddleware
- * (which expects a session cookie) for a Bearer-token check against
- * `process.env.AAS_API_KEY`. The endpoint is NOT user-facing; it's
- * compose-network-only and never crosses the Caddy public surface.
+ * (web → ctrl-api). It arrives in the `X-AAS-API-Key` header (NOT the
+ * standard `Authorization: Bearer ...`). Reason: Wasp's per-route `auth`
+ * middleware runs BEFORE the api fn's own middlewareConfigFn and tries to
+ * validate any Bearer token as a user session token — a service-side key
+ * gets rejected with `{"message":"Invalid credentials"}` before our
+ * handler ever runs. Using a custom header sidesteps that gate cleanly.
+ * (The `userApiProxy` pattern works only because its `alf_*` keys never
+ * pass through the auth gate — Wasp's middleware lets requests with NO
+ * Authorization header fall through to the handler.) The middleware
+ * deletion is kept as a defence-in-depth no-op.
+ *
+ * The endpoint is NOT user-facing; it's compose-network-only and never
+ * crosses the Caddy public surface.
  *
  * Why this isn't an action
  * ------------------------
@@ -100,10 +109,17 @@ export const finalizeComposioWebhook = async (
     });
     return;
   }
-  const auth = req.headers.authorization ?? "";
-  if (!auth.startsWith("Bearer ") || auth.slice(7) !== AAS_API_KEY) {
+  // Service-token comes in on a custom header — see the file-header
+  // comment for why this isn't `Authorization: Bearer ...`. Both lower-
+  // and original-case lookups since express's req.headers is lower-cased
+  // but some test harnesses preserve the original casing.
+  const headerValue =
+    (req.headers["x-aas-api-key"] as string | undefined) ??
+    (req.headers["X-AAS-API-Key"] as string | undefined) ??
+    "";
+  if (!headerValue || headerValue !== AAS_API_KEY) {
     res.status(401).json({
-      error: { code: "UNAUTHORIZED", message: "Bearer AAS_API_KEY required" },
+      error: { code: "UNAUTHORIZED", message: "X-AAS-API-Key header required" },
     });
     return;
   }


### PR DESCRIPTION
## Live failure observed after #74

Every real `connected_account.updated → ACTIVE` event reached
ctrl-api on home/joe/miguel/rj/zsolt cleanly — but the web hop collapsed
to 502. Curling web directly from inside the ctrl-api container:

```
$ curl -X POST -H "Authorization: Bearer <AAS_API_KEY>" \
       -d '{"connectionId":"ca_x"}' http://web:3000/webhook/composio/finalize
HTTP/1.1 401 Unauthorized
{"message":"Invalid credentials","data":{}}
```

That's Wasp's per-route `auth` middleware running BEFORE the api fn's
`middlewareConfigFn`. Inspecting the rendered bundle confirms:

```js
router.post(
  "/webhook/composio/finalize",
  [auth, ...finalizeComposioWebhookMiddleware],    // auth FIRST
  defineHandler(...)
);
```

`middlewareConfig.delete("authMiddleware")` only removes the express-
global hook, not the per-route `auth` shim. Any `Authorization: Bearer
...` header arriving at a Wasp `api` route is validated as a user-session
token before our handler ever runs. The reason `userApiProxy` works
despite using the same pattern is that its `alf_*` keys land via the
no-Authorization-header path — Wasp's auth falls through when the header
is absent.

## Fix

Ship `AAS_API_KEY` on a custom `X-AAS-API-Key` header instead of
`Authorization: Bearer`. Wasp's auth middleware doesn't inspect non-
Authorization headers, so the request sails through to the handler,
which validates the secret itself.

## Tests

All 14 tests in `composioWebhook.test.ts` pass; the fetch stub asserts
on the new header.

## Deploy

Same drill as #74 — wait for `build-ctrl-api.yml` + `build-web.yml`,
then `docker compose pull ctrl-api web web-client && docker compose up -d`
on home/rj/joe/zsolt/miguel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)