### PR TITLE
fix(learn): extract_facts_opus persists per-chunk work incrementally (#83)

### DIFF
--- a/packages/learn/src/activities/onboarding_v3.py
+++ b/packages/learn/src/activities/onboarding_v3.py
@@ -16,6 +16,7 @@ Steps:
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -889,6 +890,43 @@ def _fact_text_key(fact: Any) -> str:
     return " ".join(text.lower().split())
 
 
+def _chunk_fingerprint(chunk: list[dict[str, Any]]) -> str:
+    """Stable fingerprint for an email chunk (idempotency key for #83).
+
+    A SHA-256 over the chunk's identifying fields. The result is the
+    key into ``onboard["facts_partial"]`` so a Temporal retry can
+    short-circuit any chunk whose work is already on disk.
+
+    Order-stable + content-stable: ``chunk_emails_for_extraction`` is
+    deterministic (it slices a list it received in input order), so
+    the SAME corpus produces the SAME fingerprints across activity
+    retries. A re-onboarding with the SAME emails fingerprints
+    identically — that's the desired idempotency, and the stage
+    cleanup at the end of ``extract_facts_opus`` wipes
+    ``facts_partial`` so a re-onboarding with DIFFERENT emails
+    doesn't pick up stale partials.
+
+    We hash the per-email subject/from/date (not the full snippet) —
+    enough to make a collision astronomically unlikely while keeping
+    the digest cheap. ``hashlib.sha256`` is in stdlib (no new
+    dependency).
+    """
+    h = hashlib.sha256()
+    for e in chunk:
+        if not isinstance(e, dict):
+            continue
+        # Tab-separated and newline-terminated → no field can spoof a
+        # delimiter without changing the digest.
+        h.update("\t".join((
+            str(e.get("from", "")),
+            str(e.get("to", "")),
+            str(e.get("subject", "")),
+            str(e.get("date", "")),
+        )).encode("utf-8"))
+        h.update(b"\n")
+    return h.hexdigest()
+
+
 def _dedup_identity_candidates(candidates: list[dict]) -> list[dict]:
     """Last-wins dedup of identity-fact candidates by ``field``.
 
@@ -987,6 +1025,40 @@ BEHAVIORAL ANALYSIS (pre-computed from email metadata — use as ground truth):
     n_chunks = len(chunks)
     is_chunked = n_chunks > 1
 
+    # ---------------------------------------------------------------
+    # Incremental persistence — durability across activity retries (#83)
+    # ---------------------------------------------------------------
+    # Failure mode this guards against: a multi-chunk corpus where one
+    # chunk hits a transient Hermes/Nous stream drop, OR the cumulative
+    # wall-time of the loop exceeds ``start_to_close_timeout`` (15 min).
+    # Pre-fix, ``onboard["facts"]`` was persisted ONLY after the full
+    # loop, so any of these failure modes discarded ALL chunks' work
+    # on the activity-level retry. On miguel.alfred.black 2026-05-27,
+    # 4 chunks at ~8 min each blew the 15-min budget after chunk 2 and
+    # every retry restarted from chunk 0 with no progress.
+    #
+    # Design: ``onboard["facts_partial"]`` is a dict keyed by
+    # ``_chunk_fingerprint(chunk)`` carrying the per-chunk extraction
+    # result. After each chunk's LLM call returns, we write the entry
+    # AND ``_write_onboard`` immediately. On retry, we hash each chunk
+    # at loop entry and reuse any partial whose fingerprint is present
+    # — the LLM call is skipped entirely.
+    #
+    # Residual blast radius this does NOT cover:
+    #   * process death (SIGKILL, container OOM) between ``_call_llm``
+    #     returning and ``_write_onboard`` completing — that window is
+    #     <100ms and ``_write_onboard`` itself is fsync+rename atomic,
+    #     so the file is either pre-chunk-N or post-chunk-N, never
+    #     torn. The retry just re-runs chunk N.
+    #   * an operator ``mv onboard.json`` — that's an explicit reset
+    #     and the cleanup is intentional.
+    #   * a change to chunk shape (chunker rewrite, sampler shift) —
+    #     fingerprints differ → partials are unused → safe.
+    facts_partial: dict[str, Any] = onboard.get("facts_partial") or {}
+    if not isinstance(facts_partial, dict):  # defensive: corrupted shape
+        facts_partial = {}
+    chunks_resumed = 0
+
     # Per-chunk extraction. A 402 / credit-exhaustion error short-
     # circuits the WHOLE stage (we have no credits — every following
     # chunk will fail too); other errors per chunk are logged and the
@@ -997,6 +1069,28 @@ BEHAVIORAL ANALYSIS (pre-computed from email metadata — use as ground truth):
     chunks_with_failure = 0
 
     for i, chunk in enumerate(chunks):
+        fp = _chunk_fingerprint(chunk)
+
+        # Resume path: this chunk's work is already durable from a
+        # previous attempt. Skip the LLM call entirely.
+        cached = facts_partial.get(fp)
+        if isinstance(cached, dict):
+            chunk_facts = cached.get("facts") or []
+            chunk_identity = cached.get("identity") or []
+            chunks_resumed += 1
+            activity.heartbeat(
+                f"Extracting facts: chunk {i + 1}/{n_chunks} resumed "
+                f"({len(chunk_facts)} facts cached)"
+            )
+            for f in chunk_facts:
+                key = _fact_text_key(f)
+                if not key or key in seen_fact_keys:
+                    continue
+                seen_fact_keys.add(key)
+                facts.append(f)
+            identity_candidates.extend(chunk_identity)
+            continue
+
         activity.heartbeat(
             f"Extracting facts: chunk {i + 1}/{n_chunks} ({len(chunk)} emails)"
         )
@@ -1017,6 +1111,11 @@ BEHAVIORAL ANALYSIS (pre-computed from email metadata — use as ground truth):
             # failure in multi-chunk mode → log + continue so the
             # surviving chunks still contribute (resilience above
             # individual-chunk recovery).
+            #
+            # NOTE for #83: we do NOT persist a failed chunk to
+            # ``facts_partial``. The next retry SHOULD re-attempt this
+            # chunk — the surviving chunks are already durable, so
+            # only the failed ones cost LLM calls on retry.
             sentinel = _handle_llm_degraded(
                 "facts", onboard_path, exc,
                 activity_name="extract_facts_opus",
@@ -1046,6 +1145,30 @@ BEHAVIORAL ANALYSIS (pre-computed from email metadata — use as ground truth):
             logger.warning(
                 "onboarding_v3: chunk %d/%d produced 0 facts (raw len=%d)",
                 i + 1, n_chunks, len(raw or ""),
+            )
+
+        # ---- DURABILITY POINT (#83) ----
+        # Persist this chunk's result to onboard.json BEFORE accepting
+        # it into the in-memory merge. If the next chunk's LLM call
+        # hangs and Temporal kills the activity, this chunk's work
+        # survives in ``facts_partial`` and the retry will reuse it.
+        # We persist BOTH empty AND non-empty chunks: an empty chunk
+        # is a real LLM call we don't want to repeat.
+        facts_partial[fp] = {
+            "facts": chunk_facts,
+            "identity": chunk_identity,
+            "n_emails": len(chunk),
+            "ts": datetime.now(timezone.utc).isoformat(),
+        }
+        onboard["facts_partial"] = facts_partial
+        try:
+            _write_onboard(onboard_path, onboard)
+        except Exception as write_exc:  # noqa: BLE001
+            # Bookkeeping must not poison the run. Worst case: this
+            # chunk gets re-extracted on retry — same as pre-fix.
+            logger.warning(
+                "onboarding_v3: chunk %d/%d facts_partial persist failed: %s",
+                i + 1, n_chunks, write_exc,
             )
 
         # String-equality dedup, case-insensitive + whitespace-collapsed.
@@ -1096,14 +1219,20 @@ BEHAVIORAL ANALYSIS (pre-computed from email metadata — use as ground truth):
 
     logger.info(
         "onboarding_v3: extracted %d facts, %d key identity facts from %d "
-        "chunk(s) (%d emails total, %d chunk failure(s))",
+        "chunk(s) (%d emails total, %d chunk failure(s), %d chunk(s) "
+        "resumed from facts_partial)",
         len(facts), len(key_identity_facts), n_chunks, len(emails),
-        chunks_with_failure,
+        chunks_with_failure, chunks_resumed,
     )
 
     onboard["facts"] = facts
     onboard["key_identity_facts"] = key_identity_facts
     onboard["progress"]["facts_count"] = len(facts)
+    # Stage complete — wipe the per-chunk scratch so a future
+    # re-onboarding with a DIFFERENT corpus doesn't pick up stale
+    # partials (the fingerprints would miss, but better to keep the
+    # file slim — partials for 5000 emails are non-trivial bytes).
+    onboard.pop("facts_partial", None)
     _write_onboard(onboard_path, onboard)
 
     # Stage narration — Alfred working out who you are (best-effort, via Hermes).

--- a/packages/learn/tests/test_extract_facts_chunked.py
+++ b/packages/learn/tests/test_extract_facts_chunked.py
@@ -20,6 +20,17 @@ These tests pin the contract:
     candidate pool — never extracted from raw emails-in-one-shot.
   * heartbeats are emitted per chunk (Temporal needs that liveness
     signal — a 5-min sequence of chunks otherwise looks stalled).
+
+Plus (#83, incremental persistence):
+  * each chunk's result is persisted to ``onboard["facts_partial"]``
+    BEFORE the next chunk runs — so a Temporal activity timeout in
+    chunk N+1 doesn't discard chunks 1..N's LLM work on the retry.
+  * on retry, chunks whose fingerprint is already in ``facts_partial``
+    are SKIPPED — no LLM call, the cached facts are merged in.
+  * ``facts_partial`` is cleared from ``onboard.json`` once the stage
+    completes successfully (no stale scratch on the next re-onboard).
+  * a chunk that fails its LLM call is NOT persisted to
+    ``facts_partial`` — the retry MUST re-attempt it.
 """
 from __future__ import annotations
 
@@ -329,3 +340,291 @@ def test_heartbeat_emitted_per_chunk(tmp_path, monkeypatch) -> None:
     joined = " | ".join(chunk_hbs).lower()
     for i in range(1, 5):
         assert f"{i}/4" in joined or f"chunk {i}" in joined
+
+
+# --------------------------------------------------------- #83 incremental
+# Issue #83: a Temporal activity-level timeout during chunk N discarded
+# ALL chunks' work on retry. These tests pin the incremental-persistence
+# contract that fixes that wedge.
+
+
+def test_facts_partial_persists_after_each_chunk(tmp_path, monkeypatch) -> None:
+    """After every per-chunk LLM call returns, ``onboard["facts_partial"]``
+    is updated AND the file is rewritten — so a kill BETWEEN chunks
+    leaves chunks 1..N-1's work durable on disk."""
+    from src.activities.onboarding_v3 import extract_facts_opus
+    monkeypatch.setenv("AAS_API_KEY", "test-token")
+    onboard_path = _seed_onboard(tmp_path, n_emails=801)  # 3 chunks
+
+    # Snapshot the file after each _call_llm return so we can assert
+    # facts_partial grew monotonically.
+    snapshots: list[dict[str, Any]] = []
+
+    def _record_snapshot(*_a, **_kw):
+        # Re-read the file directly from disk, NOT the in-memory dict —
+        # we are testing durability.
+        try:
+            snapshots.append(json.loads(Path(onboard_path).read_text()))
+        except Exception:  # noqa: BLE001 — best-effort snapshot
+            snapshots.append({})
+
+    per_chunk = _facts_response(
+        facts=[{"category": "p", "fact": "f", "confidence": "high"}],
+        identity=[{"field": "name", "value": "J", "display": "F"}],
+    )
+    synth = json.dumps({"key_identity_facts": [
+        {"field": "name", "value": "J", "display": "F"},
+    ]})
+
+    # Capture a snapshot every time _call_llm is invoked — BEFORE the
+    # next call we want to see the previous chunk's partial already on
+    # disk.
+    seq = [per_chunk, per_chunk, per_chunk, synth]
+    call_idx = {"i": 0}
+
+    async def _mock_call(*_a, **_kw):
+        # Snapshot the file BEFORE this call, then return next response.
+        _record_snapshot()
+        r = seq[call_idx["i"]]
+        call_idx["i"] += 1
+        return r
+
+    with patch("src.activities.onboarding_v3._call_llm", new=_mock_call):
+        _run(lambda: extract_facts_opus(onboard_path))
+
+    # Snapshots in order: before chunk 1, before chunk 2, before chunk 3,
+    # before synthesis. Pre-chunk-2 snapshot must contain chunk 1's
+    # partial; pre-chunk-3 must contain chunks 1 + 2.
+    assert len(snapshots) >= 3
+    pre_chunk1 = snapshots[0].get("facts_partial") or {}
+    pre_chunk2 = snapshots[1].get("facts_partial") or {}
+    pre_chunk3 = snapshots[2].get("facts_partial") or {}
+    assert len(pre_chunk1) == 0
+    assert len(pre_chunk2) == 1
+    assert len(pre_chunk3) == 2
+
+    # Final file: facts_partial wiped after the successful run.
+    final = json.loads(Path(onboard_path).read_text())
+    assert "facts_partial" not in final or final["facts_partial"] in (
+        {}, None
+    )
+
+
+def test_resume_skips_chunks_with_cached_partials(
+    tmp_path, monkeypatch,
+) -> None:
+    """If ``onboard["facts_partial"]`` already holds chunks 1 + 2 at
+    activity entry, only chunk 3 (and the synthesis pass) call the LLM."""
+    from src.activities._email_sampling import chunk_emails_for_extraction
+    from src.activities.onboarding_v3 import (
+        _chunk_fingerprint,
+        extract_facts_opus,
+    )
+
+    monkeypatch.setenv("AAS_API_KEY", "test-token")
+    onboard_path = _seed_onboard(tmp_path, n_emails=801)  # 3 chunks
+
+    # Pre-seed facts_partial with chunks 1 and 2 (simulating a prior
+    # activity attempt that durably persisted those before timing out
+    # mid-chunk-3).
+    emails = [_email(i) for i in range(801)]
+    chunks = chunk_emails_for_extraction(emails)
+    assert len(chunks) == 3
+    cached_partials = {
+        _chunk_fingerprint(chunks[0]): {
+            "facts": [{"category": "p", "fact": "cached A",
+                       "confidence": "high"}],
+            "identity": [{"field": "name", "value": "A", "display": "F"}],
+            "n_emails": len(chunks[0]),
+            "ts": "2026-05-27T15:00:00+00:00",
+        },
+        _chunk_fingerprint(chunks[1]): {
+            "facts": [{"category": "p", "fact": "cached B",
+                       "confidence": "high"}],
+            "identity": [{"field": "name", "value": "B", "display": "F"}],
+            "n_emails": len(chunks[1]),
+            "ts": "2026-05-27T15:05:00+00:00",
+        },
+    }
+    data = json.loads(Path(onboard_path).read_text())
+    data["facts_partial"] = cached_partials
+    Path(onboard_path).write_text(json.dumps(data))
+
+    fresh_chunk3 = _facts_response(
+        facts=[{"category": "p", "fact": "fresh C", "confidence": "high"}],
+        identity=[{"field": "name", "value": "C", "display": "F"}],
+    )
+    synth = json.dumps({"key_identity_facts": [
+        {"field": "name", "value": "A", "display": "F"},
+    ]})
+    mock = AsyncMock(side_effect=[fresh_chunk3, synth])
+    with patch("src.activities.onboarding_v3._call_llm", new=mock):
+        _run(lambda: extract_facts_opus(onboard_path))
+
+    # Only TWO LLM calls — chunk 3 + synthesis. Chunks 1+2 were resumed.
+    assert mock.await_count == 2
+
+    # All three chunks' facts are present in the final result.
+    final = json.loads(Path(onboard_path).read_text())
+    fact_texts = {f["fact"] for f in final["facts"]}
+    assert fact_texts == {"cached A", "cached B", "fresh C"}
+
+
+def test_chunk_failure_does_not_poison_facts_partial(
+    tmp_path, monkeypatch,
+) -> None:
+    """A chunk whose LLM call RAISES is NOT persisted to facts_partial —
+    the retry must re-attempt it. Surviving chunks ARE persisted."""
+    from src.activities.onboarding_v3 import extract_facts_opus
+    monkeypatch.setenv("AAS_API_KEY", "test-token")
+    onboard_path = _seed_onboard(tmp_path, n_emails=801)  # 3 chunks
+
+    # Intercept facts_partial state at the moment the failing chunk
+    # raises. We read it FROM DISK between calls.
+    seen_partial_sizes: list[int] = []
+
+    a = _facts_response(
+        facts=[{"category": "p", "fact": "fact A", "confidence": "high"}],
+        identity=[{"field": "name", "value": "A", "display": "F"}],
+    )
+    c = _facts_response(
+        facts=[{"category": "p", "fact": "fact C", "confidence": "high"}],
+        identity=[{"field": "name", "value": "C", "display": "F"}],
+    )
+    synth = json.dumps({"key_identity_facts": [
+        {"field": "name", "value": "A", "display": "F"},
+    ]})
+
+    seq: list[Any] = [a, RuntimeError("transient hermes 5xx"), c, synth]
+    call_idx = {"i": 0}
+
+    async def _mock_call(*_a, **_kw):
+        # Read facts_partial size BEFORE returning this call's result.
+        try:
+            d = json.loads(Path(onboard_path).read_text())
+            seen_partial_sizes.append(len(d.get("facts_partial") or {}))
+        except Exception:  # noqa: BLE001
+            seen_partial_sizes.append(-1)
+        item = seq[call_idx["i"]]
+        call_idx["i"] += 1
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    with patch("src.activities.onboarding_v3._call_llm", new=_mock_call):
+        _run(lambda: extract_facts_opus(onboard_path))
+
+    # Sequence of facts_partial sizes seen BEFORE each LLM call:
+    #   chunk 1 → 0 (empty)
+    #   chunk 2 → 1 (chunk 1 persisted)
+    #   chunk 3 → 1 (chunk 2 FAILED, NOT persisted)
+    #   synth   → 2 (chunk 3 persisted)
+    assert seen_partial_sizes[0] == 0
+    assert seen_partial_sizes[1] == 1
+    # Chunk 2 raised → still 1 (the failed chunk MUST not poison the cache).
+    assert seen_partial_sizes[2] == 1
+    assert seen_partial_sizes[3] == 2
+
+    # Final output merges chunks 1 + 3, drops chunk 2, NOT degraded.
+    final = json.loads(Path(onboard_path).read_text())
+    fact_texts = {f["fact"] for f in final["facts"]}
+    assert fact_texts == {"fact A", "fact C"}
+    assert "facts" not in final.get("degraded_stages", [])
+    # And facts_partial is cleared at end-of-stage.
+    assert not final.get("facts_partial")
+
+
+def test_resume_with_all_chunks_cached_makes_no_chunk_llm_calls(
+    tmp_path, monkeypatch,
+) -> None:
+    """If every chunk's fingerprint is already in facts_partial, the
+    per-chunk extraction loop makes ZERO LLM calls — only the identity
+    synthesis pass runs (multi-chunk only)."""
+    from src.activities._email_sampling import chunk_emails_for_extraction
+    from src.activities.onboarding_v3 import (
+        _chunk_fingerprint,
+        extract_facts_opus,
+    )
+
+    monkeypatch.setenv("AAS_API_KEY", "test-token")
+    onboard_path = _seed_onboard(tmp_path, n_emails=801)  # 3 chunks
+
+    emails = [_email(i) for i in range(801)]
+    chunks = chunk_emails_for_extraction(emails)
+    cached = {
+        _chunk_fingerprint(c): {
+            "facts": [{"category": "p", "fact": f"cached {i}",
+                       "confidence": "high"}],
+            "identity": [{"field": "name", "value": f"C{i}",
+                          "display": "F"}],
+            "n_emails": len(c),
+            "ts": "2026-05-27T15:00:00+00:00",
+        } for i, c in enumerate(chunks)
+    }
+    data = json.loads(Path(onboard_path).read_text())
+    data["facts_partial"] = cached
+    Path(onboard_path).write_text(json.dumps(data))
+
+    synth = json.dumps({"key_identity_facts": [
+        {"field": "name", "value": "C0", "display": "F"},
+    ]})
+    mock = AsyncMock(side_effect=[synth])
+    with patch("src.activities.onboarding_v3._call_llm", new=mock):
+        _run(lambda: extract_facts_opus(onboard_path))
+
+    # Only the synthesis pass — zero per-chunk LLM calls.
+    assert mock.await_count == 1
+
+    final = json.loads(Path(onboard_path).read_text())
+    fact_texts = {f["fact"] for f in final["facts"]}
+    assert fact_texts == {"cached 0", "cached 1", "cached 2"}
+
+
+def test_corrupt_facts_partial_is_ignored(tmp_path, monkeypatch) -> None:
+    """A facts_partial that isn't a dict (corrupted) is silently ignored —
+    the activity recomputes from scratch and rewrites the field with a
+    valid dict shape."""
+    from src.activities.onboarding_v3 import extract_facts_opus
+    monkeypatch.setenv("AAS_API_KEY", "test-token")
+    onboard_path = _seed_onboard(tmp_path, n_emails=801)  # 3 chunks
+
+    data = json.loads(Path(onboard_path).read_text())
+    data["facts_partial"] = "this is not a dict"  # corrupt shape
+    Path(onboard_path).write_text(json.dumps(data))
+
+    per_chunk = _facts_response(
+        facts=[{"category": "p", "fact": "f", "confidence": "high"}],
+        identity=[{"field": "name", "value": "J", "display": "F"}],
+    )
+    synth = json.dumps({"key_identity_facts": [
+        {"field": "name", "value": "J", "display": "F"},
+    ]})
+    mock = AsyncMock(side_effect=[per_chunk, per_chunk, per_chunk, synth])
+    with patch("src.activities.onboarding_v3._call_llm", new=mock):
+        _run(lambda: extract_facts_opus(onboard_path))
+
+    # All 3 chunks called (cache was unusable) + 1 synth.
+    assert mock.await_count == 4
+    final = json.loads(Path(onboard_path).read_text())
+    # Cleanup wiped the field at end-of-stage.
+    assert not final.get("facts_partial")
+
+
+def test_chunk_fingerprint_is_stable_and_distinguishing() -> None:
+    """The fingerprint is content-stable (same chunk → same hash) AND
+    distinguishing (different chunks → different hash). This is the
+    idempotency-key contract."""
+    from src.activities.onboarding_v3 import _chunk_fingerprint
+
+    a = [_email(1), _email(2), _email(3)]
+    b = [_email(1), _email(2), _email(3)]  # same content
+    c = [_email(1), _email(2), _email(4)]  # one email differs
+    d = [_email(2), _email(1), _email(3)]  # same content, REORDERED
+
+    assert _chunk_fingerprint(a) == _chunk_fingerprint(b)
+    assert _chunk_fingerprint(a) != _chunk_fingerprint(c)
+    # Order matters: the chunker is deterministic, so a reorder would
+    # represent a real chunk-shape change.
+    assert _chunk_fingerprint(a) != _chunk_fingerprint(d)
+    # Empty chunk has a stable fingerprint too (SHA of empty input).
+    assert _chunk_fingerprint([]) == _chunk_fingerprint([])


### PR DESCRIPTION
## Problem

When `extract_facts_opus` (in `packages/learn/src/activities/onboarding_v3.py`) processes a tenant's Gmail corpus in chunks and any chunk hits a Temporal `start_to_close_timeout` or transient LLM-side error, ALL chunks' partial work was discarded — the activity rolled back to `facts=[]` on retry.

This wedged `miguel.alfred.black` 2026-05-27: 4 chunks at ~8 min each on Nous, one transient stream drop, every retry restarted at chunk 0 with no progress. He saw an empty `/verify` for hours.

The PR-#82 UI counterpart (just merged) covers the user-visible side of the wedge. This PR is the backend half — the actual recovery of partial work.

## Design choice

**A — incremental disk persistence with per-chunk fingerprint as idempotency key.**

Considered:
- **B (heartbeat-details checkpointing)** — no prior `heartbeat_details` usage in this codebase, would be a net-new pattern, and has a ~2MB payload ceiling that a big corpus could approach.
- **C (per-chunk child activities)** — touches the workflow body, would require a `workflow.patched()` gate, larger blast radius.
- **A (this PR)** — onboard.json is already the canonical durable state for the onboarding pipeline (written 14× elsewhere in this file). `_write_onboard` is already fsync + atomic-rename. Smallest viable change.

## Mechanism

- New `_chunk_fingerprint(chunk)` — SHA-256 over per-email `from/to/subject/date`. Stable across activity retries because `chunk_emails_for_extraction` is deterministic.
- `extract_facts_opus` now maintains `onboard["facts_partial"]` — a dict keyed by chunk fingerprint with `{facts, identity, n_emails, ts}`.
- After every successful per-chunk LLM call, the entry is written and `_write_onboard` runs immediately. The atomic rename means the on-disk file is either pre-chunk-N or post-chunk-N, never torn.
- At loop entry on a retry, each chunk's fingerprint is checked against `facts_partial`. If present, the cached facts are merged in and the LLM call is skipped entirely (full LLM-cost recovery).
- Failed chunks are NOT persisted — the retry must re-attempt them.
- At end-of-stage success, `facts_partial` is wiped (clean exit; no stale scratch).

## Residual blast radius

What this fix DOES cover:
- Single-chunk transient errors (the miguel scenario): chunks 1..N-1 survive, retry reuses them, only the failed chunk re-pays cost.
- Activity-level timeout: same.
- Worker process restart between chunks: same — onboard.json is on a persistent volume.
- Temporal server restart: same.

What this fix does NOT cover (called out for awareness):
- Process death (SIGKILL / OOM) in the <100ms window between `_call_llm` returning and `_write_onboard` completing. `_write_onboard`'s tempfile+fsync+rename means no torn file, but the chunk's work is lost. Retry just re-runs that one chunk. No silent data loss.
- Operator `mv onboard.json` — explicit reset, intentional cleanup. (The wedge-memory unstick playbook does exactly this.)
- Chunker rewrite that shifts chunk-shape — fingerprints diverge, all partials become unused; safe (no false positives), but no recovery either.

## Tests

`packages/learn/tests/test_extract_facts_chunked.py` — 6 new test cases, all green:

| Test | What it pins |
|---|---|
| `test_facts_partial_persists_after_each_chunk` | The pre-chunk-N snapshot on disk already contains chunks 1..N-1's partials |
| `test_resume_skips_chunks_with_cached_partials` | Pre-seeded cache means only the missing chunk + synth call the LLM |
| `test_chunk_failure_does_not_poison_facts_partial` | A failed chunk is NOT added to the cache; surviving chunks are |
| `test_resume_with_all_chunks_cached_makes_no_chunk_llm_calls` | Full-cache hit → zero per-chunk LLM calls |
| `test_corrupt_facts_partial_is_ignored` | A non-dict `facts_partial` (corrupted JSON shape) is silently treated as empty |
| `test_chunk_fingerprint_is_stable_and_distinguishing` | Same content → same hash; different content → different hash |

Pre-existing 11 tests in this file unchanged. Full learn-package suite: 2164 passed, 101 skipped, 0 regressions.

## Non-determinism / replay

This change is entirely inside an `@activity.defn` (`extract_facts_opus`). The workflow body in `packages/learn/src/workflows/onboarding_pipeline.py` is untouched. No `workflow.patched()` needed.

Activity contract is unchanged: same name, same return shape (`{"facts": int, "key_identity_facts": int}` or the degrade-sentinel). Replay-safe for in-flight workflows.

Closes #83. Companion to #82 (UI-side empty-state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)