### PR TITLE
feat(paperclip): HTTP-mode hermes_local adapter — call hermes:18789 instead of spawning a CLI

### DIFF
--- a/.github/workflows/build-paperclip.yml
+++ b/.github/workflows/build-paperclip.yml
@@ -1,0 +1,78 @@
+# Build + push alfred-black-paperclip — the upstream
+# ghcr.io/paperclipai/paperclip image overlaid with our patched
+# hermes-paperclip-adapter (HTTP-mode execute() against the tenant's
+# local hermes container at :18789). See packages/paperclip/DESIGN.md.
+name: build-paperclip
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/paperclip/**"
+      - ".github/workflows/build-paperclip.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: build-paperclip-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-adapter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install adapter deps
+        working-directory: packages/paperclip/adapter
+        run: npm ci --no-audit --no-fund
+
+      - name: Typecheck
+        working-directory: packages/paperclip/adapter
+        run: npm run typecheck
+
+      - name: Build adapter
+        working-directory: packages/paperclip/adapter
+        run: npm run build
+
+      - name: Unit tests
+        working-directory: packages/paperclip/adapter
+        run: npm test
+
+  build:
+    runs-on: ubuntu-latest
+    needs: test-adapter
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: packages/paperclip/dockerfiles/paperclip.Dockerfile
+          # Single platform — upstream paperclip image is amd64-only today
+          # (the digest pin in the Dockerfile resolves to a linux/amd64
+          # manifest). Re-evaluate when upstream ships multi-arch.
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ssdavidai00/alfred-black-paperclip:latest
+            ssdavidai00/alfred-black-paperclip:sha-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1275,7 +1275,13 @@ services:
   # 2026-05-26). If a future Paperclip release ships /api/health, switch
   # to `curl -fsS http://127.0.0.1:3100/api/health` for a tighter signal.
   paperclip:
-    image: ghcr.io/paperclipai/paperclip@sha256:711d29717855abbd84d0e576a0a07daff8e9007a229fb8220d8203d492e886e4
+    # alfred-black-paperclip: upstream ghcr.io/paperclipai/paperclip image
+    # overlaid with our patched hermes-paperclip-adapter (HTTP-mode execute()
+    # against the tenant's local hermes container at :18789). See
+    # packages/paperclip/DESIGN.md for the rationale; the Dockerfile pins
+    # the upstream base by digest with a tripwire that fails the build on
+    # upstream version drift.
+    image: ssdavidai00/alfred-black-paperclip:latest
     restart: unless-stopped
     env_file:
       - .env
@@ -1286,8 +1292,23 @@ services:
       - PAPERCLIP_PUBLIC_URL=https://paperclip.${DOMAIN}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      # ── HTTP-mode hermes_local adapter ─────────────────────────────────
+      # Where our patched adapter sends the per-heartbeat /v1/responses call.
+      # The compose-network DNS name `hermes` resolves to the main gateway
+      # at :18789 (see the hermes service above). Override per-tenant if
+      # you point paperclip at a non-default gateway.
+      - HERMES_GATEWAY_URL=http://hermes:18789
+      # The adapter reads Hermes' API_SERVER_KEY out of
+      # /hermes-state/profiles/main/.env at call time. Override the base
+      # dir here if you mount hermes_data somewhere else.
+      - HERMES_CONFIG_DIR=/hermes-state/profiles
     volumes:
       - paperclip_data:/paperclip
+      # Read-only mount so the patched adapter can resolve Hermes'
+      # API_SERVER_KEY from the rendered profile .env. Without this the
+      # adapter falls back to no Authorization header and Hermes returns
+      # 401. Mirrors the ctrl-api mount (server.ts:readHermesMainApiKey).
+      - hermes_data:/hermes-state:ro
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3100/sign-in >/dev/null 2>&1 || exit 1"]
       interval: 15s

--- a/packages/hermes/init/bootstrap-paperclip.sh
+++ b/packages/hermes/init/bootstrap-paperclip.sh
@@ -50,8 +50,11 @@
 #      Response: {bootstrapAccepted:true}.
 #   8. POST /api/companies/ {"name":"Alfred", description:"..."} → company id.
 #   9. POST /api/companies/<id>/agents {name:"hermes", role:"ceo", ...} →
-#      agent id. adapterType=openclaw_gateway because Alfred's Hermes is
-#      the agent's runtime.
+#      agent id. adapterType=hermes_local because Alfred's Hermes is
+#      the agent's runtime — the alfred-black paperclip image ships a
+#      patched hermes-paperclip-adapter whose execute() POSTs every
+#      heartbeat to hermes:18789/v1/responses (see
+#      packages/paperclip/DESIGN.md).
 #  10. POST /api/agents/<id>/keys {name:"hermes-runtime"} → token: pcp_… .
 #      This is the long-lived token Hermes' paperclip MCP server uses.
 #  11. Persist the password + token tuple. Two artifacts:
@@ -562,17 +565,24 @@ if not company_id:
 log(f"  company id: {company_id}")
 
 # --------------------------------------------------------------------------
-# Step 9 - create the CEO agent. adapterType=openclaw_gateway because
-# Alfred's Hermes is the runtime: Paperclip's HTTP adapter will send
-# heartbeats to ${TENANT}/api/v1/channels/paperclip/heartbeat, which
-# ctrl-api translates into a Hermes /v1/responses call.
+# Step 9 - create the CEO agent. adapterType=hermes_local because the
+# alfred-black paperclip image ships a patched hermes-paperclip-adapter
+# whose execute() calls hermes:18789/v1/responses over HTTP — every
+# heartbeat round-trips through the tenant's own Hermes Agent
+# container, no CLI binary required. See packages/paperclip/DESIGN.md
+# for the mapping.
+#
+# Why not adapterType="openclaw_gateway"? That was the previous default;
+# it pointed at a WebSocket gateway protocol Paperclip ships out-of-the-
+# box but which alfred-black doesn't run. Live observation: agents
+# created with openclaw_gateway never actually executed a heartbeat.
 # --------------------------------------------------------------------------
 log(f"step 9: creating agent '{os.environ['PAPERCLIP_SEED_AGENT_NAME']}' (CEO)")
 agent_body = {
     "name": os.environ["PAPERCLIP_SEED_AGENT_NAME"],
     "role": "ceo",
     "title": os.environ["PAPERCLIP_SEED_AGENT_TITLE"],
-    "adapterType": "openclaw_gateway",
+    "adapterType": "hermes_local",
     "capabilities": os.environ["PAPERCLIP_SEED_AGENT_CAPABILITIES"],
 }
 code, body, _ = request("POST", f"/api/companies/{company_id}/agents", agent_body)

--- a/packages/paperclip/DESIGN.md
+++ b/packages/paperclip/DESIGN.md
@@ -1,0 +1,142 @@
+# Paperclip Hermes-HTTP Adapter — Design Note
+
+Local-only fork of upstream `hermes-paperclip-adapter@0.2.0` that swaps the
+child-process backend (spawn `hermes chat -q …`) for a tenant-local HTTP call
+against alfred-black's own Hermes Agent container (`hermes:18789/v1/responses`).
+
+The Paperclip sidecar runs `ghcr.io/paperclipai/paperclip` upstream; that image
+has no `hermes` CLI binary. Our Hermes Agent runs in a separate container and
+already serves an OpenAI-compatible HTTP surface that every other channel
+(Telegram, Slack, SMS, voice-bridge, paperclip-via-ctrl-api) routes through.
+This fork makes the `hermes_local` adapter follow the same path so Paperclip
+heartbeats execute against real Hermes rather than a missing binary.
+
+## Why ship this at all
+
+Today the seed bootstrap (PR #84, `bootstrap-paperclip.sh`) creates the CEO
+agent with `adapterType: "openclaw_gateway"` — a Paperclip-bundled WebSocket
+adapter that expects an OpenClaw gateway endpoint that doesn't exist on our
+tenants. The adapter therefore never executes a task, even though the agent
+appears configured in Paperclip's UI. Two adapter types could plausibly run
+the agent locally:
+
+| Adapter         | Backend                                 | Works on alfred-black?           |
+|-----------------|-----------------------------------------|----------------------------------|
+| `http`          | webhook → `ctrl-api`                    | yes (already wired, lane I)      |
+| `openclaw_gateway` | WebSocket → OpenClaw gateway service | no (no such service deployed)    |
+| `hermes_local`  | spawn `hermes` CLI in paperclip image   | no (binary missing)              |
+| `hermes_local`* | **POST hermes:18789/v1/responses**      | **this PR — wire-up**            |
+
+The `http` adapter via ctrl-api is the supported runtime path today, and
+remains the recommended adapter for channels that need ctrl-api journaling.
+The `hermes_local` HTTP backend is preferable as the *managed-employee*
+runtime — it lets Paperclip own the per-agent session, retries, skill list,
+and transcript surface without forcing every heartbeat through ctrl-api.
+
+## Mapping table
+
+| Upstream behaviour            | HTTP-mode replacement                                |
+|-------------------------------|------------------------------------------------------|
+| Spawn `hermes chat -q PROMPT` | `POST {HERMES_GATEWAY_URL}/v1/responses` with `{ input: PROMPT }` |
+| `-Q` quiet mode               | Always quiet; `/v1/responses` JSON is structured     |
+| `-m model`                    | Not passed (Hermes config.yaml owns the model)       |
+| `--provider`                  | Not passed (Hermes config.yaml owns the provider)    |
+| `-t toolsets`                 | Not passed (Hermes profile owns the toolset)         |
+| `-w` worktree                 | Dropped (no spawn, no cwd)                           |
+| `--checkpoints`               | Dropped                                              |
+| `-v` verbose                  | Dropped (we surface response as-is)                  |
+| `--source tool`               | Implicit — sessions are tagged by `X-Hermes-Session-Key` prefix `paperclip-<agentId>` |
+| `--resume <sessionId>`        | Same `X-Hermes-Session-Key` reused across heartbeats; Hermes' own state handles continuity. `sessionParams.sessionKey` is round-tripped through Paperclip's session codec |
+| `~/.hermes/skills/` scan      | Same scan if `~/.hermes/skills/` is mounted; otherwise empty list |
+| `hermes --version` env test   | `GET {HERMES_GATEWAY_URL}/health`                    |
+| stdout regex parsing          | Walk `output[].content[].text` from the Responses-API envelope (matches ctrl-api `extractHermesText`) |
+| Token usage from stdout regex | `response.usage.{input,output}_tokens` from the JSON envelope |
+| Cost regex                    | Dropped (Hermes doesn't surface USD here); `costUsd` left `null` |
+
+## Session continuity
+
+Upstream stores `{ sessionId: "<hermes-cli-session-id>" }` in `sessionParams`
+and passes it to the next run via `--resume`. We instead derive a stable
+`sessionKey` from the agent id (`paperclip-<paperclipAgentId>`) and reuse it
+across heartbeats — Hermes' gateway already keys its message history off the
+`X-Hermes-Session-Key` header. The codec still serializes `{ sessionKey }`
+so Paperclip's UI surfaces the displayId.
+
+Backwards-compat in the codec: if the persisted blob still holds the old
+`sessionId` field, accept it as a `sessionKey` so an existing agent that's
+been on `hermes_local` (e.g. while we were iterating) keeps working without
+a forced reset.
+
+## Authentication
+
+Hermes' `/v1/responses` validates `Authorization: Bearer <key>` against
+`API_SERVER_KEY` written into `/hermes-state/profiles/main/.env` by the
+hermes-init container. This file is the authoritative source of truth (see
+memory: `paperclip-integration` "Hermes API auth reads /hermes-state/
+profiles/main/.env API_SERVER_KEY, not /opt/alfred/.env's
+HERMES_API_SERVER_KEY"). We mount `hermes_data:/hermes-state:ro` into the
+paperclip container and read the key at call time, matching the pattern
+ctrl-api's `channels_paperclip.ts::readHermesMainApiKey()` already uses.
+
+Provider keys (Anthropic / OpenAI / OpenRouter / Z.AI) are never touched —
+they live ONLY inside the hermes container, in `config.yaml` (operator-owned).
+
+## Vault and ctrl-api boundaries
+
+Upstream's adapter does not write to any vault. Our patched version preserves
+that — it never opens `/vault` directly. If a future upstream change adds
+vault writes, the build will fail on the `HERMES_PAPERCLIP_ADAPTER_REF` needle
+check (see `Dockerfile`) and force a re-review before the swap proceeds.
+
+## Compose changes
+
+`paperclip` service gains:
+
+```yaml
+volumes:
+  - paperclip_data:/paperclip
+  - hermes_data:/hermes-state:ro   # ← new, read-only
+environment:
+  - HERMES_GATEWAY_URL=http://hermes:18789  # ← new, optional override
+```
+
+The paperclip image is rebuilt to `ssdavidai00/alfred-black-paperclip:latest`
+and the `image:` line is swapped. `image-sha` pinning carries through to a
+follow-up.
+
+## Tripwire / upstream-drift detection
+
+Image build verifies the upstream package version is exactly `0.2.0` before
+applying the overlay. If upstream ships `0.2.1` or `0.3.0`, the build fails
+fast with a message telling the operator to re-audit `execute.ts` against
+the new upstream source.
+
+## Limits
+
+* No streaming. `/v1/responses` is request/response. Paperclip's UI receives
+  the full transcript at the end of the run. ctrl-api's `channels_paperclip`
+  works the same way; the operator-visible difference is "one paragraph
+  appears at the end" vs "the cursor visibly moves" — for the heartbeat
+  cadence (every N seconds) this is the right trade-off.
+
+* No streaming `onLog` deltas. We emit a synthetic `[hermes]` boot/exit
+  prologue + the response as a single stdout chunk, then a final exit-code
+  line. Paperclip's transcript UI renders this as one assistant turn.
+
+* `--reasoning-effort` / extended-thinking knobs are dropped. Hermes config
+  controls these per profile and overriding from Paperclip would let an
+  operator silently change the principal's reasoning-budget posture.
+
+## Future / out of scope
+
+* Generic `HERMES_TRANSPORT=http|cli` mode in upstream
+  `NousResearch/hermes-paperclip-adapter` — see the follow-up issue. Until
+  upstream takes that PR, this fork stays local-only per Sir's
+  "ask-before-upstream-for-tenant-work" rule.
+
+* Skill *sync* (push paperclip-managed skills into Hermes' skill dir) is a
+  no-op even upstream. We surface what's mounted at `~/.hermes/skills/`
+  read-only and stop there.
+
+* Cost USD propagation — would need Hermes' gateway to attach a
+  `cost_usd` field to the `usage` block. Not present today.

--- a/packages/paperclip/adapter/package-lock.json
+++ b/packages/paperclip/adapter/package-lock.json
@@ -1,0 +1,569 @@
+{
+  "name": "@alfred-black/hermes-paperclip-adapter-http",
+  "version": "0.2.0-alfred.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@alfred-black/hermes-paperclip-adapter-http",
+      "version": "0.2.0-alfred.1",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsx": "^4.20.0",
+        "typescript": "^5.7.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/packages/paperclip/adapter/package.json
+++ b/packages/paperclip/adapter/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@alfred-black/hermes-paperclip-adapter-http",
+  "version": "0.2.0-alfred.1",
+  "description": "Local fork of hermes-paperclip-adapter@0.2.0 that calls hermes:18789/v1/responses via HTTP instead of spawning a hermes CLI binary. Tenant-only. Not published.",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js",
+    "./server": "./dist/server/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "test": "node --test --import tsx tests/*.test.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.20.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/packages/paperclip/adapter/src/index.ts
+++ b/packages/paperclip/adapter/src/index.ts
@@ -1,0 +1,70 @@
+/**
+ * Hermes Agent adapter for Paperclip — HTTP-mode fork.
+ *
+ * Public top-level exports (matches upstream's `index.ts` surface).
+ */
+
+import { ADAPTER_TYPE, ADAPTER_LABEL } from "./shared/constants.js";
+
+export const type = ADAPTER_TYPE;
+export const label = ADAPTER_LABEL;
+
+/**
+ * In HTTP mode the model list comes from Hermes config.yaml — Paperclip
+ * cannot influence it. We surface an empty list so the Paperclip UI shows
+ * "managed by Hermes" instead of a curated set the operator might think
+ * is authoritative.
+ */
+export const models: { id: string; label: string }[] = [];
+
+export const agentConfigurationDoc = `# Hermes Agent (HTTP mode) — Configuration
+
+This is the alfred-black local fork of \`hermes-paperclip-adapter\`. It
+calls the tenant's existing Hermes Agent container over HTTP instead of
+spawning a \`hermes\` CLI inside the paperclip container.
+
+## How it works
+
+Every heartbeat:
+
+1. Renders a wake-up prompt from \`promptTemplate\` (Mustache-lite syntax).
+2. POSTs the prompt to \`{HERMES_GATEWAY_URL}/v1/responses\` with
+   \`X-Hermes-Session-Key: paperclip-<agentId>\`.
+3. Surfaces the assistant text + token usage back to Paperclip.
+
+Hermes' own message history (keyed by session-key) handles continuity
+across heartbeats. No \`--resume\`, no CLI args.
+
+## Configuration
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| hermesGatewayUrl | string | http://hermes:18789 | Hermes main gateway base URL. Falls back to \`HERMES_GATEWAY_URL\` env var. |
+| timeoutSec | number | 300 | Per-call timeout (seconds). |
+| sessionKey | string | (derived) | Pin a specific Hermes session key. Default is \`paperclip-<agentId>\`. |
+| promptTemplate | string | (built-in) | Custom wake-up prompt. Mustache-lite: \`{{var}}\` + \`{{#section}}…{{/section}}\`. |
+
+## Available Template Variables
+
+- \`{{agentId}}\` — Paperclip agent ID
+- \`{{agentName}}\` — Agent display name
+- \`{{companyId}}\` — Paperclip company ID
+- \`{{companyName}}\` — Company display name
+- \`{{runId}}\` — Current heartbeat run ID
+- \`{{taskId}}\` / \`{{taskTitle}}\` / \`{{taskBody}}\` — Task fields (when assigned)
+- \`{{commentId}}\` — Comment ID (when triggered by a comment)
+- \`{{wakeReason}}\` — Why this heartbeat fired
+- \`{{projectName}}\` — Project name (when scoped to a project)
+
+## What's NOT honoured (vs upstream CLI mode)
+
+Model, provider, toolsets, verbose, worktreeMode, checkpoints, extraArgs —
+all owned by Hermes' \`config.yaml\` per the principal's operator-owned
+configuration. Setting them in Paperclip has no effect in HTTP mode.
+
+## Authentication
+
+The adapter reads Hermes' \`API_SERVER_KEY\` from
+\`/hermes-state/profiles/main/.env\` at call time. The paperclip container
+must mount \`hermes_data:/hermes-state:ro\` for this to work.
+`;

