### PR TITLE
feat(mcp-server): alfred__act_on_decision + reverse_decision

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -39,6 +39,26 @@ jobs:
         working-directory: packages/ctrl
         run: node build.mjs
 
+  test-mcp-server:
+    # tsc typecheck + node --test for the per-app tool catalogues
+    # (alfred / sure / plane / vaultwarden / execute / hermes). The tests are
+    # pure schema + buildRequest assertions; no network or env required.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Install deps
+        working-directory: packages/mcp-server
+        run: npm ci
+      - name: typecheck
+        working-directory: packages/mcp-server
+        run: npm run typecheck
+      - name: node --test
+        working-directory: packages/mcp-server
+        run: npm test
+
   test-voice-bridge:
     # tsc compile + node --test for the OpenAI Realtime session-update race fix.
     # Mock WS server is in-process; no network or OpenAI key needed (a dummy

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -9,7 +9,8 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
     "start": "node --experimental-sqlite dist/index.js",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --import tsx --test src/**/*.test.ts"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/packages/mcp-server/skills/alfred-mcp-skill.md
+++ b/packages/mcp-server/skills/alfred-mcp-skill.md
@@ -6,7 +6,7 @@ license: alfred-platform internal — see the parent monorepo's LICENSE
 
 # Alfred MCP — claude.ai Custom Connector
 
-This connector exposes Sir's tenant ctrl-api content surface to claude.ai. The 16 tools below are the ONLY way you reach his box from a claude.ai conversation — there is no shell, no `bash`, no direct HTTP. Everything goes through this MCP server's bearer token, which is bound to one tenant for one hour.
+This connector exposes Sir's tenant ctrl-api content surface to claude.ai. The 18 tools below are the ONLY way you reach his box from a claude.ai conversation — there is no shell, no `bash`, no direct HTTP. Everything goes through this MCP server's bearer token, which is bound to one tenant for one hour.
 
 The catalogue is intentionally narrow. Container restarts, credential rotation, device revocation, env mutation, log streaming, and similar high-blast-radius operations are NOT exposed here — they live behind in-tenant agents (Alfred main, chores) where trust is scoped. If Sir asks for one of those over claude.ai, route him back to his Alfred channel rather than improvising.
 
@@ -40,6 +40,20 @@ The catalogue is intentionally narrow. Container restarts, credential rotation, 
 - `get_openclaw_health` — gateway healthz envelope
 - `list_openclaw_agents` — live agent state from the gateway (model bindings, provider auth)
 - `list_openclaw_allowed_tools` — `gateway.tools.allow` + MCP-server tool inventory
+
+### Desk (briefings, decisions, state-changes) — read + act
+
+- `list_briefings` / `get_briefing` — the daily letterpress brief snapshots
+- `list_decisions` / `get_decision` — every Desk click and every autonomous fire, with state + intent + outcome
+- `list_pending_decisions` — what's on Sir's `/desk` right now (raw `needs_attention` records)
+- `list_state_changes` — the matter/task mutation ledger
+- `list_in_flight_agents` — ephemeral exec-* subagents currently working
+- `act_on_decision` — press one of the five Desk buttons (delegate / defer / done / do / noise) for a card. `delegate` and `defer` REQUIRE a `note` (instructions / when); `done` / `do` take optional context; `noise` takes nothing
+- `reverse_decision` — undo a decision (best-effort: `delegate` is marked not-reversible upstream)
+
+### Channels (1)
+
+- `notify_principal` — send Sir a message on his preferred channel (Telegram, Slack, …)
 
 ### DM pairing (1)
 
@@ -83,6 +97,18 @@ The common task queue on the learn package is `alfred-learn`. If Sir doesn't kno
 ### "Is Alfred healthy?"
 
 `get_openclaw_health` — gateway-side health (provider auth, queue depth). Pair with `list_openclaw_agents` to see which model each agent is wired to right now and whether any provider is missing credentials. If health is bad, surface what's broken to Sir; do NOT try to restart anything from this connector — that's deliberately not exposed.
