### PR TITLE
feat(ctrl,db): HA channel — schema + connect/status routes + decision_ref loop guard (#110 PR1)

### DIFF
--- a/packages/ctrl/src/db/migrate.ts
+++ b/packages/ctrl/src/db/migrate.ts
@@ -17,7 +17,11 @@ import type { DatabaseSync } from "node:sqlite";
 import m0001 from "./migrations/0001_fix_pack.sql";
 import m0002 from "./migrations/0002_alfred_journal.sql";
 import m0003 from "./migrations/0003_tailscale_connection.sql";
+<<<<<<< HEAD
 import m0004 from "./migrations/0004_channel_tokens.sql";
+=======
+import m0005 from "./migrations/0005_ha_channel.sql";
+>>>>>>> a72f573e (feat(ctrl,db): 0003_ha_channel migration — 7 ha_* tables + loop-guard index (#110 PR1))
 import m0006 from "./migrations/0006_files_table.sql";
 
 interface Migration {
@@ -31,7 +35,11 @@ const MIGRATIONS: Migration[] = [
   { version: 1, name: "fix_pack",             sql: m0001 },
   { version: 2, name: "alfred_journal",       sql: m0002 },
   { version: 3, name: "tailscale_connection", sql: m0003 },
+<<<<<<< HEAD
   { version: 4, name: "channel_tokens",       sql: m0004 },
+=======
+  { version: 5, name: "ha_channel",           sql: m0005 },
+>>>>>>> a72f573e (feat(ctrl,db): 0003_ha_channel migration — 7 ha_* tables + loop-guard index (#110 PR1))
   { version: 6, name: "files_table",          sql: m0006 },
 ];
 

--- a/packages/ctrl/src/db/migrate.ts
+++ b/packages/ctrl/src/db/migrate.ts
@@ -17,11 +17,8 @@ import type { DatabaseSync } from "node:sqlite";
 import m0001 from "./migrations/0001_fix_pack.sql";
 import m0002 from "./migrations/0002_alfred_journal.sql";
 import m0003 from "./migrations/0003_tailscale_connection.sql";
-<<<<<<< HEAD
 import m0004 from "./migrations/0004_channel_tokens.sql";
-=======
 import m0005 from "./migrations/0005_ha_channel.sql";
->>>>>>> a72f573e (feat(ctrl,db): 0003_ha_channel migration — 7 ha_* tables + loop-guard index (#110 PR1))
 import m0006 from "./migrations/0006_files_table.sql";
 
 interface Migration {
@@ -35,11 +32,8 @@ const MIGRATIONS: Migration[] = [
   { version: 1, name: "fix_pack",             sql: m0001 },
   { version: 2, name: "alfred_journal",       sql: m0002 },
   { version: 3, name: "tailscale_connection", sql: m0003 },
-<<<<<<< HEAD
   { version: 4, name: "channel_tokens",       sql: m0004 },
-=======
   { version: 5, name: "ha_channel",           sql: m0005 },
->>>>>>> a72f573e (feat(ctrl,db): 0003_ha_channel migration — 7 ha_* tables + loop-guard index (#110 PR1))
   { version: 6, name: "files_table",          sql: m0006 },
 ];
 

--- a/packages/ctrl/src/db/migrations/0005_ha_channel.sql
+++ b/packages/ctrl/src/db/migrations/0005_ha_channel.sql
@@ -1,0 +1,220 @@
+-- 0003_ha_channel — Home Assistant channel state.db schema (#110 PR1).
+--
+-- Lands the 7 ha_* tables that back the Home Assistant integration shipped
+-- by issue #110 (docs/specs/issue-110-ha-deep-integration.md §5.5):
+--
+--   ha_connection   — the singleton record of the principal's HA install
+--                     (URL, version, reachability). The LLAT itself lives
+--                     in Vaultwarden, NEVER here; this table only carries
+--                     a vault_item_id reference.
+--   ha_registry     — cached entities / devices / areas / automations /
+--                     scenes / helpers from HA. Refreshed by Phase A of
+--                     HaBootstrapWorkflow (PR5) every 6h + on demand.
+--   ha_proposal     — baseline automation packs Alfred proposes (Phase C,
+--                     PR6). Status flows pending → approved/applied/…
+--   ha_gap          — gaps Phase B finds in the HA install ("no morning
+--                     routine", "no motion lighting"); each gap can
+--                     produce a proposal.
+--   ha_run          — every write Alfred makes against HA (service_call,
+--                     automation_create, etc.). Carries the LOAD-BEARING
+--                     decision_ref + created_at columns for the loop guard
+--                     (see comment block on ha_run below).
+--   ha_event        — capped ring buffer of HA WS events the watcher saw,
+--                     populated by HaWatcherWorkflow (PR3). Diagnostic.
+--   ha_snapshot     — pre-apply YAML snapshots for rollback on Phase E
+--                     automation/scene writes (PR6).
+--
+-- Numbering note. If another PR lands a migration 0003 first, this file
+-- will need a rename (next free slot) in a follow-up commit before merge.
+-- The spec (§5.5) labels this `0003_ha_channel.sql`.
+--
+-- ────────────────────────────────────────────────────────────────────────
+-- Loop guard contract (§3 of the spec, RESOLVED Q11) — load-bearing.
+-- ────────────────────────────────────────────────────────────────────────
+-- The fundamental safety boundary between #110 (Alfred → HA writes) and
+-- #111 (HA → Alfred conversation agent) is that Alfred's OWN writes must
+-- not flow back through the WS event stream as fresh principal-relevant
+-- signals. Without the guard, `ha__call_service` toggling the kitchen
+-- light would echo back as a state_changed event → ingest as a
+-- stream_event → matter the Desk presents as a card → propose a chore
+-- → call ha__call_service again. A closed loop.
+--
+-- The contract:
+--   1. Every write (ha__call_service, ha__create_automation,
+--      ha__update_automation, ha__delete_automation, ha__create_scene,
+--      ha__apply_baseline) MINTS a `decision_ref` (ulid) BEFORE issuing
+--      the upstream HA request.
+--   2. The write is persisted in `ha_run` with that `decision_ref` and a
+--      `created_at` timestamp.
+--   3. HaWatcherWorkflow (PR3), on every inbound state_changed WS event,
+--      looks up `ha_run` by `(entity_id, created_at > now() - 30s,
+--      decision_ref IS NOT NULL)`. If a match exists, the event is
+--      SUPPRESSED at the watcher's ingress — it never becomes a
+--      stream_event, never lands as a signal, never reaches the Desk.
+--      The `ha_event` ring still keeps it (with signaled=0) for forensic.
+--
+-- The partial index `idx_ha_run_entity_recent` below is what makes step 3
+-- cheap: it indexes ONLY rows that participate in the loop-guard match
+-- (decision_ref IS NOT NULL). The watcher's per-event lookup hits an
+-- entity+time tuple inside that small set.
+--
+-- This index + the (decision_ref, created_at) columns MUST land in PR1
+-- so #111 and PR3 can both rely on the contract without an in-flight
+-- schema follow-up. This migration is the freeze point.
+
+-- ----------------------------------------------------------------------------
+-- ha_connection — the singleton row describing how to reach the principal's HA.
+-- ----------------------------------------------------------------------------
+-- CHECK (id = 1) enforces "one tenant, one HA" (spec §7 Q8 RESOLVED — multi-HA
+-- per tenant is explicitly out of scope; revisit only on explicit request).
+-- The LLAT never lives here — only the Vaultwarden item id reference.
+CREATE TABLE IF NOT EXISTS ha_connection (
+  id                  INTEGER PRIMARY KEY CHECK (id = 1),
+  ha_url              TEXT    NOT NULL,
+  label               TEXT    NOT NULL DEFAULT 'Home Assistant',
+  vault_item_id       TEXT    NOT NULL,                       -- Vaultwarden item id, NOT the LLAT
+  ha_version          TEXT,
+  state               TEXT    NOT NULL DEFAULT 'connecting',  -- unconfigured|connecting|connected|error
+  last_test_at        TEXT,
+  last_test_ok        INTEGER NOT NULL DEFAULT 0,
+  last_test_error     TEXT,
+  last_discovery_at   TEXT,
+  created_at          TEXT    NOT NULL DEFAULT (datetime('now')),
+  updated_at          TEXT    NOT NULL DEFAULT (datetime('now'))
+);
+
+-- ----------------------------------------------------------------------------
+-- ha_registry — cached entities/devices/areas/automations/scenes/helpers.
+-- ----------------------------------------------------------------------------
+-- Populated by HaBootstrapWorkflow Phase A (PR5). Read by the
+-- /api/v1/channels/ha/registry route (PR1 ships the empty read).
+CREATE TABLE IF NOT EXISTS ha_registry (
+  kind                TEXT NOT NULL,                          -- entity|device|area|automation|scene|helper
+  ha_id               TEXT NOT NULL,                          -- entity_id / device_id / area_id / automation_id
+  domain              TEXT,                                   -- entity domain (light/sensor/...)
+  area_id             TEXT,
+  friendly_name       TEXT,
+  state               TEXT,                                   -- last observed state (entities only)
+  attributes_json     TEXT,
+  payload_json        TEXT NOT NULL,                          -- the raw HA record
+  last_seen_at        TEXT NOT NULL,
+  last_changed        TEXT,
+  last_updated        TEXT,
+  PRIMARY KEY (kind, ha_id)
+);
+CREATE INDEX IF NOT EXISTS idx_ha_registry_domain ON ha_registry(kind, domain);
+CREATE INDEX IF NOT EXISTS idx_ha_registry_area   ON ha_registry(kind, area_id);
+
+-- ----------------------------------------------------------------------------
+-- ha_proposal — baseline automation packs Alfred proposes for approval.
+-- ----------------------------------------------------------------------------
+-- Status flow: pending → approved → applied | partial_applied | rejected.
+-- decision_ref points at the vault `decision/…` record minted on approval
+-- (so the Desk audit loop closes).
+CREATE TABLE IF NOT EXISTS ha_proposal (
+  id               TEXT NOT NULL PRIMARY KEY,                 -- ulid
+  ts               TEXT NOT NULL,
+  scope            TEXT NOT NULL,                             -- all|rooms|away|morning|evening|motion
+  summary          TEXT NOT NULL,
+  payload_json     TEXT NOT NULL,                             -- full pack: automations, scenes, helpers
+  status           TEXT NOT NULL DEFAULT 'pending',           -- pending|approved|applied|partial_applied|rejected
+  decision_ref     TEXT,                                      -- vault path of the decision/ record
+  applied_at       TEXT,
+  applied_summary  TEXT,
+  created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at       TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_ha_proposal_status_ts ON ha_proposal(status, ts DESC);
+
+-- ----------------------------------------------------------------------------
+-- ha_gap — gaps detected during Phase B (one per missing capability).
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS ha_gap (
+  id            TEXT NOT NULL PRIMARY KEY,                    -- ulid
+  ts            TEXT NOT NULL,
+  kind          TEXT NOT NULL,                                -- no_morning_routine|no_motion_lighting|...
+  evidence      TEXT,
+  fix_pack      TEXT,                                         -- references a baseline pack id
+  proposal_ref  TEXT,                                         -- ha_proposal.id once one is emitted
+  status        TEXT NOT NULL DEFAULT 'open',                 -- open|addressed|dismissed
+  created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_ha_gap_status_ts ON ha_gap(status, ts DESC);
+
+-- ----------------------------------------------------------------------------
+-- ha_run — write-audit ledger AND the loop-guard correlation table.
+-- ----------------------------------------------------------------------------
+-- Carries the LOAD-BEARING `decision_ref` + `created_at` columns the loop
+-- guard depends on (see the header block at the top of this migration for
+-- the full contract). Every HA-write tool MUST:
+--
+--   1. mint `decision_ref = ulid()`
+--   2. INSERT a row in ha_run with that decision_ref + the target entity_id
+--      BEFORE the upstream HA request fires
+--   3. pass the same decision_ref down to HA so it round-trips on the
+--      eventual state_changed event (when HA exposes that hook; otherwise
+--      the entity_id+time match alone is the correlation key)
+--
+-- HaWatcherWorkflow (PR3) then SELECTs from ha_run WHERE entity_id = ? AND
+-- created_at > strftime('%s','now','-30 seconds') * 1000 AND decision_ref
+-- IS NOT NULL, and SUPPRESSES the event at ingress when a row matches.
+CREATE TABLE IF NOT EXISTS ha_run (
+  id            TEXT    NOT NULL PRIMARY KEY,                 -- ulid
+  ts            TEXT    NOT NULL,
+  actor         TEXT    NOT NULL,                             -- alfred-ceo|alfred-specialist|voice|desk-click|workflow
+  kind          TEXT    NOT NULL,                             -- service_call|automation_create|automation_update|automation_delete|scene_create|proposal_apply
+  domain        TEXT,
+  service       TEXT,
+  entity_id     TEXT,
+  payload_json  TEXT    NOT NULL,
+  outcome       TEXT    NOT NULL,                             -- ok|error
+  ha_response   TEXT,
+  error         TEXT,
+  decision_ref  TEXT,                                         -- ulid; LOAD-BEARING for loop-guard (see header)
+  created_at    INTEGER NOT NULL                              -- LOAD-BEARING for loop-guard 30s window (epoch ms)
+);
+CREATE INDEX IF NOT EXISTS idx_ha_run_ts ON ha_run(ts DESC);
+
+-- Loop-guard correlation lookup. Partial — only rows with a decision_ref
+-- (i.e. Alfred-originated writes) participate in the guard, so we don't
+-- index every audit row needlessly. The watcher's per-event probe is:
+--
+--   SELECT 1 FROM ha_run
+--    WHERE entity_id = ? AND decision_ref IS NOT NULL
+--      AND created_at > strftime('%s','now','-30 seconds') * 1000
+--    LIMIT 1;
+--
+-- The (entity_id, created_at) tuple matches the partial index head-on.
+CREATE INDEX IF NOT EXISTS idx_ha_run_entity_recent
+  ON ha_run(entity_id, created_at)
+  WHERE decision_ref IS NOT NULL;
+
+-- ----------------------------------------------------------------------------
+-- ha_event — capped ring buffer of inbound HA WS events (PR3 populates).
+-- ----------------------------------------------------------------------------
+-- Bound by HA_WATCHER_EVENT_RING_SIZE (default 1000) via activity-side guard.
+CREATE TABLE IF NOT EXISTS ha_event (
+  id            TEXT    NOT NULL PRIMARY KEY,
+  ts            TEXT    NOT NULL,
+  event_type    TEXT    NOT NULL,
+  entity_id     TEXT,
+  payload_json  TEXT    NOT NULL,
+  signaled      INTEGER NOT NULL DEFAULT 0,                   -- 1 if it produced a stream_event; 0 if loop-guarded
+  created_at    TEXT    NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_ha_event_ts ON ha_event(ts DESC);
+
+-- ----------------------------------------------------------------------------
+-- ha_snapshot — pre-apply YAML snapshots, for the rollback button on /channels/ha.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS ha_snapshot (
+  id            TEXT NOT NULL PRIMARY KEY,                    -- ulid
+  ts            TEXT NOT NULL,
+  kind          TEXT NOT NULL,                                -- automation|scene
+  ha_id         TEXT NOT NULL,
+  proposal_ref  TEXT,                                         -- ha_proposal.id if part of a pack
+  payload_json  TEXT NOT NULL,                                -- pre-change full YAML
+  restored_at   TEXT,
+  created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_ha_snapshot_ts ON ha_snapshot(ts DESC);

--- a/packages/ctrl/tests/migrate.test.ts
+++ b/packages/ctrl/tests/migrate.test.ts
@@ -41,6 +41,10 @@ describe("state.db migration runner", () => {
     // + 0004_channel_tokens).
     assert.equal(v, 6, "migrated to latest version");
     assert.equal(userVersion(db), 6);
+=======
+    assert.equal(v, 4, "migrated to latest version");
+    assert.equal(userVersion(db), 4);
+>>>>>>> 37313a3f (feat(ctrl,db): 0003_ha_channel migration — 7 ha_* tables + loop-guard index (#110 PR1))
     assert.ok(cols(db, "observation").includes("processed_at"), "0001: processed_at present after migrate");
     // 0002: alfred_journal + alfred_principal tables present.
     const tables = (

--- a/packages/ctrl/tests/test_channels_ha_pr1.ts
+++ b/packages/ctrl/tests/test_channels_ha_pr1.ts
@@ -1,0 +1,592 @@
+// Lane I — /api/v1/channels/ha/* (#110 PR1).
+//
+// What's under test
+// -----------------
+// PR1 of issue #110 ships the Home Assistant channel skeleton:
+//   * 7 ha_* tables (migration 0003_ha_channel.sql)
+//   * 5 live routes (connect, status, disconnect, registry, snapshots)
+//   * 11 stub routes (501 with "lands in PR2/5/6") — verified at server
+//     wire-up time (see channels_ha.ts), not exhaustively here.
+//   * voice-bridge `self` allowlist additions per spec §7 Q13.
+//   * the load-bearing decision_ref + idx_ha_run_entity_recent loop-guard
+//     contract (full watcher-side filtering is PR3 — this PR only proves
+//     the schema + index exist and accept the row shape PR3 will read).
+//
+// Coverage (10 tests):
+//   1. Connect happy path — HA /api/ probe returns 200, /api/config returns
+//      version → 200 { ok, ha_version, state:'connected' }; ha_connection
+//      row persisted; LLAT lands in Vaultwarden, NOT in state.db.
+//   2. Connect with bad LLAT — HA returns 401 → 401 AUTH_FAILED, no
+//      Vaultwarden write, no ha_connection row.
+//   3. Connect with bad URL shape (file:// / no host) → 400 VALIDATION_ERROR.
+//   4. Status when unconfigured → 200 { connected:false, state:'unconfigured' }.
+//   5. Status after connect → 200 { connected:true, state:'connected',
+//      ha_url, ha_version }.
+//   6. Disconnect clears Vaultwarden item + ha_connection.
+//   7. Registry empty (PR5 populates) → { entities:[], ...} shape.
+//   8. Voice-bridge allowlist — accepts the 4 read routes spec §7 Q13 lists.
+//   9. Voice-bridge allowlist — REJECTS HA writes (POST /connect,
+//      POST /service, DELETE /disconnect).
+//  10. Loop-guard contract — insert a row in ha_run with decision_ref +
+//      a 10s-old created_at, prove the partial index finds it via the
+//      watcher's lookup shape.
+//
+// Privacy: this is a public OSS repo. Tests use synthetic placeholders only
+// — the LLAT is "llat_TEST_…" and never resembles a real long-lived token.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ServerResponse } from "node:http";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "channels-ha-pr1-"));
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.VAULT_PATH = path.join(tmp, "vault");
+process.env.STATE_DB_PATH = path.join(tmp, "alfred-state.db");
+process.env.INGEST_DB_PATH = path.join(tmp, "ingest.db");
+process.env.SQLITE_VEC_PATH = "";
+process.env.VAULT_CLI_URL = "http://vault-cli-stub:8087";
+process.env.HA_VAULTWARDEN_FOLDER = "Home Assistant";
+process.env.HA_LLAT_ITEM = "LLAT";
+process.env.HA_PROBE_TIMEOUT_MS = "5000";
+
+// Synthetic placeholders — never resemble a real HA LLAT.
+const VALID_LLAT = "llat_TEST_" + "0".repeat(40);
+const HA_URL = "http://homeassistant.local:8123";
+const HA_VERSION = "2025.6.1";
+
+// ── HA probe + vault-cli mock ─────────────────────────────────────────
+
+interface VaultItem {
+  id: string;
+  name: string;
+  type: 1;
+  folderId: string | null;
+  login: { username: string | null; password: string; uris: unknown[] };
+}
+interface VaultFolder {
+  id: string;
+  name: string;
+}
+let vaultStore: VaultItem[] = [];
+let vaultFolders: VaultFolder[] = [];
+
+// HA probe controls: independent for /api/ (auth) and /api/config (version).
+let haApiStatus = 200;
+let haApiVersionOk = true;
+const haCalls: { url: string; auth: string }[] = [];
+
+const originalFetch = globalThis.fetch;
+function makeJsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+globalThis.fetch = (async (input: any, init?: any) => {
+  const url = typeof input === "string" ? input : (input?.url ?? String(input));
+  const method = (init?.method ?? "GET").toUpperCase();
+  const authHeader =
+    init?.headers?.Authorization ??
+    init?.headers?.authorization ??
+    "";
+  haCalls.push({ url, auth: String(authHeader) });
+
+  // HA /api/ — auth gate.
+  if (url === `${HA_URL}/api/` && method === "GET") {
+    if (haApiStatus !== 200) {
+      return makeJsonResponse(
+        { error: "Unauthorized" },
+        haApiStatus,
+      );
+    }
+    return makeJsonResponse({ message: "API running." }, 200);
+  }
+  // HA /api/config — version pull (best-effort).
+  if (url === `${HA_URL}/api/config` && method === "GET") {
+    if (!haApiVersionOk) {
+      return makeJsonResponse({ error: "boom" }, 500);
+    }
+    return makeJsonResponse({ version: HA_VERSION }, 200);
+  }
+
+  // vault-cli folders — list + create.
+  if (url.endsWith("/list/object/folders") && method === "GET") {
+    return makeJsonResponse({ success: true, data: { data: vaultFolders } });
+  }
+  if (url.endsWith("/object/folder") && method === "POST") {
+    const body = JSON.parse(String(init?.body ?? "{}"));
+    const f: VaultFolder = {
+      id: "fld-" + String(Date.now()) + "-" + Math.random().toString(36).slice(2, 6),
+      name: body.name,
+    };
+    vaultFolders.push(f);
+    return makeJsonResponse({ success: true, data: { data: f } });
+  }
+
+  // vault-cli items — list + get + create + put + delete.
+  if (url.includes("/list/object/items")) {
+    const qIdx = url.indexOf("?");
+    const params = new URLSearchParams(qIdx >= 0 ? url.slice(qIdx + 1) : "");
+    const search = params.get("search") ?? "";
+    const filtered = search
+      ? vaultStore.filter((i) =>
+          i.name.toLowerCase().includes(search.toLowerCase()),
+        )
+      : vaultStore.slice();
+    return makeJsonResponse({ success: true, data: { data: filtered } });
+  }
+  const objMatch = url.match(/\/object\/item\/([^/?]+)/);
+  if (objMatch && method === "GET") {
+    const id = objMatch[1];
+    const item = vaultStore.find((i) => i.id === id);
+    if (!item) return makeJsonResponse({ success: false, message: "not found" }, 404);
+    return makeJsonResponse({ success: true, data: { data: item } });
+  }
+  if (url.endsWith("/object/item") && method === "POST") {
+    const body = JSON.parse(String(init?.body ?? "{}"));
+    const id =
+      "id-" + String(Date.now()) + "-" + Math.random().toString(36).slice(2, 8);
+    const item: VaultItem = {
+      id,
+      name: body.name,
+      type: 1,
+      folderId: body.folderId ?? null,
+      login: {
+        username: body.login?.username ?? null,
+        password: body.login?.password ?? "",
+        uris: body.login?.uris ?? [],
+      },
+    };
+    vaultStore.push(item);
+    return makeJsonResponse({ success: true, data: { data: item } });
+  }
+  if (objMatch && method === "PUT") {
+    const id = objMatch[1];
+    const idx = vaultStore.findIndex((i) => i.id === id);
+    if (idx < 0) return makeJsonResponse({ success: false, message: "not found" }, 404);
+    const body = JSON.parse(String(init?.body ?? "{}"));
+    vaultStore[idx] = {
+      ...vaultStore[idx],
+      name: body.name ?? vaultStore[idx].name,
+      folderId: body.folderId ?? vaultStore[idx].folderId,
+      login: { ...vaultStore[idx].login, ...(body.login ?? {}) },
+    };
+    return makeJsonResponse({ success: true, data: { data: vaultStore[idx] } });
+  }
+  if (objMatch && method === "DELETE") {
+    const id = objMatch[1];
+    const idx = vaultStore.findIndex((i) => i.id === id);
+    if (idx < 0) return makeJsonResponse({ success: false, message: "not found" }, 404);
+    vaultStore.splice(idx, 1);
+    return makeJsonResponse({ success: true });
+  }
+
+  throw new Error(`unexpected fetch in test_channels_ha_pr1: ${method} ${url}`);
+}) as typeof fetch;
+
+// ── module imports (after env + fetch are set) ─────────────────────────
+
+const { registerChannelsHaRoutes } = await import(
+  "../src/api/routes/channels_ha.js"
+);
+const { matchRoute } = await import("../src/api/server.js");
+const { handleError } = await import("../src/api/errors.js");
+const { getStateDb } = await import("../src/db/state.js");
+const {
+  setApiKey,
+  setVoiceBridgeKey,
+  authenticate,
+  _resetAuthForTests,
+} = await import("../src/api/auth.js");
+const { AuthError } = await import("../src/api/errors.js");
+
+registerChannelsHaRoutes();
+
+// ── route invoker (mirrors the channels_paperclip pattern) ─────────────
+
+interface CallResult {
+  status: number;
+  payload: any;
+}
+async function call(
+  method: string,
+  p: string,
+  body?: unknown,
+): Promise<CallResult> {
+  const m = matchRoute(method, p);
+  assert.ok(m, `${method} ${p} must be registered`);
+  let status = 0;
+  let payload: any;
+  const res = {
+    statusCode: 0,
+    setHeader() {},
+    writeHead(c: number) {
+      status = c;
+      return res;
+    },
+    end(j?: string) {
+      payload = j ? JSON.parse(j) : undefined;
+    },
+  } as unknown as ServerResponse;
+  try {
+    await m!.handler({
+      req: { method, headers: {}, url: p } as any,
+      res,
+      params: m!.params,
+      body,
+      query: new URLSearchParams(),
+    });
+  } catch (err) {
+    handleError(res, err);
+  }
+  return { status, payload };
+}
+
+function fakeReq(token: string | undefined): any {
+  return {
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+  };
+}
+
+const MASTER_KEY = "test-master-" + "x".repeat(40);
+const VOICE_KEY = "test-voice-" + "y".repeat(40);
+
+// ── tests ──────────────────────────────────────────────────────────────
+
+describe("/api/v1/channels/ha/* — #110 PR1", () => {
+  beforeEach(() => {
+    vaultStore = [];
+    vaultFolders = [];
+    haCalls.length = 0;
+    haApiStatus = 200;
+    haApiVersionOk = true;
+    // Wipe ha_connection between tests so we always start from
+    // unconfigured.
+    try {
+      getStateDb().prepare("DELETE FROM ha_connection").run();
+    } catch {
+      /* table may not exist on the very first run before migrations
+         ran — getStateDb() itself runs migrations though, so it should */
+    }
+  });
+
+  // ── 1 ──
+  it("connect happy path → 200, ha_connection row, Vaultwarden item", async () => {
+    const r = await call("POST", "/api/v1/channels/ha/connect", {
+      ha_url: HA_URL,
+      llat: VALID_LLAT,
+      label: "Main house",
+    });
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.ok, true);
+    assert.equal(r.payload.state, "connected");
+    assert.equal(r.payload.ha_version, HA_VERSION);
+
+    // ha_connection row landed.
+    const row = getStateDb()
+      .prepare("SELECT * FROM ha_connection WHERE id = 1")
+      .get() as any;
+    assert.ok(row, "ha_connection row must exist");
+    assert.equal(row.ha_url, HA_URL);
+    assert.equal(row.label, "Main house");
+    assert.equal(row.state, "connected");
+    assert.equal(row.ha_version, HA_VERSION);
+    assert.equal(Number(row.last_test_ok), 1);
+    assert.ok(
+      typeof row.vault_item_id === "string" && row.vault_item_id.length > 0,
+      "vault_item_id must be set",
+    );
+
+    // The LLAT itself is NEVER in state.db — only the Vaultwarden item id.
+    const serialised = JSON.stringify(row);
+    assert.ok(
+      !serialised.includes(VALID_LLAT),
+      "ha_connection MUST NOT carry the LLAT",
+    );
+
+    // Vaultwarden got exactly one LLAT item, in the HA folder.
+    assert.equal(vaultStore.length, 1);
+    assert.equal(vaultStore[0].name, "LLAT");
+    assert.equal(vaultStore[0].login.password, VALID_LLAT);
+    assert.ok(vaultStore[0].folderId, "folderId must be set");
+    const folder = vaultFolders.find((f) => f.id === vaultStore[0].folderId);
+    assert.ok(folder, "folder must exist");
+    assert.equal(folder!.name, "Home Assistant");
+  });
+
+  // ── 2 ──
+  it("connect with bad LLAT → 401, no vault write, no state.db row", async () => {
+    haApiStatus = 401;
+    const r = await call("POST", "/api/v1/channels/ha/connect", {
+      ha_url: HA_URL,
+      llat: "wrong-llat",
+    });
+    assert.equal(r.status, 401, JSON.stringify(r.payload));
+    assert.equal(r.payload.error.code, "AUTH_FAILED");
+
+    // No Vaultwarden write — the upsert must come AFTER the probe.
+    assert.equal(vaultStore.length, 0);
+
+    // No ha_connection row.
+    const row = getStateDb()
+      .prepare("SELECT * FROM ha_connection WHERE id = 1")
+      .get();
+    assert.equal(row, undefined);
+  });
+
+  // ── 3 ──
+  it("connect rejects malformed ha_url with 400 VALIDATION_ERROR", async () => {
+    for (const bad of [
+      { ha_url: "file:///etc/passwd", llat: VALID_LLAT, label: "x" },
+      { ha_url: "not-a-url", llat: VALID_LLAT },
+      { ha_url: "", llat: VALID_LLAT },
+      { ha_url: HA_URL, llat: "" },
+    ]) {
+      const r = await call("POST", "/api/v1/channels/ha/connect", bad);
+      assert.equal(r.status, 400, `expected 400 for ${JSON.stringify(bad)}; got ${JSON.stringify(r.payload)}`);
+      assert.equal(r.payload.error.code, "VALIDATION_ERROR");
+    }
+    // No upstream calls fired (all four short-circuit before probeHa).
+    assert.equal(haCalls.length, 0);
+  });
+
+  // ── 4 ──
+  it("status when unconfigured → 200 { connected:false, state:'unconfigured' }", async () => {
+    const r = await call("GET", "/api/v1/channels/ha/status");
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.connected, false);
+    assert.equal(r.payload.state, "unconfigured");
+    assert.equal(r.payload.ha_url, null);
+    assert.equal(r.payload.ha_version, null);
+    assert.equal(r.payload.error, null);
+  });
+
+  // ── 5 ──
+  it("status after connect → 200 { connected:true, state:'connected', ha_url, ha_version }", async () => {
+    await call("POST", "/api/v1/channels/ha/connect", {
+      ha_url: HA_URL,
+      llat: VALID_LLAT,
+    });
+    const r = await call("GET", "/api/v1/channels/ha/status");
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.connected, true);
+    assert.equal(r.payload.state, "connected");
+    assert.equal(r.payload.ha_url, HA_URL);
+    assert.equal(r.payload.ha_version, HA_VERSION);
+    assert.equal(r.payload.last_test_ok, true);
+    // Defence in depth: /status NEVER leaks the LLAT.
+    const ser = JSON.stringify(r.payload);
+    assert.ok(!ser.includes(VALID_LLAT), "/status payload must not carry the LLAT");
+  });
+
+  // ── 6 ──
+  it("disconnect clears Vaultwarden item + ha_connection", async () => {
+    // Set up — connect first.
+    await call("POST", "/api/v1/channels/ha/connect", {
+      ha_url: HA_URL,
+      llat: VALID_LLAT,
+    });
+    assert.equal(vaultStore.length, 1);
+
+    // Disconnect.
+    const r = await call("DELETE", "/api/v1/channels/ha/disconnect");
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.ok, true);
+
+    // ha_connection wiped, Vaultwarden item removed.
+    const row = getStateDb()
+      .prepare("SELECT * FROM ha_connection WHERE id = 1")
+      .get();
+    assert.equal(row, undefined);
+    assert.equal(vaultStore.length, 0);
+
+    // /status flips back to unconfigured.
+    const s = await call("GET", "/api/v1/channels/ha/status");
+    assert.equal(s.payload.state, "unconfigured");
+  });
+
+  // ── 7 ──
+  it("registry empty (PR5 populates) → spec-shaped empty buckets", async () => {
+    const r = await call("GET", "/api/v1/channels/ha/registry");
+    assert.equal(r.status, 200);
+    assert.deepEqual(r.payload, {
+      entities: [],
+      areas: [],
+      devices: [],
+      automations: [],
+      scenes: [],
+      helpers: [],
+    });
+  });
+
+  // ── 8 ──
+  it("voice-bridge allowlist accepts the 4 spec §7 Q13 read routes", () => {
+    _resetAuthForTests();
+    setApiKey(MASTER_KEY);
+    setVoiceBridgeKey(VOICE_KEY);
+
+    // Exact-match: /status, /registry.
+    for (const pathname of [
+      "/api/v1/channels/ha/status",
+      "/api/v1/channels/ha/registry",
+    ]) {
+      assert.doesNotThrow(
+        () => authenticate(fakeReq(VOICE_KEY), { method: "GET", pathname }),
+        `voice-bridge token must accept GET ${pathname}`,
+      );
+    }
+    // Pattern: /state/:entity_id, /automations.
+    for (const pathname of [
+      "/api/v1/channels/ha/state/light.kitchen",
+      "/api/v1/channels/ha/state/binary_sensor.front_door",
+      "/api/v1/channels/ha/automations",
+    ]) {
+      assert.doesNotThrow(
+        () => authenticate(fakeReq(VOICE_KEY), { method: "GET", pathname }),
+        `voice-bridge token must accept GET ${pathname}`,
+      );
+    }
+  });
+
+  // ── 9 ──
+  it("voice-bridge allowlist REJECTS HA writes", () => {
+    _resetAuthForTests();
+    setApiKey(MASTER_KEY);
+    setVoiceBridgeKey(VOICE_KEY);
+    for (const route of [
+      { method: "POST", pathname: "/api/v1/channels/ha/connect" },
+      { method: "POST", pathname: "/api/v1/channels/ha/service" },
+      { method: "DELETE", pathname: "/api/v1/channels/ha/disconnect" },
+      { method: "POST", pathname: "/api/v1/channels/ha/automation" },
+      { method: "PATCH", pathname: "/api/v1/channels/ha/automation/abc" },
+      { method: "DELETE", pathname: "/api/v1/channels/ha/automation/abc" },
+      { method: "POST", pathname: "/api/v1/channels/ha/proposal/approve" },
+      { method: "POST", pathname: "/api/v1/channels/ha/proposal/reject" },
+      { method: "POST", pathname: "/api/v1/channels/ha/discovery" },
+      // Snapshots — not on the voice surface (Q13 lists only the 4 reads above).
+      { method: "GET", pathname: "/api/v1/channels/ha/snapshots" },
+      // Prefix anti-regression: /api/v1/channels/ha-something must NOT inherit.
+      { method: "GET", pathname: "/api/v1/channels/ha-bridge/status" },
+    ]) {
+      assert.throws(
+        () => authenticate(fakeReq(VOICE_KEY), route),
+        AuthError,
+        `voice-bridge MUST reject ${route.method} ${route.pathname}`,
+      );
+    }
+  });
+
+  // ── 10 — loop-guard contract ──
+  it("loop-guard contract: ha_run row with decision_ref + recent created_at hits the partial index", () => {
+    // Simulate what PR2's ha__call_service activity does: mint a
+    // decision_ref, insert a ha_run row keyed by entity_id, then PR3's
+    // HaWatcherWorkflow performs the lookup that the partial index
+    // idx_ha_run_entity_recent backs.
+    const db = getStateDb();
+    const now = Date.now();
+    const tenSecondsAgo = now - 10_000;
+    const fortySecondsAgo = now - 40_000;
+
+    db.prepare(
+      `INSERT INTO ha_run (
+         id, ts, actor, kind, domain, service, entity_id,
+         payload_json, outcome, decision_ref, created_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      "run-recent-with-ref",
+      new Date(tenSecondsAgo).toISOString(),
+      "alfred-ceo",
+      "service_call",
+      "light",
+      "turn_off",
+      "light.kitchen",
+      JSON.stringify({}),
+      "ok",
+      "abc-decision-ref",
+      tenSecondsAgo,
+    );
+    // A second row OUTSIDE the 30s window — must NOT match.
+    db.prepare(
+      `INSERT INTO ha_run (
+         id, ts, actor, kind, domain, service, entity_id,
+         payload_json, outcome, decision_ref, created_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      "run-stale-with-ref",
+      new Date(fortySecondsAgo).toISOString(),
+      "alfred-ceo",
+      "service_call",
+      "light",
+      "turn_off",
+      "light.kitchen",
+      JSON.stringify({}),
+      "ok",
+      "older-decision-ref",
+      fortySecondsAgo,
+    );
+    // A third row WITHIN window but WITHOUT a decision_ref — non-Alfred
+    // write, must NOT match (the partial index excludes it).
+    db.prepare(
+      `INSERT INTO ha_run (
+         id, ts, actor, kind, domain, service, entity_id,
+         payload_json, outcome, decision_ref, created_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      "run-recent-without-ref",
+      new Date(tenSecondsAgo).toISOString(),
+      "voice",
+      "service_call",
+      "light",
+      "turn_off",
+      "light.kitchen",
+      JSON.stringify({}),
+      "ok",
+      null, // decision_ref intentionally absent — outside the partial index
+      tenSecondsAgo,
+    );
+
+    // The watcher's loop-guard probe — exactly the shape PR3 will run.
+    const cutoff = now - 30_000;
+    const matches = db
+      .prepare(
+        `SELECT id FROM ha_run
+          WHERE entity_id = ?
+            AND decision_ref IS NOT NULL
+            AND created_at > ?
+          ORDER BY created_at DESC`,
+      )
+      .all("light.kitchen", cutoff) as { id: string }[];
+    assert.equal(matches.length, 1, "exactly one row must match the 30s loop-guard window");
+    assert.equal(matches[0].id, "run-recent-with-ref");
+
+    // Confirm the partial index exists and is wired to the column tuple
+    // PR3 will probe — defence in depth against a future migration
+    // accidentally dropping it.
+    const indexes = db
+      .prepare(
+        `SELECT name, sql FROM sqlite_master
+          WHERE type = 'index' AND tbl_name = 'ha_run'`,
+      )
+      .all() as { name: string; sql: string | null }[];
+    const partial = indexes.find(
+      (i) => i.name === "idx_ha_run_entity_recent",
+    );
+    assert.ok(partial, "idx_ha_run_entity_recent must exist on ha_run");
+    assert.ok(
+      partial!.sql && partial!.sql.includes("decision_ref IS NOT NULL"),
+      "partial index MUST be gated on decision_ref IS NOT NULL",
+    );
+    assert.ok(
+      partial!.sql && partial!.sql.includes("entity_id"),
+      "partial index MUST include entity_id (loop-guard probe key)",
+    );
+    assert.ok(
+      partial!.sql && partial!.sql.includes("created_at"),
+      "partial index MUST include created_at (loop-guard time window)",
+    );
+  });
+});


### PR DESCRIPTION
PR1 of issue #110 (Deep Home Assistant integration). See spec at `docs/specs/issue-110-ha-deep-integration.md`. **Do not merge** until Sir reviews + smokes — Sir is away.

## What ships

**1. `0003_ha_channel.sql` migration** — all 7 ha_* tables per spec §5.5:
`ha_connection`, `ha_registry`, `ha_proposal`, `ha_gap`, `ha_run`, `ha_event`, `ha_snapshot`.
The `ha_run` table carries the **load-bearing `decision_ref` + `created_at` columns** and the partial index `idx_ha_run_entity_recent ON ha_run(entity_id, created_at) WHERE decision_ref IS NOT NULL` — this is the loop guard #111 and PR3 both rely on.

**2. `packages/ctrl/src/api/routes/channels_ha.ts`** — 5 live + 11 stubbed routes:

| Route | Status |
|---|---|
| `POST /api/v1/channels/ha/connect` | live |
| `GET /api/v1/channels/ha/status` | live |
| `DELETE /api/v1/channels/ha/disconnect` | live |
| `GET /api/v1/channels/ha/registry` | live (empty until PR5) |
| `GET /api/v1/channels/ha/snapshots` | live (empty until PR6) |
| `POST /discovery`, `GET /state/:id`, `POST /service`, `GET /audit`, `GET /automations`, `POST/PATCH/DELETE /automation[/:id]`, `GET /proposals`, `GET /proposal/:id`, `POST /proposal/{approve,reject}` | 501 NOT_IMPLEMENTED stubs (PR2/5/6) |

**3. Vaultwarden LLAT storage** — folder "Home Assistant", item "LLAT", `item.login.password` = the LLAT. Mirrors `routes/channels_omi.ts` (Groq key pattern). Token NEVER lands in state.db or .env.

**4. `packages/ctrl/src/api/auth.ts`** — voice-bridge `self` allowlist additions per spec §7 Q13 RESOLVED:
- exact: `GET /channels/ha/status`, `GET /channels/ha/registry`
- regex: `GET /channels/ha/state/:entity_id`, `GET /channels/ha/automations`
Writes intentionally absent — voice writes via MCP `ha__call_service` (PR2), same boundary as PR #98.

**5. `packages/ctrl/src/api/server.ts`** — `registerChannelsHaRoutes()` wired in.

**6. Tests** — `packages/ctrl/tests/test_channels_ha_pr1.ts` (10 tests, all green):
connect happy path / bad LLAT 401 / malformed URL 400 / status before+after connect / disconnect / registry empty shape / voice-bridge accepts 4 reads / voice-bridge rejects writes / loop-guard contract (partial-index probe).

## The loop-guard contract — lands here so #111 can rely on it

Spec §3 RESOLVED Q11: the watcher (PR3) suppresses any `state_changed` event whose target `entity_id` matches a `ha_run` row written by Alfred with a non-null `decision_ref` in the last 30 seconds. Without that, Alfred's own writes echo back as Desk signals → propose-act loop. This PR lands the schema + index + the probe-shape test so #111 (HA → Alfred) and #110 PR3 (HaWatcherWorkflow) can both build against a frozen contract.

## Env vars

| Var | Default | Purpose |
|---|---|---|
| `HA_PROBE_TIMEOUT_MS` | `5000` | `/api/` probe timeout |
| `HA_VAULTWARDEN_FOLDER` | `Home Assistant` | Vaultwarden folder name |
| `HA_LLAT_ITEM` | `LLAT` | Vaultwarden item name |

## Deferred to later PRs

- **PR2** — `home-assistant` MCP app (~16 `ha__*` tools) + the live write/read handlers behind the stubbed routes
- **PR3** — `HaWatcherWorkflow` (WS subscription + the loop-guard ingress filter that READS `ha_run`)
- **PR4** — Hermes skill + persona surface (`alfred-home-assistant-operations`)
- **PR5** — `HaBootstrapWorkflow` Phase A-B (registry discovery + gap detection)
- **PR6** — proposal pipeline Phase C-E (propose → approve → apply, with rollback via `ha_snapshot`)
- **PR7** — watcher hardening (long-lived) + token-health workflow + docs

Tracking: ssdavidai/alfred#110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)