### PR TITLE
fix(paperclip): wire Paperclip MCP with a BOARD API key (not an agent token)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1356,6 +1356,12 @@ services:
       - PAPERCLIP_SEED_EMAIL=${PAPERCLIP_SEED_EMAIL:-}
       - PAPERCLIP_SEED_NAME=${PAPERCLIP_SEED_NAME:-}
       - PAPERCLIP_SEED_COMPANY=${PAPERCLIP_SEED_COMPANY:-}
+      # HERMES_STATE_DIR points the board-key writer (step 12) at the
+      # hermes_data volume mount declared below. The MCP server reads
+      # PAPERCLIP_API_KEY from process env on stdio startup — writing
+      # it into each profile's .env here is the seam that survives
+      # `docker compose pull`.
+      - HERMES_STATE_DIR=/hermes-state
     volumes:
       - alfred_data:/alfred-data
       # RO socket — the script only invokes `docker exec` / `docker inspect`.
@@ -1367,6 +1373,17 @@ services:
       # full seed cannot complete; only the legacy invite-file fallback
       # would land.
       - ${COMPOSE_DIR_HOST:-/opt/alfred}:/srv/alfred-black
+      # hermes_data RW so step 12 can write PAPERCLIP_API_KEY into each
+      # profile's .env. The MCP server inside Hermes reads
+      # ``PAPERCLIP_API_KEY`` from process env at stdio startup; writing
+      # the board API key here is the only seam that survives
+      # `docker compose pull` (PAPERCLIP_ is in render_hermes.py's
+      # _RUNTIME_KEY_PREFIXES so future init re-renders preserve it).
+      # 2026-05-27: PR #87's smoke test caught the missing wiring — every
+      # MCP tool call from Hermes 401-ed because the agent token
+      # (PAPERCLIP_AGENT_TOKEN, scope=agent) gives 403 "Board access
+      # required" on the company-scoped routes the MCP tools call.
+      - hermes_data:/hermes-state
     entrypoint: ["./bootstrap-paperclip.sh"]
     mem_limit: 256m
     pids_limit: 256

--- a/packages/hermes/hermes-config.yaml.njk
+++ b/packages/hermes/hermes-config.yaml.njk
@@ -387,7 +387,23 @@ mcp_servers:
     args: ["/opt/paperclip-mcp/node_modules/@paperclipai/mcp-server/dist/stdio.js"]
     env:
       PAPERCLIP_API_URL: "http://paperclip:3100/api"
+      # PAPERCLIP_API_KEY is the BOARD API KEY (pcp_board_…), minted by
+      # bootstrap-paperclip.sh step 12 / migrate-paperclip-board-key.sh
+      # and persisted into this profile's .env. NOT the agent token from
+      # /opt/alfred/.env — that's the 2026-05-27 root-cause:
+      # company-scoped MCP tools 403 with "Board access required" if
+      # they're handed an agent token instead of a board key.
       PAPERCLIP_API_KEY: "${PAPERCLIP_API_KEY}"
+      # PAPERCLIP_COMPANY_ID + PAPERCLIP_AGENT_ID let the MCP server
+      # default the most common args (companyId, agentId) so the tools
+      # work without the LLM having to know the UUIDs. Source:
+      # /opt/alfred/.env (written by bootstrap-paperclip.sh step 11b);
+      # bridged through this profile's .env via the same paperclip-init
+      # path that wrote PAPERCLIP_API_KEY. If unset, the MCP tools
+      # surface a clear "companyId is required because
+      # PAPERCLIP_COMPANY_ID is not set" error.
+      PAPERCLIP_COMPANY_ID: "${PAPERCLIP_COMPANY_ID}"
+      PAPERCLIP_AGENT_ID: "${PAPERCLIP_AGENT_ID}"
     timeout: 120
     connect_timeout: 60
 

--- a/packages/hermes/init/Dockerfile
+++ b/packages/hermes/init/Dockerfile
@@ -69,6 +69,11 @@ COPY packages/hermes/init/render_sms_gateway.py ./render_sms_gateway.py
 # this image's default entrypoint.sh — keeps the main init container
 # focused on filesystem scaffolding (no docker.sock there).
 COPY packages/hermes/init/bootstrap-paperclip.sh ./bootstrap-paperclip.sh
+# paperclip_board_key.py — board API key minting + per-profile .env writer.
+# Imported by bootstrap-paperclip.sh's Python redeem block (step 12) and
+# usable as a standalone CLI (PAPERCLIP_BOARD_API_TOKEN env → writes to
+# HERMES_STATE_DIR/profiles/*/.env). Lib AND script.
+COPY packages/hermes/init/paperclip_board_key.py ./paperclip_board_key.py
 COPY packages/hermes/init/sure-bootstrap.rb    ./sure-bootstrap.rb
 COPY packages/hermes/init/sure-mutate-base.rb  ./sure-mutate-base.rb
 COPY packages/hermes/init/sure-account-mutate.rb    ./sure-account-mutate.rb

--- a/packages/hermes/init/bootstrap-paperclip.sh
+++ b/packages/hermes/init/bootstrap-paperclip.sh
@@ -718,7 +718,116 @@ except PermissionError:
 os.replace(tmp_path, env_path)
 log(f"step 11b: persisted {len(keys)} keys -> {env_path}")
 
-log("steps 6-11 complete - Paperclip is fully seeded")
+# --------------------------------------------------------------------------
+# Step 12 — mint a Paperclip BOARD API key + write PAPERCLIP_API_KEY into
+# each Hermes profile .env. This is the auth Hermes' baked-in
+# `@paperclipai/mcp-server` needs to call Paperclip's company-scoped routes
+# (the 39-of-40 tools that 403 with "Board access required" on an agent
+# token).
+#
+# The agent token persisted in step 11b is enough for Paperclip → Hermes
+# (heartbeats, /agents/me — see PR #87) but the MCP server needs board
+# scope. We use Paperclip's cli-auth challenge flow which trades our
+# active session cookie (from step 6 sign-up) for a long-lived
+# `pcp_board_...` token via:
+#
+#   POST /api/cli-auth/challenges      → pending `boardApiToken`
+#   POST /api/cli-auth/challenges/<id>/approve  → activate it
+#
+# On success we write `PAPERCLIP_API_KEY=<token>` into every Hermes
+# profile's .env under HERMES_STATE_DIR (the hermes_data volume,
+# bind-mounted into this container — see docker-compose.yaml
+# paperclip-init.volumes). render_hermes.py already lists PAPERCLIP_ in
+# _RUNTIME_KEY_PREFIXES so the key survives future init re-renders.
+#
+# Failure here is NON-FATAL — step 11 already gave us a working agent
+# (heartbeats work, paperclipMe MCP tool works). The MCP tools that
+# need board scope just keep 401-ing until the operator re-runs the
+# bootstrap OR runs migrate-paperclip-board-key.sh by hand. The
+# bootstrap script is invoked in a one-shot compose service that
+# normally only runs at first install; making it fatal would leave
+# tenants stuck on a transient cli-auth issue (e.g. paperclip restart
+# mid-flow) with no obvious recovery path.
+# --------------------------------------------------------------------------
+hermes_state_dir = os.environ.get("HERMES_STATE_DIR", "/hermes-state").strip()
+if not hermes_state_dir:
+    log("step 12: skipping board-key mint — HERMES_STATE_DIR is unset")
+else:
+    # Import paperclip_board_key from the same directory as this script.
+    # Bash invokes us via `python3 - <<PYEOF` so __file__ is unset; the
+    # expected sibling location is /setup/ in the init image
+    # (Dockerfile WORKDIR /setup + COPY paperclip_board_key.py). Fall
+    # back to PWD for a manual invocation outside the image.
+    candidates = ["/setup", os.environ.get("PWD", "")]
+    pbk = None
+    last_err = None
+    for cand in candidates:
+        if not cand:
+            continue
+        if cand not in sys.path:
+            sys.path.insert(0, cand)
+        try:
+            import paperclip_board_key as _pbk
+            pbk = _pbk
+            break
+        except ImportError as exc:
+            last_err = exc
+            continue
+    if pbk is None:
+        log(
+            f"step 12: WARN: paperclip_board_key.py not importable "
+            f"({last_err!r}); skipping board-key mint. Run "
+            f"migrate-paperclip-board-key.sh to wire it up later."
+        )
+    else:
+        try:
+            log("step 12: minting board API key via cli-auth challenge flow")
+            # The cookie jar from steps 6-11 carries an active session;
+            # the cli-auth flow's /approve endpoint uses it to authorise
+            # the new board key.
+            board_token = pbk.mint_board_key_via_api(
+                internal_url=internal_url,
+                public_url=public_url,
+                cookies=cookies,
+                client_name="alfred-paperclip-init",
+            )
+            log(
+                f"  board token captured "
+                f"({len(board_token)} chars; prefix {board_token[:11]}...)"
+            )
+            written = pbk.write_paperclip_api_key_to_profiles(
+                hermes_state_dir=hermes_state_dir,
+                token=board_token,
+                # Make the MCP server's resolveCompanyId/resolveAgentId
+                # work out-of-the-box by seeding both IDs into the
+                # per-profile .env. Without these, every company-scoped
+                # tool call surfaces "companyId is required because
+                # PAPERCLIP_COMPANY_ID is not set" until the LLM
+                # remembers to thread the UUID through.
+                company_id=company_id,
+                agent_id=agent_id,
+            )
+            for path in written:
+                log(f"  wrote PAPERCLIP_API_KEY -> {path}")
+            if not written:
+                log(
+                    f"  WARN: no Hermes profile dirs under "
+                    f"{hermes_state_dir}/profiles — nothing written. "
+                    f"Is the hermes_data volume mounted on this service?"
+                )
+            else:
+                log(
+                    f"step 12: PAPERCLIP_API_KEY persisted to "
+                    f"{len(written)} profile(s); restart hermes to pick it up"
+                )
+        except Exception as exc:
+            log(
+                f"step 12: WARN: board-key mint failed ({exc}); MCP tools "
+                f"requiring board scope will keep 401-ing until "
+                f"migrate-paperclip-board-key.sh is run"
+            )
+
+log("steps 6-12 complete - Paperclip is fully seeded")
 PYEOF
 }
 

