### PR TITLE
fix(compose): SETUID+SETGID caps for codex-builder's setpriv drop (PR 4 hotfix 2)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -360,6 +360,16 @@ services:
       # 3 profiles new privileges (they run as uid 10000 and their egress
       # paths are unrestricted today). See docs/codex-builder-runtime.md §6.
       - NET_ADMIN
+      # SETUID + SETGID — needed by PR 4's `setpriv --reuid=10001
+      # --regid=10001 ...` wrap on the codex-builder gateway's start_proc.
+      # Without these the supervisor (running as root) gets
+      # `setpriv: setresuid failed: Operation not permitted` and the
+      # codex-builder gateway crashes in a tight restart loop. cap_drop:
+      # ALL + this targeted cap_add is still a much tighter posture than
+      # the default (which doesn't drop ALL). Live-observed crash loop
+      # on home 2026-05-28 right after PR #104 landed.
+      - SETUID
+      - SETGID
     # Sized for two Python gateway processes + MCP stdio children. The
     # workers side carries the heavier task-registry boot path.
     mem_limit: 6g


### PR DESCRIPTION
PR #104's `setpriv --reuid=10001 --regid=10001` on the codex-builder gateway crashes with:

```
setpriv: setresuid failed: Operation not permitted
```

Tight loop on home 2026-05-28 20:47 UTC: 9 restarts in <60s, supervisor's crash-loop guard ready to kick in at 20.

The hermes service is `cap_drop: ALL` with a targeted `cap_add: [DAC_OVERRIDE, NET_ADMIN]`. Missing SETUID + SETGID — without them, even root cannot setresuid (setpriv refuses with EPERM).

Adding both to the hermes service ONLY. The other services that drop ALL (alfred, ctrl-api) are unaffected. main/workers/heavy run as the default user (uid 10000 baked into the image, NOT setpriv'd at runtime) so their attack surface doesn't change. Only the codex-builder gateway exercises SETUID, and only once at start.

Compose-file-only change. No image rebuild — needs to be rsynced to home + `docker compose up -d --force-recreate hermes` to apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)