### PR TITLE
fix(voice-bridge,ctrl): route composio_execute through single-VM ctrl-api

### DIFF
--- a/packages/ctrl/src/api/auth.ts
+++ b/packages/ctrl/src/api/auth.ts
@@ -7,17 +7,25 @@
 //
 //   2. Optional VOICE_BRIDGE_INTERNAL_TOKEN — a scoped, path-allowlisted
 //      Bearer for the voice-bridge sibling container. It is permitted
-//      ONLY on the two routes voice-bridge actually needs:
+//      ONLY on the routes voice-bridge actually needs:
 //
 //        GET  /api/v1/phone/voice-context   (read primer for the realtime agent)
 //        POST /api/v1/phone/transcript      (post call transcript at hangup)
+//        POST /api/v1/integrations/execute  (dispatch composio_execute tool
+//                                            calls during the realtime session
+//                                            — added 2026-05-28; without this
+//                                            the realtime agent could not call
+//                                            Composio actions on home.alfred.
+//                                            black, surfacing as a 6ms
+//                                            `composio_execute ok=false
+//                                            status=err` on every voice call.)
 //
 //      Any other route requested with this token rejects with 401, as if
 //      no token were presented. This is principle-of-least-privilege for an
 //      internal monorepo service that lives on the same docker network as
 //      ctrl-api but is large attack surface (Twilio mulaw, OpenAI Realtime
 //      WebSocket). If voice-bridge is ever compromised, the blast radius is
-//      bounded to the 2 routes — the master key never leaves ctrl-api.
+//      bounded to these routes — the master key never leaves ctrl-api.
 //
 // Both validations are constant-time (`crypto.timingSafeEqual`) so a
 // network attacker can't time the comparison to recover bytes.
