### PR TITLE
fix(ctrl-api): surface ACME_EMAIL (not OWNER_EMAIL) on Vault Login card

### DIFF
--- a/packages/ctrl/src/api/routes/claudeSetup.ts
+++ b/packages/ctrl/src/api/routes/claudeSetup.ts
@@ -249,7 +249,27 @@ export function registerClaudeSetupRoutes(): void {
     // Gated on the Vaultwarden password being provisioned. On the merged
     // single-VM stack the password is VAULTWARDEN_BW_PASSWORD and the web UI
     // is served at vault.${DOMAIN} (no per-tenant subdomain prefix). (F62)
-    const bwUser = process.env.BW_USER || process.env.OWNER_EMAIL || null;
+    //
+    // The Vaultwarden account is registered by the bootstrap-signup container
+    // with BW_USER=${ACME_EMAIL} (see docker-compose.yaml, init/init-signup
+    // services). ACME_EMAIL is the operator's email (the Let's Encrypt
+    // contact), and it is the ONLY email that ever gets a row in
+    // Vaultwarden's users table on this stack — OWNER_EMAIL is the
+    // principal's identity (rendered in the Brief, used for outbound
+    // attribution) and is NOT a Vaultwarden user. Surfacing OWNER_EMAIL on
+    // /settings#agent told principals to log into Vaultwarden as themselves,
+    // which fails with "invalid credentials" because that account doesn't
+    // exist — the password shown is correct, but for the operator's email.
+    // Prefer the real VW account email (BW_USER if a future stack sets it,
+    // otherwise ACME_EMAIL — the actual signup identity on the merged stack)
+    // and keep OWNER_EMAIL as a last-resort fallback for any pre-merge tenant
+    // that did mirror OWNER_EMAIL into the signup payload. (Vaultwarden login
+    // email mismatch, 2026-05-27.)
+    const bwUser =
+      process.env.BW_USER ||
+      process.env.ACME_EMAIL ||
+      process.env.OWNER_EMAIL ||
+      null;
     const bwPassword = process.env.VAULTWARDEN_BW_PASSWORD || process.env.BW_PASSWORD || null;
     // Surface the Vaultwarden master password to the dashboard. The
     // earlier F63/C16-style "reveal-once" treatment was wrong for this

--- a/packages/ctrl/tests/claude-setup-vault-login-email.test.ts
+++ b/packages/ctrl/tests/claude-setup-vault-login-email.test.ts
@@ -1,0 +1,106 @@
+// Vaultwarden login email — surfaced on /settings#agent (Vault Login card).
+//
+// The Vaultwarden account on the merged single-VM stack is registered by the
+// init-signup container with BW_USER=${ACME_EMAIL}; that is the ONLY email
+// the Vaultwarden users table ever sees. OWNER_EMAIL is a different
+// identity — the principal's email used for outbound attribution / the
+// Brief — and Vaultwarden has no row for it. Surfacing OWNER_EMAIL on
+// the Vault Login card told the principal "log into Vaultwarden as
+// <yourself>", which fails with "invalid credentials" on every tenant
+// (Sir live-confirmed on zsolt.alfred.black, 2026-05-27). The password
+// shown is correct, but it's the password for ACME_EMAIL, not OWNER_EMAIL.
+//
+// This test pins the resolution order:
+//   BW_USER  (a future stack might set it explicitly)
+//   ACME_EMAIL  (the merged-stack signup identity — actual VW account)
+//   OWNER_EMAIL  (last-resort fallback for any pre-merge tenant that did
+//                 mirror OWNER_EMAIL into the signup payload)
+//
+// Regression for the Vaultwarden login email mismatch.
+import { describe, it, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ServerResponse } from "node:http";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "vault-login-email-"));
+process.env.COMPOSE_DIR = tmp;
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.STATE_DB_PATH = path.join(tmp, "state.db");
+process.env.VAULT_PATH = path.join(tmp, "vault");
+process.env.SQLITE_VEC_PATH = "";
+process.env.DOMAIN = "test.alfred.black";
+fs.mkdirSync(path.join(tmp, "streams"), { recursive: true });
+fs.writeFileSync(path.join(tmp, ".env"), "PLACEHOLDER=1\n", "utf-8");
+
+const { matchRoute } = await import("../src/api/server.js");
+const { registerClaudeSetupRoutes } = await import("../src/api/routes/claudeSetup.js");
+registerClaudeSetupRoutes();
+
+async function call(method: string, pathname: string): Promise<{ status: number; payload: any }> {
+  const m = matchRoute(method, pathname);
+  assert.ok(m, `${method} ${pathname} must be registered`);
+  let status = 0;
+  let payload: any;
+  const res = {
+    writeHead(code: number) { status = code; return res; },
+    end(json?: string) { payload = json ? JSON.parse(json) : undefined; },
+  } as unknown as ServerResponse;
+  await m!.handler({ req: { url: pathname } as any, res, params: m!.params, body: undefined, query: new URLSearchParams() });
+  return { status, payload };
+}
+
+function clearEmailEnv() {
+  delete process.env.BW_USER;
+  delete process.env.ACME_EMAIL;
+  delete process.env.OWNER_EMAIL;
+  delete process.env.VAULTWARDEN_BW_PASSWORD;
+  delete process.env.BW_PASSWORD;
+}
+
+describe("claude-setup vault_login.email resolution", () => {
+  after(clearEmailEnv);
+
+  it("merged-stack default: prefers ACME_EMAIL when BW_USER is unset (the bug fix)", async () => {
+    clearEmailEnv();
+    // Mirrors the live merged stack: BW_USER is never written to .env,
+    // ACME_EMAIL is the bootstrap-signup identity, OWNER_EMAIL is the
+    // principal's identity (which Vaultwarden has no row for).
+    process.env.ACME_EMAIL = "operator@example.com";
+    process.env.OWNER_EMAIL = "principal@example.com";
+    process.env.VAULTWARDEN_BW_PASSWORD = "vw-secret";
+    const { payload } = await call("GET", "/api/v1/claude-setup");
+    assert.ok(payload.vault_login, "vault_login must be present when password is set");
+    assert.equal(
+      payload.vault_login.email,
+      "operator@example.com",
+      "must surface ACME_EMAIL (the actual VW account), NOT OWNER_EMAIL — that's the bug",
+    );
+  });
+
+  it("BW_USER wins when explicitly set (future-stack override)", async () => {
+    clearEmailEnv();
+    process.env.BW_USER = "explicit@example.com";
+    process.env.ACME_EMAIL = "operator@example.com";
+    process.env.OWNER_EMAIL = "principal@example.com";
+    process.env.VAULTWARDEN_BW_PASSWORD = "vw-secret";
+    const { payload } = await call("GET", "/api/v1/claude-setup");
+    assert.equal(payload.vault_login.email, "explicit@example.com");
+  });
+
+  it("falls back to OWNER_EMAIL only when neither BW_USER nor ACME_EMAIL is set", async () => {
+    clearEmailEnv();
+    process.env.OWNER_EMAIL = "principal@example.com";
+    process.env.VAULTWARDEN_BW_PASSWORD = "vw-secret";
+    const { payload } = await call("GET", "/api/v1/claude-setup");
+    assert.equal(payload.vault_login.email, "principal@example.com");
+  });
+
+  it("vault_login is null when no password is provisioned", async () => {
+    clearEmailEnv();
+    process.env.ACME_EMAIL = "operator@example.com";
+    const { payload } = await call("GET", "/api/v1/claude-setup");
+    assert.equal(payload.vault_login, null);
+  });
+});


