### PR TITLE
feat(paperclip): auto-bootstrap CEO invite — zero-CLI /channels setup

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1288,6 +1288,40 @@ services:
     mem_limit: 1g
     pids_limit: 512
 
+  # ── paperclip-init — one-shot CEO-invite auto-bootstrap ──────────────
+  # Paperclip's first-run requires two CLI commands inside the container:
+  #   1. `pnpm paperclipai onboard -y --bind lan`     → writes config.json + .env
+  #   2. `pnpm paperclipai auth bootstrap-ceo`        → prints the invite URL
+  # Without them the principal hits the "Instance setup required" wall on
+  # paperclip.<DOMAIN>/sign-in and has no path forward without SSH access
+  # (live-observed on home 2026-05-27, 6 manual steps to recover).
+  #
+  # This one-shot service reuses the alfred-init image (the script ships
+  # there at /setup/bootstrap-paperclip.sh) but:
+  #   * mounts /var/run/docker.sock RO so it can `docker exec` into paperclip
+  #     as the `node` user (uid 1000) — running as root creates an ownership
+  #     trap on paperclip_data;
+  #   * mounts alfred_data:/alfred-data so the parsed "Invite URL: …" lands
+  #     at /alfred-data/paperclip-ceo-invite.txt, where ctrl-api reads it
+  #     and surfaces it on the /channels Paperclip card (needs_admin_signup
+  #     setup_state, see channels_paperclip.ts).
+  #
+  # Idempotent: re-runs are a no-op once the invite file + paperclip's
+  # config.json are both present.
+  paperclip-init:
+    image: ssdavidai00/alfred-init:latest
+    restart: "no"
+    depends_on:
+      paperclip:
+        condition: service_healthy
+    volumes:
+      - alfred_data:/alfred-data
+      # RO socket — the script only invokes `docker exec` / `docker inspect`.
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    entrypoint: ["./bootstrap-paperclip.sh"]
+    mem_limit: 256m
+    pids_limit: 256
+
   # ── Vexa — transcript bot stack (profile: vexa) ─────────────────────
   # `docker compose --profile vexa up -d`. 9 services, ~3 GB resident.
   # Folded inline here (the alfred-platform fleet ran Vexa as a separate

--- a/packages/ctrl/src/api/routes/channels_paperclip.ts
+++ b/packages/ctrl/src/api/routes/channels_paperclip.ts
@@ -610,33 +610,66 @@ function recordAuthFailure(body: unknown, kind: "auth_failed" | "replay"): void 
 
 // ── Paperclip setup-state probe ───────────────────────────────────────────
 //
-// Paperclip's auto-bootstrap turned out to be a much bigger lift than the
-// integration was worth (Paperclip's `authenticated` mode requires a
-// CEO-invite ritual that touches multiple internal tables; `local_trusted`
-// mode needs additional config the container won't boot without). So the
-// /channels card carries the principal through Paperclip's own setup with
-// a polished click-through UX instead. Sir 2026-05-27.
-//
 // `setup_state` drives which sub-card the UI renders:
-//   * "needs_api_key"  — Paperclip is reachable but our PAPERCLIP_API_KEY
-//                        is blank → tell the principal to sign up at
-//                        paperclip.<DOMAIN>, then paste a Settings → API
-//                        keys value back here.
-//   * "configured"     — PAPERCLIP_API_KEY set and Paperclip accepts it
-//                        (probed: /api/companies returns 200, NOT 401/403).
-//   * "auth_failed"    — key set but Paperclip rejects → key likely
-//                        expired/revoked; prompt for a new one.
-//   * "unreachable"    — paperclip:3100 not responding → container down /
-//                        not deployed.
+//   * "needs_admin_signup" — Paperclip's `paperclip-init` one-shot has
+//                            written /alfred-data/paperclip-ceo-invite.txt
+//                            but no admin user has accepted yet. Paperclip's
+//                            /sign-in page returns the "Instance setup
+//                            required" wall. The card surfaces the invite
+//                            URL as `admin_invite_url` so the principal
+//                            clicks once and signs up — zero CLI. (Added
+//                            2026-05-27 after Sir's 6-step manual recovery.)
+//   * "needs_api_key"      — Paperclip is reachable AND past its
+//                            instance-setup wall but our PAPERCLIP_API_KEY
+//                            is blank → tell the principal to paste a
+//                            Settings → API keys value from Paperclip.
+//   * "configured"         — PAPERCLIP_API_KEY set and Paperclip accepts it
+//                            (probed: /api/companies returns 200, NOT 401/403).
+//   * "auth_failed"        — key set but Paperclip rejects → key likely
+//                            expired/revoked; prompt for a new one.
+//   * "unreachable"        — paperclip:3100 not responding → container down /
+//                            not deployed.
 type PaperclipSetupState =
+  | "needs_admin_signup"
   | "needs_api_key"
   | "configured"
   | "auth_failed"
   | "unreachable";
 
