### PR TITLE
feat(compose,db): Tailscale sidecar foundation — off-by-default profile + state table (#109 PR1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -160,6 +160,28 @@ TENANT_BASE_URL=https://${DOMAIN}
 # host. Override only for a multi-host SaaS deployment.
 SAAS_HOST=https://${DOMAIN}
 
+# Tailscale (off by default — turn on via /connections card). Issue #109.
+# When TAILSCALE_ENABLED=true (set by the operator), the principal can flip
+# the Tailscale card on /connections to start the sidecar
+# (`docker compose --profile tailscale up -d tailscale`) and approve the
+# device on login.tailscale.com once. The sidecar joins the principal's own
+# tailnet; the public *.alfred.black hostname keeps working unchanged.
+# PR 1 ships only the compose foundation — the routes (PR 2), card (PR 3),
+# and Caddy/Serve outbound (PR 4) come next. See docs/specs/issue-109-*.md.
+TAILSCALE_ENABLED=false
+# Optional — path A (pre-shared auth-key) bootstrap. Leave blank to use
+# path C (device-style auth URL), which is the recommended flow.
+TAILSCALE_AUTHKEY=
+# Tailnet device hostname. Blank → bootstrap.sh derives it from $DOMAIN
+# with dots replaced by dashes (e.g. home.alfred.black → home-alfred-black).
+# Compose's variable interpolation does not support Bash-style
+# ${VAR//./-}, so the derivation happens in bootstrap.sh.
+TAILSCALE_HOSTNAME_PREFIX=
+# Comma-separated --advertise-tags passed to `tailscale up`. Blank by
+# default (no tag advertised). Set to e.g. "tag:alfred-tenant" only if the
+# operator has declared the tag in the principal's tailnet ACL.
+TAILSCALE_TAGS=
+
 # ════════════════════════════════════════════════════════════════════
 # AUTO-GENERATED — managed by scripts/bootstrap.sh. Do not edit by hand.
 # bootstrap.sh appends each of these with `openssl rand -hex 32` if missing

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -129,6 +129,24 @@ jobs:
         run: docker compose config --quiet
       - name: docker compose config (vexa profile)
         run: docker compose --profile vexa config --quiet
+      - name: docker compose config (tailscale profile — issue #109 PR 1)
+        run: docker compose --profile tailscale config --quiet
+      - name: tailscale OFF by default (no service unless profile passed)
+        # PR 1's acceptance gate: `docker compose up -d` alone must NEVER
+        # bring up the tailscale sidecar. Profile gating is the load-bearing
+        # contract — if this assertion ever flips, every existing tenant
+        # would silently start joining a tailnet on next deploy.
+        run: |
+          set -euo pipefail
+          if docker compose config --services | grep -qx tailscale; then
+            echo "FAIL: tailscale service appeared under the default profile." >&2
+            exit 1
+          fi
+          if ! docker compose --profile tailscale config --services | grep -qx tailscale; then
+            echo "FAIL: tailscale service missing under --profile tailscale." >&2
+            exit 1
+          fi
+          echo "OK: tailscale is profile-gated, off by default."
 
   bootstrap-lint:
     runs-on: ubuntu-latest

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1450,6 +1450,47 @@ services:
     mem_limit: 256m
     pids_limit: 256
 
+  # ── Tailscale sidecar (profile: tailscale) — issue #109 PR 1 ─────────
+  # OFF by default on every fresh tenant. `docker compose up -d` does NOT
+  # start this container — only `docker compose --profile tailscale up -d`
+  # does (which PR 3's /connections card will invoke on the principal's
+  # "Turn on" click). The principal then drives Connect from the dashboard
+  # and the sidecar joins their own tailnet via Tailscale's device-style
+  # auth-URL flow (path C; see docs/specs/issue-109-tailscale-via-ui.md).
+  #
+  # Hostname: derived from $DOMAIN with dots replaced by dashes
+  # (e.g. DOMAIN=home.alfred.black → home-alfred-black). Compose's variable
+  # interpolation does NOT support Bash-style `${VAR//./-}` pattern
+  # substitution, so bootstrap.sh derives the value and writes it to .env
+  # as TAILSCALE_HOSTNAME_PREFIX. The fallback to $DOMAIN here is purely
+  # defensive — Tailscale accepts dotted hostnames but normalises them,
+  # which is less predictable than the bootstrap-derived form.
+  # See §3.2.1 of the spec.
+  #
+  # State (the node key in tailscaled.state) lives in the named volume
+  # `tailscale_data`; surviving `docker compose pull` is the whole point.
+  # PR 2 lands the ctrl-api routes that drive `tailscale up / status /
+  # logout / down` via `docker exec`; PR 3 the /connections card; PR 4
+  # `tailscale cert` + `tailscale serve` for inbound from the tailnet.
+  tailscale:
+    image: tailscale/tailscale:stable
+    profiles: ["tailscale"]
+    hostname: "${TAILSCALE_HOSTNAME_PREFIX:-${DOMAIN}}"
+    environment:
+      TS_AUTHKEY: "${TAILSCALE_AUTHKEY:-}"
+      TS_STATE_DIR: "/var/lib/tailscale"
+      TS_HOSTNAME: "${TAILSCALE_HOSTNAME_PREFIX:-${DOMAIN}}"
+      TS_USERSPACE: "false"
+      TS_EXTRA_ARGS: "--accept-routes ${TAILSCALE_TAGS:+--advertise-tags=${TAILSCALE_TAGS}}"
+    volumes:
+      - tailscale_data:/var/lib/tailscale
+      - /dev/net/tun:/dev/net/tun
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    restart: unless-stopped
+    mem_limit: 128m
+
   # ── Vexa — transcript bot stack (profile: vexa) ─────────────────────
   # `docker compose --profile vexa up -d`. 9 services, ~3 GB resident.
   # Folded inline here (the alfred-platform fleet ran Vexa as a separate
@@ -1719,6 +1760,10 @@ volumes:
   sure_pgdata:
   sure_redis:
   paperclip_data:
+  # Tailscale sidecar state — node key in tailscaled.state survives
+  # `docker compose pull/up/restart`. Issue #109 PR 1. See §3.5 of
+  # docs/specs/issue-109-tailscale-via-ui.md.
+  tailscale_data:
   vexa_redis:
   vexa_postgres:
   vexa_minio:

--- a/packages/ctrl/src/db/migrate.ts
+++ b/packages/ctrl/src/db/migrate.ts
@@ -16,6 +16,7 @@
 import type { DatabaseSync } from "node:sqlite";
 import m0001 from "./migrations/0001_fix_pack.sql";
 import m0002 from "./migrations/0002_alfred_journal.sql";
+import m0003 from "./migrations/0003_tailscale_connection.sql";
 
 interface Migration {
   version: number;
@@ -25,8 +26,9 @@ interface Migration {
 
 // Ordered, append-only. Each version is applied exactly once, in order.
 const MIGRATIONS: Migration[] = [
-  { version: 1, name: "fix_pack",       sql: m0001 },
-  { version: 2, name: "alfred_journal", sql: m0002 },
+  { version: 1, name: "fix_pack",             sql: m0001 },
+  { version: 2, name: "alfred_journal",       sql: m0002 },
+  { version: 3, name: "tailscale_connection", sql: m0003 },
 ];
 
 /**

--- a/packages/ctrl/src/db/migrations/0003_tailscale_connection.sql
+++ b/packages/ctrl/src/db/migrations/0003_tailscale_connection.sql
@@ -1,0 +1,46 @@
+-- 0003_tailscale_connection — issue #109 PR 1.
+--
+-- A singleton row holds the live state of THIS tenant's join to the
+-- principal's tailnet. The Tailscale sidecar (docker-compose `tailscale`
+-- service, gated by `profiles: [tailscale]`) is OFF by default; this table
+-- records the lifecycle once the principal flips the `/connections` card
+-- on. PR 2 lands the ctrl-api routes that read/write this row; PR 3 the
+-- web card that surfaces it. PR 1 ships only the schema so the runner
+-- order is locked in before any code reads/writes it.
+--
+-- Why singleton? Per the spec §3.5 a tenant joins exactly ONE tailnet at
+-- a time. Multiple historical rows would invite "which row is current?"
+-- ambiguity at the route layer. A `CHECK(id=1)` PK pins the table to a
+-- single row; the route layer upserts. Historical audit lives in the
+-- `audit` table (POST /api/v1/audit, signal-action events:
+-- tailscale_connect_initiated / _completed / _disconnect / _cert_regen /
+-- _serve_restored), which is the canonical "what happened when" ledger.
+--
+-- See packages/ctrl/CLAUDE.md and CLAUDE.md §Storage Architecture for the
+-- promotion contract: this is machine bookkeeping (no principal reads it
+-- directly), so it lives in state.db, not the vault.
+
+CREATE TABLE IF NOT EXISTS tailscale_connection (
+  id                   INTEGER PRIMARY KEY CHECK(id=1),
+  -- One of: disabled | starting | authenticating | connected | error.
+  -- 'disabled' is the shipped default (sidecar profile not running);
+  -- transitions are driven by the ctrl-api routes in PR 2.
+  state                TEXT NOT NULL DEFAULT 'disabled',
+  -- The 100.x.x.x address Tailscale assigned to this node, or NULL.
+  tailnet_ip           TEXT,
+  -- The full *.tail-<id>.ts.net DNS name, or NULL.
+  tailnet_hostname     TEXT,
+  -- Unix ms timestamp the most recent auth-key was redeemed (path A
+  -- only; path C — device-auth URL — leaves this NULL).
+  authkey_used_at      INTEGER,
+  -- When state='authenticating', the login.tailscale.com/a/<code> URL
+  -- the principal must visit. Cleared once state flips to 'connected'.
+  auth_url             TEXT,
+  -- Unix ms timestamp of the last `tailscale status --json` probe;
+  -- the route caches for 2s to absorb the dashboard poller.
+  last_status_probe_at INTEGER,
+  -- One-line error message when state='error'; NULL otherwise.
+  last_error           TEXT,
+  created_at           INTEGER NOT NULL,
+  updated_at           INTEGER NOT NULL
+);

--- a/packages/ctrl/tests/alfred-journal.test.ts
+++ b/packages/ctrl/tests/alfred-journal.test.ts
@@ -50,9 +50,12 @@ function tableNames(db: DatabaseSync): string[] {
 }
 
 describe("alfred_journal migration", () => {
-  it("bumps user_version to 2", () => {
+  it("bumps user_version to the latest migration", () => {
+    // 0002 alone took us to 2; 0003 (tailscale_connection — issue #109 PR 1)
+    // takes us to 3. The runner applies every migration > current version,
+    // so the value naturally tracks the highest registered version.
     const db = makeDb();
-    assert.equal(userVersion(db), 2);
+    assert.equal(userVersion(db), 3);
     db.close();
   });
 

--- a/packages/ctrl/tests/migrate.test.ts
+++ b/packages/ctrl/tests/migrate.test.ts
@@ -36,10 +36,10 @@ describe("state.db migration runner", () => {
     const db = new DatabaseSync(":memory:");
     db.exec(schema);
     const v = runMigrations(db);
-    // The latest version moves as new migrations land. Today: 2
-    // (0001_fix_pack + 0002_alfred_journal).
-    assert.equal(v, 2, "migrated to latest version");
-    assert.equal(userVersion(db), 2);
+    // The latest version moves as new migrations land. Today: 3
+    // (0001_fix_pack + 0002_alfred_journal + 0003_tailscale_connection).
+    assert.equal(v, 3, "migrated to latest version");
+    assert.equal(userVersion(db), 3);
     assert.ok(cols(db, "observation").includes("processed_at"), "0001: processed_at present after migrate");
     // 0002: alfred_journal + alfred_principal tables present.
     const tables = (
@@ -52,6 +52,45 @@ describe("state.db migration runner", () => {
       tables.includes("alfred_principal"),
       "0002: alfred_principal table created",
     );
+    // 0003: tailscale_connection singleton table present, with the
+    // CHECK(id=1) guard that pins the table to one row. Issue #109 PR 1.
+    assert.ok(
+      tables.includes("tailscale_connection"),
+      "0003: tailscale_connection table created",
+    );
+    const tsCols = cols(db, "tailscale_connection");
+    for (const required of [
+      "id",
+      "state",
+      "tailnet_ip",
+      "tailnet_hostname",
+      "authkey_used_at",
+      "auth_url",
+      "last_status_probe_at",
+      "last_error",
+      "created_at",
+      "updated_at",
+    ]) {
+      assert.ok(
+        tsCols.includes(required),
+        `0003: tailscale_connection.${required} present`,
+      );
+    }
+    // Singleton guard: a second row at id=2 must be rejected by the CHECK.
+    const now = Date.now();
+    db.prepare(
+      "INSERT INTO tailscale_connection (id, state, created_at, updated_at) VALUES (?, ?, ?, ?)",
+    ).run(1, "disabled", now, now);
+    assert.throws(
+      () =>
+        db
+          .prepare(
+            "INSERT INTO tailscale_connection (id, state, created_at, updated_at) VALUES (?, ?, ?, ?)",
+          )
+          .run(2, "disabled", now, now),
+      /CHECK constraint failed/i,
+      "0003: CHECK(id=1) blocks a second tailscale_connection row",
+    );
     db.close();
   });
 
@@ -60,7 +99,7 @@ describe("state.db migration runner", () => {
     db.exec(schema);
     runMigrations(db);
     const v2 = runMigrations(db);
-    assert.equal(v2, 2);
+    assert.equal(v2, 3);
     assert.equal(
       cols(db, "observation").filter((c) => c === "processed_at").length,
       1,

--- a/packages/ctrl/tests/tailscale-compose-lint.test.ts
+++ b/packages/ctrl/tests/tailscale-compose-lint.test.ts
@@ -1,0 +1,193 @@
+// Issue #109 PR 1 — Tailscale sidecar foundation lint.
+//
+// The PR ships a single load-bearing contract: the `tailscale` service is
+// declared in the repo's docker-compose.yaml but is OFF on every fresh
+// tenant. PR 3 will let the principal turn it on from /connections; until
+// then NOTHING about an existing tenant should change. This test reads
+// the docker-compose.yaml as YAML and asserts the structural invariants
+// that uphold that promise.
+//
+// The CI `compose-lint` job in .github/workflows/ci-check.yml runs the
+// same assertions end-to-end through the docker-compose CLI; this unit
+// test is the fast, docker-free version that catches regressions during
+// `npm test`.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import yaml from "js-yaml";
+
+const COMPOSE_PATH = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../docker-compose.yaml",
+);
+
+interface ServiceSpec {
+  image?: string;
+  profiles?: string[];
+  hostname?: string;
+  environment?: Record<string, string> | string[];
+  volumes?: (string | { source?: string; target?: string })[];
+  cap_add?: string[];
+  restart?: string;
+  // Loose for forward-compat.
+  [key: string]: unknown;
+}
+
+interface ComposeFile {
+  services: Record<string, ServiceSpec>;
+  volumes: Record<string, unknown>;
+}
+
+const compose = yaml.load(readFileSync(COMPOSE_PATH, "utf-8")) as ComposeFile;
+
+function envMap(svc: ServiceSpec): Record<string, string> {
+  const env = svc.environment;
+  if (!env) return {};
+  if (Array.isArray(env)) {
+    const out: Record<string, string> = {};
+    for (const kv of env) {
+      const eq = kv.indexOf("=");
+      if (eq < 0) continue;
+      out[kv.slice(0, eq)] = kv.slice(eq + 1);
+    }
+    return out;
+  }
+  return env as Record<string, string>;
+}
+
+describe("tailscale sidecar — compose-foundation lint (issue #109 PR 1)", () => {
+  it("the `tailscale` service is declared", () => {
+    assert.ok(
+      compose.services.tailscale,
+      "docker-compose.yaml must declare a `tailscale` service",
+    );
+  });
+
+  it("uses the official tailscale/tailscale:stable image", () => {
+    const svc = compose.services.tailscale;
+    assert.equal(
+      svc.image,
+      "tailscale/tailscale:stable",
+      "image must be the vendor-supported tailscale/tailscale:stable",
+    );
+  });
+
+  it("is profile-gated — OFF unless `--profile tailscale` is passed", () => {
+    // This is the entire "existing tenants see zero change" promise. A
+    // service without `profiles:` runs under `docker compose up -d`; this
+    // service must NEVER do that.
+    const svc = compose.services.tailscale;
+    assert.deepEqual(
+      svc.profiles,
+      ["tailscale"],
+      "profiles MUST be exactly ['tailscale'] — empty/missing would start " +
+        "the sidecar by default on every tenant deploy",
+    );
+  });
+
+  it("no OTHER default-profile service silently gained a tailscale profile", () => {
+    // Defensive: catch a refactor that accidentally tags an existing
+    // service with profile:[tailscale] (which would break it on default
+    // `docker compose up -d`).
+    const allowed = new Set(["tailscale"]);
+    for (const [name, svc] of Object.entries(compose.services)) {
+      const profiles = svc.profiles ?? [];
+      if (profiles.includes("tailscale") && !allowed.has(name)) {
+        assert.fail(
+          `service ${name} unexpectedly has the 'tailscale' profile — ` +
+            "every other service must be either default-profile or under " +
+            "an unrelated profile (vexa).",
+        );
+      }
+    }
+  });
+
+  it("derives hostname from TAILSCALE_HOSTNAME_PREFIX with $DOMAIN fallback", () => {
+    // Compose interpolation does NOT support Bash ${VAR//./-}, so the
+    // dot-to-dash rule from spec §3.2.1 lives in scripts/bootstrap.sh; the
+    // compose file just consumes the derived TAILSCALE_HOSTNAME_PREFIX,
+    // with a defensive ${DOMAIN} fallback.
+    const svc = compose.services.tailscale;
+    const expected = "${TAILSCALE_HOSTNAME_PREFIX:-${DOMAIN}}";
+    assert.equal(svc.hostname, expected, "hostname must be the documented expression");
+    const env = envMap(svc);
+    assert.equal(env.TS_HOSTNAME, expected, "TS_HOSTNAME must mirror the hostname expression");
+  });
+
+  it("passes TAILSCALE_AUTHKEY (with empty default) for path-A bootstrap", () => {
+    // Path C (device-auth URL) is the recommended flow; path A is a
+    // collapsed advanced fallback. Both rely on the same env wiring.
+    const env = envMap(compose.services.tailscale);
+    assert.equal(
+      env.TS_AUTHKEY,
+      "${TAILSCALE_AUTHKEY:-}",
+      "TS_AUTHKEY must default to empty so the device-auth URL flow is the default",
+    );
+  });
+
+  it("runs in kernel mode (TS_USERSPACE=false)", () => {
+    // Userspace mode forfeits kernel-routed MagicDNS resolution from peer
+    // containers — the whole point of the "Alfred can reach
+    // homeassistant.tail-id.ts.net" experience. Spec §3.2 (rejected).
+    const env = envMap(compose.services.tailscale);
+    assert.equal(
+      env.TS_USERSPACE,
+      "false",
+      "TS_USERSPACE must be 'false' so kernel-routed MagicDNS works for peer containers",
+    );
+  });
+
+  it("conditionally advertises tags only when TAILSCALE_TAGS is set", () => {
+    // The empty-by-default tag is the resolution of Q4: don't ship a
+    // default `tag:alfred-tenant` because the principal's tailnet ACL
+    // hasn't declared it. `${VAR:+...}` expands to nothing when the var
+    // is empty.
+    const env = envMap(compose.services.tailscale);
+    assert.equal(
+      env.TS_EXTRA_ARGS,
+      "--accept-routes ${TAILSCALE_TAGS:+--advertise-tags=${TAILSCALE_TAGS}}",
+      "TS_EXTRA_ARGS must use ${TAGS:+...} so the flag disappears when blank",
+    );
+  });
+
+  it("has the kernel capabilities the WireGuard backend requires", () => {
+    const svc = compose.services.tailscale;
+    const caps = svc.cap_add ?? [];
+    for (const required of ["NET_ADMIN", "NET_RAW"]) {
+      assert.ok(
+        caps.includes(required),
+        `cap_add must include ${required} for kernel-mode tailscaled`,
+      );
+    }
+  });
+
+  it("mounts /var/lib/tailscale on the `tailscale_data` named volume", () => {
+    // tailscaled.state lives here. Surviving `docker compose pull` is the
+    // whole point — the principal's node key persists across image updates
+    // so reconnection is a no-op on Tailscale's side.
+    const svc = compose.services.tailscale;
+    const vols = (svc.volumes ?? []).map((v) => (typeof v === "string" ? v : JSON.stringify(v)));
+    const stateMount = vols.find((v) => v.includes("/var/lib/tailscale"));
+    assert.ok(stateMount, "must mount /var/lib/tailscale");
+    assert.ok(
+      stateMount?.startsWith("tailscale_data:"),
+      "/var/lib/tailscale must be backed by the tailscale_data named volume",
+    );
+    const tunMount = vols.find((v) => v.includes("/dev/net/tun"));
+    assert.ok(tunMount, "must bind-mount /dev/net/tun for kernel WireGuard");
+  });
+
+  it("the `tailscale_data` named volume is declared at top level", () => {
+    assert.ok(
+      Object.hasOwn(compose.volumes, "tailscale_data"),
+      "tailscale_data must be in the top-level volumes: block",
+    );
+  });
+
+  it("restart policy is unless-stopped (matches every other long-lived service)", () => {
+    assert.equal(compose.services.tailscale.restart, "unless-stopped");
+  });
+});

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -202,6 +202,39 @@ if [[ -z "${existing_uid}" || "${existing_uid}" == "default" ]]; then
 fi
 
 green "Auto-secrets: ${GENERATED} generated, ${KEPT} kept (already set)."
+
+# ── 4. TAILSCALE_HOSTNAME_PREFIX (issue #109 PR 1) ──────────────────
+# The Tailscale sidecar runs only with `--profile tailscale` and is OFF on
+# every fresh tenant; the principal opts in via the /connections card. We
+# still derive the tailnet hostname here, though: compose's variable
+# interpolation does not support Bash-style `${VAR//./-}`, so the dotted
+# DOMAIN has to be transformed in shell. Writing the result to .env keeps
+# the value visible + predictable across `docker compose pull` and makes
+# the tailnet device name an operator-tunable knob (override by editing).
+# TAILSCALE_AUTHKEY is intentionally NOT auto-generated — it is either
+# pasted by the principal (path A) or unused (path C: device-auth URL).
+existing_prefix="$(trim "$(env_get TAILSCALE_HOSTNAME_PREFIX)")"
+if [[ -z "${existing_prefix}" ]]; then
+	domain_value="$(trim "$(env_get DOMAIN)")"
+	if [[ -n "${domain_value}" ]]; then
+		prefix="${domain_value//./-}"
+		if grep -qE "^#?TAILSCALE_HOSTNAME_PREFIX=" "${ENV_FILE}" 2>/dev/null; then
+			tmp="$(mktemp)"
+			awk -v v="${prefix}" '
+				$0 ~ "^#?TAILSCALE_HOSTNAME_PREFIX=" && !d { print "TAILSCALE_HOSTNAME_PREFIX=" v; d=1; next }
+				{ print }
+			' "${ENV_FILE}" > "${tmp}"
+			mv "${tmp}" "${ENV_FILE}"
+		else
+			printf 'TAILSCALE_HOSTNAME_PREFIX=%s\n' "${prefix}" >> "${ENV_FILE}"
+		fi
+		green "Derived TAILSCALE_HOSTNAME_PREFIX=${prefix} from DOMAIN."
+	fi
+fi
+
 bold ""
 green "Bootstrap complete. Next:  docker compose up -d"
 green "(Vexa is opt-in:           docker compose --profile vexa up -d)"
+green "(Tailscale is opt-in:      docker compose --profile tailscale up -d tailscale"
+green "                            — set TAILSCALE_ENABLED=true first; PR 3 will"
+green "                              wire the /connections card.)"


### PR DESCRIPTION
Lands the compose foundation for #109 (Tailscale via UI) without changing the behavior of any existing tenant. The sidecar is declared but inert until PR 3 wires the `/connections` card to start it.

## What ships in this PR

- **`docker-compose.yaml`** — new `tailscale` service (image `tailscale/tailscale:stable`, kernel mode, `NET_ADMIN` + `NET_RAW`, mounts `/dev/net/tun` and the new `tailscale_data` named volume) gated by `profiles: ["tailscale"]`. `docker compose up -d` alone does NOT start it — only `docker compose --profile tailscale up -d tailscale` does. `mem_limit: 128m`.
- **`packages/ctrl/src/db/migrations/0003_tailscale_connection.sql`** — new singleton state.db table (PK `CHECK(id=1)`) for the lifecycle row PR 2 will upsert: `state` (`disabled` | `starting` | `authenticating` | `connected` | `error`), `tailnet_ip`, `tailnet_hostname`, `authkey_used_at`, `auth_url`, `last_status_probe_at`, `last_error`, `created_at`, `updated_at`. Additive — existing schema untouched.
- **`packages/ctrl/src/db/migrate.ts`** + **`migrate.test.ts`** + **`alfred-journal.test.ts`** — wire 0003 into the runner; assert the singleton `CHECK` guard rejects a second row.
- **`.env.example`** — `TAILSCALE_ENABLED=false` (the off-by-default switch), `TAILSCALE_AUTHKEY`, `TAILSCALE_HOSTNAME_PREFIX`, `TAILSCALE_TAGS` — all documented + blank by default.
- **`scripts/bootstrap.sh`** — derives `TAILSCALE_HOSTNAME_PREFIX` from `$DOMAIN` with dots → dashes (compose's variable interpolation does NOT support Bash `${VAR//./-}`). `TAILSCALE_AUTHKEY` intentionally NOT auto-generated — it's either pasted by the principal (path A) or unused (path C: device-auth URL).
- **Tests + CI** — `tailscale-compose-lint.test.ts` (12 structural assertions against the rendered YAML) + `ci-check.yml` `compose-lint` job extended to run `docker compose --profile tailscale config --quiet` AND assert the service is invisible without the profile.

## OFF BY DEFAULT — existing tenants see zero change on this PR

The profile-gating contract is the load-bearing invariant; both the unit test and the CI gate enforce it from two directions:

- Default-profile `docker compose config --services` must NOT list `tailscale`.
- `docker compose --profile tailscale config --services` MUST list `tailscale`.

Locally verified:

```
=== default profile — must NOT include tailscale ===
0
=== --profile tailscale — must include tailscale ===
1
```

## Deferred to follow-up PRs

| PR | Scope |
|---|---|
| **PR 2** | ctrl-api routes (`/api/v1/channels/tailscale/{status,connect,disconnect,cert,serve,peers}`) + `helpers.dockerExecTailscale()`. |
| **PR 3** | Web `<TailscaleCard />` on `/connections` with the on/off toggle UX from spec §3.7, plus 4 Wasp ops. |
| **PR 4** | Tailscale Serve outbound + `tailscale cert` for the `*.tail-<id>.ts.net` inbound path; Hermes `network_mode: service:tailscale` for MagicDNS outbound to home-network peers. |
| **PR 5** | `docs/integrations/tailscale.mdx` (principal-facing guide) and the deprecation note for the legacy host-binary `/api/v1/admin/tailscale/*` routes. |

## Spec

`docs/specs/issue-109-tailscale-via-ui.md` §3.2 (sidecar) / §3.2.1 (hostname rule) / §3.7 (on-off UX) / §5.1 (route table) / §5.2 (env vars) / §6 (PR sequencing).

Closes none — keeps #109 open across PRs 2–5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)