### PR TITLE
feat(ctrl): Tailscale ctrl-api routes — connect/status/disconnect/peers (#109 PR2)

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,0 +1,8 @@
+# GitGuardian repo-level config.
+# Reference: https://docs.gitguardian.com/ggshield-docs/reference/secret-scan/all-options#yaml-configuration
+version: 2
+secret:
+  ignored-paths:
+    # Test fixtures contain synthetic auth-key shaped strings that match the
+    # Tailscale `tskey-auth-…` pattern. They are clearly marked FIXTUREONLY.
+    - "packages/ctrl/tests/channels_tailscale.test.ts"

--- a/packages/ctrl/src/api/auth.ts
+++ b/packages/ctrl/src/api/auth.ts
@@ -116,6 +116,12 @@ const VOICE_BRIDGE_ALLOWLIST: ReadonlySet<string> = new Set([
   "GET:/api/v1/learning/instincts",
   "GET:/api/v1/learning/reflections",
   "GET:/api/v1/learning/sessions",
+  // Tailscale channel — Sir asks "is Tailscale on right now?" via voice.
+  // Read-only surface (status + peer list); connect/disconnect intentionally
+  // omitted (writes go through MCP per the voice-bridge contract). Added
+  // by issue #109 PR 2 alongside the routes themselves.
+  "GET:/api/v1/channels/tailscale/status",
+  "GET:/api/v1/channels/tailscale/peers",
 ]);
 
 /**

--- a/packages/ctrl/src/api/routes/channels_tailscale.ts
+++ b/packages/ctrl/src/api/routes/channels_tailscale.ts
@@ -1,0 +1,709 @@
+// /api/v1/channels/tailscale/* — Tailscale channel routes (issue #109 PR 2).
+//
+// Spec: docs/specs/issue-109-tailscale-via-ui.md.
+//
+// What this file ships
+// --------------------
+// The six routes that drive the off-by-default Tailscale sidecar (declared by
+// `profiles: ["tailscale"]` in PR 1's docker-compose.yaml):
+//
+//   GET    /api/v1/channels/tailscale/status      — live lifecycle (fail-soft).
+//   POST   /api/v1/channels/tailscale/connect     — bring the sidecar up.
+//   POST   /api/v1/channels/tailscale/disconnect  — logout + stop.
+//   GET    /api/v1/channels/tailscale/cert        — PR 4 stub (501).
+//   POST   /api/v1/channels/tailscale/serve       — PR 4 stub (501).
+//   GET    /api/v1/channels/tailscale/peers       — peer list (fail-soft).
+//
+// Architecture
+// ------------
+// The `tailscale_connection` table (singleton, PR 1 migration 0003) is the
+// authoritative lifecycle state.db row. This module is its sole writer.
+// Live state on the sidecar is probed via `docker exec
+// alfred-black-tailscale-1 tailscale status --json`; probe failures NEVER
+// 500 — they fall through to the cached row + a `last_error`/`reason`
+// field. The dashboard polls /status; the route caches at the table level
+// (last_status_probe_at) so spammy pollers don't fork-storm.
+//
+// Every write is audited (action_type `tailscale_*`) via the existing
+// `appendAudit` helper so the audit ledger reflects who turned the tailnet
+// on, when, and from where.
+//
+// Why direct `docker compose` from ctrl-api?
+// ------------------------------------------
+// ctrl-api has the docker socket bind-mounted (see compose `volumes`); the
+// `helpers.ts` patterns (`dockerComposeCmd`, `dockerExec`) already gate
+// concurrent docker forks under a 8-slot semaphore. We reuse those.
+//
+// PR boundary
+// -----------
+// PR 3 (the `/connections` web card) drives all six routes from the dash;
+// PR 4 (Caddy + Tailscale Serve) fills in /cert + /serve. Neither lands here.
+
+import { addRoute } from "../server.js";
+import { sendJson, ValidationError, ApiError } from "../errors.js";
+import { getStateDb } from "../../db/state.js";
+import { appendAudit } from "./state.js";
+import {
+  COMPOSE_DIR,
+  dockerComposeCmd,
+  dockerExec,
+} from "../helpers.js";
+import fs from "node:fs";
+
+// ── Constants ─────────────────────────────────────────────────────────────
+
+/**
+ * Compose service name for the Tailscale sidecar (matches PR 1's
+ * `services.tailscale` block). The literal container name docker compose
+ * synthesises is `<project>-tailscale-1` — by default
+ * `alfred-black-tailscale-1`, configurable via COMPOSE_PROJECT_NAME.
+ */
+const TAILSCALE_SERVICE = "tailscale";
+
+/**
+ * Live container name for `docker exec` calls. Mirrors the pattern in
+ * channels_paperclip.ts (`docker exec alfred-black-hermes-1 …`). Overridable
+ * for tests + non-default compose project names.
+ */
+const TAILSCALE_CONTAINER =
+  process.env.TAILSCALE_CONTAINER ?? "alfred-black-tailscale-1";
+
+/**
+ * Vaultwarden item name for the auth-key Path A flow. Sir's UI surfaces this
+ * label in the credentials list.
+ */
+const VAULT_ITEM_NAME = "Tailscale Auth Key";
+
+/** Vault-cli (bw serve) base URL — same default as routes/vaultwarden.ts. */
+const VAULT_CLI_URL = process.env.VAULT_CLI_URL ?? "http://vault-cli:8087";
+
+/** `.env` file the compose run reads — same path the bootstrap script writes. */
+const ENV_PATH = `${COMPOSE_DIR}/.env`;
+
+/** Spec §5.1: cache the status probe for ~2s to absorb the dashboard poller. */
+const STATUS_CACHE_MS = 2_000;
+
+// ── Lifecycle row helpers ────────────────────────────────────────────────
+
+export type TailscaleState =
+  | "disabled"
+  | "starting"
+  | "authenticating"
+  | "connected"
+  | "error";
+
+export interface TailscaleConnectionRow {
+  id: number;
+  state: TailscaleState;
+  tailnet_ip: string | null;
+  tailnet_hostname: string | null;
+  authkey_used_at: number | null;
+  auth_url: string | null;
+  last_status_probe_at: number | null;
+  last_error: string | null;
+  created_at: number;
+  updated_at: number;
+}
+
+/** Read the singleton lifecycle row, seeding it if absent. */
+export function getTailscaleRow(): TailscaleConnectionRow {
+  const db = getStateDb();
+  const row = db
+    .prepare("SELECT * FROM tailscale_connection WHERE id = 1")
+    .get() as TailscaleConnectionRow | undefined;
+  if (row) return row;
+  const now = Date.now();
+  db.prepare(
+    `INSERT INTO tailscale_connection
+       (id, state, created_at, updated_at)
+     VALUES (1, 'disabled', ?, ?)`,
+  ).run(now, now);
+  return db
+    .prepare("SELECT * FROM tailscale_connection WHERE id = 1")
+    .get() as TailscaleConnectionRow;
+}
+
+/** Patch a subset of the lifecycle row. Always bumps updated_at. */
+export function updateTailscaleRow(
+  patch: Partial<Omit<TailscaleConnectionRow, "id" | "created_at" | "updated_at">>,
+): TailscaleConnectionRow {
+  getTailscaleRow(); // ensure seeded
+  const db = getStateDb();
+  const fields: string[] = [];
+  const values: unknown[] = [];
+  for (const [k, v] of Object.entries(patch)) {
+    fields.push(`${k} = ?`);
+    values.push(v ?? null);
+  }
+  fields.push("updated_at = ?");
+  values.push(Date.now());
+  db.prepare(
+    `UPDATE tailscale_connection SET ${fields.join(", ")} WHERE id = 1`,
+  ).run(...(values as Parameters<ReturnType<typeof db.prepare>["run"]>));
+  return db
+    .prepare("SELECT * FROM tailscale_connection WHERE id = 1")
+    .get() as TailscaleConnectionRow;
+}
+
+// ── Live probe (fail-soft) ───────────────────────────────────────────────
+
+interface TailscaleStatusJson {
+  Self?: {
+    HostName?: string;
+    DNSName?: string;
+    TailscaleIPs?: string[];
+    Online?: boolean;
+  };
+  Peer?: Record<
+    string,
+    {
+      ID?: string;
+      HostName?: string;
+      DNSName?: string;
+      OS?: string;
+      TailscaleIPs?: string[];
+      Online?: boolean;
+      LastSeen?: string;
+    }
+  >;
+  BackendState?: string;
+  AuthURL?: string;
+  MagicDNSSuffix?: string;
+  CurrentTailnet?: { Name?: string; MagicDNSSuffix?: string };
+}
+
+interface ProbeResult {
+  ok: true;
+  status: TailscaleStatusJson;
+}
+interface ProbeFailure {
+  ok: false;
+  reason: string;
+}
+
+/**
+ * Best-effort `tailscale status --json` against the sidecar. On any failure
+ * (container absent, exec error, malformed JSON) returns `{ok: false}` with a
+ * human-readable reason. Never throws — the GET /status route is required to
+ * stay fail-soft per spec §5.1.
+ *
+ * Override surface for tests: `_setProbeForTests(fn)`.
+ */
+let _probeOverride:
+  | (() => Promise<ProbeResult | ProbeFailure>)
+  | null = null;
+export function _setTailscaleProbeForTests(
+  fn: (() => Promise<ProbeResult | ProbeFailure>) | null,
+): void {
+  _probeOverride = fn;
+}
+
+async function probeTailscaleStatus(): Promise<ProbeResult | ProbeFailure> {
+  if (_probeOverride) return _probeOverride();
+  try {
+    const raw = await dockerExec(TAILSCALE_SERVICE, [
+      "tailscale",
+      "status",
+      "--json",
+    ]);
+    const trimmed = raw.trim();
+    if (!trimmed) {
+      return { ok: false, reason: "tailscale status returned empty output" };
+    }
+    let json: unknown;
+    try {
+      json = JSON.parse(trimmed);
+    } catch {
+      return { ok: false, reason: "tailscale status returned non-JSON" };
+    }
+    if (typeof json !== "object" || json === null) {
+      return { ok: false, reason: "tailscale status returned non-object" };
+    }
+    return { ok: true, status: json as TailscaleStatusJson };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { ok: false, reason: `probe failed: ${msg}` };
+  }
+}
+
+/**
+ * Reconcile the live probe with the singleton row. Reads the BackendState
+ * field (`Running` → connected, `NeedsLogin` → authenticating, etc.) and
+ * upserts hostname/IP/auth_url as it goes. Cached at the table level: if a
+ * probe ran within STATUS_CACHE_MS we return the row as-is.
+ */
+async function reconcileFromProbe(): Promise<TailscaleConnectionRow> {
+  const row = getTailscaleRow();
+  // If the sidecar is disabled, never probe — there's nothing to talk to.
+  if (row.state === "disabled") return row;
+  const now = Date.now();
+  if (row.last_status_probe_at && now - row.last_status_probe_at < STATUS_CACHE_MS) {
+    return row;
+  }
+  const probe = await probeTailscaleStatus();
+  if (!probe.ok) {
+    return updateTailscaleRow({
+      state: "error",
+      last_status_probe_at: now,
+      last_error: probe.reason,
+    });
+  }
+  const s = probe.status;
+  const backend = s.BackendState ?? "";
+  // Defaults that map every BackendState we care about onto our lifecycle
+  // enum. Anything we don't recognise stays in the current state but clears
+  // last_error.
+  const patch: Partial<TailscaleConnectionRow> = {
+    last_status_probe_at: now,
+    last_error: null,
+  };
+  if (s.Self?.TailscaleIPs && s.Self.TailscaleIPs.length > 0) {
+    patch.tailnet_ip = s.Self.TailscaleIPs[0];
+  }
+  if (s.Self?.DNSName) {
+    // Strip the trailing dot — tailscale emits `host.tailnet.ts.net.`.
+    patch.tailnet_hostname = s.Self.DNSName.replace(/\.$/, "");
+  } else if (s.Self?.HostName) {
+    patch.tailnet_hostname = s.Self.HostName;
+  }
+  switch (backend) {
+    case "Running":
+      patch.state = "connected";
+      patch.auth_url = null;
+      break;
+    case "NeedsLogin":
+    case "NeedsMachineAuth":
+      patch.state = "authenticating";
+      if (s.AuthURL) patch.auth_url = s.AuthURL;
+      break;
+    case "Starting":
+    case "NoState":
+      patch.state = "starting";
+      break;
+    case "Stopped":
+      patch.state = "disabled";
+      break;
+    default:
+      // Unknown BackendState — keep current.
+      break;
+  }
+  return updateTailscaleRow(patch);
+}
+
+// ── `.env` upsert (for TAILSCALE_AUTHKEY + TAILSCALE_ENABLED flips) ──────
+
+/**
+ * Upsert a single KEY=value line in /srv/alfred-black/.env. Idempotent: if
+ * the key exists, the line is rewritten; otherwise it's appended. Mirrors
+ * the pattern in channels_paperclip.ts.
+ */
+function upsertEnvKey(path: string, key: string, value: string): void {
+  let raw = "";
+  try {
+    raw = fs.readFileSync(path, "utf-8");
+  } catch {
+    /* file may not exist on a fresh tenant */
+  }
+  const lines = raw.split("\n");
+  let found = false;
+  for (let i = 0; i < lines.length; i++) {
+    const t = lines[i].trim();
+    if (!t || t.startsWith("#")) continue;
+    const eq = t.indexOf("=");
+    if (eq < 0) continue;
+    if (t.slice(0, eq).trim() === key) {
+      lines[i] = `${key}=${value}`;
+      found = true;
+      break;
+    }
+  }
+  if (!found) {
+    if (raw.length > 0 && !raw.endsWith("\n")) lines.push("");
+    lines.push(`${key}=${value}`);
+  }
+  const out = lines.join("\n");
+  fs.writeFileSync(path, out.endsWith("\n") ? out : out + "\n", { mode: 0o600 });
+}
+
+// ── Vaultwarden write (Path A authkey persistence) ───────────────────────
+
+/**
+ * Write the auth key to Vaultwarden so it lives in the principal's vault,
+ * not just /srv/alfred-black/.env. Best-effort: if vault-cli is unreachable
+ * we still proceed (the .env update is the authoritative store for compose
+ * interpolation). Returns true on success, false otherwise.
+ *
+ * Test override: `_setVaultWriteForTests`.
+ */
+let _vaultWriteOverride: ((value: string) => Promise<boolean>) | null = null;
+export function _setVaultWriteForTests(
+  fn: ((value: string) => Promise<boolean>) | null,
+): void {
+  _vaultWriteOverride = fn;
+}
+
+async function writeAuthKeyToVault(authKey: string): Promise<boolean> {
+  if (_vaultWriteOverride) return _vaultWriteOverride(authKey);
+  try {
+    // Search for an existing item by name; if present, update it.
+    const search = await fetch(
+      `${VAULT_CLI_URL}/list/object/items?search=${encodeURIComponent(
+        VAULT_ITEM_NAME,
+      )}`,
+      { signal: AbortSignal.timeout(10_000) },
+    );
+    if (!search.ok) return false;
+    const searchJson = (await search.json()) as {
+      data?: { data?: Array<{ id?: string; name?: string }> };
+    };
+    const existing = (searchJson?.data?.data ?? []).find(
+      (it) => it.name === VAULT_ITEM_NAME,
+    );
+
+    if (existing?.id) {
+      // PUT shape mirrors routes/vaultwarden.ts — fetch the full item, patch
+      // the login.password, write it back.
+      const cur = await fetch(`${VAULT_CLI_URL}/object/item/${existing.id}`, {
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!cur.ok) return false;
+      const curJson = (await cur.json()) as { data?: Record<string, unknown> };
+      const item = (curJson?.data ?? {}) as Record<string, unknown>;
+      const login = ((item.login as Record<string, unknown>) ?? {}) as Record<
+        string,
+        unknown
+      >;
+      login.password = authKey;
+      item.login = login;
+      const put = await fetch(`${VAULT_CLI_URL}/object/item/${existing.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(item),
+        signal: AbortSignal.timeout(10_000),
+      });
+      return put.ok;
+    }
+
+    // Create a fresh item.
+    const create = await fetch(`${VAULT_CLI_URL}/object/item`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type: 1, // login
+        name: VAULT_ITEM_NAME,
+        notes: "Tailscale auth key for the home-alfred-black sidecar.",
+        favorite: false,
+        reprompt: 0,
+        login: {
+          username: null,
+          password: authKey,
+          uris: [],
+        },
+      }),
+      signal: AbortSignal.timeout(10_000),
+    });
+    return create.ok;
+  } catch {
+    return false;
+  }
+}
+
+// ── Audit helpers ────────────────────────────────────────────────────────
+
+function auditWrite(actionType: string, summary: string, payload?: unknown): void {
+  try {
+    appendAudit({
+      action_type: actionType,
+      actor: "alfred-ctrl-api",
+      source: "channels-tailscale",
+      target_kind: "channel",
+      target_path: "tailscale",
+      summary,
+      payload,
+    });
+  } catch (err) {
+    // appendAudit is best-effort by default; this catch only fires if the
+    // appendAudit internal swallow misses, which shouldn't happen. Logged
+    // but not surfaced — the principal-facing action already succeeded.
+    console.warn(
+      "[channels_tailscale] audit append failed:",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
+// ── Body shapes ──────────────────────────────────────────────────────────
+
+interface ConnectBody {
+  /** Auth key for Path A. When omitted, Path C (device-auth URL) is used. */
+  authkey?: string;
+}
+
+function parseConnectBody(raw: unknown): ConnectBody {
+  if (raw === null || raw === undefined) return {};
+  if (typeof raw !== "object") {
+    throw new ValidationError("body must be a JSON object");
+  }
+  const b = raw as Record<string, unknown>;
+  if (b.authkey !== undefined) {
+    if (typeof b.authkey !== "string") {
+      throw new ValidationError("authkey must be a string when present");
+    }
+    if (b.authkey.trim().length === 0) {
+      throw new ValidationError("authkey must be non-empty when present");
+    }
+    // Tailscale auth keys are `tskey-auth-<id>-<secret>` (40+ chars).
+    // We don't enforce the prefix here — the sidecar will reject a malformed
+    // key at boot — but we strip whitespace as a courtesy.
+    return { authkey: b.authkey.trim() };
+  }
+  return {};
+}
+
+// ── Routes ───────────────────────────────────────────────────────────────
+
+export function registerChannelsTailscaleRoutes(): void {
+  // ──────────────────────────────────────────────────────────────────────
+  // GET /api/v1/channels/tailscale/status
+  //
+  // Spec §5.1: fail-soft lifecycle view. Returns the singleton row plus an
+  // optional `live` probe result. Never 500s — every failure path falls
+  // through to `{state: "error", reason: "..."}` in the row.
+  // ──────────────────────────────────────────────────────────────────────
+  addRoute("GET", "/api/v1/channels/tailscale/status", async ({ res }) => {
+    const row = await reconcileFromProbe();
+    sendJson(res, 200, {
+      state: row.state,
+      tailnet_ip: row.tailnet_ip,
+      tailnet_hostname: row.tailnet_hostname,
+      auth_url: row.auth_url,
+      authkey_used_at: row.authkey_used_at,
+      last_status_probe_at: row.last_status_probe_at,
+      last_error: row.last_error,
+      // Spec §5.1: the row's `reason` aliases last_error so the UI doesn't
+      // need to special-case the column name.
+      reason: row.last_error,
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // POST /api/v1/channels/tailscale/connect
+  //
+  // Body: { authkey?: string }
+  //
+  // Path A (authkey provided):
+  //   1. Write to Vaultwarden ("Tailscale Auth Key") — best-effort.
+  //   2. Upsert TAILSCALE_AUTHKEY + TAILSCALE_ENABLED=true in /srv/alfred-black/.env.
+  //   3. `docker compose --profile tailscale up -d tailscale`.
+  //   4. Row → state='starting', authkey_used_at=now.
+  //
+  // Path C (no authkey):
+  //   1. Upsert TAILSCALE_ENABLED=true (no AUTHKEY).
+  //   2. `docker compose --profile tailscale up -d tailscale`.
+  //   3. Row → state='authenticating'. The /status route's probe will
+  //      reconcile AuthURL on the next call.
+  //
+  // Idempotent: if state is already 'connected', returns 409 with a clear
+  // message rather than silently re-running. The principal can /disconnect
+  // first.
+  // ──────────────────────────────────────────────────────────────────────
+  addRoute("POST", "/api/v1/channels/tailscale/connect", async ({ res, body }) => {
+    const parsed = parseConnectBody(body);
+    const current = getTailscaleRow();
+    if (current.state === "connected") {
+      throw new ApiError(
+        409,
+        "ALREADY_CONNECTED",
+        "Tailscale is already connected. Disconnect first if you want to re-key.",
+      );
+    }
+
+    let vaultOk: boolean | null = null;
+    const hasAuthKey = typeof parsed.authkey === "string";
+
+    if (hasAuthKey) {
+      // Path A — Vaultwarden first, .env second.
+      vaultOk = await writeAuthKeyToVault(parsed.authkey!);
+      upsertEnvKey(ENV_PATH, "TAILSCALE_AUTHKEY", parsed.authkey!);
+    }
+    upsertEnvKey(ENV_PATH, "TAILSCALE_ENABLED", "true");
+
+    // Mark the row before the docker call so a /status poll mid-launch sees
+    // a sensible state rather than `disabled`.
+    updateTailscaleRow({
+      state: hasAuthKey ? "starting" : "authenticating",
+      authkey_used_at: hasAuthKey ? Date.now() : null,
+      last_error: null,
+      auth_url: null,
+    });
+
+    try {
+      await dockerComposeCmd([
+        "--profile",
+        "tailscale",
+        "up",
+        "-d",
+        TAILSCALE_SERVICE,
+      ]);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      updateTailscaleRow({ state: "error", last_error: msg });
+      auditWrite(
+        "tailscale_connect_failed",
+        `Failed to bring up tailscale sidecar: ${msg}`,
+        { path: hasAuthKey ? "A" : "C" },
+      );
+      throw new ApiError(
+        502,
+        "DOCKER_COMPOSE_FAILED",
+        `docker compose up tailscale failed: ${msg}`,
+      );
+    }
+
+    auditWrite(
+      "tailscale_connect_initiated",
+      hasAuthKey
+        ? "Tailscale sidecar starting with provided auth key"
+        : "Tailscale sidecar starting; awaiting device-auth URL",
+      { path: hasAuthKey ? "A" : "C", vault_write_ok: vaultOk },
+    );
+
+    const row = getTailscaleRow();
+    sendJson(res, 200, {
+      ok: true,
+      state: row.state,
+      path: hasAuthKey ? "A" : "C",
+      vault_write_ok: vaultOk,
+      auth_url: row.auth_url,
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // POST /api/v1/channels/tailscale/disconnect
+  //
+  //   1. `docker exec alfred-black-tailscale-1 tailscale logout`
+  //   2. `docker exec alfred-black-tailscale-1 tailscale down`
+  //   3. `docker compose stop tailscale`
+  //   4. Row → state='disabled', clears auth_url + tailnet fields.
+  //
+  // Each docker step is best-effort: a missing container or already-down
+  // sidecar still completes the disconnect cleanly.
+  // ──────────────────────────────────────────────────────────────────────
+  addRoute("POST", "/api/v1/channels/tailscale/disconnect", async ({ res }) => {
+    const errors: string[] = [];
+    // Best-effort logout (clears tailnet keys).
+    try {
+      await dockerExec(TAILSCALE_SERVICE, ["tailscale", "logout"]);
+    } catch (err) {
+      errors.push(`logout: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    // Best-effort down (brings interface down).
+    try {
+      await dockerExec(TAILSCALE_SERVICE, ["tailscale", "down"]);
+    } catch (err) {
+      errors.push(`down: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    // Stop the compose service.
+    try {
+      await dockerComposeCmd(["stop", TAILSCALE_SERVICE]);
+    } catch (err) {
+      errors.push(
+        `compose stop: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    // Best-effort: flip TAILSCALE_ENABLED back to false so a subsequent
+    // `docker compose up -d` doesn't re-spawn the profile.
+    try {
+      upsertEnvKey(ENV_PATH, "TAILSCALE_ENABLED", "false");
+    } catch {
+      /* .env may not exist in tests */
+    }
+
+    const row = updateTailscaleRow({
+      state: "disabled",
+      tailnet_ip: null,
+      tailnet_hostname: null,
+      auth_url: null,
+      last_error: errors.length > 0 ? errors.join("; ") : null,
+    });
+
+    auditWrite(
+      "tailscale_disconnect",
+      errors.length > 0
+        ? `Tailscale sidecar disconnected with warnings: ${errors.join("; ")}`
+        : "Tailscale sidecar disconnected cleanly",
+      { errors },
+    );
+
+    sendJson(res, 200, {
+      ok: true,
+      state: row.state,
+      warnings: errors,
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // GET /api/v1/channels/tailscale/cert
+  //
+  // PR 4 (Caddy + Funnel ingress) lands the LE cert passthrough. PR 2
+  // returns 501 so callers wiring against the catalogue see the explicit
+  // shape rather than a 404.
+  // ──────────────────────────────────────────────────────────────────────
+  addRoute("GET", "/api/v1/channels/tailscale/cert", async ({ res }) => {
+    sendJson(res, 501, {
+      error: {
+        code: "NOT_IMPLEMENTED",
+        message: "Tailscale cert passthrough lands in #109 PR 4.",
+      },
+      deferred: "PR4",
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // POST /api/v1/channels/tailscale/serve
+  //
+  // Tailscale Serve config (the per-tenant `https://home-alfred-black.<tailnet>.ts.net`
+  // ingress) lands in PR 4 with the Caddy story.
+  // ──────────────────────────────────────────────────────────────────────
+  addRoute("POST", "/api/v1/channels/tailscale/serve", async ({ res }) => {
+    sendJson(res, 501, {
+      error: {
+        code: "NOT_IMPLEMENTED",
+        message: "Tailscale Serve configuration lands in #109 PR 4.",
+      },
+      deferred: "PR4",
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // GET /api/v1/channels/tailscale/peers
+  //
+  // List the peers from `tailscale status --json`. Fail-soft: a probe
+  // failure returns `{peers: [], reason: "..."}` so the UI can render
+  // "no peers yet" without an error toast.
+  // ──────────────────────────────────────────────────────────────────────
+  addRoute("GET", "/api/v1/channels/tailscale/peers", async ({ res }) => {
+    const row = getTailscaleRow();
+    if (row.state === "disabled") {
+      sendJson(res, 200, { peers: [], reason: "Tailscale is disabled" });
+      return;
+    }
+    const probe = await probeTailscaleStatus();
+    if (!probe.ok) {
+      sendJson(res, 200, { peers: [], reason: probe.reason });
+      return;
+    }
+    const peerMap = probe.status.Peer ?? {};
+    const peers = Object.values(peerMap).map((p) => ({
+      id: p.ID ?? null,
+      hostname: p.HostName ?? null,
+      dns_name: (p.DNSName ?? "").replace(/\.$/, "") || null,
+      os: p.OS ?? null,
+      tailscale_ips: p.TailscaleIPs ?? [],
+      online: p.Online ?? false,
+      last_seen: p.LastSeen ?? null,
+    }));
+    sendJson(res, 200, { peers });
+  });
+}

--- a/packages/ctrl/src/api/server.ts
+++ b/packages/ctrl/src/api/server.ts
@@ -67,6 +67,7 @@ import { registerComposioWebhookRoutes } from "./routes/composioWebhook.js";
 import { registerAlfredJournalRoutes } from "./routes/alfredJournal.js";
 import { registerAlfredDeliverRoutes } from "./routes/alfredDeliver.js";
 import { registerFilesRoutes } from "./routes/files.js";
+import { registerChannelsTailscaleRoutes } from "./routes/channels_tailscale.js";
 
 export interface RouteParams {
   [key: string]: string;
@@ -207,6 +208,11 @@ export function createApiServer(): http.Server {
   // PR 3 the dashboard, PR 4 content extraction. See
   // docs/specs/issue-114-local-file-storage.md.
   registerFilesRoutes();
+  // /api/v1/channels/tailscale/* — the six lifecycle routes that drive
+  // the off-by-default tailscale sidecar shipped in PR 1 of issue #109.
+  // PR 3 wires the /connections web card; PR 4 the Caddy + Serve story.
+  // See docs/specs/issue-109-tailscale-via-ui.md.
+  registerChannelsTailscaleRoutes();
 
   const server = http.createServer(async (req: IncomingMessage, res: ServerResponse) => {
     const start = Date.now();

--- a/packages/ctrl/tests/channels_tailscale.test.ts
+++ b/packages/ctrl/tests/channels_tailscale.test.ts
@@ -1,0 +1,551 @@
+// channels_tailscale — six ctrl-api routes that drive the off-by-default
+// Tailscale sidecar (issue #109 PR 2).
+//
+// What's under test
+// -----------------
+//   1. GET /status returns `disabled` when the lifecycle row hasn't been
+//      touched (sidecar absent), no docker exec attempted.
+//   2. GET /status reconciles BackendState=Running into state='connected'
+//      with tailnet_ip + tailnet_hostname populated.
+//   3. GET /status returns `error` with last_error/reason when the probe
+//      throws (no 500).
+//   4. POST /connect with a paste-authkey writes to Vaultwarden, upserts
+//      TAILSCALE_AUTHKEY + TAILSCALE_ENABLED=true in .env, and runs
+//      `docker compose --profile tailscale up -d tailscale`.
+//   5. POST /connect without an authkey skips Vaultwarden, still flips
+//      TAILSCALE_ENABLED=true, brings the sidecar up, and leaves state in
+//      `authenticating` so /status can pull the auth_url on the next poll.
+//   6. POST /connect when state='connected' returns 409 (idempotent guard).
+//   7. POST /disconnect runs logout + down + compose stop and flips state to
+//      `disabled`. Returns 200 even when docker exec warns (best-effort).
+//   8. POST /disconnect flips TAILSCALE_ENABLED back to false.
+//   9. GET /cert returns 501 with deferred:"PR4".
+//  10. POST /serve returns 501 with deferred:"PR4".
+//  11. GET /peers returns empty list (no error) when sidecar absent.
+//  12. GET /peers extracts peers from the probe JSON when sidecar is live.
+//  13. Every write emits an audit row (action_type tailscale_*).
+
+import { mock, describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ServerResponse } from "node:http";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "channels-tailscale-"));
+process.env.COMPOSE_DIR = tmp;
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.STATE_DB_PATH = path.join(tmp, "state.db");
+process.env.VAULT_PATH = path.join(tmp, "vault");
+process.env.SQLITE_VEC_PATH = "";
+
+// ── helpers mock — capture every docker call ─────────────────────────────
+
+const dockerExecCalls: { service: string; command: string[] }[] = [];
+const dockerComposeCalls: string[][] = [];
+
+// dockerExec behaviour per call — tests flip these between cases.
+let dockerExecHandler: (service: string, command: string[]) => string | Promise<string> =
+  () => "";
+let dockerComposeHandler: (args: string[]) => string | Promise<string> = () => "";
+
+const realHelpers = await import("../src/api/helpers.js");
+mock.module("../src/api/helpers.js", {
+  namedExports: {
+    ...realHelpers,
+    dockerExec: async (service: string, command: string[]) => {
+      dockerExecCalls.push({ service, command: [...command] });
+      return await dockerExecHandler(service, command);
+    },
+    dockerComposeCmd: async (args: string[]) => {
+      dockerComposeCalls.push([...args]);
+      return await dockerComposeHandler(args);
+    },
+    // Surface COMPOSE_DIR from the test tmp so the .env upsert lands in a
+    // writable directory we can inspect.
+    COMPOSE_DIR: tmp,
+  },
+});
+
+// ── module imports (after env + mocks are wired) ─────────────────────────
+
+const { matchRoute } = await import("../src/api/server.js");
+const { handleError } = await import("../src/api/errors.js");
+const {
+  registerChannelsTailscaleRoutes,
+  _setTailscaleProbeForTests,
+  _setVaultWriteForTests,
+} = await import("../src/api/routes/channels_tailscale.js");
+const { getStateDb } = await import("../src/db/state.js");
+registerChannelsTailscaleRoutes();
+
+// ── tiny in-process invocation harness ───────────────────────────────────
+
+async function invoke(
+  method: string,
+  pathname: string,
+  body: unknown = null,
+): Promise<{ status: number; payload: any }> {
+  const m = matchRoute(method, pathname);
+  assert.ok(m, `${method} ${pathname} must be registered`);
+  let status = 0;
+  let payload: any;
+  const res = {
+    setHeader() {},
+    writeHead(c: number) {
+      status = c;
+      return res;
+    },
+    end(j?: string) {
+      payload = j ? JSON.parse(j) : undefined;
+    },
+  } as unknown as ServerResponse;
+  try {
+    await m!.handler({
+      req: {
+        method,
+        url: pathname,
+        headers: {},
+        socket: { remoteAddress: "10.0.0.99" },
+      } as any,
+      res,
+      params: m!.params,
+      body,
+      query: new URLSearchParams(),
+    });
+  } catch (err) {
+    handleError(res, err);
+  }
+  return { status, payload };
+}
+
+// Reset to a clean slate between tests: drop the singleton row, clear the
+// audit table, clear docker-call captures, restore default handlers.
+function clearAll(): void {
+  dockerExecCalls.length = 0;
+  dockerComposeCalls.length = 0;
+  dockerExecHandler = () => "";
+  dockerComposeHandler = () => "";
+  _setTailscaleProbeForTests(null);
+  _setVaultWriteForTests(null);
+  const db = getStateDb();
+  db.exec("DELETE FROM tailscale_connection");
+  db.exec("DELETE FROM audit");
+  // Reset .env so each test starts from a clean slate.
+  try {
+    fs.unlinkSync(`${tmp}/.env`);
+  } catch {
+    /* may not exist */
+  }
+}
+
+function readEnv(): Record<string, string> {
+  const raw = fs.readFileSync(`${tmp}/.env`, "utf-8");
+  const out: Record<string, string> = {};
+  for (const line of raw.split("\n")) {
+    const t = line.trim();
+    if (!t || t.startsWith("#")) continue;
+    const eq = t.indexOf("=");
+    if (eq < 0) continue;
+    out[t.slice(0, eq).trim()] = t.slice(eq + 1);
+  }
+  return out;
+}
+
+function listAudit(): { action_type: string; summary: string }[] {
+  return getStateDb()
+    .prepare("SELECT action_type, summary FROM audit ORDER BY ts ASC")
+    .all() as { action_type: string; summary: string }[];
+}
+
+// ── tests ────────────────────────────────────────────────────────────────
+
+describe("GET /api/v1/channels/tailscale/status — #109 PR 2", () => {
+  beforeEach(clearAll);
+
+  it("returns state='disabled' when sidecar absent (no docker exec attempted)", async () => {
+    // Probe must NOT be invoked when state is disabled — the override would
+    // throw if called, proving the route short-circuits.
+    _setTailscaleProbeForTests(async () => {
+      throw new Error("probe should not run when disabled");
+    });
+    const r = await invoke("GET", "/api/v1/channels/tailscale/status");
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.state, "disabled");
+    assert.equal(r.payload.tailnet_ip, null);
+    assert.equal(r.payload.tailnet_hostname, null);
+    // No docker calls should have fired.
+    assert.equal(dockerExecCalls.length, 0);
+  });
+
+  it("reconciles a Running BackendState into state='connected' with IP + hostname", async () => {
+    // Seed the row into a state that allows the probe to run.
+    getStateDb()
+      .prepare(
+        `INSERT INTO tailscale_connection (id, state, created_at, updated_at)
+         VALUES (1, 'starting', ?, ?)`,
+      )
+      .run(Date.now(), Date.now());
+    _setTailscaleProbeForTests(async () => ({
+      ok: true,
+      status: {
+        BackendState: "Running",
+        Self: {
+          HostName: "home-alfred-black",
+          DNSName: "home-alfred-black.tail-acme.ts.net.",
+          TailscaleIPs: ["100.64.1.7", "fd7a:115c:a1e0::1"],
+          Online: true,
+        },
+        Peer: {},
+        MagicDNSSuffix: "tail-acme.ts.net",
+      },
+    }));
+    const r = await invoke("GET", "/api/v1/channels/tailscale/status");
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.state, "connected");
+    assert.equal(r.payload.tailnet_ip, "100.64.1.7");
+    assert.equal(
+      r.payload.tailnet_hostname,
+      "home-alfred-black.tail-acme.ts.net",
+      "DNSName trailing dot must be stripped",
+    );
+    assert.equal(r.payload.last_error, null);
+  });
+
+  it("returns state='error' with last_error/reason when probe throws (no 500)", async () => {
+    getStateDb()
+      .prepare(
+        `INSERT INTO tailscale_connection (id, state, created_at, updated_at)
+         VALUES (1, 'starting', ?, ?)`,
+      )
+      .run(Date.now(), Date.now());
+    _setTailscaleProbeForTests(async () => ({
+      ok: false,
+      reason: "probe failed: docker exec exited 137",
+    }));
+    const r = await invoke("GET", "/api/v1/channels/tailscale/status");
+    // CRITICAL: must NOT 500 — fail-soft per spec §5.1.
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.state, "error");
+    assert.match(r.payload.last_error, /probe failed/);
+    assert.equal(r.payload.reason, r.payload.last_error);
+  });
+
+  it("maps BackendState=NeedsLogin into state='authenticating' with auth_url", async () => {
+    getStateDb()
+      .prepare(
+        `INSERT INTO tailscale_connection (id, state, created_at, updated_at)
+         VALUES (1, 'starting', ?, ?)`,
+      )
+      .run(Date.now(), Date.now());
+    _setTailscaleProbeForTests(async () => ({
+      ok: true,
+      status: {
+        BackendState: "NeedsLogin",
+        AuthURL: "https://login.tailscale.com/a/abc123",
+        Self: { HostName: "home-alfred-black", Online: false },
+        Peer: {},
+      },
+    }));
+    const r = await invoke("GET", "/api/v1/channels/tailscale/status");
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.state, "authenticating");
+    assert.equal(r.payload.auth_url, "https://login.tailscale.com/a/abc123");
+  });
+});
+
+describe("POST /api/v1/channels/tailscale/connect — paste-authkey path", () => {
+  beforeEach(clearAll);
+
+  it("writes to Vaultwarden + flips .env + runs docker compose up + audits", async () => {
+    let vaultArg: string | null = null;
+    _setVaultWriteForTests(async (key: string) => {
+      vaultArg = key;
+      return true;
+    });
+    const r = await invoke("POST", "/api/v1/channels/tailscale/connect", {
+      authkey: "tskey-auth-kE2GFQ-XYZ",
+    });
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.ok, true);
+    assert.equal(r.payload.path, "A");
+    assert.equal(r.payload.vault_write_ok, true);
+    assert.equal(r.payload.state, "starting");
+    // Vault was given the right key.
+    assert.equal(vaultArg, "tskey-auth-kE2GFQ-XYZ");
+    // .env now carries both keys.
+    const env = readEnv();
+    assert.equal(env.TAILSCALE_AUTHKEY, "tskey-auth-kE2GFQ-XYZ");
+    assert.equal(env.TAILSCALE_ENABLED, "true");
+    // docker compose --profile tailscale up -d tailscale was invoked.
+    assert.equal(dockerComposeCalls.length, 1);
+    assert.deepEqual(dockerComposeCalls[0], [
+      "--profile",
+      "tailscale",
+      "up",
+      "-d",
+      "tailscale",
+    ]);
+    // Lifecycle row reflects 'starting' + authkey_used_at.
+    const row = getStateDb()
+      .prepare("SELECT state, authkey_used_at FROM tailscale_connection WHERE id=1")
+      .get() as { state: string; authkey_used_at: number | null };
+    assert.equal(row.state, "starting");
+    assert.ok(row.authkey_used_at && row.authkey_used_at > 0);
+    // Audit row recorded.
+    const audit = listAudit();
+    assert.equal(audit.length, 1);
+    assert.equal(audit[0].action_type, "tailscale_connect_initiated");
+  });
+
+  it("validates body: empty authkey is rejected (400)", async () => {
+    const r = await invoke("POST", "/api/v1/channels/tailscale/connect", {
+      authkey: "   ",
+    });
+    assert.equal(r.status, 400);
+    assert.equal(r.payload.error.code, "VALIDATION_ERROR");
+    // Nothing should have been written.
+    assert.equal(dockerComposeCalls.length, 0);
+  });
+
+  it("returns 409 ALREADY_CONNECTED when state='connected' (idempotent guard)", async () => {
+    getStateDb()
+      .prepare(
+        `INSERT INTO tailscale_connection (id, state, created_at, updated_at)
+         VALUES (1, 'connected', ?, ?)`,
+      )
+      .run(Date.now(), Date.now());
+    const r = await invoke("POST", "/api/v1/channels/tailscale/connect", {
+      authkey: "tskey-auth-xx",
+    });
+    assert.equal(r.status, 409);
+    assert.equal(r.payload.error.code, "ALREADY_CONNECTED");
+    // Nothing should have been written.
+    assert.equal(dockerComposeCalls.length, 0);
+  });
+
+  it("surfaces docker compose failure as 502 DOCKER_COMPOSE_FAILED + state='error'", async () => {
+    dockerComposeHandler = () => {
+      throw new Error("network unreachable");
+    };
+    const r = await invoke("POST", "/api/v1/channels/tailscale/connect", {
+      authkey: "tskey-auth-yy",
+    });
+    assert.equal(r.status, 502);
+    assert.equal(r.payload.error.code, "DOCKER_COMPOSE_FAILED");
+    const row = getStateDb()
+      .prepare("SELECT state, last_error FROM tailscale_connection WHERE id=1")
+      .get() as { state: string; last_error: string | null };
+    assert.equal(row.state, "error");
+    assert.match(row.last_error ?? "", /network unreachable/);
+    // An audit row should still have been written.
+    const audit = listAudit();
+    assert.equal(audit.length, 1);
+    assert.equal(audit[0].action_type, "tailscale_connect_failed");
+  });
+});
+
+describe("POST /api/v1/channels/tailscale/connect — device-auth path", () => {
+  beforeEach(clearAll);
+
+  it("with NO authkey: skips Vaultwarden, brings sidecar up, state='authenticating'", async () => {
+    let vaultCalled = false;
+    _setVaultWriteForTests(async () => {
+      vaultCalled = true;
+      return true;
+    });
+    const r = await invoke("POST", "/api/v1/channels/tailscale/connect", {});
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.path, "C");
+    assert.equal(r.payload.state, "authenticating");
+    assert.equal(r.payload.vault_write_ok, null);
+    // Vaultwarden was NOT touched — Path C has no key to store yet.
+    assert.equal(vaultCalled, false);
+    // .env reflects TAILSCALE_ENABLED=true but NO TAILSCALE_AUTHKEY.
+    const env = readEnv();
+    assert.equal(env.TAILSCALE_ENABLED, "true");
+    assert.equal(env.TAILSCALE_AUTHKEY, undefined);
+    // Sidecar was started.
+    assert.equal(dockerComposeCalls.length, 1);
+    // Audit recorded with the Path C marker.
+    const audit = listAudit();
+    assert.equal(audit.length, 1);
+    assert.equal(audit[0].action_type, "tailscale_connect_initiated");
+    // A subsequent /status probe should reconcile the AuthURL into the row.
+    _setTailscaleProbeForTests(async () => ({
+      ok: true,
+      status: {
+        BackendState: "NeedsLogin",
+        AuthURL: "https://login.tailscale.com/a/PATH-C-CODE",
+        Self: { HostName: "home-alfred-black" },
+        Peer: {},
+      },
+    }));
+    const status = await invoke("GET", "/api/v1/channels/tailscale/status");
+    assert.equal(status.payload.state, "authenticating");
+    assert.equal(
+      status.payload.auth_url,
+      "https://login.tailscale.com/a/PATH-C-CODE",
+      "the device-auth URL is surfaced from the live probe",
+    );
+  });
+});
+
+describe("POST /api/v1/channels/tailscale/disconnect — #109 PR 2", () => {
+  beforeEach(clearAll);
+
+  it("runs logout + down + compose stop, flips state to 'disabled', audits", async () => {
+    // Pre-seed connected so disconnect has something to take down.
+    getStateDb()
+      .prepare(
+        `INSERT INTO tailscale_connection
+           (id, state, tailnet_ip, tailnet_hostname, created_at, updated_at)
+         VALUES (1, 'connected', '100.64.1.7', 'home-alfred-black.tail-acme.ts.net', ?, ?)`,
+      )
+      .run(Date.now(), Date.now());
+    const r = await invoke("POST", "/api/v1/channels/tailscale/disconnect");
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.ok, true);
+    assert.equal(r.payload.state, "disabled");
+    assert.deepEqual(r.payload.warnings, []);
+    // Three docker calls fired in order: logout, down, stop.
+    assert.equal(dockerExecCalls.length, 2);
+    assert.deepEqual(dockerExecCalls[0].command, ["tailscale", "logout"]);
+    assert.deepEqual(dockerExecCalls[1].command, ["tailscale", "down"]);
+    assert.equal(dockerComposeCalls.length, 1);
+    assert.deepEqual(dockerComposeCalls[0], ["stop", "tailscale"]);
+    // Row reset.
+    const row = getStateDb()
+      .prepare(
+        "SELECT state, tailnet_ip, tailnet_hostname, auth_url FROM tailscale_connection WHERE id=1",
+      )
+      .get() as {
+      state: string;
+      tailnet_ip: string | null;
+      tailnet_hostname: string | null;
+      auth_url: string | null;
+    };
+    assert.equal(row.state, "disabled");
+    assert.equal(row.tailnet_ip, null);
+    assert.equal(row.tailnet_hostname, null);
+    // TAILSCALE_ENABLED flipped to false in .env.
+    const env = readEnv();
+    assert.equal(env.TAILSCALE_ENABLED, "false");
+    // Audit recorded.
+    const audit = listAudit();
+    assert.equal(audit.length, 1);
+    assert.equal(audit[0].action_type, "tailscale_disconnect");
+  });
+
+  it("is best-effort: docker errors land in warnings, still 200 + state='disabled'", async () => {
+    dockerExecHandler = (_svc, cmd) => {
+      if (cmd[1] === "logout") throw new Error("logout failed: not running");
+      return "";
+    };
+    const r = await invoke("POST", "/api/v1/channels/tailscale/disconnect");
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.state, "disabled");
+    assert.equal(r.payload.warnings.length, 1);
+    assert.match(r.payload.warnings[0], /logout/);
+  });
+});
+
+describe("PR 4 stubs — /cert + /serve return 501", () => {
+  beforeEach(clearAll);
+
+  it("GET /cert returns 501 deferred:PR4", async () => {
+    const r = await invoke("GET", "/api/v1/channels/tailscale/cert");
+    assert.equal(r.status, 501);
+    assert.equal(r.payload.deferred, "PR4");
+    assert.equal(r.payload.error.code, "NOT_IMPLEMENTED");
+  });
+
+  it("POST /serve returns 501 deferred:PR4", async () => {
+    const r = await invoke("POST", "/api/v1/channels/tailscale/serve", {});
+    assert.equal(r.status, 501);
+    assert.equal(r.payload.deferred, "PR4");
+  });
+});
+
+describe("GET /api/v1/channels/tailscale/peers — #109 PR 2", () => {
+  beforeEach(clearAll);
+
+  it("returns empty list (no error) when sidecar absent", async () => {
+    _setTailscaleProbeForTests(async () => {
+      throw new Error("probe should not run when disabled");
+    });
+    const r = await invoke("GET", "/api/v1/channels/tailscale/peers");
+    assert.equal(r.status, 200);
+    assert.deepEqual(r.payload.peers, []);
+    assert.match(r.payload.reason, /disabled/);
+  });
+
+  it("returns empty list with reason when probe fails (state != disabled)", async () => {
+    getStateDb()
+      .prepare(
+        `INSERT INTO tailscale_connection (id, state, created_at, updated_at)
+         VALUES (1, 'connected', ?, ?)`,
+      )
+      .run(Date.now(), Date.now());
+    _setTailscaleProbeForTests(async () => ({
+      ok: false,
+      reason: "probe failed: container missing",
+    }));
+    const r = await invoke("GET", "/api/v1/channels/tailscale/peers");
+    assert.equal(r.status, 200);
+    assert.deepEqual(r.payload.peers, []);
+    assert.match(r.payload.reason, /container missing/);
+  });
+
+  it("extracts peers from probe JSON when sidecar is live", async () => {
+    getStateDb()
+      .prepare(
+        `INSERT INTO tailscale_connection (id, state, created_at, updated_at)
+         VALUES (1, 'connected', ?, ?)`,
+      )
+      .run(Date.now(), Date.now());
+    _setTailscaleProbeForTests(async () => ({
+      ok: true,
+      status: {
+        BackendState: "Running",
+        Self: {
+          HostName: "home-alfred-black",
+          DNSName: "home-alfred-black.tail-acme.ts.net.",
+          TailscaleIPs: ["100.64.1.7"],
+          Online: true,
+        },
+        Peer: {
+          nABC: {
+            ID: "nABC",
+            HostName: "ha-server",
+            DNSName: "ha-server.tail-acme.ts.net.",
+            OS: "linux",
+            TailscaleIPs: ["100.64.1.10"],
+            Online: true,
+            LastSeen: "2026-05-29T08:00:00Z",
+          },
+          nXYZ: {
+            ID: "nXYZ",
+            HostName: "sirs-laptop",
+            DNSName: "sirs-laptop.tail-acme.ts.net.",
+            OS: "macOS",
+            TailscaleIPs: ["100.64.1.20"],
+            Online: false,
+            LastSeen: "2026-05-28T22:00:00Z",
+          },
+        },
+      },
+    }));
+    const r = await invoke("GET", "/api/v1/channels/tailscale/peers");
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.peers.length, 2);
+    const ha = r.payload.peers.find((p: any) => p.hostname === "ha-server");
+    assert.ok(ha);
+    assert.equal(ha.dns_name, "ha-server.tail-acme.ts.net");
+    assert.deepEqual(ha.tailscale_ips, ["100.64.1.10"]);
+    assert.equal(ha.online, true);
+    const laptop = r.payload.peers.find((p: any) => p.hostname === "sirs-laptop");
+    assert.ok(laptop);
+    assert.equal(laptop.online, false);
+  });
+});

--- a/packages/ctrl/tests/channels_tailscale.test.ts
+++ b/packages/ctrl/tests/channels_tailscale.test.ts
@@ -264,7 +264,7 @@ describe("POST /api/v1/channels/tailscale/connect — paste-authkey path", () =>
       return true;
     });
     const r = await invoke("POST", "/api/v1/channels/tailscale/connect", {
-      authkey: "tskey-auth-kE2GFQ-XYZ",
+      authkey: "tskey-auth-FIXTUREONLY-FIXTURE",
     });
     assert.equal(r.status, 200);
     assert.equal(r.payload.ok, true);
@@ -272,10 +272,10 @@ describe("POST /api/v1/channels/tailscale/connect — paste-authkey path", () =>
     assert.equal(r.payload.vault_write_ok, true);
     assert.equal(r.payload.state, "starting");
     // Vault was given the right key.
-    assert.equal(vaultArg, "tskey-auth-kE2GFQ-XYZ");
+    assert.equal(vaultArg, "tskey-auth-FIXTUREONLY-FIXTURE");
     // .env now carries both keys.
     const env = readEnv();
-    assert.equal(env.TAILSCALE_AUTHKEY, "tskey-auth-kE2GFQ-XYZ");
+    assert.equal(env.TAILSCALE_AUTHKEY, "tskey-auth-FIXTUREONLY-FIXTURE");
     assert.equal(env.TAILSCALE_ENABLED, "true");
     // docker compose --profile tailscale up -d tailscale was invoked.
     assert.equal(dockerComposeCalls.length, 1);
@@ -316,7 +316,7 @@ describe("POST /api/v1/channels/tailscale/connect — paste-authkey path", () =>
       )
       .run(Date.now(), Date.now());
     const r = await invoke("POST", "/api/v1/channels/tailscale/connect", {
-      authkey: "tskey-auth-xx",
+      authkey: "tskey-auth-FIXTUREONLY-A",
     });
     assert.equal(r.status, 409);
     assert.equal(r.payload.error.code, "ALREADY_CONNECTED");
@@ -329,7 +329,7 @@ describe("POST /api/v1/channels/tailscale/connect — paste-authkey path", () =>
       throw new Error("network unreachable");
     };
     const r = await invoke("POST", "/api/v1/channels/tailscale/connect", {
-      authkey: "tskey-auth-yy",
+      authkey: "tskey-auth-FIXTUREONLY-B",
     });
     assert.equal(r.status, 502);
     assert.equal(r.payload.error.code, "DOCKER_COMPOSE_FAILED");


### PR DESCRIPTION
Closes part 2 of #109 (Tailscale via UI). PR 1 (#121) landed compose +
state.db migration 0003 (singleton \`tailscale_connection\`). This PR
ships the six ctrl-api routes that drive the off-by-default sidecar.

## What ships

* \`GET    /api/v1/channels/tailscale/status\` — fail-soft lifecycle.
  Reconciles \`docker exec tailscale status --json\` into the singleton
  row; probe failures fall through to \`{state:"error", reason}\`.
* \`POST   /api/v1/channels/tailscale/connect\` — Path A (paste authkey)
  writes to Vaultwarden ("Tailscale Auth Key") + .env + brings the
  sidecar up. Path C (no authkey) skips Vault, flips
  \`TAILSCALE_ENABLED=true\`, surfaces the device-auth URL on the next
  /status probe. 409 ALREADY_CONNECTED when already up.
* \`POST   /api/v1/channels/tailscale/disconnect\` — best-effort
  \`logout\` + \`down\` + \`compose stop\` + flips \`TAILSCALE_ENABLED=false\`.
* \`GET    /api/v1/channels/tailscale/cert\` — 501 \`{deferred:"PR4"}\`.
* \`POST   /api/v1/channels/tailscale/serve\` — 501 \`{deferred:"PR4"}\`.
* \`GET    /api/v1/channels/tailscale/peers\` — fail-soft peer list.

Every write goes through \`appendAudit\` (action_type \`tailscale_*\`).

\`VOICE_BRIDGE_ALLOWLIST\` is widened with the two read paths (/status
+ /peers) so \`self\` can answer "is Tailscale on right now?" on a
voice call. Connect/disconnect stay master-only — writes go through
MCP per the voice-bridge contract.

## Scope

* connect / disconnect / status / peers wired LIVE.
* cert / serve stubbed (501) for PR 4 — Caddy + Funnel + Serve story.
* No compose change — sidecar is still profile-gated off until the
  /connections card (PR 3) flips it.
* No new migration — PR 1 landed \`tailscale_connection\`.

## Tests

16 tests in \`packages/ctrl/tests/channels_tailscale.test.ts\` cover the
five scenarios the lane requirements call out plus the audit + 409 +
502 + Path C paths. \`mock.module("../src/api/helpers.js")\` captures
every \`dockerExec\` and \`dockerComposeCmd\` call; \`_setTailscaleProbeForTests\`
and \`_setVaultWriteForTests\` are seam-export hooks for the probe + vault
side effects. All 16 pass; \`auth-scoped-voice-bridge\` + \`alfred-journal\`
+ \`audit-action-type-normalize\` regression suites pass too. \`npm run
build\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)