+// Where paperclip-init writes the captured "Invite URL: …" from
+// `pnpm paperclipai auth bootstrap-ceo`. Bind-mounted into ctrl-api as
+// /alfred-data already (matches the other /alfred-data files we read here).
+const PAPERCLIP_INVITE_PATH = "/alfred-data/paperclip-ceo-invite.txt";
+
+/** Read the captured CEO invite URL written by the paperclip-init
+ *  bootstrap script. Returns null when the file is missing/empty/garbage
+ *  — the caller decides whether that means "still onboarding" or "old
+ *  tenant pre-paperclip-init". */
+function readPaperclipInviteUrl(): string | null {
+  // Override for tests — same pattern as HERMES_CONFIG_DIR above.
+  const p = process.env.PAPERCLIP_INVITE_FILE ?? PAPERCLIP_INVITE_PATH;
+  let raw: string;
+  try {
+    raw = fs.readFileSync(p, "utf-8");
+  } catch {
+    return null;
+  }
+  const url = raw.trim();
+  if (!url) return null;
+  // Defensive: only surface http(s) URLs — if the file is corrupted with
+  // a stray banner line, hide it rather than render garbage as a link.
+  if (!/^https?:\/\//.test(url)) return null;
+  return url;
+}
+
 const PAPERCLIP_URL = "http://paperclip:3100";
 
-async function probeSetupState(): Promise<PaperclipSetupState> {
+interface SetupProbeResult {
+  state: PaperclipSetupState;
+  admin_invite_url: string | null;
+}
+
+async function probeSetupState(): Promise<SetupProbeResult> {
   const apiKey = process.env.PAPERCLIP_API_KEY?.trim();
   // Paperclip's better-auth checks Host header against PAPERCLIP_PUBLIC_URL —
   // same trusted-origins quirk apps.ts already handles. Use the public host.
@@ -645,7 +678,10 @@ async function probeSetupState(): Promise<PaperclipSetupState> {
   }`;
   // Reach the compose-internal address but spoof Host. Node fetch drops
   // manual Host; fall back to node:http (same trick as apps.ts).
-  function probe(path: string, withAuth: boolean): Promise<number> {
+  function probe(
+    path: string,
+    withAuth: boolean,
+  ): Promise<{ status: number; body: string }> {
     return new Promise((resolve) => {
       const headers: Record<string, string> = { Host: host };
       if (withAuth && apiKey) headers.Authorization = `Bearer ${apiKey}`;
@@ -659,31 +695,80 @@ async function probeSetupState(): Promise<PaperclipSetupState> {
           timeout: 3000,
         },
         (resp) => {
-          resp.resume();
-          resolve(resp.statusCode ?? 0);
+          const chunks: Buffer[] = [];
+          // Cap body capture so a misbehaving Paperclip can't blow up
+          // ctrl-api memory. 64 KB is more than enough for the
+          // "Instance setup required" sentinel which lives in the first
+          // ~2 KB of the HTML response.
+          const LIMIT = 64 * 1024;
+          let total = 0;
+          let truncated = false;
+          resp.on("data", (c: Buffer) => {
+            if (truncated) return;
+            total += c.length;
+            if (total > LIMIT) {
+              truncated = true;
+              chunks.push(c.subarray(0, c.length - (total - LIMIT)));
+              resp.resume(); // drain remainder without buffering
+              return;
+            }
+            chunks.push(c);
+          });
+          resp.on("end", () => {
+            resolve({
+              status: resp.statusCode ?? 0,
+              body: Buffer.concat(chunks).toString("utf-8"),
+            });
+          });
         },
       );
-      req.on("error", () => resolve(0));
+      req.on("error", () => resolve({ status: 0, body: "" }));
       req.on("timeout", () => {
         req.destroy();
-        resolve(0);
+        resolve({ status: 0, body: "" });
       });
       req.end();
     });
   }
   if (!apiKey) {
-    // Confirm Paperclip is at least reachable before saying "needs key".
+    // Confirm Paperclip is at least reachable. The /sign-in body is the
+    // canonical way to distinguish "instance-setup wall" from "fully
+    // onboarded but our key is missing" — Paperclip prints a verbatim
+    // "Instance setup required" page on the former (live-confirmed on
+    // home pre-bootstrap 2026-05-27). We match on the literal phrase so
+    // a copy-tweak by Paperclip downstream doesn't silently flip
+    // tenants back to "needs_api_key" without an invite link.
     const ping = await probe("/sign-in", false);
-    if (ping === 0) return "unreachable";
-    return "needs_api_key";
+    if (ping.status === 0) {
+      return { state: "unreachable", admin_invite_url: null };
+    }
+    if (
+      ping.body.includes("Instance setup required") ||
+      ping.body.includes("instance setup required")
+    ) {
+      // Surface the invite URL we captured at init-time. When the file
+      // isn't yet present (paperclip-init still running / disabled),
+      // null tells the UI to fall through to a degraded message.
+      return {
+        state: "needs_admin_signup",
+        admin_invite_url: readPaperclipInviteUrl(),
+      };
+    }
+    return { state: "needs_api_key", admin_invite_url: null };
   }
   const probed = await probe("/api/companies", true);
-  if (probed === 0) return "unreachable";
-  if (probed === 401 || probed === 403) return "auth_failed";
+  if (probed.status === 0) {
+    return { state: "unreachable", admin_invite_url: null };
+  }
+  if (probed.status === 401 || probed.status === 403) {
+    return { state: "auth_failed", admin_invite_url: null };
+  }
   // 200 = configured. 404 etc. would be unexpected — treat as auth_failed
   // so the UI prompts for a fresh key.
-  if (probed >= 200 && probed < 300) return "configured";
-  return "auth_failed";
+  if (probed.status >= 200 && probed.status < 300) {
+    return { state: "configured", admin_invite_url: null };
+  }
+  return { state: "auth_failed", admin_invite_url: null };
 }
 
 // ── Routes ────────────────────────────────────────────────────────────────
@@ -697,18 +782,25 @@ export function registerPaperclipChannelRoutes(): void {
   addRoute("GET", "/api/v1/channels/paperclip/status", async ({ res }) => {
     const configured = Boolean(process.env.PAPERCLIP_API_KEY);
     const hasSecret = Boolean(process.env.PAPERCLIP_HEARTBEAT_SECRET);
-    const setupState = await probeSetupState();
+    const probe = await probeSetupState();
     const domain =
       process.env.DOMAIN ?? process.env.TENANT_DOMAIN ?? "alfred.black";
-    sendJson(res, 200, {
+    const payload: Record<string, unknown> = {
       configured,
       heartbeat_url: heartbeatUrl(),
       has_signing_secret: hasSecret,
       last_heartbeat_at: lastHeartbeatAt,
       recent_runs: recentRuns.slice(),
-      setup_state: setupState,
+      setup_state: probe.state,
       paperclip_origin: `https://paperclip.${domain}`,
-    });
+    };
+    // Only surface admin_invite_url when we actually need the principal to
+    // click through it. Other states must NOT leak it — once they've signed
+    // up the invite is stale and surfacing it would be confusing.
+    if (probe.state === "needs_admin_signup" && probe.admin_invite_url) {
+      payload.admin_invite_url = probe.admin_invite_url;
+    }
+    sendJson(res, 200, payload);
   });
 
   // POST /api-key — the principal pastes their freshly-generated Paperclip

--- a/packages/ctrl/tests/channels_paperclip.test.ts
+++ b/packages/ctrl/tests/channels_paperclip.test.ts
@@ -41,6 +41,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import http from "node:http";
 import type { ServerResponse } from "node:http";
 
 const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "channels-paperclip-"));
@@ -66,6 +67,12 @@ fs.writeFileSync(
   "API_SERVER_KEY=test-hermes-key\n",
 );
 process.env.HERMES_CONFIG_DIR = hermesProfilesDir;
+// paperclip-init writes the captured "Invite URL: …" to this file. Tests
+// drive `setup_state === "needs_admin_signup"` by writing / deleting this
+// path. (Production path is /alfred-data/paperclip-ceo-invite.txt; the
+// override lives in channels_paperclip.ts under PAPERCLIP_INVITE_FILE.)
+const paperclipInviteFile = path.join(tmp, "paperclip-ceo-invite.txt");
+process.env.PAPERCLIP_INVITE_FILE = paperclipInviteFile;
 
 // ── fetch mock ─────────────────────────────────────────────────────────────
 //
@@ -76,6 +83,7 @@ process.env.HERMES_CONFIG_DIR = hermesProfilesDir;
 //     opening a real HTTP socket.
 
 const originalFetch = globalThis.fetch;
