### PR TITLE
fix(codex-builder): allow auth.openai.com egress + correct codex login ritual

### DIFF
--- a/docs/codex-builder-operator-guide.md
+++ b/docs/codex-builder-operator-guide.md
@@ -178,3 +178,37 @@ the new hosts (resolved via dig at boot).
 * **Deploy key:** generate a new pair → register on github (replacing the old one) → update `CODEX_BUILDER_DEPLOY_KEY_B64` in /opt/alfred/.env → `docker compose up -d --force-recreate init hermes`. Old key is automatically replaced on next init boot.
 * **codex CLI bump:** see `[[codex-builder-pr1-cli-installed]]` — update `ARG CODEX_CLI_REF=...` in packages/hermes/Dockerfile, PR, build-hermes rolls.
 * **ChatGPT account:** swap the OAuth token by re-running `hermes -p main auth login` against the new account; restart hermes; supervisor's mirror block propagates.
+
+
+## Codex CLI authentication (one-time per tenant)
+
+Hermes-main and the codex CLI use **different OAuth schemas** even though both
+authenticate against ChatGPT Plus/Pro. Hermes-main's `auth.json` (Hermes-shape,
+2-token: access + refresh) **does not satisfy** the codex CLI, which needs the
+full 4-token shape (id_token + access_token + refresh_token + account_id).
+Mirroring Hermes's auth.json into `~/.codex/auth.json` looks superficially
+correct but `codex doctor` will report:
+
+  ✗ auth   stored credentials are incomplete
+
+So a separate one-time `codex login` ritual is required, scoped to the
+codex-builder profile:
+
+```
+docker exec -it --user codex-builder \
+  -e HOME=/hermes-state/profiles/codex-builder \
+  alfred-black-hermes-1 \
+  codex login --device-auth
+```
+
+This prints a URL + code. Open the URL in any browser, approve on ChatGPT,
+return to the terminal. The CLI writes a complete
+`/hermes-state/profiles/codex-builder/.codex/auth.json`.
+
+After that, `codex login status` returns "Logged in using ChatGPT" AND `codex
+doctor` reports `✓ auth`.
+
+> **Do NOT run `hermes auth login`** as previously documented — that refreshes
+> Hermes's own auth.json (the chat path), which is a separate concern and is
+> typically already valid.
+

--- a/packages/hermes/docker/setup-egress-jail.sh
+++ b/packages/hermes/docker/setup-egress-jail.sh
@@ -82,6 +82,8 @@ resolve_host() {
 BUILTIN_HOSTS=(
     # OpenAI (codex CLI's only LLM provider)
     api.openai.com
+    auth.openai.com         # device-auth flow (codex login --device-auth)
+    platform.openai.com     # codex login follow-up
     chatgpt.com
     # Package registries (a codex-driven `npm ci` / `pip install` / etc).
     registry.npmjs.org


### PR DESCRIPTION
Two findings from a live codex-builder smoke on home tonight.

**1. Egress jail blocked codex CLI device-auth.** PR #104 wired `api.openai.com` and `chatgpt.com` into BUILTIN_HOSTS but missed `auth.openai.com` (which `codex login --device-auth` uses for the device-code grant) and `platform.openai.com` (downstream). Sir hit:
```
Error logging in with device code: error sending request for url (https://auth.openai.com/api/accounts/deviceauth/usercode)
```
Fix: both hosts added to BUILTIN_HOSTS so every tenant gets them out of the box. Today's home was patched live via the runtime allowlist file; the durable change makes that unnecessary on future builds.

**2. Operator ritual was wrong.** Agent #298's report said `hermes -p main auth login` would unblock codex-builder. But Hermes-main and codex CLI use **different OAuth schemas** — mirroring Hermes's 2-token auth.json into codex's location passes the file-existence check but `codex doctor` reports:
```
✗ auth   stored credentials are incomplete
```
The correct ritual is `codex login --device-auth` scoped to the codex-builder profile. Operator guide updated.

**Verified live on home**: after appending the two hosts + restart, `curl https://auth.openai.com/...` from inside the sealed codex-builder profile returns HTTP 400 (route reached) instead of the previous blocked-by-iptables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)