### PR TITLE
fix(voice-bridge): wait for session.updated ACK before resolving connect()

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -39,6 +39,26 @@ jobs:
         working-directory: packages/ctrl
         run: node build.mjs
 
+  test-voice-bridge:
+    # tsc compile + node --test for the OpenAI Realtime session-update race fix.
+    # Mock WS server is in-process; no network or OpenAI key needed (a dummy
+    # key satisfies config.ts's required-env check).
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Install deps
+        working-directory: packages/voice-bridge
+        run: npm ci || npm install
+      - name: tsc + node --test
+        working-directory: packages/voice-bridge
+        env:
+          OPENAI_API_KEY: sk-ci-dummy
+          VOICE_BRIDGE_INTERNAL_TOKEN: ci-dummy-token
+        run: npm test
+
   pytest-learn:
     runs-on: ubuntu-latest
     steps:

--- a/packages/voice-bridge/package.json
+++ b/packages/voice-bridge/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/server.js",
-    "dev": "tsc --watch"
+    "dev": "tsc --watch",
+    "test": "tsc && node --test dist/*.test.js"
   },
   "engines": {
     "node": ">=22"

--- a/packages/voice-bridge/src/config.ts
+++ b/packages/voice-bridge/src/config.ts
@@ -45,6 +45,14 @@ export const config = {
   openaiApiKey: required("OPENAI_API_KEY"),
   openaiModel: optional("OPENAI_REALTIME_MODEL", "gpt-realtime-2"),
   openaiVoice: optional("OPENAI_REALTIME_VOICE", "cedar"),
+  // Optional override for the OpenAI Realtime WS base URL. Production leaves
+  // this empty and points at wss://api.openai.com/v1/realtime. Tests set it
+  // to ws://localhost:<port> with a mock server emulating session.created /
+  // session.updated to validate the connect-handshake race fix.
+  openaiRealtimeBaseUrl: optional(
+    "OPENAI_REALTIME_BASE_URL",
+    "wss://api.openai.com/v1/realtime",
+  ),
 
   // Twilio account auth token — used to verify X-Twilio-Signature on the
   // inbound TwiML webhook. When empty we still serve TwiML but log a

--- a/packages/voice-bridge/src/openai-realtime.test.ts
+++ b/packages/voice-bridge/src/openai-realtime.test.ts
@@ -1,0 +1,206 @@
+// openai-realtime.test.ts — integration tests for the connect-handshake race fix.
+//
+// The 2026-05-28 voice-bridge regression had `connect()` resolve on
+// `session.created` (default config in effect) rather than on
+// `session.updated` (our persona/VAD/tools applied). Twilio media frames and
+// the greeting trigger could therefore reach the model before its
+// configuration applied — producing dead-on-arrival hallucinations + a
+// non-interruptible turn-detector.
+//
+// These tests stand up a tiny mock OpenAI Realtime WS server and assert:
+//   1. connect() does NOT resolve on session.created alone — even after the
+//      server-side session.update has been seen — until session.updated lands.
+//   2. connect() rejects if session.updated never arrives within the 5s
+//      timeout (we use a shorter timeout via env override for test speed).
+//   3. appendAudio + triggerGreeting are no-ops while sessionReady is false.
+//
+// Runs under `node --test`. No mocha/jest dep added — just Node 22's
+// builtin test runner.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { WebSocketServer } from "ws";
+import type { AddressInfo } from "node:net";
+
+// IMPORTANT: env must be set before importing the SUT module, because config.ts
+// reads env at module-load time.
+process.env.OPENAI_API_KEY = process.env.OPENAI_API_KEY ?? "sk-test-dummy";
+process.env.VOICE_BRIDGE_INTERNAL_TOKEN =
+  process.env.VOICE_BRIDGE_INTERNAL_TOKEN ?? "test-internal-token";
+
+interface MockServer {
+  wss: WebSocketServer;
+  port: number;
+  close: () => Promise<void>;
+}
+
+async function startMockOpenAI(handler: (ws: any) => void): Promise<MockServer> {
+  const wss = new WebSocketServer({ port: 0 });
+  await new Promise<void>((resolve) => wss.once("listening", () => resolve()));
+  const port = (wss.address() as AddressInfo).port;
+  wss.on("connection", (ws) => {
+    handler(ws);
+  });
+  return {
+    wss,
+    port,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        wss.close((err) => (err ? reject(err) : resolve())),
+      ),
+  };
+}
+
+test("connect() resolves only after session.updated, not session.created", async () => {
+  let sessionUpdateSeen: any = null;
+  const server = await startMockOpenAI((ws) => {
+    // 1. send session.created immediately
+    ws.send(JSON.stringify({ type: "session.created", session: { id: "s_test" } }));
+    // 2. record the client's session.update, then delay the ACK by 200ms
+    ws.on("message", (raw: Buffer) => {
+      const ev = JSON.parse(raw.toString());
+      if (ev.type === "session.update") {
+        sessionUpdateSeen = ev;
+        setTimeout(() => {
+          ws.send(
+            JSON.stringify({
+              type: "session.updated",
+              session: ev.session,
+            }),
+          );
+        }, 200);
+      }
+    });
+  });
+
+  try {
+    process.env.OPENAI_REALTIME_BASE_URL = `ws://127.0.0.1:${server.port}/`;
+    const { OpenAIRealtimeClient } = await import("./openai-realtime.js");
+    const client = new OpenAIRealtimeClient("test-1");
+
+    const start = Date.now();
+    let resolvedAt: number | null = null;
+    let readyAtResolve = false;
+    const connectP = client
+      .connect({ instructions: "test persona" })
+      .then(() => {
+        resolvedAt = Date.now();
+        readyAtResolve = client.isReady;
+      });
+
+    // After 50ms (session.created should have arrived, session.updated should NOT),
+    // connect must still be pending.
+    await new Promise((r) => setTimeout(r, 50));
+    assert.equal(resolvedAt, null, "connect resolved on session.created — race regressed");
+    assert.equal(client.isReady, false, "isReady true before session.updated — regression");
+
+    await connectP;
+    assert.ok(resolvedAt !== null, "connect never resolved");
+    assert.ok(readyAtResolve, "isReady was false when connect resolved");
+    assert.ok(
+      (resolvedAt as number) - start >= 180,
+      `connect resolved too fast (${(resolvedAt as number) - start}ms) — must wait for session.updated (~200ms)`,
+    );
+    assert.ok(sessionUpdateSeen, "server never received session.update from client");
+    // GA-schema sanity: payload still has the expected nested shape.
+    assert.equal(sessionUpdateSeen.session.type, "realtime");
+    assert.equal(
+      sessionUpdateSeen.session.audio.input.turn_detection.type,
+      "semantic_vad",
+    );
+    assert.equal(
+      sessionUpdateSeen.session.audio.input.turn_detection.interrupt_response,
+      true,
+    );
+
+    client.close();
+  } finally {
+    await server.close();
+  }
+});
+
+test("appendAudio is dropped while sessionReady is false", async () => {
+  // Server that sends session.created + NEVER session.updated.
+  const audioReceived: string[] = [];
+  const server = await startMockOpenAI((ws) => {
+    ws.send(JSON.stringify({ type: "session.created", session: { id: "s_test2" } }));
+    ws.on("message", (raw: Buffer) => {
+      const ev = JSON.parse(raw.toString());
+      if (ev.type === "input_audio_buffer.append") audioReceived.push(ev.audio);
+    });
+  });
+
+  try {
+    process.env.OPENAI_REALTIME_BASE_URL = `ws://127.0.0.1:${server.port}/`;
+    const { OpenAIRealtimeClient } = await import("./openai-realtime.js");
+    const client = new OpenAIRealtimeClient("test-drop");
+
+    // Don't await connect — it'll never resolve. Start it then probe.
+    client.connect({ instructions: "test" }).catch(() => {
+      /* expected to reject on timeout */
+    });
+
+    // Give the WS time to open + session.created to flow.
+    await new Promise((r) => setTimeout(r, 100));
+    assert.equal(client.isReady, false);
+
+    // appendAudio should silently drop the chunk.
+    client.appendAudio("AAAA");
+    client.appendAudio("BBBB");
+
+    // Give the WS a tick to forward anything that might have been sent.
+    await new Promise((r) => setTimeout(r, 50));
+    assert.deepEqual(
+      audioReceived,
+      [],
+      "appendAudio leaked audio to the model before session.updated",
+    );
+
+    // triggerGreeting must also no-op pre-ack.
+    client.triggerGreeting();
+    await new Promise((r) => setTimeout(r, 50));
+
+    client.close();
+  } finally {
+    await server.close();
+  }
+});
+
+test("connect() rejects if session.updated never arrives", async () => {
+  // Stub the timeout via env: the SUT reads SESSION_UPDATE_ACK_TIMEOUT_MS as a
+  // const, but for this test we set the base URL to a server that sends
+  // session.created and then sits silent. The real 5s timeout would make the
+  // test slow, so we shorten it via the dedicated test env (read by SUT).
+  process.env.VOICE_BRIDGE_ACK_TIMEOUT_MS_FOR_TEST = "500";
+
+  const server = await startMockOpenAI((ws) => {
+    ws.send(JSON.stringify({ type: "session.created", session: { id: "s_silent" } }));
+    // ... and never reply to session.update
+  });
+
+  try {
+    process.env.OPENAI_REALTIME_BASE_URL = `ws://127.0.0.1:${server.port}/`;
+    const { OpenAIRealtimeClient } = await import("./openai-realtime.js");
+    const client = new OpenAIRealtimeClient("test-timeout");
+
+    const start = Date.now();
+    let rejectErr: Error | null = null;
+    try {
+      await client.connect({ instructions: "test" });
+    } catch (err) {
+      rejectErr = err as Error;
+    }
+    const elapsed = Date.now() - start;
+
+    assert.ok(rejectErr, "connect did not reject on missing session.updated");
+    assert.match(rejectErr!.message, /session\.update ACK timeout|WS closed/);
+    // Allow a wide window — even the 5s prod default would pass; we just want
+    // to know it eventually errored.
+    assert.ok(elapsed < 6_000, `timeout took too long: ${elapsed}ms`);
+
+    client.close();
+  } finally {
+    await server.close();
+    delete process.env.VOICE_BRIDGE_ACK_TIMEOUT_MS_FOR_TEST;
+  }
+});

--- a/packages/voice-bridge/src/openai-realtime.ts
+++ b/packages/voice-bridge/src/openai-realtime.ts
@@ -28,9 +28,44 @@
 //                                                 auto-cancels assistant per VAD config)
 //   conversation.item.input_audio_transcription.completed — user-utterance transcript
 //   error                                       — log + continue
+//
+// Connection handshake (race-safe — fixed 2026-05-28):
+//
+//   1. ws.open
+//   2. server → session.created          (default config in effect)
+//   3. client → session.update           (persona + VAD + tools)
+//   4. server → session.updated          (config now applied)  ← connect() resolves HERE
+//
+// The previous implementation resolved on step 2, which meant the model could
+// receive `response.create` (greeting trigger) or `input_audio_buffer.append`
+// (Twilio media) before step 4 applied. Symptoms were:
+//   * agent freelancing on the default persona instead of the RP butler
+//   * default turn-detection (no semantic VAD interrupt) → not interruptible
+//   * voice defaulted to generic American
+// The race window is small (~100–500ms on OpenAI's side) but Twilio media
+// streams start the moment Twilio gets a "start" event, so it hit every call.
 
 import { WebSocket as WsSocket } from "ws";
 import { config } from "./config.js";
+
+// Timeout for the session.update ACK. If `session.updated` doesn't land within
+// this window after we send `session.update`, we error the call hard rather
+// than silently running on default OpenAI Realtime config.
+//
+// Production default is 5s. Tests override via VOICE_BRIDGE_ACK_TIMEOUT_MS_FOR_TEST
+// so they don't have to sit on the prod timeout for every negative case. The
+// override is read at call-time, not at module-load time, because Node's test
+// runner sets env per-test.
+function ackTimeoutMs(): number {
+  const override = process.env.VOICE_BRIDGE_ACK_TIMEOUT_MS_FOR_TEST;
+  if (override) {
+    const n = Number(override);
+    if (Number.isFinite(n) && n > 0) return n;
+  }
+  return 5_000;
+}
+
+const DEBUG = process.env.VOICE_BRIDGE_DEBUG === "1";
 
 export interface RealtimeSessionConfig {
   instructions: string;
@@ -46,6 +81,11 @@ export class OpenAIRealtimeClient {
   private listeners = new Set<RealtimeListener>();
   private closed = false;
   private callId: string;
+  // True once OpenAI has echoed back `session.updated` confirming our persona
+  // + VAD + tools are applied. Until this flips, we MUST NOT send audio or
+  // request responses, otherwise the model runs on default config (generic
+  // assistant, server_vad / no interrupt, default voice).
+  private sessionReady = false;
 
   constructor(callId: string) {
     this.callId = callId;
@@ -55,13 +95,24 @@ export class OpenAIRealtimeClient {
     return !this.closed && this.ws?.readyState === this.ws?.OPEN;
   }
 
+  /** True once the model is configured with our persona/VAD/tools. */
+  get isReady(): boolean {
+    return this.isOpen && this.sessionReady;
+  }
+
   on(listener: RealtimeListener): void {
     this.listeners.add(listener);
   }
 
-  // Open the WS and wait for session.created. Resolves once configured.
+  // Open the WS, send session.update, and wait for the server's `session.updated`
+  // echo before resolving. Hard 5s timeout — we'd rather hang up than serve a
+  // call on the default OpenAI persona.
   async connect(sessionConfig: RealtimeSessionConfig): Promise<void> {
-    const url = `wss://api.openai.com/v1/realtime?model=${encodeURIComponent(config.openaiModel)}`;
+    // Read the base URL fresh at connect-time so tests can swap it between
+    // cases without having to reload the SUT module each time.
+    const baseUrl =
+      process.env.OPENAI_REALTIME_BASE_URL ?? config.openaiRealtimeBaseUrl;
+    const url = `${baseUrl}${baseUrl.includes("?") ? "&" : "?"}model=${encodeURIComponent(config.openaiModel)}`;
     return new Promise((resolve, reject) => {
       // GA endpoint does NOT want the `OpenAI-Beta: realtime=v1` header — it
       // silently flips the session into a compat mode that rejects GA-shape
@@ -72,6 +123,19 @@ export class OpenAIRealtimeClient {
         },
       });
       this.ws = ws;
+
+      let settled = false;
+      let ackTimer: NodeJS.Timeout | null = null;
+      const settle = (err?: Error) => {
+        if (settled) return;
+        settled = true;
+        if (ackTimer) {
+          clearTimeout(ackTimer);
+          ackTimer = null;
+        }
+        if (err) reject(err);
+        else resolve();
+      };
 
       ws.on("open", () => {
         // Session config arrives *after* server emits session.created. Defer the
@@ -127,7 +191,34 @@ export class OpenAIRealtimeClient {
                 : {}),
             },
           });
-          resolve();
+          // Arm the ACK timeout — if `session.updated` doesn't arrive within
+          // this window we hang up rather than run on defaults.
+          const tmo = ackTimeoutMs();
+          ackTimer = setTimeout(() => {
+            settle(
+              new Error(
+                `session.update ACK timeout after ${tmo}ms — refusing to serve call on default config`,
+              ),
+            );
+          }, tmo);
+        }
+
+        if (event.type === "session.updated" && !this.sessionReady) {
+          this.sessionReady = true;
+          if (DEBUG) {
+            // One-line debug breadcrumb so future regressions can be diagnosed
+            // without a hot-patch. Set VOICE_BRIDGE_DEBUG=1 to enable.
+            const td = event.session?.audio?.input?.turn_detection;
+            const voice = event.session?.audio?.output?.voice;
+            const instrLen =
+              typeof event.session?.instructions === "string"
+                ? event.session.instructions.length
+                : -1;
+            console.log(
+              `[realtime ${this.callId}] session.updated turn_detection=${td?.type} voice=${voice} instrLen=${instrLen}`,
+            );
+          }
+          settle();
         }
 
         for (const l of this.listeners) {
@@ -149,12 +240,21 @@ export class OpenAIRealtimeClient {
             `[realtime ${this.callId}] WS closed code=${code} reason=${reason.toString()}`,
           );
         }
+        // If the WS closes before we got `session.updated`, surface that as a
+        // connect failure so the caller disposes the call cleanly.
+        if (!settled) {
+          settle(
+            new Error(
+              `WS closed before session.updated (code=${code} reason=${reason.toString()})`,
+            ),
+          );
+        }
       });
 
       ws.on("error", (err) => {
         console.error(`[realtime ${this.callId}] WS error`, err);
         if (this.ws?.readyState === this.ws?.CONNECTING) {
-          reject(err);
+          settle(err as Error);
         }
       });
     });
