### PR TITLE
fix(web): unwedge /verify when extract_facts_opus produced zero facts

### DIFF
--- a/packages/web/src/onboarding/VerifyPage.tsx
+++ b/packages/web/src/onboarding/VerifyPage.tsx
@@ -14,6 +14,7 @@ import {
 } from "wasp/client/operations";
 import { Frame } from "../client/components/ab/Frame";
 import { RitualNav } from "../client/components/ab/RitualNav";
+import { verifyViewState } from "./verifyPageCore";
 
 type FactStatus = "pending" | "confirmed" | "edited" | "discarded";
 type Fact = {
@@ -38,6 +39,17 @@ export default function VerifyPage() {
       display: string;
     }>;
   }, [progress]);
+
+  // View-state branch: distinguish "the backend hasn't finished extracting"
+  // (waiting) from "the backend finished and produced nothing" (empty).
+  // Logic lives in verifyPageCore so the wedge behaviour is unit-tested at
+  // the contract instead of buried in render flags.
+  const stage = progress?.stage as string | undefined;
+  const view = verifyViewState({
+    stage,
+    factsCount: sourceFacts.length,
+  });
+  const factsSettled = view === "empty";
 
   const [facts, setFacts] = useState<Fact[]>([]);
   const [seeded, setSeeded] = useState(false);
