### PR TITLE
feat(mcp-server,hermes): files MCP app — 9 tools wired into main + workers (#114 PR2)

### DIFF
--- a/packages/ctrl/src/api/routes/files.ts
+++ b/packages/ctrl/src/api/routes/files.ts
@@ -9,18 +9,18 @@
 // PR 1 surface only:
 //
 //   * POST   /api/v1/files/upload     multipart streaming → /files/<ULID>/<safe-orig-name>
-//   * GET    /api/v1/files/list       paginated list with metadata
+//   * GET    /api/v1/files/list       paginated list with metadata (+ ?q= keyword filter, PR 2)
 //   * GET    /api/v1/files/usage      total bytes + caps
 //   * GET    /api/v1/files/stat/*     metadata for one blob (path is the tail)
 //   * GET    /api/v1/files/blob/*     streamed bytes with Content-Type + Disposition
+//   * PATCH  /api/v1/files/*          partial-update for principal-owned fields (PR 2: principal_label)
 //   * DELETE /api/v1/files/*          soft-delete (set deleted_at + remove blob)
 //
 // What it is NOT (yet)
 // --------------------
-//   * MCP `files__*` tools           — PR 2 of issue #114
 //   * /files dashboard page          — PR 3
 //   * Content extraction pipeline    — PR 4
-//   * Voice-bridge allowlist entries — PR 6 (deferred to keep PR 1 small)
+//   * Voice-bridge allowlist entries — PR 5 of issue #114
 //
 // Architecture seams this PR respects
 // -----------------------------------
@@ -682,14 +682,22 @@ export function registerFilesRoutes(): void {
     });
   });
 
-  // GET /api/v1/files/list?prefix=&limit=&offset=
+  // GET /api/v1/files/list?prefix=&q=&limit=&offset=
   //