+
+### "What's on my desk?" / "Handle / delegate / defer this one"
+
+1. `list_pending_decisions` — pull the open cards. Each entry has `id`, `display_headline`, `display_body`, `reasoning`, `decay_band`, plus the matter/task/source-signal provenance.
+2. Read the queue back to Sir in prose — `decay_band: fresh|aging|stale` plus the headline. Don't dump JSON.
+3. When Sir picks one (or asks you to triage), call `act_on_decision({id, action, note})`. Action menu:
+   - `delegate` — hand to Alfred. `note` REQUIRED — write what Sir would say in the Instructions box ("Settle it, then file the receipt under May expenses.").
+   - `defer` — bury until later. `note` REQUIRED — the natural-language when ("Tomorrow morning", "After the Carter meeting").
+   - `done` — mark resolved. `note` OPTIONAL but it improves the learning signal — what closed it ("Already replied on the thread").
+   - `do` — Sir's taking it himself; a `to_do` spawns within ~60s.
+   - `noise` — this kind of card should never have surfaced. No note; the gesture is the explanation.
+4. If Sir says "actually undo that", call `reverse_decision({id})` on the decision id you got back. Works cleanly for defer/done/do/noise; for delegate it reopens the Desk card but cannot un-fire what already dispatched.
 
 ### "Approve my Telegram / Slack pairing"
 