+const originalHttpRequest = http.request;
 
 let hermesOk = true;
 let hermesText = "I have logged the task and will report progress shortly.";
@@ -83,6 +91,96 @@ let hermesStatus = 200;
 let hermesShouldThrow = false;
 let hermesShouldTimeout = false;
 const hermesCalls: { url: string; sessionKey: string; input: string }[] = [];
+
+// ── paperclip:3100 mock ──────────────────────────────────────────────────
+//
+// probeSetupState() calls `http.request({hostname:"paperclip", port:3100,
+// path:"/sign-in" | "/api/companies", …})`. In the production stack that
+// resolves through Docker DNS; in the test harness `paperclip` does not
+// resolve at all (the default test environment routes those probes to
+// req.on("error") → status 0 → "unreachable"). To cover the new
+// `needs_admin_signup` branch, intercept http.request at the module level
+// and return a stub response whose body carries (or doesn't carry) the
+// "Instance setup required" sentinel string.
+//
+// State is set per-test via paperclipHttpStub.set(…) — same posture as the
+// hermesOk / hermesShouldThrow flags above.
+
+type PaperclipProbe = {
+  status: number;
+  body: string;
+};
+
+const paperclipHttpStub = {
+  // Default: paperclip not reachable (matches the live "no sidecar" case).
+  signIn: null as PaperclipProbe | null,
+  apiCompanies: null as PaperclipProbe | null,
+};
+
+// Minimal stub of an IncomingMessage — enough for the probe's data/end
+// handlers and resp.resume() (the route uses both shapes).
+function fakeIncomingMessage(p: PaperclipProbe) {
+  const handlers: Record<string, ((arg?: any) => void)[]> = {};
+  const msg: any = {
+    statusCode: p.status,
+    on(ev: string, cb: (arg?: any) => void) {
+      (handlers[ev] ||= []).push(cb);
+      return msg;
+    },
+    resume() {
+      // Drain — fire end immediately for the probe paths that don't read body.
+      setImmediate(() => (handlers["end"] || []).forEach((cb) => cb()));
+    },
+  };
+  // Deliver body bytes async to match real http semantics.
+  setImmediate(() => {
+    if (p.body) {
+      (handlers["data"] || []).forEach((cb) =>
+        cb(Buffer.from(p.body, "utf-8")),
+      );
+    }
+    (handlers["end"] || []).forEach((cb) => cb());
+  });
+  return msg;
+}
+
+(http as any).request = ((options: any, cb?: (resp: any) => void) => {
+  const host = options?.hostname ?? "";
+  const path = options?.path ?? "";
+  if (host === "paperclip") {
+    // Build a minimal ClientRequest-like object that fires either our
+    // stubbed response or an "error" if we have no probe configured.
+    const reqHandlers: Record<string, ((arg?: any) => void)[]> = {};
+    const req: any = {
+      on(ev: string, h: (arg?: any) => void) {
+        (reqHandlers[ev] ||= []).push(h);
+        return req;
+      },
+      end() {
+        let probe: PaperclipProbe | null = null;
+        if (path === "/sign-in") probe = paperclipHttpStub.signIn;
+        else if (path === "/api/companies")
+          probe = paperclipHttpStub.apiCompanies;
+        if (probe) {
+          setImmediate(() => cb?.(fakeIncomingMessage(probe!)));
+        } else {
+          setImmediate(() =>
+            (reqHandlers["error"] || []).forEach((h) =>
+              h(new Error("paperclip not stubbed")),
+            ),
+          );
+        }
+        return req;
+      },
+      destroy() {},
+      setTimeout() {},
+    };
+    return req;
+  }
+  // Anything else — fall through to the real implementation (the tests
+  // don't drive any other http.request calls today).
+  return (originalHttpRequest as any)(options, cb);
+}) as typeof http.request;
 
 function makeJsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -265,10 +363,19 @@ describe("/api/v1/channels/paperclip/* — Lane I", () => {
     hermesCalls.length = 0;
     delete process.env.PAPERCLIP_HEARTBEAT_SECRET;
     delete process.env.PAPERCLIP_API_KEY;
+    paperclipHttpStub.signIn = null;
+    paperclipHttpStub.apiCompanies = null;
+    // Reset the invite file between tests so probes don't leak state.
+    try {
+      fs.unlinkSync(paperclipInviteFile);
+    } catch {
+      /* file may not exist */
+    }
   });
 
   after(() => {
     globalThis.fetch = originalFetch;
+    (http as any).request = originalHttpRequest;
   });
 
   describe("GET /status", () => {
@@ -292,6 +399,94 @@ describe("/api/v1/channels/paperclip/* — Lane I", () => {
       assert.equal(r.status, 200);
       assert.equal(r.payload.configured, true);
       assert.equal(r.payload.has_signing_secret, true);
+    });
+
+    it("setup_state=needs_admin_signup + admin_invite_url when Paperclip shows the instance-setup wall and the invite file is present", async () => {
+      // Paperclip's /sign-in body on a fresh sidecar:
+      paperclipHttpStub.signIn = {
+        status: 200,
+        body:
+          "<!DOCTYPE html><html><body>" +
+          "<h1>Instance setup required</h1>" +
+          "<p>Run pnpm paperclipai auth bootstrap-ceo to claim this instance.</p>" +
+          "</body></html>",
+      };
+      // paperclip-init writes the captured invite URL here.
+      const invite =
+        "https://paperclip.test.alfred.black/admin/setup?token=abc123";
+      fs.writeFileSync(paperclipInviteFile, invite + "\n");
+
+      const r = await invokeRoute("GET", "/api/v1/channels/paperclip/status");
+      assert.equal(r.status, 200);
+      assert.equal(r.payload.setup_state, "needs_admin_signup");
+      assert.equal(r.payload.admin_invite_url, invite);
+    });
+
+    it("needs_admin_signup with no invite file → setup_state surfaces but admin_invite_url is absent", async () => {
+      // paperclip-init might not have completed yet (or compose hasn't been
+      // restarted). The card should still show the right state so the UI
+      // can show a degraded "still preparing your invite…" message.
+      paperclipHttpStub.signIn = {
+        status: 200,
+        body: "<h1>Instance setup required</h1>",
+      };
+      // No invite file written.
+      const r = await invokeRoute("GET", "/api/v1/channels/paperclip/status");
+      assert.equal(r.status, 200);
+      assert.equal(r.payload.setup_state, "needs_admin_signup");
+      assert.equal(r.payload.admin_invite_url, undefined);
+    });
+
+    it("setup_state=needs_api_key when /sign-in is up and NOT showing the instance-setup wall", async () => {
+      // Past the admin-signup wall, but PAPERCLIP_API_KEY is still unset.
+      paperclipHttpStub.signIn = {
+        status: 200,
+        body:
+          "<!DOCTYPE html><html><body>" +
+          "<form><input name='email'/><input name='password' type='password'/>" +
+          "<button>Sign in</button></form></body></html>",
+      };
+      // Even if the invite file is present, we must NOT surface it on
+      // needs_api_key — the principal has already signed up; the URL is stale.
+      fs.writeFileSync(
+        paperclipInviteFile,
+        "https://paperclip.test.alfred.black/admin/setup?token=stale\n",
+      );
+
+      const r = await invokeRoute("GET", "/api/v1/channels/paperclip/status");
+      assert.equal(r.status, 200);
+      assert.equal(r.payload.setup_state, "needs_api_key");
+      assert.equal(r.payload.admin_invite_url, undefined);
+    });
+
+    it("setup_state=configured when PAPERCLIP_API_KEY is set and /api/companies returns 200", async () => {
+      process.env.PAPERCLIP_API_KEY = "pck_real_key";
+      paperclipHttpStub.apiCompanies = { status: 200, body: "[]" };
+      const r = await invokeRoute("GET", "/api/v1/channels/paperclip/status");
+      assert.equal(r.status, 200);
+      assert.equal(r.payload.setup_state, "configured");
+      assert.equal(r.payload.admin_invite_url, undefined);
+    });
+
+    it("setup_state=auth_failed when /api/companies rejects the key", async () => {
+      process.env.PAPERCLIP_API_KEY = "pck_revoked";
+      paperclipHttpStub.apiCompanies = { status: 401, body: "" };
+      const r = await invokeRoute("GET", "/api/v1/channels/paperclip/status");
+      assert.equal(r.status, 200);
+      assert.equal(r.payload.setup_state, "auth_failed");
+    });
+
+    it("admin_invite_url is hidden when the invite file holds garbage", async () => {
+      paperclipHttpStub.signIn = {
+        status: 200,
+        body: "Instance setup required",
+      };
+      // Non-URL content (e.g. a stray banner line snuck through the parser).
+      fs.writeFileSync(paperclipInviteFile, "not-actually-a-url\n");
+
+      const r = await invokeRoute("GET", "/api/v1/channels/paperclip/status");
+      assert.equal(r.payload.setup_state, "needs_admin_signup");
+      assert.equal(r.payload.admin_invite_url, undefined);
     });
   });
 

