### PR TITLE
feat(hermes,compose): codex-builder profile rendering, idle by default (PR 2/5)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -260,6 +260,13 @@ services:
       - hermes_data:/hermes-state
       - vault_data:/vault
       - alfred_data:/alfred-data
+      # Sealed builder runtime workspace — mounted in the hermes container
+      # only. Owned uid 10001 mode 0700 by the init container (PR 4); the
+      # codex-builder gateway process drops to uid 10001 (PR 4) and is the
+      # only consumer. Not mounted in paperclip / ctrl-api / web / any other
+      # service: the run data is not even visible to the rest of the stack.
+      # See docs/codex-builder-runtime.md §5.
+      - hermes_codex_work:/work
     tmpfs:
       - /tmp:size=256m
     environment:
@@ -272,6 +279,17 @@ services:
       # container renders profile config from this (via its env_file: .env);
       # pinned here too so the value is unambiguous at the hermes boundary.
       - HERMES_HEAVY_MODEL=${HERMES_HEAVY_MODEL:-anthropic/claude-opus-4-6}
+      # codex-builder profile (:18793) — Sir's decision #2 in
+      # docs/codex-builder-runtime.md §11.2. Default false: the profile is
+      # rendered everywhere by the init container, but the supervisor's
+      # 4th `start_proc` only fires when this is true. Home flips this to
+      # true in /opt/alfred/.env; rj/joe/zsolt/miguel leave it unset and
+      # get an idle profile dir with no listening process on :18793.
+      - ENABLE_CODEX_BUILDER=${ENABLE_CODEX_BUILDER:-false}
+      # Model used by the codex-builder profile's supervising Hermes agent
+      # (the codex CLI invocation it shells out to uses the same model).
+      # Default tracks the latest OpenAI Codex model; overridable.
+      - HERMES_CODEX_BUILDER_MODEL=${HERMES_CODEX_BUILDER_MODEL:-gpt-5-codex}
       - NODE_OPTIONS=--max-old-space-size=3072
       - CTRL_API_URL=http://ctrl-api:3100
       # Per-job timeout (seconds) Hermes applies to every `cron` job. This is
@@ -312,6 +330,14 @@ services:
       - ALL
     cap_add:
       - DAC_OVERRIDE
+      # NET_ADMIN — needed by PR 4's iptables egress allowlist scoped to
+      # uid 10001 (codex-builder), which installs OUTPUT rules at supervisor
+      # boot to allow OpenAI / GitHub / npm / PyPI / crates.io egress and
+      # REJECT everything else for uid 10001. The cap is dormant until PR 4
+      # adds the iptables setup script; it does NOT grant any of the other
+      # 3 profiles new privileges (they run as uid 10000 and their egress
+      # paths are unrestricted today). See docs/codex-builder-runtime.md §6.
+      - NET_ADMIN
     # Sized for two Python gateway processes + MCP stdio children. The
     # workers side carries the heavier task-registry boot path.
     mem_limit: 6g
@@ -1639,6 +1665,10 @@ services:
 volumes:
   vault_data:
   hermes_data:
+  # Sealed builder runtime workspace — used by the codex-builder Hermes
+  # profile only. Owned uid 10001 mode 0700 by the init container (PR 4).
+  # See docs/codex-builder-runtime.md §5.
+  hermes_codex_work:
   alfred_data:
   temporal_data:
   ollama_data:

--- a/packages/hermes/docker/supervisor.sh
+++ b/packages/hermes/docker/supervisor.sh
@@ -7,10 +7,15 @@
 #   1. hermes -p main    gateway run   — user-facing chat (Hermes API :18789)
 #   2. hermes -p workers gateway run   — background agents (Hermes API :18790)
 #   3. hermes -p heavy   gateway run   — heavy reasoning (Hermes API :18791)
+#   4. hermes -p codex-builder gateway run — sealed builder (Hermes API
+#      :18793) — ONLY when ENABLE_CODEX_BUILDER=true. The profile dir
+#      is always rendered by the init container; this script just decides
+#      whether to launch a gateway against it. Drops to uid 10001 via
+#      `setpriv --reuid 10001`. See docs/codex-builder-runtime.md §2.
 #
 # The hermes-shim was retired in issue #40: the Hermes API server binds the
-# canonical ports (:18789 / :18790 / :18791) directly, so callers speak the
-# Hermes /v1 API natively — there is no compat layer to supervise.
+# canonical ports (:18789 / :18790 / :18791 / :18793) directly, so callers
+# speak the Hermes /v1 API natively — there is no compat layer to supervise.
 #
 # SessionStore housekeeping is no longer a supervised process: Hermes
 # v2026.5.16 natively prunes its SQLite session store and VACUUMs, driven
@@ -22,14 +27,26 @@
 #
 # Profile state (config.yaml, .env, SOUL.md, sessions, skills, the MCP
 # bundle) is rendered/deployed by the init container into
-# ${HERMES_HOME}/profiles/{main,workers,heavy}/ BEFORE this container starts —
-# `init` is a compose `service_completed_successfully` gate. This script
-# only waits for that state to appear, then launches.
+# ${HERMES_HOME}/profiles/{main,workers,heavy,codex-builder}/ BEFORE this
+# container starts — `init` is a compose `service_completed_successfully`
+# gate. This script only waits for that state to appear, then launches.
 # =============================================================================
 set -uo pipefail
 
 HERMES_HOME="${HERMES_HOME:-/opt/data}"
 PROFILES_DIR="${HERMES_HOME}/profiles"
+
+# Sir's decision #2: codex-builder is rendered on every tenant but ONLY
+# launched where the flag is true. Reads the runtime container env (set
+# from docker-compose's `environment:` block + the tenant /opt/alfred/.env).
+# Treat the empty string, "0", "false", "no", "off" as false; anything else
+# is true. Defaults to false — every tenant that doesn't explicitly opt in
+# gets the rendered profile dir + a silent no-launch.
+ENABLE_CODEX_BUILDER_RAW="${ENABLE_CODEX_BUILDER:-false}"
+case "${ENABLE_CODEX_BUILDER_RAW,,}" in
+    true|1|yes|on)  ENABLE_CODEX_BUILDER=1 ;;
+    *)              ENABLE_CODEX_BUILDER=0 ;;
+esac
 
 # Per-process restart backoff — a crash-looping process must not hammer the
 # provider or spin the CPU. Three rapid restarts then a longer cooldown.