--- a/packages/paperclip/adapter/src/server/detect-model.ts
+++ b/packages/paperclip/adapter/src/server/detect-model.ts
@@ -1,0 +1,23 @@
+/**
+ * `detectModel()` — upstream reads `~/.hermes/config.yaml`. We don't have
+ * that file in the paperclip container, AND we don't want the principal
+ * to see "Hermes is using anthropic/claude-sonnet-4" as if Paperclip
+ * could override it — model selection is operator-owned via the Hermes
+ * config.yaml. Return `null` so Paperclip's UI hides the "detected
+ * model" affordance entirely.
+ *
+ * Follow-up: if Hermes ever surfaces `GET /v1/models` (it doesn't
+ * today), we can wire that in here.
+ */
+
+export async function detectModel(
+  _configPath?: string,
+): Promise<{ model: string; provider: string; source: string } | null> {
+  return null;
+}
+
+export function parseModelFromConfig(
+  _content: string,
+): { model: string; provider: string; source: string } | null {
+  return null;
+}

--- a/packages/paperclip/adapter/src/server/execute.ts
+++ b/packages/paperclip/adapter/src/server/execute.ts
@@ -1,0 +1,228 @@
+/**
+ * HTTP-mode `execute()` for the `hermes_local` Paperclip adapter on
+ * alfred-black tenants. Replaces the upstream child-process spawn with a
+ * `POST /v1/responses` against the tenant's Hermes container.
+ *
+ * The interface is identical: Paperclip passes us an
+ * `AdapterExecutionContext`, we return an `AdapterExecutionResult`. What
+ * changes is everything between — see DESIGN.md for the mapping table.
+ */
+
+import {
+  ADAPTER_TYPE,
+  DEFAULT_HERMES_GATEWAY_URL,
+  DEFAULT_TIMEOUT_SEC,
+  SESSION_KEY_PREFIX,
+} from "../shared/constants.js";
+
+import {
+  callHermesResponses,
+  readHermesMainApiKey,
+  type HermesCallResult,
+} from "./hermes-http.js";
+
+import { buildPrompt } from "./prompt.js";
+
+import type {
+  AdapterExecutionContext,
+  AdapterExecutionResult,
+} from "../types/paperclip.js";
+
+// ── config helpers ───────────────────────────────────────────────────────
+
+function asString(v: unknown): string | undefined {
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+function asNumber(v: unknown): number | undefined {
+  return typeof v === "number" && Number.isFinite(v) ? v : undefined;
+}
+
+/**
+ * Resolve a per-agent Hermes session key. Hermes keys its message history
+ * off the `X-Hermes-Session-Key` header; using the same value across
+ * heartbeats gives us session continuity without needing the upstream
+ * `--resume <sessionId>` round-trip.
+ *
+ * Strategy:
+ *   1. If the agent.adapterConfig pins `sessionKey`, honour it (operator override).
+ *   2. Otherwise derive from `paperclip-<agentId>`.
+ *
+ * Note: NOT keyed by issue/task. One Paperclip agent = one Hermes session.
+ * Matches the existing ctrl-api heartbeat translator (channels_paperclip.ts).
+ */
+export function resolveSessionKey(
+  agentId: string,
+  config: Record<string, unknown>,
+): string {
+  const pinned = asString(config.sessionKey);
+  if (pinned) return pinned;
+  return `${SESSION_KEY_PREFIX}${agentId}`;
+}
+
+// ── main execute ─────────────────────────────────────────────────────────
+
+export interface ExecuteDeps {
+  /** Override for tests — defaults to the real HTTP path. */
+  callHermes?: (
+    sessionKey: string,
+    input: string,
+    opts: { gatewayUrl: string; apiKey: string | null; timeoutMs: number },
+  ) => Promise<HermesCallResult>;
+  /** Override for tests. */
+  readApiKey?: () => string | null;
+}
+
+export function makeExecute(deps: ExecuteDeps = {}) {
+  const callHermes =
+    deps.callHermes ??
+    (async (
+      sessionKey: string,
+      input: string,
+      opts: { gatewayUrl: string; apiKey: string | null; timeoutMs: number },
+    ) =>
+      callHermesResponses({
+        sessionKey,
+        input,
+        gatewayUrl: opts.gatewayUrl,
+        apiKey: opts.apiKey,
+        timeoutMs: opts.timeoutMs,
+      }));
+  const readApiKey = deps.readApiKey ?? (() => readHermesMainApiKey());
+
+  return async function execute(
+    ctx: AdapterExecutionContext,
+  ): Promise<AdapterExecutionResult> {
+    const agent = ctx.agent;
+    const config = (agent?.adapterConfig ?? {}) as Record<string, unknown>;
+
+    // Settings — we honour only those that make sense over HTTP.
+    const gatewayUrl =
+      asString(config.hermesGatewayUrl) ??
+      process.env.HERMES_GATEWAY_URL ??
+      DEFAULT_HERMES_GATEWAY_URL;
+    const timeoutSec = asNumber(config.timeoutSec) ?? DEFAULT_TIMEOUT_SEC;
+    const timeoutMs = Math.max(1_000, Math.floor(timeoutSec * 1000));
+
+    const sessionKey = resolveSessionKey(agent?.id ?? "", config);
+    const prompt = buildPrompt(ctx, config, agent);
+
+    // Surface the invocation envelope to Paperclip's run-history (UI calls
+    // this "command" + "commandArgs"). Helps an operator inspect a stuck
+    // run without docker-shelling into hermes.
+    try {
+      await ctx.onMeta?.({
+        adapterType: ADAPTER_TYPE,
+        command: "hermes:/v1/responses",
+        commandArgs: ["POST", gatewayUrl, `session=${sessionKey}`],
+        prompt,
+      });
+    } catch {
+      /* onMeta is optional, swallow */
+    }
+
+    await ctx.onLog(
+      "stdout",
+      `[hermes] Calling Hermes (gateway=${gatewayUrl}, session=${sessionKey}, timeout=${timeoutSec}s)\n`,
+    );
+
+    const apiKey = readApiKey();
+    const result = await callHermes(sessionKey, prompt, {
+      gatewayUrl,
+      apiKey,
+      timeoutMs,
+    });
+
+    if (!result.ok) {
+      // Map our error codes onto Paperclip's exitCode / errorMessage shape.
+      const errorMap: Record<string, string> = {
+        HERMES_TIMEOUT: "hermes_timeout",
+        HERMES_UNREACHABLE: "hermes_unreachable",
+        HERMES_AUTH: "hermes_auth_failed",
+        HERMES_HTTP: "hermes_http_error",
+      };
+      const errorCode = errorMap[result.code] ?? "hermes_unknown_error";
+      const exitCode = result.code === "HERMES_TIMEOUT" ? 124 : 1;
+
+      await ctx.onLog(
+        "stderr",
+        `[hermes] ${result.code}: ${result.detail}\n`,
+      );
+
+      return {
+        exitCode,
+        signal: null,
+        timedOut: result.code === "HERMES_TIMEOUT",
+        errorMessage: `Hermes call failed (${result.code}): ${result.detail.slice(
+          0,
+          512,
+        )}`,
+        errorCode,
+        errorMeta: {
+          httpStatus: result.status,
+          gatewayUrl,
+          sessionKey,
+        },
+        provider: null,
+        model: null,
+        // Persist the session key so the next heartbeat reuses it even on
+        // a failed turn — Hermes' message history is durable across our
+        // transport hiccups.
+        sessionParams: { sessionKey },
+        sessionDisplayId: sessionKey.slice(0, 24),
+      };
+    }
+
+    // Success path.
+    const text = result.text || "";
+    const usage = result.usage;
+
+    await ctx.onLog(
+      "stdout",
+      text || "[hermes] (empty response — agent produced no assistant text)\n",
+    );
+    if (text) {
+      await ctx.onLog("stdout", "\n");
+    }
+    await ctx.onLog(
+      "stdout",
+      `[hermes] Done. ${
+        usage
+          ? `usage: ${usage.inputTokens}in / ${usage.outputTokens}out${
+              usage.cachedInputTokens
+                ? ` / ${usage.cachedInputTokens}cached`
+                : ""
+            }`
+          : "usage: not surfaced"
+      }\n`,
+    );
+
+    const executionResult: AdapterExecutionResult = {
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      provider: null,
+      model: null,
+      summary: text ? text.slice(0, 2000) : null,
+      sessionParams: { sessionKey },
+      sessionDisplayId: sessionKey.slice(0, 24),
+      resultJson: {
+        result: text,
+        session_key: sessionKey,
+        usage: usage ?? null,
+        // Hermes' Responses envelope keeps the model + provider it picked
+        // in `raw.model` / `raw.provider` (when surfaced). Pass through
+        // for any downstream Paperclip plotting.
+        hermes_model: typeof result.raw.model === "string" ? result.raw.model : null,
+      },
+    };
+
+    if (usage) {
+      executionResult.usage = usage;
+    }
+
+    return executionResult;
+  };
+}
+
+/** Public surface — matches upstream signature. */
+export const execute = makeExecute();

--- a/packages/paperclip/adapter/src/server/hermes-http.ts
+++ b/packages/paperclip/adapter/src/server/hermes-http.ts
@@ -1,0 +1,298 @@
+/**
+ * Hermes HTTP client.
+ *
+ * Tiny, dependency-free fetch wrapper around `POST /v1/responses` and
+ * `GET /health`. Lifted from the canonical pattern in
+ * `packages/ctrl/src/api/routes/channels_paperclip.ts` so the two surfaces
+ * stay structurally consistent (we use the same fetch shape, the same
+ * extractor, the same error discrimination).
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  DEFAULT_HERMES_GATEWAY_URL,
+  DEFAULT_HERMES_CONFIG_DIR,
+} from "../shared/constants.js";
+
+// ── auth key resolver ────────────────────────────────────────────────────
+
+/**
+ * Read API_SERVER_KEY for the `main` Hermes profile out of its rendered
+ * `.env`. The per-profile file is the source of truth at runtime
+ * (`packages/ctrl/src/api/routes/channels_paperclip.ts::readHermesMainApiKey`
+ * uses the identical resolver; we observed live a mismatch between the
+ * compose-level HERMES_API_SERVER_KEY seed and the profile-level value
+ * (64 vs 43 chars), so reading the file directly is what works).
+ *
+ * Override via `HERMES_CONFIG_DIR` for tests / dev mounts.
+ */
+export function readHermesMainApiKey(
+  configDir = process.env.HERMES_CONFIG_DIR ?? DEFAULT_HERMES_CONFIG_DIR,
+): string | null {
+  const envPath = path.join(configDir, "main", ".env");
+  let raw: string;
+  try {
+    raw = fs.readFileSync(envPath, "utf-8");
+  } catch {
+    return null;
+  }
+  for (const line of raw.split("\n")) {
+    const t = line.trim();
+    if (!t || t.startsWith("#")) continue;
+    const eq = t.indexOf("=");
+    if (eq < 0) continue;
+    if (t.slice(0, eq).trim() === "API_SERVER_KEY") {
+      return t.slice(eq + 1).trim();
+    }
+  }
+  return null;
+}
+
+// ── response shape extractor ─────────────────────────────────────────────
+
+/**
+ * Walk the Hermes `/v1/responses` JSON envelope and concatenate the
+ * assistant text. Canonical shape:
+ *
+ *   { output: [..., {type:"message", role:"assistant",
+ *                    content:[{type:"output_text", text:"..."}]}],
+ *     usage: { input_tokens, output_tokens, ... }
+ *   }
+ *
+ * Tolerates `output` being a string, a single object, or absent (some
+ * mocked transports return that shape). Mirrors
+ * `extractHermesText` in `channels_paperclip.ts`.
+ */
+export function extractHermesText(resp: unknown): string {
+  if (typeof resp !== "object" || resp === null) return "";
+  const r = resp as Record<string, unknown>;
+  const out = r.output;
+
+  const partsToText = (parts: unknown): string => {
+    if (typeof parts === "string") return parts;
+    if (!Array.isArray(parts)) return "";
+    const acc: string[] = [];
+    for (const p of parts) {
+      if (typeof p === "string") {
+        acc.push(p);
+      } else if (typeof p === "object" && p !== null) {
+        const pp = p as Record<string, unknown>;
+        if (typeof pp.text === "string") acc.push(pp.text);
+        else if (typeof pp.content === "string") acc.push(pp.content);
+      }
+    }
+    return acc.filter((s) => s.length > 0).join("\n");
+  };
+
+  if (Array.isArray(out)) {
+    let messageText = "";
+    for (const item of out) {
+      if (typeof item !== "object" || item === null) continue;
+      const it = item as Record<string, unknown>;
+      if (it.type === "message") {
+        const t = partsToText(it.content);
+        if (t) messageText = t;
+      }
+    }
+    if (messageText) return messageText;
+    return partsToText(out);
+  }
+  if (typeof out === "string") return out;
+  if (typeof out === "object" && out !== null) {
+    const o = out as Record<string, unknown>;
+    if (typeof o.text === "string") return o.text;
+    if (typeof o.content === "string") return o.content;
+  }
+  const fallback = r.output_text;
+  if (typeof fallback === "string") return fallback;
+  return "";
+}
+
+/**
+ * Pull a `{ inputTokens, outputTokens, cachedInputTokens }` shape out of
+ * a Hermes `/v1/responses` envelope. Hermes follows the OpenAI Responses
+ * shape, so the canonical keys are `usage.input_tokens`,
+ * `usage.output_tokens`, `usage.input_tokens_details.cached_tokens`.
+ *
+ * Returns `null` when usage isn't surfaced.
+ */
+export interface HermesUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cachedInputTokens?: number;
+}
+
+export function extractHermesUsage(resp: unknown): HermesUsage | null {
+  if (typeof resp !== "object" || resp === null) return null;
+  const r = resp as Record<string, unknown>;
+  const u = r.usage;
+  if (typeof u !== "object" || u === null) return null;
+  const usage = u as Record<string, unknown>;
+  const num = (v: unknown): number | null =>
+    typeof v === "number" && Number.isFinite(v) ? v : null;
+  const input =
+    num(usage.input_tokens) ?? num(usage.inputTokens) ?? num(usage.prompt_tokens);
+  const output =
+    num(usage.output_tokens) ??
+    num(usage.outputTokens) ??
+    num(usage.completion_tokens);
+  if (input === null && output === null) return null;
+  const result: HermesUsage = {
+    inputTokens: input ?? 0,
+    outputTokens: output ?? 0,
+  };
+  // OpenAI Responses-API nests cached tokens under input_tokens_details.
+  const details = usage.input_tokens_details;
+  if (typeof details === "object" && details !== null) {
+    const cached = num((details as Record<string, unknown>).cached_tokens);
+    if (cached !== null) result.cachedInputTokens = cached;
+  }
+  return result;
+}
+
+// ── call surface ─────────────────────────────────────────────────────────
+
+export type HermesCallResult =
+  | {
+      ok: true;
+      text: string;
+      usage: HermesUsage | null;
+      raw: Record<string, unknown>;
+    }
+  | {
+      ok: false;
+      code: "HERMES_UNREACHABLE" | "HERMES_TIMEOUT" | "HERMES_AUTH" | "HERMES_HTTP";
+      status: number | null;
+      detail: string;
+    };
+
+export interface HermesCallOptions {
+  gatewayUrl?: string;
+  sessionKey: string;
+  input: string;
+  apiKey?: string | null;
+  timeoutMs?: number;
+  /** For tests — defaults to global `fetch`. */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * POST to `{gatewayUrl}/v1/responses` and return the parsed envelope +
+ * a flattened assistant text. Discriminates timeout (504-flavoured) from
+ * unreachable (502-flavoured) from HTTP-error (4xx/5xx with body).
+ */
+export async function callHermesResponses(
+  opts: HermesCallOptions,
+): Promise<HermesCallResult> {
+  const base = (opts.gatewayUrl ?? DEFAULT_HERMES_GATEWAY_URL).replace(
+    /\/+$/,
+    "",
+  );
+  const url = `${base}/v1/responses`;
+  const timeoutMs = opts.timeoutMs ?? 90_000;
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "X-Hermes-Session-Key": opts.sessionKey,
+  };
+  if (opts.apiKey) headers.Authorization = `Bearer ${opts.apiKey}`;
+
+  let resp: Response;
+  try {
+    resp = await fetchImpl(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ input: opts.input }),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    const name = (err as Error)?.name ?? "";
+    const isTimeout =
+      name === "TimeoutError" || name === "AbortError" || /timeout/i.test(msg);
+    return {
+      ok: false,
+      code: isTimeout ? "HERMES_TIMEOUT" : "HERMES_UNREACHABLE",
+      status: null,
+      detail: msg,
+    };
+  }
+
+  if (!resp.ok) {
+    // Read body best-effort for the error detail; truncate so we don't
+    // explode a 5MB upstream error into the Paperclip transcript.
+    let body = "";
+    try {
+      body = (await resp.text()).slice(0, 2048);
+    } catch {
+      /* ignore */
+    }
+    const isAuth = resp.status === 401 || resp.status === 403;
+    return {
+      ok: false,
+      code: isAuth ? "HERMES_AUTH" : "HERMES_HTTP",
+      status: resp.status,
+      detail: body || `Hermes returned HTTP ${resp.status}`,
+    };
+  }
+
+  let json: unknown;
+  try {
+    json = await resp.json();
+  } catch {
+    return {
+      ok: false,
+      code: "HERMES_HTTP",
+      status: resp.status,
+      detail: "Hermes returned a non-JSON body",
+    };
+  }
+  const text = extractHermesText(json);
+  const usage = extractHermesUsage(json);
+  return {
+    ok: true,
+    text,
+    usage,
+    raw: (json ?? {}) as Record<string, unknown>,
+  };
+}
+
+/**
+ * `GET {gatewayUrl}/health` — used by `testEnvironment`. Hermes' supervisor
+ * gates a 200 on both gateways being up.
+ */
+export async function pingHermesHealth(opts: {
+  gatewayUrl?: string;
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+}): Promise<{ ok: boolean; status: number | null; detail: string }> {
+  const base = (opts.gatewayUrl ?? DEFAULT_HERMES_GATEWAY_URL).replace(
+    /\/+$/,
+    "",
+  );
+  const url = `${base}/health`;
+  const timeoutMs = opts.timeoutMs ?? 5_000;
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  try {
+    const resp = await fetchImpl(url, {
+      method: "GET",
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (resp.ok) {
+      return { ok: true, status: resp.status, detail: "Hermes /health OK" };
+    }
+    return {
+      ok: false,
+      status: resp.status,
+      detail: `Hermes /health returned HTTP ${resp.status}`,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      status: null,
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/packages/paperclip/adapter/src/server/index.ts
+++ b/packages/paperclip/adapter/src/server/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Server-side adapter module — public exports.
+ *
+ * Matches upstream v0.2.0's `server/index.ts` surface so Paperclip's
+ * `adapters/registry.js` can import us at the same names.
+ */
+
+export { execute } from "./execute.js";
+export { testEnvironment } from "./test.js";
+export { detectModel } from "./detect-model.js";
+export { listSkills, syncSkills, resolveDesiredSkillNames } from "./skills.js";
+export { sessionCodec } from "./session-codec.js";

--- a/packages/paperclip/adapter/src/server/prompt.ts
+++ b/packages/paperclip/adapter/src/server/prompt.ts
@@ -1,0 +1,122 @@
+/**
+ * Wake-up prompt builder.
+ *
+ * Lifted from upstream v0.2.0's `execute.ts::buildPrompt` so the agent
+ * receives the same instructions whether it runs via the CLI or our HTTP
+ * fork — keeps the principal's mental model "Alfred, the one thing"
+ * intact (the agent's behaviour shouldn't drift based on transport).
+ *
+ * We intentionally inline the Mustache-lite handling instead of pulling
+ * `@paperclipai/adapter-utils/server-utils::renderTemplate` so this
+ * adapter has zero runtime deps — keeps the COPY-overlay surface tight.
+ */
+
+import type {
+  AdapterAgent,
+  AdapterExecutionContext,
+} from "../types/paperclip.js";
+
+const DEFAULT_PROMPT_TEMPLATE = `You are "{{agentName}}", an AI agent employee in a Paperclip-managed company.
+
+IMPORTANT: Use the \`paperclip\` MCP tools for ALL Paperclip API calls. Do NOT shell out to curl — the MCP surface is the supported path on this tenant.
+
+Your Paperclip identity:
+  Agent ID: {{agentId}}
+  Company ID: {{companyId}}
+
+{{#taskId}}
+## Assigned Task
+
+Issue ID: {{taskId}}
+Title: {{taskTitle}}
+
+{{taskBody}}
+
+## Workflow
+
+1. Work on the task using your tools.
+2. When done, mark the issue as completed via the \`paperclip\` MCP \`updateIssue\` tool with \`status: "done"\`.
+3. Post a completion comment summarizing what you did via \`paperclipAddComment\`.
+4. If this issue has a parent (referenced as TRA-XX or similar in the body / comments), post a brief notification on the parent so the owner knows {{taskId}} is closed.
+{{/taskId}}
+
+{{#commentId}}
+## Comment on This Issue
+
+Someone commented on {{taskId}}. Read it via the \`paperclip\` MCP \`listComments\` tool, then address it (reply via \`paperclipAddComment\` if needed) and continue.
+{{/commentId}}
+
+{{#noTask}}
+## Heartbeat Wake — Check for Work
+
+1. List your open issues via the \`paperclip\` MCP \`listIssues\` tool with \`assigneeAgentId: "{{agentId}}"\`.
+2. If issues found, pick the highest-priority non-done one and work on it: \`checkoutIssue\` → do the work → mark \`done\` + comment.
+3. If no issues assigned to you, scan the company backlog (\`listIssues\` with \`status: "backlog"\`) and either pick one up (set \`assigneeAgentId: "{{agentId}}"\`, then proceed) or skip if nothing fits.
+4. If truly nothing to do, post a brief status comment to the most recent open issue you've been involved with — never silently no-op.
+{{/noTask}}`;
+
+function asString(v: unknown): string | null {
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+/**
+ * Renders the upstream template against `ctx`. The Mustache subset we
+ * support is exactly what upstream uses: `{{var}}` and
+ * `{{#section}}...{{/section}}` conditional blocks.
+ */
+export function buildPrompt(
+  ctx: AdapterExecutionContext,
+  config: Record<string, unknown>,
+  agent: AdapterAgent,
+): string {
+  const template = asString(config.promptTemplate) ?? DEFAULT_PROMPT_TEMPLATE;
+  const cfg = (ctx.config ?? {}) as Record<string, unknown>;
+
+  const taskId = asString(cfg.taskId) ?? "";
+  const taskTitle = asString(cfg.taskTitle) ?? "";
+  const taskBody = asString(cfg.taskBody) ?? "";
+  const commentId = asString(cfg.commentId) ?? "";
+  const wakeReason = asString(cfg.wakeReason) ?? "";
+  const agentName = asString(agent.name) ?? "Hermes Agent";
+  const companyName = asString(cfg.companyName) ?? "";
+  const projectName = asString(cfg.projectName) ?? "";
+
+  const vars: Record<string, string> = {
+    agentId: asString(agent.id) ?? "",
+    agentName,
+    companyId: asString(agent.companyId) ?? "",
+    companyName,
+    runId: asString(ctx.runId) ?? "",
+    taskId,
+    taskTitle,
+    taskBody,
+    commentId,
+    wakeReason,
+    projectName,
+  };
+
+  let rendered = template;
+
+  // {{#taskId}}...{{/taskId}}
+  rendered = rendered.replace(
+    /\{\{#taskId\}\}([\s\S]*?)\{\{\/taskId\}\}/g,
+    taskId ? "$1" : "",
+  );
+  // {{#noTask}}...{{/noTask}}
+  rendered = rendered.replace(
+    /\{\{#noTask\}\}([\s\S]*?)\{\{\/noTask\}\}/g,
+    taskId ? "" : "$1",
+  );
+  // {{#commentId}}...{{/commentId}}
+  rendered = rendered.replace(
+    /\{\{#commentId\}\}([\s\S]*?)\{\{\/commentId\}\}/g,
+    commentId ? "$1" : "",
+  );
+
+  // Plain {{var}} substitutions — last so section markers don't leak.
+  rendered = rendered.replace(/\{\{(\w+)\}\}/g, (_full, key) =>
+    Object.prototype.hasOwnProperty.call(vars, key) ? vars[key] ?? "" : "",
+  );
+
+  return rendered;
+}

--- a/packages/paperclip/adapter/src/server/session-codec.ts
+++ b/packages/paperclip/adapter/src/server/session-codec.ts
@@ -1,0 +1,51 @@
+/**
+ * Session codec for HTTP-mode Hermes.
+ *
+ * Paperclip persists `sessionParams` between heartbeats. We use this to
+ * round-trip the Hermes session key. Compatibility shim: if an existing
+ * agent has the upstream `sessionId` (from the CLI-mode adapter), accept
+ * it as the session key so we don't force a forced reset.
+ */
+
+import type { AdapterSessionCodec } from "../types/paperclip.js";
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+export const sessionCodec: AdapterSessionCodec = {
+  deserialize(raw: unknown) {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+    const record = raw as Record<string, unknown>;
+    // Prefer the new `sessionKey` field; fall back to the legacy
+    // upstream `sessionId` so existing agents keep working.
+    const sessionKey =
+      readNonEmptyString(record.sessionKey) ??
+      readNonEmptyString(record.session_key) ??
+      readNonEmptyString(record.sessionId) ??
+      readNonEmptyString(record.session_id);
+    if (!sessionKey) return null;
+    return { sessionKey };
+  },
+  serialize(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    const sessionKey =
+      readNonEmptyString(params.sessionKey) ??
+      readNonEmptyString(params.session_key) ??
+      readNonEmptyString(params.sessionId) ??
+      readNonEmptyString(params.session_id);
+    if (!sessionKey) return null;
+    return { sessionKey };
+  },
+  getDisplayId(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    return (
+      readNonEmptyString(params.sessionKey) ??
+      readNonEmptyString(params.session_key) ??
+      readNonEmptyString(params.sessionId) ??
+      readNonEmptyString(params.session_id)
+    );
+  },
+};

--- a/packages/paperclip/adapter/src/server/skills.ts
+++ b/packages/paperclip/adapter/src/server/skills.ts
@@ -1,0 +1,65 @@
+/**
+ * Skills surface — list / sync.
+ *
+ * Upstream scans `~/.hermes/skills/` and surfaces the read-only result.
+ * In HTTP mode we don't have a Hermes filesystem to scan (the
+ * paperclip container doesn't have `hermes_data` mounted), and even if we
+ * did, the skills list belongs to Hermes' own runtime not Paperclip.
+ *
+ * We return an empty snapshot with `mode: "unsupported"` so the Paperclip
+ * UI surfaces "skill management is delegated to Hermes" rather than
+ * dangling "Loading…". `syncSkills` is a no-op for the same reason —
+ * trying to push skills from Paperclip into Hermes would silently fail.
+ *
+ * The follow-up issue for upstream tracks adding an OpenAI-Responses-API
+ * extension that lets the gateway report its loaded skill set; until
+ * then, this is the honest shape.
+ */
+
+import { ADAPTER_TYPE } from "../shared/constants.js";
+
+import type {
+  AdapterSkillContext,
+  AdapterSkillSnapshot,
+} from "../types/paperclip.js";
+
+function emptySnapshot(): AdapterSkillSnapshot {
+  return {
+    adapterType: ADAPTER_TYPE,
+    supported: false,
+    mode: "unsupported",
+    desiredSkills: [],
+    entries: [],
+    warnings: [
+      "Skill management is delegated to Hermes when running in HTTP mode. " +
+        "Hermes loads its own ~/.hermes/skills/ at startup; Paperclip cannot " +
+        "inspect or sync them from here.",
+    ],
+  };
+}
+
+export async function listSkills(
+  _ctx: AdapterSkillContext,
+): Promise<AdapterSkillSnapshot> {
+  return emptySnapshot();
+}
+
+export async function syncSkills(
+  _ctx: AdapterSkillContext,
+  _desiredSkills: string[],
+): Promise<AdapterSkillSnapshot> {
+  // No-op; surface a snapshot so the UI doesn't loop.
+  return emptySnapshot();
+}
+
+/**
+ * Upstream's `resolveDesiredSkillNames` reads `adapter-utils`'
+ * helper. We don't have desired skills in HTTP mode — return [] so
+ * Paperclip's "missing" detector never lights up.
+ */
+export function resolveDesiredSkillNames(
+  _config: Record<string, unknown>,
+  _availableEntries: unknown[],
+): string[] {
+  return [];
+}

--- a/packages/paperclip/adapter/src/server/test.ts
+++ b/packages/paperclip/adapter/src/server/test.ts
@@ -1,0 +1,111 @@
+/**
+ * `testEnvironment()` — runs when a Paperclip operator clicks "Test" on
+ * the agent. Replaces the upstream CLI-availability checks with an HTTP
+ * ping against `hermes:18789/health` plus a config-file probe.
+ */
+
+import {
+  ADAPTER_TYPE,
+  DEFAULT_HERMES_GATEWAY_URL,
+} from "../shared/constants.js";
+
+import {
+  pingHermesHealth,
+  readHermesMainApiKey,
+} from "./hermes-http.js";
+
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "../types/paperclip.js";
+
+function asString(v: unknown): string | undefined {
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+export interface TestEnvironmentDeps {
+  ping?: typeof pingHermesHealth;
+  readApiKey?: () => string | null;
+}
+
+export function makeTestEnvironment(deps: TestEnvironmentDeps = {}) {
+  const ping = deps.ping ?? pingHermesHealth;
+  const readApiKey = deps.readApiKey ?? (() => readHermesMainApiKey());
+
+  return async function testEnvironment(
+    ctx: AdapterEnvironmentTestContext,
+  ): Promise<AdapterEnvironmentTestResult> {
+    const config = (ctx.config ?? {}) as Record<string, unknown>;
+    const gatewayUrl =
+      asString(config.hermesGatewayUrl) ??
+      process.env.HERMES_GATEWAY_URL ??
+      DEFAULT_HERMES_GATEWAY_URL;
+
+    const checks: AdapterEnvironmentCheck[] = [];
+
+    // 1. Health probe.
+    const health = await ping({ gatewayUrl, timeoutMs: 5_000 });
+    if (health.ok) {
+      checks.push({
+        level: "info",
+        message: `Hermes /health reachable at ${gatewayUrl}`,
+        code: "hermes_health_ok",
+      });
+    } else {
+      checks.push({
+        level: "error",
+        message: `Hermes /health unreachable at ${gatewayUrl}`,
+        detail: health.detail,
+        hint:
+          "Verify the hermes container is running (`docker compose ps hermes`), the paperclip container has network access to it, and HERMES_GATEWAY_URL is correct.",
+        code: "hermes_health_unreachable",
+      });
+      return {
+        adapterType: ADAPTER_TYPE,
+        status: "fail",
+        checks,
+        testedAt: new Date().toISOString(),
+      };
+    }
+
+    // 2. API key resolvable?
+    const apiKey = readApiKey();
+    if (apiKey && apiKey.length > 0) {
+      checks.push({
+        level: "info",
+        message: `Hermes API_SERVER_KEY resolved (${apiKey.length} chars)`,
+        code: "hermes_api_key_ok",
+      });
+    } else {
+      checks.push({
+        level: "warn",
+        message:
+          "Hermes API_SERVER_KEY could not be read from /hermes-state/profiles/main/.env",
+        hint:
+          "Bind-mount hermes_data:/hermes-state:ro into the paperclip container and ensure the hermes-init container has rendered the main profile. Without the key, Hermes will reject /v1/responses with 401.",
+        code: "hermes_api_key_missing",
+      });
+    }
+
+    // 3. Pass-through note about model / provider.
+    checks.push({
+      level: "info",
+      message:
+        "Model + provider are managed by Hermes (operator-owned config.yaml). Paperclip-side model/provider settings are ignored in HTTP mode.",
+      code: "hermes_model_managed_by_hermes",
+    });
+
+    const hasErrors = checks.some((c) => c.level === "error");
+    const hasWarnings = checks.some((c) => c.level === "warn");
+
+    return {
+      adapterType: ADAPTER_TYPE,
+      status: hasErrors ? "fail" : hasWarnings ? "warn" : "pass",
+      checks,
+      testedAt: new Date().toISOString(),
+    };
+  };
+}
+
+export const testEnvironment = makeTestEnvironment();

--- a/packages/paperclip/adapter/src/shared/constants.ts
+++ b/packages/paperclip/adapter/src/shared/constants.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared constants for the alfred-black HTTP-mode Hermes adapter.
+ *
+ * Identifier stays `hermes_local` so Paperclip's registry resolves us
+ * through the same adapter slot — the only thing that changes is the
+ * backend (HTTP call instead of child-process spawn).
+ */
+
+export const ADAPTER_TYPE = "hermes_local";
+export const ADAPTER_LABEL = "Hermes Agent (HTTP)";
+
+/** Default Hermes gateway URL — the main profile (compose-network DNS). */
+export const DEFAULT_HERMES_GATEWAY_URL = "http://hermes:18789";
+
+/** Default per-call timeout. Mirrors upstream's DEFAULT_TIMEOUT_SEC. */
+export const DEFAULT_TIMEOUT_SEC = 300;
+
+/** Where to read Hermes' API_SERVER_KEY from on disk. */
+export const DEFAULT_HERMES_CONFIG_DIR = "/hermes-state/profiles";
+
+/** Session-key prefix used to derive a stable Hermes session per Paperclip agent. */
+export const SESSION_KEY_PREFIX = "paperclip-";

--- a/packages/paperclip/adapter/src/types/paperclip.ts
+++ b/packages/paperclip/adapter/src/types/paperclip.ts
@@ -1,0 +1,148 @@
+/**
+ * Local type stubs for `@paperclipai/adapter-utils`.
+ *
+ * Upstream's types live in the paperclip image at
+ * `/app/node_modules/@paperclipai/adapter-utils/dist/types.d.ts`. We
+ * intentionally don't depend on that package at build time so this fork
+ * stays buildable in CI without pulling Paperclip's private npm
+ * publishing. The shapes below are copied verbatim from
+ * adapter-utils@2026.325.0 (the version shipped with the
+ * `ghcr.io/paperclipai/paperclip@sha256:711d…` image) — see DESIGN.md
+ * for the tripwire that catches drift.
+ */
+
+export interface AdapterAgent {
+  id: string;
+  companyId: string;
+  name: string;
+  adapterType: string | null;
+  adapterConfig: unknown;
+}
+
+export interface AdapterRuntime {
+  sessionId: string | null;
+  sessionParams: Record<string, unknown> | null;
+  sessionDisplayId: string | null;
+  taskKey: string | null;
+}
+
+export interface UsageSummary {
+  inputTokens: number;
+  outputTokens: number;
+  cachedInputTokens?: number;
+}
+
+export type AdapterBillingType = "api" | "subscription" | "unknown";
+
+export interface AdapterExecutionResult {
+  exitCode: number | null;
+  signal: string | null;
+  timedOut: boolean;
+  errorMessage?: string | null;
+  errorCode?: string | null;
+  errorMeta?: Record<string, unknown>;
+  usage?: UsageSummary;
+  sessionId?: string | null;
+  sessionParams?: Record<string, unknown> | null;
+  sessionDisplayId?: string | null;
+  provider?: string | null;
+  model?: string | null;
+  billingType?: AdapterBillingType | null;
+  costUsd?: number | null;
+  resultJson?: Record<string, unknown> | null;
+  summary?: string | null;
+  clearSession?: boolean;
+}
+
+export interface AdapterSessionCodec {
+  deserialize(raw: unknown): Record<string, unknown> | null;
+  serialize(
+    params: Record<string, unknown> | null,
+  ): Record<string, unknown> | null;
+  getDisplayId?: (params: Record<string, unknown> | null) => string | null;
+}
+
+export interface AdapterInvocationMeta {
+  adapterType: string;
+  command: string;
+  cwd?: string;
+  commandArgs?: string[];
+  commandNotes?: string[];
+  env?: Record<string, string>;
+  prompt?: string;
+  context?: Record<string, unknown>;
+}
+
+export interface AdapterExecutionContext {
+  runId: string;
+  agent: AdapterAgent;
+  runtime: AdapterRuntime;
+  config: Record<string, unknown>;
+  context: Record<string, unknown>;
+  onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+  onMeta?: (meta: AdapterInvocationMeta) => Promise<void>;
+  authToken?: string;
+}
+
+export type AdapterEnvironmentCheckLevel = "info" | "warn" | "error";
+
+export interface AdapterEnvironmentCheck {
+  code: string;
+  level: AdapterEnvironmentCheckLevel;
+  message: string;
+  detail?: string | null;
+  hint?: string | null;
+}
+
+export type AdapterEnvironmentTestStatus = "pass" | "warn" | "fail";
+
+export interface AdapterEnvironmentTestResult {
+  adapterType: string;
+  status: AdapterEnvironmentTestStatus;
+  checks: AdapterEnvironmentCheck[];
+  testedAt: string;
+}
+
+export interface AdapterEnvironmentTestContext {
+  companyId: string;
+  adapterType: string;
+  config: Record<string, unknown>;
+  deployment?: {
+    mode?: "local_trusted" | "authenticated";
+    exposure?: "private" | "public";
+    bindHost?: string | null;
+    allowedHostnames?: string[];
+  };
+}
+
+// Skills surface — matches upstream skills.ts return shape.
+export interface AdapterSkillEntry {
+  key: string;
+  runtimeName: string | null;
+  desired: boolean;
+  managed: boolean;
+  state: "configured" | "available" | "installed" | "missing";
+  origin: string;
+  originLabel: string;
+  readOnly: boolean;
+  sourcePath: string | null;
+  targetPath: string | null;
+  detail: string | null;
+  required?: boolean;
+  requiredReason?: string | null;
+  locationLabel?: string;
+}
+
+export interface AdapterSkillSnapshot {
+  adapterType: string;
+  supported: boolean;
+  mode: "persistent" | "per-run" | "unsupported";
+  desiredSkills: string[];
+  entries: AdapterSkillEntry[];
+  warnings: string[];
+}
+
+export interface AdapterSkillContext {
+  agentId?: string;
+  config: Record<string, unknown>;
+}

--- a/packages/paperclip/adapter/tests/execute.test.ts
+++ b/packages/paperclip/adapter/tests/execute.test.ts
@@ -1,0 +1,237 @@
+/**
+ * execute() integration tests.
+ *
+ * We exercise the public makeExecute() factory with the HTTP call
+ * stubbed, so a single test asserts both the upstream-compatible result
+ * shape AND that the adapter wired the session-key / prompt / errors
+ * correctly.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { makeExecute, resolveSessionKey } from "../src/server/execute.js";
+import type {
+  AdapterAgent,
+  AdapterExecutionContext,
+} from "../src/types/paperclip.js";
+import type { HermesCallResult } from "../src/server/hermes-http.js";
+
+function makeAgent(over: Partial<AdapterAgent> = {}): AdapterAgent {
+  return {
+    id: "agent-123",
+    companyId: "company-456",
+    name: "hermes",
+    adapterType: "hermes_local",
+    adapterConfig: {},
+    ...over,
+  };
+}
+
+function makeCtx(
+  agent: AdapterAgent,
+  cfg: Partial<AdapterExecutionContext> = {},
+): AdapterExecutionContext {
+  const logs: { stream: "stdout" | "stderr"; chunk: string }[] = [];
+  const meta: unknown[] = [];
+  const ctx: AdapterExecutionContext = {
+    runId: "run-789",
+    agent,
+    runtime: {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+    },
+    config: {},
+    context: {},
+    onLog: async (stream, chunk) => {
+      logs.push({ stream, chunk });
+    },
+    onMeta: async (m) => {
+      meta.push(m);
+    },
+    ...cfg,
+  };
+  (ctx as any).__logs = logs;
+  (ctx as any).__meta = meta;
+  return ctx;
+}
+
+describe("resolveSessionKey", () => {
+  it("derives paperclip-<agentId> by default", () => {
+    assert.equal(
+      resolveSessionKey("abc", {}),
+      "paperclip-abc",
+    );
+  });
+
+  it("honours a pinned override", () => {
+    assert.equal(
+      resolveSessionKey("abc", { sessionKey: "custom-key" }),
+      "custom-key",
+    );
+  });
+});
+
+describe("execute — happy path", () => {
+  it("returns Paperclip-shaped result with usage + session params", async () => {
+    let captured: { sessionKey: string; input: string } | null = null;
+    const execute = makeExecute({
+      readApiKey: () => "stub-key",
+      callHermes: async (sessionKey, input) => {
+        captured = { sessionKey, input };
+        const result: HermesCallResult = {
+          ok: true,
+          text: "all done",
+          usage: { inputTokens: 100, outputTokens: 50 },
+          raw: { model: "anthropic/claude-sonnet-4" },
+        };
+        return result;
+      },
+    });
+
+    const agent = makeAgent();
+    const ctx = makeCtx(agent);
+    const result = await execute(ctx);
+
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.timedOut, false);
+    assert.deepEqual(result.usage, { inputTokens: 100, outputTokens: 50 });
+    assert.equal(result.summary, "all done");
+    assert.deepEqual(result.sessionParams, { sessionKey: "paperclip-agent-123" });
+    assert.equal(result.sessionDisplayId, "paperclip-agent-123");
+    assert.ok(result.resultJson);
+    assert.equal(result.resultJson?.hermes_model, "anthropic/claude-sonnet-4");
+
+    assert.ok(captured);
+    assert.equal(captured!.sessionKey, "paperclip-agent-123");
+    assert.ok(captured!.input.includes('You are "hermes"'));
+    assert.ok((ctx as any).__meta.length === 1);
+  });
+
+  it("renders task variables into the prompt", async () => {
+    let prompt: string | null = null;
+    const execute = makeExecute({
+      readApiKey: () => null,
+      callHermes: async (_session, input) => {
+        prompt = input;
+        return { ok: true, text: "", usage: null, raw: {} };
+      },
+    });
+    const ctx = makeCtx(makeAgent());
+    ctx.config = {
+      taskId: "TRA-42",
+      taskTitle: "Fix the thing",
+      taskBody: "Body of the task",
+    };
+    await execute(ctx);
+    assert.ok(prompt);
+    assert.match(prompt!, /Issue ID: TRA-42/);
+    assert.match(prompt!, /Title: Fix the thing/);
+    assert.match(prompt!, /Body of the task/);
+    // noTask section must be omitted when taskId present
+    assert.doesNotMatch(prompt!, /Heartbeat Wake/);
+  });
+
+  it("renders the noTask section when no task assigned", async () => {
+    let prompt: string | null = null;
+    const execute = makeExecute({
+      readApiKey: () => null,
+      callHermes: async (_session, input) => {
+        prompt = input;
+        return { ok: true, text: "ok", usage: null, raw: {} };
+      },
+    });
+    await execute(makeCtx(makeAgent()));
+    assert.ok(prompt);
+    assert.match(prompt!, /Heartbeat Wake/);
+    assert.doesNotMatch(prompt!, /Assigned Task/);
+  });
+});
+
+describe("execute — error paths", () => {
+  it("maps HERMES_AUTH to a 1-exit with errorCode", async () => {
+    const execute = makeExecute({
+      readApiKey: () => "wrong-key",
+      callHermes: async () => ({
+        ok: false,
+        code: "HERMES_AUTH",
+        status: 401,
+        detail: "invalid",
+      }),
+    });
+    const result = await execute(makeCtx(makeAgent()));
+    assert.equal(result.exitCode, 1);
+    assert.equal(result.timedOut, false);
+    assert.equal(result.errorCode, "hermes_auth_failed");
+    assert.match(result.errorMessage ?? "", /HERMES_AUTH/);
+  });
+
+  it("maps HERMES_TIMEOUT to exit 124 + timedOut=true", async () => {
+    const execute = makeExecute({
+      readApiKey: () => "k",
+      callHermes: async () => ({
+        ok: false,
+        code: "HERMES_TIMEOUT",
+        status: null,
+        detail: "fetch timed out",
+      }),
+    });
+    const result = await execute(makeCtx(makeAgent()));
+    assert.equal(result.exitCode, 124);
+    assert.equal(result.timedOut, true);
+    assert.equal(result.errorCode, "hermes_timeout");
+  });
+
+  it("preserves session key on transient failure", async () => {
+    const execute = makeExecute({
+      readApiKey: () => "k",
+      callHermes: async () => ({
+        ok: false,
+        code: "HERMES_UNREACHABLE",
+        status: null,
+        detail: "connection refused",
+      }),
+    });
+    const result = await execute(makeCtx(makeAgent({ id: "xyz" })));
+    assert.deepEqual(result.sessionParams, { sessionKey: "paperclip-xyz" });
+    assert.equal(result.errorCode, "hermes_unreachable");
+  });
+});
+
+describe("execute — session continuity", () => {
+  it("reuses the same session key across heartbeats", async () => {
+    const seen: string[] = [];
+    const execute = makeExecute({
+      readApiKey: () => "k",
+      callHermes: async (sessionKey) => {
+        seen.push(sessionKey);
+        return { ok: true, text: "ok", usage: null, raw: {} };
+      },
+    });
+    const agent = makeAgent({ id: "stable-id" });
+    await execute(makeCtx(agent));
+    await execute(makeCtx(agent));
+    await execute(makeCtx(agent));
+    assert.deepEqual(seen, [
+      "paperclip-stable-id",
+      "paperclip-stable-id",
+      "paperclip-stable-id",
+    ]);
+  });
+
+  it("honours a pinned sessionKey from adapterConfig", async () => {
+    let captured: string | null = null;
+    const execute = makeExecute({
+      readApiKey: () => "k",
+      callHermes: async (sessionKey) => {
+        captured = sessionKey;
+        return { ok: true, text: "ok", usage: null, raw: {} };
+      },
+    });
+    const agent = makeAgent({ adapterConfig: { sessionKey: "custom-session" } });
+    await execute(makeCtx(agent));
+    assert.equal(captured, "custom-session");
+  });
+});

--- a/packages/paperclip/adapter/tests/hermes-http.test.ts
+++ b/packages/paperclip/adapter/tests/hermes-http.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Unit tests for the HTTP client layer.
+ *
+ * We mock global fetch with a tiny in-process stub so we exercise the
+ * exact code paths Paperclip will hit at runtime. No network is touched.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  callHermesResponses,
+  extractHermesText,
+  extractHermesUsage,
+  pingHermesHealth,
+} from "../src/server/hermes-http.js";
+
+type FetchMock = {
+  fetch: typeof fetch;
+  calls: { url: string; init?: RequestInit }[];
+};
+
+function makeFetchMock(handler: (url: string, init?: RequestInit) => Response | Promise<Response>): FetchMock {
+  const calls: { url: string; init?: RequestInit }[] = [];
+  const fn: typeof fetch = async (input: any, init?: any) => {
+    const url = typeof input === "string" ? input : input.url;
+    calls.push({ url, init });
+    return handler(url, init);
+  };
+  return { fetch: fn, calls };
+}
+
+describe("extractHermesText", () => {
+  it("walks the canonical Responses envelope", () => {
+    const envelope = {
+      output: [
+        { type: "reasoning", content: [{ type: "thought", text: "...." }] },
+        {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "hello world" }],
+        },
+      ],
+    };
+    assert.equal(extractHermesText(envelope), "hello world");
+  });
+
+  it("falls back to output_text when output is missing", () => {
+    assert.equal(extractHermesText({ output_text: "fallback" }), "fallback");
+  });
+
+  it("returns empty string for malformed envelopes", () => {
+    assert.equal(extractHermesText(null), "");
+    assert.equal(extractHermesText("not an object"), "");
+    assert.equal(extractHermesText({}), "");
+  });
+
+  it("joins multi-part assistant messages", () => {
+    const envelope = {
+      output: [
+        {
+          type: "message",
+          role: "assistant",
+          content: [
+            { type: "output_text", text: "line 1" },
+            { type: "output_text", text: "line 2" },
+          ],
+        },
+      ],
+    };
+    assert.equal(extractHermesText(envelope), "line 1\nline 2");
+  });
+});
+
+describe("extractHermesUsage", () => {
+  it("reads OpenAI Responses-API shape", () => {
+    const usage = extractHermesUsage({
+      usage: {
+        input_tokens: 120,
+        output_tokens: 45,
+        input_tokens_details: { cached_tokens: 80 },
+      },
+    });
+    assert.deepEqual(usage, {
+      inputTokens: 120,
+      outputTokens: 45,
+      cachedInputTokens: 80,
+    });
+  });
+
+  it("tolerates camelCase + chat-completions shape", () => {
+    assert.deepEqual(
+      extractHermesUsage({ usage: { prompt_tokens: 1, completion_tokens: 2 } }),
+      { inputTokens: 1, outputTokens: 2 },
+    );
+  });
+
+  it("returns null when usage is absent", () => {
+    assert.equal(extractHermesUsage({}), null);
+    assert.equal(extractHermesUsage({ usage: {} }), null);
+  });
+});
+
+describe("callHermesResponses — success", () => {
+  it("POSTs to /v1/responses with session header + bearer", async () => {
+    const mock = makeFetchMock(async () =>
+      new Response(
+        JSON.stringify({
+          output: [
+            {
+              type: "message",
+              role: "assistant",
+              content: [{ type: "output_text", text: "hi from hermes" }],
+            },
+          ],
+          usage: { input_tokens: 7, output_tokens: 3 },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const result = await callHermesResponses({
+      gatewayUrl: "http://hermes:18789",
+      sessionKey: "paperclip-abc123",
+      input: "do the thing",
+      apiKey: "test-key",
+      fetchImpl: mock.fetch,
+    });
+
+    assert.equal(mock.calls.length, 1);
+    assert.equal(mock.calls[0]!.url, "http://hermes:18789/v1/responses");
+    const init = mock.calls[0]!.init as RequestInit;
+    assert.equal(init.method, "POST");
+    const headers = init.headers as Record<string, string>;
+    assert.equal(headers["X-Hermes-Session-Key"], "paperclip-abc123");
+    assert.equal(headers.Authorization, "Bearer test-key");
+    assert.deepEqual(JSON.parse(init.body as string), { input: "do the thing" });
+
+    assert.ok(result.ok);
+    if (!result.ok) return;
+    assert.equal(result.text, "hi from hermes");
+    assert.deepEqual(result.usage, { inputTokens: 7, outputTokens: 3 });
+  });
+
+  it("strips trailing slash on the gateway URL", async () => {
+    const mock = makeFetchMock(async () =>
+      new Response(JSON.stringify({ output: [] }), { status: 200 }),
+    );
+    await callHermesResponses({
+      gatewayUrl: "http://hermes:18789/",
+      sessionKey: "k",
+      input: "x",
+      apiKey: null,
+      fetchImpl: mock.fetch,
+    });
+    assert.equal(mock.calls[0]!.url, "http://hermes:18789/v1/responses");
+  });
+});
+
+describe("callHermesResponses — failures", () => {
+  it("classifies 401 as HERMES_AUTH", async () => {
+    const mock = makeFetchMock(async () =>
+      new Response("invalid api key", { status: 401 }),
+    );
+    const result = await callHermesResponses({
+      sessionKey: "k",
+      input: "x",
+      apiKey: "bad",
+      fetchImpl: mock.fetch,
+    });
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.equal(result.code, "HERMES_AUTH");
+    assert.equal(result.status, 401);
+  });
+
+  it("classifies 5xx as HERMES_HTTP", async () => {
+    const mock = makeFetchMock(async () =>
+      new Response("oops", { status: 502 }),
+    );
+    const result = await callHermesResponses({
+      sessionKey: "k",
+      input: "x",
+      apiKey: null,
+      fetchImpl: mock.fetch,
+    });
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.equal(result.code, "HERMES_HTTP");
+    assert.equal(result.status, 502);
+  });
+
+  it("classifies network error as HERMES_UNREACHABLE", async () => {
+    const mock = makeFetchMock(async () => {
+      throw new TypeError("fetch failed");
+    });
+    const result = await callHermesResponses({
+      sessionKey: "k",
+      input: "x",
+      apiKey: null,
+      fetchImpl: mock.fetch,
+    });
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.equal(result.code, "HERMES_UNREACHABLE");
+  });
+
+  it("classifies AbortError as HERMES_TIMEOUT", async () => {
+    const mock = makeFetchMock(async () => {
+      const err = new Error("aborted");
+      err.name = "AbortError";
+      throw err;
+    });
+    const result = await callHermesResponses({
+      sessionKey: "k",
+      input: "x",
+      apiKey: null,
+      fetchImpl: mock.fetch,
+    });
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.equal(result.code, "HERMES_TIMEOUT");
+  });
+
+  it("treats non-JSON 200 as HERMES_HTTP", async () => {
+    const mock = makeFetchMock(async () =>
+      new Response("not json", {
+        status: 200,
+        headers: { "Content-Type": "text/plain" },
+      }),
+    );
+    const result = await callHermesResponses({
+      sessionKey: "k",
+      input: "x",
+      apiKey: null,
+      fetchImpl: mock.fetch,
+    });
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.equal(result.code, "HERMES_HTTP");
+  });
+});
+
+describe("pingHermesHealth", () => {
+  it("reports ok=true on 200", async () => {
+    const mock = makeFetchMock(async () => new Response("OK", { status: 200 }));
+    const res = await pingHermesHealth({
+      gatewayUrl: "http://hermes:18789",
+      fetchImpl: mock.fetch,
+    });
+    assert.equal(res.ok, true);
+    assert.equal(mock.calls[0]!.url, "http://hermes:18789/health");
+  });
+
+  it("reports ok=false on 503", async () => {
+    const mock = makeFetchMock(
+      async () => new Response("starting up", { status: 503 }),
+    );
+    const res = await pingHermesHealth({
+      gatewayUrl: "http://hermes:18789",
+      fetchImpl: mock.fetch,
+    });
+    assert.equal(res.ok, false);
+    assert.equal(res.status, 503);
+  });
+
+  it("reports ok=false on network error", async () => {
+    const mock = makeFetchMock(async () => {
+      throw new Error("ECONNREFUSED");
+    });
+    const res = await pingHermesHealth({
+      gatewayUrl: "http://hermes:18789",
+      fetchImpl: mock.fetch,
+    });
+    assert.equal(res.ok, false);
+    assert.match(res.detail, /ECONNREFUSED/);
+  });
+});

--- a/packages/paperclip/adapter/tests/session-codec.test.ts
+++ b/packages/paperclip/adapter/tests/session-codec.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Session codec tests — verify both the new shape and the legacy
+ * `sessionId` migration path stay alive.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { sessionCodec } from "../src/server/session-codec.js";
+
+describe("sessionCodec.deserialize", () => {
+  it("returns null for non-objects", () => {
+    assert.equal(sessionCodec.deserialize(null), null);
+    assert.equal(sessionCodec.deserialize("string"), null);
+    assert.equal(sessionCodec.deserialize([]), null);
+  });
+
+  it("returns null when no key field present", () => {
+    assert.equal(sessionCodec.deserialize({}), null);
+    assert.equal(sessionCodec.deserialize({ unrelated: "x" }), null);
+  });
+
+  it("reads the new sessionKey field", () => {
+    assert.deepEqual(
+      sessionCodec.deserialize({ sessionKey: "paperclip-abc" }),
+      { sessionKey: "paperclip-abc" },
+    );
+  });
+
+  it("falls back to legacy sessionId", () => {
+    assert.deepEqual(
+      sessionCodec.deserialize({ sessionId: "legacy-cli-id" }),
+      { sessionKey: "legacy-cli-id" },
+    );
+  });
+
+  it("trims whitespace", () => {
+    assert.deepEqual(
+      sessionCodec.deserialize({ sessionKey: "  paperclip-abc  " }),
+      { sessionKey: "paperclip-abc" },
+    );
+  });
+});
+
+describe("sessionCodec.serialize", () => {
+  it("normalises to {sessionKey}", () => {
+    assert.deepEqual(sessionCodec.serialize({ sessionKey: "k" }), {
+      sessionKey: "k",
+    });
+    assert.deepEqual(sessionCodec.serialize({ sessionId: "k" }), {
+      sessionKey: "k",
+    });
+  });
+
+  it("returns null for empty input", () => {
+    assert.equal(sessionCodec.serialize(null), null);
+    assert.equal(sessionCodec.serialize({}), null);
+  });
+});
+
+describe("sessionCodec.getDisplayId", () => {
+  it("surfaces whichever field is set", () => {
+    assert.equal(
+      sessionCodec.getDisplayId?.({ sessionKey: "paperclip-x" }),
+      "paperclip-x",
+    );
+    assert.equal(
+      sessionCodec.getDisplayId?.({ sessionId: "legacy-y" }),
+      "legacy-y",
+    );
+    assert.equal(sessionCodec.getDisplayId?.(null), null);
+  });
+});

--- a/packages/paperclip/adapter/tests/test-environment.test.ts
+++ b/packages/paperclip/adapter/tests/test-environment.test.ts
@@ -1,0 +1,59 @@
+/**
+ * testEnvironment() tests — verify the operator gets the right shape
+ * when clicking "Test agent" in Paperclip.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { makeTestEnvironment } from "../src/server/test.js";
+
+describe("testEnvironment", () => {
+  it("passes when hermes is healthy AND api key is readable", async () => {
+    const testEnvironment = makeTestEnvironment({
+      ping: async () => ({ ok: true, status: 200, detail: "ok" }),
+      readApiKey: () => "stub-key",
+    });
+    const res = await testEnvironment({
+      companyId: "c",
+      adapterType: "hermes_local",
+      config: {},
+    });
+    assert.equal(res.status, "pass");
+    assert.ok(res.checks.find((c) => c.code === "hermes_health_ok"));
+    assert.ok(res.checks.find((c) => c.code === "hermes_api_key_ok"));
+  });
+
+  it("warns when hermes is healthy but api key is missing", async () => {
+    const testEnvironment = makeTestEnvironment({
+      ping: async () => ({ ok: true, status: 200, detail: "ok" }),
+      readApiKey: () => null,
+    });
+    const res = await testEnvironment({
+      companyId: "c",
+      adapterType: "hermes_local",
+      config: {},
+    });
+    assert.equal(res.status, "warn");
+    assert.ok(res.checks.find((c) => c.code === "hermes_api_key_missing"));
+  });
+
+  it("fails fast when hermes /health is unreachable", async () => {
+    const testEnvironment = makeTestEnvironment({
+      ping: async () => ({
+        ok: false,
+        status: null,
+        detail: "ECONNREFUSED",
+      }),
+      readApiKey: () => "stub-key",
+    });
+    const res = await testEnvironment({
+      companyId: "c",
+      adapterType: "hermes_local",
+      config: {},
+    });
+    assert.equal(res.status, "fail");
+    assert.equal(res.checks.length, 1);
+    assert.equal(res.checks[0]!.code, "hermes_health_unreachable");
+  });
+});

--- a/packages/paperclip/adapter/tsconfig.json
+++ b/packages/paperclip/adapter/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noImplicitAny": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/packages/paperclip/dockerfiles/paperclip.Dockerfile
+++ b/packages/paperclip/dockerfiles/paperclip.Dockerfile
@@ -1,0 +1,86 @@
+# =============================================================================
+# alfred-black-paperclip
+#
+# Local fork of ghcr.io/paperclipai/paperclip that overlays a patched
+# `hermes-paperclip-adapter` whose execute() calls hermes:18789/v1/responses
+# over HTTP instead of spawning a hermes CLI binary (absent from the
+# upstream image). See packages/paperclip/DESIGN.md for the rationale.
+#
+# Build context:
+#   The build expects the repo root as the build context so it can COPY
+#   the adapter source from packages/paperclip/adapter/dist/. Build it
+#   first (`cd packages/paperclip/adapter && npm ci && npm run build`)
+#   or rely on the in-Dockerfile compile step below.
+#
+# Tripwire:
+#   We hard-pin the upstream paperclip image by digest AND assert the
+#   shipped adapter version is exactly 0.2.0. If upstream ships 0.2.1
+#   (or a different layout), the build fails fast — re-audit the
+#   upstream `execute.ts` against our fork BEFORE bumping the pin.
+# =============================================================================
+
+ARG PAPERCLIP_BASE=ghcr.io/paperclipai/paperclip@sha256:711d29717855abbd84d0e576a0a07daff8e9007a229fb8220d8203d492e886e4
+ARG HERMES_PAPERCLIP_ADAPTER_REF=0.2.0
+
+# ── Stage 1: compile the patched adapter sources to dist/ ────────────────────
+# Node 22 alpine is sufficient — tsc 5.7 + Node 20+ types, no native modules.
+FROM node:22-alpine AS adapter-build
+
+WORKDIR /build
+COPY packages/paperclip/adapter/package.json packages/paperclip/adapter/tsconfig.json ./
+RUN npm install --no-audit --no-fund --silent
+COPY packages/paperclip/adapter/src ./src
+RUN npm run build && ls -la dist/server dist/shared dist/types
+
+# ── Stage 2: overlay onto the upstream paperclip image ───────────────────────
+FROM ${PAPERCLIP_BASE} AS final
+ARG HERMES_PAPERCLIP_ADAPTER_REF
+
+# Drift detection — the upstream pnpm-store path includes the version
+# number. We refuse to build if the pinned base image ships something
+# other than the v0.2.0 layout this fork was audited against.
+USER root
+RUN set -eu; \
+    expected="hermes-paperclip-adapter@${HERMES_PAPERCLIP_ADAPTER_REF}"; \
+    if [ ! -d "/app/node_modules/.pnpm/${expected}" ]; then \
+        echo "FAIL: upstream paperclip image does not ship ${expected}"; \
+        echo "Available hermes-paperclip-adapter versions:"; \
+        ls /app/node_modules/.pnpm/ | grep hermes-paperclip || echo "  (none)"; \
+        echo ""; \
+        echo "Re-audit packages/paperclip/adapter/src against the new upstream"; \
+        echo "source BEFORE bumping HERMES_PAPERCLIP_ADAPTER_REF or PAPERCLIP_BASE."; \
+        exit 1; \
+    fi
+
+# Replace upstream's compiled dist/ with our patched build. We keep the
+# upstream package.json + LICENSE intact so pnpm + the Paperclip
+# registry continue to resolve the package by name.
+COPY --from=adapter-build /build/dist /app/node_modules/.pnpm/hermes-paperclip-adapter@0.2.0/node_modules/hermes-paperclip-adapter/dist
+
+# Smoke-import: load the patched server module under Node to catch
+# top-level syntax / resolution errors at build time rather than at the
+# first heartbeat. Resolution must run from /app/server because that is
+# where pnpm symlinks the package (`/app/server/node_modules/
+# hermes-paperclip-adapter -> .pnpm/.../hermes-paperclip-adapter`).
+RUN cd /app/server && node --input-type=module -e " \
+    import('hermes-paperclip-adapter/server').then((m) => { \
+      const required = ['execute', 'testEnvironment', 'sessionCodec', 'listSkills', 'syncSkills', 'detectModel']; \
+      for (const k of required) { \
+        if (typeof m[k] === 'undefined') { \
+          console.error('missing export:', k); process.exit(1); \
+        } \
+      } \
+      console.log('overlay: ok, exports =', Object.keys(m).sort().join(',')); \
+    }).catch((e) => { console.error(e); process.exit(1); });"
+
+# Restore upstream's default user (root) + workdir. Upstream paperclip
+# image runs as root by default (`docker image inspect …` shows
+# `Config.User=""`), even though it defines a `node` uid-1000 user for
+# the bootstrap CLI subcommands. Re-asserting root keeps the runtime
+# identity consistent across rebuilds.
+USER root
+WORKDIR /app
+
+# All other directives (CMD, ENTRYPOINT, healthcheck, port, env vars)
+# are inherited from the upstream base. Do NOT override here — the
+# patch is intentionally surgical.

--- a/packages/paperclip/scripts/migrate-agents-to-hermes-local.sh
+++ b/packages/paperclip/scripts/migrate-agents-to-hermes-local.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# =============================================================================
+# migrate-agents-to-hermes-local.sh
+#
+# One-shot operator helper to flip an already-seeded Paperclip CEO agent
+# from `adapterType: "openclaw_gateway"` (the legacy bootstrap default)
+# to `adapterType: "hermes_local"` (the patched HTTP-mode adapter — see
+# packages/paperclip/DESIGN.md).
+#
+# Why this is a separate script (and not folded into bootstrap-paperclip.sh):
+# bootstrap-paperclip.sh's idempotency probe (step 2) bails when the
+# tenant is already seeded, so a fresh run on a live tenant is a no-op.
+# This script targets the existing agent record directly.
+#
+# Inputs (env):
+#   PAPERCLIP_AGENT_ID         — UUID of the agent to migrate (required)
+#   PAPERCLIP_AGENT_TOKEN      — the pcp_… runtime key (required; read
+#                                from /opt/alfred/.env on a tenant)
+#   DOMAIN                     — tenant domain, e.g. home.alfred.black
+#                                (read from /opt/alfred/.env)
+#   ENABLE_HEARTBEAT           — "1" to also flip
+#                                runtimeConfig.heartbeat.enabled true
+#                                (default 1; set 0 to keep paused)
+#   PAPERCLIP_CONTAINER        — container name (default
+#                                alfred-black-paperclip-1)
+#
+# Usage on a tenant VPS:
+#   ssh -o IdentityAgent=none -i ~/.ssh/alfred-black-verify \
+#       root@home.alfred.black \
+#       'cd /opt/alfred && . .env && \
+#        PAPERCLIP_AGENT_ID=694921cb-… \
+#        bash /opt/alfred/migrate-agents-to-hermes-local.sh'
+#
+# Safety:
+#   * The script preserves adapterConfig.devicePrivateKeyPem if present
+#     (Paperclip generated it for openclaw_gateway; harmless to leave
+#     under hermes_local, and removing it might trip a future
+#     openclaw_gateway re-migration).
+#   * Refuses to run if the agent already has adapterType=hermes_local
+#     (idempotent — exit 0, log "already migrated").
+#   * Logs the previous adapterType so the operator can roll back.
+# =============================================================================
+set -euo pipefail
+
+PAPERCLIP_AGENT_ID="${PAPERCLIP_AGENT_ID:?PAPERCLIP_AGENT_ID is required}"
+PAPERCLIP_AGENT_TOKEN="${PAPERCLIP_AGENT_TOKEN:?PAPERCLIP_AGENT_TOKEN is required (from /opt/alfred/.env)}"
+DOMAIN="${DOMAIN:?DOMAIN is required (from /opt/alfred/.env)}"
+ENABLE_HEARTBEAT="${ENABLE_HEARTBEAT:-1}"
+PAPERCLIP_CONTAINER="${PAPERCLIP_CONTAINER:-alfred-black-paperclip-1}"
+
+log() { echo "[migrate-agent] $*" >&2; }
+
+# Resolve the live paperclip container if the default name doesn't match
+# (multi-tenant compose project names differ — joe is alfred-joe, etc.).
+if ! docker inspect "$PAPERCLIP_CONTAINER" >/dev/null 2>&1; then
+    resolved=$(docker ps --filter "label=com.docker.compose.service=paperclip" \
+        --format '{{.Names}}' 2>/dev/null | head -n1 || true)
+    if [[ -n "$resolved" ]]; then
+        log "container '$PAPERCLIP_CONTAINER' not found; using '$resolved'"
+        PAPERCLIP_CONTAINER="$resolved"
+    else
+        log "ERROR: no paperclip container found"
+        exit 1
+    fi
+fi
+
+# 1. Read current state.
+agent_json=$(docker exec "$PAPERCLIP_CONTAINER" curl -sS \
+    -H "Authorization: Bearer $PAPERCLIP_AGENT_TOKEN" \
+    -H "Origin: https://paperclip.$DOMAIN" \
+    "http://localhost:3100/api/agents/$PAPERCLIP_AGENT_ID")
+
+current_type=$(echo "$agent_json" | python3 -c \
+    "import sys,json; d=json.loads(sys.stdin.read()); print(d.get('adapterType') or '')" 2>/dev/null || echo "")
+
+if [[ -z "$current_type" ]]; then
+    log "ERROR: could not read current adapterType. Response was:"
+    echo "$agent_json" | head -c 500 >&2
+    echo "" >&2
+    exit 1
+fi
+
+log "current adapterType: $current_type"
+
+if [[ "$current_type" == "hermes_local" ]]; then
+    log "already migrated — nothing to do"
+    exit 0
+fi
+
+# 2. Compose the PATCH body — preserve any existing devicePrivateKeyPem.
+patch_body=$(echo "$agent_json" | python3 -c "
+import sys, json, os
+d = json.loads(sys.stdin.read())
+prev_config = d.get('adapterConfig') or {}
+prev_runtime = d.get('runtimeConfig') or {}
+# Carry the device key forward — harmless under hermes_local and lets us
+# roll back to openclaw_gateway without losing the identity.
+new_config = {}
+if isinstance(prev_config, dict) and prev_config.get('devicePrivateKeyPem'):
+    new_config['_legacy_devicePrivateKeyPem'] = prev_config['devicePrivateKeyPem']
+new_runtime = dict(prev_runtime) if isinstance(prev_runtime, dict) else {}
+if os.environ.get('ENABLE_HEARTBEAT', '1') == '1':
+    hb = new_runtime.get('heartbeat') or {}
+    hb['enabled'] = True
+    new_runtime['heartbeat'] = hb
+out = {
+    'adapterType': 'hermes_local',
+    'adapterConfig': new_config,
+    'runtimeConfig': new_runtime,
+}
+print(json.dumps(out))
+")
+
+log "patch body: $patch_body"
+
+# 3. PATCH the agent.
+patch_response=$(docker exec "$PAPERCLIP_CONTAINER" curl -sS -X PATCH \
+    -H "Authorization: Bearer $PAPERCLIP_AGENT_TOKEN" \
+    -H "Origin: https://paperclip.$DOMAIN" \
+    -H "Content-Type: application/json" \
+    -d "$patch_body" \
+    "http://localhost:3100/api/agents/$PAPERCLIP_AGENT_ID")
+
+new_type=$(echo "$patch_response" | python3 -c \
+    "import sys,json; d=json.loads(sys.stdin.read()); print(d.get('adapterType') or '')" 2>/dev/null || echo "")
+
+if [[ "$new_type" != "hermes_local" ]]; then
+    log "ERROR: PATCH did not flip adapterType. Response:"
+    echo "$patch_response" | head -c 500 >&2
+    echo "" >&2
+    exit 1
+fi
+
+log "✓ migrated agent $PAPERCLIP_AGENT_ID: openclaw_gateway → hermes_local"
+log "  heartbeat enabled: $ENABLE_HEARTBEAT"
+log "  rollback: PATCH adapterType back to \"openclaw_gateway\" and restore"
+log "  devicePrivateKeyPem from adapterConfig._legacy_devicePrivateKeyPem"


### PR DESCRIPTION
## What this does

Forks upstream `hermes-paperclip-adapter@0.2.0`'s `execute()` to call our
own Hermes container's `POST /v1/responses` over the compose network,
instead of spawning a `hermes` CLI binary that doesn't exist in the
upstream paperclip image. Same adapter slot (`hermes_local`), same
upstream surface contract (`AdapterExecutionResult` etc.) — the only
thing that changes is the transport.

Today, every Paperclip CEO agent the bootstrap script seeds is parked on
`adapterType: "openclaw_gateway"`, which expects an OpenClaw WebSocket
gateway we don't run. Live observation: no heartbeats actually execute.
After this PR, seeded agents land on `hermes_local` from minute one and
the heartbeat round-trips through the tenant's existing Hermes.

See `packages/paperclip/DESIGN.md` for the full mapping table.

## Design choice — B (custom image), not A (bind-mount)

The override surface is 5 files (execute, test, skills, detect-model,
session-codec, index) + sourcemaps. Bind-mount path-pinning
`v0.2.0` would be fragile across any upstream image bump and would
leave a confusing "look at /opt/alfred/.../bind-mount" footprint on
every tenant. Image rebuild gives clean ownership, lets CI catch
upstream drift via a build-time tripwire (`HERMES_PAPERCLIP_ADAPTER_REF`
needle), and keeps the patched layer inspectable as a Docker image.

The base image is pinned by digest. The build fails fast if upstream
ships `0.2.1` or a different package layout — re-audit before bumping.

## What the smoke test ran (local)

* `cd packages/paperclip/adapter && npm run build` — `tsc` clean
* `npm test` — 38 tests pass (success path, all four error codes,
  session continuity across heartbeats, codec migration from legacy
  `sessionId`, testEnvironment pass / warn / fail)
* `docker build -f packages/paperclip/dockerfiles/paperclip.Dockerfile .`
  — succeeds; the build-time smoke import logs
  `overlay: ok, exports = detectModel,execute,listSkills,resolveDesiredSkillNames,sessionCodec,syncSkills,testEnvironment`
  before the image is exported

## Bootstrap change

`packages/hermes/init/bootstrap-paperclip.sh` step 9 now creates the CEO
agent with `adapterType: "hermes_local"` so new tenants start on the
working runtime. The 5 already-seeded tenants
(home/rj/joe/zsolt/miguel) still hold `openclaw_gateway`; once this PR
is merged + the image deployed to home, a `PATCH /api/agents/<id>`
against each finishes the migration.

## Compose change

```yaml
paperclip:
  image: ssdavidai00/alfred-black-paperclip:latest      # was: ghcr.io/paperclipai/paperclip@sha256:711d…
  volumes:
    - hermes_data:/hermes-state:ro                       # new — read API_SERVER_KEY at call time
  environment:
    - HERMES_GATEWAY_URL=http://hermes:18789
    - HERMES_CONFIG_DIR=/hermes-state/profiles
```

Read-only mount so the patched adapter resolves `API_SERVER_KEY` from
`/hermes-state/profiles/main/.env` (the live source of truth — the
compose-level `HERMES_API_SERVER_KEY` is a seed, not the runtime key).
Same pattern `ctrl-api/channels_paperclip.ts::readHermesMainApiKey`
already uses.

## What I deliberately did NOT do

* **No upstream PR.** Per Sir's "ask-before-upstream-for-tenant-work"
  rule, this stays local. The right long-term fix is a generic
  `HERMES_TRANSPORT=http|cli` knob in
  `NousResearch/hermes-paperclip-adapter`; follow-up issue is filed
  separately (see end of PR).

* **No vault writes.** Upstream's adapter doesn't touch `/vault`, and
  neither does the fork. ctrl-api remains the sole writer.

* **No streaming.** `/v1/responses` is request/response. Paperclip's
  UI receives the full transcript at the end of the run, same as ctrl-
  api's existing `channels_paperclip` lane.

* **No `--reasoning-effort` pass-through.** Hermes config.yaml is
  operator-owned; letting Paperclip override the principal's
  reasoning posture silently is the wrong default.

## Residual risks

1. **First-deploy permissions.** `hermes_data` is owned `10000:10000`
   inside the hermes container; the paperclip container runs as root,
   which bypasses POSIX checks, so the read works. If a future
   refactor moves paperclip to a non-root uid, the `API_SERVER_KEY`
   read silently returns null and every heartbeat fails 401 — the
   `testEnvironment` warning would surface this. Worth a tenant-side
   smoke verify (`POST /api/agents/<id>/test`) post-deploy.

2. **Bootstrap re-run on existing tenants is a no-op.** The script's
   idempotency probe (step 2) bails when `PAPERCLIP_AGENT_TOKEN` is
   already set — so even after this PR, existing tenants keep their
   `openclaw_gateway` agents until a one-time PATCH lands. The PR
   description above tracks that follow-up.

3. **Upstream drift.** If `ghcr.io/paperclipai/paperclip` rebases on
   `hermes-paperclip-adapter@0.2.1`, the build tripwire fires before
   we ship a broken image. But a major upstream redesign (e.g.
   different module resolution path) needs a manual diff against
   `packages/paperclip/adapter/src/`.

4. **No `onMeta` for tool-card rendering.** Upstream's CLI mode parses
   stdout for `┊ 💬 …` lines and surfaces tool calls in Paperclip's UI
   as cards. HTTP mode receives the assistant text as one chunk — no
   tool-call breakdown. Real-time streaming would be the upstream
   answer; punted to follow-up.

## Follow-ups

* Upstreaming a generic HTTP transport — separate issue, not this PR.
* Migrate the 5 live agents off `openclaw_gateway` — one-shot PATCH
  script, deferred until this image is live on every tenant.
* Memory updates (`paperclip-integration`) — deferred until merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)