### PR TITLE
feat(ctrl,db): channel_tokens table + HA conversation /turn route (#111 PR1)

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -53,8 +53,15 @@
 	# COMPOSIO_WEBHOOK_SECRET is unset). Discovery #293 found the Caddy
 	# matcher was never updated and every Composio webhook was 405-ing
 	# at the SPA's nginx.
+	#
+	# /api/v1/channels/ha/turn is the Home Assistant conversation-agent
+	# inbound surface (#111 PR1). The handler validates a per-installation
+	# bearer against the shared channel_tokens table (channel='ha-conversation')
+	# — same pattern as Paperclip's heartbeat (HMAC instead of bearer),
+	# routed through the same Caddy gate so HA can reach ctrl-api directly
+	# rather than bouncing through the SPA's nginx (which would 405).
 	@public_webhooks {
-		path /api/v1/streams/omi/* /api/v1/plane/webhook /api/v1/webhooks/plane/steward /api/v1/webhooks/vexa /api/v1/webhooks/in/* /api/v1/channels/email/inbound /api/v1/channels/paperclip/* /api/v1/composio/webhook
+		path /api/v1/streams/omi/* /api/v1/plane/webhook /api/v1/webhooks/plane/steward /api/v1/webhooks/vexa /api/v1/webhooks/in/* /api/v1/channels/email/inbound /api/v1/channels/paperclip/* /api/v1/channels/ha/turn /api/v1/composio/webhook
 	}
 	handle @public_webhooks {
 		reverse_proxy ctrl-api:3100

--- a/packages/ctrl/src/api/auth.ts
+++ b/packages/ctrl/src/api/auth.ts
@@ -50,6 +50,11 @@
 import crypto from "node:crypto";
 import type { IncomingMessage } from "node:http";
 import { AuthError } from "./errors.js";
+import { getStateDb } from "../db/state.js";
+import {
+  validateChannelToken,
+  type ChannelTokenMeta,
+} from "../db/channelTokens.js";
 
 let apiKeyBuf: Buffer | null = null;
 let voiceBridgeKeyBuf: Buffer | null = null;
@@ -223,4 +228,80 @@ export function authenticate(
   }
 
   throw new AuthError("Invalid API key");
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Shared channel-token bearer path.
+//
+// Used by channel-keyed routes (HA-conversation /turn, future HA-voice
+// /audio, future Paperclip /heartbeat post-migration) to swap an inbound
+// bearer for the `channel_tokens` row that authorises it. The token shape
+// is `<prefix>_<48hex>` per channel; the validator (a) sha256-hashes the
+// raw bytes, (b) looks up by `(channel, token_hash)` with
+// `revoked_at IS NULL`, (c) bumps `last_used_at` + `last_used_ip` as a
+// side effect.
+//
+// IMPORTANT: this path is OUTSIDE the master-key authenticate() flow. A
+// channel-keyed route's place in server.ts must either:
+//   * list its path in `isPublic` so the global gate doesn't pre-empt it
+//     with a 401, OR
+//   * accept the master key in addition (the master AAS_API_KEY route also
+//     reaches the handler; the handler can opt into channelTokenBearer for
+//     the non-master case).
+//
+// The contract: when this returns a `ChannelTokenMeta`, the request is
+// authenticated as the principal that minted the row. When it throws
+// AuthError, the global error path returns 401.
+// ──────────────────────────────────────────────────────────────────────────
+
+/** Extract the bearer token bytes from `Authorization: Bearer <token>`.
+ *  Returns null if absent or malformed (so the caller decides whether to
+ *  401 or fall through to another auth path). */
+export function extractBearerToken(req: IncomingMessage): string | null {
+  const header = req.headers.authorization;
+  if (!header || typeof header !== "string") return null;
+  if (!header.startsWith("Bearer ")) return null;
+  const tok = header.slice(7).trim();
+  return tok.length > 0 ? tok : null;
+}
+
+/** Best-effort source ip for the `last_used_ip` column. Honours
+ *  X-Forwarded-For when behind Caddy (the apex passes traffic through to
+ *  ctrl-api with the original remote in the header). */
+function extractRemoteIp(req: IncomingMessage): string | null {
+  const xff = req.headers["x-forwarded-for"];
+  if (typeof xff === "string" && xff.length > 0) {
+    // first hop is the originating client
+    const first = xff.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  const sock = (req as { socket?: { remoteAddress?: string } }).socket;
+  return sock?.remoteAddress ?? null;
+}
+
+/** Authenticate a channel-keyed bearer for one channel. Throws AuthError
+ *  on no/bad/revoked token. Returns the row metadata on success.
+ *
+ *  Side-effect: bumps `last_used_at` and `last_used_ip` on the matched
+ *  row.
+ *
+ *  This is the single function every channel route imports — there is no
+ *  parallel auth module. */
+export function channelTokenBearer(
+  req: IncomingMessage,
+  channel: string,
+): ChannelTokenMeta {
+  const raw = extractBearerToken(req);
+  if (!raw) {
+    throw new AuthError("Missing or malformed Authorization header");
+  }
+  const meta = validateChannelToken(getStateDb(), channel, raw, {
+    ip: extractRemoteIp(req),
+  });
+  if (!meta) {
+    // Don't leak whether the token was unknown vs revoked vs wrong-channel
+    // — every failure mode is the same 401 to the caller.
+    throw new AuthError("Invalid or revoked token");
+  }
+  return meta;
 }

--- a/packages/ctrl/src/api/routes/channel_tokens.ts
+++ b/packages/ctrl/src/api/routes/channel_tokens.ts
@@ -1,0 +1,156 @@
+// Shared /api/v1/channel-tokens/* surface — every channel's bearer-token
+// rotation/audit/revoke lives here.
+//
+// Background. Sir's decision Q2 (issue #111) ratifies a single shared
+// `channel_tokens` table for every per-channel bearer the platform issues.
+// HA-conversation is the first user (this PR); HA Voice (#112) joins next;
+// Paperclip migrates onto it later as housekeeping. The HTTP surface is
+// uniform: mint by channel name, list by channel name, revoke by id,
+// rotate by id. Channel-specific shape (HA installation id, etc.) rides
+// along on `scope` — opaque to this module, meaningful to the channel
+// route that issued the token.
+//
+// All four endpoints are bearer-authed by the master AAS_API_KEY — they
+// are operator-facing tooling, not external surfaces. The TOKENS THIS
+// MODULE MINTS are what external surfaces (HA, Paperclip, …) actually
+// validate against.
+//
+// PRIVACY: the raw token is shown EXACTLY ONCE at mint. Only sha256(raw)
+// is stored. Listing endpoints return a public-safe view (no token_hash,
+// no raw). Compare with the voice-bridge token UX: same posture (one
+// reveal, no recovery) but plumbed through the shared table this time.
+
+import { addRoute } from "../server.js";
+import { sendJson, ValidationError, NotFoundError } from "../errors.js";
+import { getStateDb } from "../../db/state.js";
+import {
+  mintChannelToken,
+  listChannelTokens,
+  revokeChannelToken,
+  rotateChannelToken,
+  getChannelTokenMeta,
+} from "../../db/channelTokens.js";
+
+/** The set of channel names this module accepts at mint time. Each entry
+ *  here also pins a token-prefix discipline in db/channelTokens.ts's
+ *  `generateRawToken`. Adding a new channel: add the name here AND the
+ *  prefix arm there. We refuse unknown channels at the HTTP layer so a
+ *  typo can't fragment the audit trail with `channel='ha_conversation'`
+ *  vs `channel='ha-conversation'`. */
+const KNOWN_CHANNELS: ReadonlySet<string> = new Set([
+  "ha-conversation",
+  "ha-voice",
+  "paperclip-heartbeat",
+]);
+
+interface MintBody {
+  channel: string;
+  label?: string | null;
+  scope?: Record<string, unknown> | null;
+}
+
+function parseMintBody(raw: unknown): MintBody {
+  if (typeof raw !== "object" || raw === null) {
+    throw new ValidationError("body must be a JSON object");
+  }
+  const b = raw as Record<string, unknown>;
+  if (typeof b.channel !== "string" || b.channel.length === 0) {
+    throw new ValidationError("channel must be a non-empty string");
+  }
+  if (!KNOWN_CHANNELS.has(b.channel)) {
+    throw new ValidationError(
+      `channel must be one of ${[...KNOWN_CHANNELS].join(", ")}`,
+    );
+  }
+  let label: string | null = null;
+  if (b.label !== undefined && b.label !== null) {
+    if (typeof b.label !== "string") {
+      throw new ValidationError("label must be a string or omitted");
+    }
+    label = b.label;
+  }
+  let scope: Record<string, unknown> | null = null;
+  if (b.scope !== undefined && b.scope !== null) {
+    if (typeof b.scope !== "object" || Array.isArray(b.scope)) {
+      throw new ValidationError("scope must be a JSON object or omitted");
+    }
+    scope = b.scope as Record<string, unknown>;
+  }
+  return { channel: b.channel, label, scope };
+}
+
+export function registerChannelTokenRoutes(): void {
+  // POST /channel-tokens/mint — mint a new token. Returns the raw token
+  // EXACTLY ONCE. The caller must capture and store it now; there is no
+  // recovery path.
+  addRoute("POST", "/api/v1/channel-tokens/mint", async ({ res, body }) => {
+    const parsed = parseMintBody(body);
+    const result = mintChannelToken(getStateDb(), {
+      channel: parsed.channel,
+      label: parsed.label,
+      scope: parsed.scope,
+    });
+    // Shape mirrors the once-only-reveal pattern used by Paperclip's
+    // bootstrap and by voice-bridge's pairing: `token` at top level, the
+    // public-safe meta under `meta` so the caller can persist whichever
+    // piece they need.
+    sendJson(res, 201, {
+      token: result.raw,
+      meta: result.meta,
+    });
+  });
+
+  // GET /channel-tokens?channel=… — list active tokens for a channel.
+  // Public-safe view: no raw token, no hash. `?include_revoked=1` returns
+  // tombstones too for audit views.
+  addRoute("GET", "/api/v1/channel-tokens", async ({ res, query }) => {
+    const channel = query.get("channel");
+    if (!channel) {
+      throw new ValidationError("channel query parameter is required");
+    }
+    const includeRevoked = query.get("include_revoked") === "1";
+    const tokens = listChannelTokens(getStateDb(), channel, {
+      includeRevoked,
+    });
+    sendJson(res, 200, { tokens });
+  });
+
+  // POST /channel-tokens/:id/revoke — soft-revoke. Sets `revoked_at`.
+  // Idempotent: a second revoke is a no-op (the existing `revoked_at`
+  // stays). Returns the row for confirmation.
+  addRoute(
+    "POST",
+    "/api/v1/channel-tokens/:id/revoke",
+    async ({ res, params }) => {
+      const id = params.id;
+      if (!id) throw new ValidationError("id is required");
+      const meta = revokeChannelToken(getStateDb(), id);
+      if (!meta) throw new NotFoundError(`channel_token ${id} not found`);
+      sendJson(res, 200, { ok: true, meta });
+    },
+  );
+
+  // POST /channel-tokens/:id/rotate — mint a new token in the same channel
+  // that points back at the old via `rotated_from`. Returns the new raw
+  // token ONCE. Does NOT revoke the old token automatically — caller does
+  // that once the new one is installed on the consuming side.
+  addRoute(
+    "POST",
+    "/api/v1/channel-tokens/:id/rotate",
+    async ({ res, params }) => {
+      const id = params.id;
+      if (!id) throw new ValidationError("id is required");
+      // Surface the not-found explicitly so the operator gets a clear
+      // message rather than a generic 500.
+      const existing = getChannelTokenMeta(getStateDb(), id);
+      if (!existing) throw new NotFoundError(`channel_token ${id} not found`);
+      const result = rotateChannelToken(getStateDb(), id);
+      if (!result) throw new NotFoundError(`channel_token ${id} not found`);
+      sendJson(res, 201, {
+        token: result.raw,
+        meta: result.meta,
+        rotated_from: id,
+      });
+    },
+  );
+}

--- a/packages/ctrl/src/api/routes/channels_ha.ts
+++ b/packages/ctrl/src/api/routes/channels_ha.ts
@@ -1,0 +1,415 @@
+// /api/v1/channels/ha/* — Home Assistant channel routes.
+//
+// Issue #111 spec: docs/specs/issue-111-ha-conversation-agent.md.
+//
+// This PR (#111 PR1) ships ONLY the `/turn` route — the non-streaming
+// inbound handler that translates one HA conversation turn into one
+// Hermes-main `/v1/responses` call and returns HA's expected envelope.
+//
+// PRs #110 and later extend this file with the rest of the HA surface
+// (token mint affordance on top of channel-tokens, /rooms upload, /health
+// probe, /status card data). The "coordinate with #110 PR1" note in the
+// PR description spells it out: whichever lane lands first creates the
+// file minimally and the other ADDS to it. This file is the minimal
+// shape.
+//
+// PR3 (#111 PR3, tool partitioning) will extend this file to forward
+// HA-side tool calls in the response; for PR1 we return text only.
+// PR4 (#111 PR4, curated MCP catalog) will inject the curator. PR5
+// (voice-context primer + ha_room enrichment) will pre-fetch the primer.
+// All of those are seams marked here for future PRs but NOT shipped.
+
+import { addRoute } from "../server.js";
+import { sendJson, ValidationError, ApiError } from "../errors.js";
+import { getStateDb } from "../../db/state.js";
+import { appendJournal } from "../../db/alfredJournal.js";
+import { channelTokenBearer } from "../auth.js";
+import fs from "node:fs";
+
+const HERMES_MAIN_URL =
+  process.env.HERMES_GATEWAY_URL ?? "http://hermes:18789";
+const HERMES_TIMEOUT_MS = 90_000;
+
+// Rate-limit per haInstanceId — 30 turns / sliding minute. In-memory
+// sliding window. Spec §5.1 / §6.PR2 / O8.
+const RATE_LIMIT_PER_MIN = 30;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const rateLimitBuckets = new Map<string, number[]>();
+
+function checkRateLimit(haInstanceId: string): boolean {
+  const now = Date.now();
+  const cutoff = now - RATE_LIMIT_WINDOW_MS;
+  const bucket = rateLimitBuckets.get(haInstanceId) ?? [];
+  // Prune anything outside the window.
+  const live = bucket.filter((ts) => ts > cutoff);
+  if (live.length >= RATE_LIMIT_PER_MIN) {
+    rateLimitBuckets.set(haInstanceId, live);
+    return false;
+  }
+  live.push(now);
+  rateLimitBuckets.set(haInstanceId, live);
+  return true;
+}
+
+// Exported for tests so they can clear the in-memory window without
+// reaching into private state. NOT part of the HTTP surface.
+export function _resetHaRateLimitForTests(): void {
+  rateLimitBuckets.clear();
+}
+
+// ── /turn body shape ──────────────────────────────────────────────────────
+//
+// Spec §3 minimum: text, conversation_id, language, agent_id, ha_install_id.
+// We name fields camelCase consistently with the Paperclip channel; HA's
+// custom component sends camelCase via Python's `aiohttp` body.
+
+interface TurnBody {
+  text: string;
+  conversationId: string;
+  language: string;
+  agentId: string;
+  haInstallId: string;
+  /** Optional satellite device id (null when input is text-only). PR5+
+   *  uses this for the deviceId → area lookup against the registry. */
+  deviceId?: string | null;
+}
+
+function parseTurnBody(raw: unknown): TurnBody {
+  if (typeof raw !== "object" || raw === null) {
+    throw new ValidationError("body must be a JSON object");
+  }
+  const b = raw as Record<string, unknown>;
+  if (typeof b.text !== "string" || b.text.length === 0) {
+    throw new ValidationError("text must be a non-empty string");
+  }
+  if (typeof b.conversationId !== "string" || b.conversationId.length === 0) {
+    throw new ValidationError("conversationId must be a non-empty string");
+  }
+  if (typeof b.language !== "string" || b.language.length === 0) {
+    throw new ValidationError("language must be a non-empty string");
+  }
+  if (typeof b.agentId !== "string" || b.agentId.length === 0) {
+    throw new ValidationError("agentId must be a non-empty string");
+  }
+  if (typeof b.haInstallId !== "string" || b.haInstallId.length === 0) {
+    throw new ValidationError("haInstallId must be a non-empty string");
+  }
+  let deviceId: string | null = null;
+  if (b.deviceId !== undefined && b.deviceId !== null) {
+    if (typeof b.deviceId !== "string") {
+      throw new ValidationError("deviceId must be a string or null");
+    }
+    deviceId = b.deviceId;
+  }
+  return {
+    text: b.text,
+    conversationId: b.conversationId,
+    language: b.language,
+    agentId: b.agentId,
+    haInstallId: b.haInstallId,
+    deviceId,
+  };
+}
+
+// ── Hermes call ───────────────────────────────────────────────────────────
+//
+// Same pattern as channels_paperclip.ts — read per-profile API_SERVER_KEY
+// from /hermes-state/profiles/main/.env, POST /v1/responses with
+// X-Hermes-Session-Key. The Hermes' own response shape (`output: [...]`) is
+// flattened down to a single string for PR1; tool partitioning lands in
+// PR3.
+
+interface HermesCallResult {
+  ok: true;
+  text: string;
+}
+interface HermesCallFailure {
+  ok: false;
+  code: "HERMES_UNREACHABLE" | "HERMES_TIMEOUT";
+  detail: string;
+}
+
+function extractHermesText(resp: unknown): string {
+  if (typeof resp !== "object" || resp === null) return "";
+  const r = resp as Record<string, unknown>;
+  const out = r.output;
+
+  const partsToText = (parts: unknown): string => {
+    if (typeof parts === "string") return parts;
+    if (!Array.isArray(parts)) return "";
+    const acc: string[] = [];
+    for (const p of parts) {
+      if (typeof p === "string") {
+        acc.push(p);
+      } else if (typeof p === "object" && p !== null) {
+        const pp = p as Record<string, unknown>;
+        if (typeof pp.text === "string") acc.push(pp.text);
+        else if (typeof pp.content === "string") acc.push(pp.content);
+      }
+    }
+    return acc.filter((s) => s.length > 0).join("\n");
+  };
+
+  if (Array.isArray(out)) {
+    let messageText = "";
+    for (const item of out) {
+      if (typeof item !== "object" || item === null) continue;
+      const it = item as Record<string, unknown>;
+      if (it.type === "message") {
+        const t = partsToText(it.content);
+        if (t) messageText = t;
+      }
+    }
+    if (messageText) return messageText;
+    return partsToText(out);
+  }
+  if (typeof out === "string") return out;
+  if (typeof out === "object" && out !== null) {
+    const o = out as Record<string, unknown>;
+    if (typeof o.text === "string") return o.text;
+    if (typeof o.content === "string") return o.content;
+  }
+  const fallback = r.output_text;
+  if (typeof fallback === "string") return fallback;
+  return "";
+}
+
+/** Same .env-driven key resolution as channels_paperclip.ts — Hermes' main
+ *  gateway validates Bearer against /hermes-state/profiles/main/.env's
+ *  API_SERVER_KEY at runtime (the /opt/alfred/.env HERMES_API_SERVER_KEY
+ *  is a *seed*; once Hermes regenerates per-profile, the file is
+ *  authoritative). Test override: HERMES_CONFIG_DIR. */
+function readHermesMainApiKey(): string | null {
+  const baseDir = process.env.HERMES_CONFIG_DIR ?? "/hermes-state/profiles";
+  const envPath = `${baseDir}/main/.env`;
+  let raw: string;
+  try {
+    raw = fs.readFileSync(envPath, "utf-8");
+  } catch {
+    return null;
+  }
+  for (const line of raw.split("\n")) {
+    const t = line.trim();
+    if (!t || t.startsWith("#")) continue;
+    const eq = t.indexOf("=");
+    if (eq < 0) continue;
+    if (t.slice(0, eq).trim() === "API_SERVER_KEY") {
+      return t.slice(eq + 1).trim();
+    }
+  }
+  return null;
+}
+
+async function callHermes(
+  sessionKey: string,
+  input: string,
+): Promise<HermesCallResult | HermesCallFailure> {
+  const url = `${HERMES_MAIN_URL}/v1/responses`;
+  const apiKey = readHermesMainApiKey() ?? "";
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "X-Hermes-Session-Key": sessionKey,
+  };
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+
+  let resp: Response;
+  try {
+    resp = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ input }),
+      signal: AbortSignal.timeout(HERMES_TIMEOUT_MS),
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    const isTimeout =
+      (err as Error)?.name === "TimeoutError" ||
+      (err as Error)?.name === "AbortError" ||
+      /timeout/i.test(msg);
+    return {
+      ok: false,
+      code: isTimeout ? "HERMES_TIMEOUT" : "HERMES_UNREACHABLE",
+      detail: msg,
+    };
+  }
+  if (!resp.ok) {
+    return {
+      ok: false,
+      code: "HERMES_UNREACHABLE",
+      detail: `Hermes returned HTTP ${resp.status}`,
+    };
+  }
+  let json: unknown;
+  try {
+    json = await resp.json();
+  } catch {
+    return {
+      ok: false,
+      code: "HERMES_UNREACHABLE",
+      detail: "Hermes returned a non-JSON body",
+    };
+  }
+  return { ok: true, text: extractHermesText(json) };
+}
+
+// ── alfred_journal helpers ────────────────────────────────────────────────
+//
+// One row per direction. channel = "ha-conversation" (distinct from the
+// future "ha-voice" from #112), chat_id = "ha-<haInstallId>" — same shape
+// as the Hermes session key so the journal pivots cleanly.
+//
+// Per spec §3.5: source_kind splits inbound ("ha-conversation-turn") from
+// outbound ("ha-conversation-reply"); source_ref is "<haInstallId>/<convId>"
+// so the audit can group by either dimension.
+
+function journalIn(
+  haInstallId: string,
+  conversationId: string,
+  message: string,
+  metadata: Record<string, unknown>,
+): void {
+  try {
+    appendJournal(getStateDb(), {
+      channel: "ha-conversation",
+      chat_id: `ha-${haInstallId}`,
+      direction: "inbound",
+      message,
+      source_kind: "ha-conversation-turn",
+      source_ref: `${haInstallId}/${conversationId}`,
+      hermes_session_id: `ha-${haInstallId}`,
+      hermes_profile: "main",
+      status: "received",
+      metadata,
+    });
+  } catch (e) {
+    console.warn(
+      "[channels_ha] alfred_journal inbound append failed:",
+      e instanceof Error ? e.message : String(e),
+    );
+  }
+}
+
+function journalOut(
+  haInstallId: string,
+  conversationId: string,
+  message: string,
+  status: "delivered" | "failed",
+  metadata: Record<string, unknown>,
+  deliveryError: string | null = null,
+): void {
+  try {
+    appendJournal(getStateDb(), {
+      channel: "ha-conversation",
+      chat_id: `ha-${haInstallId}`,
+      direction: "outbound",
+      message,
+      source_kind: "ha-conversation-reply",
+      source_ref: `${haInstallId}/${conversationId}`,
+      hermes_session_id: `ha-${haInstallId}`,
+      hermes_profile: "main",
+      status,
+      delivery_error: deliveryError,
+      metadata,
+    });
+  } catch (e) {
+    console.warn(
+      "[channels_ha] alfred_journal outbound append failed:",
+      e instanceof Error ? e.message : String(e),
+    );
+  }
+}
+
+// ── Routes ────────────────────────────────────────────────────────────────
+
+export function registerHaChannelRoutes(): void {
+  // POST /turn — the HA-conversation inbound handler.
+  //
+  // Auth: `channelTokenBearer("ha-conversation")`. The scoped bearer for
+  // the HA install is the only thing that can call this — a leaked token
+  // cannot reach any other surface.
+  //
+  // Rate-limit: 30 turns/min per haInstanceId (in-memory sliding window).
+  // 403 RATE_LIMITED on exceed.
+  //
+  // Hermes: session key = `ha-<haInstallId>` (per spec §3.3 — per-install
+  // continuity, NOT per-conversation_id).
+  //
+  // Response shape: HA's standard `ConversationEntity` envelope so the
+  // custom component can hand it straight to its chat_log.
+  addRoute("POST", "/api/v1/channels/ha/turn", async ({ req, res, body }) => {
+    const started = Date.now();
+
+    // Auth FIRST — never touch the body until the bearer is valid. Throws
+    // AuthError → 401 if absent / revoked / mismatched-channel.
+    channelTokenBearer(req, "ha-conversation");
+
+    // Validate the body shape.
+    const parsed = parseTurnBody(body);
+
+    // Rate-limit per HA installation. Returns 403 with RATE_LIMITED on
+    // exceed — the custom component surfaces this as a HA error result
+    // ("Alfred is busy, try again in a moment" per spec §5.1).
+    if (!checkRateLimit(parsed.haInstallId)) {
+      throw new ApiError(
+        403,
+        "RATE_LIMITED",
+        `more than ${RATE_LIMIT_PER_MIN} turns/min for haInstallId=${parsed.haInstallId}`,
+      );
+    }
+
+    const sessionKey = `ha-${parsed.haInstallId}`;
+    const inboundMetadata: Record<string, unknown> = {
+      conversationId: parsed.conversationId,
+      language: parsed.language,
+      agentId: parsed.agentId,
+    };
+    if (parsed.deviceId) inboundMetadata.deviceId = parsed.deviceId;
+
+    journalIn(parsed.haInstallId, parsed.conversationId, parsed.text, inboundMetadata);
+
+    const hermesStarted = Date.now();
+    const result = await callHermes(sessionKey, parsed.text);
+    const hermesMs = Date.now() - hermesStarted;
+
+    if (!result.ok) {
+      const status = result.code === "HERMES_TIMEOUT" ? 504 : 502;
+      journalOut(
+        parsed.haInstallId,
+        parsed.conversationId,
+        "",
+        "failed",
+        { conversationId: parsed.conversationId, hermes_ms: hermesMs },
+        result.detail,
+      );
+      throw new ApiError(status, result.code, result.detail);
+    }
+
+    journalOut(
+      parsed.haInstallId,
+      parsed.conversationId,
+      result.text,
+      "delivered",
+      { conversationId: parsed.conversationId, hermes_ms: hermesMs },
+    );
+
+    // HA's `ConversationEntity` envelope. The custom component lifts
+    // `response.speech.plain.speech` for TTS. `conversation_id` echoes
+    // back so HA can correlate. `hermesSessionId` + `timing` are extras
+    // the custom component logs but ignores for user-facing rendering.
+    sendJson(res, 200, {
+      response: {
+        speech: {
+          plain: {
+            speech: result.text,
+          },
+        },
+      },
+      conversation_id: parsed.conversationId,
+      hermesSessionId: sessionKey,
+      timing: {
+        hermes_ms: hermesMs,
+        total_ms: Date.now() - started,
+      },
+    });
+  });
+}

