### PR TITLE
fix(hermes,init): per-uid ACL denies for codex-builder isolation (PR 4 hotfix)

### DIFF
--- a/packages/hermes/init/Dockerfile
+++ b/packages/hermes/init/Dockerfile
@@ -29,7 +29,17 @@ FROM python:3.12-slim-bookworm
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     rsync gettext-base git ca-certificates curl gnupg \
+    acl \
+    util-linux \
     && rm -rf /var/lib/apt/lists/*
+# acl + util-linux: setfacl (codex-builder uid-10001 negative ACL on
+# /vault, /alfred-data, other-profile dirs) + setpriv (the negative-
+# assert spot-checks in step 7b). PR 4b — without these the existing
+# "world readable" perms on /vault (0644) etc. defeat the uid-only
+# negative-asserts because uid 10001 reads as "other". ACL deny rules
+# preserve every other consumer's read access (alfred-learn uid 1000,
+# vault-cli root, hermes main uid 10000) while specifically blocking
+# uid 10001. ~2 MB added.
 
 # docker-ce-cli only — bootstrap-paperclip.sh shells out to `docker exec`
 # / `docker inspect` against the paperclip sidecar (via the docker socket

--- a/packages/hermes/init/entrypoint.sh
+++ b/packages/hermes/init/entrypoint.sh
@@ -656,6 +656,65 @@ EOF
         echo "[init] [codex-builder] CODEX_BUILDER_DEPLOY_KEY_B64 unset — git push will fail clean (no key)"
     fi
 
+    # --- Apply ACL deny for uid 10001 across the surrounding FS ----------
+    # The Posix-perm story alone doesn't tighten enough: /vault, /alfred-
+    # data, and the other profile .env files end up 0644 world-readable
+    # because every other consumer (ctrl-api, alfred-learn, vault-cli) is
+    # either root (DAC_OVERRIDE) or uid 1000 (must keep reading /vault).
+    # We cannot safely chmod those to 0640 without breaking those siblings.
+    #
+    # `setfacl -m u:10001:---` adds a per-uid deny ACL that is independent
+    # of owner/group/world bits — uid 10001 is denied read regardless of
+    # the underlying mode. Other uids keep their existing access verbatim.
+    #
+    # Idempotent: re-running adds the same ACL entries, which setfacl
+    # treats as a no-op.
+    #
+    # Coverage:
+    #   * /vault  — the principal's surface
+    #   * /alfred-data/.gateway-token (file, not the whole dir — alfred-
+    #     learn still needs to read other files there)
+    #   * other-profile dirs (main / workers / heavy)
+    #
+    # The codex-builder's OWN profile dir is OWNED by uid 10001 (the
+    # chowns above), so an ACL deny would lock the gateway out of its
+    # own state. We explicitly do NOT setfacl that dir.
+    if command -v setfacl >/dev/null 2>&1; then
+        setfacl -R -m u:10001:--- /vault 2>/dev/null \
+            && echo "[init] [codex-builder] denied uid 10001 read on /vault (ACL)" \
+            || echo "[init] [codex-builder] WARNING: setfacl /vault failed (filesystem may not support ACLs?)"
+        if [[ -f /alfred-data/.gateway-token ]]; then
+            setfacl -m u:10001:--- /alfred-data/.gateway-token 2>/dev/null \
+                && echo "[init] [codex-builder] denied uid 10001 read on /alfred-data/.gateway-token (ACL)"
+        fi
+        for p in main workers heavy; do
+            P_ENV="$HERMES_DATA_DIR/profiles/$p/.env"
+            if [[ -f "$P_ENV" ]]; then
+                setfacl -m u:10001:--- "$P_ENV" 2>/dev/null \
+                    && echo "[init] [codex-builder] denied uid 10001 read on profiles/$p/.env (ACL)"
+            fi
+            # auth.json + config.yaml are also sensitive — main/auth.json
+            # is the OAuth credential we mirror, but the codex-builder
+            # ALREADY HAS its own copy (PR 2 mirror). Deny uid 10001 from
+            # reading the SOURCE so a compromised codex-builder cannot
+            # walk back to main and read its sibling's auth.
+            for sensitive in auth.json config.yaml; do
+                P_FILE="$HERMES_DATA_DIR/profiles/$p/$sensitive"
+                if [[ -f "$P_FILE" ]]; then
+                    setfacl -m u:10001:--- "$P_FILE" 2>/dev/null || true
+                fi
+            done
+        done
+        # The codex-builder's parent dir (profiles/) needs uid 10001 to
+        # be able to CHDIR through it to reach codex-builder/. Posix
+        # behaviour: cd through a dir needs x (execute) only, not r.
+        # Mode 0755 on profiles/ is fine; our ACL denies on individual
+        # files don't change directory traversal.
+    else
+        echo "[init] [codex-builder] WARNING: setfacl missing — falling back to perm-only isolation"
+        echo "[init] [codex-builder]   Install acl package in the init image (apt-get install acl)."
+    fi
+
     # --- Negative-asserts: the codex-builder uid 10001 must NOT be able to
     #     read these paths. We test by `setpriv --reuid 10001 cat <file>`
     #     and fail the init if any of them succeed. Defense-in-depth — the


### PR DESCRIPTION
PR #104's negative-asserts caught the holes live on home:

```
[init] [codex-builder] FAIL: uid 10001 can read /vault/SOUL.md
[init] [codex-builder] FAIL: uid 10001 can read /alfred-data/.gateway-token
[init] [codex-builder] FAIL: uid 10001 can read /hermes-state/profiles/main/.env
[init] [codex-builder] FAIL: uid 10001 can read /hermes-state/profiles/workers/.env
[init] [codex-builder] FAIL: uid 10001 can read /hermes-state/profiles/heavy/.env
[init] [codex-builder] FATAL: 5 FS isolation assertion(s) failed
```

The assertions worked correctly — the perms are world-readable because every other consumer needs that 0644 (per the explicit comments in step 4 + step 7 of entrypoint.sh: alfred-learn uid 1000 needs to read `.gateway-token`, ctrl-api root reads /vault as root, etc.).

Chmod-ing the world bit off would break alfred-learn. POSIX ACLs are the right tool — `setfacl -m u:10001:---` denies uid 10001 specifically without changing any other uid's read access.

## Verified in a temp container against the live home volume

```
$ docker run --rm -v alfred-black_vault_data:/vault python:3.12-slim-bookworm bash -c \
    'apt-get -qq install -y acl >/dev/null && \
     setfacl -R -m u:10001:--- /vault && \
     setpriv --reuid=10001 --regid=10001 --clear-groups cat /vault/SOUL.md'
cat: /vault/SOUL.md: Permission denied
```

Meanwhile root + uid 10000 + uid 1000 readers are unaffected.

## What lands

- `packages/hermes/init/Dockerfile` — +acl, +util-linux (~2 MB).
- `packages/hermes/init/entrypoint.sh` — new `setfacl` block in step 7b BEFORE the negative-asserts. Applies to:
  - `/vault` (recursive)
  - `/alfred-data/.gateway-token`
  - `/hermes-state/profiles/{main,workers,heavy}/{.env,auth.json,config.yaml}`
- Idempotent (re-runs are no-ops). Soft-fails with a WARNING if setfacl is missing or the FS doesn't support ACLs; the negative-asserts after this step would catch a complete setfacl failure.
- codex-builder's OWN profile dir is owned by uid 10001 and is NOT given an ACL deny (that would lock the gateway out of its own state).

## Sibling non-regression

- alfred-learn (uid 1000) still reads /vault
- ctrl-api (root) still reads everything
- hermes-main (uid 10000) still reads /vault/SOUL.md (group 10000 has r--)
- paperclip (root) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)