### PR TITLE
fix(learn,caddy): composio recurring-break — UUID stream glob + webhook route

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -43,8 +43,18 @@
 	# its webhooks (per their docs), so the handler validates a
 	# shared-secret `?token=` query param against AGENTMAIL_WEBHOOK_TOKEN
 	# baked into the URL configured in the AgentMail console.
+	#
+	# /api/v1/composio/webhook is included so Composio can POST connection
+	# lifecycle events (connection_added / _deleted / _failed, scope revoke,
+	# etc.) straight to ctrl-api. Composio composes its callback URL from
+	# our SaaS-registered base, which on alfred-black is the apex. PR #72
+	# added the in-process 1-min reconciler; PR #74 added the route + the
+	# unsigned-fallback policy (the handler WARN-logs when
+	# COMPOSIO_WEBHOOK_SECRET is unset). Discovery #293 found the Caddy
+	# matcher was never updated and every Composio webhook was 405-ing
+	# at the SPA's nginx.
 	@public_webhooks {
-		path /api/v1/streams/omi/* /api/v1/plane/webhook /api/v1/webhooks/plane/steward /api/v1/webhooks/vexa /api/v1/webhooks/in/* /api/v1/channels/email/inbound /api/v1/channels/paperclip/*
+		path /api/v1/streams/omi/* /api/v1/plane/webhook /api/v1/webhooks/plane/steward /api/v1/webhooks/vexa /api/v1/webhooks/in/* /api/v1/channels/email/inbound /api/v1/channels/paperclip/* /api/v1/composio/webhook
 	}
 	handle @public_webhooks {
 		reverse_proxy ctrl-api:3100

--- a/packages/learn/src/activities/steward.py
+++ b/packages/learn/src/activities/steward.py
@@ -1095,11 +1095,27 @@ def _gmail_query_matches(query: str, fields: dict[str, str]) -> bool:
 # ---------------------------------------------------------------------------
 
 # Stream files are written by streams.ts as ``<safe_id>.jsonl`` under
-# ALFRED_DATA_DIR/streams. Composio-gmail streams have ids of the form
-# ``composio-gmail-*`` (the underscore-equivalent on disk after the
-# safe-filename pass). We glob for both the canonical pattern AND any
-# stream named exactly ``gmail`` since some tenants run the legacy
-# direct-pull stream under that id.
+# ALFRED_DATA_DIR/streams, and their configs live alongside under
+# ``streams/configs/<safe_id>.json`` (see ctrl-api streams.ts —
+# ``getStreamConfigPath`` / ``getStreamEventsPath``).
+#
+# Historically we matched gmail streams by *filename* (``composio-gmail*``,
+# ``gmail.jsonl``, ``gmail-*``). That works only when auto-config wrote
+# the canonical id ``composio-gmail-gmail-fetch-emails``. UI-created or
+# UUID-id streams (e.g. ``f7446eaf-…``) write to a sibling JSONL that
+# none of those globs touch, so steward read a 4-day-stale legacy file
+# and reported "stale gmail stream" while the real Composio pull was
+# alive and well in a UUID-named JSONL. Discovery #293, fix landed via
+# Composio recurring-break PR.
+#
+# The correct selector is ``composio_action == "GMAIL_FETCH_EMAILS"``
+# on the stream config — that's tenant-agnostic and survives the legacy
+# auto-config ↔ UI naming split. We walk ``streams/configs/`` for any
+# config carrying that action and resolve the matching ``<id>.jsonl``.
+# The legacy filename globs remain a fallback for tenants whose configs
+# dir is empty (early pre-auto-config tenants, dev fixtures, etc.).
+_GMAIL_COMPOSIO_ACTION = "GMAIL_FETCH_EMAILS"
+
 _GMAIL_STREAM_GLOBS = (
     "composio-gmail*.jsonl",
     "gmail.jsonl",
@@ -1108,11 +1124,58 @@ _GMAIL_STREAM_GLOBS = (
 
 
 def _list_gmail_stream_files(streams_dir: str) -> list[str]:
-    """Return absolute paths of every gmail-shaped JSONL stream file."""
+    """Return absolute paths of every gmail-shaped JSONL stream file.
+
+    Primary selector: any stream config under ``<streams_dir>/configs/``
+    whose ``composio_action`` is ``GMAIL_FETCH_EMAILS``. The config's
+    ``id`` (after the same safe-filename pass as ctrl-api streams.ts)
+    resolves to ``<streams_dir>/<safe_id>.jsonl``.
+
+    Fallback: legacy filename glob (``composio-gmail*.jsonl`` etc.) —
+    kept so a tenant whose configs dir is missing (pre-auto-config or
+    fixture-only) still picks up canonical-id JSONLs.
+
+    Files that don't exist on disk yet (stream config exists, JSONL not
+    written) are silently dropped — the freshness check downstream
+    handles the "no data yet" state.
+    """
     out: list[str] = []
+
+    # Primary: walk stream configs, select by composio_action.
+    configs_dir = os.path.join(streams_dir, "configs")
+    try:
+        config_names = os.listdir(configs_dir)
+    except OSError:
+        config_names = []
+    for name in config_names:
+        if not name.endswith(".json"):
+            continue
+        cfg_path = os.path.join(configs_dir, name)
+        try:
+            with open(cfg_path, "r", encoding="utf-8") as f:
+                cfg = json.load(f)
+        except (OSError, ValueError, json.JSONDecodeError):
+            continue
+        if not isinstance(cfg, dict):
+            continue
+        if cfg.get("composio_action") != _GMAIL_COMPOSIO_ACTION:
+            continue
+        stream_id = cfg.get("id") or os.path.splitext(name)[0]
+        if not isinstance(stream_id, str) or not stream_id:
+            continue
+        # Mirror ctrl-api streams.ts getStreamEventsPath sanitisation
+        # (``[^a-zA-Z0-9_-]`` → ``_``) so we land on the same file.
+        safe_id = re.sub(r"[^a-zA-Z0-9_-]", "_", stream_id)
+        jsonl_path = os.path.join(streams_dir, f"{safe_id}.jsonl")
+        if os.path.exists(jsonl_path):
+            out.append(jsonl_path)
+
+    # Fallback: legacy filename glob — covers tenants without a configs
+    # dir and the canonical auto-config id case.
     for pattern in _GMAIL_STREAM_GLOBS:
         out.extend(glob.glob(os.path.join(streams_dir, pattern)))
-    # Dedup while preserving order.
+
+    # Dedup while preserving order (config-driven hits take precedence).
     seen: set[str] = set()
     uniq: list[str] = []
     for p in out:

--- a/packages/learn/tests/test_steward_gmail_stream_selection.py
+++ b/packages/learn/tests/test_steward_gmail_stream_selection.py
@@ -1,0 +1,203 @@
+"""Tests for ``steward._list_gmail_stream_files`` — the Composio recurring-break
+fix for discovery #293.
+
+Background: gmail stream selection used to glob JSONLs by filename
+(``composio-gmail*.jsonl``, ``gmail.jsonl``, ``gmail-*.jsonl``). That
+missed UUID-id streams (e.g. ``f7446eaf-…``) created via the UI / a
+non-auto-config path, even though those JSONLs were the LIVE pull
+target. Steward then read a stale legacy file and reported zero
+signals.
+
+The fix selects streams by ``composio_action == "GMAIL_FETCH_EMAILS"``
+in ``<streams_dir>/configs/<id>.json`` and resolves them to the
+sibling ``<id>.jsonl``. The legacy filename glob remains a fallback.
+
+These tests cover:
+
+* the primary selector picks up UUID-named gmail streams,
+* non-gmail composio streams are NOT picked up,
+* the legacy filename glob still fires when the configs dir is empty
+  / absent,
+* config + glob results dedup correctly,
+* config files with non-existent JSONLs are silently dropped,
+* malformed config JSON does not crash the activity.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from src.activities.steward import _list_gmail_stream_files  # noqa: E402
+
+
+def _write_config(configs_dir: Path, stream_id: str, composio_action: str) -> None:
+    cfg = {
+        "id": stream_id,
+        "name": f"test-{stream_id}",
+        "enabled": True,
+        "composio_action": composio_action,
+    }
+    (configs_dir / f"{stream_id}.json").write_text(json.dumps(cfg))
+
+
+def _touch_jsonl(streams_dir: Path, stream_id: str) -> Path:
+    p = streams_dir / f"{stream_id}.jsonl"
+    p.write_text("")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Primary selector — composio_action == GMAIL_FETCH_EMAILS
+# ---------------------------------------------------------------------------
+
+
+def test_picks_up_uuid_named_gmail_stream(tmp_path: Path) -> None:
+    """The discovery-#293 case: stream id is a UUID, legacy globs miss."""
+    streams_dir = tmp_path
+    configs_dir = streams_dir / "configs"
+    configs_dir.mkdir()
+
+    uuid_id = "f7446eaf-b57b-4a18-a7e3-5bb05bde25fc"
+    _write_config(configs_dir, uuid_id, "GMAIL_FETCH_EMAILS")
+    expected = _touch_jsonl(streams_dir, uuid_id)
+
+    result = _list_gmail_stream_files(str(streams_dir))
+    assert str(expected) in result
+
+
+def test_picks_up_canonical_auto_config_id(tmp_path: Path) -> None:
+    """The auto-config id still works through the primary selector."""
+    streams_dir = tmp_path
+    configs_dir = streams_dir / "configs"
+    configs_dir.mkdir()
+
+    cid = "composio-gmail-gmail-fetch-emails"
+    _write_config(configs_dir, cid, "GMAIL_FETCH_EMAILS")
+    expected = _touch_jsonl(streams_dir, cid)
+
+    result = _list_gmail_stream_files(str(streams_dir))
+    assert str(expected) in result
+
+
+def test_ignores_non_gmail_composio_streams(tmp_path: Path) -> None:
+    """Notion / GitHub / Calendar streams must NOT be returned."""
+    streams_dir = tmp_path
+    configs_dir = streams_dir / "configs"
+    configs_dir.mkdir()
+
+    _write_config(configs_dir, "notion-stream", "NOTION_FETCH_DATA")
+    _touch_jsonl(streams_dir, "notion-stream")
+    _write_config(
+        configs_dir, "calendar-stream", "GOOGLECALENDAR_EVENTS_LIST"
+    )
+    _touch_jsonl(streams_dir, "calendar-stream")
+
+    result = _list_gmail_stream_files(str(streams_dir))
+    assert result == []
+
+
+def test_drops_config_with_missing_jsonl(tmp_path: Path) -> None:
+    """A config that points at a non-existent JSONL is silently dropped.
+
+    Freshness check downstream owns the "no data yet" decision; we
+    return only files that actually exist on disk.
+    """
+    streams_dir = tmp_path
+    configs_dir = streams_dir / "configs"
+    configs_dir.mkdir()
+
+    _write_config(configs_dir, "no-data-yet", "GMAIL_FETCH_EMAILS")
+    # NOT touching the JSONL file.
+
+    result = _list_gmail_stream_files(str(streams_dir))
+    assert result == []
+
+
+def test_malformed_config_does_not_crash(tmp_path: Path) -> None:
+    """A garbage config file gets skipped, other configs still work."""
+    streams_dir = tmp_path
+    configs_dir = streams_dir / "configs"
+    configs_dir.mkdir()
+
+    (configs_dir / "broken.json").write_text("{not valid json")
+
+    uuid_id = "f7446eaf-uuid-stream"
+    _write_config(configs_dir, uuid_id, "GMAIL_FETCH_EMAILS")
+    expected = _touch_jsonl(streams_dir, uuid_id)
+
+    result = _list_gmail_stream_files(str(streams_dir))
+    assert str(expected) in result
+
+
+# ---------------------------------------------------------------------------
+# Fallback — legacy filename glob
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_glob_fires_when_configs_dir_absent(tmp_path: Path) -> None:
+    """Tenant with no configs dir: filename glob still works."""
+    streams_dir = tmp_path
+    # NOT creating configs/.
+
+    legacy = streams_dir / "composio-gmail-gmail-fetch-emails.jsonl"
+    legacy.write_text("")
+
+    result = _list_gmail_stream_files(str(streams_dir))
+    assert str(legacy) in result
+
+
+def test_legacy_glob_fires_when_configs_dir_empty(tmp_path: Path) -> None:
+    streams_dir = tmp_path
+    (streams_dir / "configs").mkdir()
+
+    legacy = streams_dir / "gmail.jsonl"
+    legacy.write_text("")
+
+    result = _list_gmail_stream_files(str(streams_dir))
+    assert str(legacy) in result
+
+
+# ---------------------------------------------------------------------------
+# Dedup + combined behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_dedup_when_config_and_glob_both_hit(tmp_path: Path) -> None:
+    """The canonical auto-config id hits BOTH the config selector AND
+    the legacy ``composio-gmail*`` glob — must only appear once."""
+    streams_dir = tmp_path
+    configs_dir = streams_dir / "configs"
+    configs_dir.mkdir()
+
+    cid = "composio-gmail-gmail-fetch-emails"
+    _write_config(configs_dir, cid, "GMAIL_FETCH_EMAILS")
+    expected = _touch_jsonl(streams_dir, cid)
+
+    result = _list_gmail_stream_files(str(streams_dir))
+    matches = [p for p in result if p == str(expected)]
+    assert len(matches) == 1
+
+
+def test_returns_uuid_and_legacy_when_both_present(tmp_path: Path) -> None:
+    """The home.alfred.black live state: a UUID stream AND a stale
+    legacy file both exist. Both end up in the result; the freshness
+    check downstream picks the live one."""
+    streams_dir = tmp_path
+    configs_dir = streams_dir / "configs"
+    configs_dir.mkdir()
+
+    uuid_id = "f7446eaf-b57b-4a18-a7e3-5bb05bde25fc"
+    _write_config(configs_dir, uuid_id, "GMAIL_FETCH_EMAILS")
+    uuid_jsonl = _touch_jsonl(streams_dir, uuid_id)
+
+    legacy_jsonl = streams_dir / "composio-gmail-gmail-fetch-emails.jsonl"
+    legacy_jsonl.write_text("")
+
+    result = _list_gmail_stream_files(str(streams_dir))
+    assert str(uuid_jsonl) in result
+    assert str(legacy_jsonl) in result


### PR DESCRIPTION
## Why

Discovery #293 ([report](/tmp/composio-recurring-break-discovery.md), summary in commit msg) traced Sir's recurring "Composio not working" cycle to two distinct issues, neither solved by re-authenticating Composio. The connection is healthy end-to-end; the breakage is downstream-only.

## What changes

### 1. `packages/learn/src/activities/steward.py` — stream selection by `composio_action`

`_list_gmail_stream_files` used to glob JSONLs by filename pattern. UUID-id streams (e.g. `f7446eaf-…`) write to a sibling JSONL no glob touches, so steward read a stale legacy file and reported "stale gmail stream" 44+ times/24h on home — while fresh Composio data sat in the UUID JSONL.

Fix: walk `<streams_dir>/configs/*.json`, select configs with `composio_action == "GMAIL_FETCH_EMAILS"`, resolve each to `<streams_dir>/<safe_id>.jsonl` (mirroring ctrl-api `streams.ts::getStreamEventsPath` sanitisation). Legacy filename glob kept as a fallback for tenants without a configs dir.

### 2. `caddy/Caddyfile` — add `/api/v1/composio/webhook` to `@public_webhooks`

The matcher omitted the path, so Composio's lifecycle POSTs fell through to the SPA's nginx (HTTP 405). PR #72 + PR #74 assumed Caddy had the path; it never did. Zero `/composio/webhook` hits in ctrl-api logs over 24h on home.

One-line addition with comment explaining why it's a public webhook (the handler validates its own signature, plus the unsigned-fallback policy in #74).

## Tests

`packages/learn/tests/test_steward_gmail_stream_selection.py` — 9 new unit tests:

- UUID-named gmail stream picked up (the #293 case)
- canonical auto-config id picked up
- non-gmail composio streams (Notion, Calendar) ignored
- config with missing JSONL silently dropped
- malformed JSON config doesn't crash
- legacy glob fallback when configs dir absent / empty
- dedup when config AND glob both hit the same file
- both UUID + legacy stale file returned (freshness check downstream picks live)

All 9 pass locally.

## Verify gate

Both fixes are hot-deploy verified on home.alfred.black **before merging** (issue #293 playbook):

- steward log line shows N > 0 signals from the UUID JSONL, no stale-stream warning
- `curl -X POST https://home.alfred.black/api/v1/composio/webhook` reaches ctrl-api (ctrl-api response, not nginx 405)

## Not in this change

- The stale legacy `composio-gmail-gmail-fetch-emails.jsonl` cleanup (#293 fix #3). The glob fix alone resolves Sir's symptom; cleanup is hygiene.
- `COMPOSIO_WEBHOOK_SECRET` tightening. The route deliberately accepts unsigned bodies when the secret is unset (PR #74 policy); tighten later in a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)