### PR TITLE
fix(hermes): paperclip can read Hermes profile .env without 401-storm

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1309,6 +1309,9 @@ services:
       # API_SERVER_KEY from the rendered profile .env. Without this the
       # adapter falls back to no Authorization header and Hermes returns
       # 401. Mirrors the ctrl-api mount (server.ts:readHermesMainApiKey).
+      # The .env is rendered 0o644 by the init container
+      # (packages/hermes/init/render_hermes.py) so the paperclip node
+      # server (uid 1000) can read it without supplementary-group plumbing.
       - hermes_data:/hermes-state:ro
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3100/sign-in >/dev/null 2>&1 || exit 1"]

--- a/packages/hermes/docker/supervisor.sh
+++ b/packages/hermes/docker/supervisor.sh
@@ -299,9 +299,35 @@ fi
 # `cd "${PROFILES_DIR}/<p>" && exec hermes …` aligns the gateway's cwd
 # with its profile dir. `exec` hands the PID directly to hermes so the
 # supervisor's `kill -0 $pid` bookkeeping still tracks the real process.
-start_proc "hermes-main"     "cd \"${PROFILES_DIR}/main\"    && TERMINAL_CWD=${PROFILES_DIR}/main    exec hermes -p main gateway run --replace"
-start_proc "hermes-workers"  "cd \"${PROFILES_DIR}/workers\" && TERMINAL_CWD=${PROFILES_DIR}/workers exec hermes -p workers gateway run --replace"
-start_proc "hermes-heavy"    "cd \"${PROFILES_DIR}/heavy\"   && TERMINAL_CWD=${PROFILES_DIR}/heavy   exec hermes -p heavy gateway run --replace"
+#
+# .env source-and-export contract (the 2026-05-28 hardening):
+#   `set -a; . "${PROFILES_DIR}/<p>/.env"; set +a` reads the per-profile
+#   .env rendered by the init container and exports every KEY=VALUE pair
+#   into the gateway's process environment BEFORE `exec hermes`. Without
+#   this the running gateway depends entirely on Hermes' internal
+#   `load_hermes_dotenv()` (gateway/run.py imports `hermes_cli.env_loader`),
+#   which is fragile in two ways:
+#     (a) the profile override (hermes_cli/main.py:_apply_profile_override)
+#         must fire so HERMES_HOME points at the profile dir, otherwise
+#         the wrong .env loads — a future CLI refactor could regress this
+#         silently.
+#     (b) `/proc/<pid>/environ` shows the gateway's initial env, not
+#         os.environ after Python loads it; operators (and ctrl-api's
+#         channels code, see channels_paperclip.ts:readHermesMainApiKey)
+#         that diagnose 401s by inspecting /proc see EMPTY API_SERVER_KEY
+#         and conclude the gateway boots unauthenticated. Sourcing the
+#         file here makes the auth key explicit, visible, and unambiguous.
+#   Sir 2026-05-28 — this hardening was prompted by a live paperclip-MCP
+#   heartbeat 401 storm on home where the running gateway accepted the
+#   profile key but /proc/<hermes-pid>/environ looked empty, sending
+#   operators chasing a phantom config-load bug for an hour.
+#
+# Idempotent + crash-loop-safe: `start_proc` re-eval's the full command
+# string on each restart, so a profile .env edited after first boot is
+# picked up the next time the supervisor respawns that gateway.
+start_proc "hermes-main"     "cd \"${PROFILES_DIR}/main\"    && set -a && . \"${PROFILES_DIR}/main/.env\"    && set +a && TERMINAL_CWD=${PROFILES_DIR}/main    exec hermes -p main gateway run --replace"
+start_proc "hermes-workers"  "cd \"${PROFILES_DIR}/workers\" && set -a && . \"${PROFILES_DIR}/workers/.env\" && set +a && TERMINAL_CWD=${PROFILES_DIR}/workers exec hermes -p workers gateway run --replace"
+start_proc "hermes-heavy"    "cd \"${PROFILES_DIR}/heavy\"   && set -a && . \"${PROFILES_DIR}/heavy/.env\"   && set +a && TERMINAL_CWD=${PROFILES_DIR}/heavy   exec hermes -p heavy gateway run --replace"
 
 # =============================================================================
 # Supervise — restart any worker that exits while we are not shutting down.

--- a/packages/hermes/init/render_hermes.py
+++ b/packages/hermes/init/render_hermes.py
@@ -402,8 +402,40 @@ def main() -> int:
     # value across re-renders.
     env_out = _merge_preserve_runtime_keys(env_out, env_path)
     env_path.write_text(env_out, encoding="utf-8")