@@ -92,7 +109,11 @@ trap shutdown TERM INT
 # launch before that exists, Hermes boots with no API key / no MCP config.
 wait_for_profiles() {
     local waited=0
-    for profile in main workers heavy; do
+    local profiles_to_wait=(main workers heavy)
+    if (( ENABLE_CODEX_BUILDER == 1 )); then
+        profiles_to_wait+=(codex-builder)
+    fi
+    for profile in "${profiles_to_wait[@]}"; do
         local cfg="${PROFILES_DIR}/${profile}/config.yaml"
         local env="${PROFILES_DIR}/${profile}/.env"
         while [[ ! -f "$cfg" || ! -f "$env" ]]; do
@@ -108,7 +129,7 @@ wait_for_profiles() {
             fi
         done
     done
-    log "all Hermes profiles provisioned under ${PROFILES_DIR}"
+    log "all Hermes profiles provisioned under ${PROFILES_DIR} (codex-builder enabled=${ENABLE_CODEX_BUILDER})"
 }
 
 # =============================================================================
@@ -137,6 +158,19 @@ hermes profile use main 2>/dev/null || true
 # either is missing OR is smaller (heuristic: empty or env-pointer-only).
 # Idempotent — re-running this on every boot is a no-op once the per-profile
 # files are sized at-least the main one.
+#
+# Sir's decision #1 (docs/codex-builder-runtime.md §11.1, overruling the
+# design-doc recommendation): codex-builder uses the SHARED openai-codex
+# auth, NOT a separate `codex login --device-auth` ritual per tenant. So
+# when ENABLE_CODEX_BUILDER=1 AND the profile dir exists, we mirror the
+# same main/auth.json into:
+#   - profiles/codex-builder/auth.json (Hermes' LLM provider auth — what
+#     the supervising agent uses for its own /v1/responses calls)
+#   - profiles/codex-builder/.codex/auth.json (the codex CLI's auth file —
+#     the CLI reads $CODEX_HOME/auth.json, which the .env points at
+#     /hermes-state/profiles/codex-builder/.codex).
+# Same OAuth token, two file locations, one shared ChatGPT identity.
+# Survives `docker compose pull` because hermes_data is a named volume.
 HERMES_ROOT="${HERMES_HOME:-/hermes-state}"
 MAIN_AUTH="$HERMES_ROOT/profiles/main/auth.json"
 if [[ -f "$MAIN_AUTH" && -s "$MAIN_AUTH" ]]; then
@@ -150,6 +184,28 @@ if [[ -f "$MAIN_AUTH" && -s "$MAIN_AUTH" ]]; then
             log "propagated main/auth.json -> $p/auth.json (${MAIN_SIZE} bytes)"
         fi
     done
+
+    # codex-builder mirror — gated on the flag + the rendered profile.
+    if (( ENABLE_CODEX_BUILDER == 1 )) \
+       && [[ -d "$HERMES_ROOT/profiles/codex-builder" ]]; then
+        CB_AUTH="$HERMES_ROOT/profiles/codex-builder/auth.json"
+        CB_SIZE=0
+        [[ -f "$CB_AUTH" ]] && CB_SIZE=$(stat -c%s "$CB_AUTH" 2>/dev/null || echo 0)
+        if [[ "$CB_SIZE" -lt "$MAIN_SIZE" ]]; then
+            cp "$MAIN_AUTH" "$CB_AUTH"
+            log "propagated main/auth.json -> codex-builder/auth.json (${MAIN_SIZE} bytes, Hermes-LLM auth)"
+        fi
+        # Codex CLI's own auth — reads $CODEX_HOME/auth.json. .env sets
+        # CODEX_HOME=/hermes-state/profiles/codex-builder/.codex.
+        mkdir -p "$HERMES_ROOT/profiles/codex-builder/.codex"
+        CLI_AUTH="$HERMES_ROOT/profiles/codex-builder/.codex/auth.json"
+        CLI_SIZE=0
+        [[ -f "$CLI_AUTH" ]] && CLI_SIZE=$(stat -c%s "$CLI_AUTH" 2>/dev/null || echo 0)
+        if [[ "$CLI_SIZE" -lt "$MAIN_SIZE" ]]; then
+            cp "$MAIN_AUTH" "$CLI_AUTH"
+            log "propagated main/auth.json -> codex-builder/.codex/auth.json (${MAIN_SIZE} bytes, codex-CLI auth)"
+        fi
+    fi
 fi
 
 # Consolidate the Alfred-personalised SOUL.md to the file Hermes actually
@@ -328,6 +384,33 @@ fi
 start_proc "hermes-main"     "cd \"${PROFILES_DIR}/main\"    && set -a && . \"${PROFILES_DIR}/main/.env\"    && set +a && TERMINAL_CWD=${PROFILES_DIR}/main    exec hermes -p main gateway run --replace"
 start_proc "hermes-workers"  "cd \"${PROFILES_DIR}/workers\" && set -a && . \"${PROFILES_DIR}/workers/.env\" && set +a && TERMINAL_CWD=${PROFILES_DIR}/workers exec hermes -p workers gateway run --replace"
 start_proc "hermes-heavy"    "cd \"${PROFILES_DIR}/heavy\"   && set -a && . \"${PROFILES_DIR}/heavy/.env\"   && set +a && TERMINAL_CWD=${PROFILES_DIR}/heavy   exec hermes -p heavy gateway run --replace"
+
+# --- codex-builder gateway (Sir's decision #2 — flag-gated, home only) -------
+# The 4th profile, only launched when ENABLE_CODEX_BUILDER=1. Renders fleet-
+# wide via the init container, but a non-home tenant never starts the process.
+#
+# PR 2 of 5: this launches under the container's default uid (10000, same as
+# the other 3 gateways). PR 4 will swap the body for `setpriv --reuid 10001
+# --regid 10001 --clear-groups --reset-env hermes -p codex-builder gateway
+# run --replace` once the FS-isolation init step has chowned the profile dir
+# + /work to uid 10001. Verifying PR 2 means: the gateway boots on :18793
+# and answers /health. PR 4 verifies: uid-10001 cannot read /vault.
+#
+# `cd ${PROFILES_DIR}/codex-builder` lines up AGENTS.md auto-discovery and
+# matches the established pattern. `set -a; . .env; set +a` source-and-
+# exports the codex-builder positive-allowlist (the 2026-05-28 hardening
+# from PR #92) — the .env's CODEX_HOME / CODEX_WORKSPACE_ROOT / GIT_SSH_
+# COMMAND flow through to the gateway process here.
+if (( ENABLE_CODEX_BUILDER == 1 )); then
+    start_proc "hermes-codex-builder" \
+        "cd \"${PROFILES_DIR}/codex-builder\" \
+         && set -a && . \"${PROFILES_DIR}/codex-builder/.env\" && set +a \
+         && TERMINAL_CWD=${PROFILES_DIR}/codex-builder/workspace \
+         exec hermes -p codex-builder gateway run --replace"
+    log "codex-builder gateway enabled (ENABLE_CODEX_BUILDER=1) — launching on :18793"
+else
+    log "codex-builder gateway disabled (ENABLE_CODEX_BUILDER!=1) — profile dir is rendered but no process launched"
+fi
 
 # =============================================================================
 # Supervise — restart any worker that exits while we are not shutting down.

--- a/packages/hermes/hermes-config.yaml.njk
+++ b/packages/hermes/hermes-config.yaml.njk
@@ -47,6 +47,20 @@
 # =============================================================================
 # Model
 # =============================================================================
+{%- if profile == "codex-builder" %}
+# codex-builder is the sealed-runtime builder profile (docs/codex-builder-
+# runtime.md §2). Provider is HARD-PINNED to openai-codex — the codex CLI
+# this profile shells out to authenticates via ChatGPT OAuth, and the
+# supervising agent's LLM turns should use the same provider so the system
+# stays internally consistent. NOT overridable from .env: a future tenant
+# .env edit cannot accidentally swing this profile back to openrouter.
+model:
+  default: "{{ codex_builder_model | default('gpt-5-codex') }}"
+  provider: "openai-codex"
+  # No base_url for openai-codex — Hermes resolves the endpoint internally
+  # from the ChatGPT auth.json (shared with main per Sir's decision #1).
+  max_tokens: 8192
+{%- else %}
 model:
 {%- if is_main %}
   # User-facing Alfred — a capable model for the live chat surface.
@@ -80,6 +94,7 @@ model:
   # Sir 2026-05-27 — see joe.alfred.black cdsk incident: tool routing died
   # on this exact gate while the OpenRouter key still had $46 of credit.
   max_tokens: 8192
+{%- endif %}
 
 # =============================================================================
 # Agent behaviour
@@ -88,10 +103,18 @@ agent:
   # Tool-calling iteration ceiling per conversation.
 {%- if is_main %}
   max_turns: 80
+{%- elif profile == "codex-builder" %}
+  # codex-builder spends most of its turns shelling out to `codex exec`;
+  # 50 is consistent with workers/heavy and matches Sir's hand-off spec.
+  max_turns: 50
+  # Reason hard, act cheap — most "thought" happens inside the codex CLI.
+  reasoning_effort: "high"
 {%- else %}
   max_turns: 50
 {%- endif %}
+{%- if profile != "codex-builder" %}
   reasoning_effort: "medium"
+{%- endif %}
   verbose: false
   # Graceful drain on gateway stop/restart — let in-flight agents finish.
   restart_drain_timeout: 60
@@ -116,6 +139,18 @@ cron:
   # gateway process's own HERMES_HOME, so this affects main-profile cron jobs
   # only. The workers profile renders no `cron:` block and is unaffected.
   wrap_response: false
+{%- elif profile == "codex-builder" %}
+# codex-builder cron job — daily GC of /work/runs older than 7 days. Sir's
+# spec calls for ephemeral workspaces; the run dir is left in place after
+# a run for operator forensics (see docs/codex-builder-runtime.md §5) and
+# GC'd on this schedule. wrap_response: false because the only consumer is
+# `cleanup-old-runs` and the gateway's response wrap would just be noise.
+cron:
+  wrap_response: false
+  jobs:
+    - name: cleanup-old-runs
+      schedule: "13 3 * * *"
+      command: "find /work/runs -maxdepth 1 -mindepth 1 -type d -mtime +7 -exec rm -rf {} +"
 {%- else %}
 # Workers profile: no cron consumers — cron is left at Hermes defaults.
 {%- endif %}
@@ -144,10 +179,12 @@ memory:
   nudge_interval: 10
   flush_min_turns: 6
 {%- else %}
-  # Workers are stateless classification/curation agents — no conversation
-  # memory. This is the Hermes equivalent of OpenClaw's
-  # `plugins.slots.memory = "none"` on the workers gateway: it stops the
-  # unbounded memory-store growth that caused the QMD compaction death loop.
+  # Workers/heavy/codex-builder are stateless classification/curation/build
+  # agents — no conversation memory. This is the Hermes equivalent of
+  # OpenClaw's `plugins.slots.memory = "none"` on the workers gateway: it
+  # stops the unbounded memory-store growth that caused the QMD compaction
+  # death loop. codex-builder additionally is one-shot per run — there is
+  # no "user" or "principal" identity here, so user_profile would be empty.
   memory_enabled: false
   user_profile_enabled: false
   nudge_interval: 0
@@ -164,6 +201,13 @@ session_reset:
   mode: both
   idle_minutes: 1440
   at_hour: 4
+{%- elif profile == "codex-builder" %}
+  # Builder runs are one-shot per Paperclip issue — reset aggressively
+  # so the next run starts with no carry-over context. 5 min is well
+  # under the 30-min terminal.timeout below; a successful run finishes
+  # and the session goes idle, the next heartbeat finds it reset.
+  mode: idle
+  idle_minutes: 5
 {%- else %}
   # Workers run one-shot tasks; reset aggressively on idle so a worker
   # session never lingers and accumulates transcript.
@@ -180,6 +224,17 @@ delegation:
   max_iterations: 50
   max_concurrent_children: 3
   max_spawn_depth: 1
+{%- elif profile == "codex-builder" %}
+  # codex-builder NEVER delegates. The whole point is one sealed
+  # supervisor per Paperclip issue, driving codex-CLI through a
+  # restricted terminal. A spawned sub-agent would inherit none of the
+  # workspace mount logic and could undermine the security boundary by
+  # routing back through main's MCP catalogue (the orchestrator
+  # pattern in §1 is "Paperclip splits the work, not Hermes").
+  max_iterations: 50
+  max_concurrent_children: 1
+  max_spawn_depth: 0
+  subagent_auto_approve: false
 {%- else %}
   # Concurrency cap = 1. Background workers serialise all LLM calls — this
   # is the Hermes equivalent of OpenClaw's `agents.defaults.maxConcurrent: 1`
@@ -208,10 +263,12 @@ approvals:
   mode: smart
   timeout: 60
 {%- else %}
-  # Background workers run autonomously on cron/batch pipelines with no TTY
-  # and no human to answer a prompt — a `manual`/`smart` escalation would
-  # deadlock the run. `tool_loop_guardrails` (below) is the safety net that
-  # actually fits an unattended worker: a hard stop on stuck loops.
+  # Background workers / heavy / codex-builder run autonomously on cron /
+  # batch pipelines with no TTY and no human to answer a prompt — a
+  # `manual`/`smart` escalation would deadlock the run. For codex-builder
+  # specifically: the codex CLI's own `--sandbox workspace-write` is the
+  # safety net, not Hermes' approval surface. `tool_loop_guardrails`
+  # (below) is the additional belt-and-braces stop on stuck loops.
   mode: off
 {%- endif %}
 
@@ -245,9 +302,20 @@ terminal:
   # diverges (e.g. /hermes-state), so it now derives from the runtime profile
   # dir render_hermes bakes in. Pointed at the profile dir root (not the
   # workspace/ subdir) so it co-locates with the AGENTS.md the gateway loads.
+{%- if profile == "codex-builder" %}
+  # codex-builder runs codex out of /work (a separately-mounted named volume
+  # owned by uid 10001). workspace/ is a symlink into /work/runs created by
+  # the per-run prep script (PR 4); this cwd is the entry point.
+  cwd: "{{ runtime_profile_dir }}/workspace"
+  # 30-min wall-clock budget per `codex exec` (Sir's decision #3). Matches
+  # the Paperclip-side runTimeoutMs (see docs/codex-builder-runtime.md §7).
+  timeout: 1800
+  lifetime_seconds: 3600
+{%- else %}
   cwd: "{{ runtime_profile_dir }}/workspace"
   timeout: 180
   lifetime_seconds: 300
+{%- endif %}
 
 # =============================================================================
 # Skills
@@ -285,6 +353,14 @@ platform_toolsets:
   discord: [hermes-discord]
   whatsapp: [hermes-whatsapp]
   signal: [hermes-signal]
+{%- elif profile == "codex-builder" %}
+  # Sealed surface: terminal + file ONLY. No web (egress is iptables-
+  # restricted, see docs/codex-builder-runtime.md §6), no skills (none
+  # rendered into the profile dir), no todo (one-shot agent — no list to
+  # maintain), no vision (no images in code reviews here), no delegation
+  # (max_spawn_depth: 0 above is the hard fence; this is the soft one).
+  # The agent has exactly one verb: run terminal commands in /work/runs.
+  cli: [terminal, file]
 {%- else %}
   # Workers: terminal + file + web + skills + todo + delegation. No
   # messaging toolset — workers never deliver to a channel directly
@@ -295,6 +371,15 @@ platform_toolsets:
 # =============================================================================
 # MCP (Model Context Protocol) servers
 # =============================================================================
+{%- if profile == "codex-builder" %}
+# codex-builder: explicitly empty. No ctrl-api, no Paperclip, no Plane,
+# no Sure, no Vaultwarden, no execute, no Composio. The supervisor agent
+# has zero MCP tools — its only verb is `terminal`. This is the hard
+# fence per docs/codex-builder-runtime.md §6: any future operator who
+# adds an MCP server here must justify why the sealed runtime should
+# gain a new external reach.
+mcp_servers: {}
+{%- else %}
 # Six servers, identical on both profiles — migrated verbatim from the
 # OpenClaw `mcp.servers` block. One HTTP proxy + five stdio apps. Hermes
 # auto-namespaces every tool as mcp_<server>_<tool>.
@@ -406,6 +491,7 @@ mcp_servers:
       PAPERCLIP_AGENT_ID: "${PAPERCLIP_AGENT_ID}"
     timeout: 120
     connect_timeout: 60
+{%- endif %}{# end mcp_servers else (codex-builder gets mcp_servers: {} above) #}
 
 {%- if is_main %}
 # =============================================================================

--- a/packages/hermes/hermes-profile.env.njk
+++ b/packages/hermes/hermes-profile.env.njk
@@ -38,8 +38,11 @@
 # OpenAI-compatible API server
 # -----------------------------------------------------------------------------
 # Enabled so callers can reach this profile over /v1/runs + /v1/responses.
-# Hermes binds the canonical port (18789 main / 18790 workers) directly on
-# 0.0.0.0 — the hermes-shim that used to front it was retired in issue #40.
+# Hermes binds the canonical port (18789 main / 18790 workers / 18791 heavy /
+# 18793 codex-builder) directly on 0.0.0.0 — the hermes-shim that used to
+# front it was retired in issue #40. The codex-builder port is COMPOSE-
+# INTERNAL only (no host publish, no Caddy entry, no Tailscale Serve) —
+# the only caller is the paperclip adapter inside the same compose network.
 API_SERVER_ENABLED=true
 API_SERVER_PORT={{ api_server_port }}
 API_SERVER_HOST={{ api_server_host }}
@@ -51,6 +54,49 @@ API_SERVER_CORS_ORIGINS={{ api_server_cors }}
 {%- endif %}
 # Advertise this profile's name on /v1/models.
 API_SERVER_MODEL_NAME={{ profile }}
+
+{%- if profile == "codex-builder" %}
+
+# -----------------------------------------------------------------------------
+# codex-builder runtime
+# -----------------------------------------------------------------------------
+# Per docs/codex-builder-runtime.md, this profile is a POSITIVE-ALLOWLIST
+# environment: every key absent here is INTENTIONALLY omitted. The
+# runtime-key preservation list (_RUNTIME_KEY_PREFIXES in render_hermes.py)
+# explicitly skips this profile, so a /channels Save Token write into
+# another profile cannot leak in.
+#
+# Specifically OMITTED (and why):
+#   OPENROUTER_API_KEY  — profile uses openai-codex provider exclusively.
+#   ANTHROPIC_API_KEY   — same.
+#   OPENAI_API_KEY      — codex CLI auth is OAuth-via-ChatGPT, not REST.
+#   COMPOSIO_API_KEY    — no MCP catalogue, nothing to authenticate to.
+#   COMPOSIO_USER_ID    — same.
+#   AAS_API_KEY         — no ctrl-api access. Every ctrl-api call 401s.
+#   PAPERCLIP_API_KEY   — profile MUST NOT call paperclip back. The
+#                         paperclip-adapter is the ONLY thing that calls
+#                         the profile, never the other way around.
+#   TWILIO_/SLACK_/TELEGRAM_/DISCORD_/SMS_/WHATSAPP_ — no channels.
+#
+# CODEX_HOME points at the profile dir. Per Sir's decision #1, this dir's
+# auth.json is MIRRORED from main/auth.json at supervisor boot (shared
+# openai-codex provider auth) — a one-time `codex login` ritual on main
+# is sufficient.
+CODEX_HOME=/hermes-state/profiles/codex-builder/.codex
+# Workspace mount — see docs/codex-builder-runtime.md §5. Owned uid 10001
+# mode 0700 by the init container.
+CODEX_WORKSPACE_ROOT=/work
+# SSH key for git push, written by the PR 4 init step. Until then this
+# variable is set but the file doesn't exist — `git push` will fail clean
+# with "no such file" instead of leaking an ambient agent identity.
+GIT_SSH_COMMAND=ssh -i /hermes-state/profiles/codex-builder/.ssh/codex_id_ed25519 -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes
+# Egress filter (PR 4) reads this. Default deny — only positively-listed
+# domains/CIDRs reach the network.
+CODEX_NETWORK_ALLOWLIST_FILE=/hermes-state/profiles/codex-builder/network-allowlist.txt
+GATEWAY_ALLOW_ALL_USERS=false
+HERMES_HUMAN_DELAY_MODE=off
+
+{%- else %}
 
 # -----------------------------------------------------------------------------
 # LLM provider keys
@@ -83,3 +129,4 @@ COMPOSIO_USER_ID={{ composio_user_id }}
 GATEWAY_ALLOW_ALL_USERS=false
 {%- endif %}
 HERMES_HUMAN_DELAY_MODE=off
+{%- endif %}

--- a/packages/hermes/init/entrypoint.sh
+++ b/packages/hermes/init/entrypoint.sh
@@ -35,7 +35,25 @@ echo "=== alfred-black init container ==="
 HERMES_DATA_DIR="${HERMES_DATA_DIR:-/hermes-data}"
 # Where the HERMES RUNTIME container sees the same volume (its HERMES_HOME).
 HERMES_RUNTIME_HOME="${HERMES_RUNTIME_HOME:-/opt/data}"
+
+# Profiles whose state we render on every tenant. The codex-builder profile
+# (PR 2 of docs/codex-builder-runtime.md) is rendered fleet-wide so the port
+# layout stays uniform, but the SUPERVISOR only LAUNCHES its gateway when
+# ENABLE_CODEX_BUILDER=true in the runtime container env. Home flips that
+# flag true; rj/joe/zsolt/miguel leave it unset.
+#
+# PROFILES holds the "regular" profiles that get the full deploy treatment:
+# skills/, MCP bundle, AGENTS.md, SOUL.md. codex-builder is rendered (config
+# + .env + dir scaffold) but does NOT receive any of those — it is a sealed
+# runtime with no MCP catalogue and no skill library. See PROFILES_RENDERED
+# below for the broader set the renderer iterates over.
 PROFILES=(main workers heavy)
+# Every profile we render config + .env for. Each one gets profile_dir +
+# workspace/ + mcp/ created; codex-builder additionally gets its own
+# .codex/ + .ssh/ + workspace/runs/ tree but skips the skills + MCP-bundle
+# deploys further down. The supervisor reads ENABLE_CODEX_BUILDER to decide
+# whether to launch a gateway against the codex-builder dir.
+PROFILES_RENDERED=(main workers heavy codex-builder)
 
 # Resolve bundled paths via the installed alfred Python package.
 SCAFFOLD_DIR=$(python3 -c "from alfred._data import get_scaffold_dir; print(get_scaffold_dir())")
@@ -93,10 +111,20 @@ echo "[init] memories dir ready at $MEMORIES_DIR (chmod 0777 for cross-container
 # gets its own copy of: skills/, mcp-stdio/ (the 5-app bundle), mcp/
 # (ctrl-server.mjs), AGENTS.md, and a workspace/ scratch dir.
 # =============================================================================
-for profile in "${PROFILES[@]}"; do
+for profile in "${PROFILES_RENDERED[@]}"; do
     PROFILE_DIR="$HERMES_DATA_DIR/profiles/$profile"
-    mkdir -p "$PROFILE_DIR/skills" "$PROFILE_DIR/workspace" "$PROFILE_DIR/mcp"
-    echo "[init] Profile dir ready: $PROFILE_DIR"
+    if [[ "$profile" == "codex-builder" ]]; then
+        # Sealed runtime — no skills/, no mcp/ (mcp_servers: {} in
+        # config.yaml means the gateway never spawns an MCP child). Lay
+        # down workspace/ (terminal cwd) + .codex/ (CODEX_HOME) + .ssh/
+        # (PR 4 deploy key dst); the chown/chmod hardening to uid 10001
+        # happens in PR 4.
+        mkdir -p "$PROFILE_DIR/workspace" "$PROFILE_DIR/.codex" "$PROFILE_DIR/.ssh"
+        echo "[init] Profile dir ready (sealed): $PROFILE_DIR"
+    else
+        mkdir -p "$PROFILE_DIR/skills" "$PROFILE_DIR/workspace" "$PROFILE_DIR/mcp"
+        echo "[init] Profile dir ready: $PROFILE_DIR"
+    fi
 done
 
 # --- 2.0. One-time skill consolidation ---------------------------------------
@@ -449,7 +477,7 @@ fi
 # API_SERVER_KEY in each .env.
 # =============================================================================
 echo "[init] Rendering Hermes profile configs..."
-for profile in "${PROFILES[@]}"; do
+for profile in "${PROFILES_RENDERED[@]}"; do
     INIT_PROFILE_DIR="$HERMES_DATA_DIR/profiles/$profile"
     RUNTIME_PROFILE_DIR="$HERMES_RUNTIME_HOME/profiles/$profile"
     mkdir -p "$INIT_PROFILE_DIR"

--- a/packages/hermes/init/render_hermes.py
+++ b/packages/hermes/init/render_hermes.py
@@ -24,7 +24,7 @@ Environment (read for template variables):
     HERMES_API_CORS_ORIGINS  (optional CORS allowlist)
 
 Positional:
-    <profile>       "main" | "workers" | "heavy"
+    <profile>       "main" | "workers" | "heavy" | "codex-builder"
     <profile_dir>   absolute path where this process WRITES config.yaml +
                     .env (the init container's view of the volume,
                     e.g. /hermes-data/profiles/main)
@@ -33,8 +33,8 @@ Positional:
                     API_SERVER_KEY in the profile .env
 
 The Hermes API server binds the canonical ports 18789 (main) / 18790
-(workers) / 18791 (heavy) directly — the hermes-shim that used to front it
-was retired in issue #40.
+(workers) / 18791 (heavy) / 18793 (codex-builder) directly — the
+hermes-shim that used to front it was retired in issue #40.
 
 Path-baking: the absolute paths baked INTO the rendered config.yaml
 (mcp-stdio dir, ctrl-server.mjs, NODE_PATH) must be valid in the HERMES
@@ -63,7 +63,23 @@ from jinja2 import Environment, FileSystemLoader, StrictUndefined
 # The hermes-shim was retired (issue #40); the Hermes API server now binds
 # these ports directly. Must match docker/supervisor.sh and the EXPOSE in
 # the Dockerfile.
-_API_SERVER_PORT = {"main": 18789, "workers": 18790, "heavy": 18791}
+#
+# codex-builder (:18793) is the sealed-runtime builder profile (PR 2 of the
+# codex-builder build, docs/codex-builder-runtime.md). It is rendered on
+# every tenant for fleet-uniform port layout, but the supervisor only
+# LAUNCHES it when ENABLE_CODEX_BUILDER=true in the per-tenant compose env.
+# So home gets the running gateway; rj/joe/zsolt/miguel get an idle profile
+# dir but no listening process on :18793.
+_API_SERVER_PORT = {
+    "main": 18789,
+    "workers": 18790,
+    "heavy": 18791,
+    "codex-builder": 18793,
+}
+
+# Profiles this script knows how to render. Adding a profile is two changes:
+# this set + a port mapping above. Everything else flows from the templates.
+_KNOWN_PROFILES = frozenset(_API_SERVER_PORT.keys())
 
 # The template renders the `model:` block with `provider: openrouter`. Hermes
 # owns provider/model selection natively (`hermes model`, with a live model
@@ -230,11 +246,23 @@ def _parse_env_keys(text: str) -> dict[str, str]:
     return out
 
 
-def _merge_preserve_runtime_keys(rendered: str, env_path: Path) -> str:
+def _merge_preserve_runtime_keys(
+    rendered: str, env_path: Path, profile: str
+) -> str:
     """Append runtime-managed keys (TELEGRAM_*, SLACK_*, …) from the
     existing .env to the freshly-rendered output, if they aren't already
     present in the render.
+
+    codex-builder is the explicit exception: its .env is a STRICT
+    positive allowlist (no provider keys, no MCP keys, no channel keys),
+    and any preservation step would be a leak vector — a stray
+    TELEGRAM_BOT_TOKEN written by ctrl-api into the wrong profile would
+    survive across re-renders here without preservation being skipped.
+    The sealed runtime exists exactly to keep secret surfaces small;
+    treat the per-profile .env as the surface authority.
     """
+    if profile == "codex-builder":
+        return rendered
     if not env_path.exists():
         return rendered
     try:
@@ -287,9 +315,10 @@ def main() -> int:
     template_dir = Path(sys.argv[3])
     gateway_token = sys.argv[4].strip()
 
-    if profile not in ("main", "workers", "heavy"):
+    if profile not in _KNOWN_PROFILES:
+        valid = "|".join(sorted(_KNOWN_PROFILES))
         print(
-            f"error: profile must be main|workers|heavy, got {profile!r}",
+            f"error: profile must be {valid}, got {profile!r}",
             file=sys.stderr,
         )
         return 2
@@ -353,6 +382,13 @@ def main() -> int:
         main_model=os.environ.get("HERMES_MAIN_MODEL", "x-ai/grok-4.3"),
         workers_model=os.environ.get("HERMES_WORKERS_MODEL", "openai/gpt-4.1-nano"),
         heavy_model=os.environ.get("HERMES_HEAVY_MODEL", "anthropic/claude-opus-4-6"),
+        # codex-builder runs Hermes' supervising agent on the same openai-
+        # codex model the CLI it shells out to uses. Overridable so a
+        # future Codex model bump is a one-line .env change, not a
+        # template+rebuild. See docs/codex-builder-runtime.md §2.
+        codex_builder_model=os.environ.get(
+            "HERMES_CODEX_BUILDER_MODEL", "gpt-5-codex"
+        ),
     )
     config_path = profile_dir / "config.yaml"
     # config.yaml is operator-owned: once it exists, `hermes config` / the
@@ -400,7 +436,7 @@ def main() -> int:
     # everything not in the template" rule) so an operator who hand-edits the
     # file with a stale provider key doesn't accidentally pin that stale
     # value across re-renders.
-    env_out = _merge_preserve_runtime_keys(env_out, env_path)
+    env_out = _merge_preserve_runtime_keys(env_out, env_path, profile)
     env_path.write_text(env_out, encoding="utf-8")
     # .env carries the API key + provider keys. We want it permissive
     # enough that sibling containers in the SAME compose stack — paperclip

--- a/packages/hermes/init/test_render_preserve.py
+++ b/packages/hermes/init/test_render_preserve.py
@@ -64,7 +64,7 @@ def test_merge_preserves_telegram_keys_from_existing_env(tmp_path: Path) -> None
         "API_SERVER_PORT=18789\n"
         "OPENROUTER_API_KEY=newkey\n"  # template overrides
     )