--- a/packages/ctrl/src/api/server.ts
+++ b/packages/ctrl/src/api/server.ts
@@ -57,6 +57,8 @@ import { registerSmsRoutes } from "./routes/sms.js";
 import { registerVoiceRoutes } from "./routes/voice.js";
 import { registerOmiChannelRoutes } from "./routes/channels_omi.js";
 import { registerPaperclipChannelRoutes } from "./routes/channels_paperclip.js";
+import { registerHaChannelRoutes } from "./routes/channels_ha.js";
+import { registerChannelTokenRoutes } from "./routes/channel_tokens.js";
 import { registerComposioWebhookRoutes } from "./routes/composioWebhook.js";
 import { registerAlfredJournalRoutes } from "./routes/alfredJournal.js";
 import { registerAlfredDeliverRoutes } from "./routes/alfredDeliver.js";
@@ -175,6 +177,14 @@ export function createApiServer(): http.Server {
   registerVoiceRoutes();
   registerOmiChannelRoutes();
   registerPaperclipChannelRoutes();
+  // /api/v1/channels/ha/* — Home Assistant conversation agent (#111). PR1
+  // ships the non-streaming /turn route; #110 PR1 extends with discovery
+  // routes; PR3+ extends with tool partitioning + streaming.
+  registerHaChannelRoutes();
+  // /api/v1/channel-tokens/* — shared per-channel bearer-token surface
+  // (#111 PR1, Sir's decision Q2). HA-conversation tokens land here; HA
+  // Voice (#112) joins next; Paperclip migrates onto it later.
+  registerChannelTokenRoutes();
   registerComposioWebhookRoutes();
   // The one-Alfred continuity layer — alfred_journal + principal mapping
   // (the persistence + lookup surface) plus alfred-deliver (the unified
@@ -232,6 +242,12 @@ export function createApiServer(): http.Server {
         // <ts>.<raw-body>), not bearer-authed. Lane V's Caddy
         // @public_webhooks matcher passes /api/v1/channels/paperclip/* through.
         pathname === "/api/v1/channels/paperclip/heartbeat" ||
+        // Home Assistant conversation /turn — bearer-authed via the shared
+        // channel_tokens table (channel='ha-conversation'). The route
+        // calls channelTokenBearer() itself; the global master-key gate
+        // would otherwise 401 every HA install whose bearer is NOT the
+        // master AAS_API_KEY. Issue #111 PR1.
+        pathname === "/api/v1/channels/ha/turn" ||
         // Composio webhook is HMAC-validated against COMPOSIO_WEBHOOK_SECRET
         // (Standard-Webhooks scheme on `webhook-signature` / older shape on
         // `x-composio-signature`). Composio cannot send a Bearer header so

--- a/packages/ctrl/src/db/channelTokens.ts
+++ b/packages/ctrl/src/db/channelTokens.ts
@@ -1,0 +1,235 @@
+// channel_tokens DB helpers — the shared per-channel bearer-token surface.
+//
+// Split out from routes/channel_tokens.ts so the helpers can be unit-tested
+// in isolation (same posture as alfredJournal.ts). The route module imports
+// these helpers; the auth path imports `validateChannelToken` to swap a raw
+// bearer for the row.
+//
+// Schema lives in migrations/0003_channel_tokens.sql. These functions are
+// the documented contract for everything else — the route, the auth path,
+// the future Paperclip migration when its keys re-home onto this table.
+
+import crypto from "node:crypto";
+import type { DatabaseSync } from "node:sqlite";
+import { ulid } from "./ulid.js";
+
+export interface ChannelTokenRow {
+  id: string;
+  channel: string;
+  token_hash: string;
+  label: string | null;
+  scope_json: string | null;
+  created_at: number;
+  last_used_at: number | null;
+  last_used_ip: string | null;
+  rotated_from: string | null;
+  revoked_at: number | null;
+}
+
+/** Public-safe view of a token row — never includes `token_hash`. The raw
+ *  token plaintext is shown ONCE at mint and not stored anywhere. */
+export interface ChannelTokenMeta {
+  id: string;
+  channel: string;
+  label: string | null;
+  scope: Record<string, unknown> | null;
+  created_at: number;
+  last_used_at: number | null;
+  last_used_ip: string | null;
+  rotated_from: string | null;
+  revoked_at: number | null;
+}
+
+function rowToMeta(r: ChannelTokenRow): ChannelTokenMeta {
+  let scope: Record<string, unknown> | null = null;
+  if (r.scope_json) {
+    try {
+      const parsed = JSON.parse(r.scope_json);
+      scope = parsed && typeof parsed === "object" ? parsed : null;
+    } catch {
+      scope = null;
+    }
+  }
+  return {
+    id: r.id,
+    channel: r.channel,
+    label: r.label,
+    scope,
+    created_at: r.created_at,
+    last_used_at: r.last_used_at,
+    last_used_ip: r.last_used_ip,
+    rotated_from: r.rotated_from,
+    revoked_at: r.revoked_at,
+  };
+}
+
+/** sha256(raw) → lowercase hex. The only one-way function between a raw
+ *  token and the row that authorises it. */
+export function hashToken(raw: string): string {
+  return crypto.createHash("sha256").update(raw).digest("hex");
+}
+
+/** Token shapes per channel. Each channel picks its own prefix so a leaked
+ *  token is recognisable at-a-glance in logs (`ha_…` is HA, `pcp_…` is
+ *  Paperclip, etc.). 24 random bytes → 48 hex chars → 192 bits of entropy. */
+function generateRawToken(channel: string): string {
+  const prefix = channel === "ha-conversation" || channel === "ha-voice"
+    ? "ha_"
+    : channel === "paperclip-heartbeat"
+      ? "pcp_"
+      : "ct_"; // generic fall-back for unknown channels
+  const random = crypto.randomBytes(24).toString("hex");
+  return `${prefix}${random}`;
+}
+
+export interface MintResult {
+  /** The raw token — shown to the caller ONCE and never retrievable again. */
+  raw: string;
+  /** The persisted row, sans token_hash, in public-safe shape. */
+  meta: ChannelTokenMeta;
+}
+
+/** Mint a new token for `channel`. Optional `label` and `scope` are
+ *  channel-specific metadata that ride along on the row. The raw token is
+ *  returned to the caller exactly once; from this point on only the
+ *  sha256 hash exists in the DB. */
+export function mintChannelToken(
+  db: DatabaseSync,
+  fields: {
+    channel: string;
+    label?: string | null;
+    scope?: Record<string, unknown> | null;
+    rotated_from?: string | null;
+  },
+): MintResult {
+  const id = ulid();
+  const raw = generateRawToken(fields.channel);
+  const token_hash = hashToken(raw);
+  const created_at = Date.now();
+  const scope_json = fields.scope ? JSON.stringify(fields.scope) : null;
+  const label = fields.label ?? null;
+  const rotated_from = fields.rotated_from ?? null;
+
+  db.prepare(
+    `INSERT INTO channel_tokens
+       (id, channel, token_hash, label, scope_json,
+        created_at, last_used_at, last_used_ip,
+        rotated_from, revoked_at)
+     VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, ?, NULL)`,
+  ).run(id, fields.channel, token_hash, label, scope_json, created_at, rotated_from);
+
+  const row = db
+    .prepare("SELECT * FROM channel_tokens WHERE id = ?")
+    .get(id) as ChannelTokenRow;
+  return { raw, meta: rowToMeta(row) };
+}
+
+/** List active (non-revoked) tokens for a channel, newest first. Public-safe
+ *  view — never includes token_hash. */
+export function listChannelTokens(
+  db: DatabaseSync,
+  channel: string,
+  opts: { includeRevoked?: boolean } = {},
+): ChannelTokenMeta[] {
+  const sql = opts.includeRevoked
+    ? `SELECT * FROM channel_tokens
+         WHERE channel = ?
+         ORDER BY created_at DESC, id DESC`
+    : `SELECT * FROM channel_tokens
+         WHERE channel = ? AND revoked_at IS NULL
+         ORDER BY created_at DESC, id DESC`;
+  const rows = db.prepare(sql).all(channel) as ChannelTokenRow[];
+  return rows.map(rowToMeta);
+}
+
+/** Get one token row by id. Returns the public-safe view. */
+export function getChannelTokenMeta(
+  db: DatabaseSync,
+  id: string,
+): ChannelTokenMeta | null {
+  const row = db
+    .prepare("SELECT * FROM channel_tokens WHERE id = ?")
+    .get(id) as ChannelTokenRow | undefined;
+  return row ? rowToMeta(row) : null;
+}
+
+/** Revoke a token by id. Idempotent: revoking a revoked token is a no-op
+ *  but reports back the row. Returns null if no such id. */
+export function revokeChannelToken(
+  db: DatabaseSync,
+  id: string,
+): ChannelTokenMeta | null {
+  const existing = db
+    .prepare("SELECT * FROM channel_tokens WHERE id = ?")
+    .get(id) as ChannelTokenRow | undefined;
+  if (!existing) return null;
+  if (existing.revoked_at === null) {
+    db.prepare(
+      "UPDATE channel_tokens SET revoked_at = ? WHERE id = ?",
+    ).run(Date.now(), id);
+  }
+  const row = db
+    .prepare("SELECT * FROM channel_tokens WHERE id = ?")
+    .get(id) as ChannelTokenRow;
+  return rowToMeta(row);
+}
+
+/** Authentication path: swap a raw bearer for the row that authorises it
+ *  on the given channel. On match, side-effect: bump `last_used_at` and
+ *  `last_used_ip`. Returns null on no match / revoked. */
+export function validateChannelToken(
+  db: DatabaseSync,
+  channel: string,
+  rawToken: string,
+  opts: { ip?: string | null } = {},
+): ChannelTokenMeta | null {
+  if (!rawToken) return null;
+  const token_hash = hashToken(rawToken);
+  const row = db
+    .prepare(
+      `SELECT * FROM channel_tokens
+         WHERE channel = ? AND token_hash = ? AND revoked_at IS NULL
+         LIMIT 1`,
+    )
+    .get(channel, token_hash) as ChannelTokenRow | undefined;
+  if (!row) return null;
+
+  db.prepare(
+    "UPDATE channel_tokens SET last_used_at = ?, last_used_ip = ? WHERE id = ?",
+  ).run(Date.now(), opts.ip ?? null, row.id);
+
+  const fresh = db
+    .prepare("SELECT * FROM channel_tokens WHERE id = ?")
+    .get(row.id) as ChannelTokenRow;
+  return rowToMeta(fresh);
+}
+
+/** Rotate a token: mint a new one in the same channel that points at the
+ *  old via `rotated_from`. Does NOT revoke the old token automatically —
+ *  the caller decides when to revoke (typically after the new token is
+ *  installed on the consuming side). Returns { raw, meta } for the new
+ *  token. */
+export function rotateChannelToken(
+  db: DatabaseSync,
+  oldId: string,
+): MintResult | null {
+  const old = db
+    .prepare("SELECT * FROM channel_tokens WHERE id = ?")
+    .get(oldId) as ChannelTokenRow | undefined;
+  if (!old) return null;
+  let scope: Record<string, unknown> | null = null;
+  if (old.scope_json) {
+    try {
+      const parsed = JSON.parse(old.scope_json);
+      scope = parsed && typeof parsed === "object" ? parsed : null;
+    } catch {
+      scope = null;
+    }
+  }
+  return mintChannelToken(db, {
+    channel: old.channel,
+    label: old.label,
+    scope,
+    rotated_from: oldId,
+  });
+}

--- a/packages/ctrl/src/db/migrate.ts
+++ b/packages/ctrl/src/db/migrate.ts
@@ -17,6 +17,7 @@ import type { DatabaseSync } from "node:sqlite";
 import m0001 from "./migrations/0001_fix_pack.sql";
 import m0002 from "./migrations/0002_alfred_journal.sql";
 import m0003 from "./migrations/0003_tailscale_connection.sql";
+import m0004 from "./migrations/0004_channel_tokens.sql";
 import m0006 from "./migrations/0006_files_table.sql";
 
 interface Migration {
@@ -30,6 +31,7 @@ const MIGRATIONS: Migration[] = [
   { version: 1, name: "fix_pack",             sql: m0001 },
   { version: 2, name: "alfred_journal",       sql: m0002 },
   { version: 3, name: "tailscale_connection", sql: m0003 },
+  { version: 4, name: "channel_tokens",       sql: m0004 },
   { version: 6, name: "files_table",          sql: m0006 },
 ];
 

--- a/packages/ctrl/src/db/migrations/0004_channel_tokens.sql
+++ b/packages/ctrl/src/db/migrations/0004_channel_tokens.sql
@@ -1,0 +1,68 @@
+-- 0003_channel_tokens — the shared per-channel bearer-token surface.
+--
+-- Background. ctrl-api accepts inbound traffic from a growing set of external
+-- channels: Paperclip (`pcp_*` board/agent keys + bootstrap), Home Assistant
+-- conversation agent (issue #111, this migration), HA Voice (issue #112, later),
+-- and a queue of future channels (Matter / HomeKit / arbitrary household
+-- automations). Each new channel has historically invented its own auth
+-- shape — Paperclip's per-Hermes-profile `PAPERCLIP_API_KEY`, voice-bridge's
+-- `VOICE_BRIDGE_INTERNAL_TOKEN`, the master `AAS_API_KEY` for everything
+-- else. The result is a fragmented rotation story and no audit pivot.
+--
+-- Sir's call (issue #111, decision Q2): one shared `channel_tokens` table.
+-- Each row is one bearer token, keyed by `channel` so per-channel rotation +
+-- listing + revoke is uniform. `token_hash` is `sha256(raw)`; the raw token
+-- is shown once at mint and never stored. `scope_json` carries
+-- channel-specific scope (e.g. HA installation id) so the auth path doesn't
+-- need a parallel sidecar table for trivial scope data.
+--
+-- HA (the immediate user) writes one row per install with
+-- `channel='ha-conversation'`, label='ha:<haInstanceId>', and the install
+-- uuid in `scope_json.haInstanceId`. The validator path looks up by
+-- `(channel, token_hash)` — a leaked HA token cannot reach the master surface
+-- and cannot impersonate a Paperclip key because the channel discriminator
+-- pins it.
+--
+-- Paperclip migration is OPTIONAL and follows in a separate housekeeping
+-- pass. The existing Paperclip auth (per-Hermes-profile `PAPERCLIP_API_KEY`
+-- + bootstrap-issued board/agent keys) keeps working as-is; nothing in this
+-- migration touches Paperclip's surface. When Paperclip's next iteration
+-- lands, its key writes pick up `channel='paperclip-heartbeat'` rows here
+-- for one rotation+audit story.
+--
+-- Constraints / discipline:
+--   * `token_hash` is sha256-of-raw — never reversible. Plaintext shown
+--     once at mint.
+--   * The hot lookup index `(token_hash) WHERE revoked_at IS NULL` covers
+--     auth on every request. Uniqueness is enforced at mint time by
+--     generating fresh random bytes (collision probability is 1 in 2^192
+--     per 24-byte token).
+--   * Indexes are partial (`WHERE revoked_at IS NULL`) so the hot lookup
+--     path skips tombstones — a revoked token is just history.
+
+CREATE TABLE IF NOT EXISTS channel_tokens (
+  id              TEXT PRIMARY KEY,    -- ULID
+  channel         TEXT NOT NULL,       -- 'ha-conversation' | 'ha-voice' |
+                                       -- 'paperclip-heartbeat' | …
+  token_hash      TEXT NOT NULL,       -- sha256(raw token), hex-lowercase
+  label           TEXT,                -- human-friendly label, optional
+  scope_json      TEXT,                -- JSON: channel-specific scope
+                                       -- (e.g. {"haInstanceId":"<uuid>"})
+  created_at      INTEGER NOT NULL,    -- unix ms
+  last_used_at    INTEGER,             -- unix ms; null until first use
+  last_used_ip    TEXT,                -- best-effort source ip
+  rotated_from    TEXT,                -- prev token id when this row is
+                                       -- a rotation (FK soft — old row may
+                                       -- have been pruned in long-tail cleanup)
+  revoked_at      INTEGER              -- unix ms; null when active
+);
+
+-- Hot path 1: list active tokens for a channel ("show me my HA tokens").
+CREATE INDEX IF NOT EXISTS idx_channel_tokens_channel
+  ON channel_tokens(channel) WHERE revoked_at IS NULL;
+
+-- Hot path 2: auth lookup by token_hash on every authenticated request.
+-- The validator queries with (token_hash, channel) so a leaked hash cannot
+-- be replayed against a different channel's allowlist.
+CREATE INDEX IF NOT EXISTS idx_channel_tokens_hash
+  ON channel_tokens(token_hash) WHERE revoked_at IS NULL;

--- a/packages/ctrl/tests/alfred-journal.test.ts
+++ b/packages/ctrl/tests/alfred-journal.test.ts
@@ -52,8 +52,9 @@ function tableNames(db: DatabaseSync): string[] {
 describe("alfred_journal migration", () => {
   it("bumps user_version to the latest migration", () => {
     // 0002 alone took us to 2; 0003 (tailscale_connection — issue #109 PR 1)
-    // takes us to 3. The runner applies every migration > current version,
-    // so the value naturally tracks the highest registered version.
+    // takes us to 3; 0004 (channel_tokens — issue #111 PR 1) takes us to 4.
+    // The runner applies every migration > current version, so the value
+    // naturally tracks the highest registered version.
     const db = makeDb();
     assert.equal(userVersion(db), 6);
     db.close();

--- a/packages/ctrl/tests/channel_tokens.test.ts
+++ b/packages/ctrl/tests/channel_tokens.test.ts
@@ -1,0 +1,333 @@
+// channel_tokens — the shared per-channel bearer-token surface (#111 PR1).
+//
+// What's under test
+// -----------------
+// The DB helpers (mintChannelToken / listChannelTokens / revokeChannelToken /
+// rotateChannelToken / validateChannelToken) and the four HTTP routes
+// (POST /channel-tokens/mint, GET /channel-tokens, POST /:id/revoke,
+//  POST /:id/rotate). The auth side (channelTokenBearer) is exercised in
+// channels_ha.test.ts; here we focus on the table contract.
+//
+// Coverage:
+//   1. Migration creates channel_tokens at user_version=3.
+//   2. mintChannelToken: returns the raw token ONCE; persists sha256(raw).
+//   3. mintChannelToken: subsequent mint on same channel returns a different
+//      raw token (entropy + fresh ULID).
+//   4. mintChannelToken: HA channel prefixes raw with `ha_`.
+//   5. listChannelTokens: returns the public-safe view (no raw, no hash).
+//   6. revokeChannelToken: sets revoked_at; subsequent validateChannelToken
+//      returns null on the revoked token.
+//   7. validateChannelToken: bumps last_used_at + last_used_ip.
+//   8. validateChannelToken: cross-channel use of a valid token is rejected.
+//   9. rotateChannelToken: mints a new token; rotated_from points at the
+//      old; old token still validates until separately revoked.
+//  10. Route POST /mint validates channel against KNOWN_CHANNELS.
+//  11. Route GET /channel-tokens?channel=… requires the channel query.
+//  12. Route POST /:id/revoke is idempotent.
+//  13. Route POST /:id/rotate echoes the rotated_from.
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ServerResponse } from "node:http";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "channel-tokens-"));
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.STATE_DB_PATH = path.join(tmp, "alfred-state.db");
+process.env.VAULT_PATH = path.join(tmp, "vault");
+process.env.SQLITE_VEC_PATH = "";
+
+const { getStateDb } = await import("../src/db/state.js");
+const {
+  mintChannelToken,
+  listChannelTokens,
+  revokeChannelToken,
+  rotateChannelToken,
+  validateChannelToken,
+  hashToken,
+} = await import("../src/db/channelTokens.js");
+const { matchRoute } = await import("../src/api/server.js");
+const { handleError } = await import("../src/api/errors.js");
+const { registerChannelTokenRoutes } = await import(
+  "../src/api/routes/channel_tokens.js"
+);
+registerChannelTokenRoutes();
+
+async function invokeRoute(
+  method: string,
+  p: string,
+  opts: { body?: unknown; query?: string; params?: Record<string, string> } = {},
+): Promise<{ status: number; payload: any }> {
+  const m = matchRoute(method, p);
+  assert.ok(m, `${method} ${p} must be registered`);
+  let status = 0;
+  let payload: any;
+  const res = {
+    setHeader() {},
+    writeHead(c: number) {
+      status = c;
+      return res;
+    },
+    end(j?: string) {
+      payload = j ? JSON.parse(j) : undefined;
+    },
+  } as unknown as ServerResponse;
+  try {
+    await m!.handler({
+      req: { method, url: p, headers: {} } as any,
+      res,
+      params: opts.params ?? m!.params,
+      body: opts.body,
+      query: new URLSearchParams(opts.query ?? ""),
+    });
+  } catch (err) {
+    handleError(res, err);
+  }
+  return { status, payload };
+}
+
+function userVersion(): number {
+  return (
+    getStateDb().prepare("PRAGMA user_version").get() as {
+      user_version: number;
+    }
+  ).user_version;
+}
+
+function clearChannelTokens(): void {
+  getStateDb().exec("DELETE FROM channel_tokens");
+}
+
+describe("channel_tokens — DB helpers (#111 PR1)", () => {
+  beforeEach(() => {
+    clearChannelTokens();
+  });
+
+  it("migration creates the channel_tokens table at user_version >= 3", () => {
+    assert.ok(userVersion() >= 3, "user_version must be at least 3");
+    const tables = (
+      getStateDb()
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name='channel_tokens'",
+        )
+        .all() as { name: string }[]
+    ).map((r) => r.name);
+    assert.deepEqual(tables, ["channel_tokens"]);
+  });
+
+  it("mintChannelToken returns the raw token; persists sha256(raw)", () => {
+    const { raw, meta } = mintChannelToken(getStateDb(), {
+      channel: "ha-conversation",
+      label: "ha:test-uuid-1",
+      scope: { haInstanceId: "test-uuid-1" },
+    });
+    assert.ok(raw.startsWith("ha_"), "HA channel raw token must use ha_ prefix");
+    assert.equal(raw.length, 3 + 48, "raw token = prefix + 48 hex chars");
+    assert.equal(meta.channel, "ha-conversation");
+    assert.equal(meta.label, "ha:test-uuid-1");
+    assert.deepEqual(meta.scope, { haInstanceId: "test-uuid-1" });
+    assert.equal(meta.revoked_at, null);
+    // The row in the DB must carry sha256(raw), not raw itself.
+    const stored = getStateDb()
+      .prepare("SELECT token_hash FROM channel_tokens WHERE id = ?")
+      .get(meta.id) as { token_hash: string } | undefined;
+    assert.ok(stored, "row exists");
+    assert.equal(stored!.token_hash, hashToken(raw));
+    // Raw must NOT appear in the DB at all.
+    const stillRaw = getStateDb()
+      .prepare("SELECT COUNT(*) AS n FROM channel_tokens WHERE token_hash = ?")
+      .get(raw) as { n: number };
+    assert.equal(stillRaw.n, 0, "raw token must not appear as any token_hash");
+  });
+
+  it("subsequent mint on same channel returns a different raw token", () => {
+    const a = mintChannelToken(getStateDb(), { channel: "ha-conversation" });
+    const b = mintChannelToken(getStateDb(), { channel: "ha-conversation" });
+    assert.notEqual(a.raw, b.raw, "two mints must differ");
+    assert.notEqual(a.meta.id, b.meta.id, "two mints must have different ULIDs");
+  });
+
+  it("listChannelTokens returns the public-safe view (no raw, no hash)", () => {
+    mintChannelToken(getStateDb(), { channel: "ha-conversation" });
+    mintChannelToken(getStateDb(), { channel: "ha-conversation" });
+    mintChannelToken(getStateDb(), { channel: "ha-voice" });
+    const haTokens = listChannelTokens(getStateDb(), "ha-conversation");
+    assert.equal(haTokens.length, 2, "two ha-conversation tokens");
+    for (const t of haTokens) {
+      assert.equal(
+        (t as Record<string, unknown>).token_hash,
+        undefined,
+        "token_hash never appears on the public view",
+      );
+      assert.equal(t.channel, "ha-conversation");
+    }
+    const haVoice = listChannelTokens(getStateDb(), "ha-voice");
+    assert.equal(haVoice.length, 1, "ha-voice scoping works");
+  });
+
+  it("revokeChannelToken sets revoked_at; validateChannelToken rejects after", () => {
+    const { raw, meta } = mintChannelToken(getStateDb(), {
+      channel: "ha-conversation",
+    });
+    const before = validateChannelToken(getStateDb(), "ha-conversation", raw);
+    assert.ok(before, "active token validates before revoke");
+    const revoked = revokeChannelToken(getStateDb(), meta.id);
+    assert.ok(revoked && revoked.revoked_at, "revoked_at populated");
+    const after = validateChannelToken(getStateDb(), "ha-conversation", raw);
+    assert.equal(after, null, "revoked token no longer validates");
+    // List with includeRevoked sees the tombstone.
+    const withRevoked = listChannelTokens(getStateDb(), "ha-conversation", {
+      includeRevoked: true,
+    });
+    assert.ok(
+      withRevoked.find((t) => t.id === meta.id && t.revoked_at),
+      "revoked row is visible with includeRevoked=true",
+    );
+    // Active list excludes it.
+    const active = listChannelTokens(getStateDb(), "ha-conversation");
+    assert.equal(active.length, 0);
+  });
+
+  it("validateChannelToken bumps last_used_at + last_used_ip", () => {
+    const { raw, meta } = mintChannelToken(getStateDb(), {
+      channel: "ha-conversation",
+    });
+    assert.equal(meta.last_used_at, null);
+    const v = validateChannelToken(getStateDb(), "ha-conversation", raw, {
+      ip: "10.0.0.7",
+    });
+    assert.ok(v, "validates");
+    assert.ok(v!.last_used_at, "last_used_at bumped");
+    assert.equal(v!.last_used_ip, "10.0.0.7");
+  });
+
+  it("validateChannelToken refuses cross-channel use of a valid token", () => {
+    const { raw } = mintChannelToken(getStateDb(), {
+      channel: "ha-conversation",
+    });
+    // Same raw token, wrong channel name -> null.
+    const v = validateChannelToken(getStateDb(), "ha-voice", raw);
+    assert.equal(v, null);
+  });
+
+  it("rotateChannelToken: new token points at old via rotated_from", () => {
+    const { raw: oldRaw, meta: oldMeta } = mintChannelToken(getStateDb(), {
+      channel: "ha-conversation",
+      label: "ha:abc",
+      scope: { haInstanceId: "abc" },
+    });
+    const next = rotateChannelToken(getStateDb(), oldMeta.id);
+    assert.ok(next, "rotation succeeds");
+    assert.notEqual(next!.raw, oldRaw);
+    assert.equal(next!.meta.rotated_from, oldMeta.id);
+    assert.equal(next!.meta.label, "ha:abc", "label is carried forward");
+    assert.deepEqual(
+      next!.meta.scope,
+      { haInstanceId: "abc" },
+      "scope is carried forward",
+    );
+    // Old token still validates until separately revoked — the caller
+    // decides when to flip the switch.
+    const stillValid = validateChannelToken(
+      getStateDb(),
+      "ha-conversation",
+      oldRaw,
+    );
+    assert.ok(stillValid, "old raw still valid pre-revoke");
+  });
+});
+
+describe("channel_tokens — HTTP routes (#111 PR1)", () => {
+  beforeEach(() => {
+    clearChannelTokens();
+  });
+
+  it("POST /mint validates channel against KNOWN_CHANNELS", async () => {
+    const bad = await invokeRoute("POST", "/api/v1/channel-tokens/mint", {
+      body: { channel: "bogus" },
+    });
+    assert.equal(bad.status, 400);
+    assert.equal(bad.payload.error.code, "VALIDATION_ERROR");
+  });
+
+  it("POST /mint returns the raw token in the response, exactly once", async () => {
+    const r = await invokeRoute("POST", "/api/v1/channel-tokens/mint", {
+      body: {
+        channel: "ha-conversation",
+        label: "ha:home-uuid",
+        scope: { haInstanceId: "home-uuid" },
+      },
+    });
+    assert.equal(r.status, 201);
+    assert.ok(
+      r.payload.token.startsWith("ha_"),
+      "HA channel mint returns ha_-prefixed raw",
+    );
+    assert.equal(r.payload.meta.channel, "ha-conversation");
+    assert.equal(r.payload.meta.label, "ha:home-uuid");
+    // Listing must NOT echo the raw back.
+    const list = await invokeRoute("GET", "/api/v1/channel-tokens", {
+      query: "channel=ha-conversation",
+    });
+    assert.equal(list.status, 200);
+    assert.equal(list.payload.tokens.length, 1);
+    assert.equal(
+      list.payload.tokens[0].token,
+      undefined,
+      "list response never carries raw token",
+    );
+    assert.equal(
+      list.payload.tokens[0].token_hash,
+      undefined,
+      "list response never carries token_hash",
+    );
+  });
+
+  it("GET /channel-tokens requires channel=…", async () => {
+    const r = await invokeRoute("GET", "/api/v1/channel-tokens");
+    assert.equal(r.status, 400);
+    assert.equal(r.payload.error.code, "VALIDATION_ERROR");
+  });
+
+  it("POST /:id/revoke is idempotent", async () => {
+    const mint = await invokeRoute("POST", "/api/v1/channel-tokens/mint", {
+      body: { channel: "ha-conversation" },
+    });
+    const id = mint.payload.meta.id;
+    const first = await invokeRoute(
+      "POST",
+      "/api/v1/channel-tokens/:id/revoke",
+      { params: { id } },
+    );
+    assert.equal(first.status, 200);
+    assert.ok(first.payload.meta.revoked_at);
+    const firstRevokedAt = first.payload.meta.revoked_at;
+    // Second revoke: still 200, same revoked_at (idempotent).
+    const second = await invokeRoute(
+      "POST",
+      "/api/v1/channel-tokens/:id/revoke",
+      { params: { id } },
+    );
+    assert.equal(second.status, 200);
+    assert.equal(second.payload.meta.revoked_at, firstRevokedAt);
+  });
+
+  it("POST /:id/rotate returns the new raw token + rotated_from", async () => {
+    const mint = await invokeRoute("POST", "/api/v1/channel-tokens/mint", {
+      body: { channel: "ha-conversation" },
+    });
+    const oldId = mint.payload.meta.id;
+    const rot = await invokeRoute(
+      "POST",
+      "/api/v1/channel-tokens/:id/rotate",
+      { params: { id: oldId } },
+    );
+    assert.equal(rot.status, 201);
+    assert.ok(rot.payload.token.startsWith("ha_"));
+    assert.equal(rot.payload.rotated_from, oldId);
+    assert.equal(rot.payload.meta.rotated_from, oldId);
+    assert.notEqual(rot.payload.meta.id, oldId);
+  });
+});

--- a/packages/ctrl/tests/channels_ha_turn.test.ts
+++ b/packages/ctrl/tests/channels_ha_turn.test.ts
@@ -1,0 +1,316 @@
+// channels_ha — POST /api/v1/channels/ha/turn (#111 PR1).
+//
+// What's under test
+// -----------------
+// The Home Assistant conversation-agent inbound handler:
+//   * channelTokenBearer auth against channel='ha-conversation';
+//   * body shape validation;
+//   * Hermes /v1/responses round-trip with session key ha-<haInstallId>;
+//   * the HA response envelope ({response.speech.plain.speech, conversation_id});
+//   * alfred_journal inbound + outbound rows;
+//   * the 30/min sliding rate-limit per haInstallId.
+//
+// PR3+ will extend with tool partitioning; PR4+ with curated catalog; PR5+
+// with the voice-context primer. None of those land in PR1, so they are
+// NOT covered here.
+//
+// Coverage:
+//   1. Missing bearer → 401.
+//   2. Wrong-channel token → 401 (cross-channel impersonation refused).
+//   3. Valid token + valid body → 200 + HA envelope.
+//   4. journalIn + journalOut rows written (channel='ha-conversation').
+//   5. Hermes session key is `ha-<haInstallId>`.
+//   6. Hermes upstream failure → 502.
+//   7. Hermes timeout → 504.
+//   8. 30 turns inside the window → 30 succeed, the 31st is 403 RATE_LIMITED.
+//   9. Body validation: missing text, missing haInstallId, etc.
+
+import { describe, it, beforeEach, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ServerResponse } from "node:http";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "channels-ha-"));
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.STATE_DB_PATH = path.join(tmp, "alfred-state.db");
+process.env.VAULT_PATH = path.join(tmp, "vault");
+process.env.SQLITE_VEC_PATH = "";
+process.env.HERMES_GATEWAY_URL = "http://hermes-stub:18789";
+
+const hermesProfilesDir = path.join(tmp, "hermes-profiles");
+fs.mkdirSync(path.join(hermesProfilesDir, "main"), { recursive: true });
+fs.writeFileSync(
+  path.join(hermesProfilesDir, "main", ".env"),
+  "API_SERVER_KEY=test-hermes-key\n",
+);
+process.env.HERMES_CONFIG_DIR = hermesProfilesDir;
+
+// ── fetch mock ─────────────────────────────────────────────────────────────
+
+const originalFetch = globalThis.fetch;
+
+let hermesOk = true;
+let hermesText = "Good morning, Sir.";
+let hermesStatus = 200;
+let hermesShouldThrow = false;
+let hermesShouldTimeout = false;
+const hermesCalls: {
+  url: string;
+  sessionKey: string;
+  input: string;
+}[] = [];
+
+function makeJsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+globalThis.fetch = (async (input: any, init?: any) => {
+  const url = typeof input === "string" ? input : (input?.url ?? String(input));
+  if (url.endsWith("/v1/responses")) {
+    if (hermesShouldThrow) throw new Error("fetch failed: ECONNREFUSED");
+    if (hermesShouldTimeout) {
+      const err: any = new Error("The operation was aborted due to timeout");
+      err.name = "TimeoutError";
+      throw err;
+    }
+    const headers = init?.headers ?? {};
+    const sessionKey = headers["X-Hermes-Session-Key"] ?? "";
+    const bodyJson = JSON.parse(String(init?.body ?? "{}"));
+    hermesCalls.push({ url, sessionKey, input: bodyJson.input ?? "" });
+    if (!hermesOk) {
+      return makeJsonResponse({ error: { message: "boom" } }, hermesStatus);
+    }
+    return makeJsonResponse(
+      {
+        output: [
+          {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: hermesText }],
+          },
+        ],
+      },
+      200,
+    );
+  }
+  throw new Error(`unexpected fetch in channels_ha test: ${url}`);
+}) as typeof fetch;
+
+// ── module imports (after env + fetch are set) ─────────────────────────────
+
+const { matchRoute } = await import("../src/api/server.js");
+const { handleError } = await import("../src/api/errors.js");
+const { registerHaChannelRoutes, _resetHaRateLimitForTests } = await import(
+  "../src/api/routes/channels_ha.js"
+);
+const { getStateDb } = await import("../src/db/state.js");
+const { mintChannelToken } = await import("../src/db/channelTokens.js");
+registerHaChannelRoutes();
+
+async function invokeTurn(
+  body: unknown,
+  authToken: string | null,
+): Promise<{ status: number; payload: any }> {
+  const m = matchRoute("POST", "/api/v1/channels/ha/turn");
+  assert.ok(m, "POST /api/v1/channels/ha/turn must be registered");
+  let status = 0;
+  let payload: any;
+  const res = {
+    setHeader() {},
+    writeHead(c: number) {
+      status = c;
+      return res;
+    },
+    end(j?: string) {
+      payload = j ? JSON.parse(j) : undefined;
+    },
+  } as unknown as ServerResponse;
+  const headers: Record<string, string> = {};
+  if (authToken !== null) headers.authorization = `Bearer ${authToken}`;
+  try {
+    await m!.handler({
+      req: {
+        method: "POST",
+        url: "/api/v1/channels/ha/turn",
+        headers,
+        socket: { remoteAddress: "10.0.0.99" },
+      } as any,
+      res,
+      params: m!.params,
+      body,
+      query: new URLSearchParams(),
+    });
+  } catch (err) {
+    handleError(res, err);
+  }
+  return { status, payload };
+}
+
+function validBody(over: Partial<Record<string, unknown>> = {}): any {
+  return {
+    text: "What's on my brief?",
+    conversationId: "01HXXXXCONV1",
+    language: "en",
+    agentId: "conversation.alfred_conversation",
+    haInstallId: "home-install-uuid-1",
+    ...over,
+  };
+}
+
+function mintHaToken(): string {
+  return mintChannelToken(getStateDb(), {
+    channel: "ha-conversation",
+    label: "ha:home-install-uuid-1",
+    scope: { haInstanceId: "home-install-uuid-1" },
+  }).raw;
+}
+
+function clearAll(): void {
+  hermesOk = true;
+  hermesText = "Good morning, Sir.";
+  hermesStatus = 200;
+  hermesShouldThrow = false;
+  hermesShouldTimeout = false;
+  hermesCalls.length = 0;
+  _resetHaRateLimitForTests();
+  getStateDb().exec("DELETE FROM channel_tokens");
+  getStateDb().exec("DELETE FROM alfred_journal");
+}
+
+describe("POST /api/v1/channels/ha/turn — #111 PR1", () => {
+  beforeEach(() => {
+    clearAll();
+  });
+
+  after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("rejects a request without a bearer (401)", async () => {
+    const r = await invokeTurn(validBody(), null);
+    assert.equal(r.status, 401);
+  });
+
+  it("rejects an unknown bearer (401)", async () => {
+    const r = await invokeTurn(validBody(), "ha_ffffffffffffffff");
+    assert.equal(r.status, 401);
+  });
+
+  it("rejects a bearer minted for a different channel (cross-channel)", async () => {
+    // Mint for ha-voice and try to use on the ha-conversation route.
+    const tok = mintChannelToken(getStateDb(), {
+      channel: "ha-voice",
+    }).raw;
+    const r = await invokeTurn(validBody(), tok);
+    assert.equal(r.status, 401);
+  });
+
+  it("rejects a revoked token", async () => {
+    const tok = mintHaToken();
+    // Find the row by hashing and revoking. (Simpler: list + revoke via
+    // helper.) We use the helper.
+    const { hashToken: hash } = await import("../src/db/channelTokens.js");
+    const hashed = hash(tok);
+    getStateDb()
+      .prepare("UPDATE channel_tokens SET revoked_at = ? WHERE token_hash = ?")
+      .run(Date.now(), hashed);
+    const r = await invokeTurn(validBody(), tok);
+    assert.equal(r.status, 401);
+  });
+
+  it("returns HA's envelope on success", async () => {
+    const tok = mintHaToken();
+    hermesText = "Your brief is ready, Sir.";
+    const r = await invokeTurn(validBody(), tok);
+    assert.equal(r.status, 200);
+    assert.equal(
+      r.payload.response.speech.plain.speech,
+      "Your brief is ready, Sir.",
+    );
+    assert.equal(r.payload.conversation_id, "01HXXXXCONV1");
+    assert.equal(r.payload.hermesSessionId, "ha-home-install-uuid-1");
+    assert.ok(typeof r.payload.timing.hermes_ms === "number");
+    assert.ok(typeof r.payload.timing.total_ms === "number");
+  });
+
+  it("calls Hermes with X-Hermes-Session-Key=ha-<haInstallId>", async () => {
+    const tok = mintHaToken();
+    await invokeTurn(validBody(), tok);
+    assert.equal(hermesCalls.length, 1);
+    assert.equal(hermesCalls[0].sessionKey, "ha-home-install-uuid-1");
+    assert.equal(hermesCalls[0].input, "What's on my brief?");
+  });
+
+  it("writes inbound + outbound alfred_journal rows", async () => {
+    const tok = mintHaToken();
+    await invokeTurn(validBody(), tok);
+    const rows = getStateDb()
+      .prepare(
+        "SELECT direction, channel, chat_id, message, source_kind FROM alfred_journal ORDER BY ts ASC",
+      )
+      .all() as {
+      direction: string;
+      channel: string;
+      chat_id: string;
+      message: string;
+      source_kind: string;
+    }[];
+    assert.equal(rows.length, 2, "one inbound + one outbound");
+    assert.equal(rows[0].direction, "inbound");
+    assert.equal(rows[0].channel, "ha-conversation");
+    assert.equal(rows[0].chat_id, "ha-home-install-uuid-1");
+    assert.equal(rows[0].source_kind, "ha-conversation-turn");
+    assert.equal(rows[1].direction, "outbound");
+    assert.equal(rows[1].source_kind, "ha-conversation-reply");
+  });
+
+  it("returns 502 when Hermes is unreachable", async () => {
+    const tok = mintHaToken();
+    hermesShouldThrow = true;
+    const r = await invokeTurn(validBody(), tok);
+    assert.equal(r.status, 502);
+    assert.equal(r.payload.error.code, "HERMES_UNREACHABLE");
+  });
+
+  it("returns 504 when Hermes times out", async () => {
+    const tok = mintHaToken();
+    hermesShouldTimeout = true;
+    const r = await invokeTurn(validBody(), tok);
+    assert.equal(r.status, 504);
+    assert.equal(r.payload.error.code, "HERMES_TIMEOUT");
+  });
+
+  it("rate-limit: 30 turns OK, 31st returns 403 RATE_LIMITED", async () => {
+    const tok = mintHaToken();
+    for (let i = 0; i < 30; i++) {
+      const r = await invokeTurn(validBody(), tok);
+      assert.equal(r.status, 200, `turn ${i + 1} should be 200`);
+    }
+    const over = await invokeTurn(validBody(), tok);
+    assert.equal(over.status, 403);
+    assert.equal(over.payload.error.code, "RATE_LIMITED");
+  });
+
+  it("validates body: missing text", async () => {
+    const tok = mintHaToken();
+    const r = await invokeTurn(validBody({ text: "" }), tok);
+    assert.equal(r.status, 400);
+  });
+
+  it("validates body: missing haInstallId", async () => {
+    const tok = mintHaToken();
+    const r = await invokeTurn(validBody({ haInstallId: undefined }), tok);
+    assert.equal(r.status, 400);
+  });
+
+  it("validates body: missing conversationId", async () => {
+    const tok = mintHaToken();
+    const r = await invokeTurn(validBody({ conversationId: undefined }), tok);
+    assert.equal(r.status, 400);
+  });
+});

--- a/packages/ctrl/tests/migrate.test.ts
+++ b/packages/ctrl/tests/migrate.test.ts
@@ -36,8 +36,9 @@ describe("state.db migration runner", () => {
     const db = new DatabaseSync(":memory:");
     db.exec(schema);
     const v = runMigrations(db);
-    // The latest version moves as new migrations land. Today: 3
-    // (0001_fix_pack + 0002_alfred_journal + 0003_tailscale_connection).
+    // Latest version moves as new migrations land. Today: 4
+    // (0001_fix_pack + 0002_alfred_journal + 0003_tailscale_connection
+    // + 0004_channel_tokens).
     assert.equal(v, 6, "migrated to latest version");
     assert.equal(userVersion(db), 6);
     assert.ok(cols(db, "observation").includes("processed_at"), "0001: processed_at present after migrate");
@@ -91,6 +92,20 @@ describe("state.db migration runner", () => {
       /CHECK constraint failed/i,
       "0003: CHECK(id=1) blocks a second tailscale_connection row",
     );
+
+    // 0004: channel_tokens table present (issue #111 PR 1).
+    assert.ok(
+      tables.includes("channel_tokens"),
+      "0004: channel_tokens table created",
+    );
+    const ctCols = cols(db, "channel_tokens");
+    for (const required of ["id", "channel", "token_hash", "created_at"]) {
+      assert.ok(
+        ctCols.includes(required),
+        `0004: channel_tokens.${required} present`,
+      );
+    }
+
     db.close();
   });
 


### PR DESCRIPTION
## Summary

PR1 of [issue #111](https://github.com/ssdavidai/alfred/issues/111) — the **shared `channel_tokens` lane** + the **non-streaming HA conversation `/turn` route**.

Spec source of truth: `docs/specs/issue-111-ha-conversation-agent.md` §3, §4, §5.3, §5.3a, §6 PR1.

## What ships

| Lane | File | Purpose |
|---|---|---|
| **state.db migration** | `packages/ctrl/src/db/migrations/0003_channel_tokens.sql` | new shared table; `token_hash = sha256(raw)`; partial indexes on active rows |
| **DB helpers** | `packages/ctrl/src/db/channelTokens.ts` | mint / list / revoke / rotate / validate, public-safe view (never returns hash) |
| **Operator routes** | `packages/ctrl/src/api/routes/channel_tokens.ts` | `POST /channel-tokens/mint`, `GET /channel-tokens?channel=…`, `POST /channel-tokens/:id/revoke`, `POST /channel-tokens/:id/rotate` — raw token returned **exactly once** at mint+rotate |
| **HA conversation /turn** | `packages/ctrl/src/api/routes/channels_ha.ts` | non-streaming POST: bearer auth via `channel_tokens`, 30/min sliding rate-limit per `haInstallId`, Hermes session key `ha-<haInstallId>`, HA's `ConversationEntity` envelope back |
| **Shared auth helper** | `packages/ctrl/src/api/auth.ts` | `channelTokenBearer(req, channel)` — bumps `last_used_at` + `last_used_ip` on match. Used here by HA; HA Voice (#112) and Paperclip-migrated will reuse |
| **Caddy ingress** | `caddy/Caddyfile` | `/api/v1/channels/ha/turn` added to `@public_webhooks` (so HA hits ctrl-api directly, not the SPA's nginx) |
| **alfred_journal continuity** | (no new code — call existing helpers) | inbound + outbound rows with `channel='ha-conversation'`, `chat_id='ha-<haInstallId>'` matching the Hermes session key |
| **Tests** | `tests/channel_tokens.test.ts`, `tests/channels_ha_turn.test.ts` | 26 new tests; existing migrate / alfred-journal tests updated to ratchet the user_version floor |

## What does NOT ship (downstream PRs)

| PR | Surface |
|---|---|
| **#111 PR2** | HACS-installable HA custom component (`alfred-ha` repo) |
| **#111 PR3** | Tool partitioning: HA-side tool calls forwarded back to HA |
| **#111 PR4** | Curated MCP catalog (`packages/mcp-server/src/curate/ha.ts`) |
| **#111 PR5** | Voice-context primer + ha_room enrichment (depends on #110) |
| **#111 PR6** | Streaming (`_attr_supports_streaming`) + fast-path |
| **#111 PR7** | HACS catalogue submission + `ai_task` |

## Shared-lane note

Sir's decision Q2 (spec §5.3): every channel-keyed bearer rides this one table. HA now (`channel='ha-conversation'`), HA Voice next (`channel='ha-voice'`, #112), Paperclip when it migrates (`channel='paperclip-heartbeat'`, optional housekeeping pass). One rotation+audit story.

## Coordination notes

- **#110 PR1:** `channels_ha.ts` exists minimal here (the `/turn` route only). #110 PR1 will add discovery + LLAT-ingest endpoints to the same file. Merge order is either-first; the file has no overlapping routes between the two PRs so it's a clean merge. The loop-guard `decision_ref` contract (spec §3.6) lands in #110 PR1 and this PR honours it when PR3 wires `ha__call_service`.
- **#112:** uses `channelTokenBearer(req, 'ha-voice')` to ride the same shared lane.
- **Paperclip migration:** OPTIONAL and explicitly out of scope here. Existing PAPERCLIP_API_KEY-on-Hermes-profile keeps working unchanged.

## Verification

```
$ npm test -- channel_tokens.test.ts channels_ha_turn.test.ts migrate.test.ts alfred-journal.test.ts auth.test.ts auth-scoped-voice-bridge.test.ts channels_paperclip.test.ts
ℹ tests 88 — pass 88, fail 0

$ npm run build
Build complete — dist/api.mjs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)