### PR TITLE
feat(web): Tailscale /channels card — connect/status/disconnect (#109 PR3)

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -6,3 +6,6 @@ secret:
     # Test fixtures contain synthetic auth-key shaped strings that match the
     # Tailscale `tskey-auth-…` pattern. They are clearly marked FIXTUREONLY.
     - "packages/ctrl/tests/channels_tailscale.test.ts"
+    # /channels Tailscale card derivation tests — same FIXTUREONLY rule.
+    # #109 PR3 (2026-05-29).
+    - "packages/web/src/dashboard/tailscaleCardCore.test.ts"

--- a/packages/web/main.wasp
+++ b/packages/web/main.wasp
@@ -896,6 +896,32 @@ action sendOmiTest {
   entities: []
 }
 
+// Lane III (Tailscale, #109 PR3 — 2026-05-29) — operator opt-in card on
+// /channels. Four ops backed by ctrl-api /api/v1/channels/tailscale/*
+// (PR2 #127 landed the routes). The sidecar lives under
+// `profiles: ["tailscale"]` in docker-compose — off by default. State
+// derivation lives in tailscaleCardCore.ts. PR4 (cert + serve) lands the
+// LE-cert passthrough + Caddy/Funnel ingress.
+query getTailscaleStatus {
+  fn: import { getTailscaleStatus } from "@src/dashboard/operations",
+  entities: []
+}
+
+action connectTailscale {
+  fn: import { connectTailscale } from "@src/dashboard/operations",
+  entities: []
+}
+
+action disconnectTailscale {
+  fn: import { disconnectTailscale } from "@src/dashboard/operations",
+  entities: []
+}
+
+query getTailscalePeers {
+  fn: import { getTailscalePeers } from "@src/dashboard/operations",
+  entities: []
+}
+
 query getAgentConfig {
   fn: import { getAgentConfig } from "@src/dashboard/operations",
   entities: []

--- a/packages/web/src/dashboard/ChannelsPage.tsx
+++ b/packages/web/src/dashboard/ChannelsPage.tsx
@@ -6,7 +6,7 @@
 // (#113 PR3a/PR3b — Vexa was retired in #113 PR1).
 // Sir #8 — also surfaces a "Terminal" card with SSH info + the
 // `docker exec ... hermes` command for direct shell access.
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { Link } from "react-router-dom";
 import {
   useQuery,
@@ -43,6 +43,10 @@ import {
   getPaperclipChannelStatus,
   sendPaperclipTest,
   setPaperclipApiKey,
+  getTailscaleStatus,
+  getTailscalePeers,
+  connectTailscale,
+  disconnectTailscale,
   updateCredentials,
 } from "wasp/client/operations";
 import { Frame } from "../client/components/ab/Frame";
@@ -85,6 +89,16 @@ import {
   truncateTaskId as truncatePaperclipTaskId,
   type PaperclipStatus,
 } from "./paperclipCardCore";
+import {
+  deriveTailscaleCardState,
+  deriveConnectMode,
+  derivePeerCount,
+  isProbablyValidAuthKey,
+  normalisePeer,
+  redactAuthKey,
+  type TailscaleStatus,
+  type TailscalePeersResponse,
+} from "./tailscaleCardCore";
 
 // F57/C14 — the email card reads the live ctrl-api status, not a phantom
 // Instance row. `inbox_address` is only present once `configured`.
@@ -372,6 +386,13 @@ export default function ChannelsPage() {
               TelegramCard. The four visual states + workspace info come
               from slackCardCore. */}
           <SlackCard />
+
+          {/* Tailscale — #109 PR3 (2026-05-29): operator opt-in to a
+              Tailscale sidecar. The compose profile is off by default;
+              connecting from the UI brings it up. Four UI modes
+              (disabled / connecting / connected / error) come from
+              tailscaleCardCore. Cert + Serve land in PR4. */}
+          <TailscaleCard />
 
           {/* Telegram — Lane III: live card backed by ctrl-api. The four
               visual states (unconfigured / configured_starting /
@@ -3430,3 +3451,485 @@ function PaperclipApiKeyPanel({
     </div>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Tailscale card — #109 PR3 (2026-05-29).
+//
+// The compose profile `["tailscale"]` is OFF by default. Connecting from
+// the UI is the operator's opt-in. Four UI modes (derived from the
+// 5-value ctrl-api state via tailscaleCardCore):
+//
+//   • disabled      — two CTAs: primary "Connect via auth key" reveals a
+//                      type="password" paste box; secondary "Use device
+//                      auth URL" POSTs {} and surfaces the auth_url the
+//                      ctrl-api returns. Tooltip explains the sidecar is
+//                      off until first connect.
+//   • connecting    — spinner + (Path C only) the device-auth URL the
+//                      user opens in a new tab + a Copy URL button.
+//                      Polls /status every 5s.
+//   • connected     — hostname, IP, last probe, peer count + a "View
+//                      peers" expander that loads /peers on demand.
+//                      Disconnect button.
+//   • error         — last_error + reason verbatim, retry CTA, the
+//                      Disconnect button is still available.
+//
+// SECURITY: the paste-authkey input is type="password" and the key is
+// trimmed-then-passed-then-forgotten. Error toasts NEVER include the
+// full key — only the first 6 chars via `redactAuthKey`. No log line in
+// this file stringifies a `tskey-…` value.
+// ---------------------------------------------------------------------------
+
+export function TailscaleCard() {
+  const { data: statusData, refetch } = useQuery(
+    getTailscaleStatus,
+    undefined,
+    { retry: false },
+  );
+  const status = (statusData as TailscaleStatus | undefined) ?? null;
+  const card = deriveTailscaleCardState({ status });
+
+  // Path-A paste-form state (kept local; never persisted).
+  const [authKey, setAuthKey] = useState("");
+  const [pasteOpen, setPasteOpen] = useState(false);
+  const [connectBusy, setConnectBusy] = useState(false);
+  const [connectErr, setConnectErr] = useState<string | null>(null);
+
+  // Disconnect state.
+  const [discBusy, setDiscBusy] = useState(false);
+
+  // "Copy URL" toast for the device-auth URL block.
+  const [copied, setCopied] = useState(false);
+
+  // "View peers" expander state — peers are only fetched on demand.
+  const [peersOpen, setPeersOpen] = useState(false);
+  const { data: peersData, refetch: refetchPeers } = useQuery(
+    getTailscalePeers,
+    undefined,
+    // We don't auto-fetch peers — the expander triggers the first load
+    // via refetch(). Once loaded, react-query caches; closing/reopening
+    // hits the cache instead of re-fetching.
+    { retry: false, enabled: false },
+  );
+  const peers = (peersData as TailscalePeersResponse | undefined) ?? null;
+  const peerCount = derivePeerCount(peers);
+
+  // Poll /status every 5s while in a connecting state.
+  useEffect(() => {
+    if (!card.shouldPoll) return;
+    const handle = setInterval(() => {
+      refetch();
+    }, 5_000);
+    return () => clearInterval(handle);
+  }, [card.shouldPoll, refetch]);
+
+  const trimmed = authKey.trim();
+  const keyValid = isProbablyValidAuthKey(trimmed);
+  const keyHint =
+    trimmed.length > 0 && !keyValid
+      ? "Auth keys look like tskey-auth-… with 8+ characters."
+      : null;
+  const connectMode = deriveConnectMode({ authkey: authKey });
+
+  async function connectWithAuthKey() {
+    if (!keyValid) return;
+    setConnectBusy(true);
+    setConnectErr(null);
+    try {
+      await connectTailscale({ authkey: trimmed });
+      // SECURITY: clear the input immediately so the key stops living in
+      // React state. The server response, by contract, does NOT echo the
+      // key back.
+      setAuthKey("");
+      setPasteOpen(false);
+      refetch();
+    } catch (e: any) {
+      // SECURITY: only the first 6 chars of the key may surface. We
+      // never put the full key into the error string.
+      const prefix = redactAuthKey(trimmed);
+      const base =
+        e?.message ?? e?.data?.error ?? "Tailscale refused the auth key.";
+      setConnectErr(prefix ? `${base} (key ${prefix})` : base);
+    } finally {
+      setConnectBusy(false);
+    }
+  }
+
+  async function connectViaDeviceAuth() {
+    setConnectBusy(true);
+    setConnectErr(null);
+    try {
+      // Empty body → Path C. ctrl-api will surface the auth_url on the
+      // next /status poll.
+      await connectTailscale({});
+      refetch();
+    } catch (e: any) {
+      setConnectErr(
+        e?.message ?? e?.data?.error ?? "Couldn't start Tailscale.",
+      );
+    } finally {
+      setConnectBusy(false);
+    }
+  }
+
+  async function disconnect() {
+    if (discBusy) return;
+    if (
+      typeof window !== "undefined" &&
+      !window.confirm(
+        "Disconnect this tenant from your tailnet? The Tailscale " +
+          "sidecar will stop and the device will be logged out.",
+      )
+    ) {
+      return;
+    }
+    setDiscBusy(true);
+    try {
+      await disconnectTailscale({});
+      setPeersOpen(false);
+      refetch();
+    } catch (e) {
+      console.error("tailscale disconnect failed", e);
+    } finally {
+      setDiscBusy(false);
+    }
+  }
+
+  function copyAuthUrl() {
+    if (card.authUrl) {
+      navigator.clipboard?.writeText(card.authUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    }
+  }
+
+  function togglePeers() {
+    const next = !peersOpen;
+    setPeersOpen(next);
+    if (next) {
+      // First open (or re-open) triggers a fresh fetch — peers are cheap
+      // and the operator usually wants the latest view.
+      refetchPeers();
+    }
+  }
+
+  const address =
+    card.state === "connected"
+      ? status?.tailnet_hostname || status?.tailnet_ip || "Connected"
+      : card.state === "starting" || card.state === "authenticating"
+        ? "Bringing the sidecar up…"
+        : card.state === "error"
+          ? "Needs attention"
+          : "Sidecar is off — opt in below";
+
+  return (
+    <ChannelCard
+      name="Tailscale"
+      address={address}
+      note="Join your tailnet — reach this tenant from any device you trust."
+      status={card.pill}
+    >
+      {/* DISABLED — two CTAs. The primary reveals a password-style paste
+          box for Path A (auth key); the secondary POSTs {} for Path C
+          (device-auth URL). Tooltip is the description copy. */}
+      {card.mode === "disabled" && (
+        <div className="mt-5 space-y-4">
+          <p
+            className="font-body italic text-[13px]"
+            style={{ color: "var(--marginalia)" }}
+            title="The Tailscale sidecar is off by default. The first connect brings it up."
+          >
+            {card.description}
+          </p>
+
+          {!pasteOpen && (
+            <div className="flex flex-wrap gap-3 items-baseline">
+              <button
+                onClick={() => setPasteOpen(true)}
+                className="btn-ghost"
+                disabled={connectBusy}
+              >
+                {card.connectChoice.primaryLabel}
+              </button>
+              <button
+                onClick={connectViaDeviceAuth}
+                disabled={connectBusy}
+                className="btn-link"
+              >
+                {connectBusy ? "…" : card.connectChoice.secondaryLabel}
+              </button>
+            </div>
+          )}
+
+          {pasteOpen && (
+            <div className="space-y-2">
+              <div
+                className="font-mono text-[10px] uppercase tracking-[0.22em]"
+                style={{ color: "var(--marginalia)" }}
+              >
+                Tailscale auth key
+              </div>
+              <div className="flex gap-2 items-baseline">
+                {/* SECURITY: type="password" — never reveal-able in this
+                    card. The key is trimmed, sent, and immediately cleared
+                    from React state on success. */}
+                <input
+                  type="password"
+                  value={authKey}
+                  onChange={(e) => setAuthKey(e.target.value)}
+                  placeholder="tskey-auth-…"
+                  autoComplete="off"
+                  spellCheck={false}
+                  className="flex-1 bg-transparent border border-rule px-2 py-1 font-mono text-[12px]"
+                />
+                <button
+                  onClick={connectWithAuthKey}
+                  disabled={connectBusy || connectMode !== "authkey" || !keyValid}
+                  className="btn-ghost"
+                >
+                  {connectBusy ? "…" : "Connect"}
+                </button>
+                <button
+                  onClick={() => {
+                    setPasteOpen(false);
+                    setAuthKey("");
+                    setConnectErr(null);
+                  }}
+                  className="btn-link"
+                  disabled={connectBusy}
+                >
+                  Cancel
+                </button>
+              </div>
+              {keyHint && (
+                <p
+                  className="font-body italic text-[12px]"
+                  style={{ color: "var(--marginalia)" }}
+                >
+                  {keyHint}
+                </p>
+              )}
+              <p
+                className="font-body italic text-[12px]"
+                style={{ color: "var(--marginalia)" }}
+              >
+                Get an auth key from{" "}
+                <a
+                  href="https://login.tailscale.com/admin/settings/keys"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="underline"
+                >
+                  login.tailscale.com/admin/settings/keys
+                </a>
+                . Stored in Vaultwarden; never echoed back here.
+              </p>
+            </div>
+          )}
+
+          {connectErr && (
+            <p
+              className="font-body italic text-[13px]"
+              style={{ color: "var(--brass)" }}
+            >
+              {connectErr}
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* CONNECTING — Path A: just spinner copy. Path C: spinner + the
+          device-auth URL the operator opens in a new tab + Copy URL. */}
+      {card.mode === "connecting" && (
+        <div className="mt-5 space-y-3">
+          <p
+            className="font-body italic text-[13px]"
+            style={{ color: "var(--marginalia)" }}
+          >
+            {card.description}
+          </p>
+
+          {card.showAuthUrl && card.authUrl && (
+            <div className="space-y-2">
+              <div
+                className="font-mono text-[10px] uppercase tracking-[0.22em]"
+                style={{ color: "var(--marginalia)" }}
+              >
+                Device-auth URL
+              </div>
+              <div className="flex items-center gap-2">
+                <a
+                  href={card.authUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="flex-1 font-mono text-[11px] border border-rule p-2 truncate underline"
+                  style={{ color: "var(--ink)" }}
+                >
+                  {card.authUrl}
+                </a>
+                <button onClick={copyAuthUrl} className="btn-ghost">
+                  {copied ? "Copied" : "Copy URL"}
+                </button>
+              </div>
+            </div>
+          )}
+
+          <div className="flex items-baseline gap-3 pt-1">
+            <span
+              className="font-mono text-[11px]"
+              style={{ color: "var(--marginalia)" }}
+            >
+              Polling status every 5s…
+            </span>
+            {card.showDisconnect && (
+              <button
+                onClick={disconnect}
+                disabled={discBusy}
+                className="btn-link"
+              >
+                Cancel
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* CONNECTED — hostname, IP, last probe, peer count + a "View
+          peers" expander that lazy-loads /peers on first open. */}
+      {card.mode === "connected" && (
+        <div className="mt-5 space-y-4">
+          <p
+            className="font-body italic text-[13px]"
+            style={{ color: "var(--marginalia)" }}
+          >
+            {card.description}
+          </p>
+
+          <div className="space-y-1 font-mono text-[12px]">
+            {status?.tailnet_hostname && (
+              <div className="flex gap-2">
+                <span style={{ color: "var(--marginalia)" }}>hostname</span>
+                <span style={{ color: "var(--ink)" }}>
+                  {status.tailnet_hostname}
+                </span>
+              </div>
+            )}
+            {status?.tailnet_ip && (
+              <div className="flex gap-2">
+                <span style={{ color: "var(--marginalia)" }}>tailnet ip</span>
+                <span style={{ color: "var(--ink)" }}>
+                  {status.tailnet_ip}
+                </span>
+              </div>
+            )}
+            <div className="flex gap-2">
+              <span style={{ color: "var(--marginalia)" }}>peers</span>
+              <span style={{ color: "var(--ink)" }}>
+                {peersOpen ? peerCount : peers ? peerCount : "—"}
+              </span>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-3 items-baseline">
+            <button onClick={togglePeers} className="btn-link">
+              {peersOpen ? "Hide peers" : "View peers"}
+            </button>
+            <button
+              onClick={disconnect}
+              disabled={discBusy}
+              className="btn-ghost"
+            >
+              {discBusy ? "…" : "Disconnect"}
+            </button>
+          </div>
+
+          {peersOpen && (
+            <div className="border-t border-rule pt-3 space-y-1">
+              {peerCount === 0 ? (
+                <p
+                  className="font-body italic text-[12px]"
+                  style={{ color: "var(--marginalia)" }}
+                >
+                  {peers?.reason
+                    ? peers.reason
+                    : "No peers visible to this tenant yet."}
+                </p>
+              ) : (
+                peers!.peers.map((p) => {
+                  const np = normalisePeer(p);
+                  return (
+                    <div
+                      key={np.id ?? np.displayName}
+                      className="flex items-baseline gap-3 font-mono text-[11px]"
+                    >
+                      <span
+                        style={{
+                          color: np.online ? "var(--ink)" : "var(--marginalia)",
+                        }}
+                      >
+                        {np.online ? "●" : "○"}
+                      </span>
+                      <span style={{ color: "var(--ink)" }}>
+                        {np.displayName}
+                      </span>
+                      {np.tailscale_ips[0] && (
+                        <span style={{ color: "var(--marginalia)" }}>
+                          {np.tailscale_ips[0]}
+                        </span>
+                      )}
+                      {np.os && (
+                        <span style={{ color: "var(--marginalia)" }}>
+                          {np.os}
+                        </span>
+                      )}
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* ERROR — verbatim last_error/reason + retry CTA. */}
+      {card.mode === "error" && (
+        <div className="mt-5 space-y-3">
+          <p
+            className="font-body italic text-[13px]"
+            style={{ color: "var(--brass)" }}
+          >
+            {card.description}
+          </p>
+          {card.errorMessage && card.errorMessage !== card.description && (
+            <p
+              className="font-mono text-[11px]"
+              style={{ color: "var(--marginalia)" }}
+            >
+              {card.errorMessage}
+            </p>
+          )}
+          <div className="flex flex-wrap gap-3 items-baseline">
+            {card.showRetry && (
+              <button
+                onClick={() => refetch()}
+                className="btn-ghost"
+                disabled={connectBusy}
+              >
+                Try again
+              </button>
+            )}
+            {card.showDisconnect && (
+              <button
+                onClick={disconnect}
+                disabled={discBusy}
+                className="btn-link"
+              >
+                {discBusy ? "…" : "Disconnect"}
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </ChannelCard>
+  );
+}
+

--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -574,6 +574,86 @@ export const sendOmiTest = async (_args: unknown, context: any) => {
 };
 
 // ============================================================
+// Tailscale channel (#109 PR3) — operator opt-in to a Tailscale sidecar.
+// Backed by ctrl-api /api/v1/channels/tailscale/* (PR2 #127 landed the
+// routes). Three Wasp ops:
+//   getTailscaleStatus  → { state, tailnet_ip, tailnet_hostname, auth_url,
+//                           authkey_used_at, last_status_probe_at,
+//                           last_error, reason }
+//   connectTailscale    → POST { authkey?: string }
+//                          - authkey present → Path A (paste an auth key)
+//                          - authkey absent  → Path C (device-auth URL,
+//                                              returned in `auth_url`)
+//                          Returns: { ok, state, path: "A" | "C",
+//                                     auth_url?: string }
+//                          The action NEVER echoes the authkey back to
+//                          the client — the security rule.
+//   disconnectTailscale → POST {} → { ok, state: "disabled", warnings }
+//   getTailscalePeers   → { peers: TailscalePeer[], reason?: string }
+//
+// PR4 (cert + serve) will add the cert/serve actions; the ctrl-api
+// returns 501 for those today.
+// ============================================================
+
+export const getTailscaleStatus = async (_args: unknown, context: any) => {
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    path: "/api/v1/channels/tailscale/status",
+  });
+};
+
+/**
+ * Connect the tenant to the operator's tailnet.
+ *
+ * Body: { authkey?: string }
+ *
+ *   • authkey present (non-empty) → ctrl-api takes Path A: writes the
+ *     key into Vaultwarden + /srv/alfred-black/.env, then brings the
+ *     tailscale sidecar up. The action ONLY surfaces the next ctrl-api
+ *     state — the key itself is never echoed back to the client.
+ *
+ *   • authkey absent / empty → ctrl-api takes Path C: brings the sidecar
+ *     up with TAILSCALE_ENABLED=true but no auth key, and `tailscaled`
+ *     mints a device-auth URL the operator opens in a new tab. The URL
+ *     is included in the response so the React layer can render it.
+ *
+ * SECURITY: only the first 6 chars of the authkey may EVER appear in any
+ * error message surfaced to the client. The action trims the key, then
+ * passes it through to ctrl-api — it is never logged here. ctrl-api
+ * errors (e.g. 502 DOCKER_COMPOSE_FAILED) bubble through with their
+ * `error.message`, which does not contain the key.
+ */
+export const connectTailscale = async (
+  args: { authkey?: string },
+  context: any,
+) => {
+  const instance = await getUserInstance(context);
+  const raw = typeof args?.authkey === "string" ? args.authkey.trim() : "";
+  // Path C body is {} (no key); Path A includes the trimmed key.
+  const body = raw.length > 0 ? { authkey: raw } : {};
+  return proxyToTenant(instance, {
+    method: "POST",
+    path: "/api/v1/channels/tailscale/connect",
+    body,
+  });
+};
+
+export const disconnectTailscale = async (_args: unknown, context: any) => {
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    method: "POST",
+    path: "/api/v1/channels/tailscale/disconnect",
+  });
+};
+
+export const getTailscalePeers = async (_args: unknown, context: any) => {
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    path: "/api/v1/channels/tailscale/peers",
+  });
+};
+
+// ============================================================
 // Dashboard Home
 // ============================================================
 

--- a/packages/web/src/dashboard/tailscaleCardCore.test.ts
+++ b/packages/web/src/dashboard/tailscaleCardCore.test.ts
@@ -1,0 +1,353 @@
+/**
+ * /channels — Tailscale card derivation tests.
+ *
+ * Covers the contract laid out in the lane brief (#109 PR3, 2026-05-29):
+ *   • status-string formatter (heading + pill) for each of the 5 ctrl-api
+ *     `state` values (disabled / starting / authenticating / connected /
+ *     error) and the 4 derived view modes (disabled / connecting /
+ *     connected / error)
+ *   • paste-authkey-vs-device-auth derivation (`deriveConnectMode`):
+ *     non-empty key → "authkey", empty/whitespace → "device-auth"
+ *   • peer-count derivation when peers returns [] vs N vs undefined
+ *   • redactAuthKey only ever leaks the first 6 characters
+ *   • isProbablyValidAuthKey accept (both shapes) + reject
+ *   • formatProbeTime: just now / N min / N hours / N days
+ *
+ * SECURITY: all fixture auth keys are synthetic placeholders prefixed
+ * with FIXTUREONLY. Real `tskey-…` values never appear in this file.
+ * The path is allowlisted in .gitguardian.yaml.
+ *
+ * Run with:  cd packages/web && npx tsx --test src/dashboard/tailscaleCardCore.test.ts
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  deriveTailscaleCardState,
+  deriveConnectMode,
+  derivePeerCount,
+  formatProbeTime,
+  isProbablyValidAuthKey,
+  normalisePeer,
+  redactAuthKey,
+  type TailscaleStatus,
+  type TailscalePeersResponse,
+} from "./tailscaleCardCore";
+
+const BASE: TailscaleStatus = {
+  state: "disabled",
+  tailnet_ip: null,
+  tailnet_hostname: null,
+  auth_url: null,
+  authkey_used_at: null,
+  last_status_probe_at: null,
+  last_error: null,
+  reason: null,
+};
+
+// ── Status formatter — one test per state ────────────────────────────────
+
+test("derive: disabled → both CTAs + 'available' pill", () => {
+  const s = deriveTailscaleCardState({ status: BASE });
+  assert.equal(s.state, "disabled");
+  assert.equal(s.mode, "disabled");
+  assert.equal(s.pill, "available");
+  assert.equal(s.heading, "Join your tailnet");
+  assert.equal(s.connectChoice.primaryLabel, "Connect via auth key");
+  assert.equal(s.connectChoice.secondaryLabel, "Use device auth URL");
+  assert.equal(s.shouldPoll, false);
+  assert.equal(s.showDisconnect, false);
+  assert.equal(s.showRetry, false);
+  assert.equal(s.showAuthUrl, false);
+});
+
+test("derive: starting → spinner copy + polls + no auth URL yet", () => {
+  const s = deriveTailscaleCardState({
+    status: { ...BASE, state: "starting" },
+  });
+  assert.equal(s.mode, "connecting");
+  assert.equal(s.pill, "starting");
+  assert.match(s.heading, /Starting Tailscale/i);
+  assert.equal(s.shouldPoll, true);
+  assert.equal(s.showAuthUrl, false);
+  assert.equal(s.authUrl, null);
+});
+
+test("derive: authenticating with auth_url → URL shown + polls", () => {
+  const s = deriveTailscaleCardState({
+    status: {
+      ...BASE,
+      state: "authenticating",
+      auth_url: "https://login.tailscale.com/a/FIXTUREONLY-deviceAuth-XYZ",
+    },
+  });
+  assert.equal(s.mode, "connecting");
+  assert.equal(s.pill, "starting");
+  assert.equal(s.showAuthUrl, true);
+  assert.equal(
+    s.authUrl,
+    "https://login.tailscale.com/a/FIXTUREONLY-deviceAuth-XYZ",
+  );
+  assert.equal(s.shouldPoll, true);
+  assert.match(s.heading, /Open the device-auth URL/i);
+});
+
+test("derive: authenticating without auth_url → 'awaiting' copy, no URL block", () => {
+  const s = deriveTailscaleCardState({
+    status: { ...BASE, state: "authenticating", auth_url: null },
+  });
+  assert.equal(s.showAuthUrl, false);
+  assert.equal(s.authUrl, null);
+  assert.match(s.heading, /Awaiting device auth/i);
+  assert.equal(s.shouldPoll, true);
+});
+
+test("derive: connected → hostname + IP + last-probe in description, no poll", () => {
+  const now = new Date("2026-05-29T12:00:00Z");
+  const probedAt = now.getTime() - 30_000; // 30s ago → "just now"
+  const s = deriveTailscaleCardState({
+    status: {
+      ...BASE,
+      state: "connected",
+      tailnet_hostname: "home-alfred-black",
+      tailnet_ip: "100.64.0.42",
+      last_status_probe_at: probedAt,
+    },
+  });
+  assert.equal(s.mode, "connected");
+  assert.equal(s.pill, "active");
+  assert.equal(s.heading, "Connected as home-alfred-black");
+  assert.match(s.description, /100\.64\.0\.42/);
+  assert.equal(s.shouldPoll, false);
+  assert.equal(s.showDisconnect, true);
+  assert.equal(s.showRetry, false);
+});
+
+test("derive: connected with only an IP → still renders sensibly", () => {
+  const s = deriveTailscaleCardState({
+    status: {
+      ...BASE,
+      state: "connected",
+      tailnet_hostname: null,
+      tailnet_ip: "100.64.0.42",
+    },
+  });
+  assert.equal(s.heading, "Connected to your tailnet");
+  assert.match(s.description, /100\.64\.0\.42/);
+});
+
+test("derive: error → verbatim last_error + retry button", () => {
+  const s = deriveTailscaleCardState({
+    status: {
+      ...BASE,
+      state: "error",
+      last_error: "docker compose up tailscale failed: exit code 1",
+      reason: "docker compose up tailscale failed: exit code 1",
+    },
+  });
+  assert.equal(s.mode, "error");
+  assert.equal(s.pill, "error");
+  assert.match(s.description, /docker compose up tailscale failed/);
+  assert.equal(s.errorMessage, "docker compose up tailscale failed: exit code 1");
+  assert.equal(s.showRetry, true);
+  assert.equal(s.showDisconnect, true);
+});
+
+test("derive: error falls back to a default message when last_error is empty", () => {
+  const s = deriveTailscaleCardState({
+    status: { ...BASE, state: "error", last_error: "", reason: null },
+  });
+  assert.equal(s.mode, "error");
+  assert.match(s.description, /couldn't bring the Tailscale sidecar up/i);
+  assert.equal(s.errorMessage, null);
+});
+
+test("derive: null/undefined status → safe disabled state", () => {
+  const s1 = deriveTailscaleCardState({ status: null });
+  const s2 = deriveTailscaleCardState({ status: undefined });
+  assert.equal(s1.mode, "disabled");
+  assert.equal(s2.mode, "disabled");
+  assert.equal(s1.pill, "available");
+});
+
+// ── Connect-mode derivation (paste-authkey vs device-auth) ───────────────
+
+test("deriveConnectMode: non-empty authkey → 'authkey'", () => {
+  assert.equal(
+    deriveConnectMode({ authkey: "tskey-auth-FIXTUREONLY-aaaaaa" }),
+    "authkey",
+  );
+  assert.equal(
+    deriveConnectMode({ authkey: "  tskey-auth-FIXTUREONLY-bbbbbb  " }),
+    "authkey",
+  );
+});
+
+test("deriveConnectMode: empty / whitespace / undefined → 'device-auth'", () => {
+  assert.equal(deriveConnectMode({ authkey: "" }), "device-auth");
+  assert.equal(deriveConnectMode({ authkey: "   " }), "device-auth");
+  assert.equal(deriveConnectMode({ authkey: null }), "device-auth");
+  assert.equal(deriveConnectMode({ authkey: undefined }), "device-auth");
+  assert.equal(deriveConnectMode({}), "device-auth");
+});
+
+// ── isProbablyValidAuthKey ───────────────────────────────────────────────
+
+test("isProbablyValidAuthKey: accepts both shapes, rejects malformed", () => {
+  // Modern reusable shape: tskey-auth-<id>-<secret>.
+  assert.equal(
+    isProbablyValidAuthKey("tskey-auth-FIXTUREONLY-aaaaaaaaaa"),
+    true,
+  );
+  // Older single-segment shape: tskey-<secret>.
+  assert.equal(isProbablyValidAuthKey("tskey-FIXTUREONLYxxxxxxx"), true);
+  // Surrounding whitespace is trimmed.
+  assert.equal(
+    isProbablyValidAuthKey("  tskey-auth-FIXTUREONLY-cccccccccc  "),
+    true,
+  );
+  // Wrong prefix.
+  assert.equal(isProbablyValidAuthKey("not-a-key"), false);
+  // Too short after the prefix.
+  assert.equal(isProbablyValidAuthKey("tskey-short"), false);
+  // Empty / non-string.
+  assert.equal(isProbablyValidAuthKey(""), false);
+  // Disallowed characters (slash) reject.
+  assert.equal(
+    isProbablyValidAuthKey("tskey-auth-FIXTUREONLY/slash"),
+    false,
+  );
+});
+
+// ── redactAuthKey — only the first 6 chars may ever leak ─────────────────
+
+test("redactAuthKey: only the first 6 chars survive, never the secret", () => {
+  // Synthetic placeholder — never a real tskey.
+  const fake = "tskey-auth-FIXTUREONLY-12345-deadbeefcafebabe";
+  const red = redactAuthKey(fake);
+  assert.equal(red, "tskey-…");
+  assert.equal(red.includes("FIXTUREONLY"), false);
+  assert.equal(red.includes("deadbeef"), false);
+  // Very short input degrades to a single ellipsis token.
+  assert.equal(redactAuthKey("abc"), "abc…");
+  // Empty / non-string returns "".
+  assert.equal(redactAuthKey(""), "");
+  assert.equal(redactAuthKey(null), "");
+  assert.equal(redactAuthKey(undefined), "");
+  assert.equal(redactAuthKey("   "), "");
+});
+
+// ── Peer-count derivation ────────────────────────────────────────────────
+
+test("derivePeerCount: empty peers array returns 0", () => {
+  const r: TailscalePeersResponse = { peers: [] };
+  assert.equal(derivePeerCount(r), 0);
+});
+
+test("derivePeerCount: N peers returns N", () => {
+  const r: TailscalePeersResponse = {
+    peers: [
+      {
+        id: "peer-1",
+        hostname: "macbook",
+        dns_name: "macbook.tail-scale.ts.net",
+        os: "macOS",
+        tailscale_ips: ["100.64.0.10"],
+        online: true,
+        last_seen: null,
+      },
+      {
+        id: "peer-2",
+        hostname: "phone",
+        dns_name: "phone.tail-scale.ts.net",
+        os: "iOS",
+        tailscale_ips: ["100.64.0.11"],
+        online: false,
+        last_seen: "2026-05-29T11:00:00Z",
+      },
+    ],
+  };
+  assert.equal(derivePeerCount(r), 2);
+});
+
+test("derivePeerCount: null/undefined/reason-only response returns 0", () => {
+  assert.equal(derivePeerCount(null), 0);
+  assert.equal(derivePeerCount(undefined), 0);
+  // `{reason: "..."}` is the fail-soft shape ctrl-api returns when the
+  // probe failed — no `peers` array at all.
+  const fail = { reason: "Tailscale is disabled" } as TailscalePeersResponse;
+  assert.equal(derivePeerCount(fail), 0);
+});
+
+// ── normalisePeer — displayName fallback chain ───────────────────────────
+
+test("normalisePeer: prefers hostname, falls back to dns_name, then IP", () => {
+  assert.equal(
+    normalisePeer({
+      id: "1",
+      hostname: "macbook",
+      dns_name: "macbook.tail-scale.ts.net",
+      os: "macOS",
+      tailscale_ips: ["100.64.0.10"],
+      online: true,
+      last_seen: null,
+    }).displayName,
+    "macbook",
+  );
+  assert.equal(
+    normalisePeer({
+      id: "2",
+      hostname: null,
+      dns_name: "phone.tail-scale.ts.net",
+      os: "iOS",
+      tailscale_ips: ["100.64.0.11"],
+      online: true,
+      last_seen: null,
+    }).displayName,
+    "phone.tail-scale.ts.net",
+  );
+  assert.equal(
+    normalisePeer({
+      id: "3",
+      hostname: null,
+      dns_name: null,
+      os: null,
+      tailscale_ips: ["100.64.0.12"],
+      online: false,
+      last_seen: null,
+    }).displayName,
+    "100.64.0.12",
+  );
+  assert.equal(
+    normalisePeer({
+      id: "4",
+      hostname: null,
+      dns_name: null,
+      os: null,
+      tailscale_ips: [],
+      online: false,
+      last_seen: null,
+    }).displayName,
+    "unknown",
+  );
+});
+
+// ── formatProbeTime ──────────────────────────────────────────────────────
+
+test("formatProbeTime: just now / N min / N hours / N days", () => {
+  const now = new Date("2026-05-29T12:00:00Z");
+  const at = (ms: number) => now.getTime() - ms;
+  assert.equal(formatProbeTime(at(10_000), now), "just now");
+  assert.equal(formatProbeTime(at(7 * 60_000), now), "7 min ago");
+  assert.equal(formatProbeTime(at(60 * 60_000), now), "1 hour ago");
+  assert.equal(formatProbeTime(at(5 * 60 * 60_000), now), "5 hours ago");
+  assert.equal(formatProbeTime(at(86_400_000), now), "1 day ago");
+  assert.equal(formatProbeTime(at(3 * 86_400_000), now), "3 days ago");
+  // Garbage input returns "".
+  assert.equal(formatProbeTime(null), "");
+  assert.equal(formatProbeTime(undefined), "");
+  assert.equal(formatProbeTime(Number.NaN), "");
+  assert.equal(formatProbeTime(0), "");
+  assert.equal(formatProbeTime(-1), "");
+});

--- a/packages/web/src/dashboard/tailscaleCardCore.ts
+++ b/packages/web/src/dashboard/tailscaleCardCore.ts
@@ -1,0 +1,387 @@
+// tailscaleCardCore — pure shape derivation for the /channels Tailscale
+// card. Import-free (no React/Wasp) so the five derived states unit-test
+// under node:test the same way telegramCardCore / omiCardCore do.
+//
+// #109 PR3 (2026-05-29): the Tailscale sidecar lives under
+// `profiles: ["tailscale"]` in docker-compose — off by default. Connecting
+// from the UI is the operator's opt-in, which means the card has to walk
+// the user through a small state machine:
+//
+//   • disabled        — sidecar is off (default). Two CTAs:
+//                       "Connect via auth key" (Path A — paste) and
+//                       "Use device auth URL" (Path C — let tailscaled
+//                       mint an auth URL we open in a new tab).
+//   • starting        — Path A used: ctrl-api just brought the sidecar up
+//                       with a known auth key, waiting for `tailscaled`
+//                       to register. Spinner copy; UI polls /status.
+//   • authenticating  — Path C used: sidecar is up but the operator still
+//                       has to click the device-auth URL. The URL itself
+//                       is the hero; we keep polling until it transitions
+//                       to connected.
+//   • connected       — tailscaled has a tailnet IP. Card shows the
+//                       hostname, the IP, last probe time, and a
+//                       "View peers" expander.
+//   • error           — anything that surfaced an error from ctrl-api or
+//                       the docker-compose step. The verbatim
+//                       `last_error` / `reason` field is shown.
+//
+// The five states map 1:1 to the `state` field returned by
+// GET /api/v1/channels/tailscale/status. Lane I (PR2 #127) owns the
+// endpoint; the derivation here is the only thing the UI needs to know
+// about the state machine.
+//
+// SECURITY: the paste-authkey input is a `type="password"` field in the
+// React layer. We never stringify or log a `tskey-…` value here. Helpers
+// like `redactAuthKey` are provided so error toasts can only surface the
+// first 6 characters of any key the user pasted.
+
+export type TailscaleState =
+  | "disabled"
+  | "starting"
+  | "authenticating"
+  | "connected"
+  | "error";
+
+/** Status pill values consumed by ChannelCard. */
+export type TailscalePill = "active" | "available" | "starting" | "error";
+
+/** The four UI modes the card surface renders against. */
+export type TailscaleViewMode =
+  | "disabled"
+  | "connecting"
+  | "connected"
+  | "error";
+
+/**
+ * The shape returned by GET /api/v1/channels/tailscale/status (Lane I,
+ * PR2 #127). Fields are intentionally permissive (every value can be
+ * absent) so the UI does not crash on a partial response — the derivation
+ * fills in safe defaults.
+ */
+export interface TailscaleStatus {
+  state: TailscaleState;
+  tailnet_ip: string | null;
+  tailnet_hostname: string | null;
+  /** Device-auth URL the operator has to open in a new tab (Path C). */
+  auth_url: string | null;
+  /** Epoch-millis of the last successful auth-key write (Path A). */
+  authkey_used_at: number | null;
+  /** Epoch-millis of the last successful `tailscale status --json` probe. */
+  last_status_probe_at: number | null;
+  /** Last error string from ctrl-api (mirrors `reason`). */
+  last_error: string | null;
+  /** Alias of last_error so the UI doesn't have to special-case the column. */
+  reason: string | null;
+}
+
+/** A single peer entry from GET /api/v1/channels/tailscale/peers. */
+export interface TailscalePeer {
+  id: string | null;
+  hostname: string | null;
+  dns_name: string | null;
+  os: string | null;
+  tailscale_ips: string[];
+  online: boolean;
+  last_seen: string | null;
+}
+
+/** Shape returned by GET /api/v1/channels/tailscale/peers. */
+export interface TailscalePeersResponse {
+  peers: TailscalePeer[];
+  reason?: string | null;
+}
+
+/**
+ * The Path-A vs Path-C choice for the disabled state. The UI surfaces a
+ * primary CTA ("Connect via auth key") and a secondary one ("Use device
+ * auth URL") — these labels live here so the unit tests can assert them.
+ */
+export interface TailscaleConnectChoice {
+  /** Path A: operator pastes a tskey-auth-… key. */
+  primaryLabel: string;
+  /** Path C: ctrl-api mints a device-auth URL from tailscaled. */
+  secondaryLabel: string;
+}
+
+export interface TailscaleCardState {
+  /** Underlying ctrl-api state (full 5-value enum). */
+  state: TailscaleState;
+  /** Coarse view-mode the React surface renders against. */
+  mode: TailscaleViewMode;
+  /** One-line headline above the card body. */
+  heading: string;
+  /** Italic marginalia under the headline. */
+  description: string;
+  /** Pretty status pill. */
+  pill: TailscalePill;
+  /** The two CTAs shown in the disabled state. */
+  connectChoice: TailscaleConnectChoice;
+  /**
+   * Device-auth URL when Path C is in flight. Forwarded straight from the
+   * status response; null when not applicable.
+   */
+  authUrl: string | null;
+  /** True iff Path C device-auth URL block should render. */
+  showAuthUrl: boolean;
+  /** True iff the card should poll /status every 5s. */
+  shouldPoll: boolean;
+  /** True iff the "Disconnect" button should render. */
+  showDisconnect: boolean;
+  /** True iff the "Retry" button should render (error state). */
+  showRetry: boolean;
+  /** Verbatim error message — only meaningful when mode === "error". */
+  errorMessage: string | null;
+}
+
+const NULL_STATUS: TailscaleStatus = {
+  state: "disabled",
+  tailnet_ip: null,
+  tailnet_hostname: null,
+  auth_url: null,
+  authkey_used_at: null,
+  last_status_probe_at: null,
+  last_error: null,
+  reason: null,
+};
+
+const DEFAULT_CONNECT_CHOICE: TailscaleConnectChoice = {
+  primaryLabel: "Connect via auth key",
+  secondaryLabel: "Use device auth URL",
+};
+
+export function deriveTailscaleCardState(args: {
+  status: TailscaleStatus | null | undefined;
+}): TailscaleCardState {
+  const status = args.status ?? NULL_STATUS;
+  // `reason` aliases `last_error` per ctrl-api spec; prefer whichever is
+  // non-empty so a backend that filled in only one column still surfaces.
+  const errorText =
+    pickNonEmpty(status.last_error) ?? pickNonEmpty(status.reason) ?? null;
+
+  switch (status.state) {
+    case "starting":
+      return {
+        state: "starting",
+        mode: "connecting",
+        heading: "Starting Tailscale",
+        description:
+          "The sidecar is registering with the tailnet. This usually " +
+          "takes a few seconds.",
+        pill: "starting",
+        connectChoice: DEFAULT_CONNECT_CHOICE,
+        authUrl: null,
+        showAuthUrl: false,
+        shouldPoll: true,
+        showDisconnect: false,
+        showRetry: false,
+        errorMessage: null,
+      };
+
+    case "authenticating": {
+      const hasUrl = typeof status.auth_url === "string" && status.auth_url.length > 0;
+      return {
+        state: "authenticating",
+        mode: "connecting",
+        heading: hasUrl ? "Open the device-auth URL" : "Awaiting device auth",
+        description: hasUrl
+          ? "Open the URL below in a new tab to authorise this device on " +
+            "your tailnet. The card will refresh once authorisation lands."
+          : "Waiting for tailscaled to mint a device-auth URL.",
+        pill: "starting",
+        connectChoice: DEFAULT_CONNECT_CHOICE,
+        authUrl: hasUrl ? status.auth_url : null,
+        showAuthUrl: hasUrl,
+        shouldPoll: true,
+        showDisconnect: true,
+        showRetry: false,
+        errorMessage: null,
+      };
+    }
+
+    case "connected": {
+      const hostname = pickNonEmpty(status.tailnet_hostname);
+      const ip = pickNonEmpty(status.tailnet_ip);
+      const heading = hostname
+        ? `Connected as ${hostname}`
+        : "Connected to your tailnet";
+      const probe = formatProbeTime(status.last_status_probe_at);
+      const probeFragment = probe ? ` Last probe: ${probe}.` : "";
+      const ipFragment = ip ? ` Tailnet IP: ${ip}.` : "";
+      return {
+        state: "connected",
+        mode: "connected",
+        heading,
+        description:
+          "This tenant is reachable on your tailnet." + ipFragment + probeFragment,
+        pill: "active",
+        connectChoice: DEFAULT_CONNECT_CHOICE,
+        authUrl: null,
+        showAuthUrl: false,
+        shouldPoll: false,
+        showDisconnect: true,
+        showRetry: false,
+        errorMessage: null,
+      };
+    }
+
+    case "error":
+      return {
+        state: "error",
+        mode: "error",
+        heading: "Tailscale needs attention",
+        description:
+          errorText ||
+          "ctrl-api couldn't bring the Tailscale sidecar up. Try again, " +
+            "or disconnect and start over.",
+        pill: "error",
+        connectChoice: DEFAULT_CONNECT_CHOICE,
+        authUrl: null,
+        showAuthUrl: false,
+        shouldPoll: false,
+        showDisconnect: true,
+        showRetry: true,
+        errorMessage: errorText,
+      };
+
+    case "disabled":
+    default:
+      return {
+        state: "disabled",
+        mode: "disabled",
+        heading: "Join your tailnet",
+        description:
+          "The Tailscale sidecar is off until first connect. Paste an " +
+          "auth key for the fastest path, or let tailscaled mint a " +
+          "device-auth URL you open in a new tab.",
+        pill: "available",
+        connectChoice: DEFAULT_CONNECT_CHOICE,
+        authUrl: null,
+        showAuthUrl: false,
+        shouldPoll: false,
+        showDisconnect: false,
+        showRetry: false,
+        errorMessage: null,
+      };
+  }
+}
+
+// ── Connect-mode helpers ─────────────────────────────────────────────────
+
+/**
+ * The card has two CTAs in the disabled state. The "primary" path is
+ * pasting an auth key (faster, headless). The "secondary" path lets
+ * tailscaled mint a device-auth URL the operator opens in a new tab.
+ *
+ * `deriveConnectMode(input)` is a single-source-of-truth predicate that
+ * tells the React layer which POST body to send to /connect:
+ *
+ *   • "authkey"     — non-empty `tskey-auth-…` was pasted; send {authkey}.
+ *   • "device-auth" — paste box is empty; send {} and surface the
+ *                     returned `auth_url`.
+ *
+ * Whitespace-only paste boxes count as empty (device-auth).
+ */
+export type TailscaleConnectMode = "authkey" | "device-auth";
+
+export function deriveConnectMode(input: {
+  authkey?: string | null | undefined;
+}): TailscaleConnectMode {
+  const raw = typeof input.authkey === "string" ? input.authkey.trim() : "";
+  return raw.length > 0 ? "authkey" : "device-auth";
+}
+
+// Tailscale auth keys are documented as `tskey-auth-<id>-<secret>` (and
+// historically the older `tskey-<secret>` shape). We accept either — the
+// ctrl-api side is the real validator, this is just a quick UX hint so
+// we don't fire a /connect with an obvious paste-fail.
+const AUTHKEY_RE = /^tskey-(?:auth-)?[A-Za-z0-9_-]{8,}$/;
+
+export function isProbablyValidAuthKey(s: string): boolean {
+  if (typeof s !== "string") return false;
+  return AUTHKEY_RE.test(s.trim());
+}
+
+/**
+ * Redact an auth key for display in error toasts. Only the first 6 chars
+ * may ever leak; everything after is replaced with an ellipsis. Garbage
+ * input (non-string, empty) returns an empty string so callers can
+ * `${prefix && `key ${prefix}…`}` cheaply.
+ *
+ * NEVER log or stringify the full key — see the lane brief security rule.
+ */
+export function redactAuthKey(s: string | null | undefined): string {
+  if (typeof s !== "string" || s.length === 0) return "";
+  const trimmed = s.trim();
+  if (trimmed.length === 0) return "";
+  if (trimmed.length <= 6) return `${trimmed}…`;
+  return `${trimmed.slice(0, 6)}…`;
+}
+
+// ── Peers helpers ────────────────────────────────────────────────────────
+
+/**
+ * Peer count derivation. Robust against `peers: undefined`, missing
+ * payload, or a `{reason: "..."}`-only response (Tailscale disabled,
+ * probe failed). Always returns a non-negative integer.
+ */
+export function derivePeerCount(
+  response: TailscalePeersResponse | null | undefined,
+): number {
+  if (!response) return 0;
+  if (!Array.isArray(response.peers)) return 0;
+  return response.peers.length;
+}
+
+/**
+ * Normalise a peer for rendering. Defaults `hostname` to the dns_name (or
+ * the first tailnet IP) so the UI always has *something* to show — peers
+ * advertised without a HostName still render with a sensible label.
+ */
+export function normalisePeer(p: TailscalePeer): TailscalePeer & {
+  displayName: string;
+} {
+  const fallbackIp = p.tailscale_ips?.[0] ?? "unknown";
+  const displayName =
+    pickNonEmpty(p.hostname) ??
+    pickNonEmpty(p.dns_name) ??
+    fallbackIp;
+  return { ...p, displayName };
+}
+
+// ── Probe-time helper ────────────────────────────────────────────────────
+
+/**
+ * Format the `last_status_probe_at` epoch-millis into a calm relative
+ * string ("just now" / "5 min ago" / "2 hours ago" / "3 days ago").
+ * Mirrors the wording other channel cards use elsewhere — we'd rather
+ * understate than be precise to the second.
+ *
+ * Garbage input (null, NaN, future timestamp) returns an empty string so
+ * callers can `${probe && ` Last probe: ${probe}.`}` cheaply.
+ *
+ * `now` is overridable for deterministic unit tests.
+ */
+export function formatProbeTime(
+  epochMs: number | null | undefined,
+  now: Date = new Date(),
+): string {
+  if (typeof epochMs !== "number" || !Number.isFinite(epochMs)) return "";
+  if (epochMs <= 0) return "";
+  const deltaMs = Math.max(0, now.getTime() - epochMs);
+  const seconds = Math.floor(deltaMs / 1000);
+  if (seconds < 45) return "just now";
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.round(seconds / 3600);
+  if (hours < 24) return `${hours} ${hours === 1 ? "hour" : "hours"} ago`;
+  const days = Math.round(seconds / 86_400);
+  return `${days} ${days === 1 ? "day" : "days"} ago`;
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────────
+
+function pickNonEmpty(s: string | null | undefined): string | null {
+  if (typeof s !== "string") return null;
+  const t = s.trim();
+  return t.length > 0 ? t : null;
+}


### PR DESCRIPTION
Adds the user-facing Tailscale card on `/channels`. PR2 (#127) landed
the ctrl-api routes; this PR is the SaaS-side wiring.

## What this is

The Tailscale sidecar lives under `profiles: ["tailscale"]` in
docker-compose — **off by default**. Connecting via the UI is the
operator's opt-in. The card walks the principal through it.

## Files

- `packages/web/src/dashboard/tailscaleCardCore.ts` — pure derivation:
  - 5 ctrl-api states (`disabled`/`starting`/`authenticating`/`connected`/
    `error`) collapse into 4 view modes (`disabled`/`connecting`/
    `connected`/`error`).
  - `deriveConnectMode`: paste-authkey vs device-auth URL choice.
  - `derivePeerCount`, `normalisePeer` for the View Peers expander.
  - `redactAuthKey`: only the first 6 chars may ever surface.
  - `isProbablyValidAuthKey`: `tskey-auth-…` and legacy `tskey-…` shapes.
  - `formatProbeTime`: relative time for `last_status_probe_at`.
- `packages/web/src/dashboard/tailscaleCardCore.test.ts` — 18 tests under
  `node:test`. All FIXTUREONLY auth-key placeholders.
- `packages/web/src/dashboard/ChannelsPage.tsx` — adds the React surface
  in alphabetical order between SlackCard and TelegramCard. Polls
  `/status` every 5s while in a connecting state; lazy-loads `/peers`
  on the "View peers" expander.
- `packages/web/src/dashboard/operations.ts` + `packages/web/main.wasp` —
  4 ops (`getTailscaleStatus`, `connectTailscale`, `disconnectTailscale`,
  `getTailscalePeers`), all routed through `tenantProxy`. The
  `connectTailscale` action takes `{authkey?: string}` — passes
  through to ctrl-api but NEVER echoes the key back to the client.
- `.gitguardian.yaml` — allowlists the new test path the same way the
  ctrl-api test path was allowlisted.

## The 4 card states

```
┌─────────────────────────────────────────────────────┐
│ Tailscale                          Not connected    │
│ Sidecar is off — opt in below                       │
│ Join your tailnet — reach this tenant from any      │
│ device you trust.                                   │
│                                                     │
│ The Tailscale sidecar is off until first connect.   │
│ Paste an auth key for the fastest path, or let      │
│ tailscaled mint a device-auth URL you open…         │
│                                                     │
│ [ Connect via auth key ]   Use device auth URL      │
└─────────────────────────────────────────────────────┘
   ↑ disabled

┌─────────────────────────────────────────────────────┐
│ Tailscale                             Starting      │
│ Bringing the sidecar up…                            │
│                                                     │
│ Open the URL below in a new tab to authorise this   │
│ device on your tailnet. The card will refresh once  │
│ authorisation lands.                                │
│                                                     │
│ DEVICE-AUTH URL                                     │
│ ┌───────────────────────────────────────┐ ┌──────┐ │
│ │ https://login.tailscale.com/a/abc…    │ │ Copy │ │
│ └───────────────────────────────────────┘ └──────┘ │
│                                                     │
│ Polling status every 5s…   Cancel                   │
└─────────────────────────────────────────────────────┘
   ↑ connecting (Path C — device auth)

┌─────────────────────────────────────────────────────┐
│ Tailscale                             Connected     │
│ home-alfred-black                                   │
│ Join your tailnet — reach this tenant from any…     │
│                                                     │
│ This tenant is reachable on your tailnet.           │
│ Tailnet IP: 100.64.0.42. Last probe: 5 min ago.     │
│                                                     │
│ hostname    home-alfred-black                       │
│ tailnet ip  100.64.0.42                             │
│ peers       3                                       │
│                                                     │
│ Hide peers   [ Disconnect ]                         │
│ ─────────────────────────────────────────────────── │
│ ● macbook       100.64.0.10   macOS                 │
│ ● phone         100.64.0.11   iOS                   │
│ ○ desktop       100.64.0.12   Linux                 │
└─────────────────────────────────────────────────────┘
   ↑ connected (with peers expander open)

┌─────────────────────────────────────────────────────┐
│ Tailscale                         Needs attention   │
│ Needs attention                                     │
│                                                     │
│ docker compose up tailscale failed: exit code 1     │
│                                                     │
│ [ Try again ]   Disconnect                          │
└─────────────────────────────────────────────────────┘
   ↑ error
```

## Security

- The paste-authkey input is `type="password"` with `autoComplete="off"`.
  The key is trimmed, sent through `tenantProxy`, and immediately
  cleared from React state on success.
- Only the **first 6 chars** of the key may EVER appear in error toasts
  (via `redactAuthKey`).
- No log line or commit message in this PR stringifies a `tskey-…`
  value. Fixtures are all `tskey-auth-FIXTUREONLY-…` placeholders.

## Test count

- **18 new tests** in `tailscaleCardCore.test.ts` (all pass under
  `node:test`).
- Other dashboard card tests still pass: 71 baseline + 18 new = **89
  total**.
- The 24 pre-existing ctrl-api test failures are baseline — no ctrl
  code was touched here.

## Constraints honoured

- No new ctrl-api routes (PR4 will add cert + serve; ctrl-api returns
  501 today).
- No edits to docker-compose, migrations, or ctrl-api code.
- One PR for one logical change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)