-    out = _merge_preserve_runtime_keys(rendered, env_path)
+    out = _merge_preserve_runtime_keys(rendered, env_path, "main")
 
     # Template's value for OPENROUTER_API_KEY wins.
     parsed = _parse_env_keys(out)
@@ -80,14 +80,46 @@ def test_merge_preserves_telegram_keys_from_existing_env(tmp_path: Path) -> None
 def test_no_existing_env_returns_rendered_unchanged(tmp_path: Path) -> None:
     env_path = tmp_path / ".env"  # does not exist
     rendered = "API_SERVER_PORT=18789\n"
-    assert _merge_preserve_runtime_keys(rendered, env_path) == rendered
+    assert _merge_preserve_runtime_keys(rendered, env_path, "main") == rendered
+
+
+def test_codex_builder_skips_runtime_preservation(tmp_path: Path) -> None:
+    """codex-builder is the sealed-runtime profile (PR 2 of
+    docs/codex-builder-runtime.md). Its .env is a strict positive allowlist
+    — preserving runtime-managed keys would be a leak vector. Even when the
+    existing .env carries TELEGRAM_/SLACK_/PAPERCLIP_/AAS_ keys (e.g. from
+    a misconfigured operator copy), the preservation step MUST return the
+    rendered output unchanged for this profile.
+    """
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "OPENROUTER_API_KEY=should-never-be-here\n"
+        "TELEGRAM_BOT_TOKEN=leak-vector-1\n"
+        "PAPERCLIP_API_KEY=leak-vector-2\n"
+        "TWILIO_ACCOUNT_SID=AC" + ("0" * 32) + "\n"
+    )
+    rendered = (
+        "API_SERVER_PORT=18793\n"
+        "API_SERVER_MODEL_NAME=codex-builder\n"
+        "CODEX_HOME=/hermes-state/profiles/codex-builder/.codex\n"
+    )
+    out = _merge_preserve_runtime_keys(rendered, env_path, "codex-builder")
+
+    # Strict equality — the rendered output must be returned untouched.
+    assert out == rendered
+    parsed = _parse_env_keys(out)
+    assert "TELEGRAM_BOT_TOKEN" not in parsed
+    assert "PAPERCLIP_API_KEY" not in parsed
+    assert "TWILIO_ACCOUNT_SID" not in parsed
+    # Even the OPENROUTER_API_KEY "in the existing file" did not flow through.
+    assert "OPENROUTER_API_KEY" not in parsed
 
 
 def test_non_allowlisted_keys_are_not_preserved(tmp_path: Path) -> None:
     env_path = tmp_path / ".env"
     env_path.write_text("MY_RANDOM_EDIT=foo\nSOME_LEGACY=bar\n")
     rendered = "API_SERVER_PORT=18789\n"