@@ -119,13 +131,64 @@ export default function VerifyPage() {
           Confirm what Alfred has learned.
         </h1>
 
-        {!seeded && (
+        {!seeded && !factsSettled && (
           <p
             className="font-body italic text-[16px]"
             style={{ color: "var(--marginalia)" }}
           >
             A moment — Alfred is sorting his observations.
           </p>
+        )}
+
+        {/*
+          Empty-state finale. The backend reached the verification gate
+          (or beyond) but produced no key identity facts — most often
+          because extract_facts_opus degraded against the LLM (a 402
+          credit dip, a chunk timeout, an empty inbox). Without this
+          branch the principal saw the "sorting" line forever, even
+          though there was nothing more to sort. Alfred speaks in his
+          own voice here and offers a single, honest way forward; the
+          continue handler submits empty corrections, which the
+          /onboarding/corrections endpoint accepts and uses to advance
+          the workflow into the brief stage exactly as a normal
+          confirmation would.
+        */}
+        {!seeded && factsSettled && (
+          <div className="space-y-6">
+            <p
+              className="font-body italic text-[18px]"
+              style={{ color: "var(--ink)" }}
+            >
+              I haven&rsquo;t yet found enough about you to confirm, sir.
+              The first sweep was a quiet one — we&rsquo;ll get acquainted
+              as we go.
+            </p>
+            <p
+              className="font-body text-[14px]"
+              style={{ color: "var(--marginalia)" }}
+            >
+              You may tell me anything you&rsquo;d like me to remember
+              before we continue. A sentence will do.
+            </p>
+            <div>
+              <input
+                value={extra}
+                onChange={(e) => setExtra(e.target.value)}
+                placeholder="Anything you&rsquo;d like me to know."
+                className="w-full bg-transparent outline-none border-b font-display italic text-[22px] pb-2"
+                style={{ borderColor: "var(--brass)" }}
+              />
+            </div>
+            <div className="border-t border-rule pt-8 flex items-baseline justify-end">
+              <button
+                disabled={submitting}
+                onClick={handleContinue}
+                className="btn-brass"
+              >
+                {submitting ? "A moment…" : "Continue →"}
+              </button>
+            </div>
+          </div>
         )}
 
         {seeded && pendingCount > 0 && (
@@ -259,15 +322,24 @@ export default function VerifyPage() {
           </div>
         )}
 
-        <div className="mt-14 border-t border-rule pt-8 flex items-baseline justify-end">
-          <button
-            disabled={!allTouched || submitting}
-            onClick={handleContinue}
-            className="btn-brass"
-          >
-            {submitting ? "A moment…" : "Continue →"}
-          </button>
-        </div>
+        {/*
+          The standard Continue rail. Hidden in the empty-state finale
+          (which renders its own Continue) so the principal does not see
+          two side-by-side Continue buttons. Visible whenever the user
+          has facts to confirm — gated by `seeded` to avoid flashing on
+          the pre-hydration paint.
+        */}
+        {seeded && (
+          <div className="mt-14 border-t border-rule pt-8 flex items-baseline justify-end">
+            <button
+              disabled={!allTouched || submitting}
+              onClick={handleContinue}
+              className="btn-brass"
+            >
+              {submitting ? "A moment…" : "Continue →"}
+            </button>
+          </div>
+        )}
       </section>
     </Frame>
   );

--- a/packages/web/src/onboarding/verifyPageCore.test.ts
+++ b/packages/web/src/onboarding/verifyPageCore.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for /verify's view-state decision (verifyPageCore).
+ *
+ * The wedge being fixed: /verify polled `getOnboardingProgress` every 8s
+ * and gated its "loading" message on whether key_identity_facts was empty.
+ * When extract_facts_opus degraded (e.g. a 402 credit dip during fact
+ * extraction on miguel.alfred.black on 2026-05-27), key_identity_facts
+ * stayed empty FOREVER and the page sat on
+ * "A moment — Alfred is sorting his observations."
+ *
+ *   cd packages/web && npx tsx --test src/onboarding/verifyPageCore.test.ts
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  FACTS_SETTLED_STAGES,
+  verifyViewState,
+} from "./verifyPageCore";
+
+test("backend mid-pipeline + empty facts → waiting (the calm spinner)", () => {
+  const state = verifyViewState({ stage: "facts", factsCount: 0 });
+  assert.equal(state, "waiting");
+});
+
+test("backend at metadata stage + empty facts → waiting", () => {
+  const state = verifyViewState({ stage: "metadata", factsCount: 0 });
+  assert.equal(state, "waiting");
+});
+
+test("getOnboardingProgress not yet resolved + empty facts → waiting", () => {
+  const state = verifyViewState({ stage: undefined, factsCount: 0 });
+  assert.equal(state, "waiting");
+});
+
+test("non-zero facts → list (the happy path)", () => {
+  const state = verifyViewState({
+    stage: "awaiting_verification",
+    factsCount: 8,
+  });
+  assert.equal(state, "list");
+});
+
+test("non-zero facts BEFORE settle (early hydrate) → list", () => {
+  // Defensive: if some future change has the backend stamp facts before
+  // setting stage=awaiting_verification, we should still render them.
+  const state = verifyViewState({ stage: "personalize", factsCount: 3 });
+  assert.equal(state, "list");
+});
+
+test("awaiting_verification + 0 facts → empty (the wedge fix)", () => {
+  // Live miguel.alfred.black state on 2026-05-27 18:00Z:
+  //   stage=awaiting_verification, key_identity_facts=[]
+  // The old code showed "Alfred is sorting his observations" forever.
+  const state = verifyViewState({
+    stage: "awaiting_verification",
+    factsCount: 0,
+  });
+  assert.equal(state, "empty");
+});
+
+test("post-verification stages also count as settled", () => {
+  // A workflow that completed all the way to `done` with zero facts —
+  // e.g. the brief-stage workflow that runs after corrections — should
+  // also show the empty state if the principal navigates back to
+  // /verify, never the eternal spinner.
+  for (const stage of ["brief", "packs", "chores", "done"] as const) {
+    const state = verifyViewState({ stage, factsCount: 0 });
+    assert.equal(state, "empty", `stage=${stage} should resolve to empty`);
+  }
+});
+
+test("FACTS_SETTLED_STAGES covers every post-facts stage from STAGE_ORDER", () => {
+  // STAGE_ORDER in onboarding_pipeline.py is:
+  //   metadata, profiler, facts, patterns, personalize,
+  //   awaiting_verification, brief, packs, chores, done
+  // Everything strictly AFTER `personalize` is settled.
+  const expected = new Set([
+    "awaiting_verification",
+    "brief",
+    "packs",
+    "chores",
+    "done",
+  ]);
+  assert.deepEqual(new Set(FACTS_SETTLED_STAGES), expected);
+});
+
+test("stages strictly before awaiting_verification are NOT settled", () => {
+  for (const stage of [
+    "metadata",
+    "profiler",
+    "facts",
+    "patterns",
+    "personalize",
+  ]) {
+    assert.equal(
+      FACTS_SETTLED_STAGES.has(stage),
+      false,
+      `stage=${stage} must not be classified as settled`,
+    );
+  }
+});

--- a/packages/web/src/onboarding/verifyPageCore.ts
+++ b/packages/web/src/onboarding/verifyPageCore.ts
@@ -1,0 +1,82 @@
+/**
+ * /verify — view-state decision for the "Confirm what Alfred has learned"
+ * page.
+ *
+ * The original page had two display branches, gated only by a local
+ * `seeded` flag that flipped to true the first time the backend returned
+ * a non-empty `key_identity_facts` list. When the backend completed the
+ * pipeline with ZERO key identity facts — the usual cause is an
+ * extract_facts_opus degrade (a 402 credit dip, a per-chunk timeout, or
+ * a sparse inbox) — `seeded` stayed false forever and the page sat on
+ * "A moment — Alfred is sorting his observations." The principal had no
+ * way past the screen.
+ *
+ * This module makes the decision explicit. The page now has THREE
+ * top-level view states:
+ *
+ *   "waiting"    The backend is still working on facts. Show the calm
+ *                "Alfred is sorting his observations" line and poll.
+ *   "list"       The backend produced one or more facts. Render the
+ *                normal confirm/edit/discard list.
+ *   "empty"      The backend reached or passed the verification gate
+ *                AND returned zero key identity facts. Show an
+ *                Alfred-voiced acknowledgement and a way to continue
+ *                (submits empty corrections → the workflow advances
+ *                into the brief stage).
+ *
+ * "Settled" means the workflow's facts stage has run to completion (or
+ * to degrade) and the result is in onboard.json. The backend tells us
+ * this via the `stage` field on `getOnboardingProgress`: anything at
+ * `awaiting_verification` or later is past the facts stage. Before
+ * `awaiting_verification`, an empty key_identity_facts list is just a
+ * "the LLM hasn't landed yet" signal, and we keep waiting.
+ */
+
+export type VerifyViewState = "waiting" | "list" | "empty";
+
+/**
+ * Stages at which `extract_facts_opus` has already run — successfully
+ * or to a degrade. Past these points an empty key_identity_facts list
+ * is the FINAL answer, not a still-loading signal.
+ *
+ * Includes every stage the OnboardingPipelineWorkflow can persist after
+ * the awaiting_verification gate: the brief stage runs as a separate
+ * workflow triggered by /onboarding/corrections, and the post-brief
+ * stages (packs, chores, done) may persist on the second workflow.
+ * Treating all of them as settled keeps `/verify` honest no matter
+ * which workflow the principal lands on. See
+ * packages/learn/src/workflows/onboarding_pipeline.py STAGE_ORDER.
+ */
+export const FACTS_SETTLED_STAGES: ReadonlySet<string> = new Set([
+  "awaiting_verification",
+  "brief",
+  "packs",
+  "chores",
+  "done",
+]);
+
+export interface VerifyViewInputs {
+  /** The current onboarding stage from getOnboardingProgress. May be
+   *  undefined on the very first paint before the query resolves. */
+  stage: string | undefined;
+  /** The key_identity_facts array length the backend returned. */
+  factsCount: number;
+}
+
+/**
+ * Pick the view state for /verify. Pure of React state; the hydration
+ * flag (`seeded`) is layered on top of this in the page itself so the
+ * facts list never re-shuffles mid-edit. The page consults this on
+ * every render to decide between the three top-level branches.
+ */
+export function verifyViewState(inputs: VerifyViewInputs): VerifyViewState {
+  const { stage, factsCount } = inputs;
+
+  if (factsCount > 0) return "list";
+
+  // No facts. Decide based on stage.
+  if (stage && FACTS_SETTLED_STAGES.has(stage)) return "empty";
+
+  // The backend has not yet reached the verification gate. Keep waiting.
+  return "waiting";
+}


### PR DESCRIPTION
## Symptom

The first-time onboarding ritual wedged at **/verify** ("Confirm what
Alfred has learned"). The principal saw "A moment — Alfred is sorting
his observations." forever and had no way to advance.

Live on `miguel.alfred.black` 2026-05-27 starting ~15:11Z. The
OnboardingPipelineWorkflow completed cleanly to
`stage=awaiting_verification`, but the LLM extraction had degraded:

```
stage:                  awaiting_verification
patterns:               11    ← discover_patterns_opus succeeded
facts:                  0
key_identity_facts:     0     ← what /verify renders
degraded_stages:        ["facts"]
```

Cause of the empty facts: `extract_facts_opus` chunked Miguel's 1439
emails into 4 parts. Every chunk's `_call_llm` returned a 402 from
OpenRouter (transient credit dip during a heavy burst), the parser
saw 0 facts, and `_mark_stage_degraded_empty_parse` correctly stamped
the stage as degraded. The workflow `_safe_stage_wrapper` did exactly
what it's designed to do — advance past a degraded stage — and the
pipeline reached the awaiting_verification gate with empty facts.

## Why the UI hung

`VerifyPage.tsx` had a single gate flag `seeded`:

```ts
useEffect(() => {
  if (seeded || sourceFacts.length === 0) return;  // never flips
  setSeeded(true);
}, [sourceFacts, seeded]);

{!seeded && <p>A moment — Alfred is sorting his observations.</p>}
```

With `sourceFacts.length === 0` forever, `seeded` never flipped and the
loading line was the only thing the page rendered.

## Fix

Distinguish "still loading" from "settled-but-empty" via the
backend's `stage` field:

- `stage` ∈ {metadata, profiler, facts, patterns, personalize}
  → still loading. Keep the calm "sorting observations" line.
- `stage` ∈ {awaiting_verification, brief, packs, chores, done}
  → settled. Show an Alfred-voiced acknowledgement and a Continue
  button that submits empty corrections (the existing
  `/api/v1/onboarding/corrections` endpoint accepts empty input and
  advances the workflow into the brief stage exactly as a normal
  confirmation does).

Alfred's voice in the empty-state finale:

> "I haven't yet found enough about you to confirm, sir. The first
> sweep was a quiet one — we'll get acquainted as we go."
>
> "You may tell me anything you'd like me to remember before we
> continue. A sentence will do."

The decision is extracted to a pure helper (`verifyPageCore.ts`) so
the wedge behaviour is unit-tested at the contract rather than buried
in render flags. Sibling onboarding `*Core.ts` files follow the same
node:test convention.

## Test plan

- 9 new unit tests in `verifyPageCore.test.ts`, all passing locally.
- Confirmed `rulesEmptyStateCore.test.ts` etc. still pass (20 tests).
- Live hot-fix on `miguel.alfred.black` is being applied in parallel
  (re-running the pipeline with a fresh OpenRouter balance produces
  non-empty key_identity_facts; that path takes the existing "list"
  view, unchanged).

## Scope

UI only. Touches just `packages/web/src/onboarding/VerifyPage.tsx`
and two new files in the same directory. No changes to the backend
or the workflow contract.

## Related

- Affects every tenant whose first-run extract_facts_opus degrades.
  Will recur on any fresh onboarding hitting transient credit dips,
  Hermes overloads, or low-volume inboxes.
- Backend bug surfaced during diagnosis: when one of several email
  chunks times out, the activity discards the partial work from the
  surviving chunks. Out of scope for this PR; filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)