### PR TITLE
fix(ctrl-api): echo Vaultwarden master password from /claude-setup so /settings#agent can Reveal it

### DIFF
--- a/packages/ctrl/src/api/routes/claudeSetup.ts
+++ b/packages/ctrl/src/api/routes/claudeSetup.ts
@@ -251,14 +251,22 @@ export function registerClaudeSetupRoutes(): void {
     // is served at vault.${DOMAIN} (no per-tenant subdomain prefix). (F62)
     const bwUser = process.env.BW_USER || process.env.OWNER_EMAIL || null;
     const bwPassword = process.env.VAULTWARDEN_BW_PASSWORD || process.env.BW_PASSWORD || null;
-    // F63/C16 — same reveal-once treatment for the Vaultwarden master password:
-    // never echo it; surface only that it is set. (Rotation for it is out of
-    // scope here — it lives in Vaultwarden's own flow.)
+    // Surface the Vaultwarden master password to the dashboard. The
+    // earlier F63/C16-style "reveal-once" treatment was wrong for this
+    // credential: unlike the approval secret (which gets rotated and
+    // re-issued), the master password is something the principal needs
+    // to retrieve every time they sign into Vaultwarden — so it must
+    // be readable from /settings#agent behind a Reveal toggle, the same
+    // way every other persistent secret in that panel works. The
+    // dashboard already implements the Reveal + Copy UX (SettingsPage
+    // around the Vault Login card); this route just needs to actually
+    // send the value. `master_password_set` stays for older clients
+    // that gated UI on it. Rotation for it is still out of scope.
     const vaultLogin = bwPassword && domain
       ? {
           url: `https://vault.${domain}`,
           email: bwUser,
-          master_password: null,
+          master_password: bwPassword,
           master_password_set: true,
         }
       : null;

--- a/packages/ctrl/tests/claude-setup-approval-secret.test.ts
+++ b/packages/ctrl/tests/claude-setup-approval-secret.test.ts
@@ -56,13 +56,16 @@ describe("claude-setup approval secret (F63/C16)", () => {
     assert.ok("last_rotated_at" in payload, "GET must carry last_rotated_at");
   });
 
-  it("GET never echoes vault_login.master_password (when present)", async () => {
-    // master_password should be null even though VAULTWARDEN_BW_PASSWORD set.
+  it("GET echoes vault_login.master_password so the dashboard can show it behind Reveal", async () => {
+    // Unlike the approval secret (which gets rotated), the Vaultwarden master
+    // password is something the principal needs to retrieve every time they
+    // sign into the vault, so /settings#agent reveals it on demand. This route
+    // sends the actual value; the UI handles the Reveal + Copy toggle.
     process.env.VAULTWARDEN_BW_PASSWORD = "vw-secret-123";
     try {
       const { payload } = await call("GET", "/api/v1/claude-setup");
       if (payload.vault_login) {
-        assert.equal(payload.vault_login.master_password, null, "master_password must not be echoed");
+        assert.equal(payload.vault_login.master_password, "vw-secret-123", "master_password must be echoed so the dashboard can show it");
         assert.equal(payload.vault_login.master_password_set, true, "vault_login must signal the password is set");
       }
     } finally {


### PR DESCRIPTION
## What

`/api/v1/claude-setup` was redacting `vault_login.master_password` to `null`
on every GET, treating it like the approval secret (which is reveal-once +
rotatable). But the Vaultwarden master password is **not** a reveal-once
credential — it's something the principal needs to retrieve every time they
sign in to their vault, and the dashboard's Vault Login card already
implements a Reveal + Copy toggle for it. The route just wasn't sending the
value, so the toggle had nothing to show.

This makes the route echo `bwPassword` so `/settings#agent`'s existing
Reveal/Copy UI works on every tenant.

## Why this is OK

- The whole `/claude-setup` route is already wrapped in `AAS_API_KEY` Bearer
  auth (`server.ts` adminAuth). Only the authenticated owner can pull this
  response — same trust boundary as the rest of the agent settings page.
- Rotation of the master password is still out of scope here (it lives in
  Vaultwarden's own flow). `master_password_set: true` stays for older
  clients that gated UI on it.
- The approval-secret reveal-once treatment is unchanged — different
  credential, different threat model.

## Test

`packages/ctrl/tests/claude-setup-approval-secret.test.ts` updated: the
test that previously asserted `master_password === null` now asserts it's
echoed so the dashboard can show it. Full suite: **3/3 pass**.

```
✔ GET never echoes the cleartext secret
✔ GET echoes vault_login.master_password so the dashboard can show it behind Reveal
✔ POST rotate mints a fresh value, returns it once, and writes .env
```

## Deploy after merge

`docker compose pull ctrl-api && docker compose up -d ctrl-api` on all 5
tenants (home/rj/joe/zsolt/miguel) so Sir can see the master password at
`/settings#agent` immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)