### PR TITLE
feat(web): /files page — browser + upload + preview + quota (#114 PR3)

### DIFF
--- a/packages/web/main.wasp
+++ b/packages/web/main.wasp
@@ -353,6 +353,17 @@ page VaultPage {
   component: import VaultPage from "@src/dashboard/VaultPage"
 }
 
+// /files — principal-facing blob store (#114 PR3). Distinct from /vault:
+// the vault is the principal's knowledge surface (markdown the principal
+// reads and edits); /files is raw blob storage (PDFs, images, audio,
+// archives) that Alfred can read but the principal owns. Backed by
+// `files_data` named volume + ctrl-api routes shipped in PR1.
+route FilesRoute { path: "/files", to: FilesPage }
+page FilesPage {
+  authRequired: true,
+  component: import FilesPage from "@src/dashboard/FilesPage"
+}
+
 // /matters + /matters/:id — long-running concerns (M4 #859).
 route MattersRoute { path: "/matters", to: MattersPage }
 page MattersPage {
@@ -537,6 +548,34 @@ query getVaultRecord {
 // cached on the tenant side).
 query getVaultTitleIndex {
   fn: import { getVaultTitleIndex } from "@src/dashboard/operations",
+  entities: []
+}
+
+// /files — principal-facing blob store (#114 PR3). Read endpoints flow
+// through standard Wasp queries; upload + blob (multipart / raw bytes)
+// ride through src/server/filesProxy.ts (registered in setup.ts).
+query getFilesUsage {
+  fn: import { getFilesUsage } from "@src/dashboard/operations",
+  entities: []
+}
+
+query getFilesList {
+  fn: import { getFilesList } from "@src/dashboard/operations",
+  entities: []
+}
+
+query getFileStat {
+  fn: import { getFileStat } from "@src/dashboard/operations",
+  entities: []
+}
+
+action updateFileLabel {
+  fn: import { updateFileLabel } from "@src/dashboard/operations",
+  entities: []
+}
+
+action deleteFile {
+  fn: import { deleteFile } from "@src/dashboard/operations",
   entities: []
 }
 

--- a/packages/web/src/client/components/ab/Frame.tsx
+++ b/packages/web/src/client/components/ab/Frame.tsx
@@ -24,6 +24,7 @@ const PRIMARY: NavItem[] = [
   { to: "/decisions", label: "Decisions", icon: "approval" },
   { to: "/matters", label: "Matters", icon: "matter" },
   { to: "/vault", label: "Vault", icon: "calling_card" },
+  { to: "/files", label: "Files", icon: "envelope" },
   { to: "/channels", label: "Channels", icon: "voice" },
   { to: "/chores", label: "Chores", icon: "pocket_watch" },
   { to: "/instincts", label: "Patterns", icon: "monocle" },

--- a/packages/web/src/dashboard/FilesPage.tsx
+++ b/packages/web/src/dashboard/FilesPage.tsx
@@ -1,0 +1,1012 @@
+// FilesPage — principal-facing blob store (#114 PR3).
+//
+// What this page is
+// -----------------
+// /files is the principal's raw storage surface — PDFs the accountant
+// sends, screenshots the household drops in, archive ZIPs, the odd MP3.
+// Vault is for markdown the principal reads and edits; /files is for
+// blobs Alfred can read but the principal owns. Distinct vocabulary,
+// distinct page. Backed by the `files_data` named volume + the ctrl-api
+// /api/v1/files/* surface shipped in PR1 and PATCH-extended in PR2.
+//
+// Layout (matches VaultPage's letterpress idiom):
+//
+//   ┌─ Frame ────────────────────────────────────────────────────────┐
+//   │  Files                                       + Upload          │
+//   │  [────── quota strip ──────]                                    │
+//   │  ┌──────────┬─────────────────────────┬─────────────────────┐   │
+//   │  │  tree    │   list (drop zone)      │   preview pane      │   │
+//   │  │  search  │                         │   stat + body       │   │
+//   │  └──────────┴─────────────────────────┴─────────────────────┘   │
+//   └────────────────────────────────────────────────────────────────┘
+//
+// Logic in FilesPageCore.ts is tested independently; this file is the
+// UI shell + the side-effect plumbing (uploads, blob preview fetches,
+// optimistic label edits).
+import { useEffect, useMemo, useRef, useState } from "react";
+import { config } from "wasp/client";
+import {
+  useQuery,
+  useAction,
+  getFilesUsage,
+  getFilesList,
+  getFileStat,
+  updateFileLabel,
+  deleteFile,
+} from "wasp/client/operations";
+import { Frame } from "../client/components/ab/Frame";
+import {
+  buildPrefixTree,
+  deriveQuotaView,
+  derivePreviewMode,
+  formatBytes,
+  formatUploadedAt,
+  labelDraftFor,
+  makeDebounceController,
+  reduceLabelEdit,
+  shortSha,
+  shouldRejectUpload,
+  uploadPercent,
+  type FileRow,
+  type FilesUsage,
+  type LabelEditState,
+  type PreviewMode,
+  type UploadItem,
+} from "./FilesPageCore";
+
+// ── localStorage session token (mirrors ChatWidget / TerminalPage) ──────────
+
+function getWaspSessionId(): string | null {
+  try {
+    const raw = localStorage.getItem("wasp:sessionId");
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Wasp server base — the SPA host and the api. host differ. */
+function apiBase(): string {
+  return (config.apiUrl ?? "").replace(/\/$/, "");
+}
+
+/** Build a `/api/files/blob/...` URL for the preview pane. The browser
+ *  attaches the session via `?token=` since <img>/<iframe> can't carry
+ *  an Authorization header. */
+function blobUrl(path: string): string {
+  const token = getWaspSessionId();
+  const enc = path
+    .split("/")
+    .filter(Boolean)
+    .map(encodeURIComponent)
+    .join("/");
+  const base = `${apiBase()}/api/files/blob/${enc}`;
+  return token ? `${base}?token=${encodeURIComponent(token)}` : base;
+}
+
+// ── upload helper ──────────────────────────────────────────────────────────
+
+interface UploadCallbacks {
+  onProgress: (loaded: number) => void;
+  onDone: (path: string) => void;
+  onError: (status: number, message: string) => void;
+}
+
+/** Native XHR for the multipart upload — `fetch` doesn't surface upload
+ *  progress events, and the principal expects a live progress bar on a
+ *  2 GB PDF. The body is a FormData with one `file` part + optional
+ *  text fields. */
+function uploadFile(file: File, callbacks: UploadCallbacks): XMLHttpRequest {
+  const xhr = new XMLHttpRequest();
+  xhr.open("POST", `${apiBase()}/api/files/upload`);
+  const token = getWaspSessionId();
+  if (token) xhr.setRequestHeader("Authorization", `Bearer ${token}`);
+
+  xhr.upload.addEventListener("progress", (e) => {
+    if (e.lengthComputable) callbacks.onProgress(e.loaded);
+  });
+
+  xhr.addEventListener("load", () => {
+    if (xhr.status >= 200 && xhr.status < 300) {
+      try {
+        const body = JSON.parse(xhr.responseText);
+        callbacks.onDone(String(body.path ?? ""));
+      } catch {
+        callbacks.onError(xhr.status, "Server response was not JSON");
+      }
+    } else {
+      let message = xhr.statusText || `HTTP ${xhr.status}`;
+      try {
+        const body = JSON.parse(xhr.responseText);
+        if (typeof body?.message === "string") message = body.message;
+        else if (typeof body?.error === "string") message = body.error;
+      } catch {
+        /* keep statusText fallback */
+      }
+      callbacks.onError(xhr.status, message);
+    }
+  });
+
+  xhr.addEventListener("error", () => {
+    callbacks.onError(0, "Network error");
+  });
+
+  const fd = new FormData();
+  fd.append("file", file);
+  fd.append("original_filename", file.name);
+  xhr.send(fd);
+  return xhr;
+}
+
+// ── tiny toast helper (this file's only side-effect surface) ────────────────
+//
+// We don't pull in a toast library; the existing `useToast` hook on
+// DeskPage requires Wasp's Toaster setup which isn't mounted on every
+// page. For /files we render a small banner at the bottom-right.
+
+interface Banner {
+  id: number;
+  tone: "error" | "info" | "success";
+  text: string;
+}
+
+// ── label edit map (one state per row) ─────────────────────────────────────
+
+type LabelEditMap = Record<string, LabelEditState>;
+
+// ── page ───────────────────────────────────────────────────────────────────
+
+export default function FilesPage() {
+  // Quota + list state. Refetch interval is generous (every 30s) because
+  // /usage is cheap (one SQL aggregate) and the page is editorial, not
+  // dashboardy — the strip just needs to be roughly correct.
+  const {
+    data: usageData,
+    refetch: refetchUsage,
+  } = useQuery(getFilesUsage, undefined, { retry: false });
+
+  // Search + prefix filter. `appliedQuery` is the value actually sent to
+  // the server (debounced); `pendingQuery` is what's in the input box.
+  const [pendingQuery, setPendingQuery] = useState("");
+  const [appliedQuery, setAppliedQuery] = useState("");
+  const [activePrefix, setActivePrefix] = useState("");
+
+  const {
+    data: listData,
+    refetch: refetchList,
+    isFetching: listFetching,
+  } = useQuery(
+    getFilesList,
+    { q: appliedQuery, prefix: activePrefix, limit: 200 },
+    { retry: false },
+  );
+
+  // Debounce the search box. 300ms cooldown — the controller lives for
+  // the lifetime of the page; the effect rewires onEmit each render so
+  // the latest `setAppliedQuery` reference is used.
+  const debounceRef = useRef<ReturnType<typeof makeDebounceController> | null>(
+    null,
+  );
+  if (!debounceRef.current) {
+    debounceRef.current = makeDebounceController(300, (v) =>
+      setAppliedQuery(v),
+    );
+  }
+  useEffect(() => {
+    return () => debounceRef.current?.cancel();
+  }, []);
+
+  function onSearchChange(value: string) {
+    setPendingQuery(value);
+    debounceRef.current?.push(value);
+  }
+
+  // List rows + tree.
+  const rows: FileRow[] = useMemo(() => {
+    const items = (listData as any)?.items;
+    return Array.isArray(items) ? (items as FileRow[]) : [];
+  }, [listData]);
+
+  const tree = useMemo(() => buildPrefixTree(rows), [rows]);
+
+  // Selection.
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const selectedRow = useMemo(
+    () => rows.find((r) => r.path === selectedPath) ?? null,
+    [rows, selectedPath],
+  );
+
+  // When the row list refreshes, drop selection if it disappeared.
+  useEffect(() => {
+    if (selectedPath && !rows.some((r) => r.path === selectedPath)) {
+      setSelectedPath(null);
+    }
+  }, [rows, selectedPath]);
+
+  // Stat for the selected row — drives the side-panel detail strip.
+  const { data: statData } = useQuery(
+    getFileStat,
+    { path: selectedPath ?? "" },
+    { enabled: Boolean(selectedPath), retry: false },
+  );
+
+  // Label edit map — one entry per row currently being edited.
+  const [labelEdits, setLabelEdits] = useState<LabelEditMap>({});
+  const labelEditAction = useAction(updateFileLabel);
+
+  function beginLabelEdit(row: FileRow) {
+    // Seed from the row's current canonical value — any prior edit state
+    // for this row is intentionally discarded (the reducer treats begin
+    // as an unconditional fresh start).
+    setLabelEdits((m) => ({
+      ...m,
+      [row.path]: reduceLabelEdit(
+        { kind: "idle", value: row.principal_label },
+        { type: "begin" },
+      ),
+    }));
+  }
+
+  function updateLabelDraft(path: string, draft: string) {
+    setLabelEdits((m) => {
+      const cur = m[path];
+      if (!cur) return m;
+      return { ...m, [path]: reduceLabelEdit(cur, { type: "change", draft }) };
+    });
+  }
+
+  function cancelLabelEdit(path: string) {
+    setLabelEdits((m) => {
+      const cur = m[path];
+      if (!cur) return m;
+      return { ...m, [path]: reduceLabelEdit(cur, { type: "cancel" }) };
+    });
+  }
+
+  async function commitLabelEdit(path: string) {
+    const cur = labelEdits[path];
+    if (!cur || cur.kind !== "editing") return;
+    const draft = cur.draft;
+    setLabelEdits((m) => ({
+      ...m,
+      [path]: reduceLabelEdit(cur, { type: "commit" }),
+    }));
+    try {
+      const next = await labelEditAction({
+        path,
+        principal_label: draft.trim() === "" ? null : draft.trim(),
+      });
+      setLabelEdits((m) => {
+        const cur2 = m[path];
+        if (!cur2) return m;
+        return {
+          ...m,
+          [path]: reduceLabelEdit(cur2, {
+            type: "saved",
+            value: (next as FileRow).principal_label,
+          }),
+        };
+      });
+      // Refetch list so the canonical row reflects the new label.
+      refetchList();
+    } catch (err: any) {
+      setLabelEdits((m) => {
+        const cur2 = m[path];
+        if (!cur2) return m;
+        return {
+          ...m,
+          [path]: reduceLabelEdit(cur2, {
+            type: "failed",
+            error: err?.message ?? "Save failed",
+          }),
+        };
+      });
+      addBanner("error", `Could not update label: ${err?.message ?? "error"}`);
+    }
+  }
+
+  // Delete handler.
+  const deleteAction = useAction(deleteFile);
+  async function onDelete(row: FileRow) {
+    const ok = window.confirm(
+      `Delete ${row.original_filename ?? row.path}? This is a soft-delete; the blob is removed but the row stays in the audit trail.`,
+    );
+    if (!ok) return;
+    try {
+      await deleteAction({ path: row.path });
+      addBanner("info", `Removed ${row.original_filename ?? row.path}`);
+      if (selectedPath === row.path) setSelectedPath(null);
+      refetchList();
+      refetchUsage();
+    } catch (err: any) {
+      addBanner("error", `Delete failed: ${err?.message ?? "error"}`);
+    }
+  }
+
+  // Upload zone — drag/drop + file-input. Tracks each in-flight upload as
+  // an UploadItem; completion refetches the list + usage.
+  const [uploads, setUploads] = useState<UploadItem[]>([]);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  function startUploads(files: File[]) {
+    const usage = (usageData ?? null) as FilesUsage | null;
+    const fresh: UploadItem[] = [];
+    for (const file of files) {
+      const reject = usage ? shouldRejectUpload(file.size, usage) : null;
+      if (reject) {
+        fresh.push({
+          key: `r-${Date.now()}-${Math.random()}`,
+          filename: file.name,
+          size: file.size,
+          loaded: 0,
+          status: "rejected",
+          error: reject,
+        });
+        addBanner("error", `Rejected ${file.name}: ${reject}`);
+        continue;
+      }
+      const key = `u-${Date.now()}-${Math.random()}`;
+      const queued: UploadItem = {
+        key,
+        filename: file.name,
+        size: file.size,
+        loaded: 0,
+        status: "queued",
+      };
+      fresh.push(queued);
+      // Mutate to "uploading" + start the XHR on next tick so the row
+      // appears in the queue first.
+      setTimeout(() => beginUploadXhr(key, file), 0);
+    }
+    if (fresh.length > 0) setUploads((u) => [...fresh, ...u]);
+  }
+
+  function beginUploadXhr(key: string, file: File) {
+    setUploads((u) =>
+      u.map((it) => (it.key === key ? { ...it, status: "uploading" } : it)),
+    );
+    uploadFile(file, {
+      onProgress: (loaded) => {
+        setUploads((u) =>
+          u.map((it) => (it.key === key ? { ...it, loaded } : it)),
+        );
+      },
+      onDone: (path) => {
+        setUploads((u) =>
+          u.map((it) =>
+            it.key === key
+              ? { ...it, status: "completed", loaded: it.size, resultPath: path }
+              : it,
+          ),
+        );
+        addBanner("success", `Uploaded ${file.name}`);
+        refetchList();
+        refetchUsage();
+      },
+      onError: (status, message) => {
+        setUploads((u) =>
+          u.map((it) =>
+            it.key === key
+              ? { ...it, status: "failed", error: `[${status}] ${message}` }
+              : it,
+          ),
+        );
+        addBanner("error", `Upload failed for ${file.name}: ${message}`);
+      },
+    });
+  }
+
+  function onFilePick(e: React.ChangeEvent<HTMLInputElement>) {
+    const files = Array.from(e.target.files ?? []);
+    if (files.length > 0) startUploads(files);
+    e.target.value = "";
+  }
+
+  function onDragOver(e: React.DragEvent) {
+    e.preventDefault();
+    setDragHot(true);
+  }
+  function onDragLeave(e: React.DragEvent) {
+    e.preventDefault();
+    setDragHot(false);
+  }
+  function onDrop(e: React.DragEvent) {
+    e.preventDefault();
+    setDragHot(false);
+    const files = Array.from(e.dataTransfer?.files ?? []);
+    if (files.length > 0) startUploads(files);
+  }
+  const [dragHot, setDragHot] = useState(false);
+
+  // Banner toasts.
+  const [banners, setBanners] = useState<Banner[]>([]);
+  function addBanner(tone: Banner["tone"], text: string) {
+    const id = Date.now() + Math.random();
+    setBanners((b) => [...b, { id, tone, text }]);
+    setTimeout(() => {
+      setBanners((b) => b.filter((it) => it.id !== id));
+    }, 5000);
+  }
+
+  // Quota view.
+  const quota = usageData ? deriveQuotaView(usageData as FilesUsage) : null;
+  const quotaColor =
+    quota?.band === "alarm"
+      ? "var(--alarm, #b94a48)"
+      : quota?.band === "warn"
+        ? "var(--amber, #c9952c)"
+        : "var(--brass)";
+
+  return (
+    <Frame>
+      <section className="mx-auto max-w-[1280px] px-8 py-10">
+        {/* Heading + upload action */}
+        <div className="flex items-baseline justify-between mb-4">
+          <div
+            className="font-mono text-[10px] uppercase tracking-[0.28em]"
+            style={{ color: "var(--brass)" }}
+          >
+            Files
+          </div>
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            className="font-mono text-[10px] uppercase tracking-[0.22em]"
+            style={{ color: "var(--brass)" }}
+          >
+            + Upload
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            onChange={onFilePick}
+            className="hidden"
+          />
+        </div>
+
+        <p
+          className="font-body text-[14px] mb-6 max-w-[58ch]"
+          style={{ color: "var(--marginalia)" }}
+        >
+          Raw documents Alfred can read on your behalf. Drop PDFs, screenshots,
+          archives — anything that doesn't belong in the vault as markdown.
+        </p>
+
+        {/* Quota strip */}
+        {quota && (
+          <div className="border border-rule p-3 mb-6">
+            <div
+              className="font-mono text-[10px] uppercase tracking-[0.22em] flex items-baseline justify-between mb-2"
+              style={{ color: "var(--marginalia)" }}
+            >
+              <span>Quota</span>
+              <span style={{ color: quotaColor }}>{quota.summaryLabel}</span>
+            </div>
+            <div
+              className="w-full h-1.5"
+              style={{ background: "color-mix(in oklab, var(--brass) 12%, transparent)" }}
+            >
+              <div
+                className="h-full transition-all"
+                style={{
+                  width: `${Math.max(2, Math.round(quota.fractionOfSoft * 100))}%`,
+                  background: quotaColor,
+                }}
+              />
+            </div>
+            <div
+              className="font-mono text-[10px] mt-2 flex items-baseline justify-between"
+              style={{ color: "var(--marginalia)" }}
+            >
+              <span>
+                {quota.usedLabel} of {quota.softCapLabel} soft cap
+              </span>
+              <span>
+                Per-upload limit{" "}
+                {formatBytes((usageData as FilesUsage).upload_hard_bytes)}
+              </span>
+            </div>
+          </div>
+        )}
+
+        {/* In-flight uploads */}
+        {uploads.length > 0 && (
+          <div className="border border-rule p-3 mb-6">
+            <div
+              className="font-mono text-[10px] uppercase tracking-[0.22em] mb-2"
+              style={{ color: "var(--marginalia)" }}
+            >
+              Uploads
+            </div>
+            <ul className="space-y-1">
+              {uploads.map((u) => (
+                <UploadRow key={u.key} item={u} />
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* Three-pane grid */}
+        <div
+          className={`grid grid-cols-[220px_1fr_320px] gap-6 border-t border-rule pt-6 min-h-[560px] ${
+            dragHot ? "ring-2 ring-[color:var(--brass)] ring-opacity-50" : ""
+          }`}
+          onDragOver={onDragOver}
+          onDragLeave={onDragLeave}
+          onDrop={onDrop}
+        >
+          {/* Left — prefix tree */}
+          <aside
+            className="border-r border-rule pr-4 overflow-auto"
+            style={{ maxHeight: "70vh" }}
+          >
+            <input
+              value={pendingQuery}
+              onChange={(e) => onSearchChange(e.target.value)}
+              placeholder="Search files…"
+              className="w-full bg-transparent border border-rule px-3 py-2 mb-4 font-body text-[14px] outline-none"
+              style={{ borderColor: "var(--rule)" }}
+            />
+            <button
+              type="button"
+              onClick={() => setActivePrefix("")}
+              className="w-full text-left flex items-baseline gap-2 py-1"
+              style={{
+                color: activePrefix === "" ? "var(--ink)" : "var(--marginalia)",
+              }}
+            >
+              <span
+                className="font-mono text-[10px] w-3"
+                style={{ color: "var(--brass)" }}
+              >
+                ▾
+              </span>
+              <span className="font-display italic text-[16px]">All files</span>
+              <span
+                className="font-mono text-[10px] ml-auto"
+                style={{ color: "var(--marginalia)" }}
+              >
+                {tree.count}
+              </span>
+            </button>
+            <ul className="mt-1">
+              {tree.children.map((node) => {
+                const active = activePrefix === node.prefix;
+                return (
+                  <li key={node.prefix}>
+                    <button
+                      type="button"
+                      onClick={() => setActivePrefix(node.prefix)}
+                      className="w-full text-left flex items-baseline gap-2 py-1 pl-5"
+                      style={{
+                        color: active ? "var(--ink)" : "var(--marginalia)",
+                        borderLeft: active
+                          ? "1px solid var(--brass)"
+                          : "1px solid transparent",
+                        marginLeft: -1,
+                      }}
+                    >
+                      <span className="font-mono text-[11px] truncate">
+                        {node.segment.slice(0, 10)}…
+                      </span>
+                      <span
+                        className="font-mono text-[10px] ml-auto"
+                        style={{ color: "var(--marginalia)" }}
+                      >
+                        {node.count}
+                      </span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          </aside>
+
+          {/* Centre — list + drop zone */}
+          <div
+            className="overflow-auto"
+            style={{ maxHeight: "70vh" }}
+          >
+            <div
+              className="border border-dashed p-4 mb-4 text-center"
+              style={{
+                borderColor: dragHot ? "var(--brass)" : "var(--rule)",
+                background: dragHot
+                  ? "color-mix(in oklab, var(--brass) 8%, transparent)"
+                  : "transparent",
+              }}
+            >
+              <div
+                className="font-mono text-[11px] uppercase tracking-[0.22em]"
+                style={{ color: "var(--marginalia)" }}
+              >
+                Drop files here, or use Upload above
+              </div>
+            </div>
+
+            {listFetching && rows.length === 0 && (
+              <p
+                className="font-body italic text-[14px]"
+                style={{ color: "var(--marginalia)" }}
+              >
+                Reading the file store…
+              </p>
+            )}
+            {!listFetching && rows.length === 0 && (
+              <p
+                className="font-body italic text-[14px]"
+                style={{ color: "var(--marginalia)" }}
+              >
+                {appliedQuery || activePrefix
+                  ? "Nothing matches that filter."
+                  : "No files yet. Drop one in to begin."}
+              </p>
+            )}
+
+            {rows.length > 0 && (
+              <table className="w-full font-body text-[13px]">
+                <thead>
+                  <tr
+                    className="font-mono text-[10px] uppercase tracking-[0.18em]"
+                    style={{ color: "var(--marginalia)" }}
+                  >
+                    <th className="text-left py-2 pr-3">Name</th>
+                    <th className="text-right py-2 pr-3">Size</th>
+                    <th className="text-left py-2 pr-3">Uploaded</th>
+                    <th className="text-left py-2 pr-3">Label</th>
+                    <th className="text-left py-2 pr-3">SHA-256</th>
+                    <th className="w-8"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows.map((row) => {
+                    const sel = row.path === selectedPath;
+                    const edit = labelEdits[row.path];
+                    const label = labelDraftFor(
+                      edit ?? { kind: "idle", value: row.principal_label },
+                      row.principal_label,
+                    );
+                    return (
+                      <tr
+                        key={row.id}
+                        onClick={() => setSelectedPath(row.path)}
+                        className="cursor-pointer hover:bg-[color-mix(in_oklab,var(--brass)_4%,transparent)]"
+                        style={{
+                          borderTop: "1px solid var(--rule)",
+                          background: sel
+                            ? "color-mix(in oklab, var(--brass) 8%, transparent)"
+                            : "transparent",
+                        }}
+                      >
+                        <td className="py-2 pr-3 truncate max-w-[260px]">
+                          {row.original_filename ?? row.path}
+                        </td>
+                        <td
+                          className="py-2 pr-3 text-right font-mono text-[11px]"
+                          style={{ color: "var(--marginalia)" }}
+                        >
+                          {formatBytes(row.size_bytes)}
+                        </td>
+                        <td
+                          className="py-2 pr-3 font-mono text-[11px]"
+                          style={{ color: "var(--marginalia)" }}
+                        >
+                          {formatUploadedAt(row.uploaded_at)}
+                        </td>
+                        <td className="py-2 pr-3" onClick={(e) => e.stopPropagation()}>
+                          {edit && (edit.kind === "editing" || edit.kind === "saving") ? (
+                            <input
+                              autoFocus
+                              value={edit.draft}
+                              onChange={(e) =>
+                                updateLabelDraft(row.path, e.target.value)
+                              }
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter") {
+                                  e.preventDefault();
+                                  commitLabelEdit(row.path);
+                                }
+                                if (e.key === "Escape") {
+                                  e.preventDefault();
+                                  cancelLabelEdit(row.path);
+                                }
+                              }}
+                              onBlur={() => {
+                                // onBlur after Enter would otherwise double-fire commit;
+                                // the reducer ignores commit on non-editing states so it's
+                                // safe, but we skip if already saving for clarity.
+                                if (edit.kind === "editing") commitLabelEdit(row.path);
+                              }}
+                              disabled={edit.kind === "saving"}
+                              className="bg-transparent border border-rule px-2 py-1 font-body text-[12px] w-full outline-none"
+                            />
+                          ) : (
+                            <button
+                              type="button"
+                              onClick={() => beginLabelEdit(row)}
+                              className="text-left font-body text-[12px] italic"
+                              style={{
+                                color: label ? "var(--ink)" : "var(--marginalia)",
+                              }}
+                              title="Click to edit label"
+                            >
+                              {label || "(add label)"}
+                            </button>
+                          )}
+                        </td>
+                        <td
+                          className="py-2 pr-3 font-mono text-[11px]"
+                          style={{ color: "var(--marginalia)" }}
+                        >
+                          {shortSha(row.sha256)}
+                        </td>
+                        <td onClick={(e) => e.stopPropagation()}>
+                          <button
+                            type="button"
+                            onClick={() => onDelete(row)}
+                            className="font-mono text-[10px]"
+                            style={{ color: "var(--marginalia)" }}
+                            title="Delete"
+                          >
+                            ✕
+                          </button>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            )}
+          </div>
+
+          {/* Right — preview pane */}
+          <aside
+            className="border-l border-rule pl-4 overflow-auto sticky top-6"
+            style={{ maxHeight: "70vh" }}
+          >
+            {selectedRow ? (
+              <PreviewPane row={selectedRow} stat={statData as FileRow | null} />
+            ) : (
+              <p
+                className="font-body italic text-[14px]"
+                style={{ color: "var(--marginalia)" }}
+              >
+                Select a file to preview.
+              </p>
+            )}
+          </aside>
+        </div>
+
+        {/* Banners */}
+        {banners.length > 0 && (
+          <div className="fixed bottom-6 right-6 space-y-2 z-40">
+            {banners.map((b) => (
+              <div
+                key={b.id}
+                className="border px-4 py-2 font-mono text-[11px] max-w-[420px]"
+                style={{
+                  borderColor:
+                    b.tone === "error"
+                      ? "var(--alarm, #b94a48)"
+                      : b.tone === "success"
+                        ? "var(--brass)"
+                        : "var(--rule)",
+                  background: "var(--paper, #faf6ef)",
+                  color: "var(--ink)",
+                }}
+              >
+                {b.text}
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </Frame>
+  );
+}
+
+// ── upload row ─────────────────────────────────────────────────────────────
+
+function UploadRow({ item }: { item: UploadItem }) {
+  const pct = Math.round(uploadPercent(item));
+  const isDone = item.status === "completed";
+  const isFailed = item.status === "failed" || item.status === "rejected";
+  const tone = isFailed
+    ? "var(--alarm, #b94a48)"
+    : isDone
+      ? "var(--brass)"
+      : "var(--marginalia)";
+  return (
+    <li className="font-mono text-[11px]">
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="truncate flex-1">
+          {item.filename}{" "}
+          <span style={{ color: "var(--marginalia)" }}>
+            ({formatBytes(item.size)})
+          </span>
+        </span>
+        <span style={{ color: tone }}>
+          {isDone ? "✓ done" : isFailed ? `✗ ${item.error ?? "failed"}` : `${pct}%`}
+        </span>
+      </div>
+      {!isFailed && (
+        <div
+          className="w-full h-[2px] mt-1"
+          style={{ background: "var(--rule)" }}
+        >
+          <div
+            className="h-full"
+            style={{ width: `${pct}%`, background: tone }}
+          />
+        </div>
+      )}
+    </li>
+  );
+}
+
+// ── preview pane ───────────────────────────────────────────────────────────
+
+function PreviewPane({
+  row,
+  stat,
+}: {
+  row: FileRow;
+  stat: FileRow | null;
+}) {
+  const mode: PreviewMode = useMemo(
+    () => derivePreviewMode(row.content_type, row.original_filename ?? row.path),
+    [row],
+  );
+  const url = blobUrl(row.path);
+  const filename = row.original_filename ?? row.path;
+  const stat_size = stat?.size_bytes ?? row.size_bytes;
+  const stat_uploaded = stat?.uploaded_at ?? row.uploaded_at;
+
+  return (
+    <div className="space-y-3">
+      <div className="font-mono text-[10px] uppercase tracking-[0.22em]" style={{ color: "var(--brass)" }}>
+        Preview
+      </div>
+      <div className="font-display text-[18px] italic break-words">{filename}</div>
+      <div className="font-mono text-[11px]" style={{ color: "var(--marginalia)" }}>
+        {formatBytes(stat_size)} · {formatUploadedAt(stat_uploaded)}
+      </div>
+
+      {mode === "image" && (
+        <img
+          src={url}
+          alt={filename}
+          className="max-w-full border border-rule"
+        />
+      )}
+
+      {mode === "pdf" && (
+        <iframe
+          src={url}
+          title={filename}
+          className="w-full border border-rule"
+          style={{ height: 480 }}
+        />
+      )}
+
+      {mode === "text" && <TextPreview url={url} />}
+
+      {mode === "audio" && (
+        <audio controls className="w-full" src={url} />
+      )}
+
+      {mode === "video" && (
+        <video controls className="w-full max-h-[420px]" src={url} />
+      )}
+
+      {mode === "unknown" && (
+        <div
+          className="border border-dashed p-4 font-mono text-[11px]"
+          style={{ color: "var(--marginalia)" }}
+        >
+          No inline preview for this file type.
+        </div>
+      )}
+
+      <a
+        href={url}
+        download={filename}
+        className="font-mono text-[10px] uppercase tracking-[0.22em] block mt-3"
+        style={{ color: "var(--brass)" }}
+      >
+        ↓ Download
+      </a>
+
+      {/* Full stat */}
+      <details className="border-t border-rule pt-3 mt-3">
+        <summary
+          className="cursor-pointer font-mono text-[10px] uppercase tracking-[0.22em]"
+          style={{ color: "var(--marginalia)" }}
+        >
+          Details
+        </summary>
+        <dl className="grid grid-cols-[100px_1fr] gap-y-1 mt-3 font-mono text-[11px]">
+          <dt style={{ color: "var(--marginalia)" }}>path</dt>
+          <dd className="break-all">{row.path}</dd>
+          <dt style={{ color: "var(--marginalia)" }}>sha256</dt>
+          <dd className="break-all">{row.sha256}</dd>
+          <dt style={{ color: "var(--marginalia)" }}>content-type</dt>
+          <dd>{row.content_type ?? "—"}</dd>
+          <dt style={{ color: "var(--marginalia)" }}>uploaded by</dt>
+          <dd>{row.uploaded_by}</dd>
+          {row.last_accessed_at && (
+            <>
+              <dt style={{ color: "var(--marginalia)" }}>last read</dt>
+              <dd>{formatUploadedAt(row.last_accessed_at)}</dd>
+            </>
+          )}
+        </dl>
+      </details>
+    </div>
+  );
+}
+
+// ── text preview (small fetch, bail above 256k) ────────────────────────────
+
+function TextPreview({ url }: { url: string }) {
+  const [body, setBody] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setBody(null);
+    setError(null);
+    (async () => {
+      try {
+        const r = await fetch(url, { credentials: "omit" });
+        if (!r.ok) {
+          if (!cancelled) setError(`HTTP ${r.status}`);
+          return;
+        }
+        const text = await r.text();
+        if (cancelled) return;
+        // Cap at 256k chars so we don't blow up the page on a 20 MB CSV.
+        if (text.length > 256_000) {
+          setBody(text.slice(0, 256_000) + "\n\n… (truncated)");
+        } else {
+          setBody(text);
+        }
+      } catch (err: any) {
+        if (!cancelled) setError(err?.message ?? "fetch failed");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  if (error) {
+    return (
+      <div
+        className="font-mono text-[11px] border border-rule p-3"
+        style={{ color: "var(--alarm, #b94a48)" }}
+      >
+        Could not load preview: {error}
+      </div>
+    );
+  }
+  if (body === null) {
+    return (
+      <div
+        className="font-mono text-[11px] italic"
+        style={{ color: "var(--marginalia)" }}
+      >
+        Loading preview…
+      </div>
+    );
+  }
+  return (
+    <pre
+      className="border border-rule p-3 overflow-auto font-mono text-[11px]"
+      style={{ maxHeight: 360, whiteSpace: "pre-wrap" }}
+    >
+      {body}
+    </pre>
+  );
+}

--- a/packages/web/src/dashboard/FilesPageCore.test.ts
+++ b/packages/web/src/dashboard/FilesPageCore.test.ts
@@ -1,0 +1,373 @@
+/**
+ * /files — pure logic tests for the principal-facing blob browser
+ * (#114 PR3). Mirrors the *CardCore.test.ts pattern used elsewhere on
+ * the dashboard so the page can lean on tested fundamentals while the
+ * React layer stays UI-only.
+ *
+ * Run with:
+ *   cd packages/web && npx tsx --test src/dashboard/FilesPageCore.test.ts
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildPrefixTree,
+  deriveQuotaView,
+  derivePreviewMode,
+  filterByPrefix,
+  formatBytes,
+  formatUploadedAt,
+  labelDraftFor,
+  makeDebounceController,
+  reduceLabelEdit,
+  shortSha,
+  shouldRejectUpload,
+  uploadPercent,
+  type FileRow,
+  type FilesUsage,
+  type LabelEditState,
+  type UploadItem,
+} from "./FilesPageCore";
+
+// ── shared fixtures ────────────────────────────────────────────────────────
+
+const MB = 1024 * 1024;
+const GB = 1024 * MB;
+
+const USAGE_FRESH: FilesUsage = {
+  used_bytes: 0,
+  count: 0,
+  soft_cap_bytes: 10 * GB,
+  hard_cap_bytes: 20 * GB,
+  upload_soft_bytes: 250 * MB,
+  upload_hard_bytes: 2 * GB,
+};
+
+const FROZEN_NOW = new Date("2026-05-29T12:00:00Z");
+
+function rowAt(uploaded_at: number, path: string, extras: Partial<FileRow> = {}): FileRow {
+  return {
+    id: path.split("/")[0] ?? "X",
+    path,
+    size_bytes: 1024,
+    sha256: "deadbeefcafebabe000000000000000000000000000000000000000000000000",
+    content_type: null,
+    original_filename: path.split("/").pop() ?? null,
+    principal_label: null,
+    uploaded_by: "principal",
+    uploaded_at,
+    last_accessed_at: null,
+    deleted_at: null,
+    ...extras,
+  };
+}
+
+// ── 1 · quota math ─────────────────────────────────────────────────────────
+
+test("formatBytes: B / KB / MB / GB rendering", () => {
+  assert.equal(formatBytes(0), "0 B");
+  assert.equal(formatBytes(512), "512 B");
+  assert.equal(formatBytes(1024), "1 KB");
+  assert.equal(formatBytes(1536), "1.5 KB");
+  assert.equal(formatBytes(MB), "1 MB");
+  assert.equal(formatBytes(2 * GB), "2 GB");
+  assert.equal(formatBytes(-1), "0 B"); // defensive
+});
+
+test("deriveQuotaView: empty store is calm at 0%", () => {
+  const v = deriveQuotaView(USAGE_FRESH);
+  assert.equal(v.band, "calm");
+  assert.equal(v.fractionOfSoft, 0);
+  assert.equal(v.percentOfSoft, 0);
+  assert.equal(v.usedLabel, "0 B");
+  assert.equal(v.softCapLabel, "10 GB");
+  assert.equal(v.summaryLabel, "0% of 10 GB used");
+});
+
+test("deriveQuotaView: 50% of soft is calm", () => {
+  const v = deriveQuotaView({ ...USAGE_FRESH, used_bytes: 5 * GB });
+  assert.equal(v.band, "calm");
+  assert.equal(v.fractionOfSoft, 0.5);
+  assert.equal(Math.round(v.percentOfSoft), 50);
+});
+
+test("deriveQuotaView: 80% of soft trips the amber warn band", () => {
+  const v = deriveQuotaView({ ...USAGE_FRESH, used_bytes: 8 * GB });
+  assert.equal(v.band, "warn");
+  assert.equal(v.fractionOfSoft, 0.8);
+});
+
+test("deriveQuotaView: ≥ hard cap is the alarm band, bar pinned at 100%", () => {
+  const v = deriveQuotaView({ ...USAGE_FRESH, used_bytes: 20 * GB });
+  assert.equal(v.band, "alarm");
+  assert.equal(v.fractionOfSoft, 1); // clamped
+  assert.equal(Math.round(v.percentOfSoft), 200);
+});
+
+test("deriveQuotaView: just over hard cap stays alarm", () => {
+  const v = deriveQuotaView({ ...USAGE_FRESH, used_bytes: 22 * GB });
+  assert.equal(v.band, "alarm");
+});
+
+// ── 2 · preview mode ───────────────────────────────────────────────────────
+
+test("derivePreviewMode: content-type wins for image/*", () => {
+  assert.equal(derivePreviewMode("image/png", "blob"), "image");
+  assert.equal(derivePreviewMode("image/jpeg", "anything.zzz"), "image");
+});
+
+test("derivePreviewMode: application/pdf → pdf", () => {
+  assert.equal(derivePreviewMode("application/pdf", null), "pdf");
+});
+
+test("derivePreviewMode: text/* and structured-text fall into text", () => {
+  assert.equal(derivePreviewMode("text/plain", "x.txt"), "text");
+  assert.equal(derivePreviewMode("application/json", "x.json"), "text");
+  assert.equal(derivePreviewMode("text/markdown", "x.md"), "text");
+});
+
+test("derivePreviewMode: extension fallback when content-type is missing", () => {
+  assert.equal(derivePreviewMode(null, "report.PDF"), "pdf");
+  assert.equal(derivePreviewMode("", "notes.md"), "text");
+  assert.equal(derivePreviewMode(null, "screenshot.png"), "image");
+  assert.equal(derivePreviewMode(null, "track.mp3"), "audio");
+  assert.equal(derivePreviewMode(null, "clip.webm"), "video");
+});
+
+test("derivePreviewMode: truly unknown blob is unknown (caller renders stat + download)", () => {
+  assert.equal(derivePreviewMode(null, "archive.bin"), "unknown");
+  assert.equal(derivePreviewMode("application/octet-stream", "no-ext"), "unknown");
+});
+
+// ── 3 · search debounce ────────────────────────────────────────────────────
+//
+// We avoid node:timers/promises here so the test stays deterministic — a
+// hand-rolled fake scheduler advances "time" synchronously and tracks
+// whether the pending handle was correctly cleared on the next push.
+
+function makeFakeScheduler() {
+  const pending: { ms: number; cb: () => void; handle: number }[] = [];
+  let nextHandle = 1;
+  return {
+    setTimeout(cb: () => void, ms: number) {
+      const handle = nextHandle++;
+      pending.push({ ms, cb, handle });
+      return handle;
+    },
+    clearTimeout(handle: unknown) {
+      const idx = pending.findIndex((p) => p.handle === handle);
+      if (idx >= 0) pending.splice(idx, 1);
+    },
+    /** Fire every pending callback in FIFO order. */
+    flush() {
+      while (pending.length > 0) {
+        const next = pending.shift()!;
+        next.cb();
+      }
+    },
+    countPending() {
+      return pending.length;
+    },
+  };
+}
+
+test("makeDebounceController: emits the latest value after the cooldown", () => {
+  const fake = makeFakeScheduler();
+  let last = "";
+  const ctl = makeDebounceController(
+    300,
+    (v) => {
+      last = v;
+    },
+    fake,
+  );
+  ctl.push("a");
+  assert.equal(fake.countPending(), 1);
+  assert.equal(ctl.pending(), true);
+  assert.equal(last, ""); // not yet emitted
+
+  fake.flush();
+  assert.equal(last, "a");
+  assert.equal(ctl.pending(), false);
+});
+
+test("makeDebounceController: a new push resets the timer (keystroke storm)", () => {
+  const fake = makeFakeScheduler();
+  let emissions = 0;
+  let last = "";
+  const ctl = makeDebounceController(
+    300,
+    (v) => {
+      emissions += 1;
+      last = v;
+    },
+    fake,
+  );
+  ctl.push("a");
+  ctl.push("ab");
+  ctl.push("abc");
+  // Only ONE pending timer should exist — the prior two were cleared.
+  assert.equal(fake.countPending(), 1);
+  fake.flush();
+  assert.equal(emissions, 1);
+  assert.equal(last, "abc");
+});
+
+test("makeDebounceController: cancel() drops the pending emission", () => {
+  const fake = makeFakeScheduler();
+  let emissions = 0;
+  const ctl = makeDebounceController(
+    300,
+    () => {
+      emissions += 1;
+    },
+    fake,
+  );
+  ctl.push("x");
+  ctl.cancel();
+  assert.equal(ctl.pending(), false);
+  fake.flush();
+  assert.equal(emissions, 0);
+});
+
+// ── 4 · label-edit state machine ───────────────────────────────────────────
+
+test("reduceLabelEdit: idle → editing → saving → settled", () => {
+  let s: LabelEditState = { kind: "idle", value: null };
+  s = reduceLabelEdit(s, { type: "begin" });
+  assert.equal(s.kind, "editing");
+  s = reduceLabelEdit(s, { type: "change", draft: "Tax 2024" });
+  assert.equal(s.kind, "editing");
+  if (s.kind === "editing") assert.equal(s.draft, "Tax 2024");
+  s = reduceLabelEdit(s, { type: "commit" });
+  assert.equal(s.kind, "saving");
+  s = reduceLabelEdit(s, { type: "saved", value: "Tax 2024" });
+  assert.equal(s.kind, "settled");
+  if (s.kind === "settled") assert.equal(s.value, "Tax 2024");
+});
+
+test("reduceLabelEdit: saving → failed reverts to the original value", () => {
+  let s: LabelEditState = { kind: "idle", value: "old" };
+  s = reduceLabelEdit(s, { type: "begin" });
+  s = reduceLabelEdit(s, { type: "change", draft: "new" });
+  s = reduceLabelEdit(s, { type: "commit" });
+  s = reduceLabelEdit(s, { type: "failed", error: "503" });
+  assert.equal(s.kind, "reverted");
+  if (s.kind === "reverted") {
+    assert.equal(s.value, "old");
+    assert.equal(s.error, "503");
+  }
+});
+
+test("reduceLabelEdit: editing → cancel restores the original value", () => {
+  let s: LabelEditState = { kind: "idle", value: "keep me" };
+  s = reduceLabelEdit(s, { type: "begin" });
+  s = reduceLabelEdit(s, { type: "change", draft: "DROP TABLE" });
+  s = reduceLabelEdit(s, { type: "cancel" });
+  assert.equal(s.kind, "idle");
+  if (s.kind === "idle") assert.equal(s.value, "keep me");
+});
+
+test("labelDraftFor: optimistic display during editing/saving", () => {
+  const idle: LabelEditState = { kind: "idle", value: "row" };
+  assert.equal(labelDraftFor(idle, "fallback"), "row");
+  const editing: LabelEditState = { kind: "editing", draft: "typed", original: "row" };
+  assert.equal(labelDraftFor(editing, "fallback"), "typed");
+  const saving: LabelEditState = { kind: "saving", draft: "typed", original: "row" };
+  assert.equal(labelDraftFor(saving, "fallback"), "typed");
+  const settled: LabelEditState = { kind: "settled", value: "confirmed" };
+  assert.equal(labelDraftFor(settled, "fallback"), "confirmed");
+  const reverted: LabelEditState = { kind: "reverted", value: "row", error: "x" };
+  assert.equal(labelDraftFor(reverted, "fallback"), "row");
+});
+
+// ── 5 · upload state ───────────────────────────────────────────────────────
+
+test("uploadPercent: clamps and reports 100 on completed", () => {
+  const queued: UploadItem = {
+    key: "k",
+    filename: "a.pdf",
+    size: 100,
+    loaded: 0,
+    status: "queued",
+  };
+  assert.equal(uploadPercent(queued), 0);
+  const half: UploadItem = { ...queued, status: "uploading", loaded: 50 };
+  assert.equal(uploadPercent(half), 50);
+  const done: UploadItem = { ...queued, status: "completed", loaded: 100 };
+  assert.equal(uploadPercent(done), 100);
+  // Server's reported `loaded` overshooting is clamped — XHR
+  // progressEvent.total can occasionally exceed `size` by a header byte.
+  const over: UploadItem = { ...queued, status: "uploading", loaded: 200 };
+  assert.equal(uploadPercent(over), 100);
+});
+
+test("shouldRejectUpload: oversize trips per-upload hard cap", () => {
+  const reason = shouldRejectUpload(3 * GB, USAGE_FRESH);
+  assert.match(reason ?? "", /per-upload hard cap/);
+});
+
+test("shouldRejectUpload: tail would push past tenant hard cap", () => {
+  const near = { ...USAGE_FRESH, used_bytes: 19.9 * GB };
+  const reason = shouldRejectUpload(0.5 * GB, near);
+  assert.match(reason ?? "", /hard cap/);
+});
+
+test("shouldRejectUpload: well-within is accepted", () => {
+  assert.equal(shouldRejectUpload(10 * MB, USAGE_FRESH), null);
+});
+
+// ── 6 · prefix tree + display helpers ──────────────────────────────────────
+
+test("buildPrefixTree: groups by leading ULID segment, newest-first", () => {
+  const rows: FileRow[] = [
+    rowAt(1000, "01ABC/old.pdf"),
+    rowAt(3000, "01XYZ/newest.png"),
+    rowAt(2000, "01ABC/middle.pdf"),
+  ];
+  const tree = buildPrefixTree(rows);
+  assert.equal(tree.count, 3);
+  assert.equal(tree.children.length, 2);
+  // Newest ULID surfaced first because we sort by uploaded_at desc
+  // and pull the leading segment as we go.
+  assert.equal(tree.children[0].segment, "01XYZ");
+  assert.equal(tree.children[0].count, 1);
+  assert.equal(tree.children[1].segment, "01ABC");
+  assert.equal(tree.children[1].count, 2);
+});
+
+test("filterByPrefix: a prefix narrows the list, empty returns input", () => {
+  const rows: FileRow[] = [
+    rowAt(1, "01ABC/a.pdf"),
+    rowAt(2, "01XYZ/b.png"),
+    rowAt(3, "01ABC/c.txt"),
+  ];
+  assert.equal(filterByPrefix(rows, "").length, 3);
+  assert.equal(filterByPrefix(rows, "01ABC/").length, 2);
+  assert.equal(filterByPrefix(rows, "01XYZ/").length, 1);
+  assert.equal(filterByPrefix(rows, "01NOPE/").length, 0);
+});
+
+test("shortSha: 12-char column display, safe on short or null-ish inputs", () => {
+  assert.equal(shortSha("deadbeefcafebabe1234"), "deadbeefcafe");
+  assert.equal(shortSha("abc"), "abc");
+  assert.equal(shortSha(""), "");
+});
+
+test("formatUploadedAt: relative buckets up to a week, then ISO date", () => {
+  const min = 60_000;
+  const hour = 60 * min;
+  const day = 24 * hour;
+  const now = FROZEN_NOW;
+  assert.equal(formatUploadedAt(now.getTime() - 30_000, now), "just now");
+  assert.equal(formatUploadedAt(now.getTime() - 5 * min, now), "5 min ago");
+  assert.equal(formatUploadedAt(now.getTime() - 2 * hour, now), "2 h ago");
+  assert.equal(formatUploadedAt(now.getTime() - 3 * day, now), "3 d ago");
+  // Beyond a week → ISO date (YYYY-MM-DD)
+  assert.match(
+    formatUploadedAt(now.getTime() - 30 * day, now),
+    /^\d{4}-\d{2}-\d{2}$/,
+  );
+  assert.equal(formatUploadedAt(now.getTime() + 60_000, now), "in the future");
+});

--- a/packages/web/src/dashboard/FilesPageCore.ts
+++ b/packages/web/src/dashboard/FilesPageCore.ts
@@ -1,0 +1,458 @@
+// FilesPageCore — pure logic for /files (#114 PR3).
+//
+// Why this file exists
+// --------------------
+// FilesPage.tsx mixes React state, Wasp queries, framer-motion, and DOM
+// drag/drop wiring. The four pieces that actually deserve test coverage
+// are pure functions of inputs:
+//
+//   * quota math    — `used / soft_cap`, the 80%-of-soft warning band,
+//                     the at-hard-cap red band, byte formatting.
+//   * preview mode  — given a filename + content-type, which preview
+//                     do we render? image / text / pdf / unknown.
+//   * search debounce — the cooldown timer the search box uses so we
+//                     don't fire a `/list?q=` on every keystroke.
+//   * label edit    — optimistic-update state machine the inline pencil
+//                     uses (idle → editing → saving → settled|reverted).
+//
+// All four are deterministic, side-effect-free, and free of React. The
+// page composes them and wires them to `useState` / `useEffect`.
+
+// ── shared file row shape (mirrors the ctrl-api response) ──────────────────
+//
+// `path` is the relative tail under FILES_ROOT (`<ULID>/<safe-name>`).
+// `principal_label` is the only field /files lets the principal edit
+// (PR2 of #114 — PATCH /api/v1/files/:path).
+export interface FileRow {
+  id: string;
+  path: string;
+  size_bytes: number;
+  sha256: string;
+  content_type: string | null;
+  original_filename: string | null;
+  principal_label: string | null;
+  uploaded_by: string;
+  uploaded_at: number;
+  last_accessed_at: number | null;
+  deleted_at: number | null;
+}
+
+export interface FilesUsage {
+  used_bytes: number;
+  count: number;
+  soft_cap_bytes: number;
+  hard_cap_bytes: number;
+  upload_soft_bytes: number;
+  upload_hard_bytes: number;
+}
+
+// ── 1 · quota math ─────────────────────────────────────────────────────────
+
+export type QuotaBand = "calm" | "warn" | "alarm";
+
+export interface QuotaView {
+  /** 0..1 of soft cap (clamped to [0,1] — used for the bar width). */
+  fractionOfSoft: number;
+  /** True percent of soft cap (may exceed 100). */
+  percentOfSoft: number;
+  /** Band used to colour the bar — sage (calm), amber (warn ≥ 80% soft),
+   *  red (alarm at or past hard cap). */
+  band: QuotaBand;
+  /** Human-readable used + soft cap pair (e.g. "1.2 GB / 10 GB"). */
+  usedLabel: string;
+  softCapLabel: string;
+  /** "12% of 10 GB used" line shown next to the bar. */
+  summaryLabel: string;
+}
+
+/** Bytes → human ("1.2 GB"). Binary (1024) base, two-letter unit. Negative
+ *  inputs are treated as zero (the server should never send one but we
+ *  defend the strip). */
+export function formatBytes(bytes: number): string {
+  const n = Math.max(0, Math.floor(bytes));
+  if (n < 1024) return `${n} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let value = n / 1024;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  // Show one decimal for non-byte units, but trim a trailing ".0" so
+  // "1 GB" doesn't render as "1.0 GB".
+  const fixed = value.toFixed(1);
+  const trimmed = fixed.endsWith(".0") ? fixed.slice(0, -2) : fixed;
+  return `${trimmed} ${units[unit]}`;
+}
+
+/** Derive the quota strip view from a `/usage` response. */
+export function deriveQuotaView(u: FilesUsage): QuotaView {
+  const soft = Math.max(1, u.soft_cap_bytes); // /1 guard, never /0
+  const hard = Math.max(soft, u.hard_cap_bytes);
+  const used = Math.max(0, u.used_bytes);
+  const fraction = Math.min(1, used / soft);
+  const percentExact = (used / soft) * 100;
+  // Spec: amber at 80% of soft; red at or past hard cap.
+  const band: QuotaBand =
+    used >= hard ? "alarm" : percentExact >= 80 ? "warn" : "calm";
+  const usedLabel = formatBytes(used);
+  const softCapLabel = formatBytes(soft);
+  const summaryLabel = `${Math.round(percentExact)}% of ${softCapLabel} used`;
+  return {
+    fractionOfSoft: fraction,
+    percentOfSoft: percentExact,
+    band,
+    usedLabel,
+    softCapLabel,
+    summaryLabel,
+  };
+}
+
+// ── 2 · preview mode ───────────────────────────────────────────────────────
+
+export type PreviewMode =
+  | "image"
+  | "pdf"
+  | "text"
+  | "audio"
+  | "video"
+  | "unknown";
+
+const EXT_TO_MODE: Record<string, PreviewMode> = {
+  png: "image",
+  jpg: "image",
+  jpeg: "image",
+  gif: "image",
+  webp: "image",
+  svg: "image",
+  pdf: "pdf",
+  txt: "text",
+  md: "text",
+  json: "text",
+  csv: "text",
+  html: "text",
+  htm: "text",
+  log: "text",
+  yaml: "text",
+  yml: "text",
+  xml: "text",
+  ts: "text",
+  tsx: "text",
+  js: "text",
+  jsx: "text",
+  py: "text",
+  go: "text",
+  rs: "text",
+  sh: "text",
+  mp3: "audio",
+  wav: "audio",
+  m4a: "audio",
+  ogg: "audio",
+  mp4: "video",
+  webm: "video",
+  mov: "video",
+};
+
+/** Decide the preview mode from the row's content type + filename. The
+ *  content type is preferred when present (the server sniffed it from the
+ *  upload); the extension is a fallback for blobs the server couldn't
+ *  identify (no Content-Type from the upload AND an unknown extension). */
+export function derivePreviewMode(
+  contentType: string | null | undefined,
+  filename: string | null | undefined,
+): PreviewMode {
+  const ct = (contentType ?? "").toLowerCase();
+  if (ct.startsWith("image/")) return "image";
+  if (ct === "application/pdf") return "pdf";
+  if (ct.startsWith("audio/")) return "audio";
+  if (ct.startsWith("video/")) return "video";
+  // text/* AND a small allowlist of structured text types we trust the
+  // browser to render in a <pre> without escaping pain.
+  if (
+    ct.startsWith("text/") ||
+    ct === "application/json" ||
+    ct === "application/xml" ||
+    ct === "application/x-yaml"
+  ) {
+    return "text";
+  }
+
+  const name = filename ?? "";
+  const dot = name.lastIndexOf(".");
+  if (dot < 0) return "unknown";
+  const ext = name.slice(dot + 1).toLowerCase();
+  return EXT_TO_MODE[ext] ?? "unknown";
+}
+
+// ── 3 · search debounce ────────────────────────────────────────────────────
+
+export interface DebounceController {
+  /** Trigger a new emission. Resets any pending timer; emits after `delayMs`. */
+  push(value: string): void;
+  /** Cancel the pending emission (e.g. on unmount). */
+  cancel(): void;
+  /** True iff a deferred emission is currently scheduled. */
+  pending(): boolean;
+}
+
+/** Build a debounce controller. `delayMs` typically 300 for search boxes;
+ *  `onEmit` is called with the latest pushed value after the cooldown.
+ *
+ *  Why a controller and not a hook: hooks aren't testable without a
+ *  React renderer. The page wraps this in a useEffect; the test asserts
+ *  the timing contract directly with `setTimeout`-style fake timers. */
+export function makeDebounceController(
+  delayMs: number,
+  onEmit: (value: string) => void,
+  scheduler: {
+    setTimeout: (cb: () => void, ms: number) => unknown;
+    clearTimeout: (handle: unknown) => void;
+  } = globalThis as unknown as {
+    setTimeout: (cb: () => void, ms: number) => unknown;
+    clearTimeout: (handle: unknown) => void;
+  },
+): DebounceController {
+  let handle: unknown = null;
+  let lastValue = "";
+
+  function clear() {
+    if (handle !== null) {
+      scheduler.clearTimeout(handle);
+      handle = null;
+    }
+  }
+
+  return {
+    push(value: string) {
+      lastValue = value;
+      clear();
+      handle = scheduler.setTimeout(() => {
+        handle = null;
+        onEmit(lastValue);
+      }, delayMs);
+    },
+    cancel() {
+      clear();
+    },
+    pending() {
+      return handle !== null;
+    },
+  };
+}
+
+// ── 4 · label-edit state machine ───────────────────────────────────────────
+
+export type LabelEditState =
+  | { kind: "idle"; value: string | null }
+  | { kind: "editing"; draft: string; original: string | null }
+  | { kind: "saving"; draft: string; original: string | null }
+  | { kind: "settled"; value: string | null }
+  | { kind: "reverted"; value: string | null; error: string };
+
+export type LabelEditEvent =
+  | { type: "begin" }
+  | { type: "change"; draft: string }
+  | { type: "commit" }
+  | { type: "cancel" }
+  | { type: "saved"; value: string | null }
+  | { type: "failed"; error: string };
+
+/** Pure reducer driving the inline-pencil edit. Optimistic-update logic
+ *  (apply the draft to the row immediately on `commit`, then either
+ *  `saved` confirms or `failed` reverts) is split between this state
+ *  machine and the row-level optimistic value held in `labelDraftFor()`. */
+export function reduceLabelEdit(
+  state: LabelEditState,
+  event: LabelEditEvent,
+): LabelEditState {
+  switch (state.kind) {
+    case "idle":
+    case "settled":
+    case "reverted":
+      if (event.type === "begin") {
+        const original =
+          state.kind === "idle"
+            ? state.value
+            : state.kind === "settled"
+              ? state.value
+              : state.value;
+        return { kind: "editing", draft: original ?? "", original };
+      }
+      return state;
+    case "editing":
+      if (event.type === "change") {
+        return { ...state, draft: event.draft };
+      }
+      if (event.type === "cancel") {
+        return { kind: "idle", value: state.original };
+      }
+      if (event.type === "commit") {
+        return { kind: "saving", draft: state.draft, original: state.original };
+      }
+      return state;
+    case "saving":
+      if (event.type === "saved") {
+        return { kind: "settled", value: event.value };
+      }
+      if (event.type === "failed") {
+        return {
+          kind: "reverted",
+          value: state.original,
+          error: event.error,
+        };
+      }
+      return state;
+    default:
+      return state;
+  }
+}
+
+/** Optimistic value to render the row with during an edit cycle. While
+ *  editing/saving, the UI shows the draft; while settled, it shows the
+ *  newly-saved value; while reverted, the original. */
+export function labelDraftFor(
+  state: LabelEditState,
+  fallback: string | null,
+): string | null {
+  switch (state.kind) {
+    case "idle":
+      return state.value ?? fallback;
+    case "editing":
+    case "saving":
+      return state.draft;
+    case "settled":
+      return state.value;
+    case "reverted":
+      return state.value;
+  }
+}
+
+// ── 5 · upload state machine ───────────────────────────────────────────────
+//
+// The DnD upload zone tracks each in-flight upload as a UploadItem. This
+// is the pure helper that derives the visual state from progress numbers,
+// so the test can assert "at byte 0 of N we're queued; at N of N we're
+// done; mid-stream we're uploading with a percent".
+
+export type UploadStatus =
+  | "queued"
+  | "uploading"
+  | "completed"
+  | "failed"
+  | "rejected";
+
+export interface UploadItem {
+  /** Stable client-side key (random per session). */
+  key: string;
+  filename: string;
+  size: number;
+  loaded: number;
+  status: UploadStatus;
+  /** Set on `failed`/`rejected`. */
+  error?: string;
+  /** Set on `completed` — the server-returned path so the UI can refresh
+   *  the list view + jump to the new row. */
+  resultPath?: string;
+}
+
+/** Percent (0..100) for a queued/uploading row. Completed reports 100,
+ *  failed/rejected report whatever progress was made. */
+export function uploadPercent(item: UploadItem): number {
+  if (item.status === "completed") return 100;
+  if (item.size <= 0) return 0;
+  return Math.min(100, Math.max(0, (item.loaded / item.size) * 100));
+}
+
+/** Decide whether a queued upload should be rejected outright before
+ *  we even open a request — e.g. it would push us past the hard cap.
+ *  Returns null when accepted, or a human-readable reason when not. */
+export function shouldRejectUpload(
+  size: number,
+  usage: FilesUsage,
+): string | null {
+  if (size > usage.upload_hard_bytes) {
+    return `File exceeds the ${formatBytes(usage.upload_hard_bytes)} per-upload hard cap.`;
+  }
+  if (usage.used_bytes + size > usage.hard_cap_bytes) {
+    return "Upload would push the file store past its hard cap.";
+  }
+  return null;
+}
+
+// ── 6 · path helpers ───────────────────────────────────────────────────────
+//
+// Two pure helpers the page uses to build the breadcrumb / prefix tree
+// from a flat list of `<ULID>/<safe-name>` paths.
+
+export interface PrefixNode {
+  /** The path segment for THIS node (e.g. "01HX..." or a virtual
+   *  group). Empty string for the root. */
+  segment: string;
+  /** The full prefix from root down to this node (`a/b/`-style). */
+  prefix: string;
+  /** Direct children of this node (other prefix nodes — leaves omitted). */
+  children: PrefixNode[];
+  /** Number of files whose `path` starts with this node's prefix. */
+  count: number;
+}
+
+/** Build a one-level prefix tree from the flat list of rows. Files
+ *  uploaded via PR1 always have a `<ULID>/<filename>` shape, so the
+ *  ULID is the only "directory" — the tree is intentionally shallow,
+ *  matching the spec's "no subdirectories yet" stance. Returned in
+ *  most-recently-uploaded-first order (the ULID prefix is monotonic). */
+export function buildPrefixTree(rows: FileRow[]): PrefixNode {
+  const root: PrefixNode = {
+    segment: "",
+    prefix: "",
+    children: [],
+    count: rows.length,
+  };
+  const byTopSeg = new Map<string, PrefixNode>();
+  // Iterate newest-first so child order is newest-first by construction.
+  const ordered = [...rows].sort((a, b) => b.uploaded_at - a.uploaded_at);
+  for (const row of ordered) {
+    const norm = row.path.replace(/\\/g, "/");
+    const first = norm.split("/", 1)[0];
+    if (!first) continue;
+    let node = byTopSeg.get(first);
+    if (!node) {
+      node = { segment: first, prefix: `${first}/`, children: [], count: 0 };
+      byTopSeg.set(first, node);
+      root.children.push(node);
+    }
+    node.count += 1;
+  }
+  return root;
+}
+
+/** Filter a row list to those under `prefix` (POSIX path comparison).
+ *  An empty prefix returns the input unchanged. */
+export function filterByPrefix(rows: FileRow[], prefix: string): FileRow[] {
+  if (!prefix) return rows;
+  return rows.filter((r) => r.path.startsWith(prefix));
+}
+
+/** Truncate a sha256 hex string to a stable 12-char prefix (the column
+ *  shows enough to disambiguate; the full hash is in the side panel). */
+export function shortSha(sha: string): string {
+  return (sha ?? "").slice(0, 12);
+}
+
+/** Format an ISO-ms timestamp as "2 hours ago" / "yesterday" / a date.
+ *  The fixed "now" is injectable for tests. */
+export function formatUploadedAt(
+  uploadedAtMs: number,
+  now: Date = new Date(),
+): string {
+  const delta = now.getTime() - uploadedAtMs;
+  if (delta < 0) return "in the future";
+  const minute = 60_000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (delta < minute) return "just now";
+  if (delta < hour) return `${Math.floor(delta / minute)} min ago`;
+  if (delta < day) return `${Math.floor(delta / hour)} h ago`;
+  if (delta < 7 * day) return `${Math.floor(delta / day)} d ago`;
+  return new Date(uploadedAtMs).toISOString().slice(0, 10);
+}

--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -2318,3 +2318,111 @@ export const getVaultTitleIndex = async (
     return { titles: [] };
   }
 };
+
+// ============================================================
+// /files — principal-facing blob store (#114 PR3)
+// ============================================================
+//
+// PR1 shipped the routes (POST /upload, GET /list/usage/stat/blob, PATCH,
+// DELETE) on ctrl-api. Upload + blob ride through filesProxy.ts (raw
+// multipart/binary); the rest go through the standard Wasp queries +
+// actions below so the page can subscribe with `useQuery` and the
+// existing 60s `proxyToTenant` plumbing.
+//
+// Path encoding: file paths are `<ULID>/<safe-name>`. Both halves are
+// safe per the ctrl-api `sanitizeFilename`, so we splice into the path
+// directly. We DO percent-encode each segment defensively for the
+// :path-style endpoints (stat/patch/delete) since a future PR may
+// loosen `sanitizeFilename`.
+
+/** Safely encode each segment of a `<ULID>/<filename>` path. */
+function encodeFilesPath(p: string): string {
+  return p
+    .split("/")
+    .filter(Boolean)
+    .map((seg) => encodeURIComponent(seg))
+    .join("/");
+}
+
+/** GET /api/v1/files/usage — used by the quota strip + upload pre-flight. */
+export const getFilesUsage = async (_args: unknown, context: any) => {
+  if (!context.user) throw new HttpError(401, "Not authenticated");
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, { path: "/api/v1/files/usage" });
+};
+
+/** GET /api/v1/files/list?prefix=&q=&limit=&offset= */
+export const getFilesList = async (
+  args: {
+    prefix?: string;
+    q?: string;
+    limit?: number;
+    offset?: number;
+  } | undefined,
+  context: any,
+) => {
+  if (!context.user) throw new HttpError(401, "Not authenticated");
+  const instance = await getUserInstance(context);
+  const query: Record<string, string> = {};
+  if (args?.prefix?.trim()) query.prefix = args.prefix.trim();
+  if (args?.q?.trim()) query.q = args.q.trim();
+  if (typeof args?.limit === "number" && args.limit > 0) {
+    query.limit = String(Math.floor(args.limit));
+  }
+  if (typeof args?.offset === "number" && args.offset >= 0) {
+    query.offset = String(Math.floor(args.offset));
+  }
+  return proxyToTenant(instance, {
+    path: "/api/v1/files/list",
+    query,
+  });
+};
+
+/** GET /api/v1/files/stat/:path — side-panel metadata for a selected row. */
+export const getFileStat = async (
+  args: { path: string },
+  context: any,
+) => {
+  if (!context.user) throw new HttpError(401, "Not authenticated");
+  if (typeof args?.path !== "string" || !args.path.trim()) {
+    throw new HttpError(400, "path required");
+  }
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    path: `/api/v1/files/stat/${encodeFilesPath(args.path)}`,
+  });
+};
+
+/** PATCH /api/v1/files/:path — inline pencil edit for principal_label.
+ *  PR2 of #114 added the route; PR3 surfaces it on the page. */
+export const updateFileLabel = async (
+  args: { path: string; principal_label: string | null },
+  context: any,
+) => {
+  if (!context.user) throw new HttpError(401, "Not authenticated");
+  if (typeof args?.path !== "string" || !args.path.trim()) {
+    throw new HttpError(400, "path required");
+  }
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    method: "PATCH",
+    path: `/api/v1/files/${encodeFilesPath(args.path)}`,
+    body: { principal_label: args.principal_label },
+  });
+};
+
+/** DELETE /api/v1/files/:path — soft-delete (tombstone + blob unlink). */
+export const deleteFile = async (
+  args: { path: string },
+  context: any,
+) => {
+  if (!context.user) throw new HttpError(401, "Not authenticated");
+  if (typeof args?.path !== "string" || !args.path.trim()) {
+    throw new HttpError(400, "path required");
+  }
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    method: "DELETE",
+    path: `/api/v1/files/${encodeFilesPath(args.path)}`,
+  });
+};

--- a/packages/web/src/server/filesProxy.ts
+++ b/packages/web/src/server/filesProxy.ts
@@ -1,0 +1,228 @@
+// filesProxy — browser ↔ ctrl-api bridge for /files (#114 PR3).
+//
+// Wasp queries/actions can't carry multipart streams (they JSON-encode
+// args) and can't return raw binary, so the upload + blob endpoints have
+// to live as custom Express routes registered on the Wasp server. The
+// rest of /files (list/usage/stat/patch/delete) goes through the
+// standard `proxyToTenant` queries in operations.ts.
+//
+// Auth: Wasp session token via Bearer (same pattern as chatProxy /
+// terminalProxy). The browser pulls its token from
+// `localStorage["wasp:auth"]`; this module validates it via
+// `getSessionAndUserFromBearerToken` and only then forwards to ctrl-api
+// with the shared AAS_API_KEY secret.
+//
+// CORS: matches the chat proxy — the SPA host is allowed to call the
+// `api.` server with Authorization + Content-Type headers.
+//
+// Streaming model:
+//   POST /api/files/upload          → POST /api/v1/files/upload
+//     multipart body relayed byte-for-byte via Node's stream piping;
+//     no buffering, no temp file. Content-Length is preserved.
+//   GET  /api/files/blob/:path*     → GET /api/v1/files/blob/:path*
+//     upstream response is piped back as-is (Content-Type +
+//     Content-Disposition preserved) so <img>/<video>/<iframe> in the
+//     preview pane work without round-tripping through JSON.
+
+import express from "express";
+import cors from "cors";
+import type { Application, Request, Response, RequestHandler } from "express";
+import type { IncomingMessage } from "http";
+import { getSessionAndUserFromBearerToken } from "wasp/auth/session";
+
+const CTRL_API_URL = process.env.CTRL_API_URL ?? "http://ctrl-api:3100";
+const CTRL_API_KEY = process.env.AAS_API_KEY ?? "";
+
+// 10 min — generous because a 2 GB upload over a busy compose network
+// can run for 5+ minutes; the ctrl-api side enforces the hard cap.
+const UPLOAD_TIMEOUT_MS = 10 * 60_000;
+const BLOB_TIMEOUT_MS = 60_000;
+
+export const FILES_ROUTE_PREFIX = "/api/files";
+
+/** CORS policy mirroring chatProxy's — needed because these routes live
+ *  outside Wasp's router and the SPA host is on a different origin from
+ *  the `api.` server. */
+function filesCors(): RequestHandler {
+  const origin = process.env.WASP_WEB_CLIENT_URL ?? true;
+  return cors({
+    origin,
+    methods: ["GET", "POST", "OPTIONS"],
+    allowedHeaders: ["Authorization", "Content-Type", "Accept"],
+    credentials: false,
+  });
+}
+
+function bearerOf(req: Request): string | null {
+  const header = req.headers.authorization;
+  if (header?.startsWith("Bearer ")) return header.slice(7);
+  const q = req.query?.token;
+  if (typeof q === "string" && q.length > 0) return q;
+  return null;
+}
+
+/** Inject `?token=` as an Authorization header so the Wasp auth helper
+ *  can read it (it reads from `req.headers.authorization` only). */
+function withInjectedBearer(req: Request): IncomingMessage {
+  const token = bearerOf(req);
+  if (token) {
+    (req as unknown as IncomingMessage).headers.authorization =
+      `Bearer ${token}`;
+  }
+  return req as unknown as IncomingMessage;
+}
+
+async function getUserIdFromRequest(
+  req: IncomingMessage,
+): Promise<string | null> {
+  try {
+    const result = await getSessionAndUserFromBearerToken(req as any);
+    return result?.user.id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function registerFilesProxy(app: Application): void {
+  app.use(FILES_ROUTE_PREFIX, filesCors());
+
+  // ── POST /api/files/upload ───────────────────────────────────────
+  //
+  // Relays a multipart body straight through to ctrl-api. We do NOT
+  // attach `express.json()` (the body is binary) and we do NOT buffer
+  // — the request is piped into a fetch with `req` as the body so the
+  // 2 GB hard cap holds without filling RAM.
+  app.post("/api/files/upload", async (req: Request, res: Response) => {
+    try {
+      const userId = await getUserIdFromRequest(withInjectedBearer(req));
+      if (!userId) {
+        res.status(401).json({ error: "not_authenticated" });
+        return;
+      }
+      if (!CTRL_API_KEY) {
+        res.status(500).json({ error: "AAS_API_KEY not configured" });
+        return;
+      }
+
+      const upstreamHeaders: Record<string, string> = {
+        Authorization: `Bearer ${CTRL_API_KEY}`,
+      };
+      const ct = req.headers["content-type"];
+      if (typeof ct === "string") upstreamHeaders["Content-Type"] = ct;
+      const cl = req.headers["content-length"];
+      if (typeof cl === "string") upstreamHeaders["Content-Length"] = cl;
+
+      const ctrl = new AbortController();
+      const timer = setTimeout(() => ctrl.abort(), UPLOAD_TIMEOUT_MS);
+      // `duplex: "half"` is required by undici (Node's built-in fetch)
+      // for any request with a streaming body; without it the call
+      // throws "RequestInit: duplex option is required when sending a
+      // body".
+      const upstream = await fetch(`${CTRL_API_URL}/api/v1/files/upload`, {
+        method: "POST",
+        headers: upstreamHeaders,
+        body: req as unknown as ReadableStream,
+        // @ts-expect-error — `duplex` is undici-specific, not in stock
+        // RequestInit, but Node 22's fetch needs it for streamed bodies.
+        duplex: "half",
+        signal: ctrl.signal,
+      }).finally(() => clearTimeout(timer));
+
+      const text = await upstream.text();
+      res.status(upstream.status);
+      res.setHeader(
+        "Content-Type",
+        upstream.headers.get("content-type") ?? "application/json",
+      );
+      res.send(text);
+    } catch (err: any) {
+      if (err?.name === "AbortError") {
+        res.status(504).json({ error: "Upload timed out" });
+        return;
+      }
+      res
+        .status(502)
+        .json({ error: "Upload proxy failed", message: err?.message ?? "" });
+    }
+  });
+
+  // ── GET /api/files/blob/* ────────────────────────────────────────
+  //
+  // Streams raw bytes from ctrl-api back to the browser. Content-Type
+  // and Content-Disposition are preserved so <img>, <iframe>, <audio>,
+  // <video>, and download links all work. Express's `*` wildcard
+  // captures the entire `<ULID>/<filename>` tail in `req.params[0]`.
+  app.get(/^\/api\/files\/blob\/(.+)$/, async (req: Request, res: Response) => {
+    try {
+      const userId = await getUserIdFromRequest(withInjectedBearer(req));
+      if (!userId) {
+        res.status(401).json({ error: "not_authenticated" });
+        return;
+      }
+      if (!CTRL_API_KEY) {
+        res.status(500).json({ error: "AAS_API_KEY not configured" });
+        return;
+      }
+      const tail = req.params[0] ?? "";
+      if (!tail) {
+        res.status(400).json({ error: "path required" });
+        return;
+      }
+
+      const ctrl = new AbortController();
+      const timer = setTimeout(() => ctrl.abort(), BLOB_TIMEOUT_MS);
+      const upstream = await fetch(
+        `${CTRL_API_URL}/api/v1/files/blob/${tail}`,
+        {
+          headers: { Authorization: `Bearer ${CTRL_API_KEY}` },
+          signal: ctrl.signal,
+        },
+      );
+
+      if (!upstream.ok || !upstream.body) {
+        clearTimeout(timer);
+        const text = await upstream.text().catch(() => "");
+        res.status(upstream.status).send(text);
+        return;
+      }
+
+      res.status(upstream.status);
+      const passthrough = [
+        "content-type",
+        "content-length",
+        "content-disposition",
+        "cache-control",
+      ];
+      for (const h of passthrough) {
+        const v = upstream.headers.get(h);
+        if (v) res.setHeader(h, v);
+      }
+
+      // Pipe the web stream into the express response. Node's fetch
+      // returns a Web ReadableStream; convert via `Readable.fromWeb`.
+      const { Readable } = await import("node:stream");
+      const nodeStream = Readable.fromWeb(
+        upstream.body as unknown as import("node:stream/web").ReadableStream,
+      );
+      nodeStream.on("error", (err) => {
+        // Headers already sent; the most we can do is end the response.
+        console.error("[filesProxy] blob stream error", err);
+        try {
+          res.end();
+        } catch {
+          /* noop */
+        }
+      });
+      nodeStream.on("end", () => clearTimeout(timer));
+      nodeStream.pipe(res);
+    } catch (err: any) {
+      if (err?.name === "AbortError") {
+        res.status(504).json({ error: "Blob fetch timed out" });
+        return;
+      }
+      res
+        .status(502)
+        .json({ error: "Blob proxy failed", message: err?.message ?? "" });
+    }
+  });
+}

--- a/packages/web/src/server/setup.ts
+++ b/packages/web/src/server/setup.ts
@@ -5,6 +5,7 @@ import { registerAgentMailReceiver } from "./agentmailReceiver";
 import { registerOAuth2Routes } from "./oauth2";
 import { attachTerminalProxy, registerTerminalStatusRoute } from "./terminalProxy";
 import { registerChatProxy } from "./chatProxy";
+import { registerFilesProxy } from "./filesProxy";
 
 export const serverSetup: ServerSetupFn = async ({ app, server }) => {
   app.use("/api/v1", v1ApiProxy);
@@ -31,5 +32,15 @@ export const serverSetup: ServerSetupFn = async ({ app, server }) => {
     console.log("[setup] Chat proxy registered successfully");
   } catch (err) {
     console.error("[setup] Failed to register chat proxy:", err);
+  }
+  try {
+    // /files (#114 PR3) — multipart upload + blob streaming proxy.
+    // Mounts POST /api/files/upload and GET /api/files/blob/*. The
+    // rest of /files (list/usage/stat/patch/delete) goes through the
+    // standard Wasp queries in dashboard/operations.ts.
+    registerFilesProxy(app);
+    console.log("[setup] Files proxy registered successfully");
+  } catch (err) {
+    console.error("[setup] Failed to register files proxy:", err);
   }
 };


### PR DESCRIPTION
PR3 of issue #114. Ships the principal-facing `/files` page on top of the ctrl-api routes from PR1 (#125) and the MCP catalogue from PR2 (#130).

## What ships

### Page (`packages/web/src/dashboard/FilesPage.tsx`)

```
┌─ /files ────────────────────────────────────────────────────┐
│ FILES                                          + Upload     │
│ Raw documents Alfred can read on your behalf.               │
│                                                             │
│ ┌─ Quota ───────────────────────────────── 12% of 10 GB ─┐  │
│ │ ████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ │  │
│ │ 1.2 GB of 10 GB soft cap   Per-upload limit 2 GB       │  │
│ └────────────────────────────────────────────────────────┘  │
│                                                             │
│ Uploads — invoice.pdf (12 MB)              45% ░░░          │
│                                                             │
│ ┌─ tree ───┬─ list + drop zone ───────────┬─ preview ────┐  │
│ │ All 23   │ ┌─ Drop files here ────────┐ │ invoice.pdf  │  │
│ │  01HX… 8 │ │                          │ │ 1.2 MB · 2h  │  │
│ │  01HY… 5 │ └──────────────────────────┘ │ ┌──────────┐ │  │
│ │  01HZ… 3 │ Name       Size  Up   Label  │ │  PDF     │ │  │
│ │          │ invoice.p  1.2M  2h   ✎ Q4   │ │  inline  │ │  │
│ │          │ photo.jpg  44K   3h   ✎      │ │  iframe  │ │  │
│ │          │ data.csv   12K   1d   ✎      │ └──────────┘ │  │
│ └──────────┴──────────────────────────────┴──────────────┘  │
└─────────────────────────────────────────────────────────────┘
```

* **Left rail** — prefix tree grouped by ULID segment, "All files" default, click to filter.
* **Centre** — drop-zone above, row table (Name · Size · Uploaded · Label · SHA-256), click selects, ✕ soft-deletes.
* **Right** — sticky preview pane. Image / PDF (inline `<iframe>`) / text (fetch + `<pre>`) / audio / video / unknown-with-stat. Download button under every mode.
* **Quota strip** — pulls `/api/v1/files/usage`; sage → amber at 80% soft → red at hard cap.
* **Inline label edit** — pencil on each row, optimistic PATCH, revert on error.
* **Search** — 300 ms debounced, server-side `?q=` (no client filter).

### Server seam (`packages/web/src/server/filesProxy.ts`)

Wasp queries can't carry multipart streams or return binary, so two Express routes register from `serverSetup`:

* `POST /api/files/upload` → `POST /api/v1/files/upload` (multipart relayed via `duplex: "half"`, no buffering)
* `GET /api/files/blob/*` → `GET /api/v1/files/blob/*` (response piped with `Content-Type` + `Content-Disposition` preserved so `<img>`/`<iframe>`/`<audio>`/`<video>` all work)

Auth = Wasp session token via `Authorization: Bearer` header or `?token=` query (the latter is needed because `<img src>` can't carry a header). Both forwarded to ctrl-api with the shared `AAS_API_KEY`.

The rest of `/files` (list / usage / stat / patch / delete) goes through standard Wasp queries + actions in `packages/web/src/dashboard/operations.ts` using `proxyToTenant`.

### Logic + tests

`FilesPageCore.ts` holds every piece of logic React doesn't need to render:

* `formatBytes`, `deriveQuotaView` — quota math + band colouring
* `derivePreviewMode` — content-type-first, extension fallback
* `makeDebounceController` — the search-box cooldown (injectable scheduler for tests)
* `reduceLabelEdit` + `labelDraftFor` — pure reducer for the inline pencil
* `uploadPercent`, `shouldRejectUpload` — DnD upload pre-flight
* `buildPrefixTree`, `filterByPrefix`, `shortSha`, `formatUploadedAt` — list display helpers

`FilesPageCore.test.ts` covers all of the above — 26 tests, all green.

```
ℹ tests 26
ℹ pass 26
ℹ fail 0
```

All 171 web tests pass (144 pre-existing + 26 new + 1 prior counted).

### Wiring

* `packages/web/main.wasp` — `route FilesRoute { path: "/files" }`, page `FilesPage`, five queries + actions (`getFilesUsage`, `getFilesList`, `getFileStat`, `updateFileLabel`, `deleteFile`).
* `packages/web/src/server/setup.ts` — `registerFilesProxy(app)` alongside the chat / terminal proxies.
* `packages/web/src/client/components/ab/Frame.tsx` — `Files` added to the PRIMARY left rail next to `Vault`.

## Constraints honoured

* Vocabulary stays distinct — no "vault" language on `/files`; the page lede calls them "raw documents Alfred can read on your behalf".
* No write to channel_tokens, no MCP catalogue mutation, no migration.
* All ctrl-api contact via `tenantProxy.ts` / `filesProxy.ts` — never from the client.
* Voice catalogue untouched (PR5 of #114).
* `ChannelsPage.tsx` untouched.
* `wasp build` + `tsc --build` (server) + `vite build` (client) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)