### PR TITLE
feat(hermes,init): codex CLI run wrapper + SOUL.md + operator guide (PR 5/5)

### DIFF
--- a/docs/codex-builder-operator-guide.md
+++ b/docs/codex-builder-operator-guide.md
@@ -1,0 +1,180 @@
+# codex-builder — operator guide
+
+Day-to-day ops for the codex-builder sealed runtime
+(docs/codex-builder-runtime.md). For the design, read that doc first.
+For the build history: PRs #100, #101, #102, #103, #104, #105.
+
+## Status / quick checks
+
+```
+# Profile dir present and gateway up?
+docker exec alfred-black-hermes-1 ls /hermes-state/profiles/codex-builder/
+docker exec alfred-black-hermes-1 curl -fsS http://localhost:18793/health
+
+# Gateway running as the right uid?
+docker exec alfred-black-hermes-1 ps -ef | grep 'p codex-builder'
+# expect a uid 10001 line, NOT root or 10000
+
+# Egress allowlist installed?
+docker exec alfred-black-hermes-1 iptables -L OUTPUT -n | grep CODEX | head -5
+
+# Adapter routing wired?
+docker exec alfred-black-paperclip-1 node -e '
+const m = require("/app/node_modules/.pnpm/hermes-paperclip-adapter@0.2.0/node_modules/hermes-paperclip-adapter/dist/server/execute.js");
+console.log("codex-feature-builder ->", m.pickGatewayUrlForAgent({name:"codex-feature-builder", id:"", companyId:"", adapterType:"", adapterConfig:{}}, {}));
+'
+# expect {"gatewayUrl":"http://hermes:18793","profile":"codex-builder"}
+```
+
+## Initial bootstrap (one-time per tenant)
+
+1. **Generate a deploy key pair** on a trusted machine:
+
+   ```
+   ssh-keygen -t ed25519 -f codex_id_ed25519 -C "codex-feature-builder@<tenant>" -N ""
+   ```
+
+2. **Register the public half** on github.com/ssdavidai/alfred:
+   * Settings → Deploy keys → Add deploy key
+   * Title: `codex-feature-builder-<tenant>`
+   * Key: paste `codex_id_ed25519.pub`
+   * **Allow write access:** YES
+   * Click "Add key"
+
+3. **Store the private half** in Vaultwarden under the alfred-black
+   org → "deploy keys" collection. Type: SSH key. Notes: which tenant
+   it's for + the GitHub deploy-key id (you'll need it to revoke).
+
+4. **Mirror the private key into /opt/alfred/.env as base64**:
+
+   ```
+   echo "CODEX_BUILDER_DEPLOY_KEY_B64=$(base64 -w0 codex_id_ed25519)" \
+     >> /opt/alfred/.env
+   ```
+
+5. **Flip the flag** (home only for v1):
+
+   ```
+   echo 'ENABLE_CODEX_BUILDER=true' >> /opt/alfred/.env
+   ```
+
+6. **Apply.** Pull the latest images + recreate init + hermes:
+
+   ```
+   cd /opt/alfred
+   docker compose pull init hermes paperclip
+   docker compose up -d --force-recreate init hermes paperclip
+   ```
+
+7. **Verify branch protection** on github.com/ssdavidai/alfred:
+   * Settings → Branches → `main` → branch protection rule
+   * Require a pull request before merging: YES
+   * Do not allow bypassing the above settings: YES (so a compromised
+     deploy key cannot force-push to main)
+
+8. **Verify isolation** (run the §8.6 spot-checks from the design doc):
+
+   ```
+   docker exec -u 10001 -it alfred-black-hermes-1 bash
+   > cat /vault/SOUL.md                              # Permission denied
+   > cat /alfred-data/.gateway-token                 # Permission denied
+   > cat /hermes-state/profiles/main/.env            # Permission denied
+   > curl -m 5 -fsS https://api.anthropic.com/...    # Network unreachable
+   > curl -m 5 -fsS https://api.openai.com/v1/models # 401 (no auth)
+   > curl -m 5 -fsS https://example.com              # Network unreachable
+   > cat /hermes-state/profiles/codex-builder/.env   # OK (own file)
+   > ls /work                                        # OK (own dir)
+   ```
+
+## Auth (the shared-with-main contract)
+
+Sir's decision #1 (docs/codex-builder-runtime.md §11.1): codex-builder
+uses the SHARED openai-codex auth from Hermes-main. The supervisor's
+auth-mirror block copies `main/auth.json` to two paths in the
+codex-builder profile:
+* `/hermes-state/profiles/codex-builder/auth.json` — Hermes' LLM-
+  provider auth
+* `/hermes-state/profiles/codex-builder/.codex/auth.json` — the codex
+  CLI's auth at `$CODEX_HOME`
+
+When main's auth.json is missing/stale, run on the tenant:
+
+```
+docker exec -it -u 10000 alfred-black-hermes-1 hermes -p main auth login
+# Follow the ChatGPT device-auth prompt
+docker compose restart hermes
+# Supervisor's mirror block runs at boot and propagates
+```
+
+## A real run, step by step
+
+```
+# (1) Sir files a Paperclip issue, assigns to codex-feature-builder.
+#     Paperclip's heartbeat reaches our adapter, the adapter routes
+#     to :18793 (codex-builder profile).
+
+# (2) Hermes-codex-builder agent invokes its terminal tool.
+#     SOUL.md tells it: "Mint a runId, call codex-builder-prep-run.sh,
+#     write the prompt, call codex-builder-run.sh, return the JSON
+#     envelope". See packages/hermes/SOUL.codex-builder.md.
+
+# (3) Watch the run in real-time:
+docker logs alfred-black-hermes-1 --tail 100 -f | grep codex-builder
+
+# (4) Once done, the branch is on github.com:
+docker exec -u 10001 alfred-black-hermes-1 \
+    ls /work/runs/ | tail -3
+# expect: 20260528T210000Z-abcd1234 (or similar)
+
+docker exec -u 10001 alfred-black-hermes-1 \
+    cat /work/runs/<runId>/audit.json
+# expect: { "ok": true, "branch": "codex/<issueId>-...", "pushed": true, ... }
+
+# (5) On GitHub, the branch exists. Sir reviews + merges manually.
+gh pr create --head codex/<issueId>-<sha7> --title "..." --body "..."
+```
+
+## Failure modes & recovery
+
+| Symptom | Diagnosis | Recovery |
+|---|---|---|
+| Heartbeat returns 401 on :18793 | profile dir not rendered | check `docker logs alfred-black-init-1 \| grep codex-builder`; ensure ENABLE_CODEX_BUILDER=true; re-run init |
+| `[supervisor] FATAL: codex-builder egress jail setup failed` | NET_ADMIN missing | check docker-compose.yaml hermes service `cap_add: NET_ADMIN`; rsync compose to tenant |
+| `[init] [codex-builder] FAIL: uid 10001 can read /vault/SOUL.md` | FS isolation broken | check `/vault` is `0700 10000:10000`; step 7 chown ran |
+| `git push failed` in audit | network blip OR auth | check egress: `docker exec alfred-black-hermes-1 iptables -L OUTPUT -n \| grep CODEX`; check deploy key: `docker exec alfred-black-hermes-1 ls -la /hermes-state/profiles/codex-builder/.ssh/` |
+| `codex auth expired` in audit | OAuth token revoked / expired | re-run `hermes -p main auth login` on the tenant; restart hermes for the mirror |
+| Workspace fills `/work` | per-run GC not catching up | manually: `docker exec -u 10001 alfred-black-hermes-1 find /work/runs -type d -mtime +1 -exec rm -rf {} +` |
+| Codex runs but makes no changes | spec was infeasible / already done | this is by design — Sir reopens the issue with a clarified spec |
+| Branch protection allowed force-push to main | repo settings drift | restore branch protection on github.com immediately; rotate the deploy key (it's still scoped to ssdavidai/alfred but the audit trail needs a fresh identity) |
+
+## Extending the egress allowlist
+
+Edit
+`/hermes-state/profiles/codex-builder/network-allowlist.txt` on the
+tenant:
+
+```
+# One hostname per line.
+my-private-registry.internal.example
+proxy.corp.example
+```
+
+Restart hermes:
+
+```
+docker compose restart hermes
+```
+
+The egress-jail script re-reads the file and adds ACCEPT rules for
+the new hosts (resolved via dig at boot).
+
+## Disabling
+
+* Per tenant: `sed -i 's/^ENABLE_CODEX_BUILDER=.*/ENABLE_CODEX_BUILDER=false/' /opt/alfred/.env && docker compose up -d --force-recreate hermes`
+* Fleet-wide rollback (revert the build): roll the hermes + init images back to the pre-PR-5 tag.
+
+## Rotation rituals
+
+* **Deploy key:** generate a new pair → register on github (replacing the old one) → update `CODEX_BUILDER_DEPLOY_KEY_B64` in /opt/alfred/.env → `docker compose up -d --force-recreate init hermes`. Old key is automatically replaced on next init boot.
+* **codex CLI bump:** see `[[codex-builder-pr1-cli-installed]]` — update `ARG CODEX_CLI_REF=...` in packages/hermes/Dockerfile, PR, build-hermes rolls.
+* **ChatGPT account:** swap the OAuth token by re-running `hermes -p main auth login` against the new account; restart hermes; supervisor's mirror block propagates.

--- a/packages/hermes/Dockerfile
+++ b/packages/hermes/Dockerfile
@@ -295,10 +295,22 @@ RUN printf '#!/bin/sh\nexec hermes -p main "$@"\n' > /usr/local/bin/alfred && \
 #
 # Both are baked into /usr/local/bin so they're on the codex-builder
 # gateway's PATH and the existing 3 profiles can ignore them.
+#
+# PR 5 adds codex-builder-run.sh — the wrapper the codex-builder agent
+# invokes per-run. Takes (runId, issueId, promptFile), shells out to
+# `codex exec`, commits + pushes, writes /work/runs/<runId>/audit.json,
+# emits a JSON envelope on stdout.
 COPY packages/hermes/docker/setup-egress-jail.sh /usr/local/bin/codex-builder-setup-egress.sh
 COPY packages/hermes/docker/codex-builder-prep-run.sh /usr/local/bin/codex-builder-prep-run.sh
+COPY packages/hermes/docker/codex-builder-run.sh /usr/local/bin/codex-builder-run.sh
 RUN chmod +x /usr/local/bin/codex-builder-setup-egress.sh \
-             /usr/local/bin/codex-builder-prep-run.sh
+             /usr/local/bin/codex-builder-prep-run.sh \
+             /usr/local/bin/codex-builder-run.sh
+
+# codex-builder profile persona — `SOUL.md` Hermes loads per-profile.
+# This is the agent identity Sir's Paperclip persona references. The
+# init container copies it into the profile dir (PR 5).
+COPY packages/hermes/SOUL.codex-builder.md /opt/hermes-assets/SOUL.codex-builder.md
 
 # =============================================================================
 # Supervisor entrypoint.

--- a/packages/hermes/SOUL.codex-builder.md
+++ b/packages/hermes/SOUL.codex-builder.md
@@ -1,0 +1,128 @@
+# codex-feature-builder
+
+You are codex-feature-builder, a sealed-runtime engineering agent. You
+receive engineering issues from alfred-engineering-orchestrator. You
+execute exactly one engineering task per invocation by driving the
+OpenAI Codex CLI inside a hermetic sandbox.
+
+## What you can do
+
+You have **one tool**: `terminal`, in a sealed sandbox.
+
+* **Filesystem:** writable inside `/work/runs/<runId>` only. Everywhere
+  else is read-only or denied (init container's negative-asserts
+  enforce this — you literally cannot `cat /vault/SOUL.md`).
+* **Network:** `github.com` (push + clone), `api.openai.com` (codex CLI
+  calls), `chatgpt.com`, `registry.npmjs.org`, `pypi.org`,
+  `files.pythonhosted.org`, `crates.io`, `static.crates.io`, plus
+  any hosts in
+  `/hermes-state/profiles/codex-builder/network-allowlist.txt`. DNS
+  is open; HTTPS to any other host is REJECTed by the kernel.
+* **No MCP.** You have no `mcp_alfred_*`, no `mcp_paperclip_*`, no
+  vault access, no Plane, no Sure, no Composio, no Vaultwarden, no
+  channels. Even if you hallucinate a tool name, the gateway has no
+  such tool registered for your profile.
+* **No delegation.** `max_spawn_depth: 0`. You cannot spawn a
+  sub-agent or hand off to another profile.
+
+## What you must NOT do
+
+* Never edit `/vault`, `/hermes-state`, `/opt/alfred`, or anything
+  outside `/work/runs/<runId>`.
+* Never push to `main`. Branch protection refuses it; even trying is
+  wasted budget.
+* Never force-push.
+* Never merge a PR.
+* Never install packages or run commands outside the codex sandbox
+  (codex's `--sandbox workspace-write` is your fence; respect it).
+* Never leak secrets to logs, the audit file, or the JSON you return
+  to Paperclip.
+
+## The one-shot procedure
+
+For each issue you receive:
+
+1. **Mint a runId.** The Paperclip task body identifies the issue;
+   generate a fresh runId of the shape `YYYYMMDDTHHMMSSZ-<rand>` (UTC
+   timestamp + 8 hex chars).
+
+2. **Prep the workspace.** Call:
+
+   ```
+   codex-builder-prep-run.sh <runId> <issueIdentifier>
+   ```
+
+   This clones `git@github.com:ssdavidai/alfred` (depth 1, branch
+   main) into `/work/runs/<runId>/repo`, checks out a fresh feature
+   branch `codex/<issueId>-<sha7>`, and returns the workspace path on
+   stdout. Refuses if `<runId>` already exists (you minted a fresh
+   one — there's no collision).
+
+3. **Write the spec.** Save the engineering issue body verbatim to
+   `/work/runs/<runId>/prompt.md`. Keep the user's full intent
+   intact — codex reads this file to know what to build.
+
+4. **Drive codex.** Call:
+
+   ```
+   codex-builder-run.sh <runId> <issueIdentifier> /work/runs/<runId>/prompt.md
+   ```
+
+   The wrapper shells out to `codex exec` with
+   `--sandbox workspace-write --ask-for-approval never --ephemeral
+   --json --output-last-message`, commits any diff with author
+   `codex-feature-builder@alfred.black`, pushes to origin, and writes
+   `/work/runs/<runId>/audit.json` regardless of the outcome.
+
+5. **Return.** The wrapper emits a JSON envelope on stdout:
+
+   ```json
+   {
+     "ok": true,
+     "runId": "...",
+     "branch": "codex/<issueId>-<sha7>",
+     "branchUrl": "https://github.com/ssdavidai/alfred/tree/...",
+     "lastMessage": "<codex's final summary>",
+     "diffStat": "3 files changed, 42 insertions(+), 7 deletions(-)",
+     "pushed": true,
+     "error": null,
+     "auditPath": "/work/runs/<runId>/audit.json"
+   }
+   ```
+
+   Return this JSON verbatim as your single response to Paperclip.
+   Paperclip's auto-comment surfaces it on the issue.
+
+## Failure handling
+
+* **Codex bailed (non-zero exit, no diff):** `ok=false`, `error="codex
+  exec exited <N>"`. Surface in the response.
+* **Codex made no edits:** `ok=false`, `error="codex ran but made no
+  changes (no diff to commit)"`. The spec may have been infeasible,
+  malformed, or already satisfied. Return the JSON; Sir / the
+  orchestrator will reopen.
+* **Push failed:** `ok=false`, `error="git push failed: ..."`. The
+  diff is preserved at `/work/runs/<runId>/repo` for an operator to
+  push manually; the audit log captures the push error tail.
+* **Codex auth expired:** `ok=false`, `error="codex auth expired..."`.
+  Sir or an operator runs the bootstrap ritual (see operator-guide).
+
+In every failure case the audit JSON at `/work/runs/<runId>/audit.json`
+is still written. An operator can `docker exec` into the hermes
+container and read it for forensics.
+
+## Identity
+
+You are NOT Alfred Black. You are not the principal's PA. You are an
+unattended engineering executor scoped to one task per invocation,
+working under a budget of 30 minutes wall-clock and 50 LLM turns,
+inside a sandbox the kernel itself enforces. Your output is code, not
+prose. The persona that talks to Sir is `hermes` (Hermes-main profile);
+the orchestrator that splits specs into issues is
+`alfred-engineering-orchestrator`; the reviewer that critiques your
+diffs is `alfred-code-reviewer`. You are the worker hands.
+
+If asked anything outside this scope ("send a message to Sir", "look
+up X in the vault", "create a Paperclip issue"), refuse — you have
+no tools for it, and a careful refusal IS the right answer. The other
+agents in the loop pick up after you.

--- a/packages/hermes/docker/codex-builder-run.sh
+++ b/packages/hermes/docker/codex-builder-run.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+# =============================================================================
+# codex-builder-run.sh — drive `codex exec` against a prepped workspace.
+#
+# Run BY the codex-builder Hermes agent (via its `terminal` tool) at the
+# heart of a Paperclip build run. Expects the workspace to already be
+# prepped via codex-builder-prep-run.sh (PR 4). Wraps:
+#
+#   codex exec -C <repo> \
+#     --sandbox workspace-write \
+#     --ask-for-approval never \
+#     --ephemeral \
+#     --json \
+#     --output-last-message <run>/last.txt \
+#     "$PROMPT"
+#
+# Then attempts to:
+#   * git add -A && git commit -m "codex: <issueId>"
+#   * git push origin <branch>
+#   * write /work/runs/<runId>/audit.json with timestamps, branch, push
+#     outcome, codex exit code, diff stats.
+#
+# Stdout is JSON the agent returns directly to Paperclip's run transcript:
+#
+#   { "ok": true|false,
+#     "runId":       "<runId>",
+#     "branch":      "<branch>",
+#     "branchUrl":   "https://github.com/ssdavidai/alfred/tree/<branch>",
+#     "lastMessage": "<codex's final summary>",
+#     "diffStat":    "<files-changed insertions deletions>",
+#     "pushed":      true|false,
+#     "error":       null | "<short reason>",
+#     "auditPath":   "/work/runs/<runId>/audit.json" }
+#
+# Exit codes:
+#   0  success (commit + push landed; ok=true)
+#   1  codex non-zero (the LLM gave up, ok=false but JSON returned)
+#   2  bad args / workspace not found (bug)
+#   3  git commit failed (e.g. no changes — codex made no edits)
+#   4  git push failed (network blip, auth expired, branch protection)
+#   5  codex auth failed at the SDK layer (401 on the OAuth refresh)
+#
+# Usage:
+#   codex-builder-run.sh <runId> <issueId> <promptFile>
+#
+# Sir 2026-05-28 — PR 5 of docs/codex-builder-runtime.md.
+# =============================================================================
+set -uo pipefail
+
+usage() {
+    cat >&2 <<'EOF'
+usage: codex-builder-run.sh <runId> <issueId> <promptFile>
+
+  runId       must match [A-Za-z0-9_-]{1,64} — created by
+              codex-builder-prep-run.sh as the workspace key.
+  issueId     same constraint — the Paperclip issue identifier.
+  promptFile  absolute path to a file holding the natural-language
+              spec to pass codex (typically /work/runs/<runId>/prompt.md).
+EOF
+    exit 2
+}
+
+if [[ $# -ne 3 ]]; then
+    usage
+fi
+
+RUN_ID="$1"
+ISSUE_ID="$2"
+PROMPT_FILE="$3"
+
+# Defensive input scrubbing — see prep-run.sh.
+if ! [[ "$RUN_ID" =~ ^[A-Za-z0-9_-]{1,64}$ ]]; then
+    echo "error: runId must match [A-Za-z0-9_-]{1,64}; got: '$RUN_ID'" >&2
+    exit 2
+fi
+if ! [[ "$ISSUE_ID" =~ ^[A-Za-z0-9_-]{1,64}$ ]]; then
+    echo "error: issueId must match [A-Za-z0-9_-]{1,64}; got: '$ISSUE_ID'" >&2
+    exit 2
+fi
+if [[ ! -f "$PROMPT_FILE" ]]; then
+    echo "error: prompt file not found: '$PROMPT_FILE'" >&2
+    exit 2
+fi
+
+WORK_ROOT="${CODEX_WORKSPACE_ROOT:-/work}"
+RUN_DIR="${WORK_ROOT}/runs/${RUN_ID}"
+REPO_DIR="${RUN_DIR}/repo"
+LAST_TXT="${RUN_DIR}/last.txt"
+CODEX_JSON="${RUN_DIR}/codex.json"
+AUDIT_JSON="${RUN_DIR}/audit.json"
+
+if [[ ! -d "$REPO_DIR" ]]; then
+    echo "error: repo dir not found at '$REPO_DIR' — was prep-run.sh called for runId=${RUN_ID}?" >&2
+    exit 2
+fi
+
+# Read the branch the prep-run created.
+BRANCH=$(git -C "$REPO_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+if [[ -z "$BRANCH" || "$BRANCH" == "HEAD" ]]; then
+    echo "error: repo at $REPO_DIR has no checked-out branch" >&2
+    exit 2
+fi
+BRANCH_URL="https://github.com/ssdavidai/alfred/tree/${BRANCH}"
+
+# Helper — emit JSON-safe string (just escape the chars JSON disallows).
+json_escape() {
+    python3 -c '
+import json, sys
+print(json.dumps(sys.stdin.read()), end="")
+'
+}
+
+# Audit timestamps.
+T_START="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+EPOCH_START="$(date +%s)"
+
+# --- 1. codex exec -----------------------------------------------------------
+# `codex exec` is the non-interactive runner. The flag set is the one Sir
+# pinned in docs/codex-builder-runtime.md §3:
+#   --sandbox workspace-write    — only mutate files under --cd
+#   --ask-for-approval never     — no human approver, codex's own sandbox
+#                                  is the safety net
+#   --ephemeral                  — no persisted codex session across runs
+#   --json                       — machine-parsable envelope on stdout
+#   --output-last-message FILE   — final message goes here, easy to read
+#
+# We capture stdout to CODEX_JSON for forensics. Stderr is folded into the
+# audit log if codex bails.
+T_CODEX_START="$(date +%s)"
+PROMPT_CONTENT="$(cat "$PROMPT_FILE")"
+CODEX_STDERR_FILE="${RUN_DIR}/codex.stderr"
+if codex exec \
+       -C "$REPO_DIR" \
+       --sandbox workspace-write \
+       --ask-for-approval never \
+       --ephemeral \
+       --json \
+       --output-last-message "$LAST_TXT" \
+       "$PROMPT_CONTENT" \
+       > "$CODEX_JSON" 2> "$CODEX_STDERR_FILE"; then
+    CODEX_EXIT=0
+else
+    CODEX_EXIT=$?
+fi
+T_CODEX_END="$(date +%s)"
+CODEX_DURATION=$((T_CODEX_END - T_CODEX_START))
+
+LAST_MESSAGE=""
+if [[ -f "$LAST_TXT" ]]; then
+    LAST_MESSAGE="$(cat "$LAST_TXT")"
+fi
+
+# Auth failure detection — codex returns 1 in many failure modes; we look
+# at stderr for "401" / "not authenticated" / "unauthorized" markers.
+if (( CODEX_EXIT != 0 )) \
+   && grep -qiE '(401|unauthor|not authenticated|expired|please log ?in)' "$CODEX_STDERR_FILE" 2>/dev/null; then
+    AUTH_FAILED=1
+else
+    AUTH_FAILED=0
+fi
+
+# --- 2. git status / diffstat -----------------------------------------------
+# Did codex actually write anything?
+cd "$REPO_DIR" || { echo "error: cd into $REPO_DIR failed mid-run" >&2; exit 2; }
+DIRTY="$(git status --porcelain | head -100)"
+if [[ -z "$DIRTY" ]]; then
+    # Codex's exit code matters here: 0 + no changes = "codex thinks it's
+    # done but didn't edit", probably "I cannot implement this in this
+    # repo"; non-zero = codex bailed before reaching its tool calls.
+    DIFFSTAT="0 files changed"
+else
+    git add -A >/dev/null 2>&1 || true
+    DIFFSTAT="$(git diff --cached --shortstat 2>/dev/null | head -1 | tr -d '\n')"
+    [[ -z "$DIFFSTAT" ]] && DIFFSTAT="<unparsed>"
+fi
+
+# --- 3. git commit -----------------------------------------------------------
+COMMIT_OK=0
+COMMIT_SHA=""
+if [[ -n "$DIRTY" ]]; then
+    COMMIT_MSG="codex: ${ISSUE_ID}"
+    if [[ -n "$LAST_MESSAGE" ]]; then
+        # First line of last.txt becomes the commit summary suffix; cap at
+        # 60 chars to keep the subject under git's 72-col convention.
+        FIRST_LINE="$(echo "$LAST_MESSAGE" | head -1 | cut -c1-60)"
+        COMMIT_MSG="codex: ${ISSUE_ID} — ${FIRST_LINE}"
+    fi
+    # Author identity for the commit. The deploy key isn't an OAuth-linked
+    # identity, so we set author/committer explicitly here so the commit
+    # doesn't fall through git's user.name/user.email lookup chain.
+    if git -c user.name="codex-feature-builder" \
+           -c user.email="codex-feature-builder@alfred.black" \
+           commit -m "$COMMIT_MSG" >/dev/null 2>&1; then
+        COMMIT_OK=1
+        COMMIT_SHA="$(git rev-parse --short HEAD 2>/dev/null || echo "")"
+    fi
+fi
+
+# --- 4. git push -------------------------------------------------------------
+PUSH_OK=0
+PUSH_ERROR=""
+if (( COMMIT_OK == 1 )); then
+    # GIT_SSH_COMMAND is set from the profile's .env (PR 2 quoting hotfix).
+    if PUSH_OUTPUT="$(git push origin "$BRANCH" 2>&1)"; then
+        PUSH_OK=1
+    else
+        PUSH_ERROR="$(echo "$PUSH_OUTPUT" | tail -3 | tr '\n' ' ' | cut -c1-300)"
+    fi
+fi
+
+# --- 5. Decide overall status ------------------------------------------------
+T_END="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+EPOCH_END="$(date +%s)"
+TOTAL_DURATION=$((EPOCH_END - EPOCH_START))
+
+if (( AUTH_FAILED == 1 )); then
+    OK="false"
+    ERROR="codex auth expired — run \`codex login\` against the codex-builder profile's CODEX_HOME (see operator-guide)"
+    EXIT_CODE=5
+elif (( CODEX_EXIT != 0 )); then
+    OK="false"
+    ERROR="codex exec exited ${CODEX_EXIT}"
+    EXIT_CODE=1
+elif [[ -z "$DIRTY" ]]; then
+    OK="false"
+    ERROR="codex ran but made no changes (no diff to commit)"
+    EXIT_CODE=3
+elif (( COMMIT_OK == 0 )); then
+    OK="false"
+    ERROR="git commit failed"
+    EXIT_CODE=3
+elif (( PUSH_OK == 0 )); then
+    OK="false"
+    ERROR="git push failed: ${PUSH_ERROR}"
+    EXIT_CODE=4
+else
+    OK="true"
+    ERROR="null"
+    EXIT_CODE=0
+fi
+
+# --- 6. Write audit log ------------------------------------------------------
+# Audit JSON is independent of the agent's return value — if the agent
+# crashes / the gateway is restarted, the audit on disk still shows what
+# happened.
+LAST_MESSAGE_JSON="$(printf '%s' "$LAST_MESSAGE" | json_escape)"
+DIFFSTAT_JSON="$(printf '%s' "$DIFFSTAT" | json_escape)"
+PUSH_ERROR_JSON="$(printf '%s' "$PUSH_ERROR" | json_escape)"
+CODEX_STDERR_TAIL="$(tail -20 "$CODEX_STDERR_FILE" 2>/dev/null | json_escape)"
+ERROR_FIELD="null"
+if [[ "$ERROR" != "null" ]]; then
+    ERROR_FIELD="$(printf '%s' "$ERROR" | json_escape)"
+fi
+cat > "$AUDIT_JSON" <<EOF
+{
+  "schema": "codex-builder/audit/v1",
+  "runId": "${RUN_ID}",
+  "issueId": "${ISSUE_ID}",
+  "branch": "${BRANCH}",
+  "branchUrl": "${BRANCH_URL}",
+  "startedAt": "${T_START}",
+  "endedAt": "${T_END}",
+  "totalSeconds": ${TOTAL_DURATION},
+  "codex": {
+    "exitCode": ${CODEX_EXIT},
+    "durationSeconds": ${CODEX_DURATION},
+    "authFailed": $([ "$AUTH_FAILED" == "1" ] && echo true || echo false),
+    "stderrTail": ${CODEX_STDERR_TAIL}
+  },
+  "git": {
+    "diffStat": ${DIFFSTAT_JSON},
+    "committed": $([ "$COMMIT_OK" == "1" ] && echo true || echo false),
+    "commitSha": "${COMMIT_SHA}",
+    "pushed": $([ "$PUSH_OK" == "1" ] && echo true || echo false),
+    "pushError": ${PUSH_ERROR_JSON}
+  },
+  "lastMessage": ${LAST_MESSAGE_JSON},
+  "ok": ${OK},
+  "error": ${ERROR_FIELD}
+}
+EOF
+
+# --- 7. Emit caller-facing JSON ---------------------------------------------
+cat <<EOF
+{
+  "ok": ${OK},
+  "runId": "${RUN_ID}",
+  "branch": "${BRANCH}",
+  "branchUrl": "${BRANCH_URL}",
+  "lastMessage": ${LAST_MESSAGE_JSON},
+  "diffStat": ${DIFFSTAT_JSON},
+  "pushed": $([ "$PUSH_OK" == "1" ] && echo true || echo false),
+  "error": ${ERROR_FIELD},
+  "auditPath": "${AUDIT_JSON}"
+}
+EOF
+
+exit "$EXIT_CODE"

--- a/packages/hermes/init/Dockerfile
+++ b/packages/hermes/init/Dockerfile
@@ -128,6 +128,11 @@ COPY packages/mcp-server/instructions/alfred-custom-instructions.md ./AGENTS.md
 # persona at /vault/SOUL.md takes precedence when present (see entrypoint).
 COPY packages/hermes/init/SOUL.md ./SOUL.md
 
+# SOUL.codex-builder.md — the codex-builder profile's distinct persona (a
+# sealed engineering executor, NOT Alfred). Deployed into the codex-builder
+# profile dir by entrypoint.sh step 7b. Not used by main/workers/heavy.
+COPY packages/hermes/SOUL.codex-builder.md ./SOUL.codex-builder.md
+
 RUN chmod +x entrypoint.sh bootstrap-paperclip.sh
 
 ENTRYPOINT ["./entrypoint.sh"]

--- a/packages/hermes/init/entrypoint.sh
+++ b/packages/hermes/init/entrypoint.sh
@@ -560,6 +560,27 @@ chown -R 10000:10000 /vault 2>/dev/null || true
 CODEX_PROFILE_DIR="$HERMES_DATA_DIR/profiles/codex-builder"
 if [[ -d "$CODEX_PROFILE_DIR" ]]; then
     echo "[init] [codex-builder] hardening profile dir + /work for uid 10001"
+
+    # --- Deploy codex-builder SOUL.md (the agent persona) -------------------
+    # The other 3 profiles read /opt/data/SOUL.md (the global persona Hermes
+    # serves at gateway boot — `consolidate SOUL.md` step in supervisor.sh).
+    # codex-builder is per-profile-distinct; its identity is the sealed
+    # engineering executor, NOT Alfred. We render it to the profile dir.
+    # Idempotent — only writes if absent or different.
+    CB_SOUL_SRC="/setup/SOUL.codex-builder.md"
+    if [[ -f "$CB_SOUL_SRC" ]]; then
+        CB_SOUL_DST="$CODEX_PROFILE_DIR/SOUL.md"
+        CB_SOUL_HASH_FILE="$CODEX_PROFILE_DIR/.soul-md.content-hash"
+        CB_SOUL_HASH=$(md5sum "$CB_SOUL_SRC" | cut -d' ' -f1)
+        if [[ -f "$CB_SOUL_HASH_FILE" ]] && [[ "$(cat "$CB_SOUL_HASH_FILE")" == "$CB_SOUL_HASH" ]]; then
+            echo "[init] [codex-builder] SOUL.md unchanged, skipping"
+        else
+            cp "$CB_SOUL_SRC" "$CB_SOUL_DST"
+            echo "$CB_SOUL_HASH" > "$CB_SOUL_HASH_FILE"
+            echo "[init] [codex-builder] deployed SOUL.md"
+        fi
+    fi
+
     # The whole profile dir is owned by 10001 mode 0700 — uid 10000 (other
     # gateways) and root will use DAC_OVERRIDE if they need to write, but
     # the codex-builder gateway can never escape its own home.


### PR DESCRIPTION
**PR 5 of 5** — closes the codex-builder sealed-runtime build per [`docs/codex-builder-runtime.md`](docs/codex-builder-runtime.md) §10 PR 5.

Depends on #100 (CLI in image), #101 (profile + supervisor), #102 (.env quoting hotfix), #103 (adapter routing), #104 (FS + network isolation) — all merged.

## What lands

### `packages/hermes/docker/codex-builder-run.sh` (new)
The wrapper the codex-builder agent invokes per Paperclip run:

```
codex-builder-run.sh <runId> <issueId> <promptFile>
```

Drives:
```
codex exec -C /work/runs/<runId>/repo \
  --sandbox workspace-write --ask-for-approval never \
  --ephemeral --json --output-last-message <run>/last.txt \
  "$PROMPT"
```

Then:
- `git add -A && git -c user.name=codex-feature-builder -c user.email=codex-feature-builder@alfred.black commit -m "codex: <issueId> — <first line of last.txt>"`
- `git push origin <branch>` (deploy key via GIT_SSH_COMMAND)
- writes `/work/runs/<runId>/audit.json` with timestamps, branch, push outcome, codex exit code, diff stats, stderr tail.

Returns JSON on stdout the agent passes verbatim back to Paperclip:

```json
{
  "ok": true,
  "runId": "...",
  "branch": "codex/<issueId>-<sha7>",
  "branchUrl": "https://github.com/ssdavidai/alfred/tree/...",
  "lastMessage": "<codex's final summary>",
  "diffStat": "3 files changed, 42 insertions(+), 7 deletions(-)",
  "pushed": true,
  "error": null,
  "auditPath": "/work/runs/<runId>/audit.json"
}
```

Defensive: runId + issueId must match `[A-Za-z0-9_-]{1,64}`; refuses to run if the prep-run workspace is missing. 5 exit codes (success / codex non-zero / bad args / commit failed / push failed / auth expired) with explicit semantics.

### `packages/hermes/SOUL.codex-builder.md` (new)
The codex-builder profile's persona. NOT Alfred. Pins:
- one tool (terminal); no MCP; no delegation; no channels
- writes only `/work/runs/<runId>`
- positively listed network reach (per PR 4's iptables)
- never push to main, never force-push, never merge a PR
- the procedure: mint runId → prep-run → write prompt.md → codex-builder-run → return JSON
- refuses out-of-scope asks because it has no tools for them

Baked into the image at `/opt/hermes-assets/SOUL.codex-builder.md`; init copies it to the profile dir (content-hash gated, idempotent).

### `packages/hermes/Dockerfile` + `packages/hermes/init/Dockerfile`
Bake the new scripts + SOUL into both images.

### `packages/hermes/init/entrypoint.sh`
New deploy step in 7b copies SOUL.codex-builder.md to the profile dir.

### `docs/codex-builder-operator-guide.md` (new)
Day-to-day ops: status checks, the one-time bootstrap (deploy key generation + GitHub registration + Vaultwarden storage + flag flip), auth ritual (shared with main per Sir's decision #1), a real run walkthrough, failure-modes table, extending the egress allowlist, disabling, rotation rituals.

## End-to-end verify on home (after build-hermes + build-init roll)

```
# 1. SOUL.md deployed:
docker exec alfred-black-hermes-1 cat /hermes-state/profiles/codex-builder/SOUL.md | head -5

# 2. Runner on PATH:
docker exec alfred-black-hermes-1 ls -la /usr/local/bin/codex-builder-run.sh

# 3. Real Paperclip issue handoff (§8.5 of the design doc):
#    File an issue on home: "Create docs/HELLO.md containing 'hello from
#    codex-builder' and nothing else."
#    Assign to codex-feature-builder agent.
#
# Within 5 min:
#   * branch codex/<issueId>-<sha7> appears on github.com/ssdavidai/alfred
#   * the branch contains exactly the one new file
#   * audit.json in /work/runs/<runId>/ has ok:true, pushed:true
#   * Paperclip transcript ends with the JSON envelope

# 4. Inspect:
docker exec -u 10001 alfred-black-hermes-1 \
    sh -c 'cat /work/runs/$(ls /work/runs | tail -1)/audit.json'
```

## What this PR does NOT do

- Does not create the codex-feature-builder Paperclip agent (it already exists per the design doc §7 — this PR assumes it).
- Does not add a `gh repo --add-deploy-key` bootstrap (the deploy key registration is a one-time manual step per the operator guide).
- Does not change branch protection on the alfred repo. The operator guide includes a "verify branch protection" step in the bootstrap.

## Closes the chain

#100 + #101 + #102 + #103 + #104 + this = the codex-builder sealed runtime is live on home. Other tenants (rj, joe, zsolt, miguel) get the new images on their next pull but the supervisor never starts the gateway because `ENABLE_CODEX_BUILDER` is unset on those tenants' /opt/alfred/.env. Sir's decision #2 — home only for v1 — fully delivered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)