### PR TITLE
fix(codex-builder): egress jail stateful fast-path so inbound responses pass

### DIFF
--- a/packages/hermes/docker/setup-egress-jail.sh
+++ b/packages/hermes/docker/setup-egress-jail.sh
@@ -147,7 +147,21 @@ except Exception:
 
 # --- 3. Install rules --------------------------------------------------------
 install_rules() {
-    # 3a. Loopback always allowed (Hermes internal IPC, the gateway's own
+    # 3a. Stateful fast-path — response packets to ANY already-established
+    # connection bypass the uid-owner catchall REJECT below. Without this
+    # the codex-builder Hermes gateway (running as uid 10001, listening
+    # on :18793) cannot send TCP SYN-ACKs back to sibling compose-network
+    # callers (e.g. paperclip → hermes:18793) — the inbound connect lands,
+    # the gateway's response packet is owned by uid 10001, and the catchall
+    # REJECT (3e) drops it before it leaves the netns. Caller sees a TCP
+    # handshake timeout. This is the standard stateful-firewall pattern:
+    # NEW connections still hit the per-host allowlist; only existing
+    # connections' responses get the express lane.
+    iptables -I OUTPUT 1 \
+        -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT \
+        -m comment --comment "${COMMENT_TAG}_FASTPATH"
+
+    # 3b. Loopback always allowed (Hermes internal IPC, the gateway's own
     # /v1 listener answering /health from inside the same container).
     iptables -A OUTPUT -m owner --uid-owner "${CODEX_UID}" \
         -d 127.0.0.0/8 -j ACCEPT \


### PR DESCRIPTION
Live-found while smoke-testing paperclip → codex-builder on home after PR #116 + Sir's `codex login --device-auth`.

**Symptom.** paperclip's HTTP client times out at TCP handshake when calling `http://hermes:18793/health` (or any codex-builder endpoint). Same call from inside the hermes container succeeds in 1ms. iptables INPUT chain is empty. API_SERVER_HOST=0.0.0.0.

**Root cause.** The codex-builder Hermes gateway runs as uid 10001 (sealed-runtime design). The egress jail's catchall `-A OUTPUT -m owner --uid-owner 10001 -j REJECT` (rule 3e) drops not just outbound NEW connections, but ALSO the gateway's RESPONSE packets to inbound connections — because the response is owned by uid 10001 (the listening process). paperclip → :18793 SYN lands, gateway's SYN-ACK is REJECTed before leaving netns, TCP retransmits and times out. The OUTPUT chain rule #142 had `pkts=10` worth of paperclip polls accumulated.

**Fix.** Insert a stateful fast-path at OUTPUT position 1:
```
iptables -I OUTPUT 1 \
  -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT \
  -m comment --comment "CODEX_BUILDER_FASTPATH"
```

Standard stateful-firewall pattern. NEW connections still hit the per-host allowlist (api.openai.com, GitHub CIDRs, pypi, etc.) and the catchall REJECT. ESTABLISHED/RELATED response packets pass — which is exactly what an inbound listener needs.

The cleanup function picks up the new rule too because the COMMENT_TAG (`CODEX_BUILDER`) is a prefix of the new tag (`CODEX_BUILDER_FASTPATH`), and the grep is substring (`grep -F`).

**Live verification on home (before/after, no service restart between):**

| Caller | Endpoint | Before | After |
|---|---|---|---|
| paperclip container | http://hermes:18793/health | TCP timeout (>5s) | 200 (1ms) |
| hermes container (internal) | http://127.0.0.1:18793/health | 200 | 200 |
| paperclip container | http://hermes:18789/health | 200 | 200 |

(The :18789 → :18793 differential is exactly the uid-10001 owner filter — main+workers+heavy run as root, codex-builder runs as uid 10001.)

This was the last piece blocking end-to-end paperclip → codex-feature-builder dispatch. Sir's `codex login --device-auth` ritual already wrote the codex CLI auth.json; the runtime is now connected and we can dispatch a real task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)