### PR TITLE
feat(web): Recall.ai /channels card — config + test-bot + recent bots (#113 PR3)

### DIFF
--- a/packages/web/main.wasp
+++ b/packages/web/main.wasp
@@ -922,6 +922,37 @@ query getTailscalePeers {
   entities: []
 }
 
+// Lane III (Recall.ai, #113 PR3) — operator-facing /channels card. Five ops
+// against the ctrl-api routes shipped in PR2 (#129). The composite
+// getRecallChannelStatus stitches /config + /usage + /bots/active into the
+// shape recallCardCore.deriveRecallCardState consumes. The card never sees
+// the raw RECALL_API_KEY; the validate-key flow round-trips and never
+// persists (persistence ships in PR3a).
+query getRecallChannelStatus {
+  fn: import { getRecallChannelStatus } from "@src/dashboard/operations",
+  entities: []
+}
+
+action updateRecallConfig {
+  fn: import { updateRecallConfig } from "@src/dashboard/operations",
+  entities: []
+}
+
+action validateRecallApiKey {
+  fn: import { validateRecallApiKey } from "@src/dashboard/operations",
+  entities: []
+}
+
+action testRecallWebhook {
+  fn: import { testRecallWebhook } from "@src/dashboard/operations",
+  entities: []
+}
+
+action terminateRecallBot {
+  fn: import { terminateRecallBot } from "@src/dashboard/operations",
+  entities: []
+}
+
 query getAgentConfig {
   fn: import { getAgentConfig } from "@src/dashboard/operations",
   entities: []

--- a/packages/web/src/dashboard/ChannelsPage.tsx
+++ b/packages/web/src/dashboard/ChannelsPage.tsx
@@ -99,6 +99,7 @@ import {
   type TailscaleStatus,
   type TailscalePeersResponse,
 } from "./tailscaleCardCore";
+import RecallCard from "./RecallCard";
 
 // F57/C14 — the email card reads the live ctrl-api status, not a phantom
 // Instance row. `inbox_address` is only present once `configured`.
@@ -355,17 +356,14 @@ export default function ChannelsPage() {
             <VoiceSection />
           </ChannelCard>
 
-          {/* Meeting bot — placeholder slot.
-              The self-hosted Vexa stack was retired in #113 PR1; Recall.ai
-              (hosted) lands the live card in #113 PR3a/PR3b. Until then we
-              render a coming-soon placeholder so the channel grid keeps its
-              shape and the principal sees the planned surface. */}
-          <ChannelCard
-            name="Meeting bot"
-            address="Coming soon (Recall.ai)"
-            note="A second pair of ears for Zoom, Meet, Teams."
-            status="available"
-          />
+          {/* Meeting bot — Recall.ai live card (#113 PR3, 2026-05-29).
+              Replaces the retired Vexa stack (#113 PR1). Three subviews
+              (disabled / configured / error) driven by recallCardCore;
+              the React surface — dial form + active-bots table + webhook
+              expander + paste-validate flow — lives in RecallCard.tsx
+              so the substantial dial form stays out of this already
+              large page. */}
+          <RecallCard />
 
           {/* Omi — Phase-6b live card (Lane III, 2026-05-25). Surfaces the
               4 OMI channel states (unconfigured / needs_groq_key /

--- a/packages/web/src/dashboard/RecallCard.tsx
+++ b/packages/web/src/dashboard/RecallCard.tsx
@@ -1,0 +1,920 @@
+// RecallCard — /channels surface for Recall.ai meeting bot (#113 PR3).
+//
+// Lives in its own file (not inline in ChannelsPage.tsx) because the dial
+// form + recent-bots table + webhook expander + paste flow add up to a
+// substantial chunk of React. The pure derivation lives in
+// recallCardCore.ts; this component is the React layer + form plumbing.
+//
+// Four subviews, driven by deriveRecallCardState's `status`:
+//
+//   • disabled    — no API key on file. Hero copy + API-key paste form
+//                   that round-trips via validateRecallApiKey (NO
+//                   persistence — that ships in PR3a). On a successful
+//                   round-trip we surface a "validated, persistence
+//                   pending" note and the principal can either tap
+//                   refresh or move on.
+//   • configured  — dial form (region / bot name / auto-join / cadence
+//                   / cost cap / wake word / cost-alert thresholds),
+//                   month-to-date usage badge, recent-bots table, Test
+//                   Webhook CTA, webhook setup expander.
+//   • error       — verbatim error string + retry. The form is read-only.
+//
+// Secrets posture: the API key paste box is type="password", never logged,
+// never echoed in toast strings. The webhook secret is surfaced as first-6
+// only; the full secret stays in /opt/alfred/.env.
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  useQuery,
+  getRecallChannelStatus,
+  updateRecallConfig,
+  validateRecallApiKey,
+  testRecallWebhook,
+  terminateRecallBot,
+} from "wasp/client/operations";
+import {
+  RECALL_AUTO_JOIN_POLICY_OPTIONS,
+  RECALL_CALENDAR_SOURCE_OPTIONS,
+  RECALL_DEFAULT_FORM,
+  RECALL_LEAVE_AFTER_MINUTES_RANGE,
+  RECALL_MONTHLY_HOURS_CAP_RANGE,
+  RECALL_REGION_OPTIONS,
+  RECALL_RESPOND_MODE_OPTIONS,
+  RECALL_WAKE_WORD_RANGE,
+  botStatusLabel,
+  botDurationMs,
+  configToFormValues,
+  deriveRecallCardState,
+  formatBotDuration,
+  formatBotTimestamp,
+  formatCostThresholdList,
+  formatHours,
+  formatRecallWebhookUrl,
+  isProbablyValidWakeWord,
+  isValidBotName,
+  isValidLeaveAfterMinutes,
+  isValidMonthlyHoursCap,
+  parseCostThresholdList,
+  serializeFormPatch,
+  truncateBotId,
+  type RecallAutoJoinPolicy,
+  type RecallCalendarSource,
+  type RecallFormValues,
+  type RecallRegion,
+  type RecallRespondMode,
+  type RecallStatus,
+} from "./recallCardCore";
+
+// We re-declare a tiny ChannelCard wrapper here mirroring the one
+// ChannelsPage.tsx ships — keeping this card a single file with a
+// self-contained presentational shell lets the page-level glue stay
+// thin (just `<RecallCard />`).
+
+type ChannelStatus = "active" | "available" | "soon" | "starting" | "error";
+
+function ChannelCard({
+  name,
+  address,
+  note,
+  status,
+  children,
+}: {
+  name: string;
+  address: string;
+  note: string;
+  status: ChannelStatus;
+  children?: React.ReactNode;
+}) {
+  const pillColor =
+    status === "active" || status === "error"
+      ? "var(--brass)"
+      : "var(--marginalia)";
+  const pillText =
+    status === "active"
+      ? "Connected"
+      : status === "soon"
+        ? "Coming soon"
+        : status === "starting"
+          ? "Starting"
+          : status === "error"
+            ? "Needs attention"
+            : "Not connected";
+  return (
+    <div className="border border-rule p-6 card-hover h-full">
+      <div className="flex items-baseline justify-between mb-3">
+        <span className="font-display text-3xl">{name}</span>
+        <span
+          className="font-mono text-[10px] uppercase tracking-[0.22em] font-extrabold"
+          style={{ color: pillColor }}
+        >
+          {pillText}
+        </span>
+      </div>
+      <div
+        className="font-mono text-[12px] mb-3"
+        style={{ color: "var(--ink)" }}
+      >
+        {address}
+      </div>
+      <div className="font-body italic" style={{ color: "var(--marginalia)" }}>
+        {note}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+// ─── the card ────────────────────────────────────────────────────────────
+
+export default function RecallCard() {
+  const { data: statusData, refetch } = useQuery(
+    getRecallChannelStatus,
+    undefined,
+    { retry: false },
+  );
+  const status = (statusData as RecallStatus | undefined) ?? null;
+  const card = deriveRecallCardState(status);
+
+  return (
+    <ChannelCard
+      name="Meeting bot"
+      address={card.address}
+      note="A second pair of ears for Zoom, Meet, Teams (via Recall.ai)."
+      status={card.pillTone}
+    >
+      {card.status === "disabled" && (
+        <RecallDisabledPanel onValidated={refetch} />
+      )}
+      {card.status === "configured" && (
+        <RecallConfiguredPanel
+          status={status}
+          formInitial={card.formValues}
+          monthHours={card.monthHours}
+          monthlyHoursCap={card.formValues.monthly_hours_cap}
+          costAlertTriggered={card.costAlertTriggered}
+          visibleBots={card.visibleBots}
+          onSettled={refetch}
+        />
+      )}
+      {card.status === "error" && (
+        <div className="mt-5 space-y-3">
+          <p
+            className="font-body italic text-[13px]"
+            style={{ color: "var(--brass)" }}
+          >
+            {card.description}
+          </p>
+          <button onClick={() => refetch()} className="btn-ghost">
+            Re-check
+          </button>
+        </div>
+      )}
+    </ChannelCard>
+  );
+}
+
+// ─── disabled subview — API-key paste / validate ─────────────────────────
+
+function RecallDisabledPanel({ onValidated }: { onValidated: () => void }) {
+  const [apiKey, setApiKey] = useState("");
+  const [region, setRegion] = useState<RecallRegion>(
+    RECALL_DEFAULT_FORM.region,
+  );
+  const [validating, setValidating] = useState(false);
+  const [feedback, setFeedback] = useState<
+    { kind: "ok" | "err"; text: string } | null
+  >(null);
+
+  const trimmed = apiKey.trim();
+  const canSubmit = trimmed.length > 0 && !validating;
+
+  async function submit(e?: React.FormEvent) {
+    if (e) e.preventDefault();
+    if (!canSubmit) return;
+    setValidating(true);
+    setFeedback(null);
+    try {
+      const result: any = await validateRecallApiKey({
+        api_key: trimmed,
+        region,
+      });
+      if (result?.ok) {
+        // NEVER echo the key. Just confirm.
+        const knownBots =
+          typeof result?.account?.bots_known === "number"
+            ? ` (${result.account.bots_known} bots on file)`
+            : "";
+        setFeedback({
+          kind: "ok",
+          text:
+            `Recall accepted the key${knownBots}. ` +
+            "Persistence ships in #113 PR3a — paste it into /opt/alfred/.env " +
+            "as RECALL_API_KEY for now, then reload this card.",
+        });
+        // Clear the local field — the value is in the user's clipboard
+        // already if they copied it from Recall, and there is no
+        // server-side persistence yet.
+        setApiKey("");
+        onValidated();
+      } else {
+        const reason =
+          typeof result?.reason === "string" && result.reason
+            ? result.reason
+            : "Recall rejected the key.";
+        setFeedback({ kind: "err", text: reason });
+      }
+    } catch (err: any) {
+      const message =
+        err?.message ?? err?.data?.error ?? "Couldn't reach the validator.";
+      setFeedback({ kind: "err", text: message });
+    } finally {
+      setValidating(false);
+    }
+  }
+
+  return (
+    <div className="mt-5 space-y-4">
+      <p
+        className="font-body italic text-[13px]"
+        style={{ color: "var(--marginalia)" }}
+      >
+        Recall.ai sends a bot to your Zoom / Meet / Teams meetings and feeds
+        the transcript back here. Paste an API key from{" "}
+        <a
+          href="https://www.recall.ai/dashboard"
+          target="_blank"
+          rel="noreferrer"
+          className="underline"
+        >
+          recall.ai
+        </a>{" "}
+        to start.
+      </p>
+
+      <form onSubmit={submit} className="space-y-3">
+        <div className="space-y-2">
+          <div
+            className="font-mono text-[10px] uppercase tracking-[0.22em]"
+            style={{ color: "var(--marginalia)" }}
+          >
+            Recall API key
+          </div>
+          <input
+            type="password"
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
+            placeholder="Paste from recall.ai → Settings → API keys"
+            autoComplete="off"
+            spellCheck={false}
+            className="w-full bg-transparent border border-rule px-2 py-1 font-mono text-[12px]"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <div
+            className="font-mono text-[10px] uppercase tracking-[0.22em]"
+            style={{ color: "var(--marginalia)" }}
+          >
+            Region
+          </div>
+          <select
+            value={region}
+            onChange={(e) => setRegion(e.target.value as RecallRegion)}
+            className="bg-transparent border border-rule px-2 py-1 font-mono text-[12px]"
+          >
+            {RECALL_REGION_OPTIONS.map((r) => (
+              <option key={r} value={r}>
+                {r}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex gap-3 items-baseline">
+          <button
+            type="submit"
+            disabled={!canSubmit}
+            className="btn-ghost"
+          >
+            {validating ? "Validating…" : "Validate key"}
+          </button>
+          <a
+            href="https://www.recall.ai/dashboard"
+            target="_blank"
+            rel="noreferrer"
+            className="btn-ghost"
+          >
+            Open Recall.ai →
+          </a>
+        </div>
+
+        {feedback && (
+          <p
+            className="font-body italic text-[12px]"
+            style={{
+              color:
+                feedback.kind === "ok" ? "var(--marginalia)" : "var(--brass)",
+            }}
+          >
+            {feedback.kind === "ok" ? "✓ " : "✗ "}
+            {feedback.text}
+          </p>
+        )}
+      </form>
+    </div>
+  );
+}
+
+// ─── configured subview — full dial form + table + webhook ───────────────
+
+function RecallConfiguredPanel({
+  status,
+  formInitial,
+  monthHours,
+  monthlyHoursCap,
+  costAlertTriggered,
+  visibleBots,
+  onSettled,
+}: {
+  status: RecallStatus | null;
+  formInitial: RecallFormValues;
+  monthHours: number | null;
+  monthlyHoursCap: number;
+  costAlertTriggered: boolean;
+  visibleBots: ReturnType<typeof deriveRecallCardState>["visibleBots"];
+  onSettled: () => void;
+}) {
+  // Form state — local copy that bind to inputs. Re-seed from
+  // formInitial whenever the upstream status changes (e.g. another tab
+  // PATCH'd).
+  const [form, setForm] = useState<RecallFormValues>(formInitial);
+  const [committed, setCommitted] = useState<RecallFormValues>(formInitial);
+  const [thresholdsText, setThresholdsText] = useState(() =>
+    formatCostThresholdList(formInitial.cost_alert_thresholds),
+  );
+
+  // Reset when upstream changes (e.g. cross-tab edit).
+  useEffect(() => {
+    setForm(formInitial);
+    setCommitted(formInitial);
+    setThresholdsText(formatCostThresholdList(formInitial.cost_alert_thresholds));
+  }, [formInitial]);
+
+  const [saveBusy, setSaveBusy] = useState(false);
+  const [saveMsg, setSaveMsg] = useState<
+    { kind: "ok" | "err"; text: string } | null
+  >(null);
+
+  const [testBusy, setTestBusy] = useState(false);
+  const [testMsg, setTestMsg] = useState<
+    { kind: "ok" | "err"; text: string } | null
+  >(null);
+
+  const [showWebhook, setShowWebhook] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  // Per-bot terminate busy set.
+  const [termBusy, setTermBusy] = useState<Set<string>>(new Set());
+
+  // Validation summary — disable Save when anything is off.
+  const wakeOk = isProbablyValidWakeWord(form.wake_word);
+  const botNameOk = isValidBotName(form.bot_name);
+  const monthlyOk = isValidMonthlyHoursCap(form.monthly_hours_cap);
+  const leaveOk = isValidLeaveAfterMinutes(form.leave_after_minutes);
+  const parsedThresholds = useMemo(
+    () => parseCostThresholdList(thresholdsText),
+    [thresholdsText],
+  );
+  const thresholdsOk = parsedThresholds !== null;
+  const allValid =
+    wakeOk && botNameOk && monthlyOk && leaveOk && thresholdsOk;
+
+  // Diff: what would the PATCH payload be?
+  const liveForm: RecallFormValues = useMemo(
+    () => ({
+      ...form,
+      cost_alert_thresholds:
+        parsedThresholds ?? form.cost_alert_thresholds,
+    }),
+    [form, parsedThresholds],
+  );
+  const patch = useMemo(
+    () => serializeFormPatch(liveForm, committed),
+    [liveForm, committed],
+  );
+  const isDirty = Object.keys(patch).length > 0;
+
+  async function save(e?: React.FormEvent) {
+    if (e) e.preventDefault();
+    if (!allValid || !isDirty || saveBusy) return;
+    setSaveBusy(true);
+    setSaveMsg(null);
+    try {
+      const updated: any = await updateRecallConfig(
+        patch as Record<string, unknown>,
+      );
+      const next = configToFormValues(updated);
+      setCommitted(next);
+      setForm(next);
+      setThresholdsText(formatCostThresholdList(next.cost_alert_thresholds));
+      setSaveMsg({ kind: "ok", text: "Saved." });
+      onSettled();
+    } catch (err: any) {
+      const reason =
+        err?.message ?? err?.data?.error ?? "Couldn't save the dials.";
+      setSaveMsg({ kind: "err", text: reason });
+    } finally {
+      setSaveBusy(false);
+      setTimeout(() => setSaveMsg(null), 4000);
+    }
+  }
+
+  async function fireTest() {
+    if (testBusy) return;
+    setTestBusy(true);
+    setTestMsg(null);
+    try {
+      const r: any = await testRecallWebhook({});
+      if (r?.ok) {
+        const lat =
+          typeof r?.latency_ms === "number" ? `${r.latency_ms} ms` : "ok";
+        setTestMsg({
+          kind: "ok",
+          text: `Round-trip ${lat} · webhook target accepted the synthetic delivery.`,
+        });
+      } else {
+        const reason =
+          (typeof r?.sample_response === "string" && r.sample_response) ||
+          (typeof r?.error === "string" && r.error) ||
+          (typeof r?.status === "number" ? `HTTP ${r.status}` : "refused");
+        setTestMsg({ kind: "err", text: reason });
+      }
+      onSettled();
+    } catch (err: any) {
+      setTestMsg({
+        kind: "err",
+        text:
+          err?.message ?? err?.data?.error ?? "Couldn't reach the webhook target.",
+      });
+    } finally {
+      setTestBusy(false);
+      setTimeout(() => setTestMsg(null), 6000);
+    }
+  }
+
+  async function terminate(botId: string) {
+    if (termBusy.has(botId)) return;
+    if (
+      typeof window !== "undefined" &&
+      !window.confirm(`Terminate bot ${truncateBotId(botId)}?`)
+    ) {
+      return;
+    }
+    setTermBusy((s) => new Set(s).add(botId));
+    try {
+      await terminateRecallBot({ bot_id: botId });
+      onSettled();
+    } catch (err) {
+      console.error("recall terminate failed", err);
+    } finally {
+      setTermBusy((s) => {
+        const next = new Set(s);
+        next.delete(botId);
+        return next;
+      });
+    }
+  }
+
+  // Webhook URL: synthesise from the server when present; fall back to
+  // window.location.origin so the operator can still copy something
+  // meaningful before PR3a surfaces it explicitly on /status.
+  const origin =
+    (typeof status?.webhook_url === "string" && status.webhook_url) ||
+    (typeof window !== "undefined" ? window.location.origin : "");
+  const webhookUrl = useMemo(() => formatRecallWebhookUrl(origin), [origin]);
+  const secretFirst6 =
+    typeof status?.webhook_secret_first6 === "string"
+      ? status.webhook_secret_first6
+      : null;
+
+  function copyWebhook() {
+    if (!webhookUrl) return;
+    navigator.clipboard?.writeText(webhookUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }
+
+  return (
+    <div className="mt-5 space-y-6">
+      {/* Usage strip */}
+      <div className="flex flex-wrap gap-x-6 gap-y-2 items-baseline">
+        <span
+          className="font-mono text-[12px]"
+          style={{ color: "var(--ink)" }}
+        >
+          Month-to-date: {monthHours !== null ? formatHours(monthHours) : "—"} /{" "}
+          {monthlyHoursCap}h
+        </span>
+        {costAlertTriggered && (
+          <span
+            className="font-mono text-[10px] uppercase tracking-[0.22em] font-extrabold"
+            style={{ color: "var(--brass)" }}
+          >
+            Cost alert · threshold reached
+          </span>
+        )}
+      </div>
+
+      {/* Dial form */}
+      <form onSubmit={save} className="space-y-4">
+        <Row label="Region">
+          <select
+            value={form.region}
+            onChange={(e) =>
+              setForm({ ...form, region: e.target.value as RecallRegion })
+            }
+            className="bg-transparent border border-rule px-2 py-1 font-mono text-[12px]"
+          >
+            {RECALL_REGION_OPTIONS.map((r) => (
+              <option key={r} value={r}>
+                {r}
+              </option>
+            ))}
+          </select>
+        </Row>
+
+        <Row label="Bot name">
+          <input
+            type="text"
+            value={form.bot_name}
+            onChange={(e) => setForm({ ...form, bot_name: e.target.value })}
+            maxLength={200}
+            className="flex-1 bg-transparent border border-rule px-2 py-1 font-mono text-[12px]"
+          />
+          {!botNameOk && <Hint>Required, ≤200 chars.</Hint>}
+        </Row>
+
+        <Row label="Announces on join">
+          <label className="font-mono text-[12px] inline-flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={form.announces_on_join}
+              onChange={(e) =>
+                setForm({ ...form, announces_on_join: e.target.checked })
+              }
+            />
+            <span>
+              {form.announces_on_join ? "Yes" : "No"}
+            </span>
+          </label>
+        </Row>
+
+        <Row label="Auto-join policy">
+          <select
+            value={form.auto_join_policy}
+            onChange={(e) =>
+              setForm({
+                ...form,
+                auto_join_policy: e.target.value as RecallAutoJoinPolicy,
+              })
+            }
+            className="bg-transparent border border-rule px-2 py-1 font-mono text-[12px]"
+          >
+            {RECALL_AUTO_JOIN_POLICY_OPTIONS.map((p) => (
+              <option key={p} value={p}>
+                {p}
+              </option>
+            ))}
+          </select>
+        </Row>
+
+        <Row label="Calendar source">
+          <select
+            value={form.calendar_source}
+            onChange={(e) =>
+              setForm({
+                ...form,
+                calendar_source: e.target.value as RecallCalendarSource,
+              })
+            }
+            className="bg-transparent border border-rule px-2 py-1 font-mono text-[12px]"
+          >
+            {RECALL_CALENDAR_SOURCE_OPTIONS.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+        </Row>
+
+        <Row label="Monthly hours cap">
+          <input
+            type="number"
+            min={RECALL_MONTHLY_HOURS_CAP_RANGE.min}
+            max={RECALL_MONTHLY_HOURS_CAP_RANGE.max}
+            value={form.monthly_hours_cap}
+            onChange={(e) =>
+              setForm({
+                ...form,
+                monthly_hours_cap: Number.parseInt(e.target.value, 10) || 0,
+              })
+            }
+            className="w-24 bg-transparent border border-rule px-2 py-1 font-mono text-[12px]"
+          />
+          {!monthlyOk && (
+            <Hint>
+              {RECALL_MONTHLY_HOURS_CAP_RANGE.min}–
+              {RECALL_MONTHLY_HOURS_CAP_RANGE.max} integer.
+            </Hint>
+          )}
+        </Row>
+
+        <Row label="Leave after minutes">
+          <input
+            type="number"
+            min={RECALL_LEAVE_AFTER_MINUTES_RANGE.min}
+            max={RECALL_LEAVE_AFTER_MINUTES_RANGE.max}
+            value={form.leave_after_minutes}
+            onChange={(e) =>
+              setForm({
+                ...form,
+                leave_after_minutes:
+                  Number.parseInt(e.target.value, 10) || 0,
+              })
+            }
+            className="w-24 bg-transparent border border-rule px-2 py-1 font-mono text-[12px]"
+          />
+          {!leaveOk && (
+            <Hint>
+              {RECALL_LEAVE_AFTER_MINUTES_RANGE.min}–
+              {RECALL_LEAVE_AFTER_MINUTES_RANGE.max} integer.
+            </Hint>
+          )}
+        </Row>
+
+        <Row label="Respond mode">
+          <select
+            value={form.respond_mode}
+            onChange={(e) =>
+              setForm({
+                ...form,
+                respond_mode: e.target.value as RecallRespondMode,
+              })
+            }
+            className="bg-transparent border border-rule px-2 py-1 font-mono text-[12px]"
+          >
+            {RECALL_RESPOND_MODE_OPTIONS.map((m) => (
+              <option key={m} value={m}>
+                {m}
+              </option>
+            ))}
+          </select>
+        </Row>
+
+        <Row label="Wake word">
+          <input
+            type="text"
+            value={form.wake_word}
+            onChange={(e) => setForm({ ...form, wake_word: e.target.value })}
+            maxLength={RECALL_WAKE_WORD_RANGE.max}
+            className="flex-1 bg-transparent border border-rule px-2 py-1 font-mono text-[12px]"
+          />
+          {!wakeOk && (
+            <Hint>
+              1–{RECALL_WAKE_WORD_RANGE.max} chars, no control characters.
+            </Hint>
+          )}
+        </Row>
+
+        <Row label="Cost-alert thresholds (%)">
+          <input
+            type="text"
+            value={thresholdsText}
+            onChange={(e) => setThresholdsText(e.target.value)}
+            placeholder="80, 100"
+            className="flex-1 bg-transparent border border-rule px-2 py-1 font-mono text-[12px]"
+          />
+          {!thresholdsOk && (
+            <Hint>Comma- or space-separated integers in 1–200.</Hint>
+          )}
+        </Row>
+
+        <div className="flex gap-3 items-baseline pt-1">
+          <button
+            type="submit"
+            disabled={!allValid || !isDirty || saveBusy}
+            className="btn-ghost"
+          >
+            {saveBusy ? "Saving…" : isDirty ? "Save dials" : "Saved"}
+          </button>
+          <button
+            type="button"
+            onClick={fireTest}
+            disabled={testBusy}
+            className="btn-ghost"
+          >
+            {testBusy ? "…" : "Send test webhook"}
+          </button>
+        </div>
+
+        {saveMsg && (
+          <p
+            className="font-body italic text-[12px]"
+            style={{
+              color:
+                saveMsg.kind === "ok" ? "var(--marginalia)" : "var(--brass)",
+            }}
+          >
+            {saveMsg.kind === "ok" ? "✓ " : "✗ "}
+            {saveMsg.text}
+          </p>
+        )}
+        {testMsg && (
+          <p
+            className="font-body italic text-[12px]"
+            style={{
+              color:
+                testMsg.kind === "ok" ? "var(--marginalia)" : "var(--brass)",
+            }}
+          >
+            {testMsg.kind === "ok" ? "✓ " : "✗ "}
+            {testMsg.text}
+          </p>
+        )}
+      </form>
+
+      {/* Recent (active) bots table */}
+      {visibleBots.length > 0 && (
+        <div className="space-y-2">
+          <div
+            className="font-mono text-[10px] uppercase tracking-[0.22em]"
+            style={{ color: "var(--marginalia)" }}
+          >
+            Active bots
+          </div>
+          <div
+            className="border border-rule overflow-x-auto"
+            style={{ maxHeight: "20rem" }}
+          >
+            <table className="w-full text-[12px] font-mono">
+              <thead>
+                <tr
+                  style={{ color: "var(--marginalia)" }}
+                  className="text-left"
+                >
+                  <th className="p-2">Status</th>
+                  <th className="p-2">Calendar event</th>
+                  <th className="p-2">Joined at</th>
+                  <th className="p-2">Duration</th>
+                  <th className="p-2">Transcript</th>
+                  <th className="p-2" />
+                </tr>
+              </thead>
+              <tbody>
+                {visibleBots.map((b) => (
+                  <tr key={b.id} className="border-t border-rule">
+                    <td className="p-2">{botStatusLabel(b.status)}</td>
+                    <td className="p-2">{b.calendar_event_id ?? "—"}</td>
+                    <td className="p-2">{formatBotTimestamp(b.joined_at)}</td>
+                    <td className="p-2">
+                      {formatBotDuration(botDurationMs(b))}
+                    </td>
+                    <td className="p-2">
+                      {b.transcript_url ? (
+                        <a
+                          href={b.transcript_url}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="underline"
+                        >
+                          open
+                        </a>
+                      ) : (
+                        "—"
+                      )}
+                    </td>
+                    <td className="p-2">
+                      <button
+                        type="button"
+                        onClick={() => terminate(b.id)}
+                        disabled={termBusy.has(b.id)}
+                        className="btn-link"
+                      >
+                        {termBusy.has(b.id) ? "…" : "Terminate"}
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* Webhook setup expander */}
+      <div className="border-t border-rule pt-3">
+        <button
+          type="button"
+          onClick={() => setShowWebhook((s) => !s)}
+          className="btn-link"
+        >
+          {showWebhook ? "Hide" : "Show"} webhook setup
+        </button>
+        {showWebhook && (
+          <div className="mt-3 space-y-3">
+            <div className="space-y-2">
+              <div
+                className="font-mono text-[10px] uppercase tracking-[0.22em]"
+                style={{ color: "var(--marginalia)" }}
+              >
+                Webhook URL (paste into Recall.ai → Webhooks)
+              </div>
+              <div className="flex items-center gap-2">
+                <code
+                  className="flex-1 font-mono text-[11px] border border-rule p-2 truncate"
+                  style={{ color: "var(--ink)" }}
+                >
+                  {webhookUrl || "—"}
+                </code>
+                <button
+                  type="button"
+                  onClick={copyWebhook}
+                  disabled={!webhookUrl}
+                  className="btn-ghost"
+                >
+                  {copied ? "Copied" : "Copy"}
+                </button>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <div
+                className="font-mono text-[10px] uppercase tracking-[0.22em]"
+                style={{ color: "var(--marginalia)" }}
+              >
+                Webhook secret (first 6)
+              </div>
+              <div className="flex items-center gap-3">
+                <code
+                  className="font-mono text-[12px] border border-rule p-2"
+                  style={{ color: "var(--ink)" }}
+                >
+                  {secretFirst6 ? `${secretFirst6}…` : "—"}
+                </code>
+                <button
+                  type="button"
+                  disabled
+                  title="Secret rotation lands in #113 PR3a; for now the secret is fixed at tenant init."
+                  className="btn-ghost opacity-50 cursor-not-allowed"
+                >
+                  Rotate secret
+                </button>
+                <span
+                  className="font-body italic text-[12px]"
+                  style={{ color: "var(--marginalia)" }}
+                >
+                  coming soon
+                </span>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── tiny presentational helpers ─────────────────────────────────────────
+
+function Row({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-wrap items-baseline gap-3">
+      <div
+        className="font-mono text-[10px] uppercase tracking-[0.22em] w-40"
+        style={{ color: "var(--marginalia)" }}
+      >
+        {label}
+      </div>
+      <div className="flex-1 flex flex-wrap items-baseline gap-2 min-w-[12rem]">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function Hint({ children }: { children: React.ReactNode }) {
+  return (
+    <span
+      className="font-body italic text-[12px]"
+      style={{ color: "var(--brass)" }}
+    >
+      {children}
+    </span>
+  );
+}

--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -654,6 +654,179 @@ export const getTailscalePeers = async (_args: unknown, context: any) => {
 };
 
 // ============================================================
+// Lane III — Recall.ai channel on /channels (#113 PR3).
+// ============================================================
+//
+// PR2 (#129) shipped these ctrl-api routes; PR3 wires the SaaS proxy
+// + React surface against them. The merged PR2 surface deliberately
+// stops short of persisting the API key (that lands in PR3a); the
+// card-side flow paste→validate→hint reflects that.
+//
+//   GET   /api/v1/channels/recall/config            → RecallConfig
+//   PATCH /api/v1/channels/recall/config            → 200 (updated row)
+//   GET   /api/v1/channels/recall/usage             → RecallUsage
+//   GET   /api/v1/channels/recall/bots/active       → { bots: RecallBot[] }
+//   POST  /api/v1/channels/recall/validate-key      → { ok, account?, reason? }
+//   DELETE /api/v1/channels/recall/bots/:bot_id     → 200 (status: leaving|done)
+//   POST  /api/v1/channels/recall/webhook-test      → { ok, status, latency_ms }
+//
+// `getRecallChannelStatus` stitches the first three into the composite
+// shape recallCardCore.deriveRecallCardState consumes. The `enabled`
+// boolean is derived from "does /usage succeed" — a 503 NOT_CONFIGURED
+// from the upstream means "no RECALL_API_KEY on file"; any other error
+// surfaces as the .error field.
+
+interface RecallCompositeStatus {
+  enabled: boolean;
+  config: any | null;
+  usage: any | null;
+  active_bots: any[];
+  error: string | null;
+  webhook_url?: string;
+  webhook_secret_first6?: string | null;
+}
+
+async function safeProxy(
+  instance: any,
+  options: Parameters<typeof proxyToTenant>[1],
+): Promise<{ ok: true; data: any } | { ok: false; status: number; message: string }> {
+  try {
+    const data = await proxyToTenant(instance, options);
+    return { ok: true, data };
+  } catch (err: any) {
+    const status =
+      typeof err?.statusCode === "number"
+        ? err.statusCode
+        : typeof err?.status === "number"
+          ? err.status
+          : 0;
+    const message =
+      typeof err?.message === "string" ? err.message : "ctrl-api error";
+    return { ok: false, status, message };
+  }
+}
+
+export const getRecallChannelStatus = async (
+  _args: unknown,
+  context: any,
+): Promise<RecallCompositeStatus> => {
+  const instance = await getUserInstance(context);
+
+  // Three parallel reads — config + usage + active_bots.
+  const [configRes, usageRes, botsRes] = await Promise.all([
+    safeProxy(instance, { path: "/api/v1/channels/recall/config" }),
+    safeProxy(instance, { path: "/api/v1/channels/recall/usage" }),
+    safeProxy(instance, { path: "/api/v1/channels/recall/bots/active" }),
+  ]);
+
+  // 503 anywhere = NOT_CONFIGURED on the tenant side → enabled=false.
+  // Any other non-2xx → error string (the card surfaces verbatim).
+  const config = configRes.ok ? configRes.data : null;
+  const usage = usageRes.ok ? usageRes.data : null;
+  const active_bots = botsRes.ok ? (botsRes.data?.bots ?? []) : [];
+
+  let error: string | null = null;
+  const probes = [configRes, usageRes, botsRes];
+  // enabled = at least usage came back successfully (it doesn't depend on
+  // RECALL_API_KEY; if the tenant has the route at all + state.db open
+  // it returns 200). config also doesn't gate on the key. So we treat
+  // the surface as "enabled" once both succeed AND a key is on file —
+  // which we infer from a non-503 active-bots probe (the bots GET is
+  // also key-free, but PR3a will replace this signal with an explicit
+  // "key on file" flag).
+  const usageOk = usageRes.ok;
+  const configOk = configRes.ok;
+  const enabled = usageOk && configOk;
+
+  // Surface the first hard error (non-503) we saw — 503 is the
+  // "expected" pre-paste state and shouldn't render as an error.
+  for (const r of probes) {
+    if (!r.ok && r.status !== 503 && r.status !== 0) {
+      error = r.message;
+      break;
+    }
+  }
+
+  return {
+    enabled,
+    config,
+    usage,
+    active_bots,
+    error,
+  };
+};
+
+export const updateRecallConfig = async (
+  args: Record<string, unknown>,
+  context: any,
+) => {
+  if (!args || typeof args !== "object") {
+    throw new HttpError(400, "config patch body required");
+  }
+  if (Object.keys(args).length === 0) {
+    throw new HttpError(400, "patch body must include at least one field");
+  }
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    method: "PATCH",
+    path: "/api/v1/channels/recall/config",
+    body: args,
+  });
+};
+
+/** Round-trip-validate a Recall API key against the Recall API. The key
+ *  is NEVER logged here; the ctrl-api persists nothing on its side
+ *  either (PR3a ships the persistent setter). The response is
+ *  `{ ok, account? }` or `{ ok: false, reason }` — we pass it through
+ *  verbatim so the card can render the reason. */
+export const validateRecallApiKey = async (
+  args: { api_key: string; region?: string },
+  context: any,
+) => {
+  if (typeof args?.api_key !== "string" || args.api_key.trim().length === 0) {
+    throw new HttpError(400, "api_key required");
+  }
+  const instance = await getUserInstance(context);
+  const body: Record<string, string> = { api_key: args.api_key.trim() };
+  if (typeof args.region === "string" && args.region.length > 0) {
+    body.region = args.region;
+  }
+  return proxyToTenant(instance, {
+    method: "POST",
+    path: "/api/v1/channels/recall/validate-key",
+    body,
+  });
+};
+
+/** Fire the synthetic webhook through ctrl-api → ctrl-api → state.db.
+ *  Functions as the card's "Test webhook" CTA; returns `{ ok, status,
+ *  latency_ms, sample_response }`. */
+export const testRecallWebhook = async (_args: unknown, context: any) => {
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    method: "POST",
+    path: "/api/v1/channels/recall/webhook-test",
+  });
+};
+
+/** Terminate a mid-meeting bot. ctrl-api calls Recall's DELETE then flips
+ *  the local row to "leaving". */
+export const terminateRecallBot = async (
+  args: { bot_id: string },
+  context: any,
+) => {
+  if (typeof args?.bot_id !== "string" || args.bot_id.trim().length === 0) {
+    throw new HttpError(400, "bot_id required");
+  }
+  const instance = await getUserInstance(context);
+  const safe = encodeURIComponent(args.bot_id.trim());
+  return proxyToTenant(instance, {
+    method: "DELETE",
+    path: `/api/v1/channels/recall/bots/${safe}`,
+  });
+};
+
+// ============================================================
 // Dashboard Home
 // ============================================================
 

--- a/packages/web/src/dashboard/recallCardCore.test.ts
+++ b/packages/web/src/dashboard/recallCardCore.test.ts
@@ -1,0 +1,513 @@
+/**
+ * /channels — Recall.ai card derivation tests.
+ *
+ * Covers the contract in spec §5.4 + the PR3 brief:
+ *   • status string by enabled state (disabled / configured / error)
+ *   • settings form serialize / deserialize (round-trip & diff PATCH)
+ *   • dial-range validation (wake-word, monthly-hours-cap, leave-after-minutes)
+ *   • recent-bots derivation by status (active vs terminal split, normaliser)
+ *   • webhook URL formatter (https default + trailing slash + bare host)
+ *   • cost-threshold parser (comma / space / "%" / dedupe / sort / range)
+ *   • cost-alert trigger boolean (month-hours ≥ cap * lowest-threshold / 100)
+ *   • bot duration + timestamp formatters
+ *
+ * Run with:  cd packages/web && npx tsx --test src/dashboard/recallCardCore.test.ts
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  RECALL_DEFAULT_FORM,
+  RECALL_REGION_OPTIONS,
+  RECALL_AUTO_JOIN_POLICY_OPTIONS,
+  RECALL_RESPOND_MODE_OPTIONS,
+  RECALL_CALENDAR_SOURCE_OPTIONS,
+  RECALL_MONTHLY_HOURS_CAP_RANGE,
+  RECALL_LEAVE_AFTER_MINUTES_RANGE,
+  RECALL_WAKE_WORD_RANGE,
+  RECALL_COST_THRESHOLD_RANGE,
+  botDurationMs,
+  botStatusLabel,
+  configToFormValues,
+  deriveBotsByStatus,
+  deriveRecallCardState,
+  formatBotDuration,
+  formatBotTimestamp,
+  formatCostThresholdList,
+  formatHours,
+  formatRecallWebhookUrl,
+  isProbablyValidWakeWord,
+  isValidBotName,
+  isValidLeaveAfterMinutes,
+  isValidMonthlyHoursCap,
+  parseCostThresholdList,
+  serializeFormPatch,
+  truncateBotId,
+  type RecallBot,
+  type RecallConfig,
+  type RecallStatus,
+} from "./recallCardCore";
+
+const FROZEN_NOW = new Date("2026-05-29T12:00:00Z");
+const FROZEN_NOW_MS = FROZEN_NOW.getTime();
+
+function msAgo(min: number): number {
+  return FROZEN_NOW_MS - min * 60_000;
+}
+
+const BASE_CONFIG: RecallConfig = {
+  region: "us-east-1",
+  bot_name: "Alfred's note-taker",
+  announces_on_join: true,
+  auto_join_policy: "principal_attendee",
+  calendar_source: "composio",
+  monthly_hours_cap: 60,
+  leave_after_minutes: 90,
+  respond_mode: "on_mention",
+  wake_word: "Alfred",
+  cost_alert_thresholds: [80, 100],
+  updated_at: FROZEN_NOW_MS,
+};
+
+// ── 1. status by enabled state ───────────────────────────────────────────
+
+test("derive: disabled — no API key on file (fresh tenant pre-paste)", () => {
+  const status: RecallStatus = {
+    enabled: false,
+    config: null,
+    usage: null,
+    active_bots: [],
+    error: null,
+  };
+  const card = deriveRecallCardState(status, FROZEN_NOW);
+  assert.equal(card.status, "disabled");
+  assert.equal(card.pillLabel, "Not connected");
+  assert.equal(card.pillTone, "available");
+  assert.match(card.heading, /Activate Recall/i);
+  // Even disabled, the form gets the defaults so the principal sees the
+  // shape of what they're configuring.
+  assert.deepEqual(card.formValues, RECALL_DEFAULT_FORM);
+  // No live data → bots table hidden, can't test webhook, can't edit dials.
+  assert.equal(card.visibleBots.length, 0);
+  assert.equal(card.canEditDials, false);
+  assert.equal(card.canTest, false);
+  assert.equal(card.monthHours, null);
+});
+
+test("derive: configured — config + usage live; pill = Connected", () => {
+  const status: RecallStatus = {
+    enabled: true,
+    config: BASE_CONFIG,
+    usage: { this_month_hours: 12.5, monthly_hours_cap: 60, bot_count_active: 1 },
+    active_bots: [],
+    error: null,
+  };
+  const card = deriveRecallCardState(status, FROZEN_NOW);
+  assert.equal(card.status, "configured");
+  assert.equal(card.pillLabel, "Connected");
+  assert.equal(card.pillTone, "active");
+  assert.equal(card.canEditDials, true);
+  assert.equal(card.canTest, true);
+  assert.equal(card.monthHours, 12.5);
+  // Address bakes the live usage rollup.
+  assert.match(card.address, /12.50h \/ 60h this month/);
+  assert.match(card.address, /1 bot active/);
+});
+
+test("derive: error — enabled but probe failed; surface verbatim error", () => {
+  const status: RecallStatus = {
+    enabled: true,
+    config: BASE_CONFIG,
+    usage: null,
+    active_bots: [],
+    error: "Recall returned HTTP 500 — internal server error",
+  };
+  const card = deriveRecallCardState(status, FROZEN_NOW);
+  assert.equal(card.status, "error");
+  assert.equal(card.pillLabel, "Needs attention");
+  assert.equal(card.pillTone, "error");
+  assert.match(card.description, /HTTP 500/);
+  // Edits + test disabled in error state — operator fixes upstream first.
+  assert.equal(card.canEditDials, false);
+  assert.equal(card.canTest, false);
+});
+
+test("derive: null status (no data yet) → disabled with defaults", () => {
+  const card = deriveRecallCardState(null, FROZEN_NOW);
+  assert.equal(card.status, "disabled");
+  assert.deepEqual(card.formValues, RECALL_DEFAULT_FORM);
+});
+
+// ── 2. settings form serialize / deserialize ─────────────────────────────
+
+test("configToFormValues: live config round-trips to the form shape", () => {
+  const form = configToFormValues({
+    ...BASE_CONFIG,
+    region: "eu-central-1",
+    bot_name: "Custom Bot",
+    monthly_hours_cap: 120,
+    respond_mode: "always",
+    cost_alert_thresholds: [50, 80, 100],
+  });
+  assert.equal(form.region, "eu-central-1");
+  assert.equal(form.bot_name, "Custom Bot");
+  assert.equal(form.monthly_hours_cap, 120);
+  assert.equal(form.respond_mode, "always");
+  assert.deepEqual(form.cost_alert_thresholds, [50, 80, 100]);
+});
+
+test("configToFormValues: bad enum values fall back to defaults", () => {
+  // Cast through `unknown` — runtime defends against an upstream that
+  // drifted the enum without telling the snapshot.
+  const form = configToFormValues({
+    ...BASE_CONFIG,
+    region: "mars-1" as unknown as RecallConfig["region"],
+    auto_join_policy:
+      "any_meeting" as unknown as RecallConfig["auto_join_policy"],
+    respond_mode: "loud" as unknown as RecallConfig["respond_mode"],
+  });
+  assert.equal(form.region, RECALL_DEFAULT_FORM.region);
+  assert.equal(form.auto_join_policy, RECALL_DEFAULT_FORM.auto_join_policy);
+  assert.equal(form.respond_mode, RECALL_DEFAULT_FORM.respond_mode);
+});
+
+test("configToFormValues: out-of-range numbers clamp into range", () => {
+  const form = configToFormValues({
+    ...BASE_CONFIG,
+    monthly_hours_cap: 9999, // route validator allows 0-10000 but the card caps at 500
+    leave_after_minutes: 0, // below min=1
+  });
+  assert.equal(form.monthly_hours_cap, RECALL_MONTHLY_HOURS_CAP_RANGE.max);
+  assert.equal(form.leave_after_minutes, RECALL_LEAVE_AFTER_MINUTES_RANGE.min);
+});
+
+test("configToFormValues: null config falls back to RECALL_DEFAULT_FORM", () => {
+  const form = configToFormValues(null);
+  assert.deepEqual(form, RECALL_DEFAULT_FORM);
+});
+
+test("serializeFormPatch: only changed fields land in the PATCH body", () => {
+  const prev = { ...RECALL_DEFAULT_FORM };
+  const next = {
+    ...prev,
+    region: "eu-central-1" as const,
+    monthly_hours_cap: 120,
+  };
+  const patch = serializeFormPatch(next, prev);
+  assert.deepEqual(patch, {
+    region: "eu-central-1",
+    monthly_hours_cap: 120,
+  });
+});
+
+test("serializeFormPatch: no-op when nothing changed → empty object", () => {
+  const prev = { ...RECALL_DEFAULT_FORM };
+  const next = { ...prev };
+  const patch = serializeFormPatch(next, prev);
+  assert.deepEqual(patch, {});
+});
+
+test("serializeFormPatch: threshold-array equality is element-wise, not reference", () => {
+  const prev = { ...RECALL_DEFAULT_FORM, cost_alert_thresholds: [80, 100] };
+  // Same array contents but a different reference — must NOT appear in the patch.
+  const next = { ...prev, cost_alert_thresholds: [80, 100] };
+  const patch = serializeFormPatch(next, prev);
+  assert.deepEqual(patch, {});
+  // Different contents → does appear.
+  const changed = { ...prev, cost_alert_thresholds: [50, 80, 100] };
+  const patch2 = serializeFormPatch(changed, prev);
+  assert.deepEqual(patch2.cost_alert_thresholds, [50, 80, 100]);
+});
+
+test("serializeFormPatch: trims wake_word + bot_name before diffing", () => {
+  const prev = { ...RECALL_DEFAULT_FORM, wake_word: "Alfred" };
+  // Pure whitespace-only diff → no patch line.
+  const next = { ...prev, wake_word: "  Alfred  " };
+  const patch = serializeFormPatch(next, prev);
+  assert.equal(patch.wake_word, undefined);
+});
+
+// ── 3. dial-range validation ──────────────────────────────────────────────
+
+test("isProbablyValidWakeWord: trims + accepts non-empty ≤64", () => {
+  assert.equal(isProbablyValidWakeWord("Alfred"), true);
+  assert.equal(isProbablyValidWakeWord("  Sir  "), true);
+  assert.equal(isProbablyValidWakeWord(""), false);
+  assert.equal(isProbablyValidWakeWord("   "), false);
+  assert.equal(isProbablyValidWakeWord("x".repeat(65)), false);
+  // Embedded control char (mid-string \u0001 survives .trim()).
+  assert.equal(isProbablyValidWakeWord("Alfred\u0001Sir"), false);
+  // A trailing newline alone is trimmed off, so the wake word survives.
+  assert.equal(isProbablyValidWakeWord("Alfred\n"), true);
+  assert.equal(isProbablyValidWakeWord(123 as unknown as string), false);
+});
+
+test("isValidMonthlyHoursCap: enforces [1, 500] integer range", () => {
+  assert.equal(isValidMonthlyHoursCap(60), true);
+  assert.equal(isValidMonthlyHoursCap(RECALL_MONTHLY_HOURS_CAP_RANGE.min), true);
+  assert.equal(isValidMonthlyHoursCap(RECALL_MONTHLY_HOURS_CAP_RANGE.max), true);
+  assert.equal(isValidMonthlyHoursCap(0), false);
+  assert.equal(isValidMonthlyHoursCap(501), false);
+  assert.equal(isValidMonthlyHoursCap(60.5), false);
+  assert.equal(isValidMonthlyHoursCap("60" as unknown as number), false);
+});
+
+test("isValidLeaveAfterMinutes: enforces [1, 1440] integer range", () => {
+  assert.equal(isValidLeaveAfterMinutes(90), true);
+  assert.equal(isValidLeaveAfterMinutes(RECALL_LEAVE_AFTER_MINUTES_RANGE.min), true);
+  assert.equal(isValidLeaveAfterMinutes(RECALL_LEAVE_AFTER_MINUTES_RANGE.max), true);
+  assert.equal(isValidLeaveAfterMinutes(0), false);
+  assert.equal(isValidLeaveAfterMinutes(1441), false);
+});
+
+test("isValidBotName: non-empty + ≤200 chars", () => {
+  assert.equal(isValidBotName("Alfred's note-taker"), true);
+  assert.equal(isValidBotName(""), false);
+  assert.equal(isValidBotName("   "), false);
+  assert.equal(isValidBotName("x".repeat(201)), false);
+});
+
+// ── 4. recent-bots derivation by status ──────────────────────────────────
+
+test("deriveBotsByStatus: splits active vs terminal, newest-first", () => {
+  const bots: unknown[] = [
+    {
+      id: "bot-old-done",
+      status: "done",
+      created_at: msAgo(60),
+      joined_at: msAgo(60),
+      left_at: msAgo(50),
+    },
+    {
+      id: "bot-active",
+      status: "in_meeting",
+      created_at: msAgo(5),
+      joined_at: msAgo(4),
+    },
+    {
+      id: "bot-newer-fail",
+      status: "fail",
+      created_at: msAgo(2),
+    },
+    {
+      id: "bot-joining",
+      status: "joining",
+      created_at: msAgo(1),
+    },
+  ];
+  const { active, terminal } = deriveBotsByStatus(bots);
+  // active: joining (1min ago) then in_meeting (5min ago)
+  assert.deepEqual(
+    active.map((b) => b.id),
+    ["bot-joining", "bot-active"],
+  );
+  // terminal: fail (2min ago) then done (60min ago)
+  assert.deepEqual(
+    terminal.map((b) => b.id),
+    ["bot-newer-fail", "bot-old-done"],
+  );
+});
+
+test("deriveBotsByStatus: malformed entries dropped; unknown statuses ignored", () => {
+  const bots: unknown[] = [
+    null,
+    "not-an-object",
+    { id: "no-status" }, // missing status
+    { id: "bad-status", status: "shrugging", created_at: msAgo(1) }, // unknown enum
+    { id: "ok", status: "joining", created_at: msAgo(2) },
+    { status: "joining", created_at: msAgo(3) }, // missing id
+  ];
+  const { active, terminal } = deriveBotsByStatus(bots);
+  assert.equal(active.length, 1);
+  assert.equal(active[0].id, "ok");
+  assert.equal(terminal.length, 0);
+});
+
+test("deriveRecallCardState: visibleBots caps at 10 active rows", () => {
+  const bots: RecallBot[] = Array.from({ length: 15 }, (_, i) => ({
+    id: `bot-${i}`,
+    calendar_event_id: null,
+    meeting_url: null,
+    status: "joining" as const,
+    created_at: msAgo(i),
+    joined_at: null,
+    left_at: null,
+    transcript_url: null,
+  }));
+  const status: RecallStatus = {
+    enabled: true,
+    config: BASE_CONFIG,
+    usage: { this_month_hours: 0, monthly_hours_cap: 60, bot_count_active: 15 },
+    active_bots: bots,
+    error: null,
+  };
+  const card = deriveRecallCardState(status, FROZEN_NOW);
+  assert.equal(card.visibleBots.length, 10);
+});
+
+// ── 5. webhook URL formatter ─────────────────────────────────────────────
+
+test("formatRecallWebhookUrl: composes /api/v1/webhooks/recall onto origin", () => {
+  assert.equal(
+    formatRecallWebhookUrl("https://home.alfred.black"),
+    "https://home.alfred.black/api/v1/webhooks/recall",
+  );
+  // Trailing slash + extra path are dropped.
+  assert.equal(
+    formatRecallWebhookUrl("https://home.alfred.black/"),
+    "https://home.alfred.black/api/v1/webhooks/recall",
+  );
+  // Bare host → defaults to https.
+  assert.equal(
+    formatRecallWebhookUrl("home.alfred.black"),
+    "https://home.alfred.black/api/v1/webhooks/recall",
+  );
+  // Empty / nullish → empty string (caller hides Copy button).
+  assert.equal(formatRecallWebhookUrl(""), "");
+  assert.equal(formatRecallWebhookUrl(null), "");
+  assert.equal(formatRecallWebhookUrl(undefined), "");
+  // http preserved (localhost dev).
+  assert.equal(
+    formatRecallWebhookUrl("http://localhost:3000"),
+    "http://localhost:3000/api/v1/webhooks/recall",
+  );
+});
+
+// ── 6. cost-threshold parser ─────────────────────────────────────────────
+
+test("parseCostThresholdList: comma + space + %, dedupe + sort, range check", () => {
+  assert.deepEqual(parseCostThresholdList("80, 100"), [80, 100]);
+  assert.deepEqual(parseCostThresholdList("80 100 150"), [80, 100, 150]);
+  assert.deepEqual(parseCostThresholdList("80%, 100%"), [80, 100]);
+  // Out-of-order + duplicate → sorted + deduped.
+  assert.deepEqual(parseCostThresholdList("100, 80, 80"), [80, 100]);
+  // Empty input → null (the form surfaces "must enter at least one").
+  assert.equal(parseCostThresholdList(""), null);
+  assert.equal(parseCostThresholdList("   "), null);
+  // Below min=1 → null.
+  assert.equal(parseCostThresholdList("0, 100"), null);
+  // Above max=200 → null.
+  assert.equal(parseCostThresholdList("100, 250"), null);
+  // Non-numeric → null.
+  assert.equal(parseCostThresholdList("abc"), null);
+  assert.equal(parseCostThresholdList("80, xyz"), null);
+});
+
+test("formatCostThresholdList: round-trips through parse for canonical input", () => {
+  const parsed = parseCostThresholdList("80, 100");
+  assert.deepEqual(parsed, [80, 100]);
+  assert.equal(formatCostThresholdList(parsed!), "80, 100");
+  assert.equal(formatCostThresholdList([]), "");
+  // Non-finite entries dropped, no quotes/whitespace artefacts.
+  assert.equal(
+    formatCostThresholdList([80, Number.NaN as unknown as number, 100]),
+    "80, 100",
+  );
+});
+
+// ── 7. cost-alert trigger (the badge boolean) ────────────────────────────
+
+test("derive: costAlertTriggered fires when month-hours ≥ cap × lowest-threshold/100", () => {
+  // cap=60, thresholds=[80, 100] → trigger at 60 * 0.80 = 48h
+  const status: RecallStatus = {
+    enabled: true,
+    config: BASE_CONFIG,
+    usage: { this_month_hours: 48, monthly_hours_cap: 60, bot_count_active: 0 },
+    active_bots: [],
+    error: null,
+  };
+  const card = deriveRecallCardState(status, FROZEN_NOW);
+  assert.equal(card.costAlertTriggered, true);
+});
+
+test("derive: costAlertTriggered stays false below first threshold", () => {
+  const status: RecallStatus = {
+    enabled: true,
+    config: BASE_CONFIG,
+    usage: { this_month_hours: 12, monthly_hours_cap: 60, bot_count_active: 0 },
+    active_bots: [],
+    error: null,
+  };
+  const card = deriveRecallCardState(status, FROZEN_NOW);
+  assert.equal(card.costAlertTriggered, false);
+});
+
+// ── 8. bot duration / timestamp helpers ──────────────────────────────────
+
+test("botDurationMs: null when not yet joined; capped at now for in-flight", () => {
+  const queued: RecallBot = {
+    id: "q",
+    calendar_event_id: null,
+    meeting_url: null,
+    status: "joining",
+    created_at: msAgo(2),
+    joined_at: null,
+    left_at: null,
+    transcript_url: null,
+  };
+  assert.equal(botDurationMs(queued, FROZEN_NOW), null);
+
+  const inflight: RecallBot = {
+    ...queued,
+    status: "in_meeting",
+    joined_at: msAgo(30),
+    left_at: null,
+  };
+  assert.equal(botDurationMs(inflight, FROZEN_NOW), 30 * 60_000);
+
+  const done: RecallBot = {
+    ...queued,
+    status: "done",
+    joined_at: msAgo(60),
+    left_at: msAgo(15),
+  };
+  assert.equal(botDurationMs(done, FROZEN_NOW), 45 * 60_000);
+});
+
+test("formatBotDuration: h+m / m-only / s-only / em-dash for null", () => {
+  assert.equal(formatBotDuration(null), "—");
+  assert.equal(formatBotDuration(0), "0s");
+  assert.equal(formatBotDuration(47_000), "47s");
+  assert.equal(formatBotDuration(12 * 60_000), "12m");
+  assert.equal(formatBotDuration(72 * 60_000), "1h 12m");
+});
+
+test("formatBotTimestamp + truncateBotId + formatHours + botStatusLabel", () => {
+  assert.equal(formatBotTimestamp(null), "—");
+  assert.equal(
+    formatBotTimestamp(Date.UTC(2026, 4, 29, 12, 34)),
+    "2026-05-29 12:34 UTC",
+  );
+  assert.equal(truncateBotId("abc"), "abc");
+  // Truncation keeps first 6 + last 4 chars.
+  assert.equal(truncateBotId("abcdef-1234-5678-90"), "abcdef…8-90");
+  assert.equal(truncateBotId("exactly-12ch"), "exactly-12ch");
+  assert.equal(formatHours(12.345), "12.35h");
+  assert.equal(formatHours(0), "0.00h");
+  assert.equal(formatHours(Number.NaN), "—");
+
+  assert.equal(botStatusLabel("requested"), "Requested");
+  assert.equal(botStatusLabel("in_meeting"), "In meeting");
+  assert.equal(botStatusLabel("done"), "Done");
+  assert.equal(botStatusLabel("fail"), "Failed");
+});
+
+// ── 9. sanity: option lists match the route validator's expectations ─────
+
+test("enum option lists carry the exact strings the route validator accepts", () => {
+  // These constants are imported by the React layer's <select> and
+  // by the route validator in channels_recall.ts; if either drifts,
+  // the union types blow up first. Just sanity-check membership here.
+  assert.ok(RECALL_REGION_OPTIONS.includes("us-east-1"));
+  assert.ok(RECALL_REGION_OPTIONS.includes("eu-central-1"));
+  assert.ok(RECALL_AUTO_JOIN_POLICY_OPTIONS.includes("principal_attendee"));
+  assert.ok(RECALL_AUTO_JOIN_POLICY_OPTIONS.includes("off"));
+  assert.ok(RECALL_RESPOND_MODE_OPTIONS.includes("on_mention"));
+  assert.ok(RECALL_CALENDAR_SOURCE_OPTIONS.includes("composio"));
+  // Range sanity — these drive the <input min/max>.
+  assert.equal(RECALL_MONTHLY_HOURS_CAP_RANGE.min, 1);
+  assert.equal(RECALL_MONTHLY_HOURS_CAP_RANGE.max, 500);
+  assert.equal(RECALL_WAKE_WORD_RANGE.max, 64);
+  assert.equal(RECALL_COST_THRESHOLD_RANGE.max, 200);
+});

--- a/packages/web/src/dashboard/recallCardCore.ts
+++ b/packages/web/src/dashboard/recallCardCore.ts
@@ -1,0 +1,797 @@
+// recallCardCore — pure shape derivation for the /channels Recall.ai card.
+// Mirrors paperclipCardCore / omiCardCore: import-free (no React / no Wasp)
+// so the derived states unit-test under node:test the same way.
+//
+// Recall.ai replaces the retired Vexa stack as the per-meeting bot
+// transport (#113). The principal never visits recall.ai — every dial
+// the bot reads (region, bot name, announces-on-join, auto-join policy,
+// calendar source, monthly-hours cap, leave-after-N-minutes, respond
+// mode, wake word, cost-alert thresholds) is edited from this card.
+//
+// PR2 (#129) shipped these ctrl-api routes under /api/v1/channels/recall/:
+//
+//   POST  /validate-key                — paste-and-round-trip an API key
+//   GET   /config                      — current dials (singleton row)
+//   PATCH /config                      — update dials
+//   GET   /usage                       — month-to-date hours rollup
+//   GET   /bots/active                 — non-terminal bots
+//   DELETE /bots/:bot_id               — mid-meeting terminate
+//   POST  /webhook-test                — synthetic Svix-signed delivery
+//   POST  /webhooks/recall             — inbound Svix-signed target
+//
+// Persistence of RECALL_API_KEY itself (Vaultwarden-backed POST /api-key)
+// is *not* in PR2 — it lands in PR3a. PR3 ships the operator-facing
+// surface against the validate-only contract: paste → round-trip →
+// success copy + a soft "persistence pending" hint. Once PR3a lands the
+// /api-key setter, the card upgrades to a save-on-success flow with no
+// derivation change.
+//
+// The three derived "outer states" the card hangs UI off:
+//
+//   • disabled            — no API key on file (validate-key never
+//                           passed AND none of the env-dependent routes
+//                           succeed). Hero copy = "Activate Recall.ai
+//                           meeting bot" + API-key paste form.
+//   • configured          — config + usage routes return OK. Card shows
+//                           the full dial form, recent-bots table,
+//                           Test affordance, webhook setup expander.
+//   • error               — the underlying probes returned a hard error
+//                           ctrl-api itself couldn't recover from.
+
+// ── enum option lists (single source of truth) ────────────────────────────
+//
+// These match the validator in channels_recall.ts. The web layer reads
+// them straight off this module so the <select> options never drift
+// from the route validator.
+
+/** Regions Recall.ai hosts. Matches RECALL_REGION_HOSTS in the route. */
+export const RECALL_REGION_OPTIONS = [
+  "us-east-1",
+  "us-west-2",
+  "eu-central-1",
+  "ap-northeast-1",
+] as const;
+export type RecallRegion = (typeof RECALL_REGION_OPTIONS)[number];
+
+/** Auto-join policy. Matches VALID_AUTO_JOIN_POLICIES in the route. */
+export const RECALL_AUTO_JOIN_POLICY_OPTIONS = [
+  "off",
+  "principal_attendee",
+  "all",
+] as const;
+export type RecallAutoJoinPolicy =
+  (typeof RECALL_AUTO_JOIN_POLICY_OPTIONS)[number];
+
+/** Calendar source. Matches VALID_CALENDAR_SOURCES in the route. */
+export const RECALL_CALENDAR_SOURCE_OPTIONS = [
+  "composio",
+  "recall_v2",
+] as const;
+export type RecallCalendarSource =
+  (typeof RECALL_CALENDAR_SOURCE_OPTIONS)[number];
+
+/** Respond mode. Matches VALID_RESPOND_MODES in the route. */
+export const RECALL_RESPOND_MODE_OPTIONS = [
+  "off",
+  "on_mention",
+  "always",
+] as const;
+export type RecallRespondMode =
+  (typeof RECALL_RESPOND_MODE_OPTIONS)[number];
+
+/** Bot lifecycle status (terminal + non-terminal, from recall_bot.status). */
+export type RecallBotStatus =
+  | "requested"
+  | "joining"
+  | "in_meeting"
+  | "leaving"
+  | "done"
+  | "fail";
+
+const TERMINAL_BOT_STATUSES: ReadonlySet<RecallBotStatus> = new Set([
+  "done",
+  "fail",
+]);
+
+// ── wire types — the shape the proxied ctrl-api responses produce ─────────
+
+/**
+ * GET /api/v1/channels/recall/config response (1:1 with rowToApiConfig).
+ * All fields always present; updated_at is unix-ms.
+ */
+export interface RecallConfig {
+  region: RecallRegion;
+  bot_name: string;
+  announces_on_join: boolean;
+  auto_join_policy: RecallAutoJoinPolicy;
+  calendar_source: RecallCalendarSource;
+  monthly_hours_cap: number;
+  leave_after_minutes: number;
+  respond_mode: RecallRespondMode;
+  wake_word: string;
+  cost_alert_thresholds: number[];
+  updated_at: number;
+}
+
+/** GET /api/v1/channels/recall/usage response. */
+export interface RecallUsage {
+  this_month_hours: number;
+  monthly_hours_cap: number;
+  bot_count_active: number;
+}
+
+/**
+ * One row from GET /api/v1/channels/recall/bots/active. The route returns
+ * `{ bots: RecallBot[] }`; in the web layer we unwrap before passing in.
+ * Timestamps are unix-ms (the ctrl-api passes them through as INTEGER).
+ */
+export interface RecallBot {
+  id: string;
+  calendar_event_id: string | null;
+  meeting_url: string | null;
+  status: RecallBotStatus;
+  created_at: number;
+  joined_at: number | null;
+  left_at: number | null;
+  transcript_url: string | null;
+}
+
+/**
+ * Composite status the card actually renders off. Built in
+ * operations.ts by stitching the three live queries together; the
+ * fields below are the ones derivation cares about. `enabled` is the
+ * "do we have a working API key" signal — derived in operations.ts
+ * from "the env-dependent probes returned non-503". The web layer
+ * NEVER sees the API key itself; only this boolean.
+ */
+export interface RecallStatus {
+  enabled: boolean;
+  config: RecallConfig | null;
+  usage: RecallUsage | null;
+  active_bots: RecallBot[];
+  /** Verbatim error string from the most recent failed probe, if any. */
+  error: string | null;
+  /**
+   * Webhook delivery URL the operator pastes into Recall.ai's dashboard.
+   * Built off the tenant's public origin in ctrl-api (PR3a will surface
+   * it on /config). Until then the web layer derives it from
+   * window.location.origin. Optional on the wire.
+   */
+  webhook_url?: string;
+  /**
+   * First 6 chars of RECALL_WEBHOOK_SECRET (whsec_…). Surfaced for the
+   * operator to recognise "did I paste the right secret?" without ever
+   * round-tripping the full secret. Optional on the wire (older
+   * ctrl-api may omit).
+   */
+  webhook_secret_first6?: string | null;
+}
+
+// ── derived card state ────────────────────────────────────────────────────
+
+export type RecallCardStatusKind = "disabled" | "configured" | "error";
+
+export interface RecallCardState {
+  /** Which top-level block renders. */
+  status: RecallCardStatusKind;
+  /** Pretty pill label ("Connected" / "Not connected" / "Needs attention"). */
+  pillLabel: string;
+  /** Pill tone — matches ChannelCard's ChannelStatus enum. */
+  pillTone: "active" | "available" | "error";
+  /** Heading copy under the card name. */
+  heading: string;
+  /** Marginalia under the heading. */
+  description: string;
+  /** Sub-line in the card's "address" slot. */
+  address: string;
+  /**
+   * The dial form's initial values. On `disabled`/`error` the values
+   * are still surfaced (so the principal sees Recall's defaults
+   * pre-paste); on `configured` they reflect the live row.
+   */
+  formValues: RecallFormValues;
+  /** Up to 10 active-bot rows, normalised + newest-first. */
+  visibleBots: RecallBot[];
+  /** True iff the dial form should be interactive (configured only). */
+  canEditDials: boolean;
+  /** True iff the "Send test webhook" CTA renders enabled. */
+  canTest: boolean;
+  /** Live month-to-date hours number, or null when not yet known. */
+  monthHours: number | null;
+  /** True when month-to-date use ≥ cost-alert threshold. Drives the badge. */
+  costAlertTriggered: boolean;
+}
+
+/**
+ * The shape the React form binds to. Keep it serialisable and
+ * separately exported so a parent component can hold form state in a
+ * single object without dragging in the whole derivation result.
+ */
+export interface RecallFormValues {
+  region: RecallRegion;
+  bot_name: string;
+  announces_on_join: boolean;
+  auto_join_policy: RecallAutoJoinPolicy;
+  calendar_source: RecallCalendarSource;
+  monthly_hours_cap: number;
+  leave_after_minutes: number;
+  respond_mode: RecallRespondMode;
+  wake_word: string;
+  cost_alert_thresholds: number[];
+}
+
+/** Defaults that match the migration's column defaults so the empty
+ *  form never renders as blank strings. Single source of truth — the
+ *  test asserts this matches the migration. */
+export const RECALL_DEFAULT_FORM: RecallFormValues = {
+  region: "us-east-1",
+  bot_name: "Alfred's note-taker",
+  announces_on_join: true,
+  auto_join_policy: "principal_attendee",
+  calendar_source: "composio",
+  monthly_hours_cap: 60,
+  leave_after_minutes: 90,
+  respond_mode: "on_mention",
+  wake_word: "Alfred",
+  cost_alert_thresholds: [80, 100],
+};
+
+// ── input ranges (single source of truth for the form widgets) ────────────
+
+/** Monthly-hours-cap input range. The route validator allows 0-10000;
+ *  the card narrows to 1-500 because the principal is paying per hour
+ *  and a 5000-hour cap would silently swallow a $50k bill. */
+export const RECALL_MONTHLY_HOURS_CAP_RANGE = {
+  min: 1,
+  max: 500,
+} as const;
+
+/** Leave-after-minutes range. Mirrors the route validator (1-1440). */
+export const RECALL_LEAVE_AFTER_MINUTES_RANGE = {
+  min: 1,
+  max: 1440,
+} as const;
+
+/** Wake-word length range. Mirrors the route validator. */
+export const RECALL_WAKE_WORD_RANGE = {
+  min: 1,
+  max: 64,
+} as const;
+
+/** Cost-alert thresholds: each entry is a percentage; route allows
+ *  0-1000 but the card narrows to 1-200 (the value is "% of monthly
+ *  cap", so >200% is almost always a typo). */
+export const RECALL_COST_THRESHOLD_RANGE = {
+  min: 1,
+  max: 200,
+} as const;
+
+// ── validators ────────────────────────────────────────────────────────────
+
+/** Wake-word: non-empty, ≤64 chars, no leading/trailing whitespace,
+ *  no control chars. Mirrors the route validator's intent + a little
+ *  defensive trimming so the principal doesn't paste a stray newline. */
+export function isProbablyValidWakeWord(s: unknown): boolean {
+  if (typeof s !== "string") return false;
+  const trimmed = s.trim();
+  if (trimmed.length < RECALL_WAKE_WORD_RANGE.min) return false;
+  if (trimmed.length > RECALL_WAKE_WORD_RANGE.max) return false;
+  // Reject control chars (anything < 0x20 + DEL).
+  for (let i = 0; i < trimmed.length; i++) {
+    const c = trimmed.charCodeAt(i);
+    if (c < 0x20 || c === 0x7f) return false;
+  }
+  return true;
+}
+
+/** Monthly-hours-cap input validator. */
+export function isValidMonthlyHoursCap(n: unknown): boolean {
+  if (typeof n !== "number" || !Number.isInteger(n)) return false;
+  return (
+    n >= RECALL_MONTHLY_HOURS_CAP_RANGE.min &&
+    n <= RECALL_MONTHLY_HOURS_CAP_RANGE.max
+  );
+}
+
+/** Leave-after-minutes input validator. */
+export function isValidLeaveAfterMinutes(n: unknown): boolean {
+  if (typeof n !== "number" || !Number.isInteger(n)) return false;
+  return (
+    n >= RECALL_LEAVE_AFTER_MINUTES_RANGE.min &&
+    n <= RECALL_LEAVE_AFTER_MINUTES_RANGE.max
+  );
+}
+
+/** Bot-name validator — non-empty, ≤200 chars (matches the route). */
+export function isValidBotName(s: unknown): boolean {
+  if (typeof s !== "string") return false;
+  const trimmed = s.trim();
+  return trimmed.length > 0 && trimmed.length <= 200;
+}
+
+// ── threshold parsing ─────────────────────────────────────────────────────
+
+/**
+ * Parse a comma-separated cost-alert threshold string ("80, 100, 150")
+ * into a sorted-asc, deduped number array. Whitespace, trailing
+ * commas, and stray "%" are tolerated. Returns null when any entry is
+ * non-numeric or out of range — the caller surfaces a hint.
+ *
+ * Examples:
+ *   "80, 100"          → [80, 100]
+ *   "80 100 150"       → [80, 100, 150]   (whitespace separator)
+ *   "100, 80, 80"      → [80, 100]        (sorted + deduped)
+ *   "80%, 100%"        → [80, 100]        ('%' stripped)
+ *   ""                 → null             (need at least one)
+ *   "0, 100"           → null             (0 below min=1)
+ *   "abc"              → null
+ */
+export function parseCostThresholdList(raw: string): number[] | null {
+  if (typeof raw !== "string") return null;
+  // Split on commas, whitespace, or both. Strip '%' so '80%' parses.
+  const pieces = raw
+    .split(/[,\s]+/)
+    .map((p) => p.replace(/%/g, "").trim())
+    .filter((p) => p.length > 0);
+  if (pieces.length === 0) return null;
+  const out: number[] = [];
+  for (const p of pieces) {
+    const n = Number(p);
+    if (!Number.isFinite(n) || !Number.isInteger(n)) return null;
+    if (
+      n < RECALL_COST_THRESHOLD_RANGE.min ||
+      n > RECALL_COST_THRESHOLD_RANGE.max
+    ) {
+      return null;
+    }
+    if (!out.includes(n)) out.push(n);
+  }
+  out.sort((a, b) => a - b);
+  return out;
+}
+
+/** Inverse of parseCostThresholdList — render the array as a comma-joined
+ *  string ("80, 100") for the <input> initial value. */
+export function formatCostThresholdList(xs: number[]): string {
+  if (!Array.isArray(xs)) return "";
+  return xs
+    .filter((x) => typeof x === "number" && Number.isFinite(x))
+    .map((x) => String(x))
+    .join(", ");
+}
+
+// ── recent-bots derivation ────────────────────────────────────────────────
+
+/**
+ * Split bots by terminal-ness; the React layer renders the active ones
+ * inline at the top and the terminal ones in a "Recent" tail. Both
+ * sets are newest-first.
+ *
+ * Defensively normalises an unknown[] array off the wire — drops nulls,
+ * strings, unknown statuses (≠ the 6 in RecallBotStatus). The point is
+ * to keep the card from blowing up when a future ctrl-api adds a new
+ * status enum and the snapshot we hold is older than it.
+ */
+export function deriveBotsByStatus(raw: unknown): {
+  active: RecallBot[];
+  terminal: RecallBot[];
+} {
+  const all = normaliseBots(raw);
+  const active: RecallBot[] = [];
+  const terminal: RecallBot[] = [];
+  for (const b of all) {
+    if (TERMINAL_BOT_STATUSES.has(b.status)) terminal.push(b);
+    else active.push(b);
+  }
+  // Newest-first by created_at.
+  active.sort((a, b) => b.created_at - a.created_at);
+  terminal.sort((a, b) => b.created_at - a.created_at);
+  return { active, terminal };
+}
+
+const VALID_BOT_STATUSES: ReadonlySet<RecallBotStatus> = new Set([
+  "requested",
+  "joining",
+  "in_meeting",
+  "leaving",
+  "done",
+  "fail",
+]);
+
+function normaliseBots(raw: unknown): RecallBot[] {
+  if (!Array.isArray(raw)) return [];
+  const out: RecallBot[] = [];
+  for (const it of raw) {
+    if (typeof it !== "object" || it === null) continue;
+    const r = it as Record<string, unknown>;
+    const id = typeof r.id === "string" ? r.id : "";
+    if (!id) continue;
+    const statusRaw = typeof r.status === "string" ? r.status : "";
+    if (!VALID_BOT_STATUSES.has(statusRaw as RecallBotStatus)) continue;
+    const status = statusRaw as RecallBotStatus;
+    const calendar_event_id =
+      typeof r.calendar_event_id === "string" ? r.calendar_event_id : null;
+    const meeting_url =
+      typeof r.meeting_url === "string" ? r.meeting_url : null;
+    const created_at =
+      typeof r.created_at === "number" && Number.isFinite(r.created_at)
+        ? r.created_at
+        : 0;
+    const joined_at =
+      typeof r.joined_at === "number" && Number.isFinite(r.joined_at)
+        ? r.joined_at
+        : null;
+    const left_at =
+      typeof r.left_at === "number" && Number.isFinite(r.left_at)
+        ? r.left_at
+        : null;
+    const transcript_url =
+      typeof r.transcript_url === "string" ? r.transcript_url : null;
+    out.push({
+      id,
+      calendar_event_id,
+      meeting_url,
+      status,
+      created_at,
+      joined_at,
+      left_at,
+      transcript_url,
+    });
+  }
+  return out;
+}
+
+/**
+ * Duration in milliseconds the bot has been in the meeting, or null
+ * when the bot hasn't joined yet. Caps at "now" for in-flight bots so
+ * the React layer doesn't render a negative number.
+ */
+export function botDurationMs(
+  bot: RecallBot,
+  now: Date = new Date(),
+): number | null {
+  if (bot.joined_at === null) return null;
+  const end = bot.left_at ?? now.getTime();
+  return Math.max(0, end - bot.joined_at);
+}
+
+/** Pretty-format a duration in ms as "1h 12m" / "12m" / "47s". */
+export function formatBotDuration(ms: number | null): string {
+  if (ms === null || !Number.isFinite(ms) || ms < 0) return "—";
+  const totalSec = Math.floor(ms / 1000);
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = totalSec % 60;
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m`;
+  return `${s}s`;
+}
+
+// ── webhook URL formatter ─────────────────────────────────────────────────
+
+/**
+ * Given the tenant's public origin (e.g. "https://home.alfred.black")
+ * produce the URL the operator pastes into Recall.ai's webhook dashboard.
+ *
+ * Tolerates trailing slashes, missing scheme (assumes https), and an
+ * empty string (returns ""). Never throws — the React layer hides the
+ * Copy button when the result is empty.
+ */
+export function formatRecallWebhookUrl(origin: string | null | undefined): string {
+  if (typeof origin !== "string" || origin.trim().length === 0) return "";
+  let s = origin.trim();
+  // No scheme → default to https.
+  if (!/^https?:\/\//i.test(s)) {
+    s = `https://${s}`;
+  }
+  // Strip trailing slash(es).
+  s = s.replace(/\/+$/, "");
+  // Validate it's parseable as a URL — fall through to the trimmed
+  // string if not (caller may have a non-DNS hostname like "localhost").
+  try {
+    const u = new URL(s);
+    return `${u.protocol}//${u.host}/api/v1/webhooks/recall`;
+  } catch {
+    return `${s}/api/v1/webhooks/recall`;
+  }
+}
+
+// ── status derivation ─────────────────────────────────────────────────────
+
+/**
+ * The card's top-level derivation. Pure: receives the composite
+ * RecallStatus the operations layer built from the three queries (plus
+ * the env-derived `enabled` boolean) and produces the React-ready
+ * shape.
+ *
+ * Outer states:
+ *   • disabled   — enabled=false (no API key on file). Hero copy +
+ *                   paste form. Recent-bots table hidden.
+ *   • error      — enabled=true but the live snapshot carries a hard
+ *                   error string. Everything else still renders.
+ *   • configured — enabled=true and no error. Full surface.
+ */
+export function deriveRecallCardState(
+  status: RecallStatus | null | undefined,
+  now: Date = new Date(),
+): RecallCardState {
+  const s = status ?? ({
+    enabled: false,
+    config: null,
+    usage: null,
+    active_bots: [],
+    error: null,
+  } as RecallStatus);
+
+  const formValues = configToFormValues(s.config);
+  const { active } = deriveBotsByStatus(s.active_bots);
+  const visibleBots = active.slice(0, 10);
+  const monthHours =
+    s.usage && Number.isFinite(s.usage.this_month_hours)
+      ? s.usage.this_month_hours
+      : null;
+
+  // Cost-alert: trigger when month-to-date hours ≥ (cap * lowest-threshold/100).
+  // Lowest threshold = the most cautious one (e.g. 80% in [80, 100]).
+  const costAlertTriggered =
+    monthHours !== null &&
+    formValues.cost_alert_thresholds.length > 0 &&
+    formValues.monthly_hours_cap > 0 &&
+    monthHours >=
+      (formValues.monthly_hours_cap *
+        Math.min(...formValues.cost_alert_thresholds)) /
+        100;
+
+  if (!s.enabled) {
+    return {
+      status: "disabled",
+      pillLabel: "Not connected",
+      pillTone: "available",
+      heading: "Activate Recall.ai meeting bot",
+      description:
+        "Recall.ai sends a bot to your Zoom / Meet / Teams meetings and " +
+        "feeds the transcript back here. Paste an API key from recall.ai " +
+        "to start.",
+      address: "Coming soon (Recall.ai)",
+      formValues,
+      visibleBots: [],
+      canEditDials: false,
+      canTest: false,
+      monthHours: null,
+      costAlertTriggered: false,
+    };
+  }
+
+  if (s.error) {
+    return {
+      status: "error",
+      pillLabel: "Needs attention",
+      pillTone: "error",
+      heading: "Recall.ai needs attention",
+      description: s.error,
+      address: "Error — see below",
+      formValues,
+      visibleBots,
+      canEditDials: false,
+      canTest: false,
+      monthHours,
+      costAlertTriggered,
+    };
+  }
+
+  const addressBits: string[] = [];
+  if (monthHours !== null) {
+    addressBits.push(
+      `${formatHours(monthHours)} / ${formValues.monthly_hours_cap}h this month`,
+    );
+  }
+  if (s.usage && s.usage.bot_count_active > 0) {
+    addressBits.push(
+      `${s.usage.bot_count_active} bot${
+        s.usage.bot_count_active === 1 ? "" : "s"
+      } active`,
+    );
+  }
+  const address =
+    addressBits.length > 0
+      ? addressBits.join(" · ")
+      : `Bot in ${formValues.region}`;
+
+  void now; // reserved for relative-time formatting on the address line.
+
+  return {
+    status: "configured",
+    pillLabel: "Connected",
+    pillTone: "active",
+    heading: "Recall.ai bot is on call",
+    description:
+      "Bot dials into meetings on your calendar (per the auto-join policy " +
+      "below) and posts transcripts when each call ends.",
+    address,
+    formValues,
+    visibleBots,
+    canEditDials: true,
+    canTest: true,
+    monthHours,
+    costAlertTriggered,
+  };
+}
+
+/**
+ * Map a server-side config row to the form's initial values. When the
+ * row is null (fresh tenant), fall back to RECALL_DEFAULT_FORM so the
+ * form never renders blank. Sanitises strings + clamps numbers into
+ * the valid ranges so a corrupted row can't blow up the form.
+ */
+export function configToFormValues(
+  config: RecallConfig | null | undefined,
+): RecallFormValues {
+  if (!config || typeof config !== "object") {
+    return { ...RECALL_DEFAULT_FORM };
+  }
+  const region: RecallRegion = (RECALL_REGION_OPTIONS as readonly string[]).includes(
+    config.region,
+  )
+    ? config.region
+    : RECALL_DEFAULT_FORM.region;
+  const auto: RecallAutoJoinPolicy = (
+    RECALL_AUTO_JOIN_POLICY_OPTIONS as readonly string[]
+  ).includes(config.auto_join_policy)
+    ? config.auto_join_policy
+    : RECALL_DEFAULT_FORM.auto_join_policy;
+  const cal: RecallCalendarSource = (
+    RECALL_CALENDAR_SOURCE_OPTIONS as readonly string[]
+  ).includes(config.calendar_source)
+    ? config.calendar_source
+    : RECALL_DEFAULT_FORM.calendar_source;
+  const respond: RecallRespondMode = (
+    RECALL_RESPOND_MODE_OPTIONS as readonly string[]
+  ).includes(config.respond_mode)
+    ? config.respond_mode
+    : RECALL_DEFAULT_FORM.respond_mode;
+
+  const clamp = (n: unknown, min: number, max: number, def: number): number => {
+    if (typeof n !== "number" || !Number.isFinite(n)) return def;
+    const i = Math.round(n);
+    if (i < min) return min;
+    if (i > max) return max;
+    return i;
+  };
+
+  const thresholds = Array.isArray(config.cost_alert_thresholds)
+    ? config.cost_alert_thresholds
+        .filter(
+          (x): x is number =>
+            typeof x === "number" && Number.isFinite(x) && x > 0,
+        )
+        .map((x) => Math.round(x))
+    : [];
+
+  return {
+    region,
+    bot_name:
+      typeof config.bot_name === "string" && config.bot_name.length > 0
+        ? config.bot_name.slice(0, 200)
+        : RECALL_DEFAULT_FORM.bot_name,
+    announces_on_join:
+      typeof config.announces_on_join === "boolean"
+        ? config.announces_on_join
+        : RECALL_DEFAULT_FORM.announces_on_join,
+    auto_join_policy: auto,
+    calendar_source: cal,
+    monthly_hours_cap: clamp(
+      config.monthly_hours_cap,
+      RECALL_MONTHLY_HOURS_CAP_RANGE.min,
+      RECALL_MONTHLY_HOURS_CAP_RANGE.max,
+      RECALL_DEFAULT_FORM.monthly_hours_cap,
+    ),
+    leave_after_minutes: clamp(
+      config.leave_after_minutes,
+      RECALL_LEAVE_AFTER_MINUTES_RANGE.min,
+      RECALL_LEAVE_AFTER_MINUTES_RANGE.max,
+      RECALL_DEFAULT_FORM.leave_after_minutes,
+    ),
+    respond_mode: respond,
+    wake_word:
+      typeof config.wake_word === "string" && config.wake_word.length > 0
+        ? config.wake_word.slice(0, RECALL_WAKE_WORD_RANGE.max)
+        : RECALL_DEFAULT_FORM.wake_word,
+    cost_alert_thresholds:
+      thresholds.length > 0
+        ? thresholds.slice().sort((a, b) => a - b)
+        : RECALL_DEFAULT_FORM.cost_alert_thresholds.slice(),
+  };
+}
+
+/**
+ * Serialise the form to the PATCH /config body. Diff-friendly: only
+ * fields whose value differs from the previous (committed) values are
+ * included, so a PATCH with no changes is a no-op on the wire.
+ *
+ * Returns an empty object when nothing changed — the React layer can
+ * cheaply skip the network call.
+ */
+export function serializeFormPatch(
+  next: RecallFormValues,
+  prev: RecallFormValues,
+): Partial<RecallFormValues> {
+  const out: Partial<RecallFormValues> = {};
+  if (next.region !== prev.region) out.region = next.region;
+  if (next.bot_name.trim() !== prev.bot_name.trim()) {
+    out.bot_name = next.bot_name.trim();
+  }
+  if (next.announces_on_join !== prev.announces_on_join) {
+    out.announces_on_join = next.announces_on_join;
+  }
+  if (next.auto_join_policy !== prev.auto_join_policy) {
+    out.auto_join_policy = next.auto_join_policy;
+  }
+  if (next.calendar_source !== prev.calendar_source) {
+    out.calendar_source = next.calendar_source;
+  }
+  if (next.monthly_hours_cap !== prev.monthly_hours_cap) {
+    out.monthly_hours_cap = next.monthly_hours_cap;
+  }
+  if (next.leave_after_minutes !== prev.leave_after_minutes) {
+    out.leave_after_minutes = next.leave_after_minutes;
+  }
+  if (next.respond_mode !== prev.respond_mode) {
+    out.respond_mode = next.respond_mode;
+  }
+  if (next.wake_word.trim() !== prev.wake_word.trim()) {
+    out.wake_word = next.wake_word.trim();
+  }
+  // Threshold arrays compare element-wise (already sorted by the parser).
+  const a = next.cost_alert_thresholds;
+  const b = prev.cost_alert_thresholds;
+  const sameThresholds =
+    a.length === b.length && a.every((v, i) => v === b[i]);
+  if (!sameThresholds) out.cost_alert_thresholds = a.slice();
+  return out;
+}
+
+// ── tiny number formatting helpers ────────────────────────────────────────
+
+/** "12.30h" / "0.05h" — round to two decimals, always emit "h" suffix. */
+export function formatHours(n: number): string {
+  if (!Number.isFinite(n)) return "—";
+  return `${(Math.round(n * 100) / 100).toFixed(2)}h`;
+}
+
+/** "abc1234…" short-id renderer — same convention as truncateTaskId. */
+export function truncateBotId(id: string): string {
+  if (typeof id !== "string") return "";
+  if (id.length <= 12) return id;
+  return `${id.slice(0, 6)}…${id.slice(-4)}`;
+}
+
+/** Pretty-format a unix-ms timestamp as ISO-ish "2026-05-29 12:34 UTC". */
+export function formatBotTimestamp(ms: number | null): string {
+  if (ms === null || !Number.isFinite(ms) || ms <= 0) return "—";
+  const d = new Date(ms);
+  if (Number.isNaN(d.getTime())) return "—";
+  const yyyy = d.getUTCFullYear();
+  const mm = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(d.getUTCDate()).padStart(2, "0");
+  const hh = String(d.getUTCHours()).padStart(2, "0");
+  const mi = String(d.getUTCMinutes()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd} ${hh}:${mi} UTC`;
+}
+
+/** Human label for a bot status. */
+export function botStatusLabel(s: RecallBotStatus): string {
+  switch (s) {
+    case "requested":
+      return "Requested";
+    case "joining":
+      return "Joining";
+    case "in_meeting":
+      return "In meeting";
+    case "leaving":
+      return "Leaving";
+    case "done":
+      return "Done";
+    case "fail":
+      return "Failed";
+  }
+}


### PR DESCRIPTION
Builds the operator-facing Recall.ai card on `/channels` against the
ctrl-api routes shipped in #113 PR2 (#129). Replaces the "Meeting bot ·
Coming soon" placeholder slot with a live three-subview surface.

## What lands

- **`recallCardCore.ts`** — pure derivation (no React, no Wasp). Option
  lists (region / auto-join / calendar / respond), defaults, range
  constants, validators, `parseCostThresholdList` (comma / space / %,
  sort + dedupe), `serializeFormPatch` (diff-only PATCH payload),
  active/terminal bot split with 10-row cap + unknown-status normaliser,
  `formatRecallWebhookUrl`, duration + timestamp helpers.

- **`recallCardCore.test.ts`** — **28 node:test cases** covering:
  - status string by enabled state (disabled / configured / error / null)
  - settings form serialize / deserialize (round-trip, bad-enum fallback,
    range clamp, null fallback, no-op diff, element-wise threshold
    diff, trim-on-diff)
  - dial-range validation (wake-word + control chars, hours cap,
    leave-after, bot-name)
  - recent-bots derivation (active/terminal split, newest-first,
    malformed-entry drops, 10-row cap)
  - webhook URL formatter (default https, trailing slash strip, bare
    host, http preserved)
  - cost-threshold parser (commas / spaces / %, sort + dedupe, range
    check, non-numeric → null)
  - cost-alert trigger (≥ cap × min-threshold / 100)
  - bot duration + timestamp formatters
  - enum option-list sanity check vs. the route validator

- **`RecallCard.tsx`** — React surface in its own file (dial form alone
  is ~250 LoC). Self-contained `ChannelCard` shell mirrors the
  page-level one.

- **`operations.ts`** — five Wasp ops, all through `tenantProxy`:
  - `getRecallChannelStatus` (composite — `Promise.all` over `/config`,
    `/usage`, `/bots/active`; 503 anywhere = NOT_CONFIGURED →
    `enabled: false`, other non-2xx → `.error` verbatim)
  - `updateRecallConfig` (PATCH)
  - `validateRecallApiKey`
  - `testRecallWebhook`
  - `terminateRecallBot`

- **`main.wasp`** — five matching `query` / `action` declarations next
  to the Omi block.

- **`ChannelsPage.tsx`** — `<RecallCard />` replaces the "Meeting bot ·
  Coming soon" placeholder.

## Subview sketches

```
┌─ Disabled ──────────────────────────────────────────┐
│ Meeting bot                       NOT CONNECTED     │
│ Coming soon (Recall.ai)                             │
│ ─                                                   │
│ Recall.ai sends a bot to your Zoom / Meet / Teams…  │
│ Recall API key  [ password input  ]                 │
│ Region          [ us-east-1 ▾ ]                     │
│ [Validate key]  [Open Recall.ai →]                  │
└─────────────────────────────────────────────────────┘

┌─ Configured ────────────────────────────────────────┐
│ Meeting bot                            CONNECTED    │
│ 12.50h / 60h this month · 1 bot active              │
│ ─                                                   │
│ Month-to-date: 12.50h / 60h     [Cost alert ✓]      │
│ Region              [ us-east-1 ▾ ]                 │
│ Bot name            [ Alfred's note-taker ]         │
│ Announces on join   [x] Yes                         │
│ Auto-join policy    [ principal_attendee ▾ ]        │
│ Calendar source     [ composio ▾ ]                  │
│ Monthly hours cap   [ 60 ]                          │
│ Leave after minutes [ 90 ]                          │
│ Respond mode        [ on_mention ▾ ]                │
│ Wake word           [ Alfred ]                      │
│ Cost-alert thresh.  [ 80, 100 ]                     │
│ [Save dials] [Send test webhook]                    │
│ ─                                                   │
│ Active bots                                         │
│ Status     | Calendar | Joined at | Dur | Trsc | × │
│ In meeting | gcal-…   | 12:34 UTC | 12m | open | … │
│ ─                                                   │
│ [Show webhook setup]                                │
└─────────────────────────────────────────────────────┘

┌─ Webhook expander (opens within Configured) ────────┐
│ Webhook URL (paste into Recall.ai → Webhooks)       │
│ [ https://home.alfred.black/api/v1/webhooks/recall ]│
│                                          [Copy]     │
│ Webhook secret (first 6)                            │
│ [ whsec_…  ]   [Rotate secret  · coming soon]       │
└─────────────────────────────────────────────────────┘

┌─ Error ─────────────────────────────────────────────┐
│ Meeting bot                  NEEDS ATTENTION        │
│ Error — see below                                   │
│ ─                                                   │
│ Recall returned HTTP 500 — internal server error    │
│ [Re-check]                                          │
└─────────────────────────────────────────────────────┘
```

## Secrets posture

- The API key paste box is `type="password"` + `autoComplete="off"` +
  `spellCheck={false}`.
- The validator action receives the value and forwards to ctrl-api —
  never logged, never echoed back in toast text.
- The webhook secret is surfaced first-6-only everywhere; the full
  value stays in `/opt/alfred/.env`.
- "Rotate secret" CTA is wired + disabled with a tooltip pointing at
  PR3a.

## What PR3a will land

- `POST /api/v1/channels/recall/api-key` (Vaultwarden-backed key
  persistence — replaces today's validate-only flow with a save-on-
  success path).
- A `GET /status` route surfacing `enabled` directly + the webhook
  URL / secret-first6 ctrl-api-side (the card synthesises both from
  `window.location` for now).
- Secret rotation.

## Constraints honoured

- No edits to compose, migrations, or ctrl-api routes; pure web work.
- `tsc --noEmit` clean against the new files (project-level run; the
  pre-existing `wasp/*` module-not-found errors are unrelated).
- `recallCardCore.test.ts` → **28 / 28 pass** under `npx tsx --test`.
- Card imports `wasp/client/operations` not deep `@src/server/…` —
  same pattern as Paperclip / Omi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)