### PR TITLE
feat(hermes,init,compose): codex-builder FS + network isolation (PR 4/5)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -147,6 +147,13 @@ services:
       - vault_data:/vault
       - hermes_data:/hermes-state
       - alfred_data:/alfred-data
+      # codex-builder workspace mount — init chowns it to 10001:10001 mode
+      # 0700 (PR 4 of docs/codex-builder-runtime.md §6) so the codex-builder
+      # gateway can mkdir /work/runs/<runId>/. NOT mounted in any other
+      # compose service (paperclip / ctrl-api / web / alfred) — the run
+      # data is invisible to the rest of the stack. See the hermes service
+      # volumes for the matching mount on the consumer side.
+      - hermes_codex_work:/work
     env_file:
       - .env
     environment:
@@ -159,6 +166,21 @@ services:
       # files from OWNER_EMAIL. env_file already injects it, but pin it
       # explicitly so the canonical name is unambiguous at this boundary (C9).
       - OWNER_EMAIL=${OWNER_EMAIL:-}
+      # codex-builder hardening (PR 4 of docs/codex-builder-runtime.md §6).
+      # When the flag is on, init step 7b chowns the codex-builder profile
+      # dir + /work to 10001:10001 mode 0700, writes the deploy key, and
+      # runs the negative-assert spot-checks (uid 10001 cannot read /vault,
+      # /alfred-data, other-profile .env files). When off, the chowns
+      # still happen but the asserts are skipped — flipping the flag on
+      # later does not require a chown sweep.
+      - ENABLE_CODEX_BUILDER=${ENABLE_CODEX_BUILDER:-false}
+      # Base64-encoded private SSH key for the GitHub deploy key on
+      # ssdavidai/alfred (repo-scoped, write-enabled). When set, init
+      # writes it to /hermes-state/profiles/codex-builder/.ssh/codex_id_ed25519
+      # owned 10001:10001 mode 0600. When empty (default everywhere except
+      # home), no key is written and PR 5's wrapper emits a clean
+      # "deploy key missing" run audit if git push is attempted.
+      - CODEX_BUILDER_DEPLOY_KEY_B64=${CODEX_BUILDER_DEPLOY_KEY_B64:-}
 
   # ── temporal — workflow engine for alfred-learn ─────────────────────
   temporal:

--- a/packages/hermes/Dockerfile
+++ b/packages/hermes/Dockerfile
@@ -55,6 +55,12 @@ ENV PYTHONUNBUFFERED=1 \
 # - curl, ca-certificates : NodeSource setup + healthcheck.
 # - procps         : the supervisor uses `pgrep`/process checks.
 # - openssh-client : agents may `git`/`ssh` from the terminal tool.
+# - iptables       : PR 4 of docs/codex-builder-runtime.md — the codex-builder
+#                    profile's egress allowlist (scoped --uid-owner 10001) is
+#                    installed at supervisor boot when ENABLE_CODEX_BUILDER=1.
+#                    Dormant on every other tenant. Adds ~10 MB to the image.
+# - dnsutils       : `dig` resolves OpenAI/GitHub/npm CIDR sets at boot for
+#                    the iptables setup. Tiny (~5 MB).
 RUN apt-get update && apt-get install -y --no-install-recommends \
         tini \
         git \
@@ -64,6 +70,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         curl ca-certificates \
         procps \
         openssh-client \
