### PR TITLE
fix(ctrl,voice-bridge): widen VOICE_BRIDGE_ALLOWLIST for `self` realtime tool

### DIFF
--- a/packages/ctrl/src/api/auth.ts
+++ b/packages/ctrl/src/api/auth.ts
@@ -7,28 +7,45 @@
 //
 //   2. Optional VOICE_BRIDGE_INTERNAL_TOKEN — a scoped, path-allowlisted
 //      Bearer for the voice-bridge sibling container. It is permitted
-//      ONLY on the routes voice-bridge actually needs:
+//      ONLY on the routes voice-bridge actually needs (see the two
+//      allowlists below). Everything else 401s as if no token were sent.
 //
-//        GET  /api/v1/phone/voice-context   (read primer for the realtime agent)
-//        POST /api/v1/phone/transcript      (post call transcript at hangup)
-//        POST /api/v1/integrations/execute  (dispatch composio_execute tool
-//                                            calls during the realtime session
-//                                            — added 2026-05-28; without this
-//                                            the realtime agent could not call
-//                                            Composio actions on home.alfred.
-//                                            black, surfacing as a 6ms
-//                                            `composio_execute ok=false
-//                                            status=err` on every voice call.)
+//      The allowlist comes in two shapes:
 //
-//      Any other route requested with this token rejects with 401, as if
-//      no token were presented. This is principle-of-least-privilege for an
-//      internal monorepo service that lives on the same docker network as
-//      ctrl-api but is large attack surface (Twilio mulaw, OpenAI Realtime
-//      WebSocket). If voice-bridge is ever compromised, the blast radius is
-//      bounded to these routes — the master key never leaves ctrl-api.
+//      (a) VOICE_BRIDGE_ALLOWLIST — exact `METHOD:/exact/path` matches.
+//          Used for routes that have no path parameters (`/voice-context`,
+//          `/transcript`, `/integrations/execute`, `/briefings`, etc.).
+//          No prefix inheritance — a future `/voice-context/raw` would not
+//          accidentally inherit privilege from `/voice-context`.
 //
-// Both validations are constant-time (`crypto.timingSafeEqual`) so a
-// network attacker can't time the comparison to recover bytes.
+//      (b) VOICE_BRIDGE_PATTERN_ALLOWLIST — anchored regexes, one per
+//          parameterized route (`/briefings/:slugDate`, `/decisions/:id`,
+//          `/vault/list/:type`, `/vault/records/*`, etc.). Each pattern is
+//          `^...$` anchored and uses a tight `[^/]+` (or path-tail) match,
+//          so adjacent routes can't inherit privilege either. The shape
+//          mirrors what the `self` realtime tool surface needs (vault
+//          read, briefings, decisions, schedules, workflows, matters,
+//          chores, signals, observations) — added 2026-05-28 when sir's
+//          home call sid CAb414732e8fce45b65d1d9f236d91b984 surfaced
+//          `tool self ok=false status=401 4ms argsLen=89` (the residual
+//          PR #95 called out: the voice-bridge `self` tool was routing
+//          correctly to single-VM ctrl-api but the scoped bearer had no
+//          path beyond the original two).
+//
+//      Writes intentionally omitted: the realtime agent has MCP coverage
+//      for the write paths it needs (alfred__act_on_decision /
+//      alfred__reverse_decision were added in PR #97, alfred__notify_*,
+//      alfred__create_vault_record, etc.). `self` stays read-only — if
+//      voice-bridge is ever compromised the blast radius is bounded to
+//      observable state, never mutation.
+//
+//      This is principle-of-least-privilege for an internal monorepo
+//      service that lives on the same docker network as ctrl-api but is
+//      large attack surface (Twilio mulaw, OpenAI Realtime WebSocket). The
+//      master key never leaves ctrl-api.
+//
+// Both token validations are constant-time (`crypto.timingSafeEqual`) so
+// a network attacker can't time the comparison to recover bytes.
 
 import crypto from "node:crypto";
 import type { IncomingMessage } from "node:http";
@@ -42,17 +59,114 @@ let voiceBridgeKeyBuf: Buffer | null = null;
  * allowed to call. The match is EXACT (no prefix matching, no wildcards) so
  * a future route accidentally named close to one of these (e.g.
  * /api/v1/phone/voice-context/raw) does NOT inherit the privilege.