-    out = _merge_preserve_runtime_keys(rendered, env_path)
+    out = _merge_preserve_runtime_keys(rendered, env_path, "main")
     parsed = _parse_env_keys(out)
     assert "MY_RANDOM_EDIT" not in parsed
     assert "SOME_LEGACY" not in parsed
@@ -101,7 +133,7 @@ def test_all_runtime_prefixes_are_picked_up(tmp_path: Path) -> None:
         lines.append(f"{prefix}SAMPLE=value-for-{prefix.lower()}")
     env_path.write_text("\n".join(lines) + "\n")
     rendered = "API_SERVER_PORT=18789\n"
-    out = _merge_preserve_runtime_keys(rendered, env_path)
+    out = _merge_preserve_runtime_keys(rendered, env_path, "main")
     parsed = _parse_env_keys(out)
     for prefix in _RUNTIME_KEY_PREFIXES:
         key = f"{prefix}SAMPLE"
@@ -115,7 +147,7 @@ def test_template_takes_precedence_for_allowlisted_keys(tmp_path: Path) -> None:
     env_path = tmp_path / ".env"
     env_path.write_text("TELEGRAM_BOT_TOKEN=stale-token\n")
     rendered = "TELEGRAM_BOT_TOKEN=template-set\n"
-    out = _merge_preserve_runtime_keys(rendered, env_path)
+    out = _merge_preserve_runtime_keys(rendered, env_path, "main")
     parsed = _parse_env_keys(out)
     assert parsed["TELEGRAM_BOT_TOKEN"] == "template-set"
 
