### PR TITLE
feat(paperclip-adapter): route codex-feature-builder agent to :18793 (PR 3/5)

### DIFF
--- a/packages/paperclip/adapter/src/server/execute.ts
+++ b/packages/paperclip/adapter/src/server/execute.ts
@@ -10,20 +10,24 @@
 
 import {
   ADAPTER_TYPE,
+  CODEX_BUILDER_AGENT_NAMES,
   DEFAULT_HERMES_GATEWAY_URL,
   DEFAULT_TIMEOUT_SEC,
+  HERMES_CODEX_BUILDER_GATEWAY_URL,
   SESSION_KEY_PREFIX,
+  type HermesProfileName,
 } from "../shared/constants.js";
 
 import {
   callHermesResponses,
-  readHermesMainApiKey,
+  readHermesProfileApiKey,
   type HermesCallResult,
 } from "./hermes-http.js";
 
 import { buildPrompt } from "./prompt.js";
 
 import type {
+  AdapterAgent,
   AdapterExecutionContext,
   AdapterExecutionResult,
 } from "../types/paperclip.js";
@@ -35,6 +39,52 @@ function asString(v: unknown): string | undefined {
 }
 function asNumber(v: unknown): number | undefined {
   return typeof v === "number" && Number.isFinite(v) ? v : undefined;
+}
+
+/**
+ * Pick the gateway URL + Hermes profile name for a given Paperclip agent.
+ *
+ * The codex-builder profile (docs/codex-builder-runtime.md) is a sealed
+ * runtime — no MCP, no channels, no AAS_API_KEY, restricted egress (PR
+ * 4) — that exists to run the OpenAI Codex CLI against issues filed for
+ * exactly one Paperclip agent name. Every other agent stays on
+ * Hermes-main at :18789 with the full MCP catalogue.
+ *
+ * Resolution order:
+ *   1. config.hermesGatewayUrl  → operator override (keeps the profile
+ *      tag in sync so the right API key is read). One-off debug knob.
+ *   2. CODEX_BUILDER_AGENT_NAMES.has(agent.name) → codex-builder.
+ *   3. process.env.HERMES_GATEWAY_URL → tenant-wide override (stays on
+ *      main-profile auth even when present, since the override targets
+ *      main's port).
+ *   4. DEFAULT_HERMES_GATEWAY_URL → http://hermes:18789 (main).
+ *
+ * Returns the URL AND the matching profile name so callers can fetch
+ * the right API_SERVER_KEY from disk.
+ */
+export function pickGatewayUrlForAgent(
+  agent: AdapterAgent | null | undefined,
+  config: Record<string, unknown>,
+): { gatewayUrl: string; profile: HermesProfileName } {
+  // Operator override wins — but we keep the profile as `main` because the
+  // override is for inspection / debug at the network layer, not a routing
+  // change at the auth layer. (If you NEED to talk to codex-builder with
+  // a different URL, set HERMES_GATEWAY_URL in the per-call env or wire
+  // a new constant — the override path is intentionally narrow.)
+  const explicit = asString(config.hermesGatewayUrl);
+  if (explicit) return { gatewayUrl: explicit, profile: "main" };
+
+  const name = (agent?.name ?? "").trim().toLowerCase();
+  if (CODEX_BUILDER_AGENT_NAMES.has(name)) {
+    return {
+      gatewayUrl: HERMES_CODEX_BUILDER_GATEWAY_URL,
+      profile: "codex-builder",
+    };
+  }
+
+  const envOverride = process.env.HERMES_GATEWAY_URL;
+  if (envOverride) return { gatewayUrl: envOverride, profile: "main" };
+  return { gatewayUrl: DEFAULT_HERMES_GATEWAY_URL, profile: "main" };
 }
 
 /**
@@ -68,8 +118,11 @@ export interface ExecuteDeps {
     input: string,
     opts: { gatewayUrl: string; apiKey: string | null; timeoutMs: number },
   ) => Promise<HermesCallResult>;
-  /** Override for tests. */
-  readApiKey?: () => string | null;
+  /**
+   * Override for tests. Receives the profile name so a test can stub a
+   * different key per profile (covers PR 3's per-profile auth split).
+   */
+  readApiKey?: (profile: HermesProfileName) => string | null;
 }
 
 export function makeExecute(deps: ExecuteDeps = {}) {
@@ -87,7 +140,8 @@ export function makeExecute(deps: ExecuteDeps = {}) {
         apiKey: opts.apiKey,
         timeoutMs: opts.timeoutMs,
       }));
