### PR TITLE
chore(ctrl): strip leftover conflict markers from migrate.test.ts

### DIFF
--- a/packages/ctrl/tests/migrate.test.ts
+++ b/packages/ctrl/tests/migrate.test.ts
@@ -36,15 +36,11 @@ describe("state.db migration runner", () => {
     const db = new DatabaseSync(":memory:");
     db.exec(schema);
     const v = runMigrations(db);
-    // Latest version moves as new migrations land. Today: 4
+    // Latest version moves as new migrations land. Today: 6
     // (0001_fix_pack + 0002_alfred_journal + 0003_tailscale_connection
-    // + 0004_channel_tokens).
+    // + 0004_channel_tokens + 0005_ha_channel + 0006_files_table).
     assert.equal(v, 6, "migrated to latest version");
     assert.equal(userVersion(db), 6);
-=======
-    assert.equal(v, 4, "migrated to latest version");
-    assert.equal(userVersion(db), 4);
->>>>>>> 37313a3f (feat(ctrl,db): 0003_ha_channel migration — 7 ha_* tables + loop-guard index (#110 PR1))
     assert.ok(cols(db, "observation").includes("processed_at"), "0001: processed_at present after migrate");
     // 0002: alfred_journal + alfred_principal tables present.
     const tables = (


### PR DESCRIPTION
PR #110's squash-merge left raw `<<<<<<<`/`=======`/`>>>>>>>` markers in
`packages/ctrl/tests/migrate.test.ts:44-47`. esbuild rejects the file
with `ERROR: Unexpected "<<"`, so every PR's CI has been running this
test in a broken state since #110 landed.

This removes the conflict block (keeping the v=6 assertion that matches
main) and updates the now-stale comment to enumerate all six landed
migrations.

**Verified locally:**
```
▶ state.db migration runner
✔ state.db migration runner (4.926541ms)
```

The other 24 ctrl-api test failures predate this commit and are
unrelated — they're real coverage gaps from the wave of new ctrl-api
routes, not parse-time breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)