### PR TITLE
feat(voice-bridge): ESPHome Native API server skeleton on :6053 (#112 PR1)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -695,6 +695,29 @@ services:
       MCP_APPROVAL_SECRET: ${MCP_APPROVAL_SECRET}
       MAX_CALL_SECONDS: "1800"
       IDLE_HANGUP_SECONDS: "60"
+      # ESPHome Native API listener (issue #112 — HA Voice). PR1 ships the
+      # connect+pair+idle skeleton; the voice_assistant audio flow lands in
+      # PR2/PR3 and the per-area budget in PR7. ESPHOME_API_ENABLED defaults
+      # to "0" inside the container — we flip it to "1" here so single-VM
+      # tenants pair with HA out of the box. HA_VOICE_API_TOKEN stays empty
+      # in PR1 (tailnet boundary per spec §5.5 Q7); PR2 wires it into the
+      # channel_tokens table from #111.
+      ESPHOME_API_ENABLED: "${ESPHOME_API_ENABLED:-1}"
+      ESPHOME_API_PORT: "6053"
+      ESPHOME_API_BIND: "0.0.0.0"
+      HA_VOICE_API_TOKEN: "${HA_VOICE_API_TOKEN:-}"
+      # Stable per-tenant seed for the synthetic ESPHome device's MAC. Empty
+      # default falls back to os.hostname(); tenants on shared hostnames
+      # (none today) would set this explicitly.
+      ESPHOME_TENANT_SEED: "${ESPHOME_TENANT_SEED:-}"
+      ESPHOME_FRIENDLY_NAME: "${ESPHOME_FRIENDLY_NAME:-Alfred}"
+    ports:
+      # ESPHome Native API on the tailnet. Plain TCP — not HTTP — so Caddy
+      # can't terminate it; HA's ESPHome integration expects no TLS on :6053
+      # (the noise-encrypted variant is out of scope for PR1, see spec §5.5).
+      # mDNS auto-discovery only works when this port is reachable from the
+      # network HA lives on; on a tailnet-only deploy, addressed by IP.
+      - "6053:6053"
     healthcheck:
       test: ["CMD-SHELL", "node -e \"require('http').get('http://127.0.0.1:9000/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))\""]
       interval: 30s

--- a/packages/voice-bridge/Dockerfile
+++ b/packages/voice-bridge/Dockerfile
@@ -1,6 +1,9 @@
 FROM node:22-slim AS build
 WORKDIR /app
 COPY package.json ./
+# Build stage skips optional deps — bonjour-service is a runtime-only
+# dependency and the TS compile doesn't need it (esphome-mdns.ts wraps the
+# import in a dynamic `await import()` with a runtime fallback).
 RUN npm install --omit-optional
 COPY tsconfig.json ./
 COPY src ./src
@@ -10,7 +13,13 @@ FROM node:22-slim
 WORKDIR /app
 ENV NODE_ENV=production
 COPY package.json ./
-RUN npm install --omit-dev --omit-optional && npm cache clean --force
+# Runtime install INCLUDES optional deps so bonjour-service is available for
+# the ESPHome Native API mDNS advertisement (issue #112 PR1). If the package
+# install fails on a constrained base image, esphome-mdns.ts logs + degrades
+# to "no mDNS, HA discovers by hostname instead".
+RUN npm install --omit-dev && npm cache clean --force
 COPY --from=build /app/dist ./dist
-EXPOSE 9000 9001
+# Ports: 9000 = HTTP+WS (Twilio Media Streams ingress + /health + /metrics),
+# 9001 = optional metrics, 6053 = ESPHome Native API for HA Voice (PR1 skeleton).
+EXPOSE 9000 9001 6053
 CMD ["node", "dist/server.js"]

--- a/packages/voice-bridge/package-lock.json
+++ b/packages/voice-bridge/package-lock.json
@@ -18,6 +18,9 @@
       },
       "engines": {
         "node": ">=22"
+      },
+      "optionalDependencies": {
+        "bonjour-service": "^1.4.0"
       }
     },
     "node_modules/@hono/node-server": {
@@ -31,6 +34,13 @@
       "peerDependencies": {
         "hono": "^4"
       }
+    },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
@@ -160,6 +170,17 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bonjour-service": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.4.0.tgz",
+      "integrity": "sha512-fGQtj1qdR9vIKjFiWPQd52qIqwjaYqhcI40JEiDuvlZ86E7ZBPBwY9fPgHy9r2rYGIjiRfctNPYz6OQU73ww2w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "multicast-dns": "^7.2.5"
       }
     },
     "node_modules/bytes": {
@@ -295,6 +316,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dns-packet": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/dunder-proto": {
@@ -759,6 +793,20 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/multicast-dns": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
+      "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "dns-packet": "^5.2.2",
+        "thunky": "^1.0.2"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      }
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -1082,6 +1130,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/thunky": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",

--- a/packages/voice-bridge/package.json
+++ b/packages/voice-bridge/package.json
@@ -18,6 +18,9 @@
     "ws": "^8.18.0",
     "@modelcontextprotocol/sdk": "^1.29.0"
   },