-  const readApiKey = deps.readApiKey ?? (() => readHermesMainApiKey());
+  const readApiKey =
+    deps.readApiKey ?? ((p: HermesProfileName) => readHermesProfileApiKey(p));
 
   return async function execute(
     ctx: AdapterExecutionContext,
@@ -95,11 +149,11 @@ export function makeExecute(deps: ExecuteDeps = {}) {
     const agent = ctx.agent;
     const config = (agent?.adapterConfig ?? {}) as Record<string, unknown>;
 
-    // Settings — we honour only those that make sense over HTTP.
-    const gatewayUrl =
-      asString(config.hermesGatewayUrl) ??
-      process.env.HERMES_GATEWAY_URL ??
-      DEFAULT_HERMES_GATEWAY_URL;
+    // Sealed-runtime routing: codex-feature-builder → :18793 (codex-builder
+    // profile), everything else → :18789 (main). Operator override via
+    // config.hermesGatewayUrl always wins but pins profile=main (the
+    // operator override targets main's auth surface).
+    const { gatewayUrl, profile } = pickGatewayUrlForAgent(agent, config);
     const timeoutSec = asNumber(config.timeoutSec) ?? DEFAULT_TIMEOUT_SEC;
     const timeoutMs = Math.max(1_000, Math.floor(timeoutSec * 1000));
 
@@ -108,12 +162,14 @@ export function makeExecute(deps: ExecuteDeps = {}) {
 
     // Surface the invocation envelope to Paperclip's run-history (UI calls
     // this "command" + "commandArgs"). Helps an operator inspect a stuck
-    // run without docker-shelling into hermes.
+    // run without docker-shelling into hermes. The profile name is in
+    // commandArgs so an operator can diff "which gateway am I hitting"
+    // from the run transcript alone.
     try {
       await ctx.onMeta?.({
         adapterType: ADAPTER_TYPE,
         command: "hermes:/v1/responses",
-        commandArgs: ["POST", gatewayUrl, `session=${sessionKey}`],
+        commandArgs: ["POST", gatewayUrl, `profile=${profile}`, `session=${sessionKey}`],
         prompt,
       });
     } catch {
@@ -122,10 +178,13 @@ export function makeExecute(deps: ExecuteDeps = {}) {
 
     await ctx.onLog(
       "stdout",
-      `[hermes] Calling Hermes (gateway=${gatewayUrl}, session=${sessionKey}, timeout=${timeoutSec}s)\n`,
+      `[hermes] Calling Hermes (gateway=${gatewayUrl}, profile=${profile}, session=${sessionKey}, timeout=${timeoutSec}s)\n`,
     );
 
-    const apiKey = readApiKey();
+    // Read the auth key from the SAME profile dir we're routing to. main's
+    // API_SERVER_KEY would 401 against codex-builder's :18793 (and vice
+    // versa) — they're independently rendered by the init container.
+    const apiKey = readApiKey(profile);
     const result = await callHermes(sessionKey, prompt, {
       gatewayUrl,
       apiKey,

--- a/packages/paperclip/adapter/src/server/hermes-http.ts
+++ b/packages/paperclip/adapter/src/server/hermes-http.ts
@@ -14,24 +14,33 @@ import path from "node:path";
 import {
   DEFAULT_HERMES_GATEWAY_URL,
   DEFAULT_HERMES_CONFIG_DIR,
+  type HermesProfileName,
 } from "../shared/constants.js";
 
 // ── auth key resolver ────────────────────────────────────────────────────
 
 /**
- * Read API_SERVER_KEY for the `main` Hermes profile out of its rendered
+ * Read API_SERVER_KEY for a given Hermes profile out of its rendered
  * `.env`. The per-profile file is the source of truth at runtime
  * (`packages/ctrl/src/api/routes/channels_paperclip.ts::readHermesMainApiKey`
- * uses the identical resolver; we observed live a mismatch between the
- * compose-level HERMES_API_SERVER_KEY seed and the profile-level value
- * (64 vs 43 chars), so reading the file directly is what works).
+ * uses the identical resolver for the main profile; we observed live a
+ * mismatch between the compose-level HERMES_API_SERVER_KEY seed and the
+ * profile-level value (64 vs 43 chars), so reading the file directly is
+ * what works).
  *
- * Override via `HERMES_CONFIG_DIR` for tests / dev mounts.
+ * codex-builder support added 2026-05-28 (PR 3 of docs/codex-builder-
+ * runtime.md): the sealed-runtime profile renders its own API_SERVER_KEY
+ * in /hermes-state/profiles/codex-builder/.env. By passing the profile
+ * name through here we can mint per-profile API auth from a single
+ * resolver — no need for a parallel readHermesCodexBuilderApiKey() copy.
+ *
+ * Override the base dir via `HERMES_CONFIG_DIR` for tests / dev mounts.
  */
-export function readHermesMainApiKey(
+export function readHermesProfileApiKey(
+  profile: HermesProfileName,
   configDir = process.env.HERMES_CONFIG_DIR ?? DEFAULT_HERMES_CONFIG_DIR,
 ): string | null {
-  const envPath = path.join(configDir, "main", ".env");
+  const envPath = path.join(configDir, profile, ".env");
   let raw: string;
   try {
     raw = fs.readFileSync(envPath, "utf-8");
@@ -48,6 +57,17 @@ export function readHermesMainApiKey(
     }
   }
   return null;
+}
+
+/**
+ * Back-compat shim. Old call sites (ctrl-api's channels_paperclip resolver,
+ * internal one-off scripts) read the main-profile key by name; preserve
+ * the entrypoint so this PR is a pure additive change for them.
+ */
+export function readHermesMainApiKey(
+  configDir = process.env.HERMES_CONFIG_DIR ?? DEFAULT_HERMES_CONFIG_DIR,
+): string | null {
+  return readHermesProfileApiKey("main", configDir);
 }
 
 // ── response shape extractor ─────────────────────────────────────────────

--- a/packages/paperclip/adapter/src/shared/constants.ts
+++ b/packages/paperclip/adapter/src/shared/constants.ts
@@ -12,11 +12,42 @@ export const ADAPTER_LABEL = "Hermes Agent (HTTP)";
 /** Default Hermes gateway URL — the main profile (compose-network DNS). */
 export const DEFAULT_HERMES_GATEWAY_URL = "http://hermes:18789";
 
+/**
+ * Compose-internal URL for the sealed `codex-builder` Hermes profile
+ * (docs/codex-builder-runtime.md). Fleet-wide port :18793 — name-based
+ * routing (see CODEX_BUILDER_AGENT_NAMES) works identically on every
+ * tenant. Never published to the host; reachable only inside the compose
+ * network from the paperclip container.
+ */
+export const HERMES_CODEX_BUILDER_GATEWAY_URL = "http://hermes:18793";
+
+/**
+ * Agent names that route to the sealed codex-builder profile.
+ *
+ * Sir's decision #3 (docs/codex-builder-runtime.md §11.6): match on
+ * agent.name for v1, accept the small risk that a UI-side rename
+ * silently re-routes traffic back to main. The list lives here so
+ * adding a second sealed-runtime agent in v2 is one constant edit.
+ *
+ * Comparison is case-insensitive — the helper lowercases the
+ * incoming name before lookup, so a UI capitalisation tweak
+ * ("Codex-Feature-Builder") doesn't bypass the route.
+ */
+export const CODEX_BUILDER_AGENT_NAMES: ReadonlySet<string> = new Set([
+  "codex-feature-builder",
+]);
+
 /** Default per-call timeout. Mirrors upstream's DEFAULT_TIMEOUT_SEC. */
 export const DEFAULT_TIMEOUT_SEC = 300;
 
 /** Where to read Hermes' API_SERVER_KEY from on disk. */
 export const DEFAULT_HERMES_CONFIG_DIR = "/hermes-state/profiles";
+
+/**
+ * Profile names whose .env we know how to read for API_SERVER_KEY.
+ * Used by readHermesProfileApiKey() to validate the argument.
+ */
+export type HermesProfileName = "main" | "codex-builder";
 
 /** Session-key prefix used to derive a stable Hermes session per Paperclip agent. */
 export const SESSION_KEY_PREFIX = "paperclip-";

--- a/packages/paperclip/adapter/tests/execute.test.ts
+++ b/packages/paperclip/adapter/tests/execute.test.ts
@@ -10,12 +10,20 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { makeExecute, resolveSessionKey } from "../src/server/execute.js";
+import {
+  makeExecute,
+  pickGatewayUrlForAgent,
+  resolveSessionKey,
+} from "../src/server/execute.js";
 import type {
   AdapterAgent,
   AdapterExecutionContext,
 } from "../src/types/paperclip.js";
 import type { HermesCallResult } from "../src/server/hermes-http.js";
+import {
+  DEFAULT_HERMES_GATEWAY_URL,
+  HERMES_CODEX_BUILDER_GATEWAY_URL,
+} from "../src/shared/constants.js";
 
 function makeAgent(over: Partial<AdapterAgent> = {}): AdapterAgent {
   return {
@@ -78,7 +86,7 @@ describe("execute — happy path", () => {
   it("returns Paperclip-shaped result with usage + session params", async () => {
     let captured: { sessionKey: string; input: string } | null = null;
     const execute = makeExecute({
-      readApiKey: () => "stub-key",
+      readApiKey: (_p) => "stub-key",
       callHermes: async (sessionKey, input) => {
         captured = { sessionKey, input };
         const result: HermesCallResult = {
@@ -113,7 +121,7 @@ describe("execute — happy path", () => {
   it("renders task variables into the prompt", async () => {
     let prompt: string | null = null;
     const execute = makeExecute({
-      readApiKey: () => null,
+      readApiKey: (_p) => null,
       callHermes: async (_session, input) => {
         prompt = input;
         return { ok: true, text: "", usage: null, raw: {} };
@@ -137,7 +145,7 @@ describe("execute — happy path", () => {
   it("renders the noTask section when no task assigned", async () => {
     let prompt: string | null = null;
     const execute = makeExecute({
-      readApiKey: () => null,
+      readApiKey: (_p) => null,
       callHermes: async (_session, input) => {
         prompt = input;
         return { ok: true, text: "ok", usage: null, raw: {} };
@@ -153,7 +161,7 @@ describe("execute — happy path", () => {
 describe("execute — error paths", () => {
   it("maps HERMES_AUTH to a 1-exit with errorCode", async () => {
     const execute = makeExecute({
-      readApiKey: () => "wrong-key",
+      readApiKey: (_p) => "wrong-key",
       callHermes: async () => ({
         ok: false,
         code: "HERMES_AUTH",
@@ -170,7 +178,7 @@ describe("execute — error paths", () => {
 
   it("maps HERMES_TIMEOUT to exit 124 + timedOut=true", async () => {
     const execute = makeExecute({
-      readApiKey: () => "k",
+      readApiKey: (_p) => "k",
       callHermes: async () => ({
         ok: false,
         code: "HERMES_TIMEOUT",
@@ -186,7 +194,7 @@ describe("execute — error paths", () => {
 
   it("preserves session key on transient failure", async () => {
     const execute = makeExecute({
-      readApiKey: () => "k",
+      readApiKey: (_p) => "k",
       callHermes: async () => ({
         ok: false,
         code: "HERMES_UNREACHABLE",
@@ -204,7 +212,7 @@ describe("execute — session continuity", () => {
   it("reuses the same session key across heartbeats", async () => {
     const seen: string[] = [];
     const execute = makeExecute({
-      readApiKey: () => "k",
+      readApiKey: (_p) => "k",
       callHermes: async (sessionKey) => {
         seen.push(sessionKey);
         return { ok: true, text: "ok", usage: null, raw: {} };
@@ -224,7 +232,7 @@ describe("execute — session continuity", () => {
   it("honours a pinned sessionKey from adapterConfig", async () => {
     let captured: string | null = null;
     const execute = makeExecute({
-      readApiKey: () => "k",
+      readApiKey: (_p) => "k",
       callHermes: async (sessionKey) => {
         captured = sessionKey;
         return { ok: true, text: "ok", usage: null, raw: {} };
@@ -233,5 +241,127 @@ describe("execute — session continuity", () => {
     const agent = makeAgent({ adapterConfig: { sessionKey: "custom-session" } });
     await execute(makeCtx(agent));
     assert.equal(captured, "custom-session");
+  });
+});
+
+// =============================================================================
+// pickGatewayUrlForAgent — codex-builder routing (PR 3 of
+// docs/codex-builder-runtime.md)
+// =============================================================================
+describe("pickGatewayUrlForAgent", () => {
+  it("routes codex-feature-builder to the codex-builder gateway", () => {
+    const result = pickGatewayUrlForAgent(
+      makeAgent({ name: "codex-feature-builder" }),
+      {},
+    );
+    assert.equal(result.gatewayUrl, HERMES_CODEX_BUILDER_GATEWAY_URL);
+    assert.equal(result.gatewayUrl, "http://hermes:18793");
+    assert.equal(result.profile, "codex-builder");
+  });
+
+  it("is case-insensitive on the agent name lookup", () => {
+    const result = pickGatewayUrlForAgent(
+      makeAgent({ name: "Codex-Feature-Builder" }),
+      {},
+    );
+    assert.equal(result.gatewayUrl, HERMES_CODEX_BUILDER_GATEWAY_URL);
+    assert.equal(result.profile, "codex-builder");
+  });
+
+  it("routes every other agent name to the main gateway", () => {
+    for (const name of [
+      "hermes",
+      "alfred-engineering-orchestrator",
+      "alfred-code-reviewer",
+      "ceo",
+      "",
+      "codex",
+      "feature-builder",
+      "codex-feature-builderx",
+    ]) {
+      const result = pickGatewayUrlForAgent(makeAgent({ name }), {});
+      assert.equal(
+        result.gatewayUrl,
+        DEFAULT_HERMES_GATEWAY_URL,
+        `name=${JSON.stringify(name)} must route to main, got ${result.gatewayUrl}`,
+      );
+      assert.equal(result.profile, "main");
+    }
+  });
+
+  it("falls back to main when agent is null or missing a name", () => {
+    assert.equal(
+      pickGatewayUrlForAgent(null, {}).gatewayUrl,
+      DEFAULT_HERMES_GATEWAY_URL,
+    );
+    assert.equal(
+      pickGatewayUrlForAgent(undefined, {}).gatewayUrl,
+      DEFAULT_HERMES_GATEWAY_URL,
+    );
+  });
+
+  it("operator override (config.hermesGatewayUrl) wins even for codex-feature-builder", () => {
+    // The override targets the network surface, not the auth surface —
+    // profile stays `main` so the caller reads the main API key.
+    const result = pickGatewayUrlForAgent(
+      makeAgent({ name: "codex-feature-builder" }),
+      { hermesGatewayUrl: "http://debug:18794" },
+    );
+    assert.equal(result.gatewayUrl, "http://debug:18794");
+    assert.equal(result.profile, "main");
+  });
+});
+
+describe("execute — routing wiring", () => {
+  it("calls the codex-builder gateway with the codex-builder API key", async () => {
+    let captured: { gatewayUrl: string; apiKey: string | null } | null = null;
+    const execute = makeExecute({
+      readApiKey: (p) =>
+        p === "codex-builder" ? "codex-builder-key" : "main-key",
+      callHermes: async (_sessionKey, _input, opts) => {
+        captured = { gatewayUrl: opts.gatewayUrl, apiKey: opts.apiKey };
+        return { ok: true, text: "ok", usage: null, raw: {} };
+      },
+    });
+    const agent = makeAgent({ name: "codex-feature-builder" });
+    await execute(makeCtx(agent));
+    assert.ok(captured);
+    assert.equal(captured!.gatewayUrl, "http://hermes:18793");
+    assert.equal(captured!.apiKey, "codex-builder-key");
+  });
+
+  it("calls the main gateway with the main API key for everyone else", async () => {
+    let captured: { gatewayUrl: string; apiKey: string | null } | null = null;
+    const execute = makeExecute({
+      readApiKey: (p) =>
+        p === "codex-builder" ? "codex-builder-key" : "main-key",
+      callHermes: async (_sessionKey, _input, opts) => {
+        captured = { gatewayUrl: opts.gatewayUrl, apiKey: opts.apiKey };
+        return { ok: true, text: "ok", usage: null, raw: {} };
+      },
+    });
+    const agent = makeAgent({ name: "alfred-engineering-orchestrator" });
+    await execute(makeCtx(agent));
+    assert.ok(captured);
+    assert.equal(captured!.gatewayUrl, "http://hermes:18789");
+    assert.equal(captured!.apiKey, "main-key");
+  });
+
+  it("logs the profile name on the [hermes] line so an operator can diff", async () => {
+    const logs: string[] = [];
+    const execute = makeExecute({
+      readApiKey: (_p) => "k",
+      callHermes: async () => ({ ok: true, text: "ok", usage: null, raw: {} }),
+    });
+    const agent = makeAgent({ name: "codex-feature-builder" });
+    const ctx = makeCtx(agent);
+    ctx.onLog = async (_stream, chunk) => {
+      logs.push(chunk);
+    };
+    await execute(ctx);
+    const callingLine = logs.find((l) => l.startsWith("[hermes] Calling"));
+    assert.ok(callingLine, "expected a [hermes] Calling log line");
+    assert.match(callingLine!, /profile=codex-builder/);
+    assert.match(callingLine!, /gateway=http:\/\/hermes:18793/);
   });
 });


### PR DESCRIPTION
**PR 3 of 5** in the codex-builder sealed-runtime build per [`docs/codex-builder-runtime.md`](docs/codex-builder-runtime.md) §10 PR 3.

Depends on #100 (Codex CLI in image), #101 (codex-builder profile + supervisor), #102 (.env quoting hotfix) — all merged.

## What this PR does

The `hermes_local` Paperclip adapter (`packages/paperclip/adapter`) now routes ONE specific agent name — `codex-feature-builder` — to the sealed codex-builder Hermes profile on `:18793`. Every other agent continues to call Hermes-main on `:18789` exactly as before.

## Mechanism

Single name-based switch in the adapter (Sir's decision #3 in `docs/codex-builder-runtime.md` §11.6):

```typescript
// constants.ts
export const HERMES_CODEX_BUILDER_GATEWAY_URL = "http://hermes:18793";
export const CODEX_BUILDER_AGENT_NAMES: ReadonlySet<string> = new Set([
  "codex-feature-builder",
]);

// execute.ts
const { gatewayUrl, profile } = pickGatewayUrlForAgent(agent, config);
const apiKey = readApiKey(profile);  // ← reads the right profile's .env
```

Resolution order:
1. `config.hermesGatewayUrl` operator override → pins `profile=main` (override targets the network surface, not the auth surface)
2. `CODEX_BUILDER_AGENT_NAMES.has(agent.name.toLowerCase())` → codex-builder
3. `process.env.HERMES_GATEWAY_URL` env override → main
4. Default `http://hermes:18789` → main

## Auth key resolver refactor

`readHermesMainApiKey()` → `readHermesProfileApiKey(profile, configDir?)`. The old entrypoint is kept as a back-compat shim — `channels_paperclip` (ctrl-api) and `testEnvironment` (the adapter health-check surface) keep working unchanged.

The init container renders each profile's `.env` independently with a fresh `API_SERVER_KEY` (in fact home's main key and codex-builder key are different right now, per the live verify in PR 2). The adapter reads the matching one for whichever gateway it's calling.

## Tests

8 new tests + 38 existing tests = **46/46 passing locally**.

| Suite | Test | What it pins |
|---|---|---|
| `pickGatewayUrlForAgent` | `codex-feature-builder → :18793` | the routing key |
| `pickGatewayUrlForAgent` | case-insensitive lookup | UI capitalisation tweak doesn't bypass |
| `pickGatewayUrlForAgent` | every other name → main | regression catch |
| `pickGatewayUrlForAgent` | null/undefined agent → main | defensive |
| `pickGatewayUrlForAgent` | operator override wins, profile stays main | auth surface stays consistent |
| `execute — routing wiring` | codex-feature-builder uses codex-builder API key | per-profile auth |
| `execute — routing wiring` | other agents use main API key | non-regression |
| `execute — routing wiring` | `[hermes] Calling` log carries `profile=codex-builder` | operator debuggability |

## Verify on home (after `build-paperclip` rolls)

```
# 1. Real heartbeat from Paperclip's API for the codex-feature-builder
#    agent (already exists on home per the design doc §7); observe logs:
docker logs alfred-black-paperclip-1 --since 1m | grep '\[hermes\]'
# expect: [hermes] Calling Hermes (gateway=http://hermes:18793, profile=codex-builder, ...)

# 2. Heartbeat any other agent → :18789, profile=main
# 3. /v1/responses arrives on the codex-builder gateway:
docker logs alfred-black-hermes-1 --since 1m | grep 18793
```

## What is intentionally NOT in this PR

- No FS isolation (PR 4). codex-builder still runs as uid 10000.
- No egress allowlist (PR 4). `cap_add: NET_ADMIN` is dormant from PR 2.
- No deploy key, no codex-builder workspace prep (PRs 4 + 5).

## Next

- **PR 4** — filesystem isolation (uid 10001, chown /work + profile dir, init asserts uid-10001 has no read bit on /vault, /alfred-data, other-profile dirs) + per-tenant deploy key + iptables egress allowlist scoped `--uid-owner 10001`.
- **PR 5** — codex CLI invocation wrapper + per-run prep script + end-to-end smoke against a real Paperclip issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)