--- a/packages/mcp-server/src/tools/alfred.test.ts
+++ b/packages/mcp-server/src/tools/alfred.test.ts
@@ -1,0 +1,201 @@
+// Tests for the act_on_decision + reverse_decision tools.
+//
+// Coverage:
+//   1. schema validation — per-action required-note rules
+//   2. buildRequest — the POST /api/v1/decisions body shape mirrors the
+//      dashboard's recordDecision() exactly for each of the five actions
+//   3. action→intent mapping (do → take_mine; the others pass through)
+//   4. source defaulting + source_record wrapping for needs_attention
+//   5. reverse_decision path encoding
+
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { ALL_ALFRED_TOOLS } from "./alfred.js";
+
+function getTool(name: string) {
+  const t = ALL_ALFRED_TOOLS.find((x) => x.name === name);
+  assert.ok(t, `tool ${name} not found`);
+  return t;
+}
+
+const actOn = getTool("act_on_decision");
+const reverse = getTool("reverse_decision");
+
+// ─── act_on_decision · schema validation ────────────────────────────────────
+
+test("act_on_decision: delegate requires note", () => {
+  const r = actOn.inputSchema.safeParse({
+    id: "2026-05-28-04-15-xyz",
+    action: "delegate",
+  });
+  assert.equal(r.success, false);
+  assert.ok(
+    String(JSON.stringify(r.error?.issues ?? r.error)).includes("delegate"),
+    "error should mention delegate",
+  );
+});
+
+test("act_on_decision: delegate with note passes", () => {
+  const r = actOn.inputSchema.safeParse({
+    id: "abc",
+    action: "delegate",
+    note: "Settle it, then file the receipt under May expenses.",
+  });
+  assert.equal(r.success, true);
+});
+
+test("act_on_decision: defer requires note (the natural-language when)", () => {
+  const r = actOn.inputSchema.safeParse({
+    id: "abc",
+    action: "defer",
+    note: "   ",
+  });
+  assert.equal(r.success, false);
+  assert.ok(
+    String(JSON.stringify(r.error?.issues ?? r.error)).includes("defer"),
+  );
+});
+
+test("act_on_decision: defer with note passes", () => {
+  const r = actOn.inputSchema.safeParse({
+    id: "abc",
+    action: "defer",
+    note: "Tomorrow morning",
+  });
+  assert.equal(r.success, true);
+});
+
+test("act_on_decision: done/do/noise allow empty note", () => {
+  for (const action of ["done", "do", "noise"] as const) {
+    const r = actOn.inputSchema.safeParse({ id: "abc", action });
+    assert.equal(r.success, true, `${action} should pass without note`);
+  }
+});
+
+test("act_on_decision: unknown action is rejected", () => {
+  const r = actOn.inputSchema.safeParse({ id: "abc", action: "delete" });
+  assert.equal(r.success, false);
+});
+
+test("act_on_decision: id required", () => {
+  const r = actOn.inputSchema.safeParse({ action: "done" });
+  assert.equal(r.success, false);
+});
+
+// ─── act_on_decision · buildRequest mapping ─────────────────────────────────
+
+test("act_on_decision · delegate · maps to POST /api/v1/decisions with intent=delegate and wrapped source_record", () => {
+  const req = actOn.buildRequest({
+    id: "2026-05-28-04-15-xyz",
+    action: "delegate",
+    note: "Settle it, then file the receipt.",
+  });
+  assert.equal(req.method, "POST");
+  assert.equal(req.path, "/api/v1/decisions");
+  assert.deepEqual(req.body, {
+    source: "needs_attention",
+    source_record: "needs_attention/2026-05-28-04-15-xyz.md",
+    intent: "delegate",
+    note: "Settle it, then file the receipt.",
+    matter_ref: "",
+    task_ref: "",
+    source_headline: "",
+    time_to_decision_ms: null,
+  });
+});
+
+test("act_on_decision · defer · intent=defer, note is the when-string", () => {
+  const req = actOn.buildRequest({
+    id: "abc",
+    action: "defer",
+    note: "After the Carter meeting",
+  });
+  assert.equal((req.body as any).intent, "defer");
+  assert.equal((req.body as any).note, "After the Carter meeting");
+  assert.equal((req.body as any).source, "needs_attention");
+  assert.equal((req.body as any).source_record, "needs_attention/abc.md");
+});
+
+test("act_on_decision · done · intent=done, optional note OK", () => {
+  const req = actOn.buildRequest({
+    id: "abc",
+    action: "done",
+    note: "Already replied on the thread",
+  });
+  assert.equal((req.body as any).intent, "done");
+  assert.equal((req.body as any).note, "Already replied on the thread");
+});
+
+test("act_on_decision · do · maps to intent=take_mine (dashboard's 'Sir takes this on')", () => {
+  const req = actOn.buildRequest({ id: "abc", action: "do", note: "" });
+  assert.equal((req.body as any).intent, "take_mine");
+  assert.equal((req.body as any).note, "");
+});
+
+test("act_on_decision · noise · intent=noise, empty note (the gesture is the explanation)", () => {
+  const req = actOn.buildRequest({ id: "abc", action: "noise" });
+  assert.equal((req.body as any).intent, "noise");
+  assert.equal((req.body as any).note, "");
+});
+
+test("act_on_decision · matter_ref / task_ref / source_headline forwarded when set", () => {
+  const req = actOn.buildRequest({
+    id: "abc",
+    action: "done",
+    note: "done",
+    matter_ref: "matter/acme.md",
+    task_ref: "task/follow-up-sam.md",
+    source_headline: "Acme contract follow-up",
+  });
+  assert.equal((req.body as any).matter_ref, "matter/acme.md");
+  assert.equal((req.body as any).task_ref, "task/follow-up-sam.md");
+  assert.equal((req.body as any).source_headline, "Acme contract follow-up");
+});
+
+test("act_on_decision · non-needs_attention sources pass id through verbatim (no wrapping)", () => {
+  const req = actOn.buildRequest({
+    id: "pattern_proposal/2026-05-28-foo.md",
+    action: "done",
+    source: "pattern_proposal",
+  });
+  // The dashboard passes recordId verbatim for non-NA sources; mirror that.
+  assert.equal(
+    (req.body as any).source_record,
+    "pattern_proposal/2026-05-28-foo.md",
+  );
+  assert.equal((req.body as any).source, "pattern_proposal");
+});
+
+test("act_on_decision · explicit source=needs_attention also wraps", () => {
+  const req = actOn.buildRequest({
+    id: "abc",
+    action: "done",
+    source: "needs_attention",
+  });
+  assert.equal((req.body as any).source_record, "needs_attention/abc.md");
+});
+
+// ─── reverse_decision ───────────────────────────────────────────────────────
+
+test("reverse_decision · POST /api/v1/decisions/:id/reverse with encoded id", () => {
+  const req = reverse.buildRequest({ id: "2026-05-28T04-15-22Z-a1b2c3d4" });
+  assert.equal(req.method, "POST");
+  assert.equal(
+    req.path,
+    "/api/v1/decisions/2026-05-28T04-15-22Z-a1b2c3d4/reverse",
+  );
+});
+
+test("reverse_decision · id with slashes is URL-encoded", () => {
+  const req = reverse.buildRequest({ id: "weird/id with space" });
+  // encodeURIComponent encodes `/` and ` `
+  assert.ok(
+    req.path === "/api/v1/decisions/weird%2Fid%20with%20space/reverse",
+    `unexpected path: ${req.path}`,
+  );
+});
+
+test("reverse_decision · id required", () => {
+  const r = reverse.inputSchema.safeParse({});
+  assert.equal(r.success, false);
+});