-    # .env carries the API key + provider keys — restrict it.
-    env_path.chmod(0o600)
+    # .env carries the API key + provider keys. We want it permissive
+    # enough that sibling containers in the SAME compose stack — paperclip
+    # (uid 1000), ctrl-api (root), vault-cli (root), the init container
+    # itself (root, writes it) — can all read it without each having to
+    # docker-engine-side `group_add` or share a numeric GID.
+    #
+    # 0o644 is deliberate, not lazy:
+    #   * The file lives in a NAMED docker volume (`hermes_data`), not a
+    #     host bind-mount. It is reachable only by containers in this
+    #     compose stack that EXPLICITLY mount the volume — we control that
+    #     list (hermes, ctrl-api, paperclip, vault-cli, sure-bootstrap).
+    #     World-readable INSIDE the container ≠ world-readable on the
+    #     host; the host's volume backing dir is root:root and unreadable
+    #     to non-root host users.
+    #   * Group-only (0o640) would require every consumer container to be
+    #     added to gid 10000 via `group_add`. That fights gosu and any
+    #     entrypoint that does its own setuid — supplementary groups are
+    #     not preserved across uid transitions inside the container
+    #     unless the consumer image adds the gid to /etc/group AND the
+    #     entrypoint calls `initgroups()` (or uses `setpriv
+    #     --init-groups`). The paperclip upstream entrypoint uses `gosu
+    #     node "$@"`, gosu inherits the caller's supplementary groups
+    #     fine, but the `node` user has no gid 10000 in /etc/group so the
+    #     supplementary group dies at the uid transition. Fixing that
+    #     properly requires customising the upstream entrypoint.
+    #   * The 0o600 default this replaces was the original cause of an
+    #     hour-long misdiagnosed paperclip-MCP HERMES_AUTH=401 storm on
+    #     home (Sir, 2026-05-28): the paperclip node server runs as UID
+    #     1000 and hit EACCES on this file, the adapter swallowed the
+    #     error and sent every heartbeat with no Authorization header,
+    #     Hermes rejected with 401, and the symptom (`invalid_api_key` on
+    #     a key that worked in a `cat`-as-root docker-exec spot-check)
+    #     sent the on-call chasing a phantom env-var bug.
+    env_path.chmod(0o644)
     print(f"[render] wrote {env_path} ({len(env_out)} bytes)")
 
     return 0


### PR DESCRIPTION
## What changed

The Hermes profile `.env` files (rendered by `packages/hermes/init/render_hermes.py` into `/hermes-state/profiles/{main,workers,heavy}/.env`) are now mode `0o644` instead of `0o600`, and the hermes-supervisor explicitly sources the per-profile `.env` into the gateway's process environment before `exec hermes`.

## Why

Symptom on home tonight (2026-05-28): every Paperclip-MCP heartbeat to the local hermes-paperclip-adapter ran into `HERMES_AUTH=invalid_api_key`. ALFA-13 stayed blocked, the hermes-CEO agent kept being moved into the `error` status after each failed retry, and a manual on-call session spent an hour chasing a phantom `API_SERVER_KEY` env-loading bug that did not exist.

### Root cause

`packages/hermes/init/render_hermes.py` rendered each profile's `.env` with mode `0o600`, owned by uid:gid `10000:10000` (hermes' runtime user). The paperclip node server runs as `uid 1000` inside the upstream `paperclipai/paperclip` image. `hermes-paperclip-adapter`'s `readHermesMainApiKey()` (the **only** resolver for the bearer token the adapter sends to Hermes' API server) opened the file with `fs.readFileSync`, hit `EACCES`, swallowed the error in its catch-and-return-null block, the adapter dispatched the heartbeat with no `Authorization` header, and Hermes' API server rejected with 401.

The symptom evaded a normal docker-exec spot-check because `docker exec <c> cat <file>` runs as root (bypasses unix perms), which made it look as if the file was readable — only the actual node server (post-`gosu`-drop) hit the permission wall.

## Fix

1. **`packages/hermes/init/render_hermes.py`** — render each profile `.env` with `0o644` (not `0o600`). The file lives in a named docker volume (`hermes_data`) reachable only by sibling containers in the same compose stack that explicitly mount it; world-readable inside the container ≠ world-readable on the host.

   Group-only (`0o640` + `group_add: \"10000\"`) was tried first but fights gosu: the upstream paperclip entrypoint drops to the `node` user via `gosu node \"$@\"`, and the `node` user has no gid 10000 in `/etc/group` so the supplementary group dies at the uid transition. Long comment in `render_hermes.py` records the reasoning so a future cleanup doesn't tighten this back.

2. **`packages/hermes/docker/supervisor.sh`** — `set -a; . \"${PROFILES_DIR}/<p>/.env\"; set +a` before `exec hermes -p <p> gateway run`. Defence-in-depth: Hermes' own `load_hermes_dotenv()` already reads the file via the profile override at startup, but doing it visibly in the supervisor makes `API_SERVER_KEY` appear in `/proc/<pid>/environ`. Without this, `/proc` shows an empty `API_SERVER_KEY` (Hermes loaded it into `os.environ` AFTER fork) and the misdirection that sent the on-call chasing a phantom env-load bug repeats.

3. **`docker-compose.yaml`** — comment-only annotation on the paperclip `hermes_data:ro` mount explaining the `0o644` requirement.

## Verified live on home.alfred.black

- `docker exec -u 1000 alfred-black-paperclip-1 cat /hermes-state/profiles/main/.env` → READS OK (post-chmod)
- `POST /api/agents/<hermes-CEO>/wakeup` → `heartbeat_runs.status = succeeded` (`exit_code 0`, 275k input / 566 output tokens)
- The hermes-CEO agent posted a status comment on ALFA-13 unprompted (its assigned issue)
- Hermes `/v1/responses` healthchecks green on main / workers / heavy
- `hermes-main` process env now visibly carries `API_SERVER_KEY` (43 chars, prefix `gDp2` — matches `/hermes-state/profiles/main/.env`)

## Rollout

Existing tenants get the chmod fix on their next `docker compose up -d --no-deps init` (the init container is the `.env` writer) once the new `ssdavidai00/alfred-openclaw` image publishes. The supervisor.sh fix lands in the next `ssdavidai00/alfred-hermes` image build.

No manual intervention required after the images publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)