+ *
+ * Routes with path parameters (e.g. `/decisions/:id`) live in
+ * VOICE_BRIDGE_PATTERN_ALLOWLIST below — anchored-regex per route, never a
+ * blanket prefix.
  */
 const VOICE_BRIDGE_ALLOWLIST: ReadonlySet<string> = new Set([
+  // Voice primer + transcript hand-off — the original two routes from
+  // Phase 4.1 (commit 85be684e).
   "GET:/api/v1/phone/voice-context",
   "POST:/api/v1/phone/transcript",
-  // composio_execute dispatch path — added 2026-05-28. The realtime agent's
-  // built-in `composio_execute` tool routes through here. Auth body is
-  // tenant-bound (one Composio user-id per ctrl-api), so this token cannot
-  // hop tenants. Action arguments are model-supplied — we accept the same
-  // surface Hermes uses through MCP, scoped to this single endpoint.
+  // composio_execute dispatch path — added 2026-05-28 in PR #95. The
+  // realtime agent's built-in `composio_execute` tool routes through here.
+  // Auth body is tenant-bound (one Composio user-id per ctrl-api), so this
+  // token cannot hop tenants.
   "POST:/api/v1/integrations/execute",
+  // ── `self` realtime tool, read-only surface — added 2026-05-28. ──────
+  // Sir said the call sid CAb414732e8fce45b65d1d9f236d91b984 logged
+  // `tool self ok=false status=401 4ms argsLen=89`. PR #95 fixed the
+  // dispatcher; this widens the allowlist to the read-only catalogue the
+  // persona file documents (vault, briefings, decisions, schedules,
+  // workflows, matters, chores, signals, observations, learning).
+  //
+  // Briefings — Sir asks "what's my brief?" / list briefings.
+  "GET:/api/v1/briefings",
+  // Vault context primer + parameterless reads.
+  "GET:/api/v1/vault/context",
+  "GET:/api/v1/vault/search",
+  "GET:/api/v1/vault/index",
+  "GET:/api/v1/vault/schema",
+  "GET:/api/v1/vault/inbox",
+  "GET:/api/v1/vault/graph",
+  "GET:/api/v1/vault/nebula-data",
+  // Decision queue — Sir asks "what's on my desk?"
+  "GET:/api/v1/decisions",
+  "GET:/api/v1/decisions/in-flight",
+  // Matters / chores / workflows / schedules — listing the top-level set.
+  "GET:/api/v1/matters",
+  "GET:/api/v1/chores",
+  "GET:/api/v1/chore-actions",
+  "GET:/api/v1/workflows",
+  "GET:/api/v1/schedules",
+  // Signals + observations top-of-list (state.db read surface).
+  "GET:/api/v1/state/signals",
+  "GET:/api/v1/state/observations",
+  // Desk queue (needs_attention) — the Desk audit ledger.
+  "GET:/api/v1/admin/needs-attention",
+  // Learning surfaces — Sir asks "what's Alfred figured out lately?"
+  "GET:/api/v1/learning/status",
+  "GET:/api/v1/learning/observations",
+  "GET:/api/v1/learning/instincts",
+  "GET:/api/v1/learning/reflections",
+  "GET:/api/v1/learning/sessions",
 ]);
