### PR TITLE
fix(codex-builder): profile dir traversable + .env readable so paperclip adapter can auth

### DIFF
--- a/packages/hermes/init/entrypoint.sh
+++ b/packages/hermes/init/entrypoint.sh
@@ -581,14 +581,33 @@ if [[ -d "$CODEX_PROFILE_DIR" ]]; then
         fi
     fi
 
-    # The whole profile dir is owned by 10001 mode 0700 — uid 10000 (other
+    # The whole profile dir is owned by 10001 mode 0711 — uid 10000 (other
     # gateways) and root will use DAC_OVERRIDE if they need to write, but
     # the codex-builder gateway can never escape its own home.
+    #
+    # Why 0711 (not 0700): the paperclip-hermes adapter runs in the paperclip
+    # container as uid 1000 (gosu node entrypoint, no DAC_OVERRIDE), and
+    # needs to read .env to pull the gateway's API_SERVER_KEY for the
+    # Authorization: Bearer header. 0700 made that EACCES so the adapter
+    # silently sent no auth header and every dispatch 401'd. The execute
+    # bit lets uid 1000 traverse to specific files (.env, see below); the
+    # missing read bit means it still can't `ls` the dir or stumble onto
+    # auth.json / .codex/ / workspace tree — and those individual files
+    # stay 0600 so even if uid 1000 knew the path it couldn't open them.
     chown -R 10001:10001 "$CODEX_PROFILE_DIR" 2>/dev/null || true
-    chmod 0700 "$CODEX_PROFILE_DIR" 2>/dev/null || true
-    # Recursive 0700 on subdirs, 0600 on files. .ssh stricter (0700/0600).
+    chmod 0711 "$CODEX_PROFILE_DIR" 2>/dev/null || true
+    # Recursive 0700 on subdirs (sealed), 0600 on files (owner-only by default).
     find "$CODEX_PROFILE_DIR" -type d -exec chmod 0700 {} + 2>/dev/null || true
     find "$CODEX_PROFILE_DIR" -type f -exec chmod 0600 {} + 2>/dev/null || true
+    # Then the two targeted opens: top-level dir back to 0711 (traverse), and
+    # .env world-readable (0644) so the paperclip adapter's uid 1000 can
+    # read API_SERVER_KEY. The .env never carries provider secrets for the
+    # codex-builder profile (codex CLI's auth lives in .codex/auth.json,
+    # which stays 0600 inside .codex/ at 0700 — uid 1000 can't reach it).
+    chmod 0711 "$CODEX_PROFILE_DIR" 2>/dev/null || true
+    if [[ -f "$CODEX_PROFILE_DIR/.env" ]]; then
+        chmod 0644 "$CODEX_PROFILE_DIR/.env" 2>/dev/null || true
+    fi
     # config.yaml ends up 0600 — that's tighter than the 0640 the other
     # profiles use but fine because the only reader is the codex-builder
     # gateway process at uid 10001 (init/hermes containers use DAC_OVERRIDE).


### PR DESCRIPTION
Live-found tonight running the first paperclip → codex-feature-builder smoke after Sir's `codex login --device-auth`. Every dispatch 401'd with `{"code":"invalid_api_key"}`.

**Root cause.** The codex-builder profile dir is sealed at mode `0700` owned by uid 10001 (the sealed-runtime design). But the paperclip-hermes adapter runs at uid 1000 (`gosu node` upstream entrypoint) and needs to read `/hermes-state/profiles/codex-builder/.env` to pull `API_SERVER_KEY` for the `Authorization: Bearer` header. With dir 0700, the adapter's `fs.readFileSync` hits EACCES, the function returns undefined silently, the `if (opts.apiKey) headers.Authorization = …` guard skips the header, dispatch lands at the gateway with no auth → 401.

Same root-cause family as PR #92 (hermes-paperclip-eacces). The difference: PR #92 only had to loosen the .env mode for the main profile (parent dir was already 0755). For codex-builder, BOTH the dir AND the .env were too tight.

**Fix — two targeted opens, inside stays sealed.**
- Top-level dir: `0711` (owner rwx, others --x). uid 1000 can traverse to a known filename but can't `ls` or stumble onto auth.json / .codex/ / workspace.
- .env: `0644` (world-readable). Contents are API_SERVER_KEY/PORT/HOST only; provider auth lives in `.codex/auth.json` which is nested in `.codex/` at 0700 (uid 1000 can't reach it).
- Everything else: still recursive `0700` dirs / `0600` files (auth.json, .codex/ tree, workspace, cache stay sealed).

**Live verification on home.**

| Probe | Before | After |
|---|---|---|
| `docker exec --user 1000 paperclip cat .../codex-builder/.env` | EACCES | API_SERVER_KEY readable |
| `curl -H 'Authorization: Bearer $KEY' :18793/v1/models` from inside hermes | 200 | 200 |
| paperclip adapter → hermes:18793 dispatch | 401 invalid_api_key | (testing now) |

Hot-fix already applied to home via host-side chmod on the docker volume (`/var/lib/docker/volumes/alfred-black_hermes_data/_data/profiles/codex-builder`); this PR makes the change durable so future tenants (and the next init re-run on home) lay down the right modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)