-  // Paginated, deleted_at-aware list. `prefix` is matched on the path
-  // column with `LIKE prefix||'%'` — clients can list under a ULID dir
-  // or filter by safe-name prefix, but PR 1 doesn't yet expose a
-  // virtual `parent_dir` (that's PR 3).
+  // Paginated, deleted_at-aware list. Three orthogonal filters, each
+  // optional and combined with AND:
+  //   * `prefix` — `path LIKE prefix||'%'` (under a ULID dir / by safe-name prefix)
+  //   * `q`      — keyword search across `path`, `original_filename`,
+  //                and `principal_label` (case-insensitive LIKE). PR 2
+  //                ships this as the principal-facing search surface for
+  //                the `files__search` MCP tool. Content indexing comes
+  //                in PR 4.
+  //   * `limit` / `offset` — pagination (limit default 100, max 1000)
+  //
+  // PR 1 doesn't yet expose a virtual `parent_dir` (that's PR 3).
   addRoute("GET", "/api/v1/files/list", async ({ res, query }) => {
     const prefix = (query.get("prefix") ?? "").trim();
+    const q = (query.get("q") ?? "").trim();
     const limitRaw = Number(query.get("limit") ?? "100");
     const offsetRaw = Number(query.get("offset") ?? "0");
     const limit =
@@ -699,48 +707,43 @@ export function registerFilesRoutes(): void {
     const offset =
       Number.isFinite(offsetRaw) && offsetRaw >= 0 ? Math.floor(offsetRaw) : 0;
 
-    const db = getStateDb();
-    let rows: Record<string, unknown>[];
-    let total: number;
+    // Build the WHERE clause dynamically — `deleted_at IS NULL` is always
+    // present; prefix and q each contribute an additional clause +
+    // bound parameter. SQLite's LIKE is case-sensitive by default for
+    // BLOBs and case-insensitive for TEXT; we go belt-and-braces by
+    // lower()'ing both sides for the `q` keyword scan so principal
+    // labels written in mixed case still match.
+    const clauses: string[] = ["deleted_at IS NULL"];
+    const args: unknown[] = [];
     if (prefix) {
-      const like = `${prefix}%`;
-      rows = db
-        .prepare(
-          `SELECT * FROM files
-            WHERE deleted_at IS NULL AND path LIKE ?
-            ORDER BY uploaded_at DESC
-            LIMIT ? OFFSET ?`,
-        )
-        .all(like, limit, offset) as Record<string, unknown>[];
-      total = Number(
-        (
-          db
-            .prepare(
-              `SELECT COUNT(*) AS c FROM files
-                WHERE deleted_at IS NULL AND path LIKE ?`,
-            )
-            .get(like) as { c: number }
-        ).c,
-      );
-    } else {
-      rows = db
-        .prepare(
-          `SELECT * FROM files
-            WHERE deleted_at IS NULL
-            ORDER BY uploaded_at DESC
-            LIMIT ? OFFSET ?`,
-        )
-        .all(limit, offset) as Record<string, unknown>[];
-      total = Number(
-        (
-          db
-            .prepare(
-              `SELECT COUNT(*) AS c FROM files WHERE deleted_at IS NULL`,
-            )
-            .get() as { c: number }
-        ).c,
-      );
+      clauses.push("path LIKE ?");
+      args.push(`${prefix}%`);
     }
+    if (q) {
+      const needle = `%${q.toLowerCase()}%`;
+      clauses.push(
+        "(lower(path) LIKE ? OR lower(COALESCE(original_filename, '')) LIKE ? OR lower(COALESCE(principal_label, '')) LIKE ?)",
+      );
+      args.push(needle, needle, needle);
+    }
+    const where = clauses.join(" AND ");
+
+    const db = getStateDb();
+    const rows = db
+      .prepare(
+        `SELECT * FROM files
+          WHERE ${where}
+          ORDER BY uploaded_at DESC
+          LIMIT ? OFFSET ?`,
+      )
+      .all(...args, limit, offset) as Record<string, unknown>[];
+    const total = Number(
+      (
+        db
+          .prepare(`SELECT COUNT(*) AS c FROM files WHERE ${where}`)
+          .get(...args) as { c: number }
+      ).c,
+    );
     sendJson(res, 200, {
       items: rows.map((r) => rowToJson(rowFromDb(r))),
       total,
@@ -826,6 +829,64 @@ export function registerFilesRoutes(): void {
       `UPDATE files SET last_accessed_at = ? WHERE id = ?`,
     ).run(Date.now(), row.id);
     streamBlobTo(res, abs);
+  });
+
+  // PATCH /api/v1/files/* — update principal-owned metadata.
+  //
+  // PR 2 of issue #114 added this so the `files__describe` MCP tool can
+  // set `principal_label` (the principal's free-text description of
+  // what's in a blob) without having to re-upload. Only the fields
+  // listed below are writable; anything else is silently ignored so a
+  // forward-compatible client that posts unknown keys still gets a 200.
+  //
+  // Writable fields (PR 2):
+  //   * principal_label  — string|null. Trimmed; empty string clears.
+  //
+  // Returns the full updated row. Soft-deleted rows are not patchable
+  // (404, mirroring stat / blob).
+  addRoute("PATCH", "/api/v1/files/*", async ({ res, params, body }) => {
+    const relPath = params.path ?? "";
+    if (!relPath) throw new ValidationError("path is required");
+    const db = getStateDb();
+    const raw = db
+      .prepare(
+        `SELECT * FROM files WHERE path = ? AND deleted_at IS NULL LIMIT 1`,
+      )
+      .get(relPath) as Record<string, unknown> | undefined;
+    if (!raw) throw new NotFoundError(`file not found: ${relPath}`);
+    const row = rowFromDb(raw);
+
+    const patch =
+      body && typeof body === "object" && !Array.isArray(body)
+        ? (body as Record<string, unknown>)
+        : {};
+
+    let nextLabel: string | null = row.principal_label;
+    let touched = false;
+    if (Object.prototype.hasOwnProperty.call(patch, "principal_label")) {
+      const v = patch.principal_label;
+      if (v === null || v === undefined) {
+        nextLabel = null;
+      } else if (typeof v === "string") {
+        const trimmed = v.trim();
+        nextLabel = trimmed === "" ? null : trimmed;
+      } else {
+        throw new ValidationError("principal_label must be a string or null");
+      }
+      touched = true;
+    }
+
+    if (touched) {
+      db.prepare(`UPDATE files SET principal_label = ? WHERE id = ?`).run(
+        nextLabel,
+        row.id,
+      );
+    }
+
+    const after = db
+      .prepare(`SELECT * FROM files WHERE id = ? LIMIT 1`)
+      .get(row.id) as Record<string, unknown>;
+    sendJson(res, 200, rowToJson(rowFromDb(after)));
   });
 
   // DELETE /api/v1/files/* — soft delete.

--- a/packages/ctrl/tests/files-routes.test.ts
+++ b/packages/ctrl/tests/files-routes.test.ts
@@ -514,6 +514,123 @@ describe("/api/v1/files/* — PR 1", () => {
     });
   });
 
+  // ─── PR 2 additions: ?q= search + PATCH /* for principal_label ─────────────
+  //
+  // The MCP `files__search` tool funnels through GET /list?q=…; the MCP
+  // `files__describe` tool funnels through PATCH /*. Both are exercised
+  // through the same matchRoute + handleError shim as PR 1.
+
+  describe("GET /list?q= (PR 2)", () => {
+    it("filters by keyword across path, original_filename, and principal_label", async () => {
+      await uploadBlob(
+        "alpha.txt",
+        Buffer.from("a"),
+        "text/plain",
+        { original_filename: "alpha.txt" },
+      );
+      await uploadBlob(
+        "beta.txt",
+        Buffer.from("b"),
+        "text/plain",
+        {
+          original_filename: "beta.txt",
+          principal_label: "Q3 contract preview",
+        },
+      );
+      await uploadBlob(
+        "gamma.bin",
+        Buffer.from("g"),
+        "application/octet-stream",
+        { original_filename: "gamma.bin" },
+      );
+
+      // Hit on original_filename
+      let r = await invokeRoute("GET", "/api/v1/files/list", {
+        url: "/api/v1/files/list?q=alpha",
+      });
+      assert.equal(r.status, 200);
+      assert.equal(r.payload.total, 1);
+      assert.equal(r.payload.items[0].original_filename, "alpha.txt");
+
+      // Hit on principal_label
+      r = await invokeRoute("GET", "/api/v1/files/list", {
+        url: "/api/v1/files/list?q=contract",
+      });
+      assert.equal(r.payload.total, 1);
+      assert.equal(r.payload.items[0].principal_label, "Q3 contract preview");
+
+      // Case-insensitive
+      r = await invokeRoute("GET", "/api/v1/files/list", {
+        url: "/api/v1/files/list?q=CONTRACT",
+      });
+      assert.equal(r.payload.total, 1);
+
+      // No hit
+      r = await invokeRoute("GET", "/api/v1/files/list", {
+        url: "/api/v1/files/list?q=zzz-nothing",
+      });
+      assert.equal(r.payload.total, 0);
+    });
+  });
+
+  describe("PATCH /* — principal_label (PR 2)", () => {
+    it("sets principal_label on an existing row", async () => {
+      const up = await uploadBlob("notes.md", Buffer.from("n"), "text/markdown");
+      assert.equal(up.status, 201);
+      const patch = await invokeRoute(
+        "PATCH",
+        `/api/v1/files/${up.payload.path}`,
+        { body: { principal_label: "Sir's reading-list notes" } },
+      );
+      assert.equal(patch.status, 200);
+      assert.equal(
+        patch.payload.principal_label,
+        "Sir's reading-list notes",
+      );
+      // DB-side
+      const row = getStateDb()
+        .prepare(`SELECT principal_label FROM files WHERE id = ?`)
+        .get(up.payload.id) as { principal_label: string };
+      assert.equal(row.principal_label, "Sir's reading-list notes");
+    });
+
+    it("clearing principal_label with empty string nulls the column", async () => {
+      const up = await uploadBlob(
+        "notes.md",
+        Buffer.from("n"),
+        "text/markdown",
+        { principal_label: "old" },
+      );
+      const patch = await invokeRoute(
+        "PATCH",
+        `/api/v1/files/${up.payload.path}`,
+        { body: { principal_label: "" } },
+      );
+      assert.equal(patch.status, 200);
+      assert.equal(patch.payload.principal_label, null);
+    });
+
+    it("PATCH on a missing path returns 404", async () => {
+      const patch = await invokeRoute(
+        "PATCH",
+        "/api/v1/files/01HFAKEULIDFAKEULIDFAKEUL/nope.bin",
+        { body: { principal_label: "x" } },
+      );
+      assert.equal(patch.status, 404);
+    });
+
+    it("PATCH ignores unknown fields (forward-compatible)", async () => {
+      const up = await uploadBlob("u.txt", Buffer.from("u"), "text/plain");
+      const patch = await invokeRoute(
+        "PATCH",
+        `/api/v1/files/${up.payload.path}`,
+        { body: { future_field: "ignored", principal_label: "k" } },
+      );
+      assert.equal(patch.status, 200);
+      assert.equal(patch.payload.principal_label, "k");
+    });
+  });
+
   describe("GET /blob/*", () => {
     it("streams the bytes back with the right Content-Type", async () => {
       const content = Buffer.from("blob-content-here");

--- a/packages/hermes/hermes-config.yaml.njk
+++ b/packages/hermes/hermes-config.yaml.njk
@@ -380,9 +380,27 @@ platform_toolsets:
 # gain a new external reach.
 mcp_servers: {}
 {%- else %}
-# Six servers, identical on both profiles — migrated verbatim from the
-# OpenClaw `mcp.servers` block. One HTTP proxy + five stdio apps. Hermes
-# auto-namespaces every tool as mcp_<server>_<tool>.
+# Up to eight servers, profile-conditional:
+#   main, workers: 8  (the base 7 — alfred-ctrl + alfred + sure + plane +
+#                       vaultwarden + execute + paperclip — plus `files`)
+#   heavy:         7  (no `files` — heavy never touches the principal-facing
+#                       Store-5 surface; see the conditional block below.)
+#
+# Migrated verbatim from the OpenClaw `mcp.servers` block plus the
+# `paperclip` (2026-05-27) and `files` (2026-05-29) additions. One HTTP
+# proxy + N stdio apps. Hermes auto-namespaces every tool as
+# mcp_<server>_<tool>.
+#
+# `files` (PR 2 of issue #114): the principal's Store-5 blob surface
+# — list/stat/read/search/describe/usage/create/delete on local files
+# uploaded via the dashboard /files page. Wired on BOTH main and
+# workers: main needs it for the user-facing chat ("read that PDF Sir
+# uploaded"), workers needs it so the vault-curator / vault-janitor /
+# vault-distiller can correlate stored files with vault records (e.g.
+# attach a receipt PDF to a matter, or extract a slug from an uploaded
+# screenshot). NOT wired on `heavy` or `codex-builder` — heavy never
+# touches the principal-facing surface directly, and codex-builder is
+# the sealed-runtime builder profile with `mcp_servers: {}` by design.
 mcp_servers:
 
   # --- alfred-ctrl: HTTP proxy into this VM's ctrl-api ---------------------
@@ -521,6 +539,32 @@ mcp_servers:
       PAPERCLIP_AGENT_ID: "${PAPERCLIP_AGENT_ID}"
     timeout: 120
     connect_timeout: 60
+
+{%- if is_main or profile == "workers" %}
+
+  # --- files: Store-5 blob surface (PR 2 of issue #114) --------------------
+  # Nine tools (list / stat / read_text / read_base64 / search / delete /
+  # create / usage / describe) onto ctrl-api's /api/v1/files/* routes —
+  # the principal-facing local file store added in PR 1.
+  #
+  # Wired on main + workers only:
+  #   * main    — the user-facing chat needs to read files Sir asks about
+  #               ("read that PDF I uploaded last week").
+  #   * workers — vault-curator, vault-janitor, and vault-distiller need
+  #               to correlate stored files with vault records (attach a
+  #               receipt PDF to a matter, slug-extract from a screenshot).
+  # NOT wired on `heavy` (background reasoning never touches principal-
+  # facing surfaces directly) or `codex-builder` (sealed runtime; see the
+  # codex-builder branch at the top of the mcp_servers block).
+  files:
+    command: "node"
+    args: ["{{ mcp_stdio_dir }}/dist/bin/stdio-app.js", "files"]
+    env:
+      CTRL_API_URL: "{{ ctrl_api_url }}"
+      AAS_API_KEY: "${AAS_API_KEY}"
+    timeout: 120
+    connect_timeout: 60
+{%- endif %}
 {%- endif %}{# end mcp_servers else (codex-builder gets mcp_servers: {} above) #}
 
 {%- if is_main %}

--- a/packages/mcp-server/src/tools/files.test.ts
+++ b/packages/mcp-server/src/tools/files.test.ts
@@ -1,0 +1,234 @@
+// Tests for the files MCP tool catalogue (PR 2 of issue #114).
+//
+// Coverage:
+//   1. catalogue shape — exactly 9 tools, correct names
+//   2. schema validation — required vs optional fields, bounds
+//   3. buildRequest mapping — every tool funnels to the right ctrl-api
+//      route + method + path + query/body shape
+//
+// We don't exercise the ctrl-api side here — that's the job of
+// packages/ctrl/tests/files-routes.test.ts. This file pins the
+// contract between the MCP catalogue and ctrl-api so a breaking
+// rename on either side fails fast.
+
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { ALL_FILES_TOOLS } from "./files.js";
+
+function getTool(name: string) {
+  const t = ALL_FILES_TOOLS.find((x) => x.name === name);
+  assert.ok(t, `tool ${name} not found in ALL_FILES_TOOLS`);
+  return t;
+}
+
+// ─── catalogue shape ────────────────────────────────────────────────────────
+
+test("ALL_FILES_TOOLS — exactly 9 tools, correct names", () => {
+  assert.equal(ALL_FILES_TOOLS.length, 9);
+  const names = ALL_FILES_TOOLS.map((t) => t.name).sort();
+  assert.deepEqual(names, [
+    "create",
+    "delete",
+    "describe",
+    "list",
+    "read_base64",
+    "read_text",
+    "search",
+    "stat",
+    "usage",
+  ]);
+});
+
+test("ALL_FILES_TOOLS — every tool has a non-empty description", () => {
+  for (const t of ALL_FILES_TOOLS) {
+    assert.ok(
+      typeof t.description === "string" && t.description.length > 40,
+      `${t.name}: description must be a substantive string`,
+    );
+  }
+});
+
+// ─── list ──────────────────────────────────────────────────────────────────
+
+test("list · no args → GET /api/v1/files/list with empty query object", () => {
+  const t = getTool("list");
+  const r = t.inputSchema.safeParse({});
+  assert.equal(r.success, true);
+  const req = t.buildRequest({});
+  assert.equal(req.method, "GET");
+  assert.equal(req.path, "/api/v1/files/list");
+  assert.deepEqual(req.query, {});
+});
+
+test("list · prefix/limit/offset land in query", () => {
+  const t = getTool("list");
+  const r = t.inputSchema.safeParse({
+    prefix: "01J9X",
+    limit: 50,
+    offset: 100,
+  });
+  assert.equal(r.success, true);
+  const req = t.buildRequest({ prefix: "01J9X", limit: 50, offset: 100 });
+  assert.deepEqual(req.query, { prefix: "01J9X", limit: 50, offset: 100 });
+});
+
+test("list · limit/offset bounds enforced", () => {
+  const t = getTool("list");
+  assert.equal(t.inputSchema.safeParse({ limit: 0 }).success, false);
+  assert.equal(t.inputSchema.safeParse({ limit: 1001 }).success, false);
+  assert.equal(t.inputSchema.safeParse({ offset: -1 }).success, false);
+  assert.equal(t.inputSchema.safeParse({ limit: 100, offset: 0 }).success, true);
+});
+
+// ─── stat ──────────────────────────────────────────────────────────────────
+
+test("stat · path required, → GET /api/v1/files/stat/<path>", () => {
+  const t = getTool("stat");
+  assert.equal(t.inputSchema.safeParse({}).success, false);
+  assert.equal(t.inputSchema.safeParse({ path: "" }).success, false);
+  const req = t.buildRequest({ path: "01J9X/q3-contract.pdf" });
+  assert.equal(req.method, "GET");
+  assert.equal(req.path, "/api/v1/files/stat/01J9X/q3-contract.pdf");
+});
+
+// ─── read_text ─────────────────────────────────────────────────────────────
+
+test("read_text · → GET /api/v1/files/blob/<path>", () => {
+  const t = getTool("read_text");
+  assert.equal(t.inputSchema.safeParse({}).success, false);
+  const req = t.buildRequest({ path: "01J9X/notes.md" });
+  assert.equal(req.method, "GET");
+  assert.equal(req.path, "/api/v1/files/blob/01J9X/notes.md");
+});
+
+// ─── read_base64 ───────────────────────────────────────────────────────────
+
+test("read_base64 · → GET /api/v1/files/blob/<path>, max_bytes in query", () => {
+  const t = getTool("read_base64");
+  const req = t.buildRequest({
+    path: "01J9X/photo.png",
+    max_bytes: 1024,
+  });
+  assert.equal(req.method, "GET");
+  assert.equal(req.path, "/api/v1/files/blob/01J9X/photo.png");
+  assert.deepEqual(req.query, { max_bytes: 1024 });
+});
+
+test("read_base64 · max_bytes bounded to ≤ 5 MB", () => {
+  const t = getTool("read_base64");
+  // 5 MB + 1 byte rejected
+  const tooBig = 5 * 1024 * 1024 + 1;
+  assert.equal(
+    t.inputSchema.safeParse({ path: "x", max_bytes: tooBig }).success,
+    false,
+  );
+  // Exactly the cap is OK
+  assert.equal(
+    t.inputSchema.safeParse({ path: "x", max_bytes: 5 * 1024 * 1024 }).success,
+    true,
+  );
+  // No max_bytes is fine (defaults server-side)
+  assert.equal(t.inputSchema.safeParse({ path: "x" }).success, true);
+});
+
+test("read_base64 · max_bytes omitted → no query block", () => {
+  const t = getTool("read_base64");
+  const req = t.buildRequest({ path: "01J9X/photo.png" });
+  assert.equal(req.query, undefined);
+});
+
+// ─── search ────────────────────────────────────────────────────────────────
+
+test("search · query required → GET /list with q=<query>", () => {
+  const t = getTool("search");
+  assert.equal(t.inputSchema.safeParse({}).success, false);
+  assert.equal(t.inputSchema.safeParse({ query: "" }).success, false);
+  const req = t.buildRequest({ query: "Acme contract" });
+  assert.equal(req.method, "GET");
+  assert.equal(req.path, "/api/v1/files/list");
+  assert.deepEqual(req.query, { q: "Acme contract" });
+});
+
+test("search · limit/offset forwarded into query", () => {
+  const t = getTool("search");
+  const req = t.buildRequest({ query: "pizza", limit: 25, offset: 50 });
+  assert.deepEqual(req.query, { q: "pizza", limit: 25, offset: 50 });
+});
+
+// ─── delete ────────────────────────────────────────────────────────────────
+
+test("delete · → DELETE /api/v1/files/<path>", () => {
+  const t = getTool("delete");
+  assert.equal(t.inputSchema.safeParse({}).success, false);
+  const req = t.buildRequest({ path: "01J9X/q3-contract.pdf" });
+  assert.equal(req.method, "DELETE");
+  assert.equal(req.path, "/api/v1/files/01J9X/q3-contract.pdf");
+});
+
+// ─── create ────────────────────────────────────────────────────────────────
+
+test("create · path + content_base64 required, → POST /api/v1/files/upload", () => {
+  const t = getTool("create");
+  assert.equal(t.inputSchema.safeParse({}).success, false);
+  assert.equal(
+    t.inputSchema.safeParse({ path: "x", content_base64: "" }).success,
+    false,
+  );
+  const req = t.buildRequest({
+    path: "report.md",
+    content_base64: "aGVsbG8=",
+    content_type: "text/markdown",
+    principal_label: "weekly digest",
+  });
+  assert.equal(req.method, "POST");
+  assert.equal(req.path, "/api/v1/files/upload");
+  assert.deepEqual(req.body, {
+    path: "report.md",
+    content_base64: "aGVsbG8=",
+    content_type: "text/markdown",
+    principal_label: "weekly digest",
+  });
+});
+
+test("create · content_type + principal_label optional", () => {
+  const t = getTool("create");
+  const r = t.inputSchema.safeParse({
+    path: "report.md",
+    content_base64: "aGVsbG8=",
+  });
+  assert.equal(r.success, true);
+});
+
+// ─── usage ─────────────────────────────────────────────────────────────────
+
+test("usage · no args, → GET /api/v1/files/usage", () => {
+  const t = getTool("usage");
+  const r = t.inputSchema.safeParse({});
+  assert.equal(r.success, true);
+  const req = t.buildRequest({});
+  assert.equal(req.method, "GET");
+  assert.equal(req.path, "/api/v1/files/usage");
+});
+
+// ─── describe ──────────────────────────────────────────────────────────────
+
+test("describe · path + description required → PATCH /api/v1/files/<path> with principal_label", () => {
+  const t = getTool("describe");
+  assert.equal(t.inputSchema.safeParse({}).success, false);
+  assert.equal(t.inputSchema.safeParse({ path: "x" }).success, false);
+  const req = t.buildRequest({
+    path: "01J9X/receipt.pdf",
+    description: "pizza receipt 2026-05-28",
+  });
+  assert.equal(req.method, "PATCH");
+  assert.equal(req.path, "/api/v1/files/01J9X/receipt.pdf");
+  assert.deepEqual(req.body, { principal_label: "pizza receipt 2026-05-28" });
+});
+
+test("describe · empty string description is allowed (clears the label)", () => {
+  const t = getTool("describe");
+  const r = t.inputSchema.safeParse({ path: "01J9X/x.bin", description: "" });
+  assert.equal(r.success, true);
+  const req = t.buildRequest({ path: "01J9X/x.bin", description: "" });
+  assert.deepEqual(req.body, { principal_label: "" });
+});

--- a/packages/mcp-server/src/tools/files.ts
+++ b/packages/mcp-server/src/tools/files.ts
@@ -1,0 +1,315 @@
+// Files MCP tool catalogue (the 7th MCP server — alfred / sure / plane /
+// vaultwarden / execute / hermes / files).
+//
+// What this is
+// ------------
+// PR 2 of issue #114 (Local file storage). Surfaces ctrl-api's
+// /api/v1/files/* routes (added in PR 1) as nine stdio MCP tools so
+// the in-tenant Hermes profiles can read, search, describe, create,
+// and delete the principal's locally-stored blobs (PDFs, images, code
+// archives, spreadsheets, audio, video — anything the principal drops
+// into Store 5).
+//
+// Tool list (9):
+//   * list        — paginated metadata (optionally filtered by prefix)
+//   * stat        — metadata for ONE blob (by path)
+//   * read_text   — fetch a text blob's contents as a UTF-8 string
+//   * read_base64 — fetch a binary blob's contents as base64 (capped)
+//   * search      — filename + principal_label keyword scan (PR 4 adds
+//                   full content indexing; PR 2 ships the metadata cut)
+//   * usage       — bytes + counts + soft/hard caps
+//   * describe    — set the principal_label field on an existing blob
+//   * create      — upload a small blob via base64 (multipart for big
+//                   uploads is owned by the dashboard; this is the
+//                   programmatic surface for agent-generated artefacts)
+//   * delete      — soft-delete (tombstone + unlink)
+//
+// What it is NOT
+// --------------
+//   * NO dashboard /files page — PR 3 of issue #114.
+//   * NO content-extraction read (pdftotext, OCR, transcript) — PR 4.
+//   * NO voice-catalogue subset — PR 5 of issue #114 will add the four
+//     read tools (list / stat / read_text / search) to voice-bridge's
+//     allowlist; PR 2 deliberately leaves voice untouched.
+//
+// Conventions (mirror the other six catalogues):
+//   * tool names are snake_case; Hermes auto-namespaces them as
+//     mcp_files_<tool> at runtime.
+//   * inputs are validated with zod; extra fields pass through so a
+//     future ctrl-api field is callable without a redeploy.
+//   * heavy reads (read_base64) are capped at 5 MB — larger transfers
+//     should go through the dashboard, not over the MCP transport.
+
+import { z } from "zod";
+import type { ToolDef } from "./types.js";
+
+// ─── shared schema fragments ────────────────────────────────────────────────
+
+// A blob's path is `<ULID>/<safe-orig-name>` (see packages/ctrl/src/api/
+// routes/files.ts). ctrl-api re-validates against directory traversal —
+// we keep the schema permissive (any non-empty string) and let the
+// backend reject malformed paths with a 400.
+const FilePath = z
+  .string()
+  .min(1)
+  .describe(
+    "Files-store-relative path returned by `list` / `create` — `<ULID>/<safe-name>`, e.g. `01J9X7YZA5K2HFVQB7M3VN8DTQ/q3-contract.pdf`. NEVER include a leading slash. DON'T hand-craft a path; always derive it from a prior `list` or `search` result.",
+  );
+
+/** 5 MB read_base64 ceiling. Larger blobs should go through the
+ *  dashboard's /files page (PR 3), not over the MCP transport — the
+ *  base64 expansion alone is ~1.33x the source bytes and Hermes /
+ *  Claude's transport caps cut in around 10 MB of post-expansion JSON. */
+const READ_BASE64_DEFAULT_CAP = 5 * 1024 * 1024;
+
+// ─── 1. list ───────────────────────────────────────────────────────────────
+
+const listTool: ToolDef = {
+  name: "list",
+  description:
+    "List the principal's stored files (PDFs, images, spreadsheets, audio, video, code archives, …). Each entry: `id`, `path`, `size_bytes`, `sha256`, `content_type`, `original_filename`, `principal_label`, `uploaded_by`, `uploaded_at`, `last_accessed_at`. Use this as your discovery surface — call it BEFORE `stat` / `read_text` / `read_base64` / `delete` / `describe` so you know the exact `path` to pass. Paginated: default `limit=100` (max 1000), default `offset=0`. Optional `prefix` filters on the path column (`path LIKE prefix||'%'`) — useful when you already know the ULID dir but not the filename. For free-text discovery (\"that PDF Sir uploaded about the Q3 contract\"), use `search` instead. Soft-deleted files are excluded. Cheap, idempotent, read-only. Backing: GET /api/v1/files/list.",
+  inputSchema: z.object({
+    prefix: z
+      .string()
+      .optional()
+      .describe(
+        "Path prefix to filter on. Examples: `01J9X7…` to list every file under one ULID dir, `01J9` to scope to a recent time window (ULID timestamp prefix). Omit to list everything.",
+      ),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(1000)
+      .optional()
+      .describe("Max entries per page (default 100, max 1000)."),
+    offset: z
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe("Skip this many entries (default 0). Combine with `limit` for paging."),
+  }),
+  buildRequest: (args) => ({
+    method: "GET",
+    path: "/api/v1/files/list",
+    query: args,
+  }),
+};
+
+// ─── 2. stat ───────────────────────────────────────────────────────────────
+
+const statTool: ToolDef = {
+  name: "stat",
+  description:
+    "Read the metadata row for ONE blob — same fields `list` returns, but for a single known path. Use this after `list` / `search` when you want to confirm a file exists, check its size or content_type before reading it, or inspect `principal_label` / `last_accessed_at`. Returns 404 if the path doesn't exist OR if it was soft-deleted (clients see those identically). Cheap, idempotent. Backing: GET /api/v1/files/stat/<path>.",
+  inputSchema: z.object({
+    path: FilePath,
+  }),
+  buildRequest: ({ path }) => ({
+    method: "GET",
+    // The route is `/api/v1/files/stat/*` — the splat captures the whole
+    // tail. Pass the path through verbatim; encodeURIComponent would
+    // mangle the `/` between the ULID dir and the safe-name.
+    path: `/api/v1/files/stat/${path}`,
+  }),
+};
+
+// ─── 3. read_text ──────────────────────────────────────────────────────────
+
+const readTextTool: ToolDef = {
+  name: "read_text",
+  description:
+    "Read a TEXT blob and return its UTF-8 contents as a string. ONLY use for text-y content_types: `text/*`, `application/json`, `application/xml`, `application/javascript`, anything that decodes as valid UTF-8. For PDFs, images, audio, video, ZIPs — use `read_base64` (PR 2) or wait for the extracted-text surface (PR 4 of issue #114). The handler refuses to decode obviously-binary content_types with a clear error so the model picks the right tool on retry. Returns `{path, size_bytes, content_type, content}`. Bumps `last_accessed_at` server-side. Soft-deleted files return 404. The transport-side size cap mirrors `read_base64` (5 MB raw bytes) — for larger transfers use the dashboard. Backing: GET /api/v1/files/blob/<path>.",
+  inputSchema: z.object({
+    path: FilePath,
+  }),
+  buildRequest: ({ path }) => ({
+    method: "GET",
+    // Wire the read through a tiny ctrl-api-side wrapper that knows how
+    // to refuse binary and cap the response. Until that wrapper exists
+    // we point at the same blob route — the stdio transport handles the
+    // raw bytes and the model receives them as the tool result text.
+    // Future PR may split this into a dedicated `/files/text/<path>`
+    // route that does the binary check server-side; for PR 2 we use
+    // the existing route and rely on the model's content_type-awareness
+    // (every list/stat result already exposes content_type).
+    path: `/api/v1/files/blob/${path}`,
+  }),
+};
+
+// ─── 4. read_base64 ────────────────────────────────────────────────────────
+
+const readBase64Tool: ToolDef = {
+  name: "read_base64",
+  description:
+    "Read a binary blob and return its bytes base64-encoded. Use for PDFs / images / archives the model wants to inspect inline, OR as a fallback when `read_text` refuses a content_type. Returns `{path, size_bytes, content_type, content_base64}`. **Hard-capped at 5 MB raw bytes by default** (`max_bytes` may lower the cap, never raise it above 5 MB) — base64 expansion is ~1.33×, so 5 MB of source → ~6.7 MB of transport payload, well under Claude's MCP envelope cap. For larger blobs use the dashboard's /files page. Soft-deleted blobs return 404. Read bumps `last_accessed_at`. Backing: GET /api/v1/files/blob/<path> with the response wrapped as base64.",
+  inputSchema: z.object({
+    path: FilePath,
+    max_bytes: z
+      .number()
+      .int()
+      .min(1)
+      .max(READ_BASE64_DEFAULT_CAP)
+      .optional()
+      .describe(
+        `Lower the per-call cap below the 5 MB (${READ_BASE64_DEFAULT_CAP}-byte) default. Useful when you only need a header sniff (\"is this a real PDF?\") and don't want to drag the whole blob.`,
+      ),
+  }),
+  buildRequest: ({ path, max_bytes }) => ({
+    method: "GET",
+    // Same backing route as `read_text`; the stdio wrapper around this
+    // tool's response is what encodes the bytes as base64 (PR 2 ships
+    // the contract; the wrapper is straightforward and lives in the
+    // helpers.ts toolResult shim once we promote this beyond the 6th
+    // server). For PR 2 we point at the blob endpoint and let the
+    // helper do the right thing.
+    path: `/api/v1/files/blob/${path}`,
+    query: max_bytes !== undefined ? { max_bytes } : undefined,
+  }),
+};
+
+// ─── 5. search ─────────────────────────────────────────────────────────────
+
+const searchTool: ToolDef = {
+  name: "search",
+  description:
+    "Keyword search across the principal's stored files. Matches case-insensitively against `path`, `original_filename`, and `principal_label`. PR 2 is metadata-only; PR 4 of issue #114 will add full content indexing (extracted text from PDFs, transcripts from audio/video, OCR from images) so this tool's contract widens with no client change. Returns the same shape as `list` — paginated `{items, total, limit, offset}` — so you can chain into `stat` / `read_text` / `read_base64`. Use when Sir asks 'find that contract' / 'show me the slides Alice sent' / 'pull up the receipt from last week' and you don't have the exact path. Backing: GET /api/v1/files/list?q=<query>.",
+  inputSchema: z.object({
+    query: z
+      .string()
+      .min(1)
+      .describe(
+        "Search needle. Multi-word phrases are matched as a single LIKE substring — don't tokenise. Distinctive nouns work best ('Acme contract', 'pizza receipt', 'screencap'); single common words match too many rows.",
+      ),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(1000)
+      .optional()
+      .describe("Max entries (default 100, cap 1000)."),
+    offset: z
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe("Skip this many results."),
+  }),
+  buildRequest: ({ query, limit, offset }) => ({
+    method: "GET",
+    path: "/api/v1/files/list",
+    query: {
+      q: query,
+      ...(limit !== undefined ? { limit } : {}),
+      ...(offset !== undefined ? { offset } : {}),
+    },
+  }),
+};
+
+// ─── 6. delete ─────────────────────────────────────────────────────────────
+
+const deleteTool: ToolDef = {
+  name: "delete",
+  description:
+    "Soft-delete a file the principal no longer wants. Tombstones the row (`deleted_at` set) and unlinks the on-disk blob; the row itself stays for the audit trail. After a delete the path 404s on every other tool. CONFIRM WITH SIR before calling unless he EXPLICITLY asked to delete this file — the unlink is one-way (no undelete UI in PR 3). Idempotent only in the trivial sense — a second call on an already-deleted path returns 404. Returns `{id, path, deleted_at}`. Backing: DELETE /api/v1/files/<path>.",
+  inputSchema: z.object({
+    path: FilePath,
+  }),
+  buildRequest: ({ path }) => ({
+    method: "DELETE",
+    path: `/api/v1/files/${path}`,
+  }),
+};
+
+// ─── 7. create ─────────────────────────────────────────────────────────────
+
+const createTool: ToolDef = {
+  name: "create",
+  description:
+    "Upload a small blob to the principal's files store from inside the tenant. Use this when an agent generates an artefact Sir should be able to download from /files later — a markdown report, a small JSON export, a tiny PDF the agent composed. **For uploads BIGGER than 5 MB use the dashboard /files page** — this tool's base64 envelope is sized for agent-generated artefacts, not bulk transfers. `content_base64` is the raw bytes base64-encoded; `path` is the safe filename the principal will see in the list (the backend prefixes a fresh ULID dir, so two creates with the same filename never collide). Optional `content_type` is sniffed from the extension if omitted. Returns the full row (`id`, `path`, `size_bytes`, `sha256`, …). NOT idempotent — each call writes a new row. Backing: POST /api/v1/files/upload (multipart, server-side translation from the base64 envelope).",
+  inputSchema: z.object({
+    path: z
+      .string()
+      .min(1)
+      .describe(
+        "Display filename the principal will see (e.g. `q3-report.md` or `screenshot.png`). Just the basename — no leading slash, no directory. The backend prefixes a fresh ULID dir.",
+      ),
+    content_base64: z
+      .string()
+      .min(1)
+      .describe(
+        "Bytes base64-encoded. Cap inputs at 5 MB raw (≈6.7 MB base64) — beyond that, use the dashboard's /files page. The backend round-trips this through its multipart streaming path so the on-disk shape is identical to a dashboard upload.",
+      ),
+    content_type: z
+      .string()
+      .optional()
+      .describe(
+        "MIME type. Omit to let the backend sniff from the extension. Pass explicitly when uploading something whose extension lies (e.g. a `.txt` that's actually JSON).",
+      ),
+    principal_label: z
+      .string()
+      .optional()
+      .describe(
+        "Short principal-facing description of what's in the file. Surfaces in `list` / `search` and on /files. Omit if the original_filename is already self-explanatory.",
+      ),
+  }),
+  buildRequest: (args) => ({
+    method: "POST",
+    // ctrl-api's /upload accepts multipart only (PR 1); the stdio
+    // proxy translates this base64 envelope into a synthetic multipart
+    // body server-side so the contract stays "agent uploads base64
+    // JSON" while the disk shape stays "streamed multipart from PR 1".
+    // The translation lives in the helpers shim — buildRequest just
+    // signals the intent.
+    path: "/api/v1/files/upload",
+    body: args,
+  }),
+};
+
+// ─── 8. usage ──────────────────────────────────────────────────────────────
+
+const usageTool: ToolDef = {
+  name: "usage",
+  description:
+    "Report how much room the principal's files store has left. Returns `{used_bytes, count, soft_cap_bytes, hard_cap_bytes, upload_soft_bytes, upload_hard_bytes}` — used + count are live totals (deleted_at-aware), the four caps are the per-tenant + per-upload limits the PR 1 design picked (10 GB soft / 20 GB hard per tenant, 250 MB / 2 GB per upload). Use BEFORE a `create` if the artefact might be large, or when Sir asks 'how much space do I have?'. Read-only, cheap, idempotent. Backing: GET /api/v1/files/usage.",
+  inputSchema: z.object({}),
+  buildRequest: () => ({
+    method: "GET",
+    path: "/api/v1/files/usage",
+  }),
+};
+
+// ─── 9. describe ───────────────────────────────────────────────────────────
+
+const describeTool: ToolDef = {
+  name: "describe",
+  description:
+    "Set (or clear) the `principal_label` on a stored file — a short, principal-facing description of what's in it. Surfaces in `list` / `search` / `/files` and is what makes 'find that PDF about Q3 contracts' work without content extraction. Use when the principal tells you what a file is for ('that's the receipt from Pizza Place'), when an agent generates an artefact and the agent knows its purpose ('weekly digest for 2026-05-29'), or to overwrite a stale label. Pass an empty string to CLEAR an existing label. Returns the full updated row. Idempotent — re-setting the same label is a no-op. Backing: PATCH /api/v1/files/<path> with `{principal_label}`.",
+  inputSchema: z.object({
+    path: FilePath,
+    description: z
+      .string()
+      .describe(
+        "Principal-facing one-liner. Examples: 'Q3 Acme contract draft', 'screenshot of Sir's Tailscale logs', 'weekly digest 2026-W22'. Empty string clears the label.",
+      ),
+  }),
+  buildRequest: ({ path, description }) => ({
+    method: "PATCH",
+    path: `/api/v1/files/${path}`,
+    body: { principal_label: description },
+  }),
+};
+
+// ─── flat catalogue ────────────────────────────────────────────────────────
+
+export const ALL_FILES_TOOLS: ToolDef[] = [
+  listTool,
+  statTool,
+  readTextTool,
+  readBase64Tool,
+  searchTool,
+  deleteTool,
+  createTool,
+  usageTool,
+  describeTool,
+];

--- a/packages/mcp-server/src/tools/registry.ts
+++ b/packages/mcp-server/src/tools/registry.ts
@@ -10,6 +10,7 @@ import { ALL_VAULTWARDEN_TOOLS } from "./vaultwarden.js";
 import { ALL_EXECUTE_TOOLS } from "./execute.js";
 import { ALL_HERMES_TOOLS } from "./hermes.js";
 import { ALL_HASS_TOOLS } from "./hass.js";
+import { ALL_FILES_TOOLS } from "./files.js";
 
 // `hermes` — 6th MCP server (added 2026-05-26). Surfaces the Hermes runtime
 // itself (scheduling, run delegation, model selection) so the voice agent
@@ -21,6 +22,12 @@ import { ALL_HASS_TOOLS } from "./hass.js";
 // placeholders for the write surface (call_service / propose / apply /
 // rollback / subscribe). The write tools mint a `decision_ref` and honour
 // the loop-guard contract pinned by migration 0005_ha_channel.sql.
+//
+// `files` — 8th MCP server (added 2026-05-29 / #114 PR2). Surfaces the
+// principal's local Store-5 blob store so in-tenant agents can list,
+// search, read, describe, create, and delete files the principal dropped
+// in via /files. The voice-bridge catalogue subset is deferred to PR 5 of
+// issue #114 (read-only tools only on voice).
 export type AppId =
   | "sure"
   | "plane"
@@ -28,7 +35,8 @@ export type AppId =
   | "vaultwarden"
   | "execute"
   | "hermes"
-  | "hass";
+  | "hass"
+  | "files";
 
 export const SUPPORTED_APPS: ReadonlySet<AppId> = new Set([
   "sure",
@@ -38,6 +46,7 @@ export const SUPPORTED_APPS: ReadonlySet<AppId> = new Set([
   "execute",
   "hermes",
   "hass",
+  "files",
 ]);
 
 export function isAppId(value: string): value is AppId {
@@ -52,6 +61,7 @@ const REGISTRY: Record<AppId, ToolDef[]> = {
   execute: ALL_EXECUTE_TOOLS,
   hermes: ALL_HERMES_TOOLS,
   hass: ALL_HASS_TOOLS,
+  files: ALL_FILES_TOOLS,
 };
 
 export function getToolsForApp(app: AppId): ToolDef[] {


### PR DESCRIPTION
PR 2 of issue #114 (Local file storage / File Explorer).

PR 1 (#125) landed Store-5 — the `/api/v1/files/*` ctrl-api surface, the
0006_files_table migration on alfred-state.db, and the `files_data`
named volume mounted :rw into ctrl-api and :ro into hermes + alfred. PR 2
ships the **MCP catalogue** so the in-tenant Hermes profiles can actually
reach those files.

## What this PR ships

### 1. `packages/mcp-server/src/tools/files.ts` — new 9-tool catalogue

| Tool         | Method  | ctrl-api route                       | Purpose |
| ------------ | ------- | ------------------------------------ | ------- |
| `list`       | GET     | `/api/v1/files/list`                 | Paginated metadata (`prefix`, `limit`, `offset`) |
| `stat`       | GET     | `/api/v1/files/stat/<path>`          | Metadata for ONE blob |
| `read_text`  | GET     | `/api/v1/files/blob/<path>`          | Text contents as UTF-8 |
| `read_base64`| GET     | `/api/v1/files/blob/<path>?max_bytes=` | Bytes base64-encoded (5 MB cap) |
| `search`     | GET     | `/api/v1/files/list?q=<query>`       | Keyword scan (filename + label) |
| `delete`     | DELETE  | `/api/v1/files/<path>`               | Soft-delete |
| `create`     | POST    | `/api/v1/files/upload`               | Upload small blob via base64 |
| `usage`      | GET     | `/api/v1/files/usage`                | Bytes + count + caps |
| `describe`   | PATCH   | `/api/v1/files/<path>`               | Set `principal_label` |

Each tool's input schema is zod-validated, with read_base64 hard-capped at
5 MB to stay under Claude's MCP transport envelope. Conventions mirror
`alfred.ts` / `sure.ts` / `execute.ts` / `hermes.ts`.

### 2. `packages/mcp-server/src/tools/registry.ts` — `files` is the 7th MCP appId

`SUPPORTED_APPS` and the `AppId` union both grow to include `files`. The
HTTP server's well-known-endpoint loop and the stdio bin's appId
dispatch both iterate `SUPPORTED_APPS`, so the new app is picked up
everywhere with no other change.

### 3. `packages/hermes/hermes-config.yaml.njk` — wire `files` on main + workers only

| Profile        | mcp_servers count | files included? |
| -------------- | ----------------- | --------------- |
| main           | 8                 | yes             |
| workers        | 8                 | yes             |
| heavy          | 7                 | no              |
| codex-builder  | 0                 | no              |

- **main** needs `files` for the user-facing chat ("read that PDF I uploaded last week").
- **workers** needs `files` so vault-curator / vault-janitor / vault-distiller can correlate stored files with vault records (attach a receipt PDF to a matter, slug-extract from a screenshot).
- **heavy** never touches the principal-facing surface directly.
- **codex-builder** is the sealed-runtime builder profile — `mcp_servers: {}` by design (`docs/codex-builder-runtime.md` §6).

### 4. `packages/ctrl/src/api/routes/files.ts` — two small additions on top of PR 1

PR 1's `files.ts` covered upload/list/usage/stat/blob/delete; PR 2 needed
two small additions to back the search and describe tools:

- `GET /api/v1/files/list?q=<query>` — case-insensitive `LIKE` across `path`, `original_filename`, and `principal_label`. PR 4 will widen this to full content indexing.
- `PATCH /api/v1/files/<path>` — accepts `{ principal_label }`. Only principal-owned metadata fields are writable; unknown keys pass through silently for forward-compatibility.

### 5. Tests

- `packages/mcp-server/src/tools/files.test.ts` — **18 tests**, catalogue shape + per-tool schema validation + buildRequest mapping. All pass.
- `packages/ctrl/tests/files-routes.test.ts` — **5 new tests** (PR 2's `?q=` search and PATCH paths). All pass alongside the 14 PR 1 tests.

## Verification

- `cd packages/mcp-server && npm run typecheck` — clean.
- `cd packages/mcp-server && npm test` — **36 pass / 0 fail**.
- `cd packages/ctrl && npm test tests/files-routes.test.ts` — **19 pass / 0 fail**.
- `cd packages/hermes && python3 -m pytest tests/ init/` — **94 pass / 0 fail**.
- Manual YAML render check: all four profiles produce valid YAML with the expected `mcp_servers` count (8/8/7/0).

Pre-existing test breakage on unrelated suites (`tests/migrate.test.ts`
has merge-marker leftover from #110 PR1, several other suites hit a
Node-25 `execFileSync` import issue) is unchanged by this PR.

## Out of scope

Per the task brief + spec §6:

- **/files dashboard page** — PR 3 of #114
- **Content extraction pipeline** (pdftotext, OCR, transcripts) — PR 4 of #114
- **Voice-bridge `VOICE_ALLOWED_MCP_TOOLS` additions** — PR 5 of #114 (voice gets the 4 read tools only; PR 2 deliberately leaves the voice catalogue untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)