@@ -38,6 +46,12 @@ let voiceBridgeKeyBuf: Buffer | null = null;
 const VOICE_BRIDGE_ALLOWLIST: ReadonlySet<string> = new Set([
   "GET:/api/v1/phone/voice-context",
   "POST:/api/v1/phone/transcript",
+  // composio_execute dispatch path — added 2026-05-28. The realtime agent's
+  // built-in `composio_execute` tool routes through here. Auth body is
+  // tenant-bound (one Composio user-id per ctrl-api), so this token cannot
+  // hop tenants. Action arguments are model-supplied — we accept the same
+  // surface Hermes uses through MCP, scoped to this single endpoint.
+  "POST:/api/v1/integrations/execute",
 ]);
 
 export function setApiKey(key: string): void {

--- a/packages/voice-bridge/src/tenant.ts
+++ b/packages/voice-bridge/src/tenant.ts
@@ -24,8 +24,15 @@ function singleVmMode(): boolean {
   return config.singleVmMode;
 }
 
-/** Build the ctrl-api URL for the current deploy mode. */
-function ctrlApiUrl(tenant: TenantContext, path: string): string {
+/** Build the ctrl-api URL for the current deploy mode.
+ *
+ *  Exported so the tool dispatchers in tools.ts share the same single-VM /
+ *  legacy-SaaS routing. Prior to 2026-05-28 tools.ts hardcoded the legacy
+ *  `https://${tailscaleHost}:3100` shape, which on single-VM (tailscaleHost
+ *  is the sentinel string "local") triggered an instant DNS failure (~6ms),
+ *  surfacing as `composio_execute ok=false status=err 6ms` during voice
+ *  calls. The fetch never even left the container. */
+export function ctrlApiUrl(tenant: TenantContext, path: string): string {
   if (singleVmMode()) {
     return `${config.saasInternalUrl}${path}`;
   }
@@ -35,10 +42,13 @@ function ctrlApiUrl(tenant: TenantContext, path: string): string {
 /**
  * Bearer token for the ctrl-api call. Single-VM mode presents this bridge's
  * own internalToken — ctrl-api's auth.ts accepts it as a SCOPED bearer for
- * the two allowlisted voice-bridge routes (and only those). Legacy SaaS
+ * the voice-bridge allowlist (see VOICE_BRIDGE_ALLOWLIST). Legacy SaaS
  * mode forwards the per-tenant aasApiKey returned by the SaaS handshake.
+ *
+ * Exported for the same reason as ctrlApiUrl above — tools.ts needs the
+ * exact same single-VM routing.
  */
-function ctrlApiAuthToken(tenant: TenantContext): string {
+export function ctrlApiAuthToken(tenant: TenantContext): string {
   return singleVmMode() ? config.internalToken : tenant.aasApiKey;
 }
 

--- a/packages/voice-bridge/src/tools.ts
+++ b/packages/voice-bridge/src/tools.ts
@@ -10,7 +10,7 @@
 // (NOT over any agent-runtime WebSocket — see README.md, issue #30), using the
 // per-call AAS_API_KEY fetched at call setup.
 
-import type { TenantContext } from "./tenant.js";
+import { ctrlApiAuthToken, ctrlApiUrl, type TenantContext } from "./tenant.js";
 
 // ── Function-tool schemas (sent to OpenAI Realtime via session.update) ───────
 
@@ -92,13 +92,21 @@ export interface ToolResult {
   error?: string;
 }
 
+// URL + auth construction is delegated to tenant.ts so the dispatcher
+// here picks up single-VM mode the same way fetchVoiceContext /
+// postCallTranscript do. The hardcoded `https://${tailscaleHost}:3100`
+// shape this file used pre-2026-05-28 failed instantly on home.alfred.black
+// because single-VM TenantContext carries `tailscaleHost: "local"` and an
+// empty aasApiKey — so every composio_execute dispatched by the realtime
+// agent died at DNS resolution in ~6ms.
+
 function buildCtrlUrl(
   tenant: TenantContext,
   endpoint: string,
   method: string,
   query?: Record<string, string>,
 ): string {
-  let url = `https://${tenant.tailscaleHost}:3100${endpoint}`;
+  let url = ctrlApiUrl(tenant, endpoint);
   if (query && method === "GET") {
     const qs = new URLSearchParams(query).toString();
     if (qs) url += (url.includes("?") ? "&" : "?") + qs;
@@ -119,7 +127,7 @@ async function ctrlFetch(
   const fetchOpts: any = {
     method: opts.method,
     headers: {
-      Authorization: `Bearer ${tenant.aasApiKey}`,
+      Authorization: `Bearer ${ctrlApiAuthToken(tenant)}`,
       "Content-Type": "application/json",
     },
     signal: AbortSignal.timeout(TOOL_TIMEOUT_MS),


### PR DESCRIPTION
## Symptom

Voice-bridge logs `[call] tool composio_execute ok=false status=err 6ms argsLen=130` on every realtime-agent attempt to call a Composio action (Calendar, Gmail, etc.) on home.alfred.black. First seen post-#93, sid `CAc28fd7e19fdf940af20beba50990bbc6`. The 6ms timing rules out a Composio outage — the fetch never left the container.

## Root cause (two bugs, compound)

### 1. `tools.ts` hardcoded the legacy multi-tenant URL shape

```ts
let url = `https://${tenant.tailscaleHost}:3100${endpoint}`;
// headers: Authorization: `Bearer ${tenant.aasApiKey}`
```

On the monorepo / single-VM build (alfred-black, joe), `tenant.ts` synthesizes a `TenantContext` with the sentinel `tailscaleHost: "local"` and an empty `aasApiKey`. The URL builder + auth helpers in `tenant.ts` already handle this correctly (`ctrlApiUrl` / `ctrlApiAuthToken`), but `tools.ts` duplicated the old shape verbatim and never picked up single-VM mode. Result: voice-bridge fetched `https://local:3100/api/v1/integrations/execute` with `Bearer ` (empty) → DNS resolution failed instantly, ~6ms.

MCP-routed tools (`alfred__list_briefings` &c.) succeeded on the same call because they go through `mcp-server:8787`, not `ctrl-api`. `composio_execute` is the only non-MCP tool the realtime agent invokes.

`dispatchSelf` was silently broken in single-VM the same way, but MCP covers its surface so the model never reached for it. Left untouched per task scope.

### 2. `ctrl-api` `VOICE_BRIDGE_ALLOWLIST` omitted `/integrations/execute`

Phase 4.1 (commit 85be684e) scoped voice-bridge's bearer to two routes only:
```
GET  /api/v1/phone/voice-context
POST /api/v1/phone/transcript
```

So even after fixing #1, the request would 401. Added the third route with rationale inline.

## Fix

- `packages/voice-bridge/src/tenant.ts` — export `ctrlApiUrl` + `ctrlApiAuthToken`.
- `packages/voice-bridge/src/tools.ts` — `buildCtrlUrl` + `ctrlFetch` now route through those helpers.
- `packages/ctrl/src/api/auth.ts` — add `POST:/api/v1/integrations/execute` to `VOICE_BRIDGE_ALLOWLIST`.

## Verify

After build + redeploy, from inside the home `hermes` container:

```sh
curl -sS -X POST http://ctrl-api:3100/api/v1/integrations/execute \
  -H "Authorization: Bearer \$VOICE_BRIDGE_INTERNAL_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"action":"GOOGLECALENDAR_EVENTS_LIST"}'
```

Should return a Composio response (or a structured 400 if no Calendar connection on this tenant), not 401.

## Residual risk

- **`dispatchSelf` still broken in single-VM mode** — same root cause as `composio_execute` had. Left untouched per task scope; MCP covers the surface so this is latent, not user-visible.
- **Allowlist widened by one route.** Composio actions are tenant-scoped at the ctrl-api side (`connected_account_id` lookup filtered by `COMPOSIO_USER_ID`), so a compromised bridge cannot pivot to another tenant — only run actions on this one's connected accounts.

## Deploy

Both `build-ctrl-api.yml` and `build-voice-bridge.yml` will trigger on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)