@@ -142,7 +174,7 @@ def test_merge_preserves_twilio_and_sms_keys_from_existing_env(tmp_path: Path) -
         "API_SERVER_PORT=18789\n"
         "OPENROUTER_API_KEY=newkey\n"  # template still wins for provider keys
     )
-    out = _merge_preserve_runtime_keys(rendered, env_path)
+    out = _merge_preserve_runtime_keys(rendered, env_path, "main")
     parsed = _parse_env_keys(out)
 
     # Template wins for OPENROUTER_API_KEY (not in the runtime allowlist).


### PR DESCRIPTION
**PR 2 of 5** in the codex-builder sealed-runtime build per [`docs/codex-builder-runtime.md`](docs/codex-builder-runtime.md) §10 PR 2.

Depends on #100 (merged) for the Codex CLI being on PATH inside the image.

## What this PR does

The init container now renders a 4th `codex-builder` Hermes profile fleet-wide (config.yaml, .env, dir scaffold). The supervisor only LAUNCHES it when `ENABLE_CODEX_BUILDER=true`. Home will get the running gateway; rj/joe/zsolt/miguel leave the flag unset and get an idle profile dir with no listening process on `:18793`.

**No agent is routed to `:18793` yet** — PR 3 adds the adapter switch. The gateway boots, exposes `/v1/responses` + `/health` on `:18793`, and is otherwise a no-op at the Paperclip surface.