@@ -167,7 +267,15 @@ export class OpenAIRealtimeClient {
 
   // Append a base64 μ-law chunk to the model's input buffer. Twilio's payload
   // passes through unchanged — both sides speak g711_ulaw natively.
+  //
+  // Hard guard: if the session is not yet ready (session.updated unseen) we
+  // drop the chunk on the floor. Happy-path callers wait for `connect()` to
+  // resolve before sending audio, so this is defence-in-depth against a race
+  // regression and against early Twilio media frames slipping past
+  // VoiceCall.initialise() (which won't happen today — `this.realtime` is
+  // null until connect resolves — but we belt-and-braces it).
   appendAudio(payloadBase64: string): void {
+    if (!this.sessionReady) return;
     this.send({ type: "input_audio_buffer.append", audio: payloadBase64 });
   }
 
@@ -178,8 +286,16 @@ export class OpenAIRealtimeClient {
   }
 
   // Greet immediately on call connect — semantic VAD waits for user speech
-  // otherwise, which would mean dead air after pickup.
+  // otherwise, which would mean dead air after pickup. We only trigger the
+  // greeting AFTER `session.updated` has applied; until then `response.create`
+  // would run on the default persona (generic American assistant, no RP).
   triggerGreeting(): void {
+    if (!this.sessionReady) {
+      console.warn(
+        `[realtime ${this.callId}] triggerGreeting() called before session.updated — refusing`,
+      );
+      return;
+    }
     this.send({ type: "response.create" });
   }
 


### PR DESCRIPTION
## Symptoms

Phone calls on `home.alfred.black` were arriving with Alfred:
1. **Hallucinating** — making things up instead of using the RP-butler persona
2. **Not interruptible** — keeps talking when Sir starts speaking

Sir hung up a call frustrated 2026-05-28.

## Root cause

`OpenAIRealtimeClient.connect()` (in `packages/voice-bridge/src/openai-realtime.ts`) resolved on `session.created`, NOT on `session.updated`.

The handshake is:

```
1. ws.open
2. server → session.created          (default OpenAI persona in effect)
3. client → session.update           (RP butler + semantic_vad + interrupt_response + tools)
4. server → session.updated          (config now applied)  ← connect() now resolves HERE
```

Pre-fix, `connect()` resolved at step 2. Twilio media starts streaming on its own clock the moment its `start` event hits us, so for a ~100–500ms window:

- The greeting (`response.create` from `triggerGreeting()`) could run on the default persona → generic American "Hello! How can I help you today?" instead of "Yes, sir?" in RP
- Default turn-detection (no `interrupt_response: true`) → Alfred not interruptible

Both symptoms collapse into one cause.

## Evidence the schema itself is correct

Direct probe of `wss://api.openai.com/v1/realtime?model=gpt-realtime-2` from inside the home container with our exact `session.update` payload echoed back:

```
UPDATED.turn_detection {"type":"semantic_vad","eagerness":"medium","create_response":true,"interrupt_response":true}
UPDATED.voice "cedar"
UPDATED.instructions.len 41
```

Field-for-field identical to what we sent. So schema drift is **not** the cause — it's purely handshake timing.

## Changes

- **`openai-realtime.ts`** — resolve `connect()` on `session.updated`, not `session.created`. Hard 5s ACK timeout that errors the call (and propagates to `VoiceCall.initialise()` → `dispose("openai-connect-failed")`) rather than running on defaults. Adds `isReady` getter. `appendAudio` and `triggerGreeting` no-op while `sessionReady` is false (defence-in-depth).
- **`config.ts`** — opt-in `OPENAI_REALTIME_BASE_URL` override for tests (and a `VOICE_BRIDGE_DEBUG=1` flag that logs one line per `session.updated` echo, so future schema-drift regressions are diagnosable without a hot-patch).
- **`openai-realtime.test.ts`** (new) — three `node:test` cases against an in-process mock WS server:
  1. `connect()` does NOT resolve on `session.created`; waits for `session.updated` (~200ms artificial delay)
  2. `appendAudio` silently drops audio while `sessionReady` is false
  3. `connect()` rejects when `session.updated` never arrives
- **`ci-check.yml`** — new `test-voice-bridge` job runs `npm test`.

## Test output

```
✔ connect() resolves only after session.updated, not session.created (215.8ms)
✔ appendAudio is dropped while sessionReady is false (213.3ms)
✔ connect() rejects if session.updated never arrives (510.8ms)
ℹ tests 3 / pass 3 / fail 0
```

## Residual risks

- **Voice-context primer failure mode** — if `fetchVoiceContext` returns null, `buildInstructions` falls back to `BASELINE_PERSONA`. That path is already handled and unaffected by this fix, but a regression there would still cause "feels generic" calls.
- **Outbound call greeting** — `triggerGreeting()` is called synchronously after `await connect()`. With this fix, by then `sessionReady === true`, so the greeting is on the right config. Verified by tests.
- **Twilio media before `initialise()` completes** — already dropped today because `this.realtime` is null in that window. Unaffected.
- **5s timeout** — if OpenAI's `session.updated` ack takes longer than 5s (would be very unusual; the probe above acknowledged in <500ms), the call disposes hard with `openai-connect-failed`. That's the right failure mode per the task spec.

## Rollout

- CI green here, then merge.
- After merge the build-voice-bridge workflow republishes `ssdavidai00/alfred-voice-bridge:latest`. Each tenant picks it up on next `docker compose pull` + restart.
- The current home tenant still runs the hot-patched verbose-logging image; that hot-patch will be replaced when the durable image rolls out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)