### PR DESCRIPTION
## What's wrong

`/settings#agent` Vault Login card shows the wrong email on every tenant.
Sir tries to log into `vault.<tenant>.alfred.black` with the credentials
the card shows, Vaultwarden returns `Username or password is incorrect`.
Live-confirmed on **zsolt.alfred.black 2026-05-27**; same drift on
home / rj / joe / zsolt / miguel (they all share the bootstrap path).

## Root cause

The Vaultwarden account is registered by the `init-signup` container with
`BW_USER=${ACME_EMAIL}` — see [`docker-compose.yaml#L696`](../blob/main/docker-compose.yaml#L696) and #L732.
`ACME_EMAIL` is the operator's email (Let's Encrypt contact) and is the
**only** row that ever lands in Vaultwarden's `users` table on this stack.

`/api/v1/claude-setup` resolves the Vault Login email as
`BW_USER || OWNER_EMAIL`. On the merged single-VM stack `BW_USER` is
never written to `.env`, so it falls through to `OWNER_EMAIL` — which
is the **principal's** identity (rendered in the Brief, used for
outbound attribution). Vaultwarden has no user row for that email. The
password shown is correct, but it's the password for the operator's
account.

### Evidence

| tenant | ACME_EMAIL | OWNER_EMAIL | VW users.email | shown on /settings#agent |
|---|---|---|---|---|
| home   | david@sabo.tech | alfred@lumberjack.so      | david@sabo.tech | **alfred@lumberjack.so** ❌ |
| rj     | david@sabo.tech | (empty)                   | david@sabo.tech | (empty) ❌ |
| joe    | david@sabo.tech | chaconstruction@gmail.com | david@sabo.tech | **chaconstruction@gmail.com** ❌ |
| zsolt  | david@sabo.tech | rapali.zsolt@gmail.com    | david@sabo.tech | **rapali.zsolt@gmail.com** ❌ |
| miguel | david@sabo.tech | (empty)                   | david@sabo.tech | (empty) ❌ |

A `bw login david@sabo.tech $VAULTWARDEN_BW_PASSWORD` succeeds on every
tenant: the password is right, the email shown is wrong.

## The fix

Insert `ACME_EMAIL` between `BW_USER` and `OWNER_EMAIL` in the resolution
order so the card surfaces the email Vaultwarden actually accepts:

```ts
const bwUser =
  process.env.BW_USER ||         // future stack might set it explicitly
  process.env.ACME_EMAIL ||      // merged-stack signup identity (actual VW account)
  process.env.OWNER_EMAIL ||     // last-resort fallback (pre-merge tenants)
  null;
```

Adds `tests/claude-setup-vault-login-email.test.ts` to pin the order
(4 cases: merged-stack default, BW_USER override, OWNER_EMAIL fallback,
no-password gate).

## Follow-up (separate decision)

Should the Vaultwarden owner be the principal's email rather than the
operator's? Today the principal cannot own their own vault — only the
operator can. That's either a deliberate operator/principal split or a
leftover from the pre-merge tenant model; either way it's a design
decision, not a hotfix. Filing as a follow-up issue.

## Test plan

- `npm test -- tests/claude-setup-vault-login-email.test.ts` — 4 passing
- `npm test -- tests/claude-setup-approval-secret.test.ts` — still passing
- `npm test -- tests/claude-setup-mcp-urls.test.ts` — still passing
- `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)