### PR TITLE
fix(paperclip): use invite-file existence as needs_admin_signup signal

### DIFF
--- a/packages/ctrl/src/api/routes/channels_paperclip.ts
+++ b/packages/ctrl/src/api/routes/channels_paperclip.ts
@@ -731,29 +731,34 @@ async function probeSetupState(): Promise<SetupProbeResult> {
     });
   }
   if (!apiKey) {
-    // Confirm Paperclip is at least reachable. The /sign-in body is the
-    // canonical way to distinguish "instance-setup wall" from "fully
-    // onboarded but our key is missing" — Paperclip prints a verbatim
-    // "Instance setup required" page on the former (live-confirmed on
-    // home pre-bootstrap 2026-05-27). We match on the literal phrase so
-    // a copy-tweak by Paperclip downstream doesn't silently flip
-    // tenants back to "needs_api_key" without an invite link.
+    // Confirm Paperclip is at least reachable.
     const ping = await probe("/sign-in", false);
     if (ping.status === 0) {
       return { state: "unreachable", admin_invite_url: null };
     }
-    if (
-      ping.body.includes("Instance setup required") ||
-      ping.body.includes("instance setup required")
-    ) {
-      // Surface the invite URL we captured at init-time. When the file
-      // isn't yet present (paperclip-init still running / disabled),
-      // null tells the UI to fall through to a degraded message.
-      return {
-        state: "needs_admin_signup",
-        admin_invite_url: readPaperclipInviteUrl(),
-      };
+    // Heuristic: when `paperclip-init` has captured an invite URL into
+    // /alfred-data/paperclip-ceo-invite.txt, the principal is presumed to
+    // be in admin-signup. Note that we cannot reliably probe Paperclip's
+    // live "has an admin signed up yet?" state — Paperclip's /sign-in is
+    // a React SPA whose 'Instance setup required' string is rendered
+    // client-side and never lands in the SSR HTML we can see from here
+    // (live-confirmed on joe + home 2026-05-27). The invite file is the
+    // best proxy: it exists iff paperclip-init has run.
+    //
+    // The card's UI accommodates the ambiguity by offering BOTH
+    // affordances on needs_admin_signup — the click-through invite link
+    // (for tenants that genuinely haven't signed up yet) AND a secondary
+    // "I've already signed up — paste my API key" path. The principal
+    // can drive the card to `configured` from either branch.
+    const inviteUrl = readPaperclipInviteUrl();
+    if (inviteUrl) {
+      return { state: "needs_admin_signup", admin_invite_url: inviteUrl };
     }
+    // No invite captured — legacy fallback. Either paperclip-init hasn't
+    // run yet (rare; service runs once at compose-up), the bootstrap
+    // failed (caller can re-run), or this is an old deploy that never
+    // had paperclip-init. The existing PR #73 paste-API-key panel handles
+    // this gracefully.
     return { state: "needs_api_key", admin_invite_url: null };
   }
   const probed = await probe("/api/companies", true);

--- a/packages/ctrl/tests/channels_paperclip.test.ts
+++ b/packages/ctrl/tests/channels_paperclip.test.ts
@@ -401,19 +401,19 @@ describe("/api/v1/channels/paperclip/* — Lane I", () => {
       assert.equal(r.payload.has_signing_secret, true);
     });
 
-    it("setup_state=needs_admin_signup + admin_invite_url when Paperclip shows the instance-setup wall and the invite file is present", async () => {
-      // Paperclip's /sign-in body on a fresh sidecar:
+    it("setup_state=needs_admin_signup + admin_invite_url when paperclip is reachable AND the invite file exists", async () => {
+      // Paperclip's /sign-in is a React SPA — the body is just the bundle
+      // HTML, never the 'Instance setup required' string (which is rendered
+      // client-side). The invite file is the authoritative signal: when
+      // paperclip-init has captured an invite, the principal needs to
+      // either click through it OR paste their API key. Both affordances
+      // live on the same panel.
       paperclipHttpStub.signIn = {
         status: 200,
-        body:
-          "<!DOCTYPE html><html><body>" +
-          "<h1>Instance setup required</h1>" +
-          "<p>Run pnpm paperclipai auth bootstrap-ceo to claim this instance.</p>" +
-          "</body></html>",
+        body: "<!DOCTYPE html><html><body><div id='root'></div></body></html>",
       };
-      // paperclip-init writes the captured invite URL here.
       const invite =
-        "https://paperclip.test.alfred.black/admin/setup?token=abc123";
+        "https://paperclip.test.alfred.black/invite/pcp_bootstrap_abc123";
       fs.writeFileSync(paperclipInviteFile, invite + "\n");
 
       const r = await invokeRoute("GET", "/api/v1/channels/paperclip/status");
@@ -422,37 +422,14 @@ describe("/api/v1/channels/paperclip/* — Lane I", () => {
       assert.equal(r.payload.admin_invite_url, invite);
     });
 
-    it("needs_admin_signup with no invite file → setup_state surfaces but admin_invite_url is absent", async () => {
-      // paperclip-init might not have completed yet (or compose hasn't been
-      // restarted). The card should still show the right state so the UI
-      // can show a degraded "still preparing your invite…" message.
+    it("setup_state=needs_api_key (legacy fallback) when paperclip is reachable but the invite file is missing", async () => {
+      // paperclip-init hasn't run yet (or this is an old deploy that
+      // never had it). The PR #73 paste-API-key flow still works.
       paperclipHttpStub.signIn = {
         status: 200,
-        body: "<h1>Instance setup required</h1>",
+        body: "<!DOCTYPE html><html><body><div id='root'></div></body></html>",
       };
       // No invite file written.
-      const r = await invokeRoute("GET", "/api/v1/channels/paperclip/status");
-      assert.equal(r.status, 200);
-      assert.equal(r.payload.setup_state, "needs_admin_signup");
-      assert.equal(r.payload.admin_invite_url, undefined);
-    });
-
-    it("setup_state=needs_api_key when /sign-in is up and NOT showing the instance-setup wall", async () => {
-      // Past the admin-signup wall, but PAPERCLIP_API_KEY is still unset.
-      paperclipHttpStub.signIn = {
-        status: 200,
-        body:
-          "<!DOCTYPE html><html><body>" +
-          "<form><input name='email'/><input name='password' type='password'/>" +
-          "<button>Sign in</button></form></body></html>",
-      };
-      // Even if the invite file is present, we must NOT surface it on
-      // needs_api_key — the principal has already signed up; the URL is stale.
-      fs.writeFileSync(
-        paperclipInviteFile,
-        "https://paperclip.test.alfred.black/admin/setup?token=stale\n",
-      );
-
       const r = await invokeRoute("GET", "/api/v1/channels/paperclip/status");
       assert.equal(r.status, 200);
       assert.equal(r.payload.setup_state, "needs_api_key");
@@ -468,6 +445,21 @@ describe("/api/v1/channels/paperclip/* — Lane I", () => {
       assert.equal(r.payload.admin_invite_url, undefined);
     });
 
+    it("configured state hides admin_invite_url even when the invite file still exists (stale URL)", async () => {
+      // Once a working API key is in place, the principal has already
+      // claimed the instance — surfacing the (now stale) invite link
+      // would be confusing. Verify the URL is intentionally withheld.
+      process.env.PAPERCLIP_API_KEY = "pck_real_key";
+      paperclipHttpStub.apiCompanies = { status: 200, body: "[]" };
+      fs.writeFileSync(
+        paperclipInviteFile,
+        "https://paperclip.test.alfred.black/invite/pcp_stale\n",
+      );
+      const r = await invokeRoute("GET", "/api/v1/channels/paperclip/status");
+      assert.equal(r.payload.setup_state, "configured");
+      assert.equal(r.payload.admin_invite_url, undefined);
+    });
+
     it("setup_state=auth_failed when /api/companies rejects the key", async () => {
       process.env.PAPERCLIP_API_KEY = "pck_revoked";
       paperclipHttpStub.apiCompanies = { status: 401, body: "" };
@@ -476,16 +468,18 @@ describe("/api/v1/channels/paperclip/* — Lane I", () => {
       assert.equal(r.payload.setup_state, "auth_failed");
     });
 
-    it("admin_invite_url is hidden when the invite file holds garbage", async () => {
+    it("falls back to needs_api_key when the invite file holds garbage", async () => {
       paperclipHttpStub.signIn = {
         status: 200,
-        body: "Instance setup required",
+        body: "<!DOCTYPE html><html><body></body></html>",
       };
-      // Non-URL content (e.g. a stray banner line snuck through the parser).
+      // Non-URL content → readPaperclipInviteUrl returns null → no invite
+      // captured → legacy needs_api_key fallback (rather than surfacing a
+      // garbage URL to the UI).
       fs.writeFileSync(paperclipInviteFile, "not-actually-a-url\n");
 
       const r = await invokeRoute("GET", "/api/v1/channels/paperclip/status");
-      assert.equal(r.payload.setup_state, "needs_admin_signup");
+      assert.equal(r.payload.setup_state, "needs_api_key");
       assert.equal(r.payload.admin_invite_url, undefined);
     });
   });

--- a/packages/web/src/dashboard/ChannelsPage.tsx
+++ b/packages/web/src/dashboard/ChannelsPage.tsx
@@ -2801,18 +2801,22 @@ function PaperclipCard() {
         </div>
       )}
 
-      {/* needs_admin_signup — paperclip-init has captured the CEO invite
-          URL but no admin has signed up yet. The principal clicks the
-          big "Set up your Paperclip account →" button (opens new tab),
-          completes Paperclip's first-run signup, comes back; the next
-          /status poll flips to "needs_api_key" and the panel below
-          takes over. Replaces the 6-step manual SSH ritual (2026-05-27). */}
+      {/* needs_admin_signup — paperclip-init captured a CEO invite URL.
+          Panel offers BOTH affordances:
+            * primary: click-through invite button (for tenants not yet
+              admin-claimed);
+            * secondary: paste API key (for tenants already claimed via a
+              prior session, or for the principal completing the flow on
+              a return visit). Pasting a working key flips /status to
+              "configured". Replaces the 6-step manual SSH ritual
+              (2026-05-27). */}
       {card.status === "needs_admin_signup" && (
         <PaperclipAdminSignupPanel
           adminInviteUrl={card.adminInviteUrl}
           paperclipOrigin={card.paperclipOrigin}
           description={card.description}
           onRefetch={refetch}
+          onSaved={refetch}
         />
       )}
 
@@ -3109,13 +3113,48 @@ function PaperclipAdminSignupPanel({
   paperclipOrigin,
   description,
   onRefetch,
+  onSaved,
 }: {
   adminInviteUrl: string;
   paperclipOrigin: string;
   description: string;
   onRefetch: () => unknown;
+  onSaved: () => Promise<unknown>;
 }) {
   const ready = Boolean(adminInviteUrl);
+  // The API-key paste form is offered as a secondary affordance for two
+  // cases the invite click-through can't cleanly handle:
+  //   1. The principal already signed up (via a prior visit, or because the
+  //      tenant was already admin-claimed before paperclip-init wrote the
+  //      invite file). The invite link would land them on a "you're
+  //      already in" page; pasting the key is the fast path.
+  //   2. Sir's manual home-recovery on 2026-05-27 — the invite was issued
+  //      but Sir hasn't claimed it yet on this device.
+  // ctrl-api treats the second affordance as the authoritative state
+  // transition: once a valid key is pasted, /status flips to configured.
+  const [apiKey, setApiKey] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  async function saveKey() {
+    const trimmed = apiKey.trim();
+    if (!trimmed) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const r: any = await setPaperclipApiKey({ api_key: trimmed });
+      if (r?.ok) {
+        setApiKey("");
+        await onSaved();
+      } else {
+        setError("Paperclip didn't accept that key. Try generating a fresh one.");
+      }
+    } catch (e: any) {
+      setError(e?.message ?? "Couldn't save the key. Check the ctrl-api logs.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
   return (
     <div className="mt-5 space-y-5">
       <p
@@ -3126,16 +3165,25 @@ function PaperclipAdminSignupPanel({
       </p>
 
       {ready ? (
-        <a
-          href={adminInviteUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          // Mirror PaperclipApiKeyPanel's button class so the visual
-          // language is identical — same fonts, same hover, same height.
-          className="btn-ghost inline-block"
-        >
-          Set up your Paperclip account →
-        </a>
+        <div className="space-y-2">
+          <a
+            href={adminInviteUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            // Mirror PaperclipApiKeyPanel's button class so the visual
+            // language is identical — same fonts, same hover, same height.
+            className="btn-ghost inline-block"
+          >
+            Set up your Paperclip account →
+          </a>
+          <p
+            className="font-body italic text-[11px]"
+            style={{ color: "var(--marginalia)" }}
+          >
+            One-time setup. After you sign up, generate an API key
+            (Paperclip → Settings → API keys) and paste it below.
+          </p>
+        </div>
       ) : (
         <div className="space-y-2">
           <p
@@ -3155,13 +3203,48 @@ function PaperclipAdminSignupPanel({
         </div>
       )}
 
-      <p
-        className="font-body italic text-[11px]"
-        style={{ color: "var(--marginalia)" }}
-      >
-        After you sign up, come back here and the card will move you to the
-        next step (paste an API key from Paperclip → Settings → API keys).
-      </p>
+      {/* Already signed up? Paste API key. This is also the natural next
+          step after the principal completes signup via the click-through
+          above — no need to re-render with a different panel. */}
+      <div className="space-y-2 pt-4 border-t border-rule">
+        <div
+          className="font-mono text-[10px] uppercase tracking-[0.22em]"
+          style={{ color: "var(--marginalia)" }}
+        >
+          Already signed up? Paste your Paperclip API key
+        </div>
+        <textarea
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          placeholder="pck_… (from Paperclip Settings → API keys)"
+          rows={2}
+          className="w-full bg-transparent border border-rule px-2 py-1 font-mono text-[11px]"
+        />
+        <div className="flex items-baseline justify-between gap-2">
+          <p
+            className="font-body italic text-[11px]"
+            style={{ color: "var(--marginalia)" }}
+          >
+            Alfred validates the key against Paperclip and only persists it
+            if it works.
+          </p>
+          <button
+            onClick={saveKey}
+            disabled={busy || !apiKey.trim()}
+            className="btn-ghost shrink-0"
+          >
+            {busy ? "Validating…" : "Save & connect"}
+          </button>
+        </div>
+        {error && (
+          <p
+            className="font-body italic text-[12px]"
+            style={{ color: "var(--brass)" }}
+          >
+            {error}
+          </p>
+        )}
+      </div>
 
       {/* Secondary deep-link, kept available in case the invite link
           expires and the principal needs to start over via Paperclip's

--- a/packages/web/src/dashboard/paperclipCardCore.test.ts
+++ b/packages/web/src/dashboard/paperclipCardCore.test.ts
@@ -154,15 +154,16 @@ test("derive: connected — allRuns clamps at 10 even if API returns more", () =
 });
 
 test("derive: needs_admin_signup — paperclip-init wrote the invite, principal hasn't claimed yet", () => {
-  // Card state when ctrl-api's probeSetupState saw the "Instance setup
-  // required" wall on /sign-in AND paperclip-init wrote the invite URL.
+  // Card state when ctrl-api saw a captured invite file (the invite-file's
+  // existence is the authoritative signal; Paperclip's React SPA never
+  // serves a server-side "Instance setup required" marker).
   const card = derivePaperclipCardState(
     {
       ...BASE,
       has_signing_secret: true,
       setup_state: "needs_admin_signup",
       admin_invite_url:
-        "https://paperclip.home.alfred.black/admin/setup?token=abc123",
+        "https://paperclip.home.alfred.black/invite/pcp_bootstrap_abc123",
     },
     FROZEN_NOW,
   );
@@ -172,10 +173,13 @@ test("derive: needs_admin_signup — paperclip-init wrote the invite, principal 
   assert.equal(card.canTest, false);
   assert.equal(
     card.adminInviteUrl,
-    "https://paperclip.home.alfred.black/admin/setup?token=abc123",
+    "https://paperclip.home.alfred.black/invite/pcp_bootstrap_abc123",
   );
-  // Copy explicitly mentions the one-click setup.
+  // Copy explicitly mentions the one-time admin claim.
   assert.match(card.heading, /admin/i);
+  // Description offers both the click-through invite link AND a "paste
+  // an existing API key" path for principals who've already signed up.
+  assert.match(card.description, /invite link|API key/i);
 });
 
 test("derive: needs_admin_signup with no invite URL → state surfaces, adminInviteUrl empty", () => {

--- a/packages/web/src/dashboard/paperclipCardCore.ts
+++ b/packages/web/src/dashboard/paperclipCardCore.ts
@@ -265,9 +265,9 @@ export function derivePaperclipCardState(
       pillTone: "available",
       heading: "Claim your Paperclip admin account",
       description:
-        "Your Paperclip instance is up but needs an admin. One-time setup — " +
-        "click the button to claim it, sign up in Paperclip, then come " +
-        "back here.",
+        "Your Paperclip instance is ready — one-time admin claim. Click " +
+        "the invite link to sign up, or paste an existing API key below " +
+        "if you've already claimed your account.",
       heartbeatUrl,
       paperclipOrigin: s.paperclip_origin || paperclipOrigin,
       canTest: false,


### PR DESCRIPTION
## Why

PR #76 used a literal "Instance setup required" string match against `/sign-in`'s response body to detect whether the principal had claimed admin yet. Deploying to home + joe on 2026-05-27 revealed this doesn't work: Paperclip's `/sign-in` is a React SPA — the "Instance setup required" message renders client-side via JS and never appears in the SSR HTML that ctrl-api can probe. Result: every tenant fell through to `needs_api_key` after the bootstrap, hiding the captured invite URL.

I exhausted every Paperclip API signal I could think of (`/api/companies`, `/api/auth/get-session`, `/api/auth/list-accounts`, etc.) — they all return identical responses in both states. `paperclipai auth bootstrap-ceo` issues fresh invites without `--force` even when an admin already exists, so it isn't a discriminator either.

## The fix

When `PAPERCLIP_API_KEY` is unset AND `/alfred-data/paperclip-ceo-invite.txt` exists, surface `needs_admin_signup` with the captured URL. The invite file is the authoritative signal — it exists iff `paperclip-init` has run. When the file is missing, fall through to the existing PR #73 `needs_api_key` path.

Once a working API key is pasted, `/status` flips to `configured` and the (now stale) invite URL is withheld from the response.

## UX

The `needs_admin_signup` panel now offers **both** affordances on the same card:

1. **Primary** — "Set up your Paperclip account →" click-through button (for tenants that haven't been admin-claimed yet)
2. **Secondary** — "Already signed up? Paste your Paperclip API key" textarea (for tenants already admin-claimed in a prior session, AND the natural next step after the principal completes signup via the click-through)

Either branch drives the card to `configured`. The principal doesn't need to know which case applies — both buttons are visible, either works.

## Tests

- `packages/ctrl/tests/channels_paperclip.test.ts` — 4 test cases rewritten to reflect the invite-file heuristic + a new "configured hides stale invite URL" case. **24 pass, 0 fail.**
- `packages/web/src/dashboard/paperclipCardCore.test.ts` — updated derive test asserts the new description copy + matches existing surface. **14 pass, 0 fail.**

## Live verification on home (after PR #76 deploy)

```
$ curl -H 'Authorization: Bearer ...' http://127.0.0.1:3100/api/v1/channels/paperclip/status
{
  "setup_state": "needs_api_key",   # ← BUG: should be needs_admin_signup
  "admin_invite_url": absent           # ← hidden because state wasn't right
}
```

This PR fixes the state so the panel can render with the click-through button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)