--- a/packages/hermes/init/migrate-paperclip-board-key.sh
+++ b/packages/hermes/init/migrate-paperclip-board-key.sh
@@ -1,0 +1,537 @@
+#!/usr/bin/env bash
+# =============================================================================
+# migrate-paperclip-board-key.sh — hot-fix the Paperclip MCP auth wiring
+# on a tenant that was seeded BEFORE step 12 of bootstrap-paperclip.sh
+# landed (home seeded pre-PR #84; rj/joe/zsolt/miguel seeded between
+# PR #84 and this fix).
+#
+# What this fixes
+# ---------------
+# Hermes' Paperclip MCP server reads `PAPERCLIP_API_KEY` from its
+# process env and sends `Authorization: Bearer <key>` on every tool
+# call. Paperclip's auth middleware accepts THREE token shapes:
+#
+#   * `pcp_board_<48hex>` (board API key) — `actor.type="board"`,
+#     scope = a user's company memberships. The MCP tools call
+#     company-scoped routes (e.g. `/api/companies/<id>/issues`) that
+#     403 with "Board access required" on agent scope.
+#   * `pcp_<…>` (agent API key) — `actor.type="agent"`, scope = one
+#     agent's own context. PR #84 wired this into
+#     `PAPERCLIP_AGENT_TOKEN`. Sufficient for Paperclip → Hermes
+#     heartbeats (PR #87) and the `paperclipMe` MCP tool, NOT for the
+#     other 39 tools.
+#   * Local agent JWT — same scope as agent key, signed by the
+#     heartbeat secret. Not what we want here.
+#
+# Until step 12 landed, NO board key existed on any tenant. Every MCP
+# call from Hermes 401-ed. This script fixes that by:
+#
+#   1. Querying the embedded Paperclip postgres to find the
+#      instance_admin user (the principal that signed up at
+#      `paperclip.<DOMAIN>`).
+#   2. Generating a `pcp_board_<48hex>` token + sha256-hashing it (same
+#      shape as Paperclip's `createBoardApiToken`).
+#   3. INSERT INTO board_api_keys (user_id, name, key_hash, expires_at)
+#      — same row shape the live auth middleware reads.
+#   4. Writing PAPERCLIP_API_KEY=<token> into each Hermes profile's
+#      .env via paperclip_board_key.py.
+#   5. Restarting hermes so the MCP server re-reads its env.
+#
+# Why direct-DB-insert and not the cli-auth challenge flow?
+# ---------------------------------------------------------
+# The cli-auth flow needs an active session cookie. The bootstrap
+# script signs up `alfred@<DOMAIN>` with a fresh password but ONLY
+# persists the password to the alfred_data volume on the first run.
+# Tenants seeded before that step landed have no recoverable password,
+# and Better-Auth has no admin "issue a session token" endpoint we can
+# call from outside. Direct-DB-insert bypasses Better-Auth — safe
+# because we already read the user_id from the same DB and use the
+# same sha256 hash the auth middleware verifies against.
+#
+# Usage
+# -----
+#
+#   ssh root@<tenant> 'bash -s' < migrate-paperclip-board-key.sh
+#
+# or, equivalently:
+#
+#   scp migrate-paperclip-board-key.sh root@<tenant>:/tmp/
+#   ssh root@<tenant> 'bash /tmp/migrate-paperclip-board-key.sh'
+#
+# Idempotent. Re-runs revoke the old key (by name) and mint a fresh
+# one. The window when no key is valid is exactly the one transaction
+# (~1ms in practice).
+#
+# Constraints
+# -----------
+#  * Tenant must have a Paperclip container running with the embedded
+#    postgres on 127.0.0.1:54329 (the default config).
+#  * Tenant must have an instance_admin user (created by step 6-7 of
+#    bootstrap-paperclip.sh OR by signing up at paperclip.<DOMAIN>
+#    manually). The CEO claim sets this role.
+#  * Hermes container must be running so the post-write restart picks
+#    up the new env. The script restarts hermes-main, -workers, -heavy
+#    if they exist (their MCP server config reuses PAPERCLIP_API_KEY).
+# =============================================================================
+set -euo pipefail
+
+LOG_PREFIX="[paperclip-board-key-migrate]"
+log() { echo "$LOG_PREFIX $*"; }
+
+PAPERCLIP_CONTAINER="${PAPERCLIP_CONTAINER:-}"
+HERMES_CONTAINER="${HERMES_CONTAINER:-}"
+KEY_NAME="${KEY_NAME:-hermes-mcp}"
+
+# --- locate containers ------------------------------------------------------
+resolve_container_by_service() {
+    local service="$1"
+    local name
+    name=$(docker ps --filter "label=com.docker.compose.service=${service}" \
+        --format '{{.Names}}' 2>/dev/null | head -n1 || true)
+    if [[ -z "$name" ]]; then
+        name=$(docker ps --format '{{.Names}}' 2>/dev/null | \
+            grep -E "(^|[-_])${service}([-_]|$)" | head -n1 || true)
+    fi
+    echo "$name"
+}
+
+if [[ -z "$PAPERCLIP_CONTAINER" ]]; then
+    PAPERCLIP_CONTAINER=$(resolve_container_by_service paperclip)
+fi
+if [[ -z "$PAPERCLIP_CONTAINER" ]]; then
+    log "ERROR: no paperclip container running; cannot continue"
+    exit 1
+fi
+log "paperclip container: $PAPERCLIP_CONTAINER"
+
+if [[ -z "$HERMES_CONTAINER" ]]; then
+    HERMES_CONTAINER=$(resolve_container_by_service hermes)
+fi
+if [[ -z "$HERMES_CONTAINER" ]]; then
+    log "ERROR: no hermes container running; cannot continue"
+    exit 1
+fi
+log "hermes container: $HERMES_CONTAINER"
+
+# --- locate the embedded pg module path (the pnpm hash varies by build) ----
+PG_MODULE=$(docker exec "$PAPERCLIP_CONTAINER" sh -c \
+    'find /app/node_modules/.pnpm -maxdepth 2 -type d -name "pg@*" 2>/dev/null | head -n1' || true)
+if [[ -z "$PG_MODULE" ]]; then
+    log "ERROR: could not locate the pg module inside the paperclip container"
+    exit 1
+fi
+PG_MODULE_PATH="${PG_MODULE}/node_modules/pg"
+log "pg module: $PG_MODULE_PATH"
+
+# --- step 1: mint board key by direct DB insert -----------------------------
+#
+# The Node script generates a fresh pcp_board_<48hex>, hashes with sha256,
+# revokes any existing key with the same name (idempotency), inserts a new
+# row, and prints the raw token on stdout. We pipe it to a temp file inside
+# the hermes container so the token never crosses the tty (the SSH session
+# would log it otherwise; the file gets chmod 600 then deleted at end).
+
+log "step 1: minting fresh board API key"
+
+# Drop the mint script into the paperclip container. Heredoc terminator
+# is quoted so bash does NOT interpolate $VAR / <SUBSHELL> patterns
+# inside the Node source — we only want PG_MODULE_PATH substituted in,
+# which we do via a sed pass below. Quoting the terminator is the
+# tightest way to avoid bash misreading angle-brackets inside a
+# comment as redirection (`alfred@<DOMAIN>` blew up exactly this way
+# in the first iteration of this script). `-i` on docker exec is
+# REQUIRED so the heredoc reaches sh's stdin inside the container.
+docker exec -i "$PAPERCLIP_CONTAINER" sh -c 'cat > /tmp/mint-board-key.js' <<'MINT_JS'
+const crypto = require('node:crypto');
+const { Client } = require("__PG_MODULE_PATH__");
+
+const KEY_NAME = process.env.KEY_NAME || 'hermes-mcp';
+const TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+(async () => {
+  const c = new Client({
+    host: '127.0.0.1', port: 54329,
+    user: 'paperclip', password: 'paperclip', database: 'paperclip',
+  });
+  await c.connect();
+
+  // Find the instance_admin user. If multiple, pick the most-recently
+  // created one — that's typically the seed user (`alfred@<DOMAIN>`),
+  // BUT on home which was seeded manually before bootstrap-paperclip.sh
+  // landed, it's `david@szabostuban.com`. Either is correct for our
+  // purposes: a board key scoped to ANY instance_admin gives the MCP
+  // server access to every company on this tenant.
+  const userRes = await c.query(`
+    SELECT u.id, u.email
+    FROM "user" u
+    INNER JOIN instance_user_roles ir ON ir.user_id = u.id
+    WHERE ir.role = 'instance_admin'
+    ORDER BY u.id
+    LIMIT 1
+  `);
+  if (userRes.rows.length === 0) {
+    // Fall back to any board-membership user (a tenant might have skipped
+    // the instance_admin role on the seed user).
+    const fallback = await c.query(`
+      SELECT u.id, u.email
+      FROM "user" u
+      INNER JOIN company_memberships m ON m.principal_id = u.id
+      WHERE m.principal_type = 'user' AND m.status = 'active'
+      ORDER BY u.id LIMIT 1
+    `);
+    if (fallback.rows.length === 0) {
+      console.error('FATAL: no board-eligible user on this tenant (no instance_admin and no active company member)');
+      process.exit(2);
+    }
+    userRes.rows = fallback.rows;
+  }
+  const userId = userRes.rows[0].id;
+
+  // Idempotency: revoke any existing key with our name. A re-run of this
+  // script should leave the tenant with exactly one active key named
+  // KEY_NAME.
+  await c.query(
+    'UPDATE board_api_keys SET revoked_at = NOW() WHERE user_id = $1 AND name = $2 AND revoked_at IS NULL',
+    [userId, KEY_NAME]
+  );
+
+  const token = 'pcp_board_' + crypto.randomBytes(24).toString('hex');
+  const keyHash = crypto.createHash('sha256').update(token).digest('hex');
+  const expiresAt = new Date(Date.now() + TTL_MS);
+
+  const inserted = await c.query(
+    `INSERT INTO board_api_keys (user_id, name, key_hash, expires_at)
+     VALUES ($1, $2, $3, $4) RETURNING id`,
+    [userId, KEY_NAME, keyHash, expiresAt]
+  );
+
+  // Emit a machine-parseable single-line key=value pair.
+  process.stdout.write('BOARD_API_TOKEN=' + token + '\n');
+  process.stderr.write('user_id=' + userId + ' key_id=' + inserted.rows[0].id + ' expires_at=' + expiresAt.toISOString() + '\n');
+
+  await c.end();
+})().catch(e => { console.error('ERROR: ' + e.message); process.exit(1); });
+MINT_JS
+
+# Substitute the pg-module path into the placeholder. We use a fixed sentinel
+# (__PG_MODULE_PATH__) rather than bash interpolation inside the heredoc so
+# the heredoc terminator can stay quoted — see the comment above the heredoc
+# for why quoting matters (angle-brackets in JS comments).
+docker exec "$PAPERCLIP_CONTAINER" sh -c \
+    "sed -i 's|__PG_MODULE_PATH__|${PG_MODULE_PATH}|g' /tmp/mint-board-key.js"
+
+# Capture the token directly into a docker exec stdin -> file in hermes so
+# it never touches our local tty/log. (The Node script writes the token to
+# stdout; the host pipe goes straight into a `docker exec -i ... tee` on the
+# hermes container.)
+TOKEN_FILE_IN_HERMES="/tmp/paperclip-board-token-$$.env"
+
+# Run mint, capture the stderr summary, and pipe stdout (the token line)
+# straight into a 0600-permissioned file in the hermes container.
+MINT_STDERR=$(mktemp)
+docker exec -e KEY_NAME="$KEY_NAME" "$PAPERCLIP_CONTAINER" \
+    node /tmp/mint-board-key.js 2>"$MINT_STDERR" | \
+    docker exec -i "$HERMES_CONTAINER" sh -c "cat > $TOKEN_FILE_IN_HERMES && chmod 600 $TOKEN_FILE_IN_HERMES" || {
+        log "ERROR: mint command failed; stderr:"
+        sed 's/^/  /' "$MINT_STDERR" >&2
+        rm -f "$MINT_STDERR"
+        exit 1
+    }
+
+if [[ -s "$MINT_STDERR" ]]; then
+    log "  mint context: $(cat "$MINT_STDERR")"
+fi
+rm -f "$MINT_STDERR"
+docker exec "$PAPERCLIP_CONTAINER" rm -f /tmp/mint-board-key.js || true
+
+# Verify the file in hermes is non-empty
+TOKEN_LEN=$(docker exec "$HERMES_CONTAINER" sh -c "wc -c < $TOKEN_FILE_IN_HERMES" | tr -d ' ')
+if [[ "${TOKEN_LEN:-0}" -lt 16 ]]; then
+    log "ERROR: token file in hermes is empty or too short ($TOKEN_LEN bytes)"
+    exit 1
+fi
+log "  token file: $TOKEN_FILE_IN_HERMES (${TOKEN_LEN} bytes)"
+
+# --- step 2: write PAPERCLIP_API_KEY into each Hermes profile's .env --------
+#
+# We do the env write FROM INSIDE the hermes container so we can read the
+# token file directly (no need to ship the value over docker exec stdin).
+# The Hermes image already has python3 + paperclip_board_key.py is NOT
+# in there yet — we ship the same `_upsert_env_key` logic inline (small
+# enough to keep self-contained). If/when we standardize on bundling
+# paperclip_board_key.py into the Hermes image, we can swap this for
+# `python3 -m paperclip_board_key`.
+
+log "step 2: writing PAPERCLIP_API_KEY (+ company/agent ids) into each Hermes profile's .env"
+
+# Read PAPERCLIP_COMPANY_ID + PAPERCLIP_AGENT_ID from the host .env so we
+# can seed the MCP server defaults. /opt/alfred/.env is the canonical
+# source — bootstrap-paperclip.sh step 11b wrote them there. If absent
+# (tenant seeded pre-PR #84 or via a different flow), we still write
+# PAPERCLIP_API_KEY and let the operator add the ids manually.
+HOST_ENV="${HOST_ENV:-/opt/alfred/.env}"
+PAPERCLIP_COMPANY_ID_VALUE=""
+PAPERCLIP_AGENT_ID_VALUE=""
+if [[ -r "$HOST_ENV" ]]; then
+    PAPERCLIP_COMPANY_ID_VALUE=$(grep -E "^PAPERCLIP_COMPANY_ID=" "$HOST_ENV" 2>/dev/null | head -n1 | cut -d= -f2- || true)
+    PAPERCLIP_AGENT_ID_VALUE=$(grep -E "^PAPERCLIP_AGENT_ID=" "$HOST_ENV" 2>/dev/null | head -n1 | cut -d= -f2- || true)
+fi
+
+docker exec -i \
+    -e PAPERCLIP_COMPANY_ID_VALUE="$PAPERCLIP_COMPANY_ID_VALUE" \
+    -e PAPERCLIP_AGENT_ID_VALUE="$PAPERCLIP_AGENT_ID_VALUE" \
+    "$HERMES_CONTAINER" python3 - "$TOKEN_FILE_IN_HERMES" <<'WRITE_PY'
+"""Read the token from argv[1] (a 0600 file inside the hermes container)
+and upsert PAPERCLIP_API_KEY=<token> into each profile's .env.
+
+This is a self-contained copy of the env-writer logic in
+paperclip_board_key.py — kept inline so this hot-fix script works against
+the current Hermes image (which doesn't ship paperclip_board_key.py).
+After PR #87+1 lands, this can be reduced to:
+
+    python3 /opt/paperclip-mcp/paperclip_board_key.py
+"""
+import os
+import sys
+from pathlib import Path
+
+token_file = Path(sys.argv[1])
+token = token_file.read_text().strip()
+if not token.startswith("BOARD_API_TOKEN="):
+    print(f"ERROR: token file has unexpected shape (first line: {token[:32]!r})", file=sys.stderr)
+    sys.exit(2)
+token = token.split("=", 1)[1].strip()
+if not token:
+    print("ERROR: token after = is empty", file=sys.stderr)
+    sys.exit(2)
+
+HERMES_STATE = Path(os.environ.get("HERMES_HOME", "/hermes-state"))
+PROFILES_DIR = HERMES_STATE / "profiles"
+if not PROFILES_DIR.is_dir():
+    print(f"ERROR: {PROFILES_DIR} does not exist", file=sys.stderr)
+    sys.exit(2)
+
+
+def upsert_env(path: Path, key: str, value: str) -> None:
+    existing = path.read_text().splitlines() if path.exists() else []
+    out = []
+    seen = False
+    for line in existing:
+        s = line.strip()
+        if not s or s.startswith("#"):
+            out.append(line); continue
+        eq = s.find("=")
+        if eq < 0:
+            out.append(line); continue
+        k = s[:eq].strip()
+        if k == key:
+            out.append(f"{key}={value}"); seen = True
+        else:
+            out.append(line)
+    if not seen:
+        out.append(f"{key}={value}")
+    tmp = path.with_suffix(path.suffix + ".paperclip-board.tmp")
+    tmp.write_text("\n".join(out) + "\n")
+    try:
+        tmp.chmod(0o600)
+    except PermissionError:
+        pass
+    os.replace(tmp, path)
+
+
+company_id = (os.environ.get("PAPERCLIP_COMPANY_ID_VALUE") or "").strip()
+agent_id = (os.environ.get("PAPERCLIP_AGENT_ID_VALUE") or "").strip()
+
+written = []
+for profile_dir in sorted(PROFILES_DIR.iterdir()):
+    if not profile_dir.is_dir():
+        continue
+    env_path = profile_dir / ".env"
+    upsert_env(env_path, "PAPERCLIP_API_KEY", token)
+    # Seed the MCP server's default companyId / agentId so the LLM
+    # doesn't need to thread UUIDs through every tool call. Skip empty
+    # values — the MCP server's nonEmpty() treats them as unset.
+    if company_id:
+        upsert_env(env_path, "PAPERCLIP_COMPANY_ID", company_id)
+    if agent_id:
+        upsert_env(env_path, "PAPERCLIP_AGENT_ID", agent_id)
+    written.append(env_path)
+    print(f"  wrote PAPERCLIP_API_KEY -> {env_path}")
+
+if not written:
+    print("ERROR: no profile dirs found under /hermes-state/profiles", file=sys.stderr)
+    sys.exit(2)
+
+extras = []
+if company_id:
+    extras.append("COMPANY_ID")
+if agent_id:
+    extras.append("AGENT_ID")
+extra_note = (" + " + " + ".join(extras)) if extras else " (COMPANY_ID/AGENT_ID skipped: not in /opt/alfred/.env)"
+print(f"OK: PAPERCLIP_API_KEY{extra_note} persisted to {len(written)} profile(s)")
+WRITE_PY
+
+# Cleanup the token file inside hermes — the env was already updated.
+docker exec "$HERMES_CONTAINER" rm -f "$TOKEN_FILE_IN_HERMES" || true
+
+# --- step 2.5: patch each profile's config.yaml so the paperclip MCP
+# server is registered AND its env: block passes PAPERCLIP_COMPANY_ID +
+# PAPERCLIP_AGENT_ID through. config.yaml is "operator-owned" (init
+# never re-renders it after first seed); tenants seeded BEFORE PR #67
+# (where paperclip MCP was added to the template) don't have the block
+# at all, and tenants seeded AFTER PR #67 but BEFORE this fix have the
+# block but only PAPERCLIP_API_KEY in env: (no COMPANY_ID/AGENT_ID).
+# The patch handles both: insert the full paperclip: block if absent,
+# else add the missing env keys.
+# --------------------------------------------------------------------------
+log "step 2.5: patching config.yaml to register paperclip MCP + thread env vars"
+docker exec -i "$HERMES_CONTAINER" python3 - <<'PATCH_PY'
+"""Two-mode idempotent patch on each profile's config.yaml:
+
+  Mode A — `paperclip:` block is absent under `mcp_servers:`. Insert
+  the full block right before the `plugins:` (or end-of-mcp_servers)
+  marker. Source: matches the post-PR #67 template.
+
+  Mode B — `paperclip:` block is present but env: is missing
+  PAPERCLIP_COMPANY_ID / PAPERCLIP_AGENT_ID (tenant on the pre-fix
+  template). Append the two ${VAR} substitution lines.
+
+Both modes write only ${VAR} substitutions — actual UUIDs live in
+the per-profile .env (written in step 2). config.yaml stays
+operator-portable.
+
+Why we patch in-place rather than `hermes mcp add`:
+  * `hermes mcp add` is interactive (`Enable all 40 tools? [y/N]`)
+    and the prompt cancels silently on closed stdin. The memory note
+    says `printf 'y\\ny\\n' | hermes mcp add ...` works but is finicky.
+  * config.yaml is YAML with a stable shape; a small regex insert is
+    deterministic and visible in the next operator review.
+  * We only patch profiles whose config.yaml exists, so a future
+    main-only build doesn't break.
+"""
+import os
+import re
+from pathlib import Path
+
+PROFILES_DIR = Path("/hermes-state/profiles")
+
+# Mode A — full block to insert when paperclip: is absent under
+# mcp_servers:. Matches the post-PR #67 template exactly.
+PAPERCLIP_FULL_BLOCK = """  paperclip:
+    command: node
+    args:
+    - /opt/paperclip-mcp/node_modules/@paperclipai/mcp-server/dist/stdio.js
+    env:
+      PAPERCLIP_API_URL: http://paperclip:3100/api
+      PAPERCLIP_API_KEY: ${PAPERCLIP_API_KEY}
+      PAPERCLIP_COMPANY_ID: "${PAPERCLIP_COMPANY_ID}"
+      PAPERCLIP_AGENT_ID: "${PAPERCLIP_AGENT_ID}"
+    timeout: 120
+    connect_timeout: 60
+"""
+
+# Mode B — env: keys to add if the block is present but missing them.
+WANTED_ENV_KEYS = [
+    ("PAPERCLIP_COMPANY_ID", "${PAPERCLIP_COMPANY_ID}"),
+    ("PAPERCLIP_AGENT_ID", "${PAPERCLIP_AGENT_ID}"),
+]
+
+# Matches the paperclip: block boundary: from its header down to the
+# next 2-space-indented mcp_servers key OR a top-level key (plugins:,
+# etc.). Greedy on header, lazy on body so we stop at the next sibling.
+PAPERCLIP_BLOCK_RE = re.compile(
+    r"(^  paperclip:\n"
+    r"(?:    [^\n]*\n)*"
+    r"    env:\n"
+    r"(?:      [^\n]*\n)*?)"
+    r"(?=    [a-z]|^[a-z]|^$|^  [a-z])",
+    re.MULTILINE,
+)
+
+# Matches the END of the mcp_servers: section so we know where to
+# insert the full paperclip block in Mode A. Anchors on the next
+# top-level key (typically `plugins:`) OR end-of-file when mcp_servers
+# is the last top-level section (live-observed on joe's workers profile
+# 2026-05-27 — its template has mcp_servers as the final block).
+END_OF_MCP_SERVERS_RE = re.compile(
+    r"(^mcp_servers:\n(?:  [^\n]*\n|    [^\n]*\n|      [^\n]*\n)*?)(?=^[a-z][a-z_]*:|\Z)",
+    re.MULTILINE,
+)
+
+added_blocks = 0
+patched_envs = 0
+already_complete = 0
+
+for profile_dir in sorted(PROFILES_DIR.iterdir()):
+    if not profile_dir.is_dir():
+        continue
+    cfg_path = profile_dir / "config.yaml"
+    if not cfg_path.exists():
+        continue
+    text = cfg_path.read_text()
+
+    m = PAPERCLIP_BLOCK_RE.search(text)
+    if not m:
+        # Mode A: insert the full block at the end of mcp_servers:.
+        m2 = END_OF_MCP_SERVERS_RE.search(text)
+        if not m2:
+            # No mcp_servers: section either — this profile is too
+            # different from the template to patch safely. Leave it.
+            print(f"  {cfg_path}: no mcp_servers: section — skipping (manual review)")
+            continue
+        # Insert PAPERCLIP_FULL_BLOCK right before the next top-level key.
+        new_text = text[:m2.end(1)] + PAPERCLIP_FULL_BLOCK + text[m2.end(1):]
+        tmp = cfg_path.with_suffix(cfg_path.suffix + ".paperclip-board.tmp")
+        tmp.write_text(new_text)
+        try:
+            tmp.chmod(0o640)
+        except PermissionError:
+            pass
+        os.replace(tmp, cfg_path)
+        print(f"  {cfg_path}: inserted full paperclip: block")
+        added_blocks += 1
+        continue
+
+    # Mode B: paperclip: is present, ensure env keys.
+    block = m.group(1)
+    new_block = block
+    added = []
+    for key, val in WANTED_ENV_KEYS:
+        if f"      {key}:" in new_block:
+            continue
+        if new_block.endswith("\n"):
+            new_block = new_block + f"      {key}: \"{val}\"\n"
+        else:
+            new_block = new_block + f"\n      {key}: \"{val}\"\n"
+        added.append(key)
+    if not added:
+        already_complete += 1
+        continue
+    new_text = text[:m.start(1)] + new_block + text[m.end(1):]
+    tmp = cfg_path.with_suffix(cfg_path.suffix + ".paperclip-board.tmp")
+    tmp.write_text(new_text)
+    try:
+        tmp.chmod(0o640)
+    except PermissionError:
+        pass
+    os.replace(tmp, cfg_path)
+    print(f"  {cfg_path}: added {', '.join(added)}")
+    patched_envs += 1
+
+print(
+    f"OK: inserted={added_blocks} env-patched={patched_envs} "
+    f"already-complete={already_complete}"
+)
+PATCH_PY
+
+# --- step 3: restart hermes so the MCP server re-reads its env --------------
+#
+# Hermes spawns the @paperclipai/mcp-server stdio subprocess on startup;
+# the subprocess inherits its env from the parent process, which reads
+# the per-profile .env at boot. A graceful restart is enough.
+
+log "step 3: restarting hermes container to pick up the new env"
+docker restart "$HERMES_CONTAINER" >/dev/null
+log "  hermes restarted"
+
+log "migration complete; verify with a Paperclip MCP tool call from Hermes"