Sir's three decisions are encoded here:
1. **SHARED auth** (overriding the design doc's recommendation of separate): supervisor.sh mirrors `main/auth.json` to BOTH `codex-builder/auth.json` (Hermes LLM-provider auth) AND `codex-builder/.codex/auth.json` (the codex CLI's auth file).
2. **Home only via `ENABLE_CODEX_BUILDER`**: gates the 4th `start_proc`, the `wait_for_profiles` set, and the auth mirror.
3. Routing/concurrency (PR 3 work) — PR 2 sets `terminal.timeout: 1800` matching the 30-min ceiling.

## Sealed-runtime knobs landed

| Block | Value | Why |
|---|---|---|
| `model.provider` | `openai-codex` HARD-PINNED | a .env edit cannot swing this profile back to openrouter |
| `model.default` | `gpt-5-codex` (env-overridable) | the supervising Hermes agent runs the same model the codex CLI it shells out to uses |
| `mcp_servers` | `{}` | no ctrl-api, Paperclip, Plane, Sure, Vaultwarden, execute, Composio |
| `platform_toolsets.cli` | `[terminal, file]` | no web, skills, messaging, delegation, todo |
| `delegation.max_spawn_depth` | `0` | hard fence — cannot delegate |
| `delegation.max_concurrent_children` | `1` | matches Sir's `maxConcurrentRuns: 1` |
| `terminal.timeout` | `1800` | 30-min budget per `codex exec` |
| `terminal.lifetime_seconds` | `3600` | 1-h hard ceiling on a terminal |
| `agent.max_turns` | `50` | consistent with workers/heavy |
| `agent.reasoning_effort` | `high` | thinks more than it acts |
| `session_reset.mode` | `idle, idle_minutes: 5` | one-shot per run |
| `approvals.mode` | `off` | codex CLI's own `--sandbox` is the safety net |
| `cron.jobs.cleanup-old-runs` | daily 03:13 | 7-day GC of `/work/runs` |
| .env | strict positive allowlist | NO OPENROUTER/ANTHROPIC/OPENAI/COMPOSIO/AAS/PAPERCLIP/TWILIO/SLACK/TELEGRAM keys |

