### PR TITLE
fix(voice-bridge): compose default to gpt-realtime-2 + pass VOICE_BRIDGE_DEBUG through

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -583,8 +583,9 @@ services:
       # scripts/bootstrap.sh if absent.
       VOICE_BRIDGE_INTERNAL_TOKEN: ${VOICE_BRIDGE_INTERNAL_TOKEN}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
-      OPENAI_REALTIME_MODEL: ${OPENAI_REALTIME_MODEL:-gpt-realtime-1.5}
+      OPENAI_REALTIME_MODEL: ${OPENAI_REALTIME_MODEL:-gpt-realtime-2}
       OPENAI_REALTIME_VOICE: ${OPENAI_REALTIME_VOICE:-cedar}
+      VOICE_BRIDGE_DEBUG: "${VOICE_BRIDGE_DEBUG:-}"
       # ctrl-api is the "SaaS internal" surface on this single-VM build —
       # the bridge calls back for tenant lookup, tool dispatch, and (in
       # Phase 3) alfred_journal writes on transcript ingest.


### PR DESCRIPTION
PR #252 bumped the code-level default model but compose still defaulted to 1.5, so the code change never took effect on any tenant. Plus VOICE_BRIDGE_DEBUG (added in PR #90 for breadcrumb logging) wasn't mapped into the container, so the flag couldn't actually be enabled per-tenant. Both fixed.

Live-verified on home tonight: setting OPENAI_REALTIME_MODEL=gpt-realtime-2 + recreating voice-bridge actually flips the model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)