--- a/packages/hermes/init/paperclip_board_key.py
+++ b/packages/hermes/init/paperclip_board_key.py
@@ -1,0 +1,415 @@
+"""Paperclip board API key wiring for Hermes' Paperclip MCP server.
+
+Why this exists
+---------------
+Hermes ships `@paperclipai/mcp-server@2026.525.0` baked into the image
+(see hermes-config.yaml.njk § paperclip). The MCP server reads
+``PAPERCLIP_API_KEY`` from its process environment and sends
+``Authorization: Bearer <key>`` on every Paperclip HTTP call.
+
+Paperclip's auth middleware (``/app/server/dist/middleware/auth.js``)
+recognises three Bearer-token shapes:
+
+  * ``pcp_board_<48hex>`` → ``boardApiKeys`` row → ``actor.type="board"``
+    – this is what the MCP tools need (they call company-scoped routes
+    that 403 with ``"Board access required"`` otherwise).
+  * ``pcp_<…>`` → ``agentApiKeys`` row → ``actor.type="agent"``
+    – this is what ``PAPERCLIP_AGENT_TOKEN`` is. Sufficient for
+    ``/agents/me`` and Paperclip → Hermes heartbeats, NOT for the 39
+    other MCP tools (they all return 403 ``"Board access required"``).
+  * Local agent JWT → same as agent-key but signed by the
+    ``PAPERCLIP_HEARTBEAT_SECRET``.
+
+PR #84 wired the agent key into ``/opt/alfred/.env`` as
+``PAPERCLIP_AGENT_TOKEN`` and that solved the Paperclip → Hermes
+heartbeat path; the reverse direction (Hermes-MCP → Paperclip) was
+left to a manual "paste your key into ``.env``" UI step that no one
+ever did. The 2026-05-27 smoke test in PR #87 caught this: every MCP
+tool call from Hermes 401-ed.
+
+This module is the seam that mints a board key headlessly and writes
+``PAPERCLIP_API_KEY`` into each Hermes profile's ``.env`` so the MCP
+server picks it up on the next ``docker compose restart hermes``.
+
+Two paths in
+------------
+
+1. **bootstrap-paperclip.sh / fresh tenant**: the script already has
+   a Better-Auth session cookie (it just signed up the seed user at
+   step 6). ``mint_board_key_via_api`` uses the cli-auth challenge
+   flow (``POST /api/cli-auth/challenges`` + ``…/:id/approve``) to
+   trade the cookie for a long-lived ``pcp_board_…`` token.
+
+2. **migrate-paperclip-board-key.sh / already-seeded tenant**: home
+   was seeded before PR #84 and the 4 newer tenants lost their seed
+   credentials file. We can't sign in again, so we mint by direct
+   ``INSERT INTO board_api_keys`` against the embedded postgres
+   (``mint_board_key_via_db``). This bypasses Better-Auth entirely;
+   it's safe because (a) we already have the user_id from the same
+   DB, (b) we hash the token with the same sha256 the runtime uses
+   to verify it, (c) the auth middleware reads from the same table.
+
+Either path lands at ``write_paperclip_api_key_to_profiles`` which
+upserts ``PAPERCLIP_API_KEY=<token>`` into every profile's ``.env``,
+matching the merge-preserve invariants in ``render_hermes.py``.
+
+Note: ``PAPERCLIP_`` is already in ``_RUNTIME_KEY_PREFIXES`` so future
+init re-renders will keep this key. Don't drop the prefix from the
+allowlist without re-checking this wiring.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import secrets
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from http.cookiejar import CookieJar
+from pathlib import Path
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Constants — keep in sync with services/board-auth.js in Paperclip.
+# ---------------------------------------------------------------------------
+
+# 24 random bytes hex-encoded = 48-char suffix; ``pcp_board_`` prefix = 10
+# chars; total 58 chars. Matches ``createBoardApiToken`` in
+# ``services/board-auth.js`` — DO NOT change without also updating
+# Paperclip's runtime (the auth middleware verifies by sha256 hash, so a
+# token of any shape works — but staying byte-compatible means CLI
+# operators can grep ``board_api_keys`` for our keys by prefix).
+BOARD_API_KEY_PREFIX = "pcp_board_"
+BOARD_API_KEY_TOKEN_BYTES = 24
+# Match BOARD_API_KEY_TTL_MS in services/board-auth.js (30 days).
+BOARD_API_KEY_TTL_DAYS = 30
+
+
+def generate_board_api_token() -> str:
+    """Generate a fresh ``pcp_board_<48hex>`` token.
+
+    Cryptographically random; uses ``secrets`` so the bytes are pulled
+    from the OS CSPRNG, not Python's ``random``. ~192 bits of entropy.
+    """
+    return BOARD_API_KEY_PREFIX + secrets.token_hex(BOARD_API_KEY_TOKEN_BYTES)
+
+
+def hash_bearer_token(token: str) -> str:
+    """SHA-256 hex hash of a bearer token.
+
+    Mirrors ``hashBearerToken`` in ``services/board-auth.js`` so the
+    auth middleware can verify a token we minted by direct DB insert.
+    """
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Path 1 — mint via the live HTTP API (preferred; uses an existing session).
+# ---------------------------------------------------------------------------
+
+
+def mint_board_key_via_api(
+    *,
+    internal_url: str,
+    public_url: str,
+    cookies: CookieJar,
+    client_name: str = "alfred-hermes-mcp",
+    timeout: int = 30,
+) -> str:
+    """Mint a board API key via Paperclip's cli-auth challenge flow.
+
+    Two-step ritual (matches the upstream CLI's behaviour at
+    ``/app/cli/src/client/board-auth.ts``):
+
+      1. POST /api/cli-auth/challenges (no auth) → returns
+         ``{id, token, boardApiToken}`` — ``boardApiToken`` is a
+         freshly-minted ``pcp_board_…`` whose db row is PENDING until
+         step 2 lands.
+      2. POST /api/cli-auth/challenges/<id>/approve with the body
+         ``{token}`` and the session cookie of a signed-in board user
+         → flips the pending row to ACTIVE and ``approved=true``.
+
+    The session cookie is what authorises step 2. The bootstrap script
+    signs up ``alfred@<DOMAIN>`` at step 6 and that user becomes the
+    sole company owner — they qualify as ``actor.type === "board"``
+    via the Better-Auth session path through the auth middleware.
+
+    Returns the activated ``pcp_board_…`` token on success. Raises on
+    any HTTP failure so the caller's ``die()`` can surface the exact
+    step that broke.
+
+    Mirrors the request-helper pattern in bootstrap-paperclip.sh —
+    Host + Origin headers point at the public origin so Better-Auth's
+    trustedOrigins allowlist accepts us even though we talk to the
+    compose-network DNS name (paperclip:3100).
+    """
+    internal_url = internal_url.rstrip("/")
+    public_url = public_url.rstrip("/")
+    public_host = urllib.parse.urlparse(public_url).netloc
+
+    opener = urllib.request.build_opener(
+        urllib.request.HTTPCookieProcessor(cookies)
+    )
+
+    def _request(method: str, path: str, body: Any | None = None) -> tuple[int, bytes]:
+        url = internal_url + path
+        data = None
+        headers = {
+            "Host": public_host,
+            "Origin": public_url,
+            "Accept": "application/json",
+            "User-Agent": "alfred-paperclip-init/1.0",
+        }
+        if body is not None:
+            data = json.dumps(body).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        req = urllib.request.Request(url, data=data, method=method, headers=headers)
+        try:
+            resp = opener.open(req, timeout=timeout)
+        except urllib.error.HTTPError as e:
+            return e.code, e.read()
+        return resp.status, resp.read()
+
+    # Step 1 — create the challenge. ``command`` is a free-text audit
+    # field; we tag with our service name so an operator paging through
+    # Paperclip's activity log can spot the key's provenance.
+    code, body = _request("POST", "/api/cli-auth/challenges", {
+        "command": "alfred-paperclip-init bootstrap",
+        "clientName": client_name,
+    })
+    if code >= 400:
+        raise RuntimeError(
+            f"POST /api/cli-auth/challenges failed with HTTP {code}: "
+            f"{body[:200].decode('utf-8', 'replace')}"
+        )
+    try:
+        created = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"POST /api/cli-auth/challenges returned non-JSON body: "
+            f"{body[:200].decode('utf-8', 'replace')}"
+        ) from exc
+
+    challenge_id = created.get("id")
+    challenge_secret = created.get("token")
+    board_api_token = created.get("boardApiToken")
+    if not (challenge_id and challenge_secret and board_api_token):
+        raise RuntimeError(
+            "POST /api/cli-auth/challenges missing one of "
+            "{id, token, boardApiToken}"
+        )
+
+    # Step 2 — approve as the signed-in board user. The cookie jar
+    # already has the session cookie from the bootstrap script's
+    # sign-up. The handler resolves req.actor via the session, mints
+    # the boardApiKey row using the pending key hash, and returns
+    # ``{approved:true, status:"approved", keyId}``.
+    code, body = _request(
+        "POST",
+        f"/api/cli-auth/challenges/{urllib.parse.quote(str(challenge_id), safe='')}/approve",
+        {"token": challenge_secret},
+    )
+    if code >= 400:
+        raise RuntimeError(
+            f"POST /api/cli-auth/challenges/{challenge_id}/approve "
+            f"failed with HTTP {code}: {body[:200].decode('utf-8', 'replace')}"
+        )
+    try:
+        approved = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            "POST /api/cli-auth/challenges/<id>/approve returned non-JSON"
+        ) from exc
+
+    if not approved.get("approved"):
+        raise RuntimeError(
+            f"cli-auth challenge approval did not resolve to approved: "
+            f"status={approved.get('status')!r}"
+        )
+
+    return board_api_token
+
+
+# ---------------------------------------------------------------------------
+# Path 2 — direct DB insert (hot-fix for tenants seeded pre-PR #84 or
+# where the seed credentials file was lost). The Node-side mint script
+# lives at packages/hermes/init/migrate-paperclip-board-key.sh — this
+# helper exists so the bootstrap script can fall back to it if the
+# cli-auth path fails partway through.
+# ---------------------------------------------------------------------------
+
+
+def board_api_key_expires_at(now: datetime | None = None) -> datetime:
+    """Return the timestamp 30 days from now (matches Paperclip's
+    ``boardApiKeyExpiresAt`` in services/board-auth.js).
+
+    UTC, microsecond-truncated to match what Paperclip writes (the
+    actual seconds-precision in postgres is fine — this just keeps the
+    string we render compatible with Paperclip's parsing).
+    """
+    base = now or datetime.now(timezone.utc)
+    return base + timedelta(days=BOARD_API_KEY_TTL_DAYS)
+
+
+# ---------------------------------------------------------------------------
+# Hermes per-profile .env writer.
+# ---------------------------------------------------------------------------
+
+# Profiles that get the PAPERCLIP_API_KEY. ``main`` is the only profile
+# whose config.yaml currently registers the paperclip MCP server, but
+# we write to all three for symmetry — if a future config.yaml seeds
+# the MCP server on workers/heavy too (e.g. for a "list issues" tool
+# call from a workers-routed task), the env will already be in place.
+DEFAULT_HERMES_PROFILES: tuple[str, ...] = ("main", "workers", "heavy")
+
+# Env var name. The MCP server reads this (config.js
+# ``readConfigFromEnv`` throws "Missing PAPERCLIP_API_KEY" without it).
+PAPERCLIP_API_KEY_NAME = "PAPERCLIP_API_KEY"
+
+
+def write_paperclip_api_key_to_profiles(
+    *,
+    hermes_state_dir: str | Path,
+    token: str,
+    company_id: str | None = None,
+    agent_id: str | None = None,
+    profiles: tuple[str, ...] = DEFAULT_HERMES_PROFILES,
+) -> list[Path]:
+    """Upsert ``PAPERCLIP_API_KEY=<token>`` (+ optional company/agent
+    ids) in each profile's ``.env``.
+
+    Mirrors the line-by-line "set or append" pattern in
+    bootstrap-paperclip.sh's step 11b. Idempotent: re-running with a
+    new token replaces the existing line; re-running with the same
+    token is a no-op (functionally — the line gets re-written with
+    identical contents).
+
+    ``company_id`` / ``agent_id`` are optional and only written when
+    non-empty. They become defaults for the MCP server's
+    ``resolveCompanyId`` / ``resolveAgentId`` so the LLM doesn't need
+    to thread the UUIDs through every tool call. Without them, every
+    company-scoped tool surfaces "companyId is required because
+    PAPERCLIP_COMPANY_ID is not set".
+
+    File permissions: 0600 (matches what render_hermes writes). Each
+    profile's ``.env`` is owned by uid 10000 (the hermes UID); we
+    preserve that on rewrite if we can.
+
+    Returns the list of paths we touched, for logging/tests.
+    """
+    if not token:
+        raise ValueError("token is empty; refusing to write empty PAPERCLIP_API_KEY")
+    if not token.startswith(BOARD_API_KEY_PREFIX):
+        # Don't strictly enforce — an operator's hand-issued board key
+        # might come from a future Paperclip release with a different
+        # prefix. Just warn-via-print so the bootstrap log makes the
+        # decision visible.
+        print(
+            f"[paperclip-board-key] WARN: token prefix is not "
+            f"{BOARD_API_KEY_PREFIX!r}; writing anyway"
+        )
+
+    extras: dict[str, str] = {}
+    if company_id:
+        extras["PAPERCLIP_COMPANY_ID"] = company_id
+    if agent_id:
+        extras["PAPERCLIP_AGENT_ID"] = agent_id
+
+    hermes_state = Path(hermes_state_dir)
+    written: list[Path] = []
+    for profile in profiles:
+        profile_dir = hermes_state / "profiles" / profile
+        if not profile_dir.is_dir():
+            # Hermes only creates profile dirs that are enabled in
+            # render_hermes.py's PROFILES list; skip missing ones
+            # silently so this works on a future ``main``-only build.
+            continue
+        env_path = profile_dir / ".env"
+        _upsert_env_key(env_path, PAPERCLIP_API_KEY_NAME, token)
+        for k, v in extras.items():
+            _upsert_env_key(env_path, k, v)
+        written.append(env_path)
+    return written
+
+
+def _upsert_env_key(env_path: Path, key: str, value: str) -> None:
+    """Set ``KEY=VALUE`` in an ``.env`` file, preserving everything else.
+
+    Atomic via temp-file + rename so a partial write never leaves the
+    file truncated (matches bootstrap-paperclip.sh's step 11b pattern).
+    """
+    existing_lines = env_path.read_text().splitlines() if env_path.exists() else []
+    out_lines: list[str] = []
+    seen = False
+    for line in existing_lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            out_lines.append(line)
+            continue
+        eq = stripped.find("=")
+        if eq < 0:
+            out_lines.append(line)
+            continue
+        k = stripped[:eq].strip()
+        if k == key:
+            out_lines.append(f"{key}={value}")
+            seen = True
+        else:
+            out_lines.append(line)
+    if not seen:
+        out_lines.append(f"{key}={value}")
+
+    tmp_path = env_path.with_suffix(env_path.suffix + ".paperclip-board.tmp")
+    tmp_path.write_text("\n".join(out_lines) + "\n")
+    try:
+        tmp_path.chmod(0o600)
+    except PermissionError:
+        # Filesystem doesn't support chmod (e.g. tmpfs on some CI
+        # images) — proceed; permissions get inherited from rename.
+        pass
+    os.replace(tmp_path, env_path)
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint — used by the bash hot-fix script.
+# ---------------------------------------------------------------------------
+
+
+def _main_write_token() -> int:
+    """CLI shim: write PAPERCLIP_API_KEY into hermes profile .envs.
+
+    Args via env:
+      * HERMES_STATE_DIR — directory of the hermes_data volume (e.g.
+        /hermes-state when mounted into a container, or the host
+        ``/var/lib/docker/volumes/alfred-black_hermes_data/_data``).
+      * PAPERCLIP_BOARD_API_TOKEN — the ``pcp_board_…`` token to write.
+
+    Exit codes: 0 success, 2 misconfig, 1 IO error.
+    """
+    state_dir = os.environ.get("HERMES_STATE_DIR", "").strip()
+    token = os.environ.get("PAPERCLIP_BOARD_API_TOKEN", "").strip()
+    if not state_dir or not token:
+        print(
+            "ERROR: HERMES_STATE_DIR and PAPERCLIP_BOARD_API_TOKEN are required",
+            flush=True,
+        )
+        return 2
+    written = write_paperclip_api_key_to_profiles(
+        hermes_state_dir=state_dir,
+        token=token,
+    )
+    for path in written:
+        print(f"[paperclip-board-key] wrote PAPERCLIP_API_KEY -> {path}")
+    if not written:
+        print(
+            f"[paperclip-board-key] WARN: no profile dirs under "
+            f"{state_dir}/profiles — nothing written"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main_write_token())

--- a/packages/hermes/init/test_paperclip_board_key.py
+++ b/packages/hermes/init/test_paperclip_board_key.py
@@ -1,0 +1,413 @@
+"""Tests for paperclip_board_key.py — board API key wiring for Hermes' MCP server.
+
+These tests pin three invariants:
+
+  1. The token shape we generate matches Paperclip's
+     ``createBoardApiToken`` so the auth middleware's sha256-and-lookup
+     verifies our tokens identically to ones minted by the upstream
+     CLI.
+  2. ``write_paperclip_api_key_to_profiles`` is idempotent + preserves
+     other env keys — the merge-preserve invariant in render_hermes.py
+     stays intact, but our writes don't depend on it.
+  3. The cli-auth challenge HTTP flow uses the right shape: POST to
+     ``/api/cli-auth/challenges`` then ``…/:id/approve`` with the
+     challenge secret in the body. We mock urlopen because the real
+     Paperclip embedded postgres isn't available in CI.
+
+The 2026-05-27 incident: Hermes' Paperclip MCP server 401-ed on every
+tool call because ``PAPERCLIP_API_KEY`` was never set in any profile
+``.env``. PR #84 wired the *agent* token into /opt/alfred/.env but the
+MCP tools need a *board* key. Don't lose this distinction in a refactor.
+"""
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import sys
+from http.cookiejar import CookieJar
+from pathlib import Path
+from unittest.mock import patch
+
+# Make the module importable without installing.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from paperclip_board_key import (  # type: ignore
+    BOARD_API_KEY_PREFIX,
+    BOARD_API_KEY_TOKEN_BYTES,
+    DEFAULT_HERMES_PROFILES,
+    PAPERCLIP_API_KEY_NAME,
+    _upsert_env_key,
+    board_api_key_expires_at,
+    generate_board_api_token,
+    hash_bearer_token,
+    mint_board_key_via_api,
+    write_paperclip_api_key_to_profiles,
+)
+
+
+# ---------------------------------------------------------------------------
+# Token-shape pins — must stay byte-compatible with services/board-auth.js
+# ---------------------------------------------------------------------------
+
+
+def test_generate_board_api_token_shape() -> None:
+    token = generate_board_api_token()
+    # Prefix matches Paperclip's createBoardApiToken
+    assert token.startswith(BOARD_API_KEY_PREFIX) == True
+    # 24 random bytes hex-encoded = 48 chars + 10-char prefix = 58 total
+    assert len(token) == len(BOARD_API_KEY_PREFIX) + BOARD_API_KEY_TOKEN_BYTES * 2
+    # All-lowercase hex after the prefix
+    suffix = token[len(BOARD_API_KEY_PREFIX):]
+    int(suffix, 16)  # raises ValueError if not hex
+
+
+def test_generate_board_api_token_is_random() -> None:
+    """Pull 100 tokens; they all differ. Catches a future regression
+    where someone seeds secrets.token_hex with a fixed value."""
+    tokens = {generate_board_api_token() for _ in range(100)}
+    assert len(tokens) == 100
+
+
+def test_hash_bearer_token_is_sha256_hex() -> None:
+    """Pin the hash algorithm — auth middleware verifies via
+    ``hashBearerToken`` in services/board-auth.js which is sha256 hex."""
+    token = "pcp_board_deadbeef" + ("0" * 40)
+    expected = hashlib.sha256(token.encode("utf-8")).hexdigest()
+    assert hash_bearer_token(token) == expected
+    # 64 hex chars
+    assert len(hash_bearer_token(token)) == 64
+
+
+def test_board_api_key_expires_at_is_30_days_out() -> None:
+    """Paperclip's BOARD_API_KEY_TTL_MS is 30*24*60*60*1000.
+    Drift here means our keys would either expire early (breaking
+    tools after N<30 days) or never (drifting from upstream's
+    expectations)."""
+    from datetime import datetime, timezone
+    now = datetime(2026, 5, 27, 0, 0, 0, tzinfo=timezone.utc)
+    expires = board_api_key_expires_at(now)
+    delta = expires - now
+    assert delta.days == 30
+    assert delta.seconds == 0
+
+
+# ---------------------------------------------------------------------------
+# Env writer — idempotency + preservation
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_env_key_creates_missing_file(tmp_path: Path) -> None:
+    env_path = tmp_path / ".env"
+    _upsert_env_key(env_path, PAPERCLIP_API_KEY_NAME, "pcp_board_test")
+    assert env_path.exists()
+    content = env_path.read_text()
+    assert f"{PAPERCLIP_API_KEY_NAME}=pcp_board_test" in content
+
+
+def test_upsert_env_key_replaces_existing_value(tmp_path: Path) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "OPENROUTER_API_KEY=keep-me\n"
+        f"{PAPERCLIP_API_KEY_NAME}=stale-value\n"
+        "TELEGRAM_BOT_TOKEN=keep-this-too\n"
+    )
+    _upsert_env_key(env_path, PAPERCLIP_API_KEY_NAME, "pcp_board_fresh")
+    text = env_path.read_text()
+    # Stale value gone, fresh value present
+    assert "stale-value" not in text
+    assert "pcp_board_fresh" in text
+    # Other keys preserved verbatim, in the same relative position
+    assert "OPENROUTER_API_KEY=keep-me" in text
+    assert "TELEGRAM_BOT_TOKEN=keep-this-too" in text
+
+
+def test_upsert_env_key_appends_when_absent(tmp_path: Path) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "API_SERVER_PORT=18789\n"
+        "OPENROUTER_API_KEY=foo\n"
+    )
+    _upsert_env_key(env_path, PAPERCLIP_API_KEY_NAME, "pcp_board_new")
+    lines = env_path.read_text().splitlines()
+    # Existing keys untouched
+    assert "API_SERVER_PORT=18789" in lines
+    assert "OPENROUTER_API_KEY=foo" in lines
+    # New key appended
+    assert f"{PAPERCLIP_API_KEY_NAME}=pcp_board_new" in lines
+
+
+def test_upsert_env_key_preserves_comments_and_blanks(tmp_path: Path) -> None:
+    """Pin that we don't gobble # comments / blank lines — operators
+    sometimes annotate the .env, and even render_hermes uses the
+    preservation footer as a marker line."""
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "# Runtime keys (preserved across init re-renders)\n"
+        "\n"
+        "OPENROUTER_API_KEY=foo\n"
+        "# this is a hand-written note from the operator\n"
+        f"{PAPERCLIP_API_KEY_NAME}=old\n"
+    )
+    _upsert_env_key(env_path, PAPERCLIP_API_KEY_NAME, "new")
+    text = env_path.read_text()
+    assert "# Runtime keys (preserved across init re-renders)" in text
+    assert "# this is a hand-written note from the operator" in text
+    assert f"{PAPERCLIP_API_KEY_NAME}=new" in text
+    assert "=old" not in text
+
+
+def test_upsert_env_key_atomic_no_partial_writes(tmp_path: Path) -> None:
+    """Pin: temp file is renamed in one step. We verify that after a
+    successful write, no .tmp sibling remains (regression check for a
+    future refactor that forgets the rename)."""
+    env_path = tmp_path / ".env"
+    env_path.write_text("FOO=bar\n")
+    _upsert_env_key(env_path, PAPERCLIP_API_KEY_NAME, "x")
+    siblings = sorted(p.name for p in env_path.parent.iterdir())
+    assert siblings == [".env"]
+
+
+def test_write_paperclip_api_key_writes_all_present_profiles(tmp_path: Path) -> None:
+    state = tmp_path / "hermes-state"
+    for profile in DEFAULT_HERMES_PROFILES:
+        d = state / "profiles" / profile
+        d.mkdir(parents=True)
+        (d / ".env").write_text("API_SERVER_PORT=18789\n")
+    written = write_paperclip_api_key_to_profiles(
+        hermes_state_dir=state,
+        token="pcp_board_" + ("a" * 48),
+    )
+    assert len(written) == len(DEFAULT_HERMES_PROFILES)
+    for path in written:
+        content = path.read_text()
+        assert f"{PAPERCLIP_API_KEY_NAME}=pcp_board_" in content
+        # API_SERVER_PORT preserved
+        assert "API_SERVER_PORT=18789" in content
+
+
+def test_write_paperclip_api_key_skips_missing_profile_dirs(tmp_path: Path) -> None:
+    """Only writes into profile dirs that exist — supports a future
+    main-only build without dragging dead writes into nonexistent
+    workers/heavy dirs."""
+    state = tmp_path / "hermes-state"
+    (state / "profiles" / "main").mkdir(parents=True)
+    (state / "profiles" / "main" / ".env").write_text("")
+    # No workers/, no heavy/ — should silently skip
+    written = write_paperclip_api_key_to_profiles(
+        hermes_state_dir=state,
+        token="pcp_board_" + ("b" * 48),
+    )
+    assert len(written) == 1
+    assert written[0] == state / "profiles" / "main" / ".env"
+
+
+def test_write_paperclip_api_key_rejects_empty_token(tmp_path: Path) -> None:
+    state = tmp_path / "hermes-state"
+    (state / "profiles" / "main").mkdir(parents=True)
+    try:
+        write_paperclip_api_key_to_profiles(hermes_state_dir=state, token="")
+    except ValueError as exc:
+        assert "empty" in str(exc).lower()
+    else:
+        assert False, "empty token should raise ValueError"
+
+
+def test_write_paperclip_api_key_also_writes_company_and_agent_ids(tmp_path: Path) -> None:
+    """When company_id / agent_id are supplied, they land alongside
+    PAPERCLIP_API_KEY in each profile's .env. The MCP server reads them
+    as default fillers for the resolveCompanyId / resolveAgentId paths
+    so the LLM doesn't need to thread UUIDs through every tool call."""
+    state = tmp_path / "hermes-state"
+    (state / "profiles" / "main").mkdir(parents=True)
+    (state / "profiles" / "main" / ".env").write_text("API_SERVER_PORT=18789\n")
+
+    written = write_paperclip_api_key_to_profiles(
+        hermes_state_dir=state,
+        token="pcp_board_" + ("c" * 48),
+        company_id="company-uuid-1",
+        agent_id="agent-uuid-1",
+    )
+
+    assert len(written) == 1
+    text = written[0].read_text()
+    assert "PAPERCLIP_API_KEY=pcp_board_" in text
+    assert "PAPERCLIP_COMPANY_ID=company-uuid-1" in text
+    assert "PAPERCLIP_AGENT_ID=agent-uuid-1" in text
+    # Existing keys preserved
+    assert "API_SERVER_PORT=18789" in text
+
+
+def test_write_paperclip_api_key_skips_empty_company_or_agent_ids(tmp_path: Path) -> None:
+    """Optional args: empty / None values must NOT write empty .env lines.
+    Otherwise re-running on a tenant that hasn't seeded the company yet
+    would persist an empty PAPERCLIP_COMPANY_ID=, which the MCP server's
+    `nonEmpty()` reads as null — better to leave the var unset entirely.
+    """
+    state = tmp_path / "hermes-state"
+    (state / "profiles" / "main").mkdir(parents=True)
+    (state / "profiles" / "main" / ".env").write_text("")
+    write_paperclip_api_key_to_profiles(
+        hermes_state_dir=state,
+        token="pcp_board_" + ("d" * 48),
+        company_id="",  # falsy
+        agent_id=None,
+    )
+    text = (state / "profiles" / "main" / ".env").read_text()
+    assert "PAPERCLIP_API_KEY=" in text
+    assert "PAPERCLIP_COMPANY_ID" not in text
+    assert "PAPERCLIP_AGENT_ID" not in text
+
+
+# ---------------------------------------------------------------------------
+# HTTP API path — mock urlopen, verify the two-call ritual
+# ---------------------------------------------------------------------------
+
+
+class _MockResponse:
+    """Stand-in for urllib's HTTPResponse object."""
+
+    def __init__(self, status: int, body: bytes) -> None:
+        self.status = status
+        self._body = body
+
+    def read(self) -> bytes:
+        return self._body
+
+
+def test_mint_board_key_via_api_happy_path() -> None:
+    """The two-call ritual succeeds and returns the boardApiToken from
+    step 1's response."""
+    cookies = CookieJar()
+
+    calls: list[tuple[str, str, dict]] = []
+
+    def fake_open(self, req, timeout=30):  # noqa: ARG001
+        body = req.data.decode("utf-8") if req.data else ""
+        calls.append((req.method, req.full_url, json.loads(body) if body else {}))
+        if req.full_url.endswith("/api/cli-auth/challenges"):
+            return _MockResponse(201, json.dumps({
+                "id": "challenge-abc",
+                "token": "secret-xyz",
+                "boardApiToken": "pcp_board_" + ("c" * 48),
+                "approvalPath": "/cli-auth/challenge-abc?token=secret-xyz",
+                "approvalUrl": None,
+                "pollPath": "/cli-auth/challenges/challenge-abc",
+                "expiresAt": "2026-06-26T00:00:00.000Z",
+                "suggestedPollIntervalMs": 1000,
+            }).encode("utf-8"))
+        if req.full_url.endswith("/api/cli-auth/challenges/challenge-abc/approve"):
+            return _MockResponse(200, json.dumps({
+                "approved": True,
+                "status": "approved",
+                "userId": "user-1",
+                "keyId": "key-1",
+                "expiresAt": "2026-06-26T00:00:00.000Z",
+            }).encode("utf-8"))
+        return _MockResponse(404, b'{"error":"not found"}')
+
+    with patch("urllib.request.OpenerDirector.open", fake_open):
+        token = mint_board_key_via_api(
+            internal_url="http://paperclip:3100",
+            public_url="https://paperclip.example.com",
+            cookies=cookies,
+        )
+
+    assert token == "pcp_board_" + ("c" * 48)
+    # Two POSTs in order: challenges then approve
+    assert len(calls) == 2
+    assert calls[0][0] == "POST"
+    assert calls[0][1].endswith("/api/cli-auth/challenges")
+    assert calls[1][0] == "POST"
+    assert calls[1][1].endswith("/api/cli-auth/challenges/challenge-abc/approve")
+    # The approve body carries the challenge secret (not the board token)
+    assert calls[1][2] == {"token": "secret-xyz"}
+
+
+def test_mint_board_key_via_api_propagates_400_with_body() -> None:
+    """Any non-2xx should surface the response body in the error so
+    bootstrap-paperclip.sh's die() can log the failing step."""
+    cookies = CookieJar()
+
+    def fake_open(self, req, timeout=30):  # noqa: ARG001
+        # Simulate the cli-auth challenges endpoint blowing up with 500
+        return _MockResponse(500, b'{"error":"db unavailable"}')
+
+    with patch("urllib.request.OpenerDirector.open", fake_open):
+        try:
+            mint_board_key_via_api(
+                internal_url="http://paperclip:3100",
+                public_url="https://paperclip.example.com",
+                cookies=cookies,
+            )
+        except RuntimeError as exc:
+            msg = str(exc)
+            assert "HTTP 500" in msg
+            assert "db unavailable" in msg
+        else:
+            assert False, "expected RuntimeError on HTTP 500"
+
+
+def test_mint_board_key_via_api_rejects_unapproved_status() -> None:
+    """If step 2 returns approved=false (e.g. expired challenge),
+    we must NOT return the pending token — that key has never been
+    activated and every API call with it would 401."""
+    cookies = CookieJar()
+
+    def fake_open(self, req, timeout=30):  # noqa: ARG001
+        if req.full_url.endswith("/api/cli-auth/challenges"):
+            return _MockResponse(201, json.dumps({
+                "id": "challenge-1",
+                "token": "secret-1",
+                "boardApiToken": "pcp_board_" + ("d" * 48),
+                "approvalPath": "/cli-auth/challenge-1?token=secret-1",
+                "approvalUrl": None,
+                "pollPath": "/cli-auth/challenges/challenge-1",
+                "expiresAt": "2026-06-26T00:00:00.000Z",
+                "suggestedPollIntervalMs": 1000,
+            }).encode("utf-8"))
+        return _MockResponse(200, json.dumps({
+            "approved": False,
+            "status": "expired",
+            "userId": "user-1",
+            "keyId": None,
+            "expiresAt": "2026-06-26T00:00:00.000Z",
+        }).encode("utf-8"))
+
+    with patch("urllib.request.OpenerDirector.open", fake_open):
+        try:
+            mint_board_key_via_api(
+                internal_url="http://paperclip:3100",
+                public_url="https://paperclip.example.com",
+                cookies=cookies,
+            )
+        except RuntimeError as exc:
+            assert "approved" in str(exc).lower()
+        else:
+            assert False, "must reject unapproved challenge"
+
+
+def test_mint_board_key_via_api_missing_fields_in_step1() -> None:
+    """Step 1 returns 200 but the response is missing the boardApiToken
+    — defensive: a Paperclip refactor that renamed the field would
+    silently fall through to an empty-string return without this guard."""
+    cookies = CookieJar()
+
+    def fake_open(self, req, timeout=30):  # noqa: ARG001
+        return _MockResponse(201, json.dumps({
+            "id": "challenge-1",
+            "token": "secret-1",
+            # boardApiToken missing
+        }).encode("utf-8"))
+
+    with patch("urllib.request.OpenerDirector.open", fake_open):
+        try:
+            mint_board_key_via_api(
+                internal_url="http://paperclip:3100",
+                public_url="https://paperclip.example.com",
+                cookies=cookies,
+            )
+        except RuntimeError as exc:
+            assert "boardApiToken" in str(exc) or "missing" in str(exc).lower()
+        else:
+            assert False, "must reject missing boardApiToken"


### PR DESCRIPTION
## Root cause

Live-observed in PR #87's smoke test on home.alfred.black 2026-05-27:
every Paperclip MCP tool call from Hermes 401-ed. Diagnosis:

- Hermes' baked `@paperclipai/mcp-server@2026.525.0` reads
  `PAPERCLIP_API_KEY` from process env and sends
  `Authorization: Bearer ${PAPERCLIP_API_KEY}` on every call.
- Paperclip's auth middleware recognises **three** bearer shapes:
  `pcp_board_<48hex>` (board), `pcp_<48hex>` (agent), local JWT.
- The 39-of-40 company-scoped tools call `/api/companies/<id>/...`
  which 403 with `{"error":"Board access required"}` on agent scope.
- PR #84 wired the **agent** token into `/opt/alfred/.env` as
  `PAPERCLIP_AGENT_TOKEN` (correct for Paperclip → Hermes heartbeats,
  PR #87).
- **`PAPERCLIP_API_KEY` was never written anywhere** — the upstream
  skill assumed the principal would paste a key from Paperclip's UI.

So the *right* token for the MCP server (board scope) didn't exist on
any tenant, AND the env var pointing at it was unset.

## Fix

Two-path wiring + bootstrap update + hot-fix for live tenants:

### Path 1 — fresh tenants (`bootstrap-paperclip.sh` step 12)

Right after the existing agent-token mint (step 10–11), call the new
`paperclip_board_key.mint_board_key_via_api()`:
1. `POST /api/cli-auth/challenges` → pending `pcp_board_…` token
2. `POST /api/cli-auth/challenges/<id>/approve` (uses the session
   cookie from step 6's sign-up of `alfred@<DOMAIN>`) → activates it
3. Write `PAPERCLIP_API_KEY` + `PAPERCLIP_COMPANY_ID` +
   `PAPERCLIP_AGENT_ID` into each Hermes profile's `.env`

Non-fatal: a mint failure leaves the agent-token path intact and the
operator can run the hot-fix script later.

### Path 2 — already-seeded tenants (`migrate-paperclip-board-key.sh`)

Tenants where `bootstrap-paperclip.sh` already ran can't recover the
seed password (it was never persisted to a stable location for them).
This standalone script:
1. Generates a `pcp_board_<48hex>` token, sha256-hashes it
2. `INSERT INTO board_api_keys` against the embedded postgres
   (bypasses Better-Auth — safe because we read user_id from the
   same DB and use the same hash the auth middleware verifies)
3. Writes PAPERCLIP_API_KEY/COMPANY_ID/AGENT_ID into each profile
4. Surgically inserts/patches `paperclip:` block in `config.yaml`
   (operator-owned, so existing tenants miss it from PR #67)
5. Restarts hermes

## Files

| File | Change |
|---|---|
| `packages/hermes/init/paperclip_board_key.py` | New lib (`mint_board_key_via_api`, `write_paperclip_api_key_to_profiles`, atomic env upsert) |
| `packages/hermes/init/test_paperclip_board_key.py` | New, 18 tests |
| `packages/hermes/init/bootstrap-paperclip.sh` | + step 12 wiring |
| `packages/hermes/init/migrate-paperclip-board-key.sh` | New hot-fix script |
| `packages/hermes/init/Dockerfile` | + COPY `paperclip_board_key.py` |
| `packages/hermes/hermes-config.yaml.njk` | + `PAPERCLIP_COMPANY_ID` / `PAPERCLIP_AGENT_ID` in MCP env block |
| `docker-compose.yaml` | `paperclip-init` mounts `hermes_data:/hermes-state` |

## Tests

```
test_paperclip_board_key.py ............ 18 passed
test_render_preserve.py ................. 10 passed
============================== 28 passed ==============================
```

Tests pin: token byte-compatibility with Paperclip's
`createBoardApiToken`, sha256 hashing, 30-day expiry TTL, idempotent
env upsert (including comment/blank-line preservation + atomic
temp-rename), optional company/agent id args, plus the cli-auth flow
with mocked urlopen (happy path, HTTP 500 body propagation,
unapproved-status rejection, missing-field defence).

## Live verification

All 5 active tenants (home, rj, joe, zsolt, miguel) hot-fixed with
`migrate-paperclip-board-key.sh`. End-to-end test on each:

```
$ curl -X POST http://hermes:18789/v1/responses \
    -H "Authorization: Bearer <hermes-key>" \
    -d '{"input": "Call paperclipListIssues. Report the result."}'
STATUS=completed RESULT={"result": "[]"}
```

No 401, no "Board access required", real (empty) result list returned.

## Residual risks

- `config.yaml` is operator-owned (init never re-renders). The hot-fix
  surgically patches it; the regex was hardened mid-migration after
  joe's workers profile turned out to have `mcp_servers:` as the LAST
  top-level section (no trailing `plugins:` anchor). Logged + tests
  cover the post-fix regex.
- The board API key TTL is **30 days** (matches Paperclip's
  `BOARD_API_KEY_TTL_MS`). After 30 days the MCP tools start 401-ing
  again. The skill memory should note this; a long-term fix is a key
  rotation cron or a TTL bump — out of scope for this PR.
- The `mint_board_key_via_db` path needs the embedded postgres
  reachable on `127.0.0.1:54329` inside the paperclip container — the
  current default. A future Paperclip release that exposes pg
  differently would need the connector updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)