+
+/**
+ * Parameterised routes the voice-bridge scoped token can read. Each entry is
+ * an anchored regex matched against the request pathname — no prefix
+ * inheritance, no wildcard between segments. Generated once at module load.
+ *
+ * The shape is deliberately tight: a `[^/]+` for `:id`-style placeholders,
+ * and a `.+` only for the documented `/vault/records/*` tail (the vault
+ * surface natively uses slash-separated record paths). Anything outside
+ * this catalogue 401s through the same code path as a wrong token would.
+ */
+const VOICE_BRIDGE_PATTERN_ALLOWLIST: ReadonlyArray<{
+  method: string;
+  regex: RegExp;
+}> = [
+  // GET /api/v1/briefings/:slugDate — read one brief by date.
+  { method: "GET", regex: /^\/api\/v1\/briefings\/[^/]+$/ },
+  // GET /api/v1/decisions/:id — read one decision (the Desk row).
+  { method: "GET", regex: /^\/api\/v1\/decisions\/[^/]+$/ },
+  // GET /api/v1/vault/list/:type — list vault records by type.
+  { method: "GET", regex: /^\/api\/v1\/vault\/list\/[^/]+$/ },
+  // GET /api/v1/vault/records/<path>  — read one vault record (path can
+  // contain slashes; the route uses an explicit /* tail). Read-only.
+  { method: "GET", regex: /^\/api\/v1\/vault\/records\/.+$/ },
+  // GET /api/v1/matters/:id — read one matter.
+  { method: "GET", regex: /^\/api\/v1\/matters\/[^/]+$/ },
+  // GET /api/v1/chores/:slug — read one chore.
+  { method: "GET", regex: /^\/api\/v1\/chores\/[^/]+$/ },
+  // GET /api/v1/chores/:slug/runs — recent runs of a chore.
+  { method: "GET", regex: /^\/api\/v1\/chores\/[^/]+\/runs$/ },
+  // GET /api/v1/chores/:slug/source — the YAML source of a chore.
+  { method: "GET", regex: /^\/api\/v1\/chores\/[^/]+\/source$/ },
+  // GET /api/v1/workflows/:wfId — read one workflow's status.
+  { method: "GET", regex: /^\/api\/v1\/workflows\/[^/]+$/ },
+  // GET /api/v1/workflows/:wfId/history — workflow history (read-only).
+  { method: "GET", regex: /^\/api\/v1\/workflows\/[^/]+\/history$/ },
+  // GET /api/v1/schedules/:schId — read one schedule's status.
+  { method: "GET", regex: /^\/api\/v1\/schedules\/[^/]+$/ },
+  // GET /api/v1/state/signals/:id — read one signal.
+  { method: "GET", regex: /^\/api\/v1\/state\/signals\/[^/]+$/ },
+  // GET /api/v1/state/observations/:id — read one observation.
+  { method: "GET", regex: /^\/api\/v1\/state\/observations\/[^/]+$/ },
+  // GET /api/v1/learning/observations/:id — one learn observation.
+  { method: "GET", regex: /^\/api\/v1\/learning\/observations\/[^/]+$/ },
+  // GET /api/v1/learning/instincts/:id — one instinct.
+  { method: "GET", regex: /^\/api\/v1\/learning\/instincts\/[^/]+$/ },
+];
+
+function voiceBridgeRouteAllowed(method: string, pathname: string): boolean {
+  if (VOICE_BRIDGE_ALLOWLIST.has(`${method}:${pathname}`)) return true;
+  for (const entry of VOICE_BRIDGE_PATTERN_ALLOWLIST) {
+    if (entry.method === method && entry.regex.test(pathname)) return true;
+  }
+  return false;
+}
 
 export function setApiKey(key: string): void {
   apiKeyBuf = Buffer.from(key);
@@ -100,10 +214,7 @@ export function authenticate(
     tokenBuf.length === voiceBridgeKeyBuf.length &&
     crypto.timingSafeEqual(tokenBuf, voiceBridgeKeyBuf)
   ) {
-    if (
-      route &&
-      VOICE_BRIDGE_ALLOWLIST.has(`${route.method}:${route.pathname}`)
-    ) {
+    if (route && voiceBridgeRouteAllowed(route.method, route.pathname)) {
       return;
     }
     // Token recognised but route not in allowlist — explicit 401 with a

--- a/packages/ctrl/tests/auth-scoped-voice-bridge.test.ts
+++ b/packages/ctrl/tests/auth-scoped-voice-bridge.test.ts
@@ -1,24 +1,37 @@
-// Phase 4.1 — ctrl-api auth.ts accepts a SCOPED voice-bridge bearer, but
-// ONLY for an explicit 2-route allowlist. Any other route requested with
-// that token rejects with 401 — same outcome as if no token were sent.
+// ctrl-api auth.ts accepts a SCOPED voice-bridge bearer, but ONLY for the
+// explicit allowlist (exact strings + anchored regex patterns). Anything
+// outside that catalogue 401s — same outcome as if no token were sent.
+//
+// History:
+//   - Phase 4.1 (commit 85be684e): two routes — /phone/voice-context,
+//     /phone/transcript.
+//   - PR #95 (2026-05-28): + POST /integrations/execute (the
+//     `composio_execute` realtime tool).
+//   - PR #98 (2026-05-28): + the read-only `self` surface — vault reads,
+//     briefings, decisions, schedules, workflows, matters, chores,
+//     signals/observations, learning. Parameterised paths land in
+//     VOICE_BRIDGE_PATTERN_ALLOWLIST (anchored regex). NO writes.
 //
 // What this pins:
 //
 //   1. The master AAS_API_KEY accepts every route (unchanged).
-//   2. The voice-bridge token accepts GET /api/v1/phone/voice-context.
-//   3. The voice-bridge token accepts POST /api/v1/phone/transcript.
-//   4. The voice-bridge token REJECTS every other /api/v1/* route — vault
-//      read, journal recall, settings, anything.
+//   2. The voice-bridge token accepts every documented allowlisted route
+//      — exact + pattern.
+//   3. The voice-bridge token REJECTS every other /api/v1/* route — admin
+//      mutations, settings, sibling channels, etc.
+//   4. The voice-bridge token REJECTS WRITES against `self`'s read
+//      catalogue (PATCH /decisions/:id, POST /streams/events, etc.)
+//      — voice writes via MCP (alfred__act_on_decision &c.), not `self`.
 //   5. A wrong token (neither master nor voice-bridge) rejects.
-//   6. A path that LOOKS LIKE one of the allowlisted routes but isn't an
-//      exact match (e.g. trailing /raw) is also rejected with the
-//      voice-bridge token — exact matching, no prefix inheritance.
+//   6. Prefix-match anti-regression — `/voice-context/raw`, `/decisions`
+//      with a trailing-slash, etc. — must still 401.
 //   7. Wrong method on an allowlisted path also rejects (POST on
-//      /voice-context, GET on /transcript).
+//      /voice-context, DELETE on /decisions/:id).
 //
 // Why this matters: voice-bridge is a network-edge service that talks to
 // Twilio (mulaw parser) and OpenAI Realtime (WebSocket). If it's ever
-// compromised the blast radius MUST be bounded to those 2 routes.
+// compromised the blast radius MUST be bounded — read-only on the
+// surfaces the realtime agent actually needs, nothing else.
 
 import { test, beforeEach } from "node:test";
 import assert from "node:assert/strict";
@@ -85,20 +98,79 @@ test("voice-bridge token accepts POST /api/v1/phone/transcript", () => {
   );
 });
 
-// ------------------------------------------------------------------ voice-bridge reject
-
-test("voice-bridge token REJECTS vault context (master-only territory)", () => {
-  assert.throws(
-    () =>
-      authenticate(fakeReq(VOICE_KEY), {
-        method: "GET",
-        pathname: "/api/v1/vault/context",
-      }),
-    AuthError,
+test("voice-bridge token accepts POST /api/v1/integrations/execute (composio_execute)", () => {
+  assert.doesNotThrow(() =>
+    authenticate(fakeReq(VOICE_KEY), {
+      method: "POST",
+      pathname: "/api/v1/integrations/execute",
+    }),
   );
 });
 
-test("voice-bridge token REJECTS alfred-journal recall (cross-channel memory)", () => {
+// ── `self` read-only surface — PR #98 (2026-05-28). ──────────────────────
+
+test("voice-bridge token accepts `self` read-only catalogue (exact paths)", () => {
+  for (const pathname of [
+    "/api/v1/briefings",
+    "/api/v1/vault/context",
+    "/api/v1/vault/search",
+    "/api/v1/vault/index",
+    "/api/v1/vault/schema",
+    "/api/v1/vault/inbox",
+    "/api/v1/vault/graph",
+    "/api/v1/vault/nebula-data",
+    "/api/v1/decisions",
+    "/api/v1/decisions/in-flight",
+    "/api/v1/matters",
+    "/api/v1/chores",
+    "/api/v1/chore-actions",
+    "/api/v1/workflows",
+    "/api/v1/schedules",
+    "/api/v1/state/signals",
+    "/api/v1/state/observations",
+    "/api/v1/admin/needs-attention",
+    "/api/v1/learning/status",
+    "/api/v1/learning/observations",
+    "/api/v1/learning/instincts",
+    "/api/v1/learning/reflections",
+    "/api/v1/learning/sessions",
+  ]) {
+    assert.doesNotThrow(
+      () => authenticate(fakeReq(VOICE_KEY), { method: "GET", pathname }),
+      `voice-bridge token must accept GET ${pathname}`,
+    );
+  }
+});
+
+test("voice-bridge token accepts `self` parameterised reads (regex allowlist)", () => {
+  for (const pathname of [
+    "/api/v1/briefings/2026-05-28",
+    "/api/v1/decisions/abc123-decision-id",
+    "/api/v1/vault/list/task",
+    "/api/v1/vault/list/note",
+    "/api/v1/vault/records/task/some/slash/separated/path.md",
+    "/api/v1/matters/some-matter-id",
+    "/api/v1/chores/morning-brief",
+    "/api/v1/chores/morning-brief/runs",
+    "/api/v1/chores/morning-brief/source",
+    "/api/v1/workflows/wf-12345",
+    "/api/v1/workflows/wf-12345/history",
+    "/api/v1/schedules/sched-1",
+    "/api/v1/state/signals/sig-1",
+    "/api/v1/state/observations/obs-1",
+    "/api/v1/learning/observations/obs-1",
+    "/api/v1/learning/instincts/inst-1",
+  ]) {
+    assert.doesNotThrow(
+      () => authenticate(fakeReq(VOICE_KEY), { method: "GET", pathname }),
+      `voice-bridge token must accept GET ${pathname}`,
+    );
+  }
+});
+
+// ------------------------------------------------------------------ voice-bridge reject
+
+test("voice-bridge token REJECTS alfred-journal recall (cross-channel memory, master-only)", () => {
   assert.throws(
     () =>
       authenticate(fakeReq(VOICE_KEY), {
@@ -131,27 +203,80 @@ test("voice-bridge token REJECTS sibling channel ops (SMS credentials)", () => {
   );
 });
 
+test("voice-bridge token REJECTS writes against `self` read surfaces", () => {
+  // `self` is intentionally read-only — voice writes via MCP
+  // (alfred__act_on_decision, alfred__reverse_decision, alfred__notify_*,
+  // alfred__create_vault_record). PATCH/POST/DELETE on the read catalogue
+  // MUST 401, even on a path that's GET-allowed.
+  for (const route of [
+    { method: "PATCH", pathname: "/api/v1/decisions/abc123" },
+    { method: "POST", pathname: "/api/v1/decisions/abc123/reverse" },
+    { method: "POST", pathname: "/api/v1/streams/events" },
+    { method: "POST", pathname: "/api/v1/vault/records" },
+    { method: "PATCH", pathname: "/api/v1/vault/records/task/foo.md" },
+    { method: "DELETE", pathname: "/api/v1/vault/records/task/foo.md" },
+    { method: "POST", pathname: "/api/v1/chores/morning-brief/trigger" },
+    { method: "POST", pathname: "/api/v1/workflows" },
+    { method: "DELETE", pathname: "/api/v1/schedules/sched-1" },
+    { method: "PATCH", pathname: "/api/v1/state/signals/sig-1" },
+  ]) {
+    assert.throws(
+      () => authenticate(fakeReq(VOICE_KEY), route),
+      AuthError,
+      `voice-bridge token MUST reject ${route.method} ${route.pathname}`,
+    );
+  }
+});
+
+test("voice-bridge token REJECTS admin mutation surfaces", () => {
+  // /admin/needs-attention (GET) is in the read catalogue, but the wider
+  // /admin surface — containers restart, env, chores emergency-pause,
+  // backups, tailscale — must stay master-only.
+  for (const route of [
+    { method: "GET", pathname: "/api/v1/admin/containers" },
+    { method: "POST", pathname: "/api/v1/admin/containers/hermes/restart" },
+    { method: "GET", pathname: "/api/v1/admin/config/env" },
+    { method: "PATCH", pathname: "/api/v1/admin/config/env" },
+    { method: "POST", pathname: "/api/v1/admin/chores/emergency-pause-all" },
+    { method: "GET", pathname: "/api/v1/admin/dashboard" },
+    { method: "GET", pathname: "/api/v1/admin/credentials" },
+    { method: "POST", pathname: "/api/v1/admin/desk-action" },
+  ]) {
+    assert.throws(
+      () => authenticate(fakeReq(VOICE_KEY), route),
+      AuthError,
+      `voice-bridge token MUST reject ${route.method} ${route.pathname}`,
+    );
+  }
+});
+
 // ---------------------------------------------------------------- exact-match pins
 
-test("voice-bridge token REJECTS a path that PREFIX-matches voice-context", () => {
-  // Anti-regression: if someone introduces /voice-context/raw or similar,
-  // the scoped token must NOT inherit privilege.
-  assert.throws(
-    () =>
-      authenticate(fakeReq(VOICE_KEY), {
-        method: "GET",
-        pathname: "/api/v1/phone/voice-context/raw",
-      }),
-    AuthError,
-  );
-  assert.throws(
-    () =>
-      authenticate(fakeReq(VOICE_KEY), {
-        method: "GET",
-        pathname: "/api/v1/phone/voice-context-extended",
-      }),
-    AuthError,
-  );
+test("voice-bridge token REJECTS prefix-match anti-regression cases", () => {
+  // Anti-regression: anchored matching only. No prefix inheritance.
+  for (const pathname of [
+    // Exact-allowlist neighbours.
+    "/api/v1/phone/voice-context/raw",
+    "/api/v1/phone/voice-context-extended",
+    "/api/v1/briefings-archive",
+    "/api/v1/decisions/in-flight/extra",
+    "/api/v1/vault/contexts", // trailing s, ≠ /vault/context
+    // Pattern-allowlist neighbours — the `[^/]+` segment must not gobble
+    // up extra segments outside the explicit route shape.
+    "/api/v1/briefings/2026-05-28/raw",
+    "/api/v1/decisions/abc/extra",
+    "/api/v1/matters/some-id/extra",
+    "/api/v1/chores/morning-brief/extra-thing",
+    "/api/v1/workflows/wf-1/extra",
+    "/api/v1/schedules/sched-1/extra",
+    "/api/v1/state/signals/sig-1/extra",
+  ]) {
+    assert.throws(
+      () => authenticate(fakeReq(VOICE_KEY), { method: "GET", pathname }),
+      AuthError,
+      `prefix neighbour ${pathname} must be rejected`,
+    );
+  }
 });
 
 test("voice-bridge token REJECTS wrong-method on allowlisted path", () => {


### PR DESCRIPTION
## Symptom

Sir's home call sid `CAb414732e8fce45b65d1d9f236d91b984` logged
`[call owner-1779987363265] tool self ok=false status=401 4ms argsLen=89`.
The realtime agent's catch-all `self` tool (proxy to ctrl-api) was
returning 401 in 4ms — same auth-shape fingerprint that `composio_execute`
showed before PR #95.

## Root cause

PR #95 fixed the dispatcher (`tools.ts` → `ctrlFetch` now routes through
single-VM `ctrlApiUrl` + `ctrlApiAuthToken`), but explicitly left the
ctrl-api side `VOICE_BRIDGE_ALLOWLIST` at the original 2 + 1 routes —
`/phone/voice-context`, `/phone/transcript`, `/integrations/execute`. Any
other endpoint the realtime agent tried to call via `self` hit
`AuthError: Token not permitted on this route` → 401, 4ms.

The persona file (`packages/voice-bridge/src/instructions.ts`) documents
`self` as "vault, streams, learning, workflows, schedules, workers, admin,
and phone outbound ops" — none of which were reachable through the scoped
token.

## Fix

`packages/ctrl/src/api/auth.ts`:

1. Keep `VOICE_BRIDGE_ALLOWLIST` (exact match) and add the parameterless
   read-only routes voice needs: briefings, vault context/search/index/
   schema/inbox/graph/nebula-data, decisions (+ in-flight), matters,
   chores, chore-actions, workflows, schedules, state/signals,
   state/observations, admin/needs-attention, learning/status,
   learning/observations, learning/instincts, learning/reflections,
   learning/sessions.

2. Add a new `VOICE_BRIDGE_PATTERN_ALLOWLIST: Array<{method, regex}>` for
   parameterised paths — each entry an anchored `^...$` regex using
   `[^/]+` for `:id`-style segments (and a deliberate `.+` only for the
   documented `/vault/records/*` tail). No prefix inheritance possible.
   Patterns cover: briefings/:slugDate, decisions/:id, vault/list/:type,
   vault/records/*, matters/:id, chores/:slug{,/runs,/source},
   workflows/:wfId{,/history}, schedules/:schId, state/signals/:id,
   state/observations/:id, learning/observations/:id,
   learning/instincts/:id.

3. New `voiceBridgeRouteAllowed()` checks the exact set first, then the
   pattern array — collapses both into the existing `authenticate()`
   branch without changing the constant-time token check.

`packages/voice-bridge/src/tools.ts` already correctly routes through
`ctrlApiUrl` + `ctrlApiAuthToken` per PR #95 — no change needed on the
voice-bridge side.

## What's intentionally NOT in the allowlist

`self` is read-only. Every write the realtime agent might want already
has MCP coverage:

- mark decision handled / held → `alfred__act_on_decision` (PR #97)
- reverse decision → `alfred__reverse_decision` (PR #97)
- notify principal → `alfred__notify_principal`
- create vault record → `alfred__create_vault_record`
- start workflow → `alfred__start_workflow`

So PATCH /decisions/:id, POST /streams/events, POST /vault/records,
DELETE /vault/records/*, POST /chores/:slug/trigger, POST /workflows,
DELETE /schedules/:id, etc. all still 401 with the voice-bridge token.
The blast radius if voice-bridge is ever compromised is bounded to
observable state — never mutation.

Admin mutation surfaces (containers restart, env edit, backups, tailscale,
chores emergency-pause, credentials, dashboard, desk-action) also stay
master-only. Only `GET /admin/needs-attention` is added to support the
Desk queue read voice already shows.

## Test coverage

`packages/ctrl/tests/auth-scoped-voice-bridge.test.ts` updated:

- `self` exact-allowlist routes (23) all accept GET with voice key.
- `self` parameterised reads (16 representative paths) all accept.
- Writes against the read catalogue (PATCH/POST/DELETE) all reject.
- Admin mutation surfaces reject.
- Expanded prefix-match anti-regression — every pattern's `[^/]+` is
  probed with a trailing `/extra` segment to ensure it doesn't gobble.
- Updated header docstring with the full history (Phase 4.1 → #95 → this).

22/22 tests pass.

## Live verify (home, pre-merge)

ctrl-api hot-deployed to home (api.mjs piped + restart). From inside
voice-bridge container, with the real VOICE_BRIDGE_INTERNAL_TOKEN:

```
GET /api/v1/briefings                          => 200 (real payload)
GET /api/v1/vault/context                      => 200
GET /api/v1/decisions                          => 200
GET /api/v1/admin/needs-attention              => 200
GET /api/v1/vault/list/task                    => 200
GET /api/v1/schedules                          => 200
GET /api/v1/state/signals                      => 200
GET /api/v1/briefings/2026-05-28-evening       => 200 (parameterised path)

GET /api/v1/admin/credentials                  => 401 "Token not permitted on this route"
GET /api/v1/admin/config/env                   => 401
PATCH /api/v1/decisions/abc-123                => 401 (write rejected on a read path)
POST /api/v1/streams/events                    => 401
DELETE /api/v1/vault/records/task/foo.md       => 401
GET /api/v1/phone/voice-context/raw            => 401 (prefix-match anti-regression)
GET /api/v1/decisions/in-flight/extra          => 401 (anchored regex)
```

In-scope: 200. Out-of-scope: 401. Exactly the surgical change the persona
needs without widening the blast radius.

## Deploy

Both `build-ctrl-api.yml` and `build-voice-bridge.yml` trigger on merge
(voice-bridge has no source diff — image rebuilds via path filter on the
voice-bridge directory will not fire here; only ctrl-api will rebuild).
Fleet roll planned: home, rj, joe, zsolt, miguel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)