### PR TITLE
feat(ctrl,db): Recall.ai ctrl-api routes + 0007 migration (#113 PR2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -254,3 +254,19 @@ TAILSCALE_TAGS=
 #PAPERCLIP_SEED_EMAIL=
 #PAPERCLIP_SEED_NAME=
 #PAPERCLIP_SEED_COMPANY=
+
+# Recall.ai — meeting bot SaaS (#113). Replaces the retired Vexa stack.
+# RECALL_BOT_NAME is the display name Recall surfaces to other meeting
+# participants when the bot joins. RECALL_REGION pins the Recall API
+# region the bot is dispatched in — must match the region your Recall
+# account is provisioned in (`us-east-1` / `us-west-2` / `eu-central-1`
+# / `ap-northeast-1`). RECALL_WEBHOOK_SECRET is the Svix signing secret
+# Recall presents on /api/v1/webhooks/recall — required for the inbound
+# webhook to verify; leave blank to disable the webhook receiver. The
+# API key itself is pasted on the /channels Recall card (PR3a) and
+# written to RECALL_API_KEY by the card POST handler — do NOT set by
+# hand below.
+RECALL_BOT_NAME="Alfred's note-taker"
+RECALL_REGION=us-east-1
+RECALL_WEBHOOK_SECRET=
+#RECALL_API_KEY=

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -67,7 +67,7 @@
 	# 405-ing at the SPA's nginx. Drop this entry when the stub goes (the
 	# PR that lands Recall.ai — #113 PR2).
 	@public_webhooks {
-		path /api/v1/streams/omi/* /api/v1/plane/webhook /api/v1/webhooks/plane/steward /api/v1/webhooks/vexa /api/v1/webhooks/in/* /api/v1/channels/email/inbound /api/v1/channels/paperclip/* /api/v1/channels/ha/turn /api/v1/composio/webhook
+		path /api/v1/streams/omi/* /api/v1/plane/webhook /api/v1/webhooks/plane/steward /api/v1/webhooks/vexa /api/v1/webhooks/recall /api/v1/webhooks/in/* /api/v1/channels/email/inbound /api/v1/channels/paperclip/* /api/v1/channels/ha/turn /api/v1/composio/webhook
 	}
 	handle @public_webhooks {
 		reverse_proxy ctrl-api:3100

--- a/packages/ctrl/src/api/routes/channels_recall.ts
+++ b/packages/ctrl/src/api/routes/channels_recall.ts
@@ -1,0 +1,1027 @@
+// /api/v1/channels/recall/* — Recall.ai channel routes (#113 PR2).
+//
+// Recall.ai replaces the retired Vexa stack (#113 PR1) as the per-meeting
+// bot transport. Everything Sir needs to configure — API key, region, bot
+// name, announcements, auto-join policy, calendar source, cost ceiling,
+// per-meeting cap, respond mode, wake word, active-bot management,
+// webhook delivery test, cost-alert thresholds — lives on the /channels
+// Recall card. **The principal never visits recall.ai.**
+//
+// This file ships the ctrl-api half of the card-driven contract per spec
+// §5.1.1, plus the inbound Svix-signed webhook target per spec §5.4.
+// The 7 outbound routes are bearer-authed via the global AAS_API_KEY
+// gate (same as every other /channels/* route except the webhook target).
+//
+// Surface:
+//
+//   POST /api/v1/channels/recall/validate-key       — paste+round-trip test
+//   GET  /api/v1/channels/recall/config             — current dials
+//   PATCH /api/v1/channels/recall/config            — update dials
+//   GET  /api/v1/channels/recall/usage              — month-to-date rollup
+//   GET  /api/v1/channels/recall/bots/active        — non-terminal bots
+//   DELETE /api/v1/channels/recall/bots/:bot_id     — mid-meeting terminate
+//   POST /api/v1/channels/recall/webhook-test       — synthetic delivery
+//   POST /api/v1/webhooks/recall                    — Svix-signed inbound
+//
+// Persistence: state.db tables recall_config / recall_bot / recall_event
+// (migration 0007_recall.sql). The card-side surface (PR3a/PR3b) reads
+// these via the GET routes; the alfred-learn dispatcher (PR4) writes
+// recall_bot rows when it creates a bot; this file owns the row updates
+// driven by inbound webhooks.
+//
+// API-key persistence: validation only round-trips the key against
+// Recall — it does NOT persist. The /channels card POST handler (PR3a)
+// is responsible for writing RECALL_API_KEY into the host .env once
+// validation succeeds, mirroring the paperclip POST /api-key pattern.
+// PR3a + PR3b own the operator-facing key paste; PR2 stops at validate.
+
+import crypto from "node:crypto";
+import { addRoute } from "../server.js";
+import { sendJson, ValidationError, ApiError } from "../errors.js";
+import { getStateDb } from "../../db/state.js";
+import type { DatabaseSync } from "node:sqlite";
+
+// ── Recall API endpoint helpers ───────────────────────────────────────────
+
+const RECALL_REGION_HOSTS: Record<string, string> = {
+  "us-east-1": "https://us-east-1.recall.ai",
+  "us-west-2": "https://us-west-2.recall.ai",
+  "eu-central-1": "https://eu-central-1.recall.ai",
+  "ap-northeast-1": "https://ap-northeast-1.recall.ai",
+};
+
+const VALID_REGIONS = Object.keys(RECALL_REGION_HOSTS);
+const VALID_AUTO_JOIN_POLICIES = ["off", "principal_attendee", "all"] as const;
+const VALID_CALENDAR_SOURCES = ["composio", "recall_v2"] as const;
+const VALID_RESPOND_MODES = ["off", "on_mention", "always"] as const;
+
+function recallBaseUrl(region: string): string {
+  return RECALL_REGION_HOSTS[region] ?? RECALL_REGION_HOSTS["us-east-1"];
+}
+
+// ── recall_config row helpers ─────────────────────────────────────────────
+//
+// The row is a singleton at id=1. On first read we lazily insert a row
+// with all defaults from the migration's column definitions. The
+// migration intentionally does NOT pre-seed the row so the
+// `updated_at` value is honest about when the operator first looked at
+// it.
+
+interface RecallConfigRow {
+  id: number;
+  region: string;
+  bot_name: string;
+  announces_on_join: number;
+  auto_join_policy: string;
+  calendar_source: string;
+  monthly_hours_cap: number;
+  leave_after_minutes: number;
+  respond_mode: string;
+  wake_word: string;
+  cost_alert_thresholds_json: string;
+  updated_at: number;
+}
+
+function getOrSeedConfig(db: DatabaseSync): RecallConfigRow {
+  const row = db
+    .prepare("SELECT * FROM recall_config WHERE id = 1")
+    .get() as RecallConfigRow | undefined;
+  if (row) return row;
+  const now = Date.now();
+  db.prepare(
+    `INSERT INTO recall_config (id, updated_at) VALUES (1, ?)`,
+  ).run(now);
+  const seeded = db
+    .prepare("SELECT * FROM recall_config WHERE id = 1")
+    .get() as RecallConfigRow;
+  return seeded;
+}
+
+function rowToApiConfig(row: RecallConfigRow): Record<string, unknown> {
+  let thresholds: number[] = [80, 100];
+  try {
+    const parsed = JSON.parse(row.cost_alert_thresholds_json);
+    if (
+      Array.isArray(parsed) &&
+      parsed.every((x) => typeof x === "number" && Number.isFinite(x))
+    ) {
+      thresholds = parsed;
+    }
+  } catch {
+    // Fall back to the default — never reject a row on a corrupted JSON
+    // field; the operator can re-PATCH to fix it.
+  }
+  return {
+    region: row.region,
+    bot_name: row.bot_name,
+    announces_on_join: row.announces_on_join === 1,
+    auto_join_policy: row.auto_join_policy,
+    calendar_source: row.calendar_source,
+    monthly_hours_cap: row.monthly_hours_cap,
+    leave_after_minutes: row.leave_after_minutes,
+    respond_mode: row.respond_mode,
+    wake_word: row.wake_word,
+    cost_alert_thresholds: thresholds,
+    updated_at: row.updated_at,
+  };
+}
+
+// ── PATCH config body validation ──────────────────────────────────────────
+
+interface ConfigPatch {
+  region?: string;
+  bot_name?: string;
+  announces_on_join?: boolean;
+  auto_join_policy?: string;
+  calendar_source?: string;
+  monthly_hours_cap?: number;
+  leave_after_minutes?: number;
+  respond_mode?: string;
+  wake_word?: string;
+  cost_alert_thresholds?: number[];
+}
+
+function parseConfigPatch(raw: unknown): ConfigPatch {
+  if (typeof raw !== "object" || raw === null) {
+    throw new ValidationError("body must be a JSON object");
+  }
+  const b = raw as Record<string, unknown>;
+  const out: ConfigPatch = {};
+
+  if (b.region !== undefined) {
+    if (typeof b.region !== "string" || !VALID_REGIONS.includes(b.region)) {
+      throw new ValidationError(
+        `region must be one of: ${VALID_REGIONS.join(", ")}`,
+      );
+    }
+    out.region = b.region;
+  }
+  if (b.bot_name !== undefined) {
+    if (typeof b.bot_name !== "string" || b.bot_name.length === 0) {
+      throw new ValidationError("bot_name must be a non-empty string");
+    }
+    if (b.bot_name.length > 200) {
+      throw new ValidationError("bot_name must be ≤200 chars");
+    }
+    out.bot_name = b.bot_name;
+  }
+  if (b.announces_on_join !== undefined) {
+    if (typeof b.announces_on_join !== "boolean") {
+      throw new ValidationError("announces_on_join must be a boolean");
+    }
+    out.announces_on_join = b.announces_on_join;
+  }
+  if (b.auto_join_policy !== undefined) {
+    if (
+      typeof b.auto_join_policy !== "string" ||
+      !VALID_AUTO_JOIN_POLICIES.includes(
+        b.auto_join_policy as (typeof VALID_AUTO_JOIN_POLICIES)[number],
+      )
+    ) {
+      throw new ValidationError(
+        `auto_join_policy must be one of: ${VALID_AUTO_JOIN_POLICIES.join(", ")}`,
+      );
+    }
+    out.auto_join_policy = b.auto_join_policy;
+  }
+  if (b.calendar_source !== undefined) {
+    if (
+      typeof b.calendar_source !== "string" ||
+      !VALID_CALENDAR_SOURCES.includes(
+        b.calendar_source as (typeof VALID_CALENDAR_SOURCES)[number],
+      )
+    ) {
+      throw new ValidationError(
+        `calendar_source must be one of: ${VALID_CALENDAR_SOURCES.join(", ")}`,
+      );
+    }
+    out.calendar_source = b.calendar_source;
+  }
+  if (b.monthly_hours_cap !== undefined) {
+    if (
+      typeof b.monthly_hours_cap !== "number" ||
+      !Number.isInteger(b.monthly_hours_cap) ||
+      b.monthly_hours_cap < 0 ||
+      b.monthly_hours_cap > 10_000
+    ) {
+      throw new ValidationError(
+        "monthly_hours_cap must be an integer between 0 and 10000",
+      );
+    }
+    out.monthly_hours_cap = b.monthly_hours_cap;
+  }
+  if (b.leave_after_minutes !== undefined) {
+    if (
+      typeof b.leave_after_minutes !== "number" ||
+      !Number.isInteger(b.leave_after_minutes) ||
+      b.leave_after_minutes < 1 ||
+      b.leave_after_minutes > 1440
+    ) {
+      throw new ValidationError(
+        "leave_after_minutes must be an integer between 1 and 1440",
+      );
+    }
+    out.leave_after_minutes = b.leave_after_minutes;
+  }
+  if (b.respond_mode !== undefined) {
+    if (
+      typeof b.respond_mode !== "string" ||
+      !VALID_RESPOND_MODES.includes(
+        b.respond_mode as (typeof VALID_RESPOND_MODES)[number],
+      )
+    ) {
+      throw new ValidationError(
+        `respond_mode must be one of: ${VALID_RESPOND_MODES.join(", ")}`,
+      );
+    }
+    out.respond_mode = b.respond_mode;
+  }
+  if (b.wake_word !== undefined) {
+    if (typeof b.wake_word !== "string" || b.wake_word.length === 0) {
+      throw new ValidationError("wake_word must be a non-empty string");
+    }
+    if (b.wake_word.length > 64) {
+      throw new ValidationError("wake_word must be ≤64 chars");
+    }
+    out.wake_word = b.wake_word;
+  }
+  if (b.cost_alert_thresholds !== undefined) {
+    if (
+      !Array.isArray(b.cost_alert_thresholds) ||
+      b.cost_alert_thresholds.length === 0 ||
+      b.cost_alert_thresholds.length > 16 ||
+      !b.cost_alert_thresholds.every(
+        (n) => typeof n === "number" && Number.isFinite(n) && n >= 0 && n <= 1000,
+      )
+    ) {
+      throw new ValidationError(
+        "cost_alert_thresholds must be a non-empty array of finite numbers in [0,1000]",
+      );
+    }
+    out.cost_alert_thresholds = (b.cost_alert_thresholds as number[]).slice();
+  }
+  if (Object.keys(out).length === 0) {
+    throw new ValidationError("patch body has no recognised fields");
+  }
+  return out;
+}
+
+// ── validate-key handler — round-trip against Recall ───────────────────────
+
+interface ValidateKeyOutcome {
+  ok: boolean;
+  account?: Record<string, unknown>;
+  reason?: string;
+}
+
+/** Round-trip an API key against Recall's read-only list-bots endpoint.
+ *  We use `/api/v1/bot/?limit=1` (the documented list path) because it
+ *  is read-only, requires no payload, and 401s on a bad key. We do NOT
+ *  persist the key on success — the /channels card POST handler (PR3a)
+ *  owns that. */
+async function validateRecallKey(
+  apiKey: string,
+  region: string,
+): Promise<ValidateKeyOutcome> {
+  const base = recallBaseUrl(region);
+  const url = `${base}/api/v1/bot/?limit=1`;
+  let resp: Response;
+  try {
+    resp = await fetch(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Token ${apiKey}`,
+        Accept: "application/json",
+      },
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
+  if (resp.status === 401 || resp.status === 403) {
+    return { ok: false, reason: "Recall rejected the API key" };
+  }
+  if (!resp.ok) {
+    let detail = "";
+    try {
+      detail = (await resp.text()).slice(0, 200);
+    } catch {
+      /* swallow */
+    }
+    return {
+      ok: false,
+      reason: `Recall returned HTTP ${resp.status}${detail ? ` — ${detail}` : ""}`,
+    };
+  }
+  // 200 OK. The list-bots endpoint returns `{results:[…]}` but doesn't
+  // surface account metadata; that's fine — the validation signal is the
+  // status code itself. Surface the count for the card to render
+  // "validated · N bots on file" if it wants.
+  let count: number | null = null;
+  try {
+    const json = (await resp.json()) as Record<string, unknown>;
+    if (typeof json.count === "number") count = json.count;
+    else if (Array.isArray(json.results)) count = json.results.length;
+  } catch {
+    /* swallow */
+  }
+  return {
+    ok: true,
+    account: { region, bots_known: count },
+  };
+}
+
+// ── usage rollup ──────────────────────────────────────────────────────────
+
+interface UsageRow {
+  this_month_hours: number;
+  monthly_hours_cap: number;
+  bot_count_active: number;
+}
+
+function computeUsage(db: DatabaseSync, cap: number): UsageRow {
+  // First of the current month, UTC. Recall bills bot-time per real
+  // minute the bot is in a meeting; we approximate from joined_at→left_at
+  // for completed bots in the current month, plus joined_at→now for
+  // in-flight bots. Anything without a joined_at doesn't count yet.
+  const now = new Date();
+  const startOfMonth = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1);
+  const nowMs = Date.now();
+
+  const completed = db
+    .prepare(
+      `SELECT COALESCE(SUM(left_at - joined_at), 0) AS ms
+         FROM recall_bot
+        WHERE joined_at IS NOT NULL
+          AND left_at IS NOT NULL
+          AND joined_at >= ?`,
+    )
+    .get(startOfMonth) as { ms: number } | undefined;
+
+  const inflight = db
+    .prepare(
+      `SELECT COALESCE(SUM(? - joined_at), 0) AS ms
+         FROM recall_bot
+        WHERE joined_at IS NOT NULL
+          AND left_at IS NULL
+          AND status NOT IN ('done','fail')
+          AND joined_at >= ?`,
+    )
+    .get(nowMs, startOfMonth) as { ms: number } | undefined;
+
+  const active = db
+    .prepare(
+      `SELECT COUNT(*) AS n
+         FROM recall_bot
+        WHERE status NOT IN ('done','fail')`,
+    )
+    .get() as { n: number };
+
+  const totalMs = (completed?.ms ?? 0) + (inflight?.ms ?? 0);
+  // Round to two decimal places.
+  const hours = Math.round((totalMs / 3_600_000) * 100) / 100;
+
+  return {
+    this_month_hours: hours,
+    monthly_hours_cap: cap,
+    bot_count_active: active.n,
+  };
+}
+
+// ── inbound webhook signature verification ─────────────────────────────────
+//
+// Recall delivers webhooks via Svix. Svix's signed-content format is
+// identical to the Standard-Webhooks scheme already used by the Composio
+// webhook (composioWebhook.ts:99-150):
+//
+//   svix-id:        <ulid-ish string>
+//   svix-timestamp: <unix-seconds>
+//   svix-signature: v1,<base64-hmac>   (space-separated for multi-key rotation)
+//
+// signing string:  `${id}.${ts}.${rawBody}`
+// algorithm:       HMAC-SHA-256, base64-encoded
+// secret prefix:   "whsec_" + base64 (sometimes raw)
+//
+// The header names Recall actually emits are `svix-id` / `svix-timestamp`
+// / `svix-signature`; some setups proxy them as the equivalent
+// `webhook-*` headers. We accept either.
+
+interface SvixVerifyResult {
+  ok: boolean;
+  reason: string;
+}
+
+function headerString(
+  h: string | string[] | undefined,
+): string | null {
+  if (!h) return null;
+  const v = Array.isArray(h) ? h[0] : h;
+  if (typeof v !== "string" || v.length === 0) return null;
+  return v;
+}
+
+function pickSvixHeaders(
+  headers: Record<string, string | string[] | undefined>,
+): { id: string | null; ts: string | null; sig: string | null } {
+  return {
+    id:
+      headerString(headers["svix-id"]) ?? headerString(headers["webhook-id"]),
+    ts:
+      headerString(headers["svix-timestamp"]) ??
+      headerString(headers["webhook-timestamp"]),
+    sig:
+      headerString(headers["svix-signature"]) ??
+      headerString(headers["webhook-signature"]),
+  };
+}
+
+function verifySvixSignature(
+  rawBody: Buffer,
+  headers: Record<string, string | string[] | undefined>,
+  secret: string,
+): SvixVerifyResult {
+  const { id, ts, sig } = pickSvixHeaders(headers);
+  if (!id || !ts || !sig) {
+    return { ok: false, reason: "missing svix-id / svix-timestamp / svix-signature" };
+  }
+  // Replay window: ±5 minutes. The timestamp itself isn't a secret; reject
+  // early so the HMAC work doesn't happen on stale deliveries.
+  const tsNum = Number.parseInt(ts, 10);
+  if (!Number.isFinite(tsNum)) {
+    return { ok: false, reason: "svix-timestamp is not a number" };
+  }
+  const nowSec = Math.floor(Date.now() / 1000);
+  if (Math.abs(nowSec - tsNum) > 300) {
+    return { ok: false, reason: "svix-timestamp outside ±5min replay window" };
+  }
+
+  const secretBytes = secret.startsWith("whsec_")
+    ? Buffer.from(secret.slice("whsec_".length), "base64")
+    : Buffer.from(secret, "utf-8");
+
+  const signed = Buffer.concat([
+    Buffer.from(`${id}.${ts}.`, "utf-8"),
+    rawBody,
+  ]);
+  const expected = crypto
+    .createHmac("sha256", secretBytes)
+    .update(signed)
+    .digest("base64");
+
+  // Header is space-separated "v1,<sig> v1,<sig2> ..." — any match wins.
+  for (const part of sig.split(" ")) {
+    const eq = part.indexOf(",");
+    if (eq < 0) continue;
+    const version = part.slice(0, eq).trim();
+    const received = part.slice(eq + 1).trim();
+    if (version !== "v1") continue;
+    const aBuf = Buffer.from(expected);
+    const bBuf = Buffer.from(received);
+    if (aBuf.length !== bBuf.length) continue;
+    try {
+      if (crypto.timingSafeEqual(aBuf, bBuf)) {
+        return { ok: true, reason: "svix signature verified" };
+      }
+    } catch {
+      /* length mismatch already filtered; ignore */
+    }
+  }
+  return { ok: false, reason: "no svix signature matched" };
+}
+
+// ── webhook event → recall_bot status mapping ──────────────────────────────
+//
+// Recall fires lifecycle events with `event` (or `type`) like
+// "bot.joining_call", "bot.in_call_recording", "bot.call_ended",
+// "bot.done", "bot.fatal", plus per-output events like
+// "transcript.done". We tolerate the synonyms and surface a small set
+// of status transitions on the parent row.
+
+const TERMINAL_STATES = new Set(["done", "fail"]);
+
+function statusFromEvent(eventType: string): string | null {
+  const t = eventType.toLowerCase();
+  if (/joining|join_call|joining_call/.test(t)) return "joining";
+  if (/in_(call|meeting)|recording|joined/.test(t)) return "in_meeting";
+  if (/leaving/.test(t)) return "leaving";
+  if (/done$|call_ended|finished/.test(t)) return "done";
+  if (/fail|fatal|error/.test(t)) return "fail";
+  return null;
+}
+
+/** Pluck the bot id out of a Recall webhook payload. Recall's V2 webhooks
+ *  put it under `data.bot.id` or `data.bot_id`; older shapes use `bot_id`
+ *  at the top level. Returns null on the shape we don't recognise. */
+function extractBotId(payload: unknown): string | null {
+  if (typeof payload !== "object" || payload === null) return null;
+  const p = payload as Record<string, unknown>;
+  if (typeof p.bot_id === "string") return p.bot_id;
+  const data = p.data;
+  if (typeof data === "object" && data !== null) {
+    const d = data as Record<string, unknown>;
+    if (typeof d.bot_id === "string") return d.bot_id;
+    const bot = d.bot;
+    if (typeof bot === "object" && bot !== null) {
+      const bo = bot as Record<string, unknown>;
+      if (typeof bo.id === "string") return bo.id;
+    }
+  }
+  return null;
+}
+
+function extractEventType(payload: unknown): string | null {
+  if (typeof payload !== "object" || payload === null) return null;
+  const p = payload as Record<string, unknown>;
+  if (typeof p.event === "string") return p.event;
+  if (typeof p.type === "string") return p.type;
+  // V3-ish shape: metadata.event_type
+  const meta = p.metadata;
+  if (typeof meta === "object" && meta !== null) {
+    const m = meta as Record<string, unknown>;
+    if (typeof m.event_type === "string") return m.event_type;
+  }
+  return null;
+}
+
+function extractTranscriptUrl(payload: unknown): string | null {
+  if (typeof payload !== "object" || payload === null) return null;
+  const p = payload as Record<string, unknown>;
+  const data = p.data;
+  if (typeof data === "object" && data !== null) {
+    const d = data as Record<string, unknown>;
+    if (typeof d.transcript_url === "string") return d.transcript_url;
+    const transcript = d.transcript;
+    if (typeof transcript === "object" && transcript !== null) {
+      const tr = transcript as Record<string, unknown>;
+      if (typeof tr.url === "string") return tr.url;
+      if (typeof tr.download_url === "string") return tr.download_url;
+    }
+  }
+  return null;
+}
+
+/** Persist one verified webhook event. Transactional: the recall_event
+ *  row + any recall_bot.status update land together so a crashed
+ *  ctrl-api never produces an event row without its row-update side
+ *  effect (or vice versa). */
+function persistWebhookEvent(
+  db: DatabaseSync,
+  payload: unknown,
+  eventAtMs: number,
+): { event_type: string; bot_id: string | null; new_status: string | null } {
+  const eventType = extractEventType(payload) ?? "unknown";
+  const botId = extractBotId(payload);
+  const newStatus = statusFromEvent(eventType);
+  const transcriptUrl = extractTranscriptUrl(payload);
+
+  db.exec("BEGIN");
+  try {
+    db.prepare(
+      `INSERT INTO recall_event (bot_id, event_type, event_at, payload_json)
+         VALUES (?, ?, ?, ?)`,
+    ).run(botId, eventType, eventAtMs, JSON.stringify(payload));
+
+    if (botId && newStatus) {
+      // Read current row so we (a) only update bots we know about, (b)
+      // never regress from a terminal state, (c) keep the joined_at /
+      // left_at columns coherent.
+      const existing = db
+        .prepare(
+          `SELECT status, joined_at, left_at FROM recall_bot WHERE id = ?`,
+        )
+        .get(botId) as
+        | { status: string; joined_at: number | null; left_at: number | null }
+        | undefined;
+      if (existing && !TERMINAL_STATES.has(existing.status)) {
+        const joinedAt =
+          newStatus === "in_meeting" && existing.joined_at === null
+            ? eventAtMs
+            : existing.joined_at;
+        const leftAt =
+          TERMINAL_STATES.has(newStatus) && existing.left_at === null
+            ? eventAtMs
+            : existing.left_at;
+        const nextTranscriptUrl = transcriptUrl ?? null;
+        db.prepare(
+          `UPDATE recall_bot
+              SET status         = ?,
+                  joined_at      = ?,
+                  left_at        = ?,
+                  transcript_url = COALESCE(?, transcript_url)
+            WHERE id = ?`,
+        ).run(newStatus, joinedAt, leftAt, nextTranscriptUrl, botId);
+      }
+    }
+    db.exec("COMMIT");
+  } catch (err) {
+    db.exec("ROLLBACK");
+    throw err;
+  }
+  return { event_type: eventType, bot_id: botId, new_status: newStatus };
+}
+
+// Exported for tests so they can directly drive the persistence layer
+// without spinning through HTTP. NOT part of the wire surface.
+export const _recallInternals = {
+  validateRecallKey,
+  verifySvixSignature,
+  persistWebhookEvent,
+  computeUsage,
+  getOrSeedConfig,
+  statusFromEvent,
+  parseConfigPatch,
+};
+
+// ── Routes ────────────────────────────────────────────────────────────────
+
+export function registerChannelsRecallRoutes(): void {
+  // POST /api/v1/channels/recall/validate-key
+  //
+  // Card-side paste flow: the operator pastes a candidate API key into
+  // the /channels Recall card; the card calls this route to confirm the
+  // key works against Recall before writing it anywhere durable.
+  // The route NEVER persists; PR3a handles persistence in a separate
+  // POST after this validation succeeds.
+  addRoute(
+    "POST",
+    "/api/v1/channels/recall/validate-key",
+    async ({ res, body }) => {
+      const b = (body ?? {}) as { api_key?: unknown; region?: unknown };
+      if (typeof b.api_key !== "string" || b.api_key.trim().length === 0) {
+        throw new ValidationError("api_key (non-empty string) is required");
+      }
+      const key = b.api_key.trim();
+      // Region is optional; default to the configured value (or 'us-east-1').
+      let region = "us-east-1";
+      if (b.region !== undefined) {
+        if (typeof b.region !== "string" || !VALID_REGIONS.includes(b.region)) {
+          throw new ValidationError(
+            `region must be one of: ${VALID_REGIONS.join(", ")}`,
+          );
+        }
+        region = b.region;
+      } else {
+        try {
+          const cfg = getOrSeedConfig(getStateDb());
+          region = cfg.region;
+        } catch {
+          /* default region is fine */
+        }
+      }
+      const outcome = await validateRecallKey(key, region);
+      // Always 200 — the {ok:false, reason} envelope tells the card what
+      // to render. Tossing a non-2xx here would force the card to also
+      // handle a generic error page on what's a normal "wrong key" path.
+      sendJson(res, 200, outcome);
+    },
+  );
+
+  // GET /api/v1/channels/recall/config
+  addRoute("GET", "/api/v1/channels/recall/config", async ({ res }) => {
+    const db = getStateDb();
+    const row = getOrSeedConfig(db);
+    sendJson(res, 200, rowToApiConfig(row));
+  });
+
+  // PATCH /api/v1/channels/recall/config
+  addRoute(
+    "PATCH",
+    "/api/v1/channels/recall/config",
+    async ({ res, body }) => {
+      const patch = parseConfigPatch(body);
+      const db = getStateDb();
+      // Make sure the row exists.
+      getOrSeedConfig(db);
+      const fields: string[] = [];
+      const values: unknown[] = [];
+      if (patch.region !== undefined) {
+        fields.push("region = ?");
+        values.push(patch.region);
+      }
+      if (patch.bot_name !== undefined) {
+        fields.push("bot_name = ?");
+        values.push(patch.bot_name);
+      }
+      if (patch.announces_on_join !== undefined) {
+        fields.push("announces_on_join = ?");
+        values.push(patch.announces_on_join ? 1 : 0);
+      }
+      if (patch.auto_join_policy !== undefined) {
+        fields.push("auto_join_policy = ?");
+        values.push(patch.auto_join_policy);
+      }
+      if (patch.calendar_source !== undefined) {
+        fields.push("calendar_source = ?");
+        values.push(patch.calendar_source);
+      }
+      if (patch.monthly_hours_cap !== undefined) {
+        fields.push("monthly_hours_cap = ?");
+        values.push(patch.monthly_hours_cap);
+      }
+      if (patch.leave_after_minutes !== undefined) {
+        fields.push("leave_after_minutes = ?");
+        values.push(patch.leave_after_minutes);
+      }
+      if (patch.respond_mode !== undefined) {
+        fields.push("respond_mode = ?");
+        values.push(patch.respond_mode);
+      }
+      if (patch.wake_word !== undefined) {
+        fields.push("wake_word = ?");
+        values.push(patch.wake_word);
+      }
+      if (patch.cost_alert_thresholds !== undefined) {
+        fields.push("cost_alert_thresholds_json = ?");
+        values.push(JSON.stringify(patch.cost_alert_thresholds));
+      }
+      fields.push("updated_at = ?");
+      values.push(Date.now());
+      const sql = `UPDATE recall_config SET ${fields.join(", ")} WHERE id = 1`;
+      db.prepare(sql).run(...values);
+      const row = getOrSeedConfig(db);
+      sendJson(res, 200, rowToApiConfig(row));
+    },
+  );
+
+  // GET /api/v1/channels/recall/usage
+  addRoute("GET", "/api/v1/channels/recall/usage", async ({ res }) => {
+    const db = getStateDb();
+    const cfg = getOrSeedConfig(db);
+    const usage = computeUsage(db, cfg.monthly_hours_cap);
+    sendJson(res, 200, usage);
+  });
+
+  // GET /api/v1/channels/recall/bots/active
+  addRoute(
+    "GET",
+    "/api/v1/channels/recall/bots/active",
+    async ({ res }) => {
+      const db = getStateDb();
+      const rows = db
+        .prepare(
+          `SELECT id, calendar_event_id, meeting_url, status,
+                  created_at, joined_at, left_at, transcript_url
+             FROM recall_bot
+            WHERE status NOT IN ('done','fail')
+            ORDER BY created_at DESC
+            LIMIT 100`,
+        )
+        .all() as Array<{
+        id: string;
+        calendar_event_id: string | null;
+        meeting_url: string | null;
+        status: string;
+        created_at: number;
+        joined_at: number | null;
+        left_at: number | null;
+        transcript_url: string | null;
+      }>;
+      sendJson(res, 200, { bots: rows });
+    },
+  );
+
+  // DELETE /api/v1/channels/recall/bots/:bot_id — mid-meeting terminate.
+  //
+  // Calls Recall's DELETE /api/v1/bot/<id>/ to instruct the bot to leave,
+  // then flips the local row's status to "leaving". The bot.left / bot.done
+  // webhook will eventually arrive and drive the row to a terminal state.
+  // Surfaces the upstream HTTP status so the card can render a useful
+  // error if Recall rejected the request (e.g. unknown bot id, expired
+  // session).
+  addRoute(
+    "DELETE",
+    "/api/v1/channels/recall/bots/:bot_id",
+    async ({ res, params }) => {
+      const botId = params.bot_id;
+      if (!botId || botId.length > 200) {
+        throw new ValidationError("bot_id must be a non-empty string ≤200 chars");
+      }
+      const apiKey = process.env.RECALL_API_KEY?.trim();
+      if (!apiKey) {
+        throw new ApiError(
+          503,
+          "NOT_CONFIGURED",
+          "RECALL_API_KEY is not set on this tenant",
+        );
+      }
+      const db = getStateDb();
+      const cfg = getOrSeedConfig(db);
+      const base = recallBaseUrl(cfg.region);
+      const url = `${base}/api/v1/bot/${encodeURIComponent(botId)}/`;
+      let resp: Response;
+      try {
+        resp = await fetch(url, {
+          method: "DELETE",
+          headers: {
+            Authorization: `Token ${apiKey}`,
+            Accept: "application/json",
+          },
+          signal: AbortSignal.timeout(10_000),
+        });
+      } catch (err) {
+        throw new ApiError(
+          502,
+          "RECALL_UNREACHABLE",
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+      if (resp.status === 404) {
+        // Bot is gone on Recall's side — mark local row terminal too so
+        // the card's active list refreshes cleanly.
+        db.prepare(
+          `UPDATE recall_bot
+              SET status = 'done',
+                  left_at = COALESCE(left_at, ?)
+            WHERE id = ? AND status NOT IN ('done','fail')`,
+        ).run(Date.now(), botId);
+        sendJson(res, 200, {
+          ok: true,
+          bot_id: botId,
+          status: "done",
+          note: "Recall reported 404; local row marked done",
+        });
+        return;
+      }
+      if (!resp.ok) {
+        let detail = "";
+        try {
+          detail = (await resp.text()).slice(0, 200);
+        } catch {
+          /* swallow */
+        }
+        throw new ApiError(
+          502,
+          "RECALL_REJECTED",
+          `Recall returned HTTP ${resp.status}${detail ? ` — ${detail}` : ""}`,
+        );
+      }
+      const now = Date.now();
+      db.prepare(
+        `UPDATE recall_bot
+            SET status = CASE WHEN status IN ('done','fail') THEN status ELSE 'leaving' END,
+                left_at = COALESCE(left_at, ?)
+          WHERE id = ?`,
+      ).run(now, botId);
+      sendJson(res, 200, { ok: true, bot_id: botId, status: "leaving" });
+    },
+  );
+
+  // POST /api/v1/channels/recall/webhook-test
+  //
+  // Fire a synthetic webhook into our own /api/v1/webhooks/recall endpoint
+  // (signed with the locally-configured RECALL_WEBHOOK_SECRET) so the card
+  // can prove the inbound delivery path works end-to-end. Same posture as
+  // channels_paperclip's /test — POST to ourselves on 127.0.0.1:AAS_PORT.
+  addRoute(
+    "POST",
+    "/api/v1/channels/recall/webhook-test",
+    async ({ res }) => {
+      const secret = process.env.RECALL_WEBHOOK_SECRET ?? "";
+      if (!secret) {
+        throw new ApiError(
+          503,
+          "NOT_CONFIGURED",
+          "RECALL_WEBHOOK_SECRET is not set on this tenant",
+        );
+      }
+      const nowSec = Math.floor(Date.now() / 1000);
+      const eventId = `evt-test-${nowSec}`;
+      const synthetic = {
+        event: "bot.synthetic_test",
+        data: {
+          bot_id: `bot-test-${nowSec}`,
+          timestamp: new Date().toISOString(),
+        },
+      };
+      const rawBody = Buffer.from(JSON.stringify(synthetic), "utf-8");
+      const secretBytes = secret.startsWith("whsec_")
+        ? Buffer.from(secret.slice("whsec_".length), "base64")
+        : Buffer.from(secret, "utf-8");
+      const signed = Buffer.concat([
+        Buffer.from(`${eventId}.${nowSec}.`, "utf-8"),
+        rawBody,
+      ]);
+      const v1 = crypto
+        .createHmac("sha256", secretBytes)
+        .update(signed)
+        .digest("base64");
+
+      const host = process.env.AAS_HOST ?? "127.0.0.1";
+      const port = process.env.AAS_PORT ?? "3100";
+      const url = `http://${host}:${port}/api/v1/webhooks/recall`;
+      const t0 = Date.now();
+      let upstream: Response;
+      try {
+        upstream = await fetch(url, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "svix-id": eventId,
+            "svix-timestamp": String(nowSec),
+            "svix-signature": `v1,${v1}`,
+          },
+          body: rawBody,
+          signal: AbortSignal.timeout(15_000),
+        });
+      } catch (err) {
+        sendJson(res, 200, {
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return;
+      }
+      const latencyMs = Date.now() - t0;
+      let bodyText = "";
+      try {
+        bodyText = await upstream.text();
+      } catch {
+        bodyText = "";
+      }
+      sendJson(res, 200, {
+        ok: upstream.ok,
+        status: upstream.status,
+        latency_ms: latencyMs,
+        sample_response: bodyText.slice(0, 200),
+      });
+    },
+  );
+}
+
+// ── Inbound webhook (separate registrar so server.ts can mark its path
+//    isPublic + isRawBody alongside Composio's). ────────────────────────────
+
+export function registerRecallWebhookRoute(): void {
+  // POST /api/v1/webhooks/recall — Svix-signed inbound.
+  //
+  // The route receives the raw bytes (server.ts whitelists this path on
+  // isRawBody so we get Buffer in `body`, not parsed JSON). We verify the
+  // svix-* headers against RECALL_WEBHOOK_SECRET, parse the body as JSON
+  // ONLY after the HMAC check, and persist the event into recall_event +
+  // update the parent recall_bot row in one transaction.
+  //
+  // 200 vs 4xx policy (mirrors composioWebhook):
+  //   * missing/bad signature                → 401 (Recall retries — fine)
+  //   * unrecognised payload shape           → 200 + WARN (don't trigger storm)
+  //   * unknown bot_id                       → 200 (we may have GC'd the row)
+  //   * persistence failed                   → 502 (Recall retries)
+  addRoute("POST", "/api/v1/webhooks/recall", async ({ req, res, body }) => {
+    const secret = process.env.RECALL_WEBHOOK_SECRET ?? "";
+    if (!secret) {
+      // Loud failure — without the secret we cannot verify, and silently
+      // accepting would let anyone on the public internet shove rows into
+      // recall_event.
+      throw new ApiError(
+        503,
+        "NOT_CONFIGURED",
+        "RECALL_WEBHOOK_SECRET is not set on this tenant",
+      );
+    }
+    // server.ts marks this path as isRawBody → body is a Buffer.
+    const rawBody =
+      body instanceof Buffer
+        ? body
+        : Buffer.from(typeof body === "string" ? body : JSON.stringify(body ?? {}), "utf-8");
+
+    const verify = verifySvixSignature(rawBody, req.headers, secret);
+    if (!verify.ok) {
+      throw new ApiError(401, "AUTH_FAILED", verify.reason);
+    }
+    // Parse JSON after the HMAC check passes.
+    let payload: unknown;
+    try {
+      payload = JSON.parse(rawBody.toString("utf-8"));
+    } catch {
+      // Recall sent a body shape we can't parse; 200 + WARN so the
+      // delivery isn't retried in a storm. We can never persist this.
+      console.warn(
+        "[recall-webhook] verified but un-parseable JSON body",
+        rawBody.toString("utf-8").slice(0, 200),
+      );
+      sendJson(res, 200, { ok: true, noop: "unparseable JSON body" });
+      return;
+    }
+    try {
+      const db = getStateDb();
+      const result = persistWebhookEvent(db, payload, Date.now());
+      sendJson(res, 200, {
+        ok: true,
+        event_type: result.event_type,
+        bot_id: result.bot_id,
+        new_status: result.new_status,
+      });
+    } catch (err) {
+      console.error(
+        "[recall-webhook] persistence failed:",
+        err instanceof Error ? err.message : String(err),
+      );
+      throw new ApiError(
+        502,
+        "PERSIST_FAILED",
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  });
+}

--- a/packages/ctrl/src/api/server.ts
+++ b/packages/ctrl/src/api/server.ts
@@ -57,6 +57,10 @@ import { registerSmsRoutes } from "./routes/sms.js";
 import { registerVoiceRoutes } from "./routes/voice.js";
 import { registerOmiChannelRoutes } from "./routes/channels_omi.js";
 import { registerPaperclipChannelRoutes } from "./routes/channels_paperclip.js";
+import {
+  registerChannelsRecallRoutes,
+  registerRecallWebhookRoute,
+} from "./routes/channels_recall.js";
 import { registerHaChannelRoutes } from "./routes/channels_ha.js";
 import { registerChannelTokenRoutes } from "./routes/channel_tokens.js";
 import { registerComposioWebhookRoutes } from "./routes/composioWebhook.js";
@@ -177,6 +181,12 @@ export function createApiServer(): http.Server {
   registerVoiceRoutes();
   registerOmiChannelRoutes();
   registerPaperclipChannelRoutes();
+  // /api/v1/channels/recall/* + /api/v1/webhooks/recall — Recall.ai
+  // meeting-bot channel (#113 PR2). Card-driven config + inbound
+  // Svix-signed webhook. The card UI lands in PR3a/3b; the alfred-learn
+  // dispatcher in PR4; the voice/webpage path in PR5/6.
+  registerChannelsRecallRoutes();
+  registerRecallWebhookRoute();
   // /api/v1/channels/ha/* — Home Assistant conversation agent (#111). PR1
   // ships the non-streaming /turn route; #110 PR1 extends with discovery
   // routes; PR3+ extends with tool partitioning + streaming.
@@ -257,7 +267,13 @@ export function createApiServer(): http.Server {
         // `x-composio-signature`). Composio cannot send a Bearer header so
         // the global auth gate must not pre-empt the HMAC check. See
         // routes/composioWebhook.ts for the full auth model.
-        pathname === "/api/v1/composio/webhook";
+        pathname === "/api/v1/composio/webhook" ||
+        // Recall.ai webhook (#113 PR2). Svix-signed
+        // (svix-id / svix-timestamp / svix-signature over the raw body
+        // keyed on RECALL_WEBHOOK_SECRET). Same posture as the Composio
+        // entry above — the HMAC validator lives in
+        // routes/channels_recall.ts and needs the exact bytes.
+        pathname === "/api/v1/webhooks/recall";
       if (!isPublic) {
         // Pass method+pathname so the scoped-token path can check the
         // route allowlist (see auth.ts VOICE_BRIDGE_ALLOWLIST). The master
@@ -291,7 +307,10 @@ export function createApiServer(): http.Server {
         pathname === "/api/v1/webhooks/plane/steward" ||
         // Composio's Standard-Webhooks scheme signs the raw body, so the
         // handler must see the exact bytes — see routes/composioWebhook.ts.
-        pathname === "/api/v1/composio/webhook";
+        pathname === "/api/v1/composio/webhook" ||
+        // Recall.ai's Svix-signed webhook also needs the raw bytes for
+        // HMAC verification (see routes/channels_recall.ts).
+        pathname === "/api/v1/webhooks/recall";
       const query = new URLSearchParams(qIdx >= 0 ? url.slice(qIdx + 1) : "");
 
       const matched = matchRoute(method, pathname);

--- a/packages/ctrl/src/db/migrate.ts
+++ b/packages/ctrl/src/db/migrate.ts
@@ -20,6 +20,7 @@ import m0003 from "./migrations/0003_tailscale_connection.sql";
 import m0004 from "./migrations/0004_channel_tokens.sql";
 import m0005 from "./migrations/0005_ha_channel.sql";
 import m0006 from "./migrations/0006_files_table.sql";
+import m0007 from "./migrations/0007_recall.sql";
 
 interface Migration {
   version: number;
@@ -35,6 +36,7 @@ const MIGRATIONS: Migration[] = [
   { version: 4, name: "channel_tokens",       sql: m0004 },
   { version: 5, name: "ha_channel",           sql: m0005 },
   { version: 6, name: "files_table",          sql: m0006 },
+  { version: 7, name: "recall",               sql: m0007 },
 ];
 
 /**

--- a/packages/ctrl/src/db/migrations/0007_recall.sql
+++ b/packages/ctrl/src/db/migrations/0007_recall.sql
@@ -1,0 +1,73 @@
+-- 0007_recall — Recall.ai channel tables (#113 PR2).
+--
+-- Replaces the retired Vexa stack (#113 PR1) with the SaaS Recall.ai
+-- bot model. Three tables land here; the routes in
+-- routes/channels_recall.ts and routes/webhooks/recall.ts read/write
+-- them. Subsequent PRs (3a/3b for the /channels card, PR4 for the
+-- alfred-learn workflows, PR5/6 for the voice/webpage path) extend
+-- this schema additively — never edit this file once merged; append
+-- a numbered follow-up migration instead (state.db migration rule).
+--
+-- Schema overview (spec §5.4.1):
+--
+--   recall_config — singleton row (id=1) carrying the operator-tunable
+--     dials the /channels card edits. `cost_alert_thresholds_json` is
+--     a JSON array of percentage thresholds (e.g. [80, 100]); the
+--     monthly-hours-cap enforcer (PR7) reads it on each rollup.
+--
+--   recall_bot — one row per dispatched bot. `id` is Recall's own bot
+--     id (we use it as primary key so the webhook handler can update
+--     by id without a separate lookup). `json` holds the full bot
+--     payload Recall returned at create time — kept verbatim so we
+--     can re-derive any field without a migration.
+--
+--   recall_event — append-only ledger of webhook deliveries. Every
+--     verified inbound webhook lands one row here; the lifecycle
+--     events (bot.joined / bot.left / transcript.done / etc.) also
+--     update the parent `recall_bot.status` row in the same
+--     transaction. The full payload is preserved in
+--     `payload_json` for forensic replay.
+
+CREATE TABLE IF NOT EXISTS recall_config (
+  id                          INTEGER PRIMARY KEY CHECK(id = 1),
+  region                      TEXT    NOT NULL DEFAULT 'us-east-1',
+  bot_name                    TEXT    NOT NULL DEFAULT 'Alfred''s note-taker',
+  announces_on_join           INTEGER NOT NULL DEFAULT 1,
+  auto_join_policy            TEXT    NOT NULL DEFAULT 'principal_attendee',
+  calendar_source             TEXT    NOT NULL DEFAULT 'composio',
+  monthly_hours_cap           INTEGER NOT NULL DEFAULT 60,
+  leave_after_minutes         INTEGER NOT NULL DEFAULT 90,
+  respond_mode                TEXT    NOT NULL DEFAULT 'on_mention',
+  wake_word                   TEXT    NOT NULL DEFAULT 'Alfred',
+  cost_alert_thresholds_json  TEXT    NOT NULL DEFAULT '[80, 100]',
+  updated_at                  INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS recall_bot (
+  id                  TEXT PRIMARY KEY,            -- Recall's bot id
+  calendar_event_id   TEXT,                        -- gcal event id (Composio)
+  meeting_url         TEXT,                        -- raw meet/zoom/teams URL
+  status              TEXT NOT NULL,               -- requested|joining|in_meeting|leaving|done|fail
+  created_at          INTEGER NOT NULL,
+  joined_at           INTEGER,
+  left_at             INTEGER,
+  transcript_url      TEXT,
+  json                TEXT NOT NULL                -- full Recall create-bot payload
+);
+
+CREATE TABLE IF NOT EXISTS recall_event (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  bot_id        TEXT,                              -- nullable: lifecycle events with no bot
+  event_type    TEXT    NOT NULL,                  -- e.g. bot.joined, transcript.done
+  event_at      INTEGER NOT NULL,
+  payload_json  TEXT    NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_recall_bot_status
+  ON recall_bot(status);
+
+CREATE INDEX IF NOT EXISTS idx_recall_bot_calendar
+  ON recall_bot(calendar_event_id);
+
+CREATE INDEX IF NOT EXISTS idx_recall_event_bot
+  ON recall_event(bot_id);

--- a/packages/ctrl/tests/channels_recall.test.ts
+++ b/packages/ctrl/tests/channels_recall.test.ts
@@ -1,0 +1,609 @@
+// channels_recall — /api/v1/channels/recall/* + /api/v1/webhooks/recall.
+//
+// What's under test
+// -----------------
+// The 7 outbound routes + 1 inbound webhook that ship in #113 PR2. The
+// route handlers depend on:
+//   * a real state.db (so the recall_config / recall_bot / recall_event
+//     tables exist post-migration);
+//   * a stubbed Recall.ai API (we don't reach out to recall.ai);
+//   * RECALL_API_KEY / RECALL_WEBHOOK_SECRET env vars.
+//
+// We drive routes through matchRoute + a handleError shim — the same
+// pattern as channels_paperclip.test.ts — so thrown ApiErrors come back
+// as JSON envelopes rather than crashing the test runner.
+//
+// Coverage (≥8 cases, per PR2 task spec):
+//   1. validate-key — Recall returns 200 → {ok:true}.
+//   2. validate-key — Recall returns 401 → {ok:false, reason:...}.
+//   3. validate-key — missing api_key body field → 400 VALIDATION_ERROR.
+//   4. validate-key — invalid region → 400 VALIDATION_ERROR.
+//   5. config — GET returns the seeded singleton row with defaults.
+//   6. config — PATCH updates fields and persists.
+//   7. config — PATCH rejects invalid enum.
+//   8. config — PATCH rejects out-of-range numeric.
+//   9. usage — empty DB returns 0 hours, 0 active bots.
+//  10. usage — joined+left rows in this month contribute hours.
+//  11. bots/active — only non-terminal bots are listed.
+//  12. bots/:id DELETE — calls Recall, flips local row to leaving.
+//  13. bots/:id DELETE — no RECALL_API_KEY → 503.
+//  14. webhook — valid signature persists event + updates bot status.
+//  15. webhook — bad signature → 401.
+//  16. webhook — stale timestamp → 401 (replay window).
+//  17. webhook — no RECALL_WEBHOOK_SECRET → 503.
+//
+// Privacy: this is a public OSS repo. No real secrets in this file.
+
+import { describe, it, before, beforeEach, after } from "node:test";
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ServerResponse } from "node:http";
+
+// ── per-suite fixture dir ────────────────────────────────────────────────
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "channels-recall-"));
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.VAULT_PATH = path.join(tmp, "vault");
+process.env.STATE_DB_PATH = path.join(tmp, "alfred-state.db");
+process.env.SQLITE_VEC_PATH = "";
+process.env.DOMAIN = "test.alfred.black";
+process.env.AAS_HOST = "127.0.0.1";
+process.env.AAS_PORT = "3100";
+delete process.env.RECALL_API_KEY;
+delete process.env.RECALL_WEBHOOK_SECRET;
+
+// ── Recall + self-loop fetch mock ────────────────────────────────────────
+
+const originalFetch = globalThis.fetch;
+
+interface RecallStub {
+  // GET /api/v1/bot/?limit=1 (validate-key path)
+  listBotsStatus: number;
+  listBotsBody: unknown;
+  // DELETE /api/v1/bot/:id/
+  deleteBotStatus: number;
+}
+
+const recallStub: RecallStub = {
+  listBotsStatus: 200,
+  listBotsBody: { count: 0, results: [] },
+  deleteBotStatus: 200,
+};
+
+let recallShouldThrow = false;
+
+let invokeRoute: (
+  method: string,
+  p: string,
+  body?: unknown,
+  headers?: Record<string, string>,
+  rawBodyBuf?: Buffer,
+) => Promise<{ status: number; payload: any }>;
+
+function makeJsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+globalThis.fetch = (async (input: any, init?: any) => {
+  const url = typeof input === "string" ? input : (input?.url ?? String(input));
+  const method = (init?.method ?? "GET").toUpperCase();
+
+  // Recall list-bots — validate-key
+  if (
+    method === "GET" &&
+    /\/api\/v1\/bot\/\?limit=1$/.test(url) &&
+    /recall\.ai/.test(url)
+  ) {
+    if (recallShouldThrow) throw new Error("recall unreachable");
+    return makeJsonResponse(recallStub.listBotsBody, recallStub.listBotsStatus);
+  }
+  // Recall delete-bot — DELETE /api/v1/bot/<id>/
+  if (
+    method === "DELETE" &&
+    /\/api\/v1\/bot\/[^/]+\/?$/.test(url) &&
+    /recall\.ai/.test(url)
+  ) {
+    if (recallShouldThrow) throw new Error("recall unreachable");
+    const status = recallStub.deleteBotStatus;
+    // 204 No Content cannot carry a body per the Fetch spec.
+    if (status === 204 || status === 205 || status === 304) {
+      return new Response(null, { status });
+    }
+    return makeJsonResponse({}, status);
+  }
+  // Self-loop from /webhook-test → /webhooks/recall
+  if (
+    method === "POST" &&
+    url.includes("/api/v1/webhooks/recall")
+  ) {
+    const headersIn = init?.headers ?? {};
+    const hdrs: Record<string, string> = {};
+    for (const [k, v] of Object.entries(headersIn)) {
+      hdrs[k.toLowerCase()] = String(v);
+    }
+    const raw =
+      init?.body instanceof Buffer
+        ? init.body
+        : Buffer.from(String(init?.body ?? ""));
+    // The webhook handler expects Buffer in body (server.ts isRawBody path).
+    const result = await invokeRoute(
+      "POST",
+      "/api/v1/webhooks/recall",
+      raw,
+      hdrs,
+    );
+    return makeJsonResponse(result.payload, result.status);
+  }
+  throw new Error(`unexpected fetch in channels_recall test: ${method} ${url}`);
+}) as typeof fetch;
+
+// ── module imports (after env + fetch are set) ─────────────────────────────
+
+const { matchRoute } = await import("../src/api/server.js");
+const { handleError } = await import("../src/api/errors.js");
+const {
+  registerChannelsRecallRoutes,
+  registerRecallWebhookRoute,
+  _recallInternals,
+} = await import("../src/api/routes/channels_recall.js");
+const { getStateDb } = await import("../src/db/state.js");
+registerChannelsRecallRoutes();
+registerRecallWebhookRoute();
+
+invokeRoute = async function (
+  method: string,
+  p: string,
+  body?: unknown,
+  headers: Record<string, string> = {},
+  _rawBodyBuf?: Buffer,
+): Promise<{ status: number; payload: any }> {
+  const m = matchRoute(method, p);
+  assert.ok(m, `${method} ${p} must be registered`);
+  let status = 0;
+  let payload: any;
+  const res = {
+    statusCode: 0,
+    setHeader() {},
+    writeHead(c: number) {
+      status = c;
+      return res;
+    },
+    end(j?: string) {
+      payload = j ? JSON.parse(j) : undefined;
+    },
+  } as unknown as ServerResponse;
+  try {
+    await m!.handler({
+      req: { method, url: p, headers } as any,
+      res,
+      params: m!.params,
+      body,
+      query: new URLSearchParams(),
+    });
+  } catch (err) {
+    handleError(res, err);
+  }
+  return { status, payload };
+};
+
+// ── signing helpers ────────────────────────────────────────────────────────
+
+const WEBHOOK_SECRET = "test-recall-secret";
+
+function signSvix(
+  rawBody: Buffer,
+  opts: { secret?: string; ts?: number; id?: string } = {},
+): Record<string, string> {
+  const secret = opts.secret ?? WEBHOOK_SECRET;
+  const ts = opts.ts ?? Math.floor(Date.now() / 1000);
+  const id = opts.id ?? `evt-${ts}`;
+  const secretBytes = secret.startsWith("whsec_")
+    ? Buffer.from(secret.slice("whsec_".length), "base64")
+    : Buffer.from(secret, "utf-8");
+  const signed = Buffer.concat([
+    Buffer.from(`${id}.${ts}.`, "utf-8"),
+    rawBody,
+  ]);
+  const v1 = crypto
+    .createHmac("sha256", secretBytes)
+    .update(signed)
+    .digest("base64");
+  return {
+    "content-type": "application/json",
+    "svix-id": id,
+    "svix-timestamp": String(ts),
+    "svix-signature": `v1,${v1}`,
+  };
+}
+
+// ── DB cleanup helpers ─────────────────────────────────────────────────────
+
+function clearDb() {
+  const db = getStateDb();
+  db.exec("DELETE FROM recall_event");
+  db.exec("DELETE FROM recall_bot");
+  db.exec("DELETE FROM recall_config");
+}
+
+function seedBot(id: string, overrides: Partial<{
+  status: string;
+  created_at: number;
+  joined_at: number | null;
+  left_at: number | null;
+}> = {}) {
+  const db = getStateDb();
+  const now = Date.now();
+  db.prepare(
+    `INSERT INTO recall_bot (id, calendar_event_id, meeting_url, status, created_at, joined_at, left_at, json)
+       VALUES (?, NULL, 'https://meet.example/abc', ?, ?, ?, ?, '{}')`,
+  ).run(
+    id,
+    overrides.status ?? "requested",
+    overrides.created_at ?? now,
+    overrides.joined_at ?? null,
+    overrides.left_at ?? null,
+  );
+}
+
+// ── tests ──────────────────────────────────────────────────────────────────
+
+describe("/api/v1/channels/recall/* + webhook — #113 PR2", () => {
+  before(() => {
+    // Initialise the DB once — applies migrations including 0007_recall.
+    getStateDb();
+  });
+
+  beforeEach(() => {
+    clearDb();
+    recallStub.listBotsStatus = 200;
+    recallStub.listBotsBody = { count: 0, results: [] };
+    recallStub.deleteBotStatus = 200;
+    recallShouldThrow = false;
+    delete process.env.RECALL_API_KEY;
+    delete process.env.RECALL_WEBHOOK_SECRET;
+  });
+
+  after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe("POST /validate-key", () => {
+    it("returns {ok:true} when Recall accepts the key", async () => {
+      recallStub.listBotsStatus = 200;
+      recallStub.listBotsBody = { count: 3, results: [] };
+      const r = await invokeRoute(
+        "POST",
+        "/api/v1/channels/recall/validate-key",
+        { api_key: "rec_test_key", region: "us-east-1" },
+      );
+      assert.equal(r.status, 200);
+      assert.equal(r.payload.ok, true);
+      assert.equal(r.payload.account.region, "us-east-1");
+      assert.equal(r.payload.account.bots_known, 3);
+    });
+
+    it("returns {ok:false} with a reason when Recall returns 401", async () => {
+      recallStub.listBotsStatus = 401;
+      recallStub.listBotsBody = { detail: "Invalid token." };
+      const r = await invokeRoute(
+        "POST",
+        "/api/v1/channels/recall/validate-key",
+        { api_key: "wrong" },
+      );
+      assert.equal(r.status, 200);
+      assert.equal(r.payload.ok, false);
+      assert.match(String(r.payload.reason), /rejected/);
+    });
+
+    it("400 VALIDATION_ERROR when api_key is missing", async () => {
+      const r = await invokeRoute(
+        "POST",
+        "/api/v1/channels/recall/validate-key",
+        {},
+      );
+      assert.equal(r.status, 400);
+      assert.equal(r.payload.error.code, "VALIDATION_ERROR");
+    });
+
+    it("400 VALIDATION_ERROR when region is not in the allowlist", async () => {
+      const r = await invokeRoute(
+        "POST",
+        "/api/v1/channels/recall/validate-key",
+        { api_key: "rec_test", region: "moon-base-1" },
+      );
+      assert.equal(r.status, 400);
+      assert.equal(r.payload.error.code, "VALIDATION_ERROR");
+    });
+  });
+
+  describe("config", () => {
+    it("GET seeds the singleton row with the migration defaults", async () => {
+      const r = await invokeRoute("GET", "/api/v1/channels/recall/config");
+      assert.equal(r.status, 200);
+      assert.equal(r.payload.region, "us-east-1");
+      assert.equal(r.payload.bot_name, "Alfred's note-taker");
+      assert.equal(r.payload.announces_on_join, true);
+      assert.equal(r.payload.auto_join_policy, "principal_attendee");
+      assert.equal(r.payload.calendar_source, "composio");
+      assert.equal(r.payload.monthly_hours_cap, 60);
+      assert.equal(r.payload.leave_after_minutes, 90);
+      assert.equal(r.payload.respond_mode, "on_mention");
+      assert.equal(r.payload.wake_word, "Alfred");
+      assert.deepEqual(r.payload.cost_alert_thresholds, [80, 100]);
+      assert.equal(typeof r.payload.updated_at, "number");
+    });
+
+    it("PATCH updates fields and the next GET reflects them", async () => {
+      const patch = {
+        bot_name: "Recall Bot",
+        announces_on_join: false,
+        monthly_hours_cap: 120,
+        wake_word: "Jeeves",
+        cost_alert_thresholds: [50, 80, 100],
+      };
+      const r = await invokeRoute(
+        "PATCH",
+        "/api/v1/channels/recall/config",
+        patch,
+      );
+      assert.equal(r.status, 200);
+      assert.equal(r.payload.bot_name, "Recall Bot");
+      assert.equal(r.payload.announces_on_join, false);
+      assert.equal(r.payload.monthly_hours_cap, 120);
+      assert.equal(r.payload.wake_word, "Jeeves");
+      assert.deepEqual(r.payload.cost_alert_thresholds, [50, 80, 100]);
+
+      const g = await invokeRoute("GET", "/api/v1/channels/recall/config");
+      assert.equal(g.payload.bot_name, "Recall Bot");
+      assert.equal(g.payload.monthly_hours_cap, 120);
+    });
+
+    it("PATCH rejects an unknown auto_join_policy with 400", async () => {
+      const r = await invokeRoute(
+        "PATCH",
+        "/api/v1/channels/recall/config",
+        { auto_join_policy: "never-ever" },
+      );
+      assert.equal(r.status, 400);
+      assert.equal(r.payload.error.code, "VALIDATION_ERROR");
+    });
+
+    it("PATCH rejects negative monthly_hours_cap with 400", async () => {
+      const r = await invokeRoute(
+        "PATCH",
+        "/api/v1/channels/recall/config",
+        { monthly_hours_cap: -5 },
+      );
+      assert.equal(r.status, 400);
+      assert.equal(r.payload.error.code, "VALIDATION_ERROR");
+    });
+
+    it("PATCH with no recognised fields → 400", async () => {
+      const r = await invokeRoute(
+        "PATCH",
+        "/api/v1/channels/recall/config",
+        { junk: "yes" },
+      );
+      assert.equal(r.status, 400);
+    });
+  });
+
+  describe("GET /usage", () => {
+    it("returns zeros when no bots exist", async () => {
+      const r = await invokeRoute("GET", "/api/v1/channels/recall/usage");
+      assert.equal(r.status, 200);
+      assert.equal(r.payload.this_month_hours, 0);
+      assert.equal(r.payload.bot_count_active, 0);
+      assert.equal(r.payload.monthly_hours_cap, 60);
+    });
+
+    it("sums completed bot durations from the current month", async () => {
+      const now = Date.now();
+      const oneHourMs = 60 * 60 * 1000;
+      // A bot that ran for exactly one hour starting "now - 2h".
+      seedBot("bot-completed", {
+        status: "done",
+        joined_at: now - 2 * oneHourMs,
+        left_at: now - oneHourMs,
+      });
+      // An in-flight bot that joined 30 minutes ago.
+      seedBot("bot-inflight", {
+        status: "in_meeting",
+        joined_at: now - 30 * 60 * 1000,
+        left_at: null,
+      });
+      const r = await invokeRoute("GET", "/api/v1/channels/recall/usage");
+      // Completed = 1h, in-flight = ~0.5h. Allow a small rounding window.
+      assert.ok(r.payload.this_month_hours >= 1.4 && r.payload.this_month_hours <= 1.6);
+      assert.equal(r.payload.bot_count_active, 1);
+    });
+  });
+
+  describe("GET /bots/active", () => {
+    it("lists only non-terminal bots, newest first", async () => {
+      seedBot("bot-1", { status: "in_meeting", created_at: 1000 });
+      seedBot("bot-2", { status: "done", created_at: 2000 });
+      seedBot("bot-3", { status: "requested", created_at: 3000 });
+      seedBot("bot-4", { status: "fail", created_at: 4000 });
+      const r = await invokeRoute(
+        "GET",
+        "/api/v1/channels/recall/bots/active",
+      );
+      assert.equal(r.status, 200);
+      const ids = r.payload.bots.map((b: any) => b.id);
+      assert.deepEqual(ids, ["bot-3", "bot-1"]);
+    });
+  });
+
+  describe("DELETE /bots/:bot_id", () => {
+    it("503 NOT_CONFIGURED when RECALL_API_KEY is unset", async () => {
+      seedBot("bot-x", { status: "in_meeting" });
+      const r = await invokeRoute(
+        "DELETE",
+        "/api/v1/channels/recall/bots/bot-x",
+      );
+      assert.equal(r.status, 503);
+      assert.equal(r.payload.error.code, "NOT_CONFIGURED");
+    });
+
+    it("calls Recall and flips the local row to leaving on 2xx", async () => {
+      process.env.RECALL_API_KEY = "rec_test_key";
+      seedBot("bot-x", { status: "in_meeting" });
+      recallStub.deleteBotStatus = 204;
+      const r = await invokeRoute(
+        "DELETE",
+        "/api/v1/channels/recall/bots/bot-x",
+      );
+      assert.equal(r.status, 200);
+      assert.equal(r.payload.status, "leaving");
+      // Local row updated to leaving + left_at populated.
+      const db = getStateDb();
+      const row = db
+        .prepare("SELECT status, left_at FROM recall_bot WHERE id = ?")
+        .get("bot-x") as { status: string; left_at: number | null };
+      assert.equal(row.status, "leaving");
+      assert.ok(row.left_at && row.left_at > 0);
+    });
+
+    it("on Recall 404 marks the local row done (it's already gone upstream)", async () => {
+      process.env.RECALL_API_KEY = "rec_test_key";
+      seedBot("bot-gone", { status: "in_meeting" });
+      recallStub.deleteBotStatus = 404;
+      const r = await invokeRoute(
+        "DELETE",
+        "/api/v1/channels/recall/bots/bot-gone",
+      );
+      assert.equal(r.status, 200);
+      assert.equal(r.payload.status, "done");
+    });
+  });
+
+  describe("POST /api/v1/webhooks/recall — Svix signed", () => {
+    it("503 NOT_CONFIGURED when RECALL_WEBHOOK_SECRET is unset", async () => {
+      const raw = Buffer.from(JSON.stringify({ event: "bot.joined" }));
+      const r = await invokeRoute(
+        "POST",
+        "/api/v1/webhooks/recall",
+        raw,
+        { "content-type": "application/json" },
+      );
+      assert.equal(r.status, 503);
+      assert.equal(r.payload.error.code, "NOT_CONFIGURED");
+    });
+
+    it("401 AUTH_FAILED when no svix headers are present", async () => {
+      process.env.RECALL_WEBHOOK_SECRET = WEBHOOK_SECRET;
+      const raw = Buffer.from(JSON.stringify({ event: "bot.joined" }));
+      const r = await invokeRoute(
+        "POST",
+        "/api/v1/webhooks/recall",
+        raw,
+        { "content-type": "application/json" },
+      );
+      assert.equal(r.status, 401);
+      assert.equal(r.payload.error.code, "AUTH_FAILED");
+    });
+
+    it("401 AUTH_FAILED when the HMAC does not validate", async () => {
+      process.env.RECALL_WEBHOOK_SECRET = WEBHOOK_SECRET;
+      const raw = Buffer.from(JSON.stringify({ event: "bot.joined" }));
+      const headers = signSvix(raw, { secret: "wrong-secret" });
+      const r = await invokeRoute(
+        "POST",
+        "/api/v1/webhooks/recall",
+        raw,
+        headers,
+      );
+      assert.equal(r.status, 401);
+    });
+
+    it("401 AUTH_FAILED when svix-timestamp is outside the ±5min window", async () => {
+      process.env.RECALL_WEBHOOK_SECRET = WEBHOOK_SECRET;
+      const raw = Buffer.from(JSON.stringify({ event: "bot.joined" }));
+      const stale = Math.floor(Date.now() / 1000) - 3600; // 1h old
+      const headers = signSvix(raw, { ts: stale });
+      const r = await invokeRoute(
+        "POST",
+        "/api/v1/webhooks/recall",
+        raw,
+        headers,
+      );
+      assert.equal(r.status, 401);
+      assert.match(String(r.payload.error.message), /replay/);
+    });
+
+    it("on valid signature, persists the event and updates the bot status", async () => {
+      process.env.RECALL_WEBHOOK_SECRET = WEBHOOK_SECRET;
+      seedBot("bot-live", { status: "joining" });
+
+      const payload = {
+        event: "bot.in_call_recording",
+        data: { bot: { id: "bot-live" } },
+      };
+      const raw = Buffer.from(JSON.stringify(payload));
+      const headers = signSvix(raw);
+      const r = await invokeRoute(
+        "POST",
+        "/api/v1/webhooks/recall",
+        raw,
+        headers,
+      );
+      assert.equal(r.status, 200);
+      assert.equal(r.payload.ok, true);
+      assert.equal(r.payload.new_status, "in_meeting");
+      // Event row + bot row reflect the update.
+      const db = getStateDb();
+      const eventCount = db
+        .prepare("SELECT COUNT(*) AS n FROM recall_event WHERE bot_id = ?")
+        .get("bot-live") as { n: number };
+      assert.equal(eventCount.n, 1);
+      const botRow = db
+        .prepare("SELECT status, joined_at FROM recall_bot WHERE id = ?")
+        .get("bot-live") as { status: string; joined_at: number | null };
+      assert.equal(botRow.status, "in_meeting");
+      assert.ok(botRow.joined_at && botRow.joined_at > 0);
+    });
+
+    it("verifySvixSignature internals — round-trip golden vector", () => {
+      const raw = Buffer.from('{"event":"bot.joined"}', "utf-8");
+      const ts = Math.floor(Date.now() / 1000);
+      const id = "evt-golden";
+      const headers = signSvix(raw, { ts, id });
+      const result = _recallInternals.verifySvixSignature(
+        raw,
+        headers,
+        WEBHOOK_SECRET,
+      );
+      assert.equal(result.ok, true);
+    });
+
+    it("does not regress a bot already in a terminal state", async () => {
+      process.env.RECALL_WEBHOOK_SECRET = WEBHOOK_SECRET;
+      seedBot("bot-done", { status: "done", joined_at: 1000, left_at: 2000 });
+      const payload = {
+        event: "bot.joining_call",
+        data: { bot: { id: "bot-done" } },
+      };
+      const raw = Buffer.from(JSON.stringify(payload));
+      const headers = signSvix(raw);
+      await invokeRoute(
+        "POST",
+        "/api/v1/webhooks/recall",
+        raw,
+        headers,
+      );
+      const db = getStateDb();
+      const row = db
+        .prepare("SELECT status FROM recall_bot WHERE id = ?")
+        .get("bot-done") as { status: string };
+      // Still done — terminal states are sticky.
+      assert.equal(row.status, "done");
+    });
+  });
+});


### PR DESCRIPTION
PR2 of #113 — Recall.ai replaces Vexa. This lands the ctrl-api half
of the card-driven contract (spec §5.1.1 + §5.4) so PR3a/PR3b can
build the /channels card on top, PR4 can wire the alfred-learn
dispatcher, and PR5/PR6 can layer the voice/webpage path.

PR1 (#126) retired the Vexa stack with 410 Gone stubs. This PR
introduces the Recall.ai schema + 7 ctrl-api routes + the inbound
Svix webhook target. **No UI surface yet — that's PR3a/3b.**

## What ships

### Migration v7 — `0007_recall.sql`

Three tables per spec §5.4.1:

| Table | Purpose |
|---|---|
| `recall_config` | Singleton (id=1) carrying the card's tunable dials — region, bot_name, announces_on_join, auto_join_policy, calendar_source, monthly_hours_cap, leave_after_minutes, respond_mode, wake_word, cost_alert_thresholds_json. Lazily seeded on first read. |
| `recall_bot` | One row per dispatched bot; primary key = Recall's own bot id. Lifecycle: requested → joining → in_meeting → leaving → done/fail. Holds calendar_event_id, meeting_url, joined/left timestamps, transcript_url, plus the full Recall create-bot JSON. |
| `recall_event` | Append-only ledger of every verified inbound webhook (payload preserved verbatim for forensic replay). |

Plus `idx_recall_bot_status`, `idx_recall_bot_calendar`, `idx_recall_event_bot`.

Registered in `packages/ctrl/src/db/migrate.ts` as version 7 — schema.sql stays the v0 baseline, never edited after merge.

### Routes — `packages/ctrl/src/api/routes/channels_recall.ts`

**Card-driven (bearer-authed via the global AAS_API_KEY gate):**

| Method · Path | Purpose |
|---|---|
| `POST /api/v1/channels/recall/validate-key` | Round-trip a candidate key against Recall's `/api/v1/bot/?limit=1` (read-only). Returns `{ok, account?}` or `{ok:false, reason}`. **Does not persist** — the /channels card POST handler (PR3a) owns key write. |
| `GET /api/v1/channels/recall/config` | Current dials. |
| `PATCH /api/v1/channels/recall/config` | Updates dials. Enum + range validated; rejects empty patches. |
| `GET /api/v1/channels/recall/usage` | `{this_month_hours, monthly_hours_cap, bot_count_active}` — sums completed + in-flight bot-minutes from the start of the current UTC month. |
| `GET /api/v1/channels/recall/bots/active` | Lists non-terminal recall_bot rows (newest first, capped at 100). |
| `DELETE /api/v1/channels/recall/bots/:bot_id` | Calls Recall `DELETE /api/v1/bot/<id>/`, flips local row to `leaving`. On Recall 404, marks local `done` (it's already gone upstream). |
| `POST /api/v1/channels/recall/webhook-test` | Self-signs a synthetic event and POSTs it to `/api/v1/webhooks/recall` on `127.0.0.1:AAS_PORT` to prove the inbound delivery path end-to-end. Same pattern as the Paperclip `/test` route. |

**Inbound webhook:**

`POST /api/v1/webhooks/recall` — Svix-signed. Validates HMAC-SHA-256 over `<svix-id>.<svix-timestamp>.<raw-body>` keyed on `RECALL_WEBHOOK_SECRET` (accepts both `svix-*` and `webhook-*` header aliases), enforces a ±5min replay window, then transactionally writes one `recall_event` row + updates the parent `recall_bot` row's status, `joined_at`, `left_at`, and `transcript_url`. Terminal states are sticky (a stale `bot.joining_call` after `bot.done` is a no-op).

Tolerates multiple Recall payload shapes for bot id extraction (`data.bot.id` / `data.bot_id` / top-level `bot_id`) and event-type fields (`event` / `type` / `metadata.event_type`).

### server.ts

Registers both `registerChannelsRecallRoutes()` and `registerRecallWebhookRoute()`. Adds `/api/v1/webhooks/recall` to both `isPublic` (HMAC is the auth) and `isRawBody` (HMAC needs the exact bytes) — same posture as the Composio webhook.

### caddy/Caddyfile

`/api/v1/webhooks/recall` added to the `@public_webhooks` matcher so the inbound POST hits ctrl-api directly instead of falling through to the SPA's nginx (which would 405).

### .env.example

```
RECALL_BOT_NAME="Alfred's note-taker"
RECALL_REGION=us-east-1
RECALL_WEBHOOK_SECRET=
#RECALL_API_KEY=
```

`RECALL_API_KEY` is a commented placeholder — the /channels card POST handler (PR3a) writes it durably via the same `upsertEnvKey` pattern Paperclip uses; the principal never sets it by hand.

### Tests — `packages/ctrl/tests/channels_recall.test.ts`

22 cases, all green:

- **validate-key** — 200 / 401 / missing field / bad region.
- **config** — seed defaults, PATCH update, invalid enum, out-of-range numeric, empty patch.
- **usage** — empty DB / current-month rollup.
- **bots/active** — only non-terminal, newest first.
- **DELETE** — 503 unconfigured, 2xx flow, Recall 404 → local done.
- **webhook** — 503 no secret, 401 no headers, 401 bad HMAC, 401 stale timestamp, valid signature persists + updates bot status, terminal-state stickiness, internal golden-vector signature check.

```
ℹ tests 22
ℹ pass 22
ℹ fail 0
```

## Deferred items

| PR | Lane | What it adds |
|---|---|---|
| PR3a | web | `/channels` Recall card minimum — paste/validate/region. |
| PR3b | web | Card full config + active-bots panel + usage meter + webhook test + cost alerts. |
| PR4 | learn | `activities/recall.py` + workflow rename, end-state feature parity with the old silent Vexa transcript capture. |
| PR5 | voice-bridge | IDLE Recall webpage + transcript wss (silent round-trip proof). |
| PR6 | voice-bridge | Wake-word + on-mention LLM turn + tool catalog. |
| PR7 | ctrl + web + learn | Hours-cap enforcement + cost-alert notifications + privacy compliance. |

## Vault item for the API key

The task brief mentions storing the Recall API key in a Vaultwarden item. The existing `claudeSetup.ts` / `channels_paperclip.ts` references just write to the host .env (Vaultwarden is the principal-facing secrets UI, not a code-side credential store). To stay minimal and consistent with how every other tenant secret lives, PR2 leaves the API key in `RECALL_API_KEY` in `/opt/alfred/.env` (written by PR3a's card POST). Surfacing it in Vaultwarden can be a follow-up if Sir wants it visible there.

## Not touched

- Vexa 410 Gone stubs from PR1 (intentional — they catch in-flight retries until Recall is live).
- alfred-learn workflows (PR4).
- voice-bridge / webpage-bot (PR5/6).
- `/channels` UI (PR3a/3b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)