### PR TITLE
fix(compose): vault-signup + vault-cli register owner at OWNER_EMAIL (not ACME_EMAIL)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -702,7 +702,7 @@ services:
         condition: service_healthy
     environment:
       - BW_SERVER_URL=http://vaultwarden:80
-      - BW_USER=${ACME_EMAIL}
+      - BW_USER=${OWNER_EMAIL:-${ACME_EMAIL}}
       - BW_PASSWORD=${VAULTWARDEN_BW_PASSWORD}
       - VAULTWARDEN_NAME=${OWNER_NAME}
       - VAULTWARDEN_ADMIN_TOKEN=${VAULTWARDEN_ADMIN_TOKEN}
@@ -738,7 +738,7 @@ services:
       - .env
     environment:
       - BW_SERVER_URL=http://vaultwarden:80
-      - BW_USER=${ACME_EMAIL}
+      - BW_USER=${OWNER_EMAIL:-${ACME_EMAIL}}
       - BW_PASSWORD=${VAULTWARDEN_BW_PASSWORD}
     depends_on:
       vaultwarden:


### PR DESCRIPTION
## What

Both \`vault-signup\` (one-shot) and \`vault-cli\` (long-running) read \`BW_USER\` from the env. They were defaulting to \`${ACME_EMAIL}\` — the operator's Let's Encrypt contact, identical across every tenant in the fleet. Result: on every fresh tenant the Vaultwarden owner was \`david@sabo.tech\`, not the principal of that tenant.

## Why it matters

The principal can never *own* their own vault. They see one email on \`/settings#agent\` but the actual user-row in Vaultwarden has a different email; login fails. Discovered today on zsolt.alfred.black.

## Fix

```diff
-      - BW_USER=${ACME_EMAIL}
+      - BW_USER=${OWNER_EMAIL:-${ACME_EMAIL}}
```

in both \`vault-signup\` and \`vault-cli\` service blocks.

\`ACME_EMAIL\` remains the operator-side Let's Encrypt renewal address (which is what it was designed for in the first place); the principal owns their vault.

## Live tenants

I'm migrating the 4 affected tenants out-of-band today (wipe the david@sabo.tech user-row, set OWNER_EMAIL in /opt/alfred/.env, re-run vault-signup). Once this PR merges and ctrl-api/the compose stack pull on those tenants, everything stays consistent.

home stays at \`david@sabo.tech\` per Sir's call — it has 11 pre-existing ciphers there, and home's principal *is* Sir. Only the dashboard label gets fixed on home (separate concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)