+        iptables \
+        dnsutils \
     && rm -rf /var/lib/apt/lists/*
 
 # --- Node.js 22 (NodeSource) --------------------------------------------------
@@ -269,6 +277,28 @@ RUN printf '#!/bin/sh\nexec hermes -p main "$@"\n' > /usr/local/bin/alfred && \
     printf '#!/bin/sh\nexec hermes -p workers "$@"\n' > /usr/local/bin/workers-cli && \
     printf '#!/bin/sh\nexec hermes -p heavy "$@"\n' > /usr/local/bin/heavy-cli && \
     chmod +x /usr/local/bin/alfred /usr/local/bin/workers-cli /usr/local/bin/heavy-cli
+
+# =============================================================================
+# codex-builder profile helpers (PR 4 of docs/codex-builder-runtime.md).
+# =============================================================================
+# Two scripts the codex-builder profile needs at runtime:
+#
+#   setup-egress-jail.sh — iptables OUTPUT chain scoped --uid-owner 10001,
+#     allowlists OpenAI/GitHub/npm/PyPI/crates.io, REJECTs everything else.
+#     Called by the supervisor at boot when ENABLE_CODEX_BUILDER=1.
+#
+#   codex-builder-prep-run.sh — invoked by the codex-builder agent at run
+#     start. Creates /work/runs/<runId>/repo as a fresh `git clone` and
+#     checks out a feature branch. Returns the workspace path on stdout.
+#     Defensive on runId/issueId — refuses path traversal, refuses to
+#     overwrite an existing run dir (collisions = bug).
+#
+# Both are baked into /usr/local/bin so they're on the codex-builder
+# gateway's PATH and the existing 3 profiles can ignore them.
+COPY packages/hermes/docker/setup-egress-jail.sh /usr/local/bin/codex-builder-setup-egress.sh
+COPY packages/hermes/docker/codex-builder-prep-run.sh /usr/local/bin/codex-builder-prep-run.sh
+RUN chmod +x /usr/local/bin/codex-builder-setup-egress.sh \
+             /usr/local/bin/codex-builder-prep-run.sh
 
 # =============================================================================
 # Supervisor entrypoint.

--- a/packages/hermes/docker/codex-builder-prep-run.sh
+++ b/packages/hermes/docker/codex-builder-prep-run.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# =============================================================================
+# codex-builder-prep-run.sh — create a fresh per-run workspace for the
+# codex-builder Hermes profile.
+#
+# Run BY the codex-builder agent (via its terminal tool) at the start of a
+# Paperclip run. Sets up:
+#
+#   /work/runs/<runId>/
+#     prompt.md   ← spec text (written separately by the agent)
+#     repo/       ← fresh `git clone --depth 1` of ssdavidai/alfred
+#     audit.json  ← run audit log (written by the wrapper at the end)
+#
+# The agent then `cd /work/runs/<runId>/repo`, checks out a feature branch
+# `codex/<issue-id>-<sha7>`, and shells out to `codex exec` (PR 5's
+# wrapper).
+#
+# Usage:
+#   codex-builder-prep-run.sh <runId> <issueIdentifier>
+#
+# Exits 0 on success with the workspace path on stdout.
+# Exits non-zero on any failure with a clear stderr message; nothing is
+# written to disk (the caller's branch checkout never happens).
+#
+# Idempotent guard: if /work/runs/<runId>/repo already exists, refuses to
+# overwrite (runIds are timestamp+random, collisions = bug). The caller
+# generates a unique runId; mid-run retries reuse the same runId so the
+# workspace is preserved.
+#
+# Sir 2026-05-28 — PR 4 of docs/codex-builder-runtime.md §5.
+# =============================================================================
+set -euo pipefail
+
+usage() {
+    cat >&2 <<'EOF'
+usage: codex-builder-prep-run.sh <runId> <issueIdentifier>
+
+Creates /work/runs/<runId>/repo as a fresh git clone of
+ssdavidai/alfred on the `main` branch, depth 1. Returns the absolute
+path on stdout.
+EOF
+    exit 2
+}
+
+if [[ $# -ne 2 ]]; then
+    usage
+fi
+
+RUN_ID="$1"
+ISSUE_ID="$2"
+
+# Defensive: runId must be alphanumeric + dashes + underscores only. No path
+# traversal, no shell-meta. issueId is a Paperclip task identifier, same.
+if ! [[ "$RUN_ID" =~ ^[A-Za-z0-9_-]{1,64}$ ]]; then
+    echo "error: runId must match [A-Za-z0-9_-]{1,64}; got: '$RUN_ID'" >&2
+    exit 2
+fi
+if ! [[ "$ISSUE_ID" =~ ^[A-Za-z0-9_-]{1,64}$ ]]; then
+    echo "error: issueId must match [A-Za-z0-9_-]{1,64}; got: '$ISSUE_ID'" >&2
+    exit 2
+fi
+
+WORK_ROOT="${CODEX_WORKSPACE_ROOT:-/work}"
+RUN_DIR="${WORK_ROOT}/runs/${RUN_ID}"
+REPO_DIR="${RUN_DIR}/repo"
+
+if [[ -e "$RUN_DIR" ]]; then
+    echo "error: ${RUN_DIR} already exists — refusing to overwrite (runId collision?)" >&2
+    exit 3
+fi
+
+mkdir -p "$RUN_DIR"
+cd "$RUN_DIR"
+
+# Clone the alfred repo. SSH is the canonical protocol — the deploy key
+# (PR 4's init step) registers as a write-capable key on this repo only.
+# GIT_SSH_COMMAND in the codex-builder .env pins -i + StrictHostKeyChecking
+# so no ambient agent identity sneaks in.
+REPO_URL="${ALFRED_REPO_URL:-git@github.com:ssdavidai/alfred.git}"
+if ! git clone --depth 1 --branch main --no-tags --quiet "$REPO_URL" "$REPO_DIR" 2>&1; then
+    echo "error: git clone failed against ${REPO_URL}" >&2
+    rm -rf "$RUN_DIR"
+    exit 4
+fi
+
+# Create the feature branch — runId-derived suffix so two branches from the
+# same issue can't collide.
+SHA7="${RUN_ID: -7}"
+BRANCH_NAME="codex/${ISSUE_ID}-${SHA7}"
+if ! git -C "$REPO_DIR" checkout -b "$BRANCH_NAME" >/dev/null 2>&1; then
+    echo "error: failed to create branch ${BRANCH_NAME}" >&2
+    rm -rf "$RUN_DIR"
+    exit 5
+fi
+
+# Write a minimal run-manifest so audit + GC have something to read even
+# if the agent crashes before the wrapper finishes.
+cat > "${RUN_DIR}/manifest.json" <<EOF
+{
+  "runId": "${RUN_ID}",
+  "issueId": "${ISSUE_ID}",
+  "branch": "${BRANCH_NAME}",
+  "repoUrl": "${REPO_URL}",
+  "preppedAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+
+# Return the workspace path on stdout for the caller.
+echo "$REPO_DIR"

--- a/packages/hermes/docker/setup-egress-jail.sh
+++ b/packages/hermes/docker/setup-egress-jail.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# =============================================================================
+# setup-egress-jail.sh — iptables egress allowlist for the codex-builder
+# Hermes profile (uid 10001).
+#
+# Run at supervisor boot ONLY when ENABLE_CODEX_BUILDER=1. Installs OUTPUT
+# rules scoped to uid 10001 that allow:
+#   * loopback (127.0.0.0/8) — Hermes' own intra-process IPC
+#   * compose-network reach to the container's own IP (so the gateway can
+#     bind 0.0.0.0:18793 and answer health-checks from inside)
+#   * DNS (UDP/TCP 53) — codex CLI + git resolve names
+#   * api.openai.com / chatgpt.com — the codex CLI's only LLM provider
+#   * github.com / api.github.com / codeload.github.com (TCP 22 + 443) —
+#     git clone + push for the alfred repo
+#   * registry.npmjs.org, pypi.org / files.pythonhosted.org, static.crates.io —
+#     codex's own test runs may need a `pip install` / `npm ci` / `cargo build`
+#   * <extra hosts read from /hermes-state/profiles/codex-builder/network-
+#     allowlist.txt>, one host per line, '#' comments — operator override
+# REJECT everything else for uid 10001.
+#
+# Uid 10000 (main/workers/heavy gateways) is UNTOUCHED — their egress is
+# fully open today and this script does NOT change that.
+#
+# Idempotent: the codex-builder OUTPUT rules are tagged with a `CODEX_BUILDER`
+# iptables comment; on re-run we delete every rule with that comment first
+# and re-install. Safe to call from a supervisor restart loop.
+#
+# This script REQUIRES NET_ADMIN. PR 2 #101 added cap_add: NET_ADMIN to the
+# hermes service. Without it, `iptables` exits 4 ("Permission denied") and
+# this script bails non-zero.
+#
+# Sir 2026-05-28 — PR 4 of docs/codex-builder-runtime.md.
+# =============================================================================
+set -uo pipefail
+
+CODEX_UID="${CODEX_BUILDER_UID:-10001}"
+ALLOWLIST_FILE="${CODEX_NETWORK_ALLOWLIST_FILE:-/hermes-state/profiles/codex-builder/network-allowlist.txt}"
+COMMENT_TAG="CODEX_BUILDER"
+
+log() { echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) [egress-jail] $*"; }
+
+# Verify NET_ADMIN actually works. If not, the rest of this script is a no-op
+# wearing a costume; surface the failure so a future operator can spot it.
+if ! iptables -L OUTPUT -n >/dev/null 2>&1; then
+    log "FATAL: iptables OUTPUT chain unreachable — NET_ADMIN missing on container?"
+    log "       (re-check docker-compose.yaml hermes service cap_add: NET_ADMIN)"
+    exit 4
+fi
+
+# --- 1. Clean old codex-builder rules (idempotency) --------------------------
+# `iptables -S OUTPUT` lists current rules; grep for our tag; convert each
+# `-A` line into a `-D` and feed it back to iptables.
+clean_old_rules() {
+    local stale
+    stale=$(iptables -S OUTPUT 2>/dev/null | grep -F -- "--comment ${COMMENT_TAG}" || true)
+    if [[ -z "$stale" ]]; then
+        return 0
+    fi
+    log "removing $(echo "$stale" | wc -l) stale ${COMMENT_TAG} rule(s) before re-install"
+    while read -r line; do
+        # Convert e.g. "-A OUTPUT -m owner --uid-owner 10001 -j REJECT ..."
+        # to "-D OUTPUT -m owner --uid-owner 10001 -j REJECT ...".
+        local del
+        del="${line/-A /-D }"
+        # shellcheck disable=SC2086
+        iptables $del 2>/dev/null || log "  warn: failed to delete: $line"
+    done <<< "$stale"
+}
+
+# --- 2. Resolve allowlist hosts to CIDRs -------------------------------------
+# `dig +short A <host>` for IPv4. We pin to A records only — IPv6 outbound is
+# rejected by the default-deny REJECT rule at the bottom (no INPUT-OUTPUT pair
+# for ::), so a host with only AAAA records would be unreachable. This is
+# acceptable because every host on the allowlist publishes an A record.
+resolve_host() {
+    local host="$1"
+    dig +short +time=3 +tries=1 A "$host" 2>/dev/null | grep -E '^[0-9.]+$' || true
+}
+
+# Built-in allowlist hosts. Operators can extend via network-allowlist.txt
+# without rebuilding the image.
+BUILTIN_HOSTS=(
+    # OpenAI (codex CLI's only LLM provider)
+    api.openai.com
+    chatgpt.com
+    # GitHub (deploy key push/pull for ssdavidai/alfred)
+    api.github.com
+    github.com
+    codeload.github.com
+    # Package registries (a codex-driven `npm ci` / `pip install` / etc).
+    registry.npmjs.org
+    pypi.org
+    files.pythonhosted.org
+    static.crates.io
+    crates.io
+)
+
+EXTRA_HOSTS=()
+if [[ -f "$ALLOWLIST_FILE" ]]; then
+    while read -r raw; do
+        # Strip comments + whitespace; skip empty lines.
+        trimmed="${raw%%#*}"
+        trimmed="${trimmed#"${trimmed%%[![:space:]]*}"}"
+        trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+        [[ -n "$trimmed" ]] && EXTRA_HOSTS+=("$trimmed")
+    done < "$ALLOWLIST_FILE"
+fi
+
+# --- 3. Install rules --------------------------------------------------------
+install_rules() {
+    # 3a. Loopback always allowed (Hermes internal IPC, the gateway's own
+    # /v1 listener answering /health from inside the same container).
+    iptables -A OUTPUT -m owner --uid-owner "${CODEX_UID}" \
+        -d 127.0.0.0/8 -j ACCEPT \
+        -m comment --comment "${COMMENT_TAG}"
+
+    # 3b. DNS — outbound to whatever resolver(s) the container is configured
+    # with. We allow ANY destination on UDP/53 + TCP/53 for uid 10001 so a
+    # later resolv.conf change doesn't break codex/git/npm.
+    iptables -A OUTPUT -m owner --uid-owner "${CODEX_UID}" \
+        -p udp --dport 53 -j ACCEPT \
+        -m comment --comment "${COMMENT_TAG}"
+    iptables -A OUTPUT -m owner --uid-owner "${CODEX_UID}" \
+        -p tcp --dport 53 -j ACCEPT \
+        -m comment --comment "${COMMENT_TAG}"
+
+    # 3c. Resolved per-host rules — one ACCEPT per (host, IP) pair, TCP 443
+    # + TCP 22 (github.com push over SSH). HTTPS is the only outbound HTTP
+    # we allow; plain HTTP egress to allowlisted hosts is unnecessary and
+    # this script does not grant it.
+    local accepted_count=0
+    local resolved_count=0
+    for host in "${BUILTIN_HOSTS[@]}" "${EXTRA_HOSTS[@]}"; do
+        local ips
+        ips=$(resolve_host "$host")
+        if [[ -z "$ips" ]]; then
+            log "  warn: DNS resolved no A records for $host (skipping)"
+            continue
+        fi
+        resolved_count=$((resolved_count + 1))
+        for ip in $ips; do
+            # TCP 443 — HTTPS
+            iptables -A OUTPUT -m owner --uid-owner "${CODEX_UID}" \
+                -p tcp -d "${ip}/32" --dport 443 -j ACCEPT \
+                -m comment --comment "${COMMENT_TAG}"
+            accepted_count=$((accepted_count + 1))
+            # TCP 22 — git push over SSH (github.com, gitlab.com if added)
+            iptables -A OUTPUT -m owner --uid-owner "${CODEX_UID}" \
+                -p tcp -d "${ip}/32" --dport 22 -j ACCEPT \
+                -m comment --comment "${COMMENT_TAG}"
+            accepted_count=$((accepted_count + 1))
+        done
+    done
+
+    # 3d. Default DENY for uid 10001 — REJECT with icmp-net-prohibited so
+    # the codex CLI sees a clean "Network is unreachable" rather than a
+    # silent timeout (better operator signal in the run audit log).
+    iptables -A OUTPUT -m owner --uid-owner "${CODEX_UID}" \
+        -j REJECT --reject-with icmp-net-prohibited \
+        -m comment --comment "${COMMENT_TAG}"
+
+    log "installed ${accepted_count} ACCEPT rules covering ${resolved_count} host(s) + 1 REJECT default"
+    log "  builtin hosts:   ${BUILTIN_HOSTS[*]}"
+    [[ ${#EXTRA_HOSTS[@]} -gt 0 ]] && log "  extra hosts:     ${EXTRA_HOSTS[*]}"
+}
+
+# --- main --------------------------------------------------------------------
+log "uid=${CODEX_UID} allowlist=${ALLOWLIST_FILE}"
+clean_old_rules
+install_rules
+log "done"

--- a/packages/hermes/docker/supervisor.sh
+++ b/packages/hermes/docker/supervisor.sh
@@ -195,9 +195,20 @@ if [[ -f "$MAIN_AUTH" && -s "$MAIN_AUTH" ]]; then
             cp "$MAIN_AUTH" "$CB_AUTH"
             log "propagated main/auth.json -> codex-builder/auth.json (${MAIN_SIZE} bytes, Hermes-LLM auth)"
         fi
+        # PR 4: the codex-builder gateway runs under uid 10001 and cannot
+        # read root-owned files. Re-chown after every copy so a fresh-on-
+        # this-boot mirror is immediately readable by the gateway. The
+        # init container also chowns the whole profile dir, but supervisor
+        # boots AFTER init so a copy here racing against init's chown
+        # would leave the file root-owned if we don't repeat.
+        chown 10001:10001 "$CB_AUTH" 2>/dev/null || true
+        chmod 0600 "$CB_AUTH" 2>/dev/null || true
+
         # Codex CLI's own auth — reads $CODEX_HOME/auth.json. .env sets
         # CODEX_HOME=/hermes-state/profiles/codex-builder/.codex.
         mkdir -p "$HERMES_ROOT/profiles/codex-builder/.codex"
+        chown 10001:10001 "$HERMES_ROOT/profiles/codex-builder/.codex" 2>/dev/null || true
+        chmod 0700 "$HERMES_ROOT/profiles/codex-builder/.codex" 2>/dev/null || true
         CLI_AUTH="$HERMES_ROOT/profiles/codex-builder/.codex/auth.json"
         CLI_SIZE=0
         [[ -f "$CLI_AUTH" ]] && CLI_SIZE=$(stat -c%s "$CLI_AUTH" 2>/dev/null || echo 0)
@@ -205,6 +216,8 @@ if [[ -f "$MAIN_AUTH" && -s "$MAIN_AUTH" ]]; then
             cp "$MAIN_AUTH" "$CLI_AUTH"
             log "propagated main/auth.json -> codex-builder/.codex/auth.json (${MAIN_SIZE} bytes, codex-CLI auth)"
         fi
+        chown 10001:10001 "$CLI_AUTH" 2>/dev/null || true
+        chmod 0600 "$CLI_AUTH" 2>/dev/null || true
     fi
 fi
 
@@ -389,12 +402,20 @@ start_proc "hermes-heavy"    "cd \"${PROFILES_DIR}/heavy\"   && set -a && . \"${
 # The 4th profile, only launched when ENABLE_CODEX_BUILDER=1. Renders fleet-
 # wide via the init container, but a non-home tenant never starts the process.
 #
-# PR 2 of 5: this launches under the container's default uid (10000, same as
-# the other 3 gateways). PR 4 will swap the body for `setpriv --reuid 10001
-# --regid 10001 --clear-groups --reset-env hermes -p codex-builder gateway
-# run --replace` once the FS-isolation init step has chowned the profile dir
-# + /work to uid 10001. Verifying PR 2 means: the gateway boots on :18793
-# and answers /health. PR 4 verifies: uid-10001 cannot read /vault.
+# PR 4 hardening:
+#   1. Egress allowlist — iptables OUTPUT rules scoped --uid-owner 10001
+#      that allow OpenAI / GitHub / npm / PyPI / crates.io and REJECT
+#      everything else. Installed BEFORE the gateway starts so the first
+#      `codex exec` already runs under the constraint. Requires the
+#      NET_ADMIN cap (added in PR 2 docker-compose.yaml).
+#   2. setpriv uid drop — `setpriv --reuid 10001 --regid 10001
+#      --clear-groups --reset-env` swaps the gateway to uid 10001 and
+#      clears the inherited environment so OPENROUTER_API_KEY,
+#      AAS_API_KEY, COMPOSIO_*, etc. (which the docker-compose service
+#      surfaces into the container's initial env) CANNOT leak into the
+#      sealed gateway's process env. We re-establish the minimum
+#      (PATH, HOME, TERM) and source the profile's positive-allowlist
+#      .env on top.
 #
 # `cd ${PROFILES_DIR}/codex-builder` lines up AGENTS.md auto-discovery and
 # matches the established pattern. `set -a; . .env; set +a` source-and-
@@ -402,12 +423,54 @@ start_proc "hermes-heavy"    "cd \"${PROFILES_DIR}/heavy\"   && set -a && . \"${
 # from PR #92) — the .env's CODEX_HOME / CODEX_WORKSPACE_ROOT / GIT_SSH_
 # COMMAND flow through to the gateway process here.
 if (( ENABLE_CODEX_BUILDER == 1 )); then
+    # 1. Install the egress allowlist BEFORE launching the gateway.
+    # `codex-builder-setup-egress.sh` is baked into /usr/local/bin in the
+    # Dockerfile (PR 4); it expects NET_ADMIN. Failure here SHOULD fail
+    # the whole supervisor — a builder gateway running without the egress
+    # filter could exfiltrate to any host (the persona prompt is the only
+    # remaining fence, and that's a soft one). Run as root (the supervisor
+    # itself runs as root inside the container) so iptables can mutate the
+    # OUTPUT chain.
+    if /usr/local/bin/codex-builder-setup-egress.sh; then
+        log "codex-builder egress jail installed (--uid-owner 10001, default REJECT)"
+    else
+        log "FATAL: codex-builder egress jail setup failed (exit $?) — refusing to launch gateway"
+        log "       check 'cap_add: NET_ADMIN' on the hermes service in docker-compose.yaml,"
+        log "       and that /usr/local/bin/codex-builder-setup-egress.sh is executable."
+        # Don't `exit` the supervisor — main/workers/heavy are already up
+        # and we don't want to take them down on a codex-builder-specific
+        # failure. Just skip the codex-builder gateway and log loudly.
+        ENABLE_CODEX_BUILDER=0
+    fi
+fi
+
+if (( ENABLE_CODEX_BUILDER == 1 )); then
+    # 2. setpriv uid drop. The chain:
+    #    setpriv --reuid 10001 --regid 10001 --clear-groups --reset-env
+    #      env -i (already done by --reset-env)
+    #      PATH=/usr/local/bin:/usr/bin:/bin
+    #      HOME=$PROFILES_DIR/codex-builder
+    #      TERM=$TERM (preserve if set; else dumb)
+    #      cd $HOME
+    #      source $HOME/.env  (positive-allowlist)
+    #      exec hermes -p codex-builder gateway run --replace
+    # `bash -c` is what start_proc invokes — we put the whole chain in
+    # one quoted command string. `--clear-groups` drops the supplementary
+    # group set (default gid 10000 would be inherited from the container
+    # default user); `--reset-env` wipes the inherited env, which is the
+    # crucial bit for keeping OPENROUTER_API_KEY etc. out of the gateway.
+    CODEX_HOME_DIR="${PROFILES_DIR}/codex-builder"
     start_proc "hermes-codex-builder" \
-        "cd \"${PROFILES_DIR}/codex-builder\" \
-         && set -a && . \"${PROFILES_DIR}/codex-builder/.env\" && set +a \
-         && TERMINAL_CWD=${PROFILES_DIR}/codex-builder/workspace \
-         exec hermes -p codex-builder gateway run --replace"
-    log "codex-builder gateway enabled (ENABLE_CODEX_BUILDER=1) — launching on :18793"
+        "exec setpriv --reuid=10001 --regid=10001 --clear-groups --reset-env \
+            env \
+              PATH=/usr/local/bin:/usr/bin:/bin \
+              HOME=\"${CODEX_HOME_DIR}\" \
+              TERM=\"\${TERM:-dumb}\" \
+              bash -c 'cd \"${CODEX_HOME_DIR}\" \
+                       && set -a && . \"${CODEX_HOME_DIR}/.env\" && set +a \
+                       && TERMINAL_CWD=\"${CODEX_HOME_DIR}/workspace\" \
+                          exec hermes -p codex-builder gateway run --replace'"
+    log "codex-builder gateway enabled (ENABLE_CODEX_BUILDER=1) — launching on :18793 as uid 10001"
 else
     log "codex-builder gateway disabled (ENABLE_CODEX_BUILDER!=1) — profile dir is rendered but no process launched"
 fi

--- a/packages/hermes/init/entrypoint.sh
+++ b/packages/hermes/init/entrypoint.sh
@@ -532,6 +532,184 @@ fi
 chown -R 10000:10000 "$HERMES_DATA_DIR" 2>/dev/null || true
 chown -R 10000:10000 /vault 2>/dev/null || true
 
+# =============================================================================
+# 7b. codex-builder profile FS isolation (PR 4 of
+#     docs/codex-builder-runtime.md §6).
+#
+# The codex-builder gateway runs under uid 10001 (PR 4 supervisor.sh
+# swap). For its sandbox to mean anything we MUST ensure uid 10001 can:
+#   * read+write /hermes-state/profiles/codex-builder/ (own state)
+#   * read+write /work (the per-run workspace mount)
+# AND cannot:
+#   * read /vault (the principal's surface)
+#   * read /alfred-data (gateway tokens + Sure/Plane bootstrap inputs)
+#   * read other profiles' .env (provider keys, channel tokens)
+#   * read main's .codex/ auth.json (codex-builder has its OWN auth at
+#     /hermes-state/profiles/codex-builder/.codex/auth.json — see PR 2
+#     supervisor.sh mirror block)
+#
+# The chowns + chmods below establish the can-read side. The cannot-read
+# side is enforced by the surrounding /vault + /alfred-data + other-
+# profile dirs being 0700 root:root or 0700 10000:10000 — anything 10001
+# tries to read is uid-mismatched, no read bit.
+#
+# Idempotent — re-runs on every init container start. Safe alongside
+# step 7's broader chown above (this block REPLACES the chown for the
+# codex-builder subtree).
+# =============================================================================
+CODEX_PROFILE_DIR="$HERMES_DATA_DIR/profiles/codex-builder"
+if [[ -d "$CODEX_PROFILE_DIR" ]]; then
+    echo "[init] [codex-builder] hardening profile dir + /work for uid 10001"
+    # The whole profile dir is owned by 10001 mode 0700 — uid 10000 (other
+    # gateways) and root will use DAC_OVERRIDE if they need to write, but
+    # the codex-builder gateway can never escape its own home.
+    chown -R 10001:10001 "$CODEX_PROFILE_DIR" 2>/dev/null || true
+    chmod 0700 "$CODEX_PROFILE_DIR" 2>/dev/null || true
+    # Recursive 0700 on subdirs, 0600 on files. .ssh stricter (0700/0600).
+    find "$CODEX_PROFILE_DIR" -type d -exec chmod 0700 {} + 2>/dev/null || true
+    find "$CODEX_PROFILE_DIR" -type f -exec chmod 0600 {} + 2>/dev/null || true
+    # config.yaml ends up 0600 — that's tighter than the 0640 the other
+    # profiles use but fine because the only reader is the codex-builder
+    # gateway process at uid 10001 (init/hermes containers use DAC_OVERRIDE).
+
+    # /work is the named volume mounted at /work in the hermes service. The
+    # init container has it mounted at /work too (we added it below).
+    # Chown to 10001:10001 mode 0700 so ONLY the codex-builder gateway can
+    # see / write the per-run dirs. The volume isn't mounted in any other
+    # service so this is also the only mount point on the box.
+    if [[ -d /work ]]; then
+        chown 10001:10001 /work 2>/dev/null || true
+        chmod 0700 /work 2>/dev/null || true
+        mkdir -p /work/runs
+        chown 10001:10001 /work/runs 2>/dev/null || true
+        chmod 0700 /work/runs 2>/dev/null || true
+    else
+        echo "[init] [codex-builder] WARNING: /work not mounted in init container —"
+        echo "[init] [codex-builder]   add it to the init service's volumes block in docker-compose.yaml"
+    fi
+
+    # Lay down a default network-allowlist.txt so a future operator can
+    # extend the egress allowlist without rebuilding the image. The egress
+    # jail script reads any additional hosts from this file at supervisor
+    # boot. Idempotent — only writes if absent (preserves operator edits).
+    NET_ALLOW="$CODEX_PROFILE_DIR/network-allowlist.txt"
+    if [[ ! -f "$NET_ALLOW" ]]; then
+        cat > "$NET_ALLOW" <<'EOF'
+# codex-builder additional network egress allowlist.
+#
+# One hostname per line, '#' starts a comment, blank lines ignored.
+# These hosts are resolved at supervisor boot via `dig +short A <host>` and
+# added as ACCEPT rules in iptables OUTPUT chain scoped --uid-owner 10001
+# (TCP 443 + TCP 22 per host). Default deny stays in place — anything not
+# listed here OR in the script's BUILTIN_HOSTS array is REJECTed.
+#
+# BUILTIN_HOSTS (already on the list, do NOT duplicate):
+#   api.openai.com  chatgpt.com
+#   api.github.com  github.com  codeload.github.com
+#   registry.npmjs.org  pypi.org  files.pythonhosted.org  static.crates.io  crates.io
+#
+# Add a host below if a codex run needs a private registry, an internal
+# package mirror, or a tenant-specific deploy target. Restart hermes to
+# apply.
+EOF
+        chown 10001:10001 "$NET_ALLOW" 2>/dev/null || true
+        chmod 0600 "$NET_ALLOW" 2>/dev/null || true
+        echo "[init] [codex-builder] seeded $NET_ALLOW"
+    fi
+
+    # --- Deploy key (read from /opt/alfred/.env via init env passthrough) ---
+    # The codex-builder profile pushes branches to ssdavidai/alfred via a
+    # repo-scoped deploy key with "Allow write access" on. The private key
+    # lives in Vaultwarden + is mirrored into the per-tenant /opt/alfred/.env
+    # as CODEX_BUILDER_DEPLOY_KEY_B64 (base64 of the OpenSSH private key).
+    # We write it here, chown to 10001, chmod 0600.
+    #
+    # When the var is empty (default everywhere except home), we skip the
+    # write — no key, no `git push` capability. PR 5's wrapper handles the
+    # absent-key case by emitting a clean "deploy key missing" run audit.
+    SSH_DIR="$CODEX_PROFILE_DIR/.ssh"
+    KEY_FILE="$SSH_DIR/codex_id_ed25519"
+    if [[ -n "${CODEX_BUILDER_DEPLOY_KEY_B64:-}" ]]; then
+        mkdir -p "$SSH_DIR"
+        # Decode and write. Tolerate either standard or URL-safe base64;
+        # standard libraries accept both.
+        if echo -n "$CODEX_BUILDER_DEPLOY_KEY_B64" | base64 -d > "$KEY_FILE" 2>/dev/null; then
+            chmod 0600 "$KEY_FILE"
+            chown 10001:10001 "$KEY_FILE"
+            echo "[init] [codex-builder] wrote deploy key $KEY_FILE ($(wc -c < "$KEY_FILE") bytes)"
+        else
+            rm -f "$KEY_FILE"
+            echo "[init] [codex-builder] WARNING: CODEX_BUILDER_DEPLOY_KEY_B64 set but failed to base64-decode — skipping"
+        fi
+        # known_hosts for github.com so the first push doesn't trip on a
+        # prompt (we have StrictHostKeyChecking=accept-new in the .env
+        # but a pre-seeded entry is more deterministic).
+        if [[ ! -f "$SSH_DIR/known_hosts" ]]; then
+            ssh-keyscan -t ed25519,ecdsa github.com 2>/dev/null > "$SSH_DIR/known_hosts" || true
+            if [[ -s "$SSH_DIR/known_hosts" ]]; then
+                chmod 0600 "$SSH_DIR/known_hosts"
+                chown 10001:10001 "$SSH_DIR/known_hosts"
+                echo "[init] [codex-builder] seeded $SSH_DIR/known_hosts with github.com keys"
+            fi
+        fi
+    else
+        echo "[init] [codex-builder] CODEX_BUILDER_DEPLOY_KEY_B64 unset — git push will fail clean (no key)"
+    fi
+
+    # --- Negative-asserts: the codex-builder uid 10001 must NOT be able to
+    #     read these paths. We test by `setpriv --reuid 10001 cat <file>`
+    #     and fail the init if any of them succeed. Defense-in-depth — the
+    #     chmods above should already block, but a single fat-fingered
+    #     chmod elsewhere in this script could open a hole that nothing
+    #     would catch otherwise.
+    #
+    # Negative-asserts are enforced ONLY when ENABLE_CODEX_BUILDER is on.
+    # On a tenant that doesn't run the codex-builder gateway, the chowns
+    # still happen for safety (so the profile dir is correctly owned if
+    # the flag is later flipped on), but the asserts are skipped — the
+    # /vault chown step 7 may not have run yet on a first-boot init+hermes
+    # pull cycle, and a transient race shouldn't fail provisioning.
+    if [[ "${ENABLE_CODEX_BUILDER:-false}" == "true" ]]; then
+        echo "[init] [codex-builder] negative-asserts: uid 10001 must NOT read these paths"
+        ASSERT_FAILS=0
+        # SOUL.md is the marker — we want a file we know exists in /vault.
+        if setpriv --reuid 10001 --regid 10001 --clear-groups \
+               cat /vault/SOUL.md > /dev/null 2>&1; then
+            echo "[init] [codex-builder] FAIL: uid 10001 can read /vault/SOUL.md"
+            ASSERT_FAILS=$((ASSERT_FAILS + 1))
+        fi
+        if setpriv --reuid 10001 --regid 10001 --clear-groups \
+               cat /alfred-data/.gateway-token > /dev/null 2>&1; then
+            echo "[init] [codex-builder] FAIL: uid 10001 can read /alfred-data/.gateway-token"
+            ASSERT_FAILS=$((ASSERT_FAILS + 1))
+        fi
+        for p in main workers heavy; do
+            P_ENV="$HERMES_DATA_DIR/profiles/$p/.env"
+            if [[ -f "$P_ENV" ]] && setpriv --reuid 10001 --regid 10001 --clear-groups \
+                   cat "$P_ENV" > /dev/null 2>&1; then
+                echo "[init] [codex-builder] FAIL: uid 10001 can read $P_ENV"
+                ASSERT_FAILS=$((ASSERT_FAILS + 1))
+            fi
+        done
+        # Positive-assert too — uid 10001 MUST be able to read its own .env
+        # (otherwise the supervisor's source-and-export will silently fail).
+        if ! setpriv --reuid 10001 --regid 10001 --clear-groups \
+               cat "$CODEX_PROFILE_DIR/.env" > /dev/null 2>&1; then
+            echo "[init] [codex-builder] FAIL: uid 10001 CANNOT read its own .env"
+            ASSERT_FAILS=$((ASSERT_FAILS + 1))
+        fi
+        if (( ASSERT_FAILS > 0 )); then
+            echo "[init] [codex-builder] FATAL: ${ASSERT_FAILS} FS isolation assertion(s) failed"
+            echo "[init] [codex-builder]   The sandbox is not effective. Refusing to allow the codex-builder gateway to start."
+            echo "[init] [codex-builder]   Check the chown/chmod above; check /vault is owned 10000:10000 mode 0700."
+            exit 71
+        fi
+        echo "[init] [codex-builder] all isolation assertions passed"
+    else
+        echo "[init] [codex-builder] ENABLE_CODEX_BUILDER not true — skipping isolation asserts (chowns still applied)"
+    fi
+fi
+
 mkdir -p /alfred-data
 chmod -R 777 /alfred-data 2>/dev/null || true
 # Keep the token readable by every service in the stack (alfred-learn is


### PR DESCRIPTION
**PR 4 of 5** — the hardest. Establishes the actual security boundary per [`docs/codex-builder-runtime.md`](docs/codex-builder-runtime.md) §6 PR 4.

Depends on #100 (CLI in image), #101 (profile + supervisor), #102 (.env quoting hotfix), #103 (adapter routing) — all merged.

## The boundary, in two layers

### Filesystem
- Profile dir + `/work` chowned `10001:10001 mode 0700` by the init container.
- Init negative-asserts uid 10001 cannot read `/vault`, `/alfred-data/.gateway-token`, or any other profile's `.env`. If ANY of those `setpriv --reuid 10001 cat <file>` checks succeeds, the init container fails with exit 71 and the codex-builder gateway does not start.
- Positive-assert too: uid 10001 MUST be able to read its OWN `.env` (so the supervisor's source-and-export works).

### Network
- iptables OUTPUT chain scoped `--uid-owner 10001` allows OpenAI, GitHub, npm, PyPI, crates.io (TCP 443 + TCP 22), DNS, loopback. Default REJECT for everything else (`--reject-with icmp-net-prohibited` so codex sees a clean "Network is unreachable").
- Installed at supervisor boot BEFORE the gateway launches. Operator-extendable via `/hermes-state/profiles/codex-builder/network-allowlist.txt` (one hostname per line).
- uid 10000 (main/workers/heavy) is UNTOUCHED — their egress stays fully open as today.

### setpriv
- The 4th gateway is now launched via `setpriv --reuid=10001 --regid=10001 --clear-groups --reset-env`. `--reset-env` wipes the container's inherited env so `OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`, `AAS_API_KEY`, `COMPOSIO_*`, `PAPERCLIP_*` (which docker-compose `environment:` surfaces) CANNOT leak into the sealed gateway.
- The bash subshell re-establishes the minimum (`PATH`, `HOME`, `TERM`) and sources the profile's positive-allowlist `.env` on top.

## New scripts baked into the image

| Path | Role |
|---|---|
| `/usr/local/bin/codex-builder-setup-egress.sh` | iptables installer (run by supervisor; idempotent, tagged `--comment CODEX_BUILDER`) |
| `/usr/local/bin/codex-builder-prep-run.sh` | Per-run workspace prep (PR 5 wires it). Defensive: refuses path traversal in runId/issueId, refuses to overwrite an existing run dir. Returns the workspace path on stdout. |

## docker-compose.yaml deltas

- `init` service mounts `hermes_codex_work:/work` so init can chown it to 10001.
- `init` service passes through `ENABLE_CODEX_BUILDER` (gates the negative-asserts) and `CODEX_BUILDER_DEPLOY_KEY_B64` (base64 of the GitHub deploy key's private half; written into the profile's `.ssh/codex_id_ed25519` owned 10001:10001 mode 0600).

## Verify on home (after build-init + build-hermes roll)

```
docker compose pull init hermes
docker compose up -d --force-recreate init hermes

# 1. init's codex-builder log lines
docker logs alfred-black-init-1 | grep '\[codex-builder\]'
# expect: "negative-asserts: uid 10001 must NOT read these paths"
# expect: "all isolation assertions passed"

# 2. gateway running as uid 10001
docker exec alfred-black-hermes-1 ps -ef | grep 'p codex-builder'
# expect: "10001 ... hermes -p codex-builder gateway run"

# 3. iptables rules installed
docker exec alfred-black-hermes-1 iptables -L OUTPUT -n | grep CODEX | wc -l
# expect: many lines (one per host × per port × per IP), one final REJECT

# 4. operator-level spot-checks (a shell AS uid 10001)
docker exec -u 10001 -it alfred-black-hermes-1 bash
> cat /vault/SOUL.md                              # Permission denied
> cat /alfred-data/.gateway-token                 # Permission denied
> cat /hermes-state/profiles/main/.env            # Permission denied
> curl -m 5 -fsS https://api.openai.com/v1/models # 401 (no auth) — L4 ok
> curl -m 5 -fsS https://api.anthropic.com/...    # Network is unreachable
> curl -m 5 -fsS https://example.com              # Network is unreachable
```

## Trade-offs taken

- The codex-builder gateway runs in the SAME container as main/workers/heavy. The boundary is uid 10001 vs uid 10000, not the container boundary. A kernel-level uid-10001 escalation to uid 10000 would compromise main's MCP secrets in the same container — mitigated by dropping every capability except DAC_OVERRIDE + NET_ADMIN, `no-new-privileges:true`, and codex's own `--sandbox workspace-write` (PR 5).
- DNS is allowed for any destination on UDP/TCP 53. A poisoned resolver could redirect github.com to an attacker's IP. Mitigation: per-host `dig +short A` at supervisor boot resolves to specific IPs; the ACCEPT rules pin those IPs, not hostnames. A subsequent DNS change after boot doesn't reopen egress.
- The egress allowlist is fail-safe — if iptables setup fails, ENABLE_CODEX_BUILDER is internally zeroed for the rest of the supervisor and the gateway doesn't launch. The container stays up serving main/workers/heavy.

## What is intentionally NOT in this PR

- No codex CLI invocation wrapper (PR 5: `/usr/local/bin/codex-builder-run.sh` calls `codex exec --sandbox workspace-write --ask-for-approval never --ephemeral --json --output-last-message`).
- No end-to-end Paperclip issue flow (PR 5).
- No Paperclip-side persona text update (PR 5).
- No `gh repo --add-deploy-key` bootstrap helper (the deploy key is generated separately and the public half registered manually; the private half lands in Vaultwarden → /opt/alfred/.env → init → profile/.ssh/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)