--- a/packages/hermes/init/Dockerfile
+++ b/packages/hermes/init/Dockerfile
@@ -28,7 +28,21 @@ RUN npm run build
 FROM python:3.12-slim-bookworm
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    rsync gettext-base git && \
+    rsync gettext-base git ca-certificates curl gnupg \
+    && rm -rf /var/lib/apt/lists/*
+
+# docker-ce-cli only — bootstrap-paperclip.sh shells out to `docker exec`
+# / `docker inspect` against the paperclip sidecar (via the docker socket
+# bind-mounted on the paperclip-init compose service). We pull JUST the
+# CLI from Docker's apt repo so we don't drag in containerd / runc the
+# way Debian's `docker.io` meta-package would. ~30 MB installed.
+RUN install -m 0755 -d /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+    chmod a+r /etc/apt/keyrings/docker.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian bookworm stable" \
+        > /etc/apt/sources.list.d/docker.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends docker-ce-cli && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /setup
@@ -50,6 +64,11 @@ RUN pip install --no-cache-dir "jinja2==3.1.6"
 COPY packages/hermes/init/entrypoint.sh        ./entrypoint.sh
 COPY packages/hermes/init/render_hermes.py     ./render_hermes.py
 COPY packages/hermes/init/render_sms_gateway.py ./render_sms_gateway.py
+# Paperclip auto-bootstrap. Invoked as the entrypoint of the sibling
+# `paperclip-init` compose service (see docker-compose.yaml). Not run by
+# this image's default entrypoint.sh — keeps the main init container
+# focused on filesystem scaffolding (no docker.sock there).
+COPY packages/hermes/init/bootstrap-paperclip.sh ./bootstrap-paperclip.sh
 COPY packages/hermes/init/sure-bootstrap.rb    ./sure-bootstrap.rb
 COPY packages/hermes/init/sure-mutate-base.rb  ./sure-mutate-base.rb
 COPY packages/hermes/init/sure-account-mutate.rb    ./sure-account-mutate.rb
@@ -104,6 +123,6 @@ COPY packages/mcp-server/instructions/alfred-custom-instructions.md ./AGENTS.md
 # persona at /vault/SOUL.md takes precedence when present (see entrypoint).
 COPY packages/hermes/init/SOUL.md ./SOUL.md
 
-RUN chmod +x entrypoint.sh
+RUN chmod +x entrypoint.sh bootstrap-paperclip.sh
 
 ENTRYPOINT ["./entrypoint.sh"]

--- a/packages/hermes/init/bootstrap-paperclip.sh
+++ b/packages/hermes/init/bootstrap-paperclip.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# =============================================================================
+# bootstrap-paperclip.sh — idempotent first-boot bootstrap of the Paperclip
+# sidecar so the principal never has to SSH to claim their CEO invite.
+#
+# Why a separate script (and a separate compose service)?
+# -------------------------------------------------------
+# The main alfred-init container has no docker.sock and no dependency on
+# paperclip's health gate — both of which we need here. So this script ships
+# in the same image but is invoked as the entrypoint of a sibling `paperclip-
+# init` compose service that:
+#   * mounts /var/run/docker.sock RO (we only run `docker exec` / `inspect`)
+#   * has alfred_data:/alfred-data so the parsed invite URL becomes a
+#     single-source-of-truth file ctrl-api reads (no docker socket needed
+#     in ctrl-api to learn the URL).
+#   * depends_on: paperclip { condition: service_healthy } so by the time
+#     this runs, paperclip's web server is up.
+#
+# What it does
+# ------------
+#   1. Wait for the paperclip container to be healthy (up to 2 min). Compose
+#      already gates on service_healthy so this is normally a single poll;
+#      kept as a belt-and-braces guard against a late health flip.
+#   2. Bail out (exit 0, idempotent) when /alfred-data/paperclip-ceo-invite.txt
+#      already exists AND paperclip's instance config.json is present inside
+#      the container. The principal has already been carried through.
+#   3. Run `pnpm paperclipai onboard -y --bind lan` as uid 1000 (`node`).
+#      Running as root creates a uid 0 ownership trap on the paperclip
+#      volume (live-observed on home 2026-05-27); --user node sidesteps it
+#      entirely. -y suppresses interactive prompts; --bind lan trusts
+#      compose-network callers.
+#   4. Run `pnpm paperclipai auth bootstrap-ceo` (also as `node`). Parse the
+#      "Invite URL: https://…" line out of stdout — Paperclip prints this
+#      banner verbatim on success.
+#   5. Write the parsed URL to /alfred-data/paperclip-ceo-invite.txt with
+#      0644 so ctrl-api (root) and the rest of the stack can read it. That
+#      file is what ctrl-api surfaces in /api/v1/channels/paperclip/status.
+#
+# Constraints
+# -----------
+#   * Every `docker exec` uses `--user node` (uid 1000). Sir's 2026-05-27
+#     manual run hit the trap of root-owned config.json + a container
+#     restart-looping unable to read its own files. Bake the user flag in.
+#   * Idempotent: re-running on an already-bootstrapped tenant is a no-op.
+#   * Tenant container name must be discoverable. Compose names containers
+#     `<project>_paperclip_1` or `<project>-paperclip-1` depending on
+#     version; resolve via `docker ps --filter label=com.docker.compose.
+#     service=paperclip --format '{{.Names}}'` so we don't hard-code home's
+#     `alfred-black-paperclip-1`.
+# =============================================================================
+set -euo pipefail
+
+LOG_PREFIX="[paperclip-bootstrap]"
+log() { echo "$LOG_PREFIX $*"; }
+
+INVITE_FILE="${INVITE_FILE:-/alfred-data/paperclip-ceo-invite.txt}"
+WAIT_TIMEOUT_SECS="${WAIT_TIMEOUT_SECS:-120}"
+WAIT_INTERVAL_SECS="${WAIT_INTERVAL_SECS:-5}"
+
+# Locate the paperclip container by compose service label. Falls back to a
+# substring match on container name so we degrade gracefully if labels are
+# stripped (e.g. some docker-in-docker setups).
+resolve_paperclip_container() {
+    local name
+    name=$(docker ps --filter "label=com.docker.compose.service=paperclip" \
+        --format '{{.Names}}' 2>/dev/null | head -n1 || true)
+    if [[ -z "$name" ]]; then
+        name=$(docker ps --format '{{.Names}}' 2>/dev/null | grep -E '(^|[-_])paperclip([-_]|$)' | head -n1 || true)
+    fi
+    echo "$name"
+}
+
+# Wait for paperclip's healthcheck to flip to "healthy". Compose's
+# `depends_on: condition: service_healthy` already does this, but we re-check
+# in-script so the script is safe to invoke standalone (e.g. manual rerun).
+wait_for_paperclip_health() {
+    local container="$1"
+    local deadline=$(( $(date +%s) + WAIT_TIMEOUT_SECS ))
+    while [[ $(date +%s) -lt $deadline ]]; do
+        local status
+        status=$(docker inspect "$container" --format '{{.State.Health.Status}}' 2>/dev/null || echo "missing")
+        case "$status" in
+            healthy)
+                log "paperclip container '$container' is healthy"
+                return 0
+                ;;
+            "")
+                # No healthcheck defined on the container — fall back to
+                # State.Status=running. Shouldn't happen on our stack
+                # (compose pins a healthcheck) but defend against drift.
+                local running
+                running=$(docker inspect "$container" --format '{{.State.Running}}' 2>/dev/null || echo "false")
+                if [[ "$running" == "true" ]]; then
+                    log "paperclip has no healthcheck but is running — proceeding"
+                    return 0
+                fi
+                ;;
+            missing)
+                log "paperclip container '$container' not found yet; retrying in ${WAIT_INTERVAL_SECS}s…"
+                ;;
+            *)
+                log "paperclip health=$status; waiting ${WAIT_INTERVAL_SECS}s…"
+                ;;
+        esac
+        sleep "$WAIT_INTERVAL_SECS"
+    done
+    log "ERROR: paperclip container did not become healthy within ${WAIT_TIMEOUT_SECS}s"
+    return 1
+}
+
+# Idempotency probe — true when we've already carried this tenant through
+# the bootstrap. The two conditions together rule out a partial first-run
+# (e.g. invite file written but the container's config.json never landed
+# because pnpm crashed mid-way).
+already_bootstrapped() {
+    local container="$1"
+    if [[ ! -s "$INVITE_FILE" ]]; then
+        return 1
+    fi
+    if ! docker exec --user node "$container" test -s /paperclip/instances/default/config.json >/dev/null 2>&1; then
+        return 1
+    fi
+    return 0
+}
+
+# Run paperclip's onboarding ritual (config.json + .env) as the `node` user.
+# -y skips prompts; --bind lan trusts compose-network callers (the alternative
+# `local` is loopback-only and breaks heartbeats from sibling containers).
+paperclip_onboard() {
+    local container="$1"
+    log "running 'pnpm paperclipai onboard -y --bind lan' (as node)…"
+    if ! docker exec --user node "$container" pnpm paperclipai onboard -y --bind lan; then
+        log "ERROR: 'pnpm paperclipai onboard' failed"
+        return 1
+    fi
+}
+
+# Run bootstrap-ceo and capture the "Invite URL: …" line. Paperclip prints
+# the URL verbatim on success (banner format, observed on home 2026-05-27).
+# We grab stdout+stderr together — early Paperclip builds wrote the banner to
+# stderr and the live one writes it to stdout; tolerate either.
+paperclip_bootstrap_ceo() {
+    local container="$1"
+    local out_file
+    out_file=$(mktemp)
+    log "running 'pnpm paperclipai auth bootstrap-ceo' (as node)…"
+    if ! docker exec --user node "$container" pnpm paperclipai auth bootstrap-ceo >"$out_file" 2>&1; then
+        log "ERROR: 'pnpm paperclipai auth bootstrap-ceo' failed; output:"
+        sed 's/^/  /' "$out_file" || true
+        rm -f "$out_file"
+        return 1
+    fi
+    local url
+    # Paperclip prints exactly: "Invite URL: https://…". Anchor on that
+    # prefix to avoid catching unrelated https://… mentions in the banner.
+    url=$(grep -oE 'Invite URL: https?://[^[:space:]]+' "$out_file" | head -n1 | sed -E 's/^Invite URL: //')
+    rm -f "$out_file"
+    if [[ -z "$url" ]]; then
+        log "ERROR: could not parse 'Invite URL:' from bootstrap-ceo output"
+        return 1
+    fi
+    log "captured invite URL: $url"
+    # Write atomically (.tmp then rename) so a partial write never leaves
+    # ctrl-api reading a truncated URL.
+    local tmp="${INVITE_FILE}.tmp"
+    printf '%s\n' "$url" > "$tmp"
+    chmod 0644 "$tmp" 2>/dev/null || true
+    mv "$tmp" "$INVITE_FILE"
+    log "wrote $INVITE_FILE"
+}
+
+# --- main ---
+log "starting Paperclip auto-bootstrap"
+
+if ! command -v docker >/dev/null 2>&1; then
+    log "ERROR: docker CLI not on PATH — cannot run 'docker exec' against paperclip"
+    exit 1
+fi
+
+PAPERCLIP_CONTAINER=$(resolve_paperclip_container)
+if [[ -z "$PAPERCLIP_CONTAINER" ]]; then
+    log "WARN: no paperclip container running — nothing to do (skipping)"
+    exit 0
+fi
+log "resolved paperclip container: $PAPERCLIP_CONTAINER"
+
+if ! wait_for_paperclip_health "$PAPERCLIP_CONTAINER"; then
+    exit 1
+fi
+
+if already_bootstrapped "$PAPERCLIP_CONTAINER"; then
+    log "already bootstrapped (invite file + config.json present) — no-op"
+    exit 0
+fi
+
+# If config.json exists but the invite file doesn't, the principal got as
+# far as onboard but bootstrap-ceo never landed (or its output file was
+# deleted). Skip the onboard step in that case so we don't reset their
+# state, but still run bootstrap-ceo.
+if docker exec --user node "$PAPERCLIP_CONTAINER" test -s /paperclip/instances/default/config.json >/dev/null 2>&1; then
+    log "config.json already present — skipping 'onboard' step"
+else
+    paperclip_onboard "$PAPERCLIP_CONTAINER" || exit 1
+fi
+
+paperclip_bootstrap_ceo "$PAPERCLIP_CONTAINER" || exit 1
+
+log "Paperclip auto-bootstrap complete"
+exit 0

--- a/packages/web/src/dashboard/ChannelsPage.tsx
+++ b/packages/web/src/dashboard/ChannelsPage.tsx
@@ -2801,6 +2801,21 @@ function PaperclipCard() {
         </div>
       )}
 
+      {/* needs_admin_signup — paperclip-init has captured the CEO invite
+          URL but no admin has signed up yet. The principal clicks the
+          big "Set up your Paperclip account →" button (opens new tab),
+          completes Paperclip's first-run signup, comes back; the next
+          /status poll flips to "needs_api_key" and the panel below
+          takes over. Replaces the 6-step manual SSH ritual (2026-05-27). */}
+      {card.status === "needs_admin_signup" && (
+        <PaperclipAdminSignupPanel
+          adminInviteUrl={card.adminInviteUrl}
+          paperclipOrigin={card.paperclipOrigin}
+          description={card.description}
+          onRefetch={refetch}
+        />
+      )}
+
       {/* needs_api_key — Paperclip is up but the principal hasn't walked
           its own setup ritual yet (P3). Two-click path: "Open Paperclip"
           → they sign up + generate an API key → paste here. Once the
@@ -3066,18 +3081,117 @@ function PaperclipCard() {
 }
 
 // ---------------------------------------------------------------------------
+// Paperclip admin-signup click-through panel (2026-05-27).
+//
+// Rendered when card.status === "needs_admin_signup". The paperclip-init
+// compose service runs `pnpm paperclipai onboard` + `pnpm paperclipai auth
+// bootstrap-ceo` automatically on first boot and writes the captured
+// "Invite URL: …" to /alfred-data/paperclip-ceo-invite.txt. ctrl-api reads
+// that file and surfaces it as `admin_invite_url`. The principal:
+//
+//   1. Clicks the big "Set up your Paperclip account →" button (new tab).
+//   2. Signs up in Paperclip's normal first-run flow (claim instance,
+//      pick a password).
+//   3. Comes back to this card; the next /status poll flips to
+//      "needs_api_key" and the PaperclipApiKeyPanel below carries them
+//      through generating + pasting an API key.
+//
+// Zero CLI. Replaces the 6-step SSH ritual Sir walked through on home.
+//
+// Edge case — invite URL not yet present (paperclip-init still running on
+// a freshly-deployed tenant): we render a "preparing your invite…"
+// placeholder + a Re-check button so the principal can poll. Once
+// adminInviteUrl arrives, the click-through CTA appears.
+// ---------------------------------------------------------------------------
+
+function PaperclipAdminSignupPanel({
+  adminInviteUrl,
+  paperclipOrigin,
+  description,
+  onRefetch,
+}: {
+  adminInviteUrl: string;
+  paperclipOrigin: string;
+  description: string;
+  onRefetch: () => unknown;
+}) {
+  const ready = Boolean(adminInviteUrl);
+  return (
+    <div className="mt-5 space-y-5">
+      <p
+        className="font-body italic text-[13px]"
+        style={{ color: "var(--marginalia)" }}
+      >
+        {description}
+      </p>
+
+      {ready ? (
+        <a
+          href={adminInviteUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          // Mirror PaperclipApiKeyPanel's button class so the visual
+          // language is identical — same fonts, same hover, same height.
+          className="btn-ghost inline-block"
+        >
+          Set up your Paperclip account →
+        </a>
+      ) : (
+        <div className="space-y-2">
+          <p
+            className="font-body italic text-[12px]"
+            style={{ color: "var(--brass)" }}
+          >
+            Preparing your invite — this usually takes about 30 seconds after
+            the Paperclip container boots.
+          </p>
+          <button
+            type="button"
+            onClick={() => onRefetch()}
+            className="btn-ghost"
+          >
+            Re-check
+          </button>
+        </div>
+      )}
+
+      <p
+        className="font-body italic text-[11px]"
+        style={{ color: "var(--marginalia)" }}
+      >
+        After you sign up, come back here and the card will move you to the
+        next step (paste an API key from Paperclip → Settings → API keys).
+      </p>
+
+      {/* Secondary deep-link, kept available in case the invite link
+          expires and the principal needs to start over via Paperclip's
+          /sign-in page. Mirrors the same "Open Paperclip →" affordance
+          PaperclipApiKeyPanel ships. */}
+      {paperclipOrigin && (
+        <a
+          href={paperclipOrigin}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-mono text-[10px] uppercase tracking-[0.22em] underline"
+          style={{ color: "var(--marginalia)" }}
+        >
+          Open Paperclip directly →
+        </a>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // P3 — Paperclip API-key paste panel.
 //
-// Rendered when card.status === "needs_api_key". Paperclip's authenticated
-// mode requires the principal to walk Paperclip's own first-run ritual
-// (CEO invite, signup, claim instance) — we can't auto-bootstrap because
-// the ritual writes through Paperclip's internal tables, not its REST API.
-// So the card guides the principal:
+// Rendered when card.status === "needs_api_key". Paperclip's API-key
+// issuance is gated by their better-auth UI, so we can't auto-bootstrap
+// that step. The card guides the principal:
 //
-//   1. "Open Paperclip" button → paperclip.<DOMAIN> in a new tab.
-//   2. They sign up + complete Paperclip's setup.
-//   3. They generate an API key (Settings → API keys).
-//   4. They paste it back here; ctrl-api validates round-trip, writes
+//   1. They've already signed up via the needs_admin_signup CTA above.
+//   2. Inside Paperclip: Settings → API keys → Generate.
+//   3. Paste it back here; ctrl-api validates round-trip, writes
 //      PAPERCLIP_API_KEY into /opt/alfred/.env + the hermes profile's
 //      .env, and kicks hermes-main so the MCP server picks it up.
 //

--- a/packages/web/src/dashboard/paperclipCardCore.test.ts
+++ b/packages/web/src/dashboard/paperclipCardCore.test.ts
@@ -153,6 +153,48 @@ test("derive: connected — allRuns clamps at 10 even if API returns more", () =
   assert.equal(card.allRuns.length, 10);
 });
 
+test("derive: needs_admin_signup — paperclip-init wrote the invite, principal hasn't claimed yet", () => {
+  // Card state when ctrl-api's probeSetupState saw the "Instance setup
+  // required" wall on /sign-in AND paperclip-init wrote the invite URL.
+  const card = derivePaperclipCardState(
+    {
+      ...BASE,
+      has_signing_secret: true,
+      setup_state: "needs_admin_signup",
+      admin_invite_url:
+        "https://paperclip.home.alfred.black/admin/setup?token=abc123",
+    },
+    FROZEN_NOW,
+  );
+  assert.equal(card.status, "needs_admin_signup");
+  assert.equal(card.pillLabel, "Setup required");
+  assert.equal(card.pillTone, "available");
+  assert.equal(card.canTest, false);
+  assert.equal(
+    card.adminInviteUrl,
+    "https://paperclip.home.alfred.black/admin/setup?token=abc123",
+  );
+  // Copy explicitly mentions the one-click setup.
+  assert.match(card.heading, /admin/i);
+});
+
+test("derive: needs_admin_signup with no invite URL → state surfaces, adminInviteUrl empty", () => {
+  // paperclip-init may still be running on a freshly-deployed tenant.
+  // The card should still pick the right state so the UI can render a
+  // "preparing your invite…" placeholder.
+  const card = derivePaperclipCardState(
+    {
+      ...BASE,
+      has_signing_secret: true,
+      setup_state: "needs_admin_signup",
+      // admin_invite_url omitted — ctrl-api withholds when file missing.
+    },
+    FROZEN_NOW,
+  );
+  assert.equal(card.status, "needs_admin_signup");
+  assert.equal(card.adminInviteUrl, "");
+});
+
 test("derive: missing_secret state takes precedence over any last_heartbeat_at", () => {
   // Defensive: even if ctrl-api returns last_heartbeat_at + has_signing_secret=false
   // (shouldn't happen, but we should fail loudly to "Setup required").

--- a/packages/web/src/dashboard/paperclipCardCore.ts
+++ b/packages/web/src/dashboard/paperclipCardCore.ts
@@ -31,16 +31,25 @@
 
 export type PaperclipStatusState =
   | "missing_secret"
+  | "needs_admin_signup"
   | "needs_api_key"
   | "awaiting"
   | "connected";
 
 // P3 — Paperclip's setup-state, probed by ctrl-api against paperclip:3100
 // (with the right Host header). See route comments in channels_paperclip.ts
-// for the four values. The card uses this to render the new sign-up + paste-
+// for the values. The card uses this to render the new sign-up + paste-
 // API-key sub-card when the principal hasn't completed Paperclip's own
 // onboarding ritual yet.
+//
+// 2026-05-27 — added `needs_admin_signup`. The paperclip-init compose
+// service runs `pnpm paperclipai auth bootstrap-ceo` automatically and
+// writes the resulting "Invite URL: …" to /alfred-data/paperclip-ceo-
+// invite.txt. ctrl-api reads that file and surfaces the URL in
+// `admin_invite_url`; the card renders a one-click "Set up your
+// Paperclip account →" button. Replaces 6 manual SSH steps.
 export type PaperclipSetupState =
+  | "needs_admin_signup"
   | "needs_api_key"
   | "configured"
   | "auth_failed"
@@ -73,6 +82,13 @@ export interface PaperclipStatus {
    *  last_heartbeat_at the old way (back-compat). */
   setup_state?: PaperclipSetupState;
   paperclip_origin?: string;
+  /** The CEO-invite URL captured by `paperclip-init` (`pnpm paperclipai
+   *  auth bootstrap-ceo`'s "Invite URL: …" banner). Only populated when
+   *  `setup_state === "needs_admin_signup"`; on other states the URL is
+   *  stale (the admin already signed up) and ctrl-api intentionally
+   *  withholds it. Card renders a single click-through "Set up your
+   *  Paperclip account →" button when present. */
+  admin_invite_url?: string;
 }
 
 export interface PaperclipCardState {
@@ -107,6 +123,15 @@ export interface PaperclipCardState {
    * null when we don't have a heartbeat yet.
    */
   lastHeartbeatRelative: string | null;
+  /**
+   * CEO-invite URL from `paperclip-init`. Non-empty only when
+   * `status === "needs_admin_signup"` AND ctrl-api supplied the URL.
+   * The React layer renders a click-through button when this is set,
+   * and a degraded "still preparing your invite…" message when the
+   * state is needs_admin_signup but this is empty (paperclip-init may
+   * still be running on a freshly-deployed tenant).
+   */
+  adminInviteUrl: string;
 }
 
 const NULL_STATUS: PaperclipStatus = {
@@ -195,6 +220,8 @@ export function derivePaperclipCardState(
   const hasMoreRuns = allRuns.length > visibleRuns.length;
   const heartbeatUrl = typeof s.heartbeat_url === "string" ? s.heartbeat_url : "";
   const paperclipOrigin = derivePaperclipOrigin(heartbeatUrl);
+  const adminInviteUrl =
+    typeof s.admin_invite_url === "string" ? s.admin_invite_url : "";
   const lastHeartbeatRelative =
     typeof s.last_heartbeat_at === "string" && s.last_heartbeat_at
       ? relativeTimeFromIso(s.last_heartbeat_at, now)
@@ -216,15 +243,46 @@ export function derivePaperclipCardState(
       hasMoreRuns,
       allRuns,
       lastHeartbeatRelative,
+      adminInviteUrl: "",
+    };
+  }
+
+  // 2026-05-27 — paperclip-init has captured the CEO invite URL but no
+  // admin has signed up yet (Paperclip's /sign-in still shows the
+  // "Instance setup required" wall). Surface the URL as a one-click
+  // setup button. ZERO CLI; replaces the 6-step SSH ritual Sir hit on
+  // 2026-05-27. Pill stays "Setup required" so the principal's eye
+  // catches it. canTest stays false — no heartbeat path until past
+  // admin signup.
+  //
+  // If admin_invite_url is empty (paperclip-init still running on a
+  // freshly-deployed tenant), the React layer renders a degraded
+  // "preparing your invite…" message — see PaperclipAdminSignupPanel.
+  if (s.setup_state === "needs_admin_signup") {
+    return {
+      status: "needs_admin_signup",
+      pillLabel: "Setup required",
+      pillTone: "available",
+      heading: "Claim your Paperclip admin account",
+      description:
+        "Your Paperclip instance is up but needs an admin. One-time setup — " +
+        "click the button to claim it, sign up in Paperclip, then come " +
+        "back here.",
+      heartbeatUrl,
+      paperclipOrigin: s.paperclip_origin || paperclipOrigin,
+      canTest: false,
+      visibleRuns,
+      hasMoreRuns,
+      allRuns,
+      lastHeartbeatRelative,
+      adminInviteUrl,
     };
   }
 
   // P3 — Paperclip's own setup ritual hasn't been walked yet. We can't
-  // auto-bootstrap Paperclip (it requires a CEO invite written through its
-  // own DB), so the card carries the principal through Paperclip's UI:
-  // "Open Paperclip → sign up → generate API key → paste it here". Once
-  // pasted, ctrl-api writes the key into the runtime and the card flips
-  // to "awaiting" (then "connected" once the first heartbeat arrives).
+  // auto-bootstrap Paperclip's API-key issuance (it lives behind better-
+  // auth in their UI), so the card carries the principal through that
+  // last step: paste the key once it's been generated.
   //
   // setup_state is set by ctrl-api ≥ P3. When the upstream is older and
   // omits the field, fall through to the legacy awaiting/connected path
@@ -249,6 +307,7 @@ export function derivePaperclipCardState(
       hasMoreRuns,
       allRuns,
       lastHeartbeatRelative,
+      adminInviteUrl: "",
     };
   }
 
@@ -269,6 +328,7 @@ export function derivePaperclipCardState(
       hasMoreRuns,
       allRuns,
       lastHeartbeatRelative,
+      adminInviteUrl: "",
     };
   }
 
@@ -287,6 +347,7 @@ export function derivePaperclipCardState(
     hasMoreRuns,
     allRuns,
     lastHeartbeatRelative,
+    adminInviteUrl: "",
   };
 }
 


### PR DESCRIPTION
## Why

Sir tried to open `https://paperclip.home.alfred.black` on 2026-05-27 and hit Paperclip's "Instance setup required" wall. The page literally asks the principal to SSH in and run `pnpm paperclipai auth bootstrap-ceo`. Manual recovery took 6 steps (including a uid 0 ownership trap from `docker exec` defaulting to root, leaving paperclip in a restart loop unable to read its own `.env`).

This is unacceptable for the /channels card's "single place a principal interacts with" contract. After this PR: when a principal visits /channels on a fresh tenant, the Paperclip card shows a single big **Set up your Paperclip account →** button that links directly to the bootstrap-ceo invite URL. They click, sign up, come back, paste API key, done. **Zero CLI.**

## The four pieces

### 1. Init-time auto-bootstrap
`packages/hermes/init/bootstrap-paperclip.sh` (new) waits for paperclip's healthcheck, runs the two pnpm commands as `--user node` (uid 1000 — sidesteps the root-ownership trap), and writes the parsed `Invite URL: …` line to `/alfred-data/paperclip-ceo-invite.txt`. **Idempotent**: bails out (exit 0) when both the invite file and paperclip's `instances/default/config.json` are already present.

I chose a **separate `paperclip-init` compose service** (not folding into the main alfred-init container) because:
* the main init has no `/var/run/docker.sock` mount today and adding one broadens its trust surface
* compose `depends_on: paperclip { service_healthy }` gives clean ordering natively
* matches the existing `plane-init` / `sure-init` pattern

The new service reuses the alfred-init image (just with a different `entrypoint:`). The Dockerfile now pulls `docker-ce-cli` (CLI-only, ~30 MB) from Docker's apt repo rather than Debian's `docker.io` meta-package which would drag in `containerd` + `runc`.

### 2. ctrl-api status route
`probeSetupState()` now distinguishes `needs_admin_signup` from `needs_api_key` by matching the literal "Instance setup required" string in `/sign-in`'s body. When `needs_admin_signup`, GET `/api/v1/channels/paperclip/status` surfaces `admin_invite_url` (read from the invite file). The URL is **intentionally withheld** on every other state — once the principal signs up, the invite is stale and surfacing it would mislead.

Test override env: `PAPERCLIP_INVITE_FILE`.

### 3. paperclipCardCore.ts
New `needs_admin_signup` member on both `PaperclipStatusState` and `PaperclipSetupState` unions. `PaperclipStatus.admin_invite_url` optional field. `PaperclipCardState.adminInviteUrl` (always-string, empty when not applicable). Derivation branch mirrors the existing `needs_api_key` branch.

### 4. ChannelsPage.tsx
New `PaperclipAdminSignupPanel` component renders:
* a 1-sentence explanation
* a big "Set up your Paperclip account →" button (opens `adminInviteUrl` in a new tab)
* a footnote: "After you sign up, come back here and the card will move you to the next step."
* a degraded "preparing your invite…" + Re-check button when `adminInviteUrl` is empty (paperclip-init still running)

Matches the visual language of `PaperclipApiKeyPanel` exactly.

## Tests

```
packages/ctrl/tests/channels_paperclip.test.ts:  24 pass, 0 fail
packages/web/src/dashboard/paperclipCardCore.test.ts: 14 pass, 0 fail
```

6 new ctrl-api cases (needs_admin_signup w/ + w/o invite URL, needs_api_key past the wall, configured, auth_failed, garbage in invite file) mocking `http.request` against paperclip:3100.
2 new web cases (state with URL, state without URL).

Also verified:
* `shellcheck` clean on `bootstrap-paperclip.sh`
* `tsc --noEmit` on ctrl/web (no new errors beyond pre-existing Wasp module resolution noise)
* docker-compose.yaml YAML-validates, both `paperclip` and `paperclip-init` services present
* `npm run build` on ctrl-api succeeds

## Constraints honoured

* **Idempotent re-run**: two-condition guard (invite file + container config.json) makes it a no-op on already-bootstrapped tenants
* **uid 1000 ownership**: every `docker exec` uses `--user node` — no root-owned files in the paperclip volume
* **No upstream Paperclip changes**
* **PR #73 not broken**: home's existing state stays at `needs_api_key` (its `/sign-in` no longer shows the instance-setup wall after Sir's manual fix)
* **Docker socket exposure**: only the new `paperclip-init` service gets the socket (RO bind), not the main alfred-init

## Deploy plan

Once CI is green:
1. `docker compose pull init ctrl-api web web-client` on each of home/rj/joe/zsolt/miguel
2. `docker compose up -d --force-recreate paperclip-init` (idempotent on home; first-run on the other 4 — but they need the paperclip block added to their override files first)
3. `docker compose up -d ctrl-api web web-client`

🤖 Generated with [Claude Code](https://claude.com/claude-code)