The `_merge_preserve_runtime_keys` runtime-key allowlist for the .env preservation step now SKIPS the codex-builder profile entirely — a stray `TELEGRAM_BOT_TOKEN` written into the dir by some future operator script cannot leak in across re-renders.

## docker-compose.yaml

- New named volume `hermes_codex_work:/work` mounted into the hermes container only (will be chowned `10001:10001 mode 0700` by PR 4's init step).
- `cap_add: NET_ADMIN` — DORMANT until PR 4 installs the iptables egress allowlist scoped `--uid-owner 10001`. Does not grant any of the existing 3 profiles new privileges (they run as uid 10000 with unrestricted egress today).
- `ENABLE_CODEX_BUILDER: ${ENABLE_CODEX_BUILDER:-false}` + `HERMES_CODEX_BUILDER_MODEL: ${HERMES_CODEX_BUILDER_MODEL:-gpt-5-codex}` passthroughs.

## Tests

11/11 in `packages/hermes/init/test_render_preserve.py` pass, including the new `test_codex_builder_skips_runtime_preservation` that pins the positive-allowlist behaviour.

## Verify on home (after merge + image roll)

```
# 1. flip the flag on home only (out of band, /opt/alfred/.env)
echo 'ENABLE_CODEX_BUILDER=true' >> /opt/alfred/.env

# 2. pull + force-recreate init + hermes
docker compose pull init hermes
docker compose up -d --force-recreate init hermes

# 3. profile dir rendered
docker exec alfred-black-hermes-1 ls /hermes-state/profiles/codex-builder/
# -> config.yaml, .env, auth.json, .codex/, .ssh/, workspace/

# 4. :18793 health
docker exec alfred-black-hermes-1 curl -fsS http://localhost:18793/health
# -> {"status": "ok"}

# 5. the 3 existing gateways still healthy
for p in 18789 18790 18791; do
  docker exec alfred-black-hermes-1 curl -fsS http://localhost:$p/health
done
```

On the other 4 tenants, after the image rolls: profile dir is rendered (uniform fleet-wide port layout) but `:18793` has no listener because the flag isn't set.

## What is intentionally NOT in this PR

- No adapter routing (PR 3).
- No uid 10001 drop (PR 4 swaps `start_proc` to `setpriv`).
- No iptables egress allowlist (PR 4 installs OUTPUT rules; the `cap_add: NET_ADMIN` here is dormant).
- No deploy key (PR 4 lays down `codex_id_ed25519` and registers the public key on the alfred repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)