--- a/packages/mcp-server/src/tools/alfred.ts
+++ b/packages/mcp-server/src/tools/alfred.ts
@@ -454,6 +454,123 @@ const briefDecisionTools: ToolDef[] = [
     }),
   },
   {
+    name: "act_on_decision",
+    description:
+      // Sir's voice — clear, no fluff. The model on the other end of the
+      // connector picks an action and sometimes types a prompt; that prompt
+      // (instructions / when / context) lands here as `note`.
+      "Act on ONE decision card sitting on Sir's desk — the exact same five buttons Sir clicks on /desk (Delegate · Defer · Done · Do · Noise) wrapped into one tool. Always `list_pending_decisions` first so you know which `id` you're acting on and which action fits.\n" +
+      "\n" +
+      "Action menu (mirrors the dashboard exactly):\n" +
+      "  • `delegate` — hand it to Alfred to do. ctrl-api re-arms the source signal and the router fires the matched instinct's agent. REQUIRES `note` = the instructions Sir would type into the 'Instructions for me' box (e.g. 'Settle it, then file the receipt under May expenses.'). 2xx with `nothing_to_delegate: true` means the card had no real signal behind it (advisory card) and stays on the Desk — surface that to Sir verbatim.\n" +
+      "  • `defer` — bury the card until a named time. REQUIRES `note` = the natural-language when ('Tomorrow morning', 'After the Carter meeting'). DecisionRouterWorkflow parses it and stamps `resurface_at`; the card drops off /desk and returns then.\n" +
+      "  • `done` — mark the card resolved. `note` is OPTIONAL context ('Already replied', 'Paid on call', 'Resolved on the thread'). The note also seeds an observation for the learning pipeline, so a one-line context is worth more than empty.\n" +
+      "  • `do` — Sir's taking this on himself. A to_do/<ts>.md spawns within ~60s and surfaces in his Backstage. `note` OPTIONAL — anything Sir wants in the to_do body.\n" +
+      "  • `noise` — this kind of card should never have surfaced. The card drops off /desk and the learning layer materialises a `signal_noise_pattern` so the next one like it is filtered upstream. `note` is OPTIONAL (the gesture itself is the explanation; leave it empty unless Sir says why).\n" +
+      "\n" +
+      "Defaults: `source` defaults to `needs_attention` (the common case — the card came from Sir's Desk). Override only when the card came from `approval`, `judgment`, `to_do`, `pattern_proposal`, or a `desk_originated` decision you just wrote. `id` is the needs_attention stem from `list_pending_decisions` (e.g. `2026-05-28-04-15-xyz`), NOT the wrapped `needs_attention/<id>.md` path — the tool wraps it for you.\n" +
+      "\n" +
+      "Returns the created decision record `{id, path, frontmatter, side_effects}`. `side_effects.dispatch_ok: false` on a delegate means the agent fired but no real backend work happened (advisory card / nothing to delegate); the card stays on the Desk in that case. Backing: POST /api/v1/decisions — the exact endpoint the dashboard buttons hit. NOT idempotent: each call writes a decision record; the synchronous source-record flip prevents double-handling of the same card, but a retry against an already-handled card returns the new decision with the source already in its target state.",
+    inputSchema: z
+      .object({
+        id: z.string().min(1).describe(
+          "Source-record id — for a Desk card, the `id` field from `list_pending_decisions` (the needs_attention stem). For other sources, the bare record id; the tool wraps the path for `needs_attention` only.",
+        ),
+        action: z.enum(["delegate", "defer", "done", "do", "noise"]).describe(
+          "Which Desk button to press. delegate=hand to Alfred · defer=resurface later · done=mark resolved · do=Sir takes it (spawns a to_do) · noise=mark as low-signal so the pattern is filtered upstream.",
+        ),
+        note: z.string().optional().describe(
+          "The prompt the dashboard collects per action. REQUIRED for `delegate` (instructions for Alfred) and `defer` (natural-language when, e.g. 'tomorrow morning'). OPTIONAL for `done` (resolution context — seeds the learning observation) and `do` (to_do body). Pass empty / omit for `noise`.",
+        ),
+        source: z
+          .enum([
+            "needs_attention",
+            "approval",
+            "judgment",
+            "to_do",
+            "desk_originated",
+            "pattern_proposal",
+            "instinct_fire",
+          ])
+          .optional()
+          .describe(
+            "Where the card came from. Defaults to `needs_attention` (the Desk queue). Override only when acting on an approval, judgment, to_do, pattern_proposal, or desk-originated decision.",
+          ),
+        matter_ref: z.string().optional().describe(
+          "Optional matter wikilink/path to attach (e.g. `matter/acme.md`). ctrl-api backfills this from the needs_attention record's target_path when omitted, so you rarely need to set it.",
+        ),
+        task_ref: z.string().optional().describe(
+          "Optional task wikilink/path to attach (e.g. `task/follow-up-sam.md`). Same backfill rule as `matter_ref`.",
+        ),
+        source_headline: z.string().optional().describe(
+          "Optional headline copied onto the decision record for ledger readability. Defaults to empty; the dashboard passes the card's `display_headline` when it has one.",
+        ),
+      })
+      .superRefine((v, ctx) => {
+        // Action-level required-note validation: mirrors the dashboard,
+        // where Delegate and Defer reveal a text input the user MUST fill.
+        // Done / Do / Noise have an optional input.
+        const needsNote = v.action === "delegate" || v.action === "defer";
+        if (needsNote && (!v.note || !v.note.trim())) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["note"],
+            message:
+              v.action === "delegate"
+                ? "`note` is required for `delegate` — pass the instructions Sir would give Alfred (e.g. 'Settle it, then file the receipt')."
+                : "`note` is required for `defer` — pass the natural-language when (e.g. 'Tomorrow morning', 'After the Carter meeting').",
+          });
+        }
+      }),
+    buildRequest: ({ id, action, note, source, matter_ref, task_ref, source_headline }) => {
+      const src = source ?? "needs_attention";
+      // The dashboard wraps the needs_attention id as `needs_attention/<id>.md`
+      // before POSTing; for other sources the recordId is passed verbatim.
+      // Mirror that exactly so ctrl-api's synchronous source-flip finds the
+      // right file.
+      const sourceRecord =
+        src === "needs_attention" ? `needs_attention/${id}.md` : id;
+      // Map the user-facing action onto the ctrl-api intent enum. `delete`
+      // is a dashboard-side label only — we use Sir's plainer word `done`
+      // for both the action and the intent, and translate `do` → `take_mine`
+      // here so callers stay in dashboard vocabulary.
+      const intent =
+        action === "do" ? "take_mine" : (action as "delegate" | "defer" | "done" | "noise");
+      return {
+        method: "POST",
+        path: "/api/v1/decisions",
+        body: {
+          source: src,
+          source_record: sourceRecord,
+          intent,
+          note: note ?? "",
+          matter_ref: matter_ref ?? "",
+          task_ref: task_ref ?? "",
+          source_headline: source_headline ?? "",
+          time_to_decision_ms: null,
+        },
+      };
+    },
+  },
+  {
+    name: "reverse_decision",
+    description:
+      "Undo a decision Sir (or Alfred autonomously) just made — flips state→reversed and the DecisionRouterWorkflow runs inverse side-effects on its next 60s tick (source-record status flips back onto the Desk, any spawned to_do gets cancelled). Use when Sir says 'undo that', 'I changed my mind on the Carter card', or after `act_on_decision` returned something that's clearly wrong.\n" +
+      "\n" +
+      "Caveat: reverse is best-effort. For `intent=delegate`, the source-record flip is reversible but an agent that already fired CANNOT be unsent — Sir gets the Desk card back, but the dispatched work in the world isn't rewound. ctrl-api marks `delegate` as not-reversible in its frontmatter (`is_reversible: false`) — calling reverse on one returns 400 with that reason. The other four intents (defer/done/take_mine/noise) reverse cleanly.\n" +
+      "\n" +
+      "Returns `{ok: true, id, path, frontmatter}` (or `{ok: true, id, already_reversed: true}` on a no-op). Idempotent. Backing: POST /api/v1/decisions/:id/reverse.",
+    inputSchema: z.object({
+      id: z.string().min(1).describe(
+        "Decision id — e.g. `2026-05-28T04-15-22Z-a1b2c3d4`. Get it from `list_decisions` or from the `id` field in a prior `act_on_decision` response.",
+      ),
+    }),
+    buildRequest: ({ id }) => ({
+      method: "POST",
+      path: `/api/v1/decisions/${encodeURIComponent(id)}/reverse`,
+    }),
+  },
+  {
     name: "list_state_changes",
     description:
       "List entries from the state-change audit ledger — the canonical record of every mutation to matter / task state-fields written through state_mutator v2 (per docs/STATE-MUTATION.md). Each entry: `{when, source, target_kind, target_path, fields_changed, reason, audit_record_path}`. Filters: `target` (full vault-relative target_path like `matter/acme.md`), `source` (writer name, e.g. `briefing.morning`, `steward`, `nightly_narrative`, `manual.<userid>`), `since` / `until` ISO timestamps, `limit` (default 50, cap 200), `offset`. Use to answer 'who changed this matter?', 'show me everything Steward did last hour', 'what mutated under the briefing source today'. Backing: indexed vault walk via /api/v1/state-changes.",

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -17,5 +17,6 @@
     "declaration": false,
     "sourceMap": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
## What this is

One MCP tool — `alfred__act_on_decision` — that mirrors the dashboard's five Desk-card action buttons (Delegate · Defer · Done · Do · Noise) with the **exact same param contract** the dashboard collects from Sir per action, plus a companion `alfred__reverse_decision`.

## The contract (matches `packages/web/src/dashboard/operations.ts::recordDecision`)

Wire shape: `POST /api/v1/decisions` with `{source, source_record, intent, note, matter_ref, task_ref, source_headline, time_to_decision_ms}`.

| MCP `action` | Wire `intent` | `note` (the prompt the dashboard collects) |
|---|---|---|
| `delegate` | `delegate` | **required** — instructions for Alfred ("Settle it, then file the receipt") |
| `defer` | `defer` | **required** — natural-language when ("Tomorrow morning") |
| `done` | `done` | optional — resolution context (seeds the learning observation) |
| `do` | `take_mine` | optional — body for the spawned to_do |
| `noise` | `noise` | empty (the gesture is the explanation) |

`source` defaults to `needs_attention` (the common case — the card came from `/desk`). `source_record` is wrapped to `needs_attention/<id>.md` for that source and passed verbatim for the other five.

Action-level required-note validation runs in a zod `superRefine` so an LLM that omits the prompt for delegate/defer gets a clean validation error pointing at the missing field, not a 4xx from ctrl-api after the wire call.

## Files

- `packages/mcp-server/src/tools/alfred.ts` — two new ToolDefs
- `packages/mcp-server/src/tools/alfred.test.ts` — 18 cases (schema validation per action, buildRequest shape per action, source-record wrapping, reverse path encoding)
- `packages/mcp-server/package.json` — `test` script via `node --import tsx --test src/**/*.test.ts`
- `packages/mcp-server/tsconfig.json` — exclude `*.test.ts` from the prod bundle
- `packages/mcp-server/skills/alfred-mcp-skill.md` — added the new tools + a Common Flow walkthrough
- `.github/workflows/ci-check.yml` — new `test-mcp-server` job

## Surfaces this lands on

Adding to `alfred.ts` automatically surfaces the tools on:
1. The HTTP MCP server (claude.ai Custom Connectors via `mcp.<tenant>.alfred.black`)
2. The stdio bundle Hermes spawns as a child process (`packages/mcp-server/src/bin/stdio-app.ts`) — so the tools land in Hermes' tool catalogue as `alfred__act_on_decision` and `alfred__reverse_decision`

## Tests

```
ℹ tests 18
ℹ pass 18
ℹ fail 0
```

## Done criteria status

- [x] Schema validation per action (delegate/defer require note; done/do/noise optional)
- [x] buildRequest mirrors the dashboard's recordDecision shape exactly
- [x] reverse_decision companion (single-id input)
- [x] Skill markdown updated with the new tools + a Common Flow
- [x] CI job for typecheck + node --test
- [x] Tests green locally
- [ ] Live verify on home — pending image build + redeploy after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)