### PR TITLE
fix(hermes): quote GIT_SSH_COMMAND in codex-builder .env (PR 2 hotfix)

### DIFF
--- a/packages/hermes/hermes-profile.env.njk
+++ b/packages/hermes/hermes-profile.env.njk
@@ -89,7 +89,14 @@ CODEX_WORKSPACE_ROOT=/work
 # SSH key for git push, written by the PR 4 init step. Until then this
 # variable is set but the file doesn't exist — `git push` will fail clean
 # with "no such file" instead of leaking an ambient agent identity.
-GIT_SSH_COMMAND=ssh -i /hermes-state/profiles/codex-builder/.ssh/codex_id_ed25519 -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes
+#
+# Quoted because the value contains spaces — supervisor.sh source-and-
+# exports this file via `set -a; . .env; set +a`, which is bash-`source`,
+# which treats unquoted spaces as shell arg separators. Without quotes
+# the line errored with "-i: command not found" and GIT_SSH_COMMAND was
+# never exported to the gateway process. Live-observed on home 2026-05-28
+# right after PR 2 #101 landed.
+GIT_SSH_COMMAND="ssh -i /hermes-state/profiles/codex-builder/.ssh/codex_id_ed25519 -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes"
 # Egress filter (PR 4) reads this. Default deny — only positively-listed
 # domains/CIDRs reach the network.
 CODEX_NETWORK_ALLOWLIST_FILE=/hermes-state/profiles/codex-builder/network-allowlist.txt


### PR DESCRIPTION
PR 2 (#101) rendered `GIT_SSH_COMMAND` with an unquoted value containing spaces. supervisor.sh source-and-exports each profile's .env via `set -a; . .env; set +a` (bash `source`), which treats unquoted spaces as shell arg separators. The line errored with `-i: command not found` and `GIT_SSH_COMMAND` was never exported to the codex-builder gateway's process env.

Live-observed on home immediately after PR 2's image rolled:

```
$ docker logs alfred-black-hermes-1 | grep 'codex-builder/.env'
/hermes-state/profiles/codex-builder/.env: line 54: -i: command not found
```

`/proc/<pid>/environ` for the codex-builder gateway had no `GIT_SSH_COMMAND`. PR 4's `git push` against the deploy key would have failed with 'unknown ssh option -i' once it ran.

One-line template fix: wrap the value in double quotes. Verified by sourcing the rendered .env into a fresh bash subshell and inspecting the exported value — full multi-token command preserved end-to-end:

```
$ bash -c 'set -a; . /tmp/test.env; set +a; echo "GIT_SSH_COMMAND=[$GIT_SSH_COMMAND]"'
GIT_SSH_COMMAND=[ssh -i /hermes-state/profiles/codex-builder/.ssh/codex_id_ed25519 -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)