+  "optionalDependencies": {
+    "bonjour-service": "^1.4.0"
+  },
   "devDependencies": {
     "@types/node": "^22.10.0",
     "@types/ws": "^8.5.13",

--- a/packages/voice-bridge/src/config.ts
+++ b/packages/voice-bridge/src/config.ts
@@ -85,6 +85,26 @@ export const config = {
   maxCallSeconds: Number(optional("MAX_CALL_SECONDS", "1800")),
   // Idle hangup if no audio either way (Phase 9 hardening)
   idleHangupSeconds: Number(optional("IDLE_HANGUP_SECONDS", "60")),
+
+  // ── ESPHome Native API (issue #112, PR1 skeleton) ───────────────────────
+  // Second listener that speaks the ESPHome Native API so Home Assistant's
+  // ESPHome integration discovers voice-bridge over mDNS and pairs with us.
+  // PR1 ships the skeleton: handshake + device info + entity list. The
+  // voice_assistant audio flow lands in PR2/PR3.
+  //
+  // Default is opt-in (ESPHOME_API_ENABLED=0) per spec §6 — flip to "1" once
+  // the audio path stabilises. PR1 deploys flip the env in docker-compose.
+  esphomeApiEnabled: optional("ESPHOME_API_ENABLED", "0") === "1",
+  esphomeApiPort: Number(optional("ESPHOME_API_PORT", "6053")),
+  esphomeApiBind: optional("ESPHOME_API_BIND", "0.0.0.0"),
+  // Optional ConnectRequest password. PR1 default = empty (tailnet boundary
+  // per spec §5.5 Q7 resolution). The HA_VOICE_API_TOKEN lane joins the
+  // channel_tokens table from #111 in PR2.
+  haVoiceApiToken: optional("HA_VOICE_API_TOKEN", ""),
+  // Tenant seed used to derive a stable locally-administered MAC for the
+  // synthetic ESPHome device. Falls back to os.hostname() in computeIdentity.
+  esphomeTenantSeed: optional("ESPHOME_TENANT_SEED", ""),
+  esphomeFriendlyName: optional("ESPHOME_FRIENDLY_NAME", "Alfred"),
 } as const;
 
 export type Config = typeof config;

--- a/packages/voice-bridge/src/esphome-mdns.ts
+++ b/packages/voice-bridge/src/esphome-mdns.ts
@@ -1,0 +1,131 @@
+// esphome-mdns.ts — advertise voice-bridge as `_esphomelib._tcp.local.` so
+// HA's ESPHome integration auto-discovers us. See spec §5.2.
+//
+// We use `bonjour-service` (a TypeScript Bonjour/Zeroconf implementation, no
+// native deps — pure JS) because it's the only Node mDNS library that works
+// out of the box on slim Docker images without libavahi. The classic `mdns`
+// package binds to libdns_sd / Avahi and is a non-starter inside our
+// node:22-slim base.
+//
+// IMPORTANT — Docker networking gotcha (see spec §4 docker-compose row):
+//   mDNS uses UDP multicast on 224.0.0.251:5353. The default Docker bridge
+//   network does not pass multicast through to the host LAN, so this
+//   advertisement is only visible to other containers on the same bridge
+//   network until the operator either (a) flips the voice-bridge service
+//   to `network_mode: host` or (b) runs an Avahi reflector on the host.
+//   PR1 ships the advertiser anyway — it's a no-op when nobody can see it,
+//   and it lights up the moment the operator addresses the networking. The
+//   HACS integration that lands in PR4 offers a "Connect by hostname"
+//   fallback for the multicast-can't-cross-bridge case.
+//
+// We make the publication best-effort: if bonjour-service is unavailable
+// (e.g. optional dep didn't install on the slim base image) or throws on
+// startup (e.g. inside a network namespace where 5353/udp is closed), we log
+// + carry on. The TCP listener on :6053 is the load-bearing path; mDNS is
+// just a convenience.
+
+import type { EsphomeServerIdentity } from "./esphome-server.js";
+
+export interface MdnsAnnounceOptions {
+  port: number;
+  identity: EsphomeServerIdentity;
+  log?: (msg: string, extra?: Record<string, unknown>) => void;
+}
+
+export interface MdnsHandle {
+  stop(): Promise<void>;
+}
+
+function defaultLog(msg: string, extra?: Record<string, unknown>): void {
+  if (extra) console.log(`[esphome-mdns] ${msg}`, extra);
+  else console.log(`[esphome-mdns] ${msg}`);
+}
+
+export async function announceEsphomeMdns(opts: MdnsAnnounceOptions): Promise<MdnsHandle> {
+  const log = opts.log ?? defaultLog;
+
+  // Lazy import — bonjour-service is an optional runtime dep. If installation
+  // failed (e.g. on a slim base image without dgram support) we still want
+  // voice-bridge to boot and serve TCP. The dynamic import lets us fall back
+  // cleanly. We tolerate either `bonjour-service` (ESM export) or fall
+  // through silently when missing.
+  let bonjourModule: unknown;
+  try {
+    // The import path is wrapped in a runtime string concat to keep the
+    // TypeScript compiler from requiring the module's types at build time —
+    // the package is optional and may not be installed in CI.
+    const modName = "bonjour-service";
+    bonjourModule = await import(modName);
+  } catch (err) {
+    log("bonjour-service unavailable — mDNS announcement skipped", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return { stop: async () => {} };
+  }
+
+  // The package exports both as a named `Bonjour` and as a default. Tolerate
+  // both shapes so a future bump doesn't break us.
+  const ctor =
+    (bonjourModule as { Bonjour?: unknown }).Bonjour ??
+    (bonjourModule as { default?: { Bonjour?: unknown } }).default?.Bonjour;
+  if (!ctor || typeof ctor !== "function") {
+    log("bonjour-service shape unexpected — mDNS announcement skipped");
+    return { stop: async () => {} };
+  }
+
+  type BonjourInstance = {
+    publish: (opts: object) => unknown;
+    destroy: () => void;
+  };
+  let instance: BonjourInstance;
+  try {
+    instance = new (ctor as new () => BonjourInstance)();
+  } catch (err) {
+    log("bonjour-service init failed — mDNS announcement skipped", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return { stop: async () => {} };
+  }
+
+  // The TXT records here mirror what a real ESPHome device publishes (cf.
+  // esphome/components/api/api_mdns.cpp). HA's ESPHome integration parses
+  // these on discovery to pre-populate the Add Integration dialog.
+  const txt: Record<string, string> = {
+    version: opts.identity.esphomeVersion,
+    mac: opts.identity.macAddress.replace(/:/g, ""),
+    platform: "alfred",
+    board: opts.identity.name,
+    network: "ethernet",
+    friendly_name: opts.identity.friendlyName,
+    project_name: opts.identity.projectName,
+    project_version: opts.identity.projectVersion,
+  };
+
+  try {
+    instance.publish({
+      name: opts.identity.friendlyName,
+      type: "esphomelib",
+      port: opts.port,
+      txt,
+    });
+    log("mDNS announce published", {
+      service: "_esphomelib._tcp.local.",
+      port: opts.port,
+      friendly_name: opts.identity.friendlyName,
+    });
+  } catch (err) {
+    log("mDNS publish failed (continuing)", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  return {
+    stop: async () => {
+      try {
+        instance.destroy();
+      } catch {
+        /* ignore */
+      }
+    },
+  };
+}

--- a/packages/voice-bridge/src/esphome-protocol.ts
+++ b/packages/voice-bridge/src/esphome-protocol.ts
@@ -1,0 +1,280 @@
+// esphome-protocol.ts — minimal hand-rolled codec for the ESPHome Native API.
+//
+// Wire shape (plaintext / unencrypted variant — leading byte 0x00):
+//
+//   <0x00> <varint payload_length> <varint message_type> <protobuf payload>
+//
+// We do NOT implement the noise-encrypted variant (leading byte 0x01); v1 of
+// the HA Voice bridge relies on the tailnet boundary for confidentiality (see
+// spec §5.5). The spec keeps the door open to a Noise_NNpsk0 variant in v2.
+//
+// We hand-roll the protobuf encoder/decoder for the small subset of messages
+// PR1 needs because (a) bringing in a 5 MB protobuf lib for ~10 messages is
+// overkill, (b) the ESPHome API .proto evolves slowly enough that pinning a
+// hand-coded subset is cheaper than tracking schema drift, and (c) protobufjs
+// adds zero value over manual varint encoding for our wire-shape needs.
+//
+// Reference: https://github.com/esphome/esphome/blob/dev/esphome/components/api/api.proto
+//
+// The protobuf encoding rules we implement:
+//   - Each field is <tag = (field_number << 3) | wire_type> <value>.
+//   - Wire types used here:
+//       0  varint           — int32, uint32, bool, enum
+//       1  fixed64          — (NOT used in PR1; reserved for sint64 fields)
+//       2  length-delimited — string, bytes, repeated, embedded message
+//       5  fixed32          — (NOT used in PR1)
+//   - Strings are length-delimited UTF-8 bytes.
+//   - Default values (0, false, "", []) are conventionally omitted on the
+//     wire — the decoder must treat absent fields as defaults.
+//   - We do NOT implement packed-repeated decoding for PR1 (no message uses it).
+//
+// Tests in test_esphome_server.test.ts assert round-trip correctness against
+// hand-computed byte sequences for each PR1 message type.
+
+// ── Message type IDs (subset for PR1) ────────────────────────────────────────
+// IDs taken from upstream esphome/components/api/api.proto. The full list is
+// large (~150 messages); we ship only what the connect+pair+idle flow needs.
+export const MessageType = {
+  HelloRequest: 1,
+  HelloResponse: 2,
+  ConnectRequest: 3,
+  ConnectResponse: 4,
+  DisconnectRequest: 5,
+  DisconnectResponse: 6,
+  PingRequest: 7,
+  PingResponse: 8,
+  DeviceInfoRequest: 9,
+  DeviceInfoResponse: 10,
+  ListEntitiesRequest: 11,
+  ListEntitiesDoneResponse: 19,
+  SubscribeStatesRequest: 20,
+  // Voice-assistant entity declaration. PR1 advertises only this one entity
+  // to satisfy the spec's "single voice_assistant component" minimum; the
+  // media_player / button / sensor companions land in PR2.
+  ListEntitiesVoiceAssistantResponse: 58,
+} as const;
+
+export type MessageTypeName = keyof typeof MessageType;
+
+// Reverse map for diagnostics + framing.
+export const MessageTypeById: Record<number, MessageTypeName> = Object.fromEntries(
+  Object.entries(MessageType).map(([k, v]) => [v, k as MessageTypeName]),
+);
+
+// ── Varint encode / decode ───────────────────────────────────────────────────
+// Standard protobuf varint: 7 bits per byte, MSB set if more bytes follow.
+// We assume non-negative values throughout PR1 (no zigzag) — the ESPHome API
+// only uses unsigned varints for the message-type and payload-length headers.
+
+export function encodeVarint(value: number): Buffer {
+  if (value < 0) throw new Error("varint values must be non-negative");
+  if (!Number.isFinite(value) || !Number.isInteger(value)) {
+    throw new Error("varint values must be finite integers");
+  }
+  const out: number[] = [];
+  let v = value;
+  while (v >= 0x80) {
+    out.push((v & 0x7f) | 0x80);
+    v >>>= 7;
+  }
+  out.push(v & 0x7f);
+  return Buffer.from(out);
+}
+
+// Decode a single varint starting at `offset` in `buf`. Returns the decoded
+// value and the offset just past the last consumed byte. Throws if `buf`
+// runs out before a terminating byte (MSB clear) is seen.
+export function decodeVarint(buf: Buffer, offset: number): { value: number; next: number } {
+  let value = 0;
+  let shift = 0;
+  let i = offset;
+  while (i < buf.length) {
+    const b = buf[i++];
+    value |= (b & 0x7f) << shift;
+    if ((b & 0x80) === 0) {
+      return { value: value >>> 0, next: i };
+    }
+    shift += 7;
+    if (shift >= 35) {
+      throw new Error("varint too long (>5 bytes) — corrupt frame?");
+    }
+  }
+  throw new Error("varint truncated — buffer ended mid-value");
+}
+
+// ── Frame encode / decode ────────────────────────────────────────────────────
+// One framed message: 0x00 + varint(len) + varint(type) + payload[len].
+
+export function encodeFrame(messageType: number, payload: Buffer): Buffer {
+  const lenVarint = encodeVarint(payload.length);
+  const typeVarint = encodeVarint(messageType);
+  return Buffer.concat([Buffer.from([0x00]), lenVarint, typeVarint, payload]);
+}
+
+export interface DecodedFrame {
+  messageType: number;
+  payload: Buffer;
+  bytesConsumed: number;
+}
+
+// Attempt to decode one frame from the start of `buf`. Returns null if the
+// buffer does not yet contain a complete frame (caller should wait for more
+// data and retry). Throws on a malformed preamble byte — that is a protocol
+// violation, not a partial frame.
+export function tryDecodeFrame(buf: Buffer): DecodedFrame | null {
+  if (buf.length === 0) return null;
+  if (buf[0] !== 0x00) {
+    if (buf[0] === 0x01) {
+      // Noise-encrypted frame — we don't speak this in v1.
+      throw new Error(
+        "noise-encrypted ESPHome frame (0x01) received — voice-bridge v1 only speaks plaintext",
+      );
+    }
+    throw new Error(`unexpected ESPHome frame preamble 0x${buf[0].toString(16).padStart(2, "0")}`);
+  }
+  try {
+    const { value: payloadLen, next: afterLen } = decodeVarint(buf, 1);
+    const { value: messageType, next: afterType } = decodeVarint(buf, afterLen);
+    const payloadEnd = afterType + payloadLen;
+    if (buf.length < payloadEnd) return null; // partial frame
+    return {
+      messageType,
+      payload: buf.subarray(afterType, payloadEnd),
+      bytesConsumed: payloadEnd,
+    };
+  } catch (err) {
+    // Truncated varint in the header — partial frame, wait for more data.
+    if (err instanceof Error && err.message.startsWith("varint truncated")) return null;
+    throw err;
+  }
+}
+
+// ── Protobuf field codec helpers ─────────────────────────────────────────────
+// Each helper writes one field; the caller composes them into a payload.
+
+const WIRE_VARINT = 0;
+const WIRE_LENGTH_DELIMITED = 2;
+
+function tag(fieldNumber: number, wireType: number): Buffer {
+  return encodeVarint((fieldNumber << 3) | wireType);
+}
+
+export function writeUint32Field(fieldNumber: number, value: number): Buffer {
+  if (value === 0) return Buffer.alloc(0); // default — omit
+  return Buffer.concat([tag(fieldNumber, WIRE_VARINT), encodeVarint(value >>> 0)]);
+}
+
+export function writeBoolField(fieldNumber: number, value: boolean): Buffer {
+  if (!value) return Buffer.alloc(0); // default — omit
+  return Buffer.concat([tag(fieldNumber, WIRE_VARINT), encodeVarint(1)]);
+}
+
+export function writeStringField(fieldNumber: number, value: string): Buffer {
+  if (value === "") return Buffer.alloc(0); // default — omit
+  const bytes = Buffer.from(value, "utf8");
+  return Buffer.concat([
+    tag(fieldNumber, WIRE_LENGTH_DELIMITED),
+    encodeVarint(bytes.length),
+    bytes,
+  ]);
+}
+
+export function writeBytesField(fieldNumber: number, value: Buffer): Buffer {
+  if (value.length === 0) return Buffer.alloc(0);
+  return Buffer.concat([
+    tag(fieldNumber, WIRE_LENGTH_DELIMITED),
+    encodeVarint(value.length),
+    value,
+  ]);
+}
+
+// ── Generic field decoder ────────────────────────────────────────────────────
+// Decodes a payload into a map of field-number → raw value. Wire types we
+// understand:
+//   varint → number
+//   length-delimited → Buffer (caller decides string vs bytes vs sub-message)
+// Unknown wire types throw; unknown field numbers are preserved (forward-compat).
+
+export type DecodedFields = Record<number, number | Buffer | Array<number | Buffer>>;
+
+export function decodeFields(payload: Buffer): DecodedFields {
+  const out: DecodedFields = {};
+  let offset = 0;
+  while (offset < payload.length) {
+    const { value: tagValue, next: afterTag } = decodeVarint(payload, offset);
+    const fieldNumber = tagValue >>> 3;
+    const wireType = tagValue & 0x07;
+    offset = afterTag;
+
+    let parsed: number | Buffer;
+    if (wireType === WIRE_VARINT) {
+      const { value, next } = decodeVarint(payload, offset);
+      parsed = value;
+      offset = next;
+    } else if (wireType === WIRE_LENGTH_DELIMITED) {
+      const { value: len, next: afterLen } = decodeVarint(payload, offset);
+      parsed = payload.subarray(afterLen, afterLen + len);
+      offset = afterLen + len;
+    } else {
+      throw new Error(
+        `unsupported wire type ${wireType} for field ${fieldNumber} (PR1 codec only handles varint + length-delimited)`,
+      );
+    }
+
+    const existing = out[fieldNumber];
+    if (existing === undefined) {
+      out[fieldNumber] = parsed;
+    } else if (Array.isArray(existing)) {
+      existing.push(parsed);
+    } else {
+      out[fieldNumber] = [existing, parsed];
+    }
+  }
+  return out;
+}
+
+export function fieldAsString(fields: DecodedFields, fieldNumber: number): string {
+  const v = fields[fieldNumber];
+  if (v === undefined) return "";
+  if (Buffer.isBuffer(v)) return v.toString("utf8");
+  throw new Error(`field ${fieldNumber} is not a string`);
+}
+
+export function fieldAsUint(fields: DecodedFields, fieldNumber: number): number {
+  const v = fields[fieldNumber];
+  if (v === undefined) return 0;
+  if (typeof v === "number") return v;
+  throw new Error(`field ${fieldNumber} is not a varint`);
+}
+
+export function fieldAsBool(fields: DecodedFields, fieldNumber: number): boolean {
+  return fieldAsUint(fields, fieldNumber) !== 0;
+}
+
+// ── Stream parser ────────────────────────────────────────────────────────────
+// One per TCP connection. Accumulates inbound bytes; yields complete frames
+// as the buffer fills. The TCP layer can deliver partial frames or several
+// frames in one chunk — this class smooths over both.
+
+export class FrameParser {
+  private buffer: Buffer = Buffer.alloc(0);
+
+  // Append a chunk and return all newly-complete frames in arrival order.
+  push(chunk: Buffer): DecodedFrame[] {
+    this.buffer = this.buffer.length === 0 ? chunk : Buffer.concat([this.buffer, chunk]);
+    const frames: DecodedFrame[] = [];
+    while (this.buffer.length > 0) {
+      const frame = tryDecodeFrame(this.buffer);
+      if (!frame) break; // partial — wait for more data
+      frames.push(frame);
+      this.buffer = this.buffer.subarray(frame.bytesConsumed);
+    }
+    return frames;
+  }
+
+  // Test helper — exposes pending bytes that haven't yet formed a complete
+  // frame. Used to assert partial-frame handling in unit tests.
+  pendingBytes(): number {
+    return this.buffer.length;
+  }
+}

--- a/packages/voice-bridge/src/esphome-server.test.ts
+++ b/packages/voice-bridge/src/esphome-server.test.ts
@@ -1,0 +1,509 @@
+// esphome-server.test.ts — integration tests for the PR1 ESPHome Native API
+// skeleton (issue #112). Verifies the wire-format codec round-trips cleanly
+// and that a real TCP client can drive the connect-pair-idle handshake
+// against the server end-to-end.
+//
+// Test surface (per spec §6 PR1 acceptance):
+//   1. Server starts on a port (we use port 0 + boundPort() so tests don't
+//      collide with a real :6053 listener).
+//   2. HelloRequest → HelloResponse with apiVersionMajor=1, apiVersionMinor=10,
+//      server_info populated, name="alfred-voice-bridge".
+//   3. ConnectRequest → ConnectResponse(invalid_password=false) when no
+//      password is configured; with-password path tested separately.
+//   4. DeviceInfoRequest → DeviceInfoResponse with model="Alfred Voice Bridge",
+//      friendly_name="Alfred", esphome_version="alfred-1.0".
+//   5. PingRequest → PingResponse (empty payload).
+//   6. ListEntitiesRequest → exactly one ListEntitiesVoiceAssistantResponse
+//      followed by ListEntitiesDoneResponse.
+//   7. Wire-format encode/decode round-trips for varints, frames, strings,
+//      bools, and uint32 fields.
+//
+// Runs under `node --test`. Same dependency posture as openai-realtime.test.ts —
+// just Node 22's builtin test runner.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import net from "node:net";
+import type { AddressInfo } from "node:net";
+
+// env must be set BEFORE importing config-bearing modules; the SUT does not
+// read env at import time but its sibling config.ts does.
+process.env.OPENAI_API_KEY = process.env.OPENAI_API_KEY ?? "sk-test-dummy";
+process.env.VOICE_BRIDGE_INTERNAL_TOKEN =
+  process.env.VOICE_BRIDGE_INTERNAL_TOKEN ?? "test-internal-token";
+
+import {
+  encodeVarint,
+  decodeVarint,
+  encodeFrame,
+  tryDecodeFrame,
+  FrameParser,
+  decodeFields,
+  fieldAsString,
+  fieldAsUint,
+  fieldAsBool,
+  writeStringField,
+  writeUint32Field,
+  writeBoolField,
+  MessageType,
+} from "./esphome-protocol.js";
+import {
+  computeIdentity,
+  buildHelloResponse,
+  buildDeviceInfoResponse,
+  buildListEntitiesVoiceAssistantResponse,
+  startEsphomeServer,
+  EMPTY_PAYLOAD,
+} from "./esphome-server.js";
+
+// ── wire-format round-trips ──────────────────────────────────────────────────
+
+test("varint encode/decode round-trips for 0, 127, 128, 16384", () => {
+  for (const v of [0, 1, 127, 128, 300, 16383, 16384, 16385, 1 << 28]) {
+    const enc = encodeVarint(v);
+    const dec = decodeVarint(enc, 0);
+    assert.equal(dec.value, v, `value ${v} round-trip`);
+    assert.equal(dec.next, enc.length, `value ${v} consumes all bytes`);
+  }
+});
+
+test("varint encoding matches known protobuf bytes for sentinel values", () => {
+  assert.deepEqual([...encodeVarint(0)], [0x00]);
+  assert.deepEqual([...encodeVarint(1)], [0x01]);
+  assert.deepEqual([...encodeVarint(127)], [0x7f]);
+  // 128 = 0b1000_0000 → varint = 0x80 0x01
+  assert.deepEqual([...encodeVarint(128)], [0x80, 0x01]);
+  // 300 = 0b1_0010_1100 → 0xac 0x02
+  assert.deepEqual([...encodeVarint(300)], [0xac, 0x02]);
+});
+
+test("varint rejects negative + non-integer values", () => {
+  assert.throws(() => encodeVarint(-1), /non-negative/);
+  assert.throws(() => encodeVarint(1.5), /finite integers/);
+  assert.throws(() => encodeVarint(Infinity), /finite integers/);
+});
+
+test("varint decode rejects a 6-byte-long sequence (corrupt)", () => {
+  // Six bytes all with high bit set = overflow — codec must reject.
+  const bad = Buffer.from([0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
+  assert.throws(() => decodeVarint(bad, 0), /too long/);
+});
+
+test("frame encode produces preamble + len + type + payload in order", () => {
+  const payload = Buffer.from([0x10, 0x20, 0x30]);
+  const frame = encodeFrame(0x07, payload);
+  assert.equal(frame[0], 0x00, "preamble byte");
+  assert.equal(frame[1], 3, "payload length");
+  assert.equal(frame[2], 0x07, "message type");
+  assert.deepEqual(frame.subarray(3), payload);
+});
+
+test("tryDecodeFrame returns null on partial input, full frame on completion", () => {
+  const inner = Buffer.from([0xaa, 0xbb]);
+  const frame = encodeFrame(MessageType.PingResponse, inner);
+  // Partial — only first 2 bytes.
+  assert.equal(tryDecodeFrame(frame.subarray(0, 2)), null);
+  // Full.
+  const decoded = tryDecodeFrame(frame);
+  assert.ok(decoded);
+  assert.equal(decoded.messageType, MessageType.PingResponse);
+  assert.deepEqual(decoded.payload, inner);
+  assert.equal(decoded.bytesConsumed, frame.length);
+});
+
+test("tryDecodeFrame rejects noise-encrypted (0x01) preamble", () => {
+  const noise = Buffer.from([0x01, 0x00, 0x00]);
+  assert.throws(() => tryDecodeFrame(noise), /noise-encrypted/);
+});
+
+test("FrameParser yields multiple frames from one chunk + handles split frames", () => {
+  const parser = new FrameParser();
+  const a = encodeFrame(MessageType.PingRequest, Buffer.alloc(0));
+  const b = encodeFrame(MessageType.PingResponse, Buffer.from([0x05]));
+  // Both in one push.
+  let frames = parser.push(Buffer.concat([a, b]));
+  assert.equal(frames.length, 2);
+  assert.equal(frames[0].messageType, MessageType.PingRequest);
+  assert.equal(frames[1].messageType, MessageType.PingResponse);
+  assert.equal(parser.pendingBytes(), 0);
+
+  // Now split a frame across two pushes.
+  const c = encodeFrame(MessageType.HelloRequest, Buffer.from([0x10, 0x11, 0x12]));
+  frames = parser.push(c.subarray(0, 2));
+  assert.equal(frames.length, 0, "no frame yet on partial input");
+  assert.equal(parser.pendingBytes(), 2);
+  frames = parser.push(c.subarray(2));
+  assert.equal(frames.length, 1);
+  assert.equal(frames[0].messageType, MessageType.HelloRequest);
+  assert.equal(parser.pendingBytes(), 0);
+});
+
+test("field encoders skip default values + decode round-trip preserves set values", () => {
+  // Build a fake payload with a mix of fields, decode, assert.
+  const payload = Buffer.concat([
+    writeUint32Field(1, 7),
+    writeStringField(2, "hello"),
+    writeBoolField(3, true),
+    writeStringField(4, ""), // default → omitted
+    writeUint32Field(5, 0), // default → omitted
+    writeBoolField(6, false), // default → omitted
+  ]);
+  const fields = decodeFields(payload);
+  assert.equal(fieldAsUint(fields, 1), 7);
+  assert.equal(fieldAsString(fields, 2), "hello");
+  assert.equal(fieldAsBool(fields, 3), true);
+  // Defaults round-trip as zero values via the accessors.
+  assert.equal(fieldAsString(fields, 4), "");
+  assert.equal(fieldAsUint(fields, 5), 0);
+  assert.equal(fieldAsBool(fields, 6), false);
+});
+
+// ── identity ─────────────────────────────────────────────────────────────────
+
+test("computeIdentity produces a stable MAC from a fixed seed + LA bit set", () => {
+  const id1 = computeIdentity({ tenantSeed: "fixed-seed" });
+  const id2 = computeIdentity({ tenantSeed: "fixed-seed" });
+  assert.equal(id1.macAddress, id2.macAddress, "same seed → same MAC");
+  assert.match(id1.macAddress, /^[0-9a-f]{2}(:[0-9a-f]{2}){5}$/);
+  // First octet must have the locally-administered bit set (0x02) + unicast
+  // (multicast bit clear).
+  const firstOctet = parseInt(id1.macAddress.slice(0, 2), 16);
+  assert.equal(firstOctet & 0x02, 0x02, "locally-administered bit");
+  assert.equal(firstOctet & 0x01, 0x00, "unicast (multicast bit clear)");
+
+  const id3 = computeIdentity({ tenantSeed: "different-seed" });
+  assert.notEqual(id1.macAddress, id3.macAddress, "different seed → different MAC");
+});
+
+test("computeIdentity sets the spec-mandated identity fields", () => {
+  const id = computeIdentity({ tenantSeed: "t1", friendlyName: "Alfred" });
+  assert.equal(id.model, "Alfred Voice Bridge");
+  assert.equal(id.name, "alfred-voice-bridge");
+  assert.equal(id.esphomeVersion, "alfred-1.0");
+  assert.equal(id.friendlyName, "Alfred");
+  assert.equal(id.manufacturer, "Alfred Black");
+  assert.equal(id.projectName, "alfred-black.voice-bridge");
+});
+
+// ── message builders (decode-self round-trip) ────────────────────────────────
+
+test("buildHelloResponse round-trips through decodeFields", () => {
+  const payload = buildHelloResponse({
+    apiVersionMajor: 1,
+    apiVersionMinor: 10,
+    serverInfo: "Alfred Voice Bridge (alfred-1.0)",
+    name: "alfred-voice-bridge",
+  });
+  const fields = decodeFields(payload);
+  assert.equal(fieldAsUint(fields, 1), 1);
+  assert.equal(fieldAsUint(fields, 2), 10);
+  assert.equal(fieldAsString(fields, 3), "Alfred Voice Bridge (alfred-1.0)");
+  assert.equal(fieldAsString(fields, 4), "alfred-voice-bridge");
+});
+
+test("buildDeviceInfoResponse encodes model + friendly_name + esphome_version", () => {
+  const identity = computeIdentity({ tenantSeed: "t1" });
+  const payload = buildDeviceInfoResponse({ usesPassword: false, identity });
+  const fields = decodeFields(payload);
+  // uses_password (1) omitted because false
+  assert.equal(fieldAsBool(fields, 1), false);
+  assert.equal(fieldAsString(fields, 2), "alfred-voice-bridge");
+  assert.equal(fieldAsString(fields, 3), identity.macAddress);
+  assert.equal(fieldAsString(fields, 4), "alfred-1.0");
+  assert.equal(fieldAsString(fields, 6), "Alfred Voice Bridge");
+  assert.equal(fieldAsBool(fields, 7), false); // has_deep_sleep
+  assert.equal(fieldAsString(fields, 8), "alfred-black.voice-bridge");
+  assert.equal(fieldAsString(fields, 12), "Alfred Black");
+  assert.equal(fieldAsString(fields, 13), "Alfred");
+});
+
+test("buildListEntitiesVoiceAssistantResponse encodes object_id + key + name", () => {
+  const payload = buildListEntitiesVoiceAssistantResponse({
+    objectId: "alfred_voice_assistant",
+    key: 0x12345678,
+    name: "Alfred",
+    uniqueId: "alfred-voice-bridge_voice_assistant",
+  });
+  const fields = decodeFields(payload);
+  assert.equal(fieldAsString(fields, 1), "alfred_voice_assistant");
+  assert.equal(fieldAsUint(fields, 2), 0x12345678);
+  assert.equal(fieldAsString(fields, 3), "Alfred");
+  assert.equal(fieldAsString(fields, 4), "alfred-voice-bridge_voice_assistant");
+});
+
+// ── end-to-end TCP server ────────────────────────────────────────────────────
+
+// Helper — connect to the server, write some frames, collect frames the server
+// sends back, then close. Returns the frames in receive order.
+async function exchange(
+  port: number,
+  outgoing: Array<{ messageType: number; payload: Buffer }>,
+  opts: { collectMs?: number } = {},
+): Promise<Array<{ messageType: number; payload: Buffer }>> {
+  const collectMs = opts.collectMs ?? 200;
+  const sock = net.connect(port, "127.0.0.1");
+  await new Promise<void>((resolve, reject) => {
+    sock.once("connect", resolve);
+    sock.once("error", reject);
+  });
+  const parser = new FrameParser();
+  const received: Array<{ messageType: number; payload: Buffer }> = [];
+  sock.on("data", (chunk: Buffer) => {
+    for (const f of parser.push(chunk)) {
+      received.push({ messageType: f.messageType, payload: f.payload });
+    }
+  });
+  for (const out of outgoing) {
+    sock.write(encodeFrame(out.messageType, out.payload));
+  }
+  await new Promise<void>((resolve) => setTimeout(resolve, collectMs));
+  sock.destroy();
+  return received;
+}
+
+test("end-to-end: HelloRequest → HelloResponse on a real TCP connection", async () => {
+  const identity = computeIdentity({ tenantSeed: "test-tenant" });
+  const handle = startEsphomeServer({
+    port: 0,
+    bindHost: "127.0.0.1",
+    identity,
+    log: () => {}, // quiet test logs
+  });
+  await handle.ready;
+  const port = handle.boundPort();
+
+  try {
+    const helloPayload = Buffer.concat([
+      writeStringField(1, "ha-test-client"),
+      writeUint32Field(2, 1),
+      writeUint32Field(3, 10),
+    ]);
+    const frames = await exchange(port, [
+      { messageType: MessageType.HelloRequest, payload: helloPayload },
+    ]);
+    assert.equal(frames.length, 1, "exactly one HelloResponse");
+    assert.equal(frames[0].messageType, MessageType.HelloResponse);
+    const fields = decodeFields(frames[0].payload);
+    assert.equal(fieldAsUint(fields, 1), 1, "api_version_major");
+    assert.equal(fieldAsUint(fields, 2), 10, "api_version_minor");
+    assert.match(fieldAsString(fields, 3), /Alfred Voice Bridge/, "server_info");
+    assert.equal(fieldAsString(fields, 4), "alfred-voice-bridge", "name");
+  } finally {
+    await handle.close();
+  }
+});
+
+test("end-to-end: ConnectRequest with empty password succeeds (PR1 default)", async () => {
+  const identity = computeIdentity({ tenantSeed: "test-tenant" });
+  const handle = startEsphomeServer({
+    port: 0,
+    bindHost: "127.0.0.1",
+    identity,
+    log: () => {},
+  });
+  await handle.ready;
+  const port = handle.boundPort();
+
+  try {
+    const frames = await exchange(port, [
+      // ConnectRequest with no password set on the server — payload is empty,
+      // matches HA's behaviour when the user leaves the password field blank
+      // in the integration config flow.
+      { messageType: MessageType.ConnectRequest, payload: EMPTY_PAYLOAD },
+    ]);
+    assert.equal(frames.length, 1);
+    assert.equal(frames[0].messageType, MessageType.ConnectResponse);
+    const fields = decodeFields(frames[0].payload);
+    // invalid_password (1) omitted from the wire because false — accessor
+    // returns false on omitted fields by design.
+    assert.equal(fieldAsBool(fields, 1), false);
+  } finally {
+    await handle.close();
+  }
+});
+
+test("end-to-end: ConnectRequest with wrong password returns invalid_password=true", async () => {
+  const identity = computeIdentity({ tenantSeed: "test-tenant" });
+  const handle = startEsphomeServer({
+    port: 0,
+    bindHost: "127.0.0.1",
+    identity,
+    password: "secret-token",
+    log: () => {},
+  });
+  await handle.ready;
+  const port = handle.boundPort();
+
+  try {
+    const wrongPwPayload = writeStringField(1, "wrong-password");
+    const frames = await exchange(port, [
+      { messageType: MessageType.ConnectRequest, payload: wrongPwPayload },
+    ]);
+    assert.equal(frames.length, 1);
+    assert.equal(frames[0].messageType, MessageType.ConnectResponse);
+    const fields = decodeFields(frames[0].payload);
+    assert.equal(fieldAsBool(fields, 1), true, "invalid_password must be true");
+  } finally {
+    await handle.close();
+  }
+});
+
+test("end-to-end: DeviceInfoRequest returns model + friendly_name + mac", async () => {
+  const identity = computeIdentity({ tenantSeed: "test-tenant-A" });
+  const handle = startEsphomeServer({
+    port: 0,
+    bindHost: "127.0.0.1",
+    identity,
+    log: () => {},
+  });
+  await handle.ready;
+  const port = handle.boundPort();
+
+  try {
+    const frames = await exchange(port, [
+      { messageType: MessageType.DeviceInfoRequest, payload: EMPTY_PAYLOAD },
+    ]);
+    assert.equal(frames.length, 1);
+    assert.equal(frames[0].messageType, MessageType.DeviceInfoResponse);
+    const fields = decodeFields(frames[0].payload);
+    assert.equal(fieldAsString(fields, 2), "alfred-voice-bridge", "name");
+    assert.equal(fieldAsString(fields, 3), identity.macAddress, "mac");
+    assert.equal(fieldAsString(fields, 4), "alfred-1.0", "esphome_version");
+    assert.equal(fieldAsString(fields, 6), "Alfred Voice Bridge", "model");
+    assert.equal(fieldAsString(fields, 12), "Alfred Black", "manufacturer");
+    assert.equal(fieldAsString(fields, 13), "Alfred", "friendly_name");
+  } finally {
+    await handle.close();
+  }
+});
+
+test("end-to-end: PingRequest returns PingResponse (keepalive)", async () => {
+  const identity = computeIdentity({ tenantSeed: "test-tenant" });
+  const handle = startEsphomeServer({
+    port: 0,
+    bindHost: "127.0.0.1",
+    identity,
+    log: () => {},
+  });
+  await handle.ready;
+  const port = handle.boundPort();
+
+  try {
+    const frames = await exchange(port, [
+      { messageType: MessageType.PingRequest, payload: EMPTY_PAYLOAD },
+    ]);
+    assert.equal(frames.length, 1);
+    assert.equal(frames[0].messageType, MessageType.PingResponse);
+    assert.equal(frames[0].payload.length, 0, "PingResponse is empty");
+  } finally {
+    await handle.close();
+  }
+});
+
+test("end-to-end: ListEntitiesRequest returns voice_assistant + done", async () => {
+  const identity = computeIdentity({ tenantSeed: "test-tenant" });
+  const handle = startEsphomeServer({
+    port: 0,
+    bindHost: "127.0.0.1",
+    identity,
+    log: () => {},
+  });
+  await handle.ready;
+  const port = handle.boundPort();
+
+  try {
+    const frames = await exchange(port, [
+      { messageType: MessageType.ListEntitiesRequest, payload: EMPTY_PAYLOAD },
+    ]);
+    // Expected: exactly 2 — one voice_assistant entity + done.
+    assert.equal(frames.length, 2, "two frames: voice_assistant + done");
+    assert.equal(frames[0].messageType, MessageType.ListEntitiesVoiceAssistantResponse);
+    const va = decodeFields(frames[0].payload);
+    assert.equal(fieldAsString(va, 1), "alfred_voice_assistant", "object_id");
+    assert.ok(fieldAsUint(va, 2) > 0, "key is non-zero");
+    assert.equal(fieldAsString(va, 3), "Alfred", "name");
+    assert.equal(frames[1].messageType, MessageType.ListEntitiesDoneResponse);
+    assert.equal(frames[1].payload.length, 0, "done payload is empty");
+  } finally {
+    await handle.close();
+  }
+});
+
+test("end-to-end: full handshake sequence Hello → Connect → DeviceInfo → ListEntities → Ping", async () => {
+  const identity = computeIdentity({ tenantSeed: "test-handshake" });
+  const handle = startEsphomeServer({
+    port: 0,
+    bindHost: "127.0.0.1",
+    identity,
+    log: () => {},
+  });
+  await handle.ready;
+  const port = handle.boundPort();
+
+  try {
+    const helloPayload = Buffer.concat([
+      writeStringField(1, "aioesphomeapi"),
+      writeUint32Field(2, 1),
+      writeUint32Field(3, 10),
+    ]);
+    const frames = await exchange(
+      port,
+      [
+        { messageType: MessageType.HelloRequest, payload: helloPayload },
+        { messageType: MessageType.ConnectRequest, payload: EMPTY_PAYLOAD },
+        { messageType: MessageType.DeviceInfoRequest, payload: EMPTY_PAYLOAD },
+        { messageType: MessageType.ListEntitiesRequest, payload: EMPTY_PAYLOAD },
+        { messageType: MessageType.SubscribeStatesRequest, payload: EMPTY_PAYLOAD },
+        { messageType: MessageType.PingRequest, payload: EMPTY_PAYLOAD },
+      ],
+      { collectMs: 300 },
+    );
+
+    // Expect: HelloResponse, ConnectResponse, DeviceInfoResponse,
+    // ListEntitiesVoiceAssistantResponse, ListEntitiesDoneResponse, PingResponse.
+    // SubscribeStatesRequest does NOT produce a response in PR1 (no entity
+    // state to push yet).
+    const types = frames.map((f) => f.messageType);
+    assert.deepEqual(
+      types,
+      [
+        MessageType.HelloResponse,
+        MessageType.ConnectResponse,
+        MessageType.DeviceInfoResponse,
+        MessageType.ListEntitiesVoiceAssistantResponse,
+        MessageType.ListEntitiesDoneResponse,
+        MessageType.PingResponse,
+      ],
+      "full PR1 handshake produces the expected response sequence",
+    );
+  } finally {
+    await handle.close();
+  }
+});
+
+test("end-to-end: unknown message type is ignored (forward compat)", async () => {
+  // Future ESPHome releases add new message types; PR1 must not disconnect on
+  // them — that would make HA upgrades break voice-bridge silently.
+  const identity = computeIdentity({ tenantSeed: "test-tenant" });
+  const handle = startEsphomeServer({
+    port: 0,
+    bindHost: "127.0.0.1",
+    identity,
+    log: () => {},
+  });
+  await handle.ready;
+  const port = handle.boundPort();
+
+  try {
+    const frames = await exchange(port, [
+      // A made-up message type. The server should log + ignore.
+      { messageType: 9999, payload: Buffer.from([0x42]) },
+      // Follow-up Ping must still work — i.e. the connection wasn't dropped.
+      { messageType: MessageType.PingRequest, payload: EMPTY_PAYLOAD },
+    ]);
+    assert.equal(frames.length, 1, "only PingResponse is returned");
+    assert.equal(frames[0].messageType, MessageType.PingResponse);
+  } finally {
+    await handle.close();
+  }
+});

--- a/packages/voice-bridge/src/esphome-server.ts
+++ b/packages/voice-bridge/src/esphome-server.ts
@@ -1,0 +1,390 @@
+// esphome-server.ts — TCP listener that speaks the ESPHome Native API.
+//
+// PR1 scope (per docs/specs/issue-112-voice-via-ha.md §6):
+//   - Accept TCP connections on :6053.
+//   - Plaintext (0x00) framing only — noise (0x01) is out of scope for v1.
+//   - HelloRequest → HelloResponse
+//   - ConnectRequest → ConnectResponse (auth optional; PR1 ships unauth'd
+//     per spec §5.5 — the HA_VOICE_API_TOKEN lane lands with #111's
+//     channel_tokens table in PR2).
+//   - DeviceInfoRequest → DeviceInfoResponse advertising
+//     "Alfred Voice Bridge", deterministic per-tenant MAC, esphome_version
+//     "alfred-1.0".
+//   - ListEntitiesRequest → one ListEntitiesVoiceAssistantResponse +
+//     ListEntitiesDoneResponse. The media_player / button / sensor companions
+//     land in PR2.
+//   - SubscribeStatesRequest → mark subscribed and idle (no entity state to
+//     push in PR1 — the voice_assistant entity is stateless on the wire).
+//   - PingRequest → PingResponse keepalive.
+//
+// EXPLICITLY NOT in PR1: voice_assistant audio flow (PR2/PR3), OpenAI bridge
+// (PR3), MCP tools (PR6), per-area budget (PR7).
+//
+// To HA's ESPHome integration the result is a discoverable "Alfred Voice
+// Bridge" device that pairs cleanly and lists one (unavailable-until-PR2)
+// voice_assistant entity.
+
+import net from "node:net";
+import crypto from "node:crypto";
+import os from "node:os";
+import {
+  MessageType,
+  MessageTypeById,
+  FrameParser,
+  encodeFrame,
+  decodeFields,
+  fieldAsString,
+  fieldAsUint,
+  writeBoolField,
+  writeStringField,
+  writeUint32Field,
+} from "./esphome-protocol.js";
+
+// ── Identity ─────────────────────────────────────────────────────────────────
+// HA's ESPHome integration keys devices by MAC. For real ESP32s that's the
+// hardware MAC; for voice-bridge we hash the tenant id (or hostname when no
+// tenant is configured) into a stable, locally-administered MAC. This means a
+// re-deploy of the same tenant re-pairs without HA seeing a new device.
+
+export interface EsphomeServerIdentity {
+  /** Free-form device name surfaced in HA discovery. e.g. "Alfred". */
+  friendlyName: string;
+  /** Short object-id-style name, lowercase + safe for HA's slug rules. */
+  name: string;
+  /** Pinned esphome version string. We use "alfred-1.0" so HA never tries to OTA-upgrade us. */
+  esphomeVersion: string;
+  /** Lower-case `aa:bb:cc:dd:ee:ff`, derived from a stable seed. */
+  macAddress: string;
+  /** "alfred-voice-bridge" — the device model HA shows in the UI. */
+  model: string;
+  /** "Alfred Black" — manufacturer string in HA. */
+  manufacturer: string;
+  /** Project namespace (mDNS TXT `project_name`). */
+  projectName: string;
+  /** Pinned project version (mDNS TXT `project_version`). */
+  projectVersion: string;
+}
+
+export function computeIdentity(opts: { tenantSeed?: string; friendlyName?: string }): EsphomeServerIdentity {
+  const seed = opts.tenantSeed && opts.tenantSeed.length > 0 ? opts.tenantSeed : os.hostname();
+  // SHA-256 of the seed, lower 6 bytes, set the locally-administered bit (0x02)
+  // and clear the multicast bit (0x01) on the first octet — same trick the
+  // ESPHome firmware uses for soft-MACs.
+  const digest = crypto.createHash("sha256").update(`alfred-voice-bridge:${seed}`).digest();
+  const macBytes = [
+    (digest[0] & 0xfc) | 0x02,
+    digest[1],
+    digest[2],
+    digest[3],
+    digest[4],
+    digest[5],
+  ];
+  const macAddress = macBytes.map((b) => b.toString(16).padStart(2, "0")).join(":");
+  return {
+    friendlyName: opts.friendlyName ?? "Alfred",
+    name: "alfred-voice-bridge",
+    esphomeVersion: "alfred-1.0",
+    macAddress,
+    model: "Alfred Voice Bridge",
+    manufacturer: "Alfred Black",
+    projectName: "alfred-black.voice-bridge",
+    projectVersion: "1.0.0",
+  };
+}
+
+// ── Message builders ─────────────────────────────────────────────────────────
+// One helper per message. Field numbers come straight from
+// esphome/components/api/api.proto. Default values are conventionally omitted
+// on the wire (see esphome-protocol.ts) — our writers do this automatically.
+
+export function buildHelloResponse(opts: {
+  apiVersionMajor: number;
+  apiVersionMinor: number;
+  serverInfo: string;
+  name: string;
+}): Buffer {
+  return Buffer.concat([
+    writeUint32Field(1, opts.apiVersionMajor),
+    writeUint32Field(2, opts.apiVersionMinor),
+    writeStringField(3, opts.serverInfo),
+    writeStringField(4, opts.name),
+  ]);
+}
+
+export function buildConnectResponse(invalidPassword: boolean): Buffer {
+  return writeBoolField(1, invalidPassword);
+}
+
+export function buildDeviceInfoResponse(opts: {
+  usesPassword: boolean;
+  identity: EsphomeServerIdentity;
+}): Buffer {
+  const { identity } = opts;
+  return Buffer.concat([
+    writeBoolField(1, opts.usesPassword),
+    writeStringField(2, identity.name),
+    writeStringField(3, identity.macAddress),
+    writeStringField(4, identity.esphomeVersion),
+    // compilation_time (5) — left empty; HA tolerates "".
+    writeStringField(6, identity.model),
+    writeBoolField(7, false), // has_deep_sleep = false (we never sleep)
+    writeStringField(8, identity.projectName),
+    writeStringField(9, identity.projectVersion),
+    // webserver_port (10) — 0; we don't expose one.
+    // legacy_bluetooth_proxy_version (11) — 0.
+    writeStringField(12, identity.manufacturer),
+    writeStringField(13, identity.friendlyName),
+  ]);
+}
+
+export function buildListEntitiesVoiceAssistantResponse(opts: {
+  objectId: string;
+  key: number;
+  name: string;
+  uniqueId: string;
+}): Buffer {
+  return Buffer.concat([
+    writeStringField(1, opts.objectId),
+    writeUint32Field(2, opts.key),
+    writeStringField(3, opts.name),
+    writeStringField(4, opts.uniqueId),
+    // disabled_by_default (5) = false
+    // icon (6) = ""
+    // entity_category (7) = 0 (NONE)
+  ]);
+}
+
+// Empty-payload messages — PingResponse, DisconnectResponse,
+// ListEntitiesDoneResponse all encode as a frame with a zero-length payload.
+export const EMPTY_PAYLOAD = Buffer.alloc(0);
+
+// ── Per-connection session ───────────────────────────────────────────────────
+
+export interface EsphomeServerOptions {
+  identity: EsphomeServerIdentity;
+  /** When non-empty, ConnectRequest.password must match. PR1 ships empty. */
+  password?: string;
+  /** Logger override for tests. */
+  log?: (msg: string, extra?: Record<string, unknown>) => void;
+}
+
+interface SessionState {
+  helloSeen: boolean;
+  connected: boolean;
+  authorized: boolean;
+  subscribedStates: boolean;
+}
+
+function defaultLog(msg: string, extra?: Record<string, unknown>): void {
+  if (extra) console.log(`[esphome] ${msg}`, extra);
+  else console.log(`[esphome] ${msg}`);
+}
+
+export class EsphomeConnection {
+  private parser = new FrameParser();
+  private state: SessionState = {
+    helloSeen: false,
+    connected: false,
+    authorized: false,
+    subscribedStates: false,
+  };
+
+  constructor(
+    private readonly socket: net.Socket,
+    private readonly opts: EsphomeServerOptions,
+  ) {
+    const remote = socket.remoteAddress ?? "?";
+    const log = opts.log ?? defaultLog;
+    log("connection accepted", { remote });
+    socket.on("data", (chunk) => this.onData(chunk));
+    socket.on("error", (err) => log("socket error", { remote, err: err.message }));
+    socket.on("close", () => log("connection closed", { remote }));
+  }
+
+  private send(messageType: number, payload: Buffer): void {
+    if (this.socket.destroyed) return;
+    const frame = encodeFrame(messageType, payload);
+    this.socket.write(frame);
+  }
+
+  private onData(chunk: Buffer): void {
+    let frames;
+    try {
+      frames = this.parser.push(chunk);
+    } catch (err) {
+      const log = this.opts.log ?? defaultLog;
+      log("frame parse error — closing connection", {
+        err: err instanceof Error ? err.message : String(err),
+      });
+      this.socket.destroy();
+      return;
+    }
+    for (const frame of frames) {
+      this.handleFrame(frame.messageType, frame.payload);
+    }
+  }
+
+  private handleFrame(messageType: number, payload: Buffer): void {
+    const log = this.opts.log ?? defaultLog;
+    const typeName = MessageTypeById[messageType] ?? `unknown(${messageType})`;
+
+    // Order matters: HelloRequest must come first per the ESPHome handshake.
+    // We're lenient — log + ignore unknown messages rather than disconnect —
+    // because the ESPHome API evolves and dropping connections on every new
+    // message type would make us brittle to HA upgrades.
+    switch (messageType) {
+      case MessageType.HelloRequest: {
+        const fields = decodeFields(payload);
+        const clientInfo = fieldAsString(fields, 1);
+        log("HelloRequest", {
+          clientInfo,
+          clientMajor: fieldAsUint(fields, 2),
+          clientMinor: fieldAsUint(fields, 3),
+        });
+        this.state.helloSeen = true;
+        const resp = buildHelloResponse({
+          // We advertise API 1.10 — matches what aioesphomeapi expects from
+          // current HA Core. Anything newer would risk HA trying to use
+          // features we don't implement; anything older drops voice_assistant.
+          apiVersionMajor: 1,
+          apiVersionMinor: 10,
+          serverInfo: `${this.opts.identity.model} (${this.opts.identity.esphomeVersion})`,
+          name: this.opts.identity.name,
+        });
+        this.send(MessageType.HelloResponse, resp);
+        return;
+      }
+      case MessageType.ConnectRequest: {
+        const fields = decodeFields(payload);
+        const password = fieldAsString(fields, 1);
+        const requirePassword = !!this.opts.password && this.opts.password.length > 0;
+        const invalid = requirePassword && password !== this.opts.password;
+        log("ConnectRequest", { requirePassword, invalid });
+        this.send(MessageType.ConnectResponse, buildConnectResponse(invalid));
+        if (!invalid) {
+          this.state.connected = true;
+          this.state.authorized = true;
+        }
+        return;
+      }
+      case MessageType.DisconnectRequest: {
+        log("DisconnectRequest");
+        this.send(MessageType.DisconnectResponse, EMPTY_PAYLOAD);
+        this.socket.end();
+        return;
+      }
+      case MessageType.PingRequest: {
+        this.send(MessageType.PingResponse, EMPTY_PAYLOAD);
+        return;
+      }
+      case MessageType.DeviceInfoRequest: {
+        log("DeviceInfoRequest");
+        const resp = buildDeviceInfoResponse({
+          usesPassword: !!this.opts.password && this.opts.password.length > 0,
+          identity: this.opts.identity,
+        });
+        this.send(MessageType.DeviceInfoResponse, resp);
+        return;
+      }
+      case MessageType.ListEntitiesRequest: {
+        log("ListEntitiesRequest");
+        // PR1 advertises exactly one voice_assistant entity. The wider entity
+        // set (media_player, button, sensor) lands in PR2 when we wire
+        // SubscribeVoiceAssistantRequest.
+        this.send(
+          MessageType.ListEntitiesVoiceAssistantResponse,
+          buildListEntitiesVoiceAssistantResponse({
+            objectId: "alfred_voice_assistant",
+            // The `key` field is a stable per-entity uint32 HA uses to address
+            // state updates. We use a hash of the object_id so re-deploys of
+            // the same identity yield the same key.
+            key: stableEntityKey("alfred_voice_assistant", this.opts.identity.macAddress),
+            name: "Alfred",
+            uniqueId: `${this.opts.identity.name}_voice_assistant`,
+          }),
+        );
+        this.send(MessageType.ListEntitiesDoneResponse, EMPTY_PAYLOAD);
+        return;
+      }
+      case MessageType.SubscribeStatesRequest: {
+        log("SubscribeStatesRequest");
+        // PR1 has no entity state to push (voice_assistant carries no state
+        // before SubscribeVoiceAssistantRequest, which lands in PR2). HA's
+        // ESPHome integration tolerates a quiet stream — it expects deltas,
+        // not heartbeats — so we simply mark ourselves subscribed and idle.
+        this.state.subscribedStates = true;
+        return;
+      }
+      default: {
+        log("unhandled message (ignored)", { typeName, messageType });
+        return;
+      }
+    }
+  }
+}
+
+// ── Server bootstrap ─────────────────────────────────────────────────────────
+
+export interface StartEsphomeServerOptions {
+  port: number;
+  bindHost: string;
+  identity: EsphomeServerIdentity;
+  password?: string;
+  log?: (msg: string, extra?: Record<string, unknown>) => void;
+}
+
+export interface EsphomeServerHandle {
+  server: net.Server;
+  /** Resolves when the listener is bound. */
+  ready: Promise<void>;
+  /** Resolved port after bind — useful when port=0 in tests. */
+  boundPort(): number;
+  close(): Promise<void>;
+}
+
+export function startEsphomeServer(opts: StartEsphomeServerOptions): EsphomeServerHandle {
+  const log = opts.log ?? defaultLog;
+  const server = net.createServer((socket) => {
+    socket.setNoDelay(true);
+    new EsphomeConnection(socket, {
+      identity: opts.identity,
+      password: opts.password,
+      log: opts.log,
+    });
+  });
+  server.on("error", (err) => log("server error", { err: err.message }));
+
+  const ready = new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(opts.port, opts.bindHost, () => {
+      server.removeListener("error", reject);
+      log(`ESPHome Native API listening on ${opts.bindHost}:${opts.port}`);
+      resolve();
+    });
+  });
+
+  return {
+    server,
+    ready,
+    boundPort: () => {
+      const addr = server.address();
+      if (addr && typeof addr === "object") return addr.port;
+      throw new Error("server not yet bound");
+    },
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function stableEntityKey(objectId: string, macAddress: string): number {
+  const digest = crypto.createHash("sha256").update(`${macAddress}|${objectId}`).digest();
+  // Lower 31 bits — HA's protobuf decoder treats this as a uint32; keep MSB
+  // clear so we never collide with the varint-encoding sign-bit ambiguity.
+  return (
+    ((digest[0] & 0x7f) << 24) | (digest[1] << 16) | (digest[2] << 8) | digest[3]
+  ) >>> 0;
+}

--- a/packages/voice-bridge/src/server.ts
+++ b/packages/voice-bridge/src/server.ts
@@ -28,6 +28,8 @@ import { config } from "./config.js";
 import { VoiceCall } from "./voice-call.js";
 import { handleTwimlInbound, TWIML_INBOUND_PATH } from "./twiml.js";
 import { connectAllMcp } from "./mcp-clients.js";
+import { computeIdentity, startEsphomeServer } from "./esphome-server.js";
+import { announceEsphomeMdns } from "./esphome-mdns.js";
 
 export function verifySig(tenantId: string, sig: string | null | undefined): boolean {
   if (!sig) return false;
@@ -157,6 +159,37 @@ httpServer.listen(config.port, () => {
 void connectAllMcp().catch((err) => {
   console.error("[mcp] connectAllMcp threw (continuing):", err);
 });
+
+// ── ESPHome Native API listener (issue #112, PR1 skeleton) ──────────────────
+// Boots a second TCP listener on :6053 that speaks the ESPHome Native API.
+// Opt-in via ESPHOME_API_ENABLED so we don't surprise existing tenants on
+// rollout — flip to "1" in docker-compose once the audio path is wired in PR2.
+// The Twilio path above is untouched; both listeners share the Node event
+// loop but the codecs are unrelated.
+if (config.esphomeApiEnabled) {
+  const identity = computeIdentity({
+    tenantSeed: config.esphomeTenantSeed || undefined,
+    friendlyName: config.esphomeFriendlyName,
+  });
+  const handle = startEsphomeServer({
+    port: config.esphomeApiPort,
+    bindHost: config.esphomeApiBind,
+    identity,
+    password: config.haVoiceApiToken || undefined,
+  });
+  handle.ready
+    .then(() =>
+      announceEsphomeMdns({
+        port: config.esphomeApiPort,
+        identity,
+      }),
+    )
+    .catch((err) => {
+      console.error("[esphome] startup failed (continuing without HA leg):", err);
+    });
+} else {
+  console.log("[esphome] ESPHOME_API_ENABLED!=1 — HA voice leg disabled");
+}
 
 // Surface uncaught failures rather than dying silently.
 process.on("uncaughtException", (err) => {


### PR DESCRIPTION
First of nine PRs implementing **issue #112 — Voice bridge via Home Assistant Voice (ESPHome-native v1)**. Spec lives at [`docs/specs/issue-112-voice-via-ha.md`](https://github.com/ssdavidai/alfred/blob/main/docs/specs/issue-112-voice-via-ha.md). PR scope is locked to §6 row 1: the connect+pair+idle skeleton. **No audio. No LLM. No MCP tools. No UI.**

## What this ships

- `packages/voice-bridge/src/esphome-protocol.ts` — hand-rolled protobuf varint + framing codec for the ESPHome Native API plaintext (`0x00`) wire shape (`<0x00> <varint len> <varint type> <payload>`). Zero runtime dependencies — chose hand-rolled over `protobufjs` because the message subset PR1 needs is ~10 messages and a 5 MB protobuf lib would dwarf voice-bridge itself. The noise-encrypted (`0x01`) variant is **NOT** implemented; v1 relies on the tailnet boundary per spec §5.5.
- `packages/voice-bridge/src/esphome-server.ts` — TCP listener on `:6053`. Answers `HelloRequest → HelloResponse` (api 1.10), `ConnectRequest → ConnectResponse` (optional password, default open), `DisconnectRequest`, `PingRequest → PingResponse`, `DeviceInfoRequest → DeviceInfoResponse` advertising `model="Alfred Voice Bridge"`, `manufacturer="Alfred Black"`, `esphome_version="alfred-1.0"`, deterministic per-tenant locally-administered MAC (SHA-256 over `tenantSeed`), and `ListEntitiesRequest → ListEntitiesVoiceAssistantResponse + ListEntitiesDoneResponse`. `SubscribeStatesRequest` is accepted and silently idle. Unknown message types are logged + ignored (forward-compat with future HA upgrades).
- `packages/voice-bridge/src/esphome-mdns.ts` — best-effort `_esphomelib._tcp.local.` advertisement via [`bonjour-service`](https://www.npmjs.com/package/bonjour-service) (pure-JS, no native deps — `mdns`/Avahi was a non-starter on `node:22-slim`). Dynamic import + optional dependency: voice-bridge boots even if the package isn't installed.
- `packages/voice-bridge/src/server.ts` — registers the ESPHome listener alongside the existing Twilio listener. Both run in the same process; the codecs don't overlap.
- `packages/voice-bridge/src/config.ts` — new env: `ESPHOME_API_ENABLED` (default `0`), `ESPHOME_API_PORT` (default `6053`), `ESPHOME_API_BIND` (default `0.0.0.0`), `HA_VOICE_API_TOKEN` (default empty — joins the `channel_tokens` table from #111 PR1 in PR2), `ESPHOME_TENANT_SEED`, `ESPHOME_FRIENDLY_NAME`.
- `packages/voice-bridge/package.json` — `bonjour-service` as an `optionalDependency`.
- `packages/voice-bridge/Dockerfile` — `EXPOSE 6053`; runtime stage now installs optional deps so mDNS works in production.
- `docker-compose.yaml` — voice-bridge service gains `6053:6053` port mapping, `ESPHOME_API_ENABLED=1` (overridable per tenant), supporting env vars.

## Twilio path unchanged

This is explicitly called out because regressing the phone path is the load-bearing risk of this work. Verified by:
1. Re-running `dist/openai-realtime.test.js` + `dist/voice-curation.test.js` — all 8 tests pass.
2. Booting the server with `ESPHOME_API_ENABLED=0` (the in-container default) and confirming only `:9000` binds, `[esphome] ESPHOME_API_ENABLED!=1 — HA voice leg disabled` is logged.
3. Booting with `ESPHOME_API_ENABLED=1` confirms both `:9000` and `:6053` bind and the mDNS advertisement publishes — no interference with the WSS upgrade path.
4. No edits to `voice-call.ts`, `openai-realtime.ts`, `twilio-stream.ts`, `tools.ts`, or `twiml.ts`.

## Tests (22 cases, all pass)

`packages/voice-bridge/src/esphome-server.test.ts`:

**Wire-format codec round-trips:**
- varint encode/decode for `0`, `127`, `128`, `16384`, `1<<28`
- sentinel byte sequences (`128 → 0x80 0x01`, `300 → 0xac 0x02`)
- negative + non-integer rejection
- 6-byte overflow rejection
- frame preamble + length + type + payload order
- `tryDecodeFrame` returns null on partial input, full frame on completion
- noise-encrypted `0x01` preamble rejection
- `FrameParser` multi-frame and split-frame handling
- field encoders skip default values (proto3 omit-default semantics)

**Identity:**
- stable MAC from a fixed seed
- LA bit set + unicast bit clear (matches ESPHome firmware soft-MAC convention)
- divergence on different seeds
- spec-mandated identity fields populated

**Message builders (decode-self round-trips):**
- `HelloResponse`, `DeviceInfoResponse`, `ListEntitiesVoiceAssistantResponse`

**End-to-end TCP:**
- `HelloRequest → HelloResponse` with api 1.10 over a real socket
- `ConnectRequest` open (PR1 default) + with-password (`invalid_password=true` on mismatch)
- `DeviceInfoRequest` returns `model="Alfred Voice Bridge"` + MAC + `friendly_name="Alfred"`
- `PingRequest → PingResponse` (empty payload)
- `ListEntitiesRequest` returns exactly `voice_assistant + done`
- Full handshake `Hello → Connect → DeviceInfo → ListEntities → SubscribeStates → Ping` produces the exact expected response sequence
- Unknown message type (`9999`) is ignored without disconnecting (forward compat)

## Library choices

- **Protobuf codec:** hand-rolled (`esphome-protocol.ts`, ~280 LoC). `@esphome/api-client` doesn't exist on npm. `protobufjs` would have been a 200 KB+ dependency for one subset of one `.proto` file. Hand-rolling kept the codec at ~280 LoC and added zero deps; tested against canonical encodings.
- **mDNS:** `bonjour-service` (pure TypeScript Bonjour/Zeroconf, no native deps). The classic `mdns` package binds to libdns_sd/Avahi — non-starter on `node:22-slim`. Optional dependency so a build env without dgram still ships; runtime falls through cleanly when missing.

## What's deferred (per spec §6)

- **PR2:** `SubscribeVoiceAssistantRequest`, `VoiceAssistantConfigurationResponse` declaring the `alfred` wake word, `VoiceAssistantRequest/Response/Audio` wire contract, echo path. `HA_VOICE_API_TOKEN` wired into the `channel_tokens` table from #111 PR1.
- **PR3:** Bridge ESPHome inbound → OpenAI Realtime, bidirectional audio, resampling 16k↔24k, `RUN_START`/`STT_END`/`TTS_START`/`TTS_END`/`RUN_END` events, barge-in via `STT_VAD_END` + `cancel_response`, `continue_conversation`.
- **PR4:** `alfred.tflite` wake-word artifact + HACS integration v0.1.
- **PR5:** One-time installation flow, no per-tenant training.
- **PR6:** `ha__*` MCP tools added to `VOICE_ALLOWED_MCP_TOOLS`, budget audit.
- **PR7:** `MAX_HA_TURNS_DAILY` per `area_id`, `voice_area_turns` table, `/desk` budget tile.
- **PR8:** `postCallTranscript` `source="ha_voice"`, `alfred_journal` indexer reads new field.
- **PR9:** `/channels` HA Voice card.

## Linked

- Spec: `docs/specs/issue-112-voice-via-ha.md` (architecture frozen 2026-05-29 — ESPHome-native v1, Wyoming listener explicitly NOT built)
- Issue: #112
- Sibling: #111 PR1 (text conversation-agent + `channel_tokens` table — feeds PR2 of this issue)
- Reference: [`esphome/api.proto`](https://github.com/esphome/esphome/blob/dev/esphome/components/api/api.proto) pinned conceptually to the upstream HEAD at time of writing

🤖 Generated with [Claude Code](https://claude.com/claude-code)