### PR TITLE
feat(web): HA-conversation setup card + voice satellites / wake-words card (#111 PR3 + #112 PR3)

### DIFF
--- a/packages/web/main.wasp
+++ b/packages/web/main.wasp
@@ -992,6 +992,36 @@ action terminateRecallBot {
   entities: []
 }
 
+// Wave C — HA conversation setup card (#111 PR3). Reads the shared
+// `channel_tokens` table for rows with `channel='ha-conversation'`
+// (one row per HA install). Mint + revoke proxy to the same shared
+// surface; both 404-fall-through to a "Coming in PR4" message so the
+// card never breaks the page.
+query getHaInstalledTokens {
+  fn: import { getHaInstalledTokens } from "@src/dashboard/operations",
+  entities: []
+}
+
+action mintHaChannelToken {
+  fn: import { mintHaChannelToken } from "@src/dashboard/operations",
+  entities: []
+}
+
+action revokeChannelToken {
+  fn: import { revokeChannelToken } from "@src/dashboard/operations",
+  entities: []
+}
+
+// Wave C — Voice satellites & wake-words card (#112 PR3). Reads the
+// list of ESPHome devices the voice-bridge has discovered on the
+// LAN. Status endpoint lands in #112 PR4; until then the operation
+// 404-falls-through to `{ devices: [], unavailable: true }` so the
+// card surfaces a helpful empty-state message instead of an error.
+query getEsphomeDevices {
+  fn: import { getEsphomeDevices } from "@src/dashboard/operations",
+  entities: []
+}
+
 query getAgentConfig {
   fn: import { getAgentConfig } from "@src/dashboard/operations",
   entities: []

--- a/packages/web/src/dashboard/ChannelsPage.tsx
+++ b/packages/web/src/dashboard/ChannelsPage.tsx
@@ -100,6 +100,8 @@ import {
   type TailscalePeersResponse,
 } from "./tailscaleCardCore";
 import RecallCard from "./RecallCard";
+import { HaConversationSetupCard } from "./HaConversationSetupCard";
+import { VoiceWakeWordsCard } from "./VoiceWakeWordsCard";
 
 // F57/C14 — the email card reads the live ctrl-api status, not a phantom
 // Instance row. `inbox_address` is only present once `configured`.
@@ -396,6 +398,28 @@ export default function ChannelsPage() {
               visual states (unconfigured / configured_starting /
               configured_running / error) come from telegramCardCore. */}
           <TelegramCard />
+
+          {/* Wave C / #111 PR3 — Voice → HA → Alfred (conversation).
+              The card surfaces the three-step install ritual for the
+              ssdavidai/alfred-ha HACS custom component, plus a table
+              of channel_tokens minted per HA install. Reads via
+              getHaInstalledTokens; mint/revoke routes are owned by
+              the shared channel-tokens surface (#111 PR1 + PR4).
+              NOTE: PR #110 PR3 will land a separate HaCard for the
+              HA *integration* status; when that ships, the canonical
+              order is <HaCard /> then this <HaConversationSetupCard />.
+              Until the alphabetical reflow lands, both new Wave-C
+              cards sit at the end of the page just before Terminal. */}
+          <HaConversationSetupCard />
+
+          {/* Wave C / #112 PR3 — Voice satellites & wake words.
+              Surfaces ESPHome devices the voice-bridge has discovered
+              (#112 PR1 listener) plus a multi-select wake-word
+              catalogue from fwartner/home-assistant-wakewords-collection.
+              Selection renders an ESPHome YAML snippet the principal
+              pastes into their satellite device YAML. Read-only —
+              wake-word install is paste-this-YAML, not click-a-button. */}
+          <VoiceWakeWordsCard />
 
           {/* Sir #8 — Terminal: SSH straight into the VM + `docker exec`
               into Hermes for the chattiest, lowest-latency door. Sir

--- a/packages/web/src/dashboard/HaConversationSetupCard.tsx
+++ b/packages/web/src/dashboard/HaConversationSetupCard.tsx
@@ -1,0 +1,424 @@
+// HaConversationSetupCard — /channels card for Issue #111 PR3.
+//
+// Documentation-first surface: the principal installs the
+// `ssdavidai/alfred-ha` HACS custom component into their Home Assistant
+// install, configures it with the tenant URL + a channel token they
+// mint here, and HA's Assist pipeline forwards conversation turns to
+// Alfred via POST /api/v1/channels/ha/turn. There are NO new ctrl-api
+// routes in PR3; the runtime is owned by #111 PR1 (the channel-token
+// table + the /turn route) and PR4 (operator-facing mint UI). What
+// this card adds is the install ritual + a table of the persisted
+// tokens.
+//
+// Read shape — `getHaInstalledTokens` proxies to
+//   GET /api/v1/channel-tokens?channel=ha-conversation
+// (which lands in PR #111 PR1). The mint + revoke actions proxy to
+// the same surface; both 404-fall-through to a "Coming in PR4" panel
+// so the card never breaks the page on a tenant that hasn't pulled
+// PR1's image.
+
+import { useState } from "react";
+import {
+  useQuery,
+  getHaInstalledTokens,
+  mintHaChannelToken,
+  revokeChannelToken,
+} from "wasp/client/operations";
+import {
+  buildHacsRepoUrl,
+  parseHaInstallId,
+  summariseInstalledHaTokens,
+  truncateInstallId,
+  formatLastUsed,
+  type ChannelTokenRow,
+} from "./haConversationCardCore";
+
+interface TokensResponse {
+  tokens: ChannelTokenRow[];
+  /** Set when ctrl-api 404s the read endpoint (tenant hasn't pulled
+   *  the image yet). The card surfaces an explanatory empty state. */
+  unavailable?: boolean;
+}
+
+interface MintResponse {
+  token: string;
+  meta?: { id?: string };
+}
+
+export function HaConversationSetupCard() {
+  const { data: tokensData, refetch } = useQuery(
+    getHaInstalledTokens,
+    undefined,
+    { retry: false },
+  );
+  const resp = (tokensData as TokensResponse | undefined) ?? null;
+  const summary = summariseInstalledHaTokens(resp?.tokens ?? []);
+  const surfaceAvailable = !(resp?.unavailable === true);
+
+  // Mint form state.
+  const [installInput, setInstallInput] = useState("");
+  const [mintBusy, setMintBusy] = useState(false);
+  const [mintErr, setMintErr] = useState<string | null>(null);
+  const [revealedToken, setRevealedToken] = useState<{
+    raw: string;
+    installId: string;
+  } | null>(null);
+
+  // Per-token revoke spinner.
+  const [revokeBusy, setRevokeBusy] = useState<Set<string>>(new Set());
+
+  // Copy-to-clipboard transient state.
+  const [copiedRepo, setCopiedRepo] = useState(false);
+  const [copiedToken, setCopiedToken] = useState(false);
+
+  function copyRepo() {
+    navigator.clipboard?.writeText(buildHacsRepoUrl());
+    setCopiedRepo(true);
+    setTimeout(() => setCopiedRepo(false), 1500);
+  }
+
+  function copyToken() {
+    if (!revealedToken) return;
+    navigator.clipboard?.writeText(revealedToken.raw);
+    setCopiedToken(true);
+    setTimeout(() => setCopiedToken(false), 1500);
+  }
+
+  async function mint() {
+    setMintErr(null);
+    const installId = parseHaInstallId(installInput);
+    if (!installId) {
+      setMintErr(
+        "Install ID must be a uuid v4 or a slug (a-zA-Z0-9_-, 8 – 64 chars).",
+      );
+      return;
+    }
+    setMintBusy(true);
+    try {
+      const r = (await mintHaChannelToken({
+        installId,
+        label: `ha:${installId}`,
+      })) as MintResponse;
+      if (typeof r?.token === "string") {
+        setRevealedToken({ raw: r.token, installId });
+        setInstallInput("");
+        await refetch();
+      } else {
+        setMintErr("ctrl-api accepted the mint but returned no token.");
+      }
+    } catch (e: any) {
+      setMintErr(
+        e?.message ??
+          e?.data?.message ??
+          "Mint failed — check the install ID and try again.",
+      );
+    } finally {
+      setMintBusy(false);
+    }
+  }
+
+  async function revoke(id: string) {
+    setRevokeBusy((prev) => {
+      const next = new Set(prev);
+      next.add(id);
+      return next;
+    });
+    try {
+      await revokeChannelToken({ id });
+      await refetch();
+    } catch (e: any) {
+      // The page-level error surface is the toast we'd add in a
+      // future polish — for now log + reload so the UI doesn't lie.
+      console.error("revoke channel token failed", e);
+    } finally {
+      setRevokeBusy((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+    }
+  }
+
+  // Render the card body via the shared ChannelCard wrapper. The
+  // wrapper lives in ChannelsPage.tsx; we don't import it here to
+  // keep this file small + tree-shake-friendly — instead we render
+  // the same visual envelope inline. The two visible "address" lines
+  // mirror what ChannelCard surfaces.
+  const haPill = surfaceAvailable && summary.installs.length > 0;
+
+  return (
+    <div className="border border-rule p-6 card-hover h-full">
+      {/* Card header — same shape as ChannelCard. */}
+      <div className="flex items-baseline justify-between mb-3">
+        <span className="font-display text-3xl">Voice → HA → Alfred</span>
+        <span
+          className="font-mono text-[10px] uppercase tracking-[0.22em] font-extrabold"
+          style={{ color: haPill ? "var(--brass)" : "var(--marginalia)" }}
+        >
+          {haPill ? "Connected" : "Setup"}
+        </span>
+      </div>
+      <div
+        className="font-mono text-[12px] mb-3"
+        style={{ color: "var(--ink)" }}
+      >
+        {surfaceAvailable
+          ? summary.installs.length === 0
+            ? "No HA installs paired yet"
+            : `${summary.installs.length} HA install${summary.installs.length === 1 ? "" : "s"} paired`
+          : "Channel-token surface not deployed yet"}
+      </div>
+      <div className="font-body italic" style={{ color: "var(--marginalia)" }}>
+        Pipe Home Assistant's Assist conversations to Alfred — same memory, in
+        the kitchen.
+      </div>
+
+      {/* Numbered three-step ritual. */}
+      <div className="mt-6 space-y-5">
+        <StepBlock
+          n={1}
+          title="Install the HACS custom repository"
+          body={
+            <>
+              <p
+                className="font-body text-[13px]"
+                style={{ color: "var(--marginalia)" }}
+              >
+                In Home Assistant: HACS → ⋮ → Custom repositories → paste below,
+                category "Integration".
+              </p>
+              <div className="flex items-center gap-2 mt-2">
+                <code
+                  className="flex-1 font-mono text-[11px] border border-rule p-2 truncate"
+                  style={{ color: "var(--ink)" }}
+                >
+                  {buildHacsRepoUrl()}
+                </code>
+                <button onClick={copyRepo} className="btn-ghost">
+                  {copiedRepo ? "Copied" : "Copy"}
+                </button>
+                <a
+                  href={buildHacsRepoUrl()}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="btn-ghost"
+                >
+                  Open README →
+                </a>
+              </div>
+            </>
+          }
+        />
+
+        <StepBlock
+          n={2}
+          title="Add the integration"
+          body={
+            <p
+              className="font-body text-[13px]"
+              style={{ color: "var(--marginalia)" }}
+            >
+              In HA: Settings → Devices &amp; Services → Add Integration →{" "}
+              <strong>Alfred Black</strong>. Supply your tenant base URL and the
+              channel token you mint in step 3.
+            </p>
+          }
+        />
+
+        <StepBlock
+          n={3}
+          title="Mint a channel token"
+          body={
+            surfaceAvailable ? (
+              <div className="space-y-3">
+                <p
+                  className="font-body text-[13px]"
+                  style={{ color: "var(--marginalia)" }}
+                >
+                  Give this HA install an ID (a uuid or a slug like{" "}
+                  <code>home-kitchen</code>) — that's how Alfred recognises the
+                  install on later requests.
+                </p>
+                <div className="flex gap-2 items-baseline">
+                  <input
+                    type="text"
+                    value={installInput}
+                    onChange={(e) => setInstallInput(e.target.value)}
+                    placeholder="home-kitchen"
+                    className="flex-1 bg-transparent border border-rule px-2 py-1 font-mono text-[12px]"
+                  />
+                  <button
+                    onClick={mint}
+                    disabled={mintBusy || !installInput.trim()}
+                    className="btn-ghost"
+                  >
+                    {mintBusy ? "…" : "Mint token"}
+                  </button>
+                </div>
+                {mintErr && (
+                  <p
+                    className="font-body italic text-[12px]"
+                    style={{ color: "var(--brass)" }}
+                  >
+                    {mintErr}
+                  </p>
+                )}
+                {revealedToken && (
+                  <div
+                    className="border border-rule p-3 space-y-2"
+                    style={{ borderColor: "var(--brass)" }}
+                  >
+                    <div
+                      className="font-mono text-[10px] uppercase tracking-[0.22em]"
+                      style={{ color: "var(--brass)" }}
+                    >
+                      One-time reveal — copy now
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <code
+                        className="flex-1 font-mono text-[11px] truncate"
+                        style={{ color: "var(--ink)" }}
+                      >
+                        {revealedToken.raw}
+                      </code>
+                      <button onClick={copyToken} className="btn-ghost">
+                        {copiedToken ? "Copied" : "Copy"}
+                      </button>
+                      <button
+                        onClick={() => setRevealedToken(null)}
+                        className="btn-ghost"
+                      >
+                        Hide
+                      </button>
+                    </div>
+                    <p
+                      className="font-body italic text-[12px]"
+                      style={{ color: "var(--marginalia)" }}
+                    >
+                      Paste this into the HA integration's "Channel token"
+                      field for install <code>{revealedToken.installId}</code>.
+                      We never store it again.
+                    </p>
+                  </div>
+                )}
+              </div>
+            ) : (
+              <div
+                className="border border-rule p-3"
+                style={{ color: "var(--marginalia)" }}
+              >
+                <p className="font-body italic text-[12px]">
+                  Coming in PR4 — the runtime mint surface lands with{" "}
+                  <code>ctrl-api</code> PR #111 PR4. In the meantime, mint
+                  manually:
+                </p>
+                <pre className="font-mono text-[10px] mt-2 overflow-x-auto whitespace-pre-wrap">
+                  {`docker exec alfred-ctrl-1 vault-cli channel-token mint \\
+  --channel ha-conversation --label ha:<installId>`}
+                </pre>
+              </div>
+            )
+          }
+        />
+      </div>
+
+      {/* Installed HA installs table. */}
+      <div className="mt-7 space-y-3">
+        <div
+          className="font-mono text-[10px] uppercase tracking-[0.22em]"
+          style={{ color: "var(--marginalia)" }}
+        >
+          Installed HA installs
+        </div>
+        {!surfaceAvailable ? (
+          <p
+            className="font-body italic text-[12px]"
+            style={{ color: "var(--marginalia)" }}
+          >
+            The shared channel-token surface isn't on this VM yet. Pull the
+            next ctrl-api image and refresh.
+          </p>
+        ) : summary.installs.length === 0 ? (
+          <p
+            className="font-body italic text-[12px]"
+            style={{ color: "var(--marginalia)" }}
+          >
+            No installs paired yet. Mint a token above to get started.
+          </p>
+        ) : (
+          <table className="w-full font-mono text-[11px]">
+            <thead>
+              <tr
+                className="text-left"
+                style={{ color: "var(--marginalia)" }}
+              >
+                <th className="font-normal pb-2">Install ID</th>
+                <th className="font-normal pb-2">Label</th>
+                <th className="font-normal pb-2">Last used</th>
+                <th className="font-normal pb-2">IP</th>
+                <th className="font-normal pb-2 text-right">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {summary.installs.map((i) => {
+                const busy = revokeBusy.has(i.tokenId);
+                return (
+                  <tr
+                    key={i.tokenId}
+                    className="border-t border-rule"
+                    style={{ color: "var(--ink)" }}
+                  >
+                    <td className="py-2" title={i.installId}>
+                      {truncateInstallId(i.installId)}
+                    </td>
+                    <td className="py-2">{i.label ?? "—"}</td>
+                    <td className="py-2">
+                      {formatLastUsed(i.lastUsedAt)}
+                    </td>
+                    <td className="py-2">{i.lastUsedIp ?? "—"}</td>
+                    <td className="py-2 text-right">
+                      <button
+                        onClick={() => revoke(i.tokenId)}
+                        disabled={busy}
+                        className="btn-ghost"
+                      >
+                        {busy ? "…" : "Revoke"}
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Numbered step block — keeps the three-step ritual visually
+ *  uniform without duplicating the markup three times. */
+function StepBlock({
+  n,
+  title,
+  body,
+}: {
+  n: number;
+  title: string;
+  body: React.ReactNode;
+}) {
+  return (
+    <div className="flex gap-4">
+      <div
+        className="font-display text-2xl flex-none w-8"
+        style={{ color: "var(--brass)" }}
+      >
+        {n}
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="font-display text-[15px] mb-1">{title}</div>
+        {body}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/dashboard/VoiceWakeWordsCard.tsx
+++ b/packages/web/src/dashboard/VoiceWakeWordsCard.tsx
@@ -1,0 +1,340 @@
+// VoiceWakeWordsCard — /channels card for Issue #112 PR3.
+//
+// Two visual sections:
+//
+//   1. Detected ESPHome devices. The voice-bridge speaks ESPHome
+//      Native API (PR #112 PR1 wired the listener; PR #112 PR2 wired
+//      OpenAI Realtime). The card reads the device-table the bridge
+//      maintains via GET /api/v1/channels/voice/esphome/devices. When
+//      that endpoint isn't deployed yet (PR4 lands the route), the
+//      card surfaces an "ESPHome listener disabled" hint instead of
+//      breaking.
+//
+//   2. Wake-word library. The card surfaces an 8-entry catalogue from
+//      github.com/fwartner/home-assistant-wakewords-collection — the
+//      principal multi-selects and the card renders an ESPHome YAML
+//      snippet they paste into their satellite's device YAML.
+//      Installation is paste-this-YAML, not click-a-button — there's
+//      no runtime mutation here.
+//
+// PR3 is documentation + read-only. The voice-bridge already knows
+// how to discover ESPHome satellites; surfacing them on /channels is
+// the principal-facing payoff.
+
+import { useMemo, useState } from "react";
+import { useQuery, getEsphomeDevices } from "wasp/client/operations";
+import {
+  WAKE_WORD_CATALOGUE,
+  WAKE_WORD_UPSTREAM_URL,
+  selectedWakeWordsToManifest,
+  upstreamUrlForEntry,
+  formatEsphomeDeviceRow,
+  type EsphomeDevice,
+} from "./voiceWakeWordsCardCore";
+
+interface DevicesResponse {
+  devices: EsphomeDevice[];
+  /** Set when ctrl-api 404s the read endpoint (#112 PR4 not deployed
+   *  yet). The card surfaces an enable-the-listener hint. */
+  unavailable?: boolean;
+}
+
+export function VoiceWakeWordsCard() {
+  const { data: devicesData } = useQuery(getEsphomeDevices, undefined, {
+    retry: false,
+  });
+  const resp = (devicesData as DevicesResponse | undefined) ?? null;
+  const devices: EsphomeDevice[] = Array.isArray(resp?.devices)
+    ? (resp!.devices as EsphomeDevice[])
+    : [];
+  const listenerAvailable = !(resp?.unavailable === true);
+
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [manifestOpen, setManifestOpen] = useState(false);
+
+  const manifest = useMemo(
+    () => selectedWakeWordsToManifest([...selected]),
+    [selected],
+  );
+
+  const [copied, setCopied] = useState(false);
+  function copyManifest() {
+    navigator.clipboard?.writeText(manifest);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }
+
+  function toggle(slug: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(slug)) next.delete(slug);
+      else next.add(slug);
+      return next;
+    });
+  }
+
+  return (
+    <div className="border border-rule p-6 card-hover h-full">
+      {/* Card header — mirrors ChannelCard. */}
+      <div className="flex items-baseline justify-between mb-3">
+        <span className="font-display text-3xl">Voice satellites</span>
+        <span
+          className="font-mono text-[10px] uppercase tracking-[0.22em] font-extrabold"
+          style={{
+            color: devices.length > 0 ? "var(--brass)" : "var(--marginalia)",
+          }}
+        >
+          {devices.length > 0
+            ? `${devices.length} on the network`
+            : listenerAvailable
+              ? "Looking"
+              : "Listener off"}
+        </span>
+      </div>
+      <div
+        className="font-mono text-[12px] mb-3"
+        style={{ color: "var(--ink)" }}
+      >
+        ESPHome Voice PE · M5Stack Atom · S3-Box
+      </div>
+      <div className="font-body italic" style={{ color: "var(--marginalia)" }}>
+        Wake words and satellites — the doors with no screens.
+      </div>
+
+      {/* Section 1 — Detected ESPHome devices */}
+      <div className="mt-6 space-y-3">
+        <div
+          className="font-mono text-[10px] uppercase tracking-[0.22em]"
+          style={{ color: "var(--marginalia)" }}
+        >
+          Detected ESPHome devices
+        </div>
+        {!listenerAvailable ? (
+          <div
+            className="border border-rule p-3 space-y-2"
+            style={{ color: "var(--marginalia)" }}
+          >
+            <p className="font-body italic text-[12px]">
+              ESPHome listener disabled. Set{" "}
+              <code>ESPHOME_API_ENABLED=1</code> in <code>/opt/alfred/.env</code>{" "}
+              and restart the voice-bridge:
+            </p>
+            <pre className="font-mono text-[10px] overflow-x-auto whitespace-pre-wrap">
+              {`docker compose --profile voice restart voice-bridge`}
+            </pre>
+          </div>
+        ) : devices.length === 0 ? (
+          <p
+            className="font-body italic text-[12px]"
+            style={{ color: "var(--marginalia)" }}
+          >
+            No ESPHome satellites discovered yet. Flash a Voice PE / S3-Box on
+            the same LAN — it'll show up here within a few seconds.
+          </p>
+        ) : (
+          <table className="w-full font-mono text-[11px]">
+            <thead>
+              <tr
+                className="text-left"
+                style={{ color: "var(--marginalia)" }}
+              >
+                <th className="font-normal pb-2">Hostname</th>
+                <th className="font-normal pb-2">IP</th>
+                <th className="font-normal pb-2">Last seen</th>
+                <th className="font-normal pb-2">Model</th>
+                <th className="font-normal pb-2">Wake word</th>
+                <th className="font-normal pb-2">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {devices.map((d) => {
+                const r = formatEsphomeDeviceRow(d);
+                return (
+                  <tr
+                    key={`${d.hostname}-${d.ip}`}
+                    className="border-t border-rule"
+                  >
+                    <td className="py-2" style={{ color: "var(--ink)" }}>
+                      {r.shortHost}
+                    </td>
+                    <td className="py-2" style={{ color: "var(--ink)" }}>
+                      {r.ip}
+                    </td>
+                    <td
+                      className="py-2"
+                      style={{ color: "var(--marginalia)" }}
+                    >
+                      {r.lastSeenRelative}
+                    </td>
+                    <td
+                      className="py-2"
+                      style={{ color: "var(--marginalia)" }}
+                    >
+                      {r.modelLabel}
+                    </td>
+                    <td className="py-2" style={{ color: "var(--ink)" }}>
+                      {r.wakeWordLabel}
+                    </td>
+                    <td
+                      className="py-2"
+                      style={{
+                        color:
+                          r.pill === "active"
+                            ? "var(--brass)"
+                            : r.pill === "error"
+                              ? "var(--brass)"
+                              : "var(--marginalia)",
+                      }}
+                    >
+                      {r.pillLabel}
+                      {r.errorLine && (
+                        <div
+                          className="font-body italic text-[10px]"
+                          style={{ color: "var(--brass)" }}
+                        >
+                          {r.errorLine}
+                        </div>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {/* Section 2 — Wake-word library */}
+      <div className="mt-7 space-y-3">
+        <div
+          className="font-mono text-[10px] uppercase tracking-[0.22em]"
+          style={{ color: "var(--marginalia)" }}
+        >
+          Wake-word library
+        </div>
+        <p
+          className="font-body italic text-[12px]"
+          style={{ color: "var(--marginalia)" }}
+        >
+          <strong>microWakeWord</strong> runs on the satellite itself — zero
+          latency, no bridge load. <strong>openWakeWord</strong> runs on the
+          voice-bridge — heavier accuracy, costs a couple of CPU cores. Pick a
+          handful, click "Generate ESPHome YAML", and paste into your device.
+        </p>
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
+          {WAKE_WORD_CATALOGUE.map((entry) => {
+            const isOn = selected.has(entry.slug);
+            return (
+              <button
+                key={entry.slug}
+                onClick={() => toggle(entry.slug)}
+                className="border border-rule p-2 text-left"
+                style={{
+                  color: isOn ? "var(--brass)" : "var(--ink)",
+                  borderColor: isOn ? "var(--brass)" : undefined,
+                }}
+              >
+                <div className="font-display text-[14px]">
+                  {entry.displayName}
+                </div>
+                <div
+                  className="font-mono text-[10px]"
+                  style={{ color: "var(--marginalia)" }}
+                >
+                  {entry.model}
+                  {entry.sha256 == null && " · unpinned"}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+        <div className="flex flex-wrap gap-3 items-baseline pt-1">
+          <button
+            onClick={() => setManifestOpen(true)}
+            disabled={selected.size === 0}
+            className="btn-ghost"
+          >
+            Generate ESPHome YAML
+          </button>
+          {selected.size > 0 && (
+            <button onClick={() => setSelected(new Set())} className="btn-ghost">
+              Clear selection ({selected.size})
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Section 3 — Upstream link */}
+      <div className="mt-7 pt-4 border-t border-rule">
+        <p
+          className="font-body italic text-[12px]"
+          style={{ color: "var(--marginalia)" }}
+        >
+          The full upstream catalogue (plus instructions for training your own
+          wake word) lives at{" "}
+          <a
+            href={WAKE_WORD_UPSTREAM_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="underline"
+            style={{ color: "var(--ink)" }}
+          >
+            fwartner/home-assistant-wakewords-collection
+          </a>
+          .
+        </p>
+      </div>
+
+      {/* Manifest modal — inline disclosure rather than a portal so
+          the card stays self-contained. */}
+      {manifestOpen && (
+        <div
+          className="mt-5 border-2 p-4 space-y-3"
+          style={{ borderColor: "var(--brass)" }}
+        >
+          <div className="flex items-baseline justify-between">
+            <span
+              className="font-mono text-[10px] uppercase tracking-[0.22em]"
+              style={{ color: "var(--brass)" }}
+            >
+              ESPHome YAML — paste under your device config
+            </span>
+            <button
+              onClick={() => setManifestOpen(false)}
+              className="btn-ghost"
+            >
+              Close
+            </button>
+          </div>
+          <pre
+            className="font-mono text-[11px] overflow-x-auto whitespace-pre-wrap p-2 border border-rule"
+            style={{ color: "var(--ink)" }}
+          >
+            {manifest}
+          </pre>
+          <div className="flex gap-3 items-baseline">
+            <button onClick={copyManifest} className="btn-ghost">
+              {copied ? "Copied" : "Copy YAML"}
+            </button>
+            {[...selected].map((slug) => {
+              const e = WAKE_WORD_CATALOGUE.find((x) => x.slug === slug);
+              if (!e) return null;
+              return (
+                <a
+                  key={slug}
+                  href={upstreamUrlForEntry(e)}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="font-mono text-[10px] underline"
+                  style={{ color: "var(--marginalia)" }}
+                >
+                  {e.slug} ↗
+                </a>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/dashboard/haConversationCardCore.test.ts
+++ b/packages/web/src/dashboard/haConversationCardCore.test.ts
@@ -1,0 +1,233 @@
+/**
+ * /channels — HA conversation setup-card helper tests (#111 PR3).
+ *
+ * The HA-conversation card is a documentation surface, not a runtime
+ * state machine — so these tests cover the small pure-function surface
+ * the card uses to validate input + summarise the persisted channel-
+ * token rows that ctrl-api returns.
+ *
+ * Covers:
+ *   • buildHacsRepoUrl is stable + points at the public custom repo
+ *   • parseHaInstallId accepts uuid v4 + plain slug; rejects junk
+ *   • summariseInstalledHaTokens groups + sorts + drops revoked rows
+ *   • truncateInstallId keeps head + tail
+ *   • formatLastUsed handles never / just-now / minutes / hours / days
+ *
+ * Run with:
+ *   cd packages/web && npx tsx --test src/dashboard/haConversationCardCore.test.ts
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildHacsRepoUrl,
+  parseHaInstallId,
+  summariseInstalledHaTokens,
+  truncateInstallId,
+  formatLastUsed,
+  type ChannelTokenRow,
+} from "./haConversationCardCore";
+
+const FROZEN_NOW = new Date("2026-05-29T12:00:00Z");
+
+function unixMsAgo(seconds: number): number {
+  return FROZEN_NOW.getTime() - seconds * 1000;
+}
+
+// ---------------------------------------------------------------------------
+// buildHacsRepoUrl — stable copyable URL
+// ---------------------------------------------------------------------------
+
+test("buildHacsRepoUrl: returns the public HACS custom-repo URL", () => {
+  assert.equal(buildHacsRepoUrl(), "https://github.com/ssdavidai/alfred-ha");
+});
+
+// ---------------------------------------------------------------------------
+// parseHaInstallId — accepts uuid v4 and plain slug
+// ---------------------------------------------------------------------------
+
+test("parseHaInstallId: accepts a HA-style uuid v4 (lowercased)", () => {
+  const id = "63B96C8A-9D6F-4A7B-BCEF-1234567890AB";
+  assert.equal(parseHaInstallId(id), "63b96c8a-9d6f-4a7b-bcef-1234567890ab");
+});
+
+test("parseHaInstallId: accepts a plain slug between 8 and 64 chars", () => {
+  assert.equal(parseHaInstallId("home-kitchen"), "home-kitchen");
+  assert.equal(parseHaInstallId("vacation_house_42"), "vacation_house_42");
+  assert.equal(parseHaInstallId("a".repeat(64)), "a".repeat(64));
+});
+
+test("parseHaInstallId: rejects empty / whitespace / too-short / too-long", () => {
+  assert.equal(parseHaInstallId(""), null);
+  assert.equal(parseHaInstallId("   "), null);
+  assert.equal(parseHaInstallId("short"), null); // 5 < 8
+  assert.equal(parseHaInstallId("a".repeat(65)), null);
+});
+
+test("parseHaInstallId: rejects strings with whitespace or quotes", () => {
+  assert.equal(parseHaInstallId("ha install"), null);
+  assert.equal(parseHaInstallId("'home-kitchen'"), null);
+  assert.equal(parseHaInstallId('"home-kitchen"'), null);
+  // tabs/newlines and unicode punctuation are also out
+  assert.equal(parseHaInstallId("home\tkitchen"), null);
+  assert.equal(parseHaInstallId("home/kitchen"), null);
+});
+
+test("parseHaInstallId: trims surrounding whitespace before validating", () => {
+  assert.equal(parseHaInstallId("  home-kitchen  "), "home-kitchen");
+});
+
+// ---------------------------------------------------------------------------
+// summariseInstalledHaTokens — group + filter + sort
+// ---------------------------------------------------------------------------
+
+test("summariseInstalledHaTokens: empty/null/undefined → empty installs", () => {
+  assert.deepEqual(summariseInstalledHaTokens(null), { installs: [] });
+  assert.deepEqual(summariseInstalledHaTokens(undefined), { installs: [] });
+  assert.deepEqual(summariseInstalledHaTokens([]), { installs: [] });
+});
+
+test("summariseInstalledHaTokens: groups ha-conversation rows + drops others", () => {
+  const rows: ChannelTokenRow[] = [
+    {
+      id: "01JXAA",
+      channel: "ha-conversation",
+      label: "ha:home",
+      scope: { haInstanceId: "home-kitchen" },
+      created_at: unixMsAgo(60),
+      last_used_at: unixMsAgo(30),
+      last_used_ip: "100.64.1.5",
+      rotated_from: null,
+      revoked_at: null,
+    },
+    {
+      id: "01JXBB",
+      channel: "paperclip-heartbeat", // dropped: wrong channel
+      label: "pcp:something",
+      scope: null,
+      created_at: unixMsAgo(120),
+      last_used_at: null,
+      last_used_ip: null,
+      rotated_from: null,
+      revoked_at: null,
+    },
+    {
+      id: "01JXCC",
+      channel: "ha-conversation",
+      label: "ha:vacation",
+      scope: { haInstanceId: "vacation_house" },
+      created_at: unixMsAgo(15),
+      last_used_at: null,
+      last_used_ip: null,
+      rotated_from: null,
+      revoked_at: null,
+    },
+  ];
+  const { installs } = summariseInstalledHaTokens(rows);
+  assert.equal(installs.length, 2);
+  // Newest-first: vacation (15s ago) before home (60s ago).
+  assert.equal(installs[0].installId, "vacation_house");
+  assert.equal(installs[0].label, "ha:vacation");
+  assert.equal(installs[1].installId, "home-kitchen");
+  assert.equal(installs[1].lastUsedIp, "100.64.1.5");
+});
+
+test("summariseInstalledHaTokens: drops revoked tokens (tombstones)", () => {
+  const rows: ChannelTokenRow[] = [
+    {
+      id: "01JXAA",
+      channel: "ha-conversation",
+      label: "ha:revoked",
+      scope: { haInstanceId: "revoked-install" },
+      created_at: unixMsAgo(60),
+      last_used_at: null,
+      last_used_ip: null,
+      rotated_from: null,
+      revoked_at: unixMsAgo(10), // tombstone
+    },
+    {
+      id: "01JXBB",
+      channel: "ha-conversation",
+      label: "ha:live",
+      scope: { haInstanceId: "live-install" },
+      created_at: unixMsAgo(30),
+      last_used_at: null,
+      last_used_ip: null,
+      rotated_from: null,
+      revoked_at: null,
+    },
+  ];
+  const { installs } = summariseInstalledHaTokens(rows);
+  assert.equal(installs.length, 1);
+  assert.equal(installs[0].installId, "live-install");
+});
+
+test("summariseInstalledHaTokens: falls back to row id when scope is missing", () => {
+  const rows: ChannelTokenRow[] = [
+    {
+      id: "01JXAA",
+      channel: "ha-conversation",
+      label: null,
+      scope: null,
+      created_at: unixMsAgo(60),
+      last_used_at: null,
+      last_used_ip: null,
+      rotated_from: null,
+      revoked_at: null,
+    },
+    {
+      id: "01JXBB",
+      channel: "ha-conversation",
+      label: "ha:malformed",
+      scope: { foo: "bar" }, // no haInstanceId key
+      created_at: unixMsAgo(30),
+      last_used_at: null,
+      last_used_ip: null,
+      rotated_from: null,
+      revoked_at: null,
+    },
+  ];
+  const { installs } = summariseInstalledHaTokens(rows);
+  assert.equal(installs.length, 2);
+  assert.equal(installs[0].installId, "01JXBB");
+  assert.equal(installs[1].installId, "01JXAA");
+});
+
+// ---------------------------------------------------------------------------
+// truncateInstallId — UI helper
+// ---------------------------------------------------------------------------
+
+test("truncateInstallId: short ids pass through unchanged", () => {
+  assert.equal(truncateInstallId("short"), "short");
+  assert.equal(truncateInstallId("home-kitchen"), "home-kitchen");
+});
+
+test("truncateInstallId: long ids get head + ellipsis + tail", () => {
+  const id = "63b96c8a-9d6f-4a7b-bcef-1234567890ab"; // 36 chars
+  const out = truncateInstallId(id);
+  assert.match(out, /…/);
+  assert.ok(out.length <= 17, `truncated id length ${out.length} > 17`);
+});
+
+// ---------------------------------------------------------------------------
+// formatLastUsed — relative-time helper
+// ---------------------------------------------------------------------------
+
+test("formatLastUsed: null → Never", () => {
+  assert.equal(formatLastUsed(null, FROZEN_NOW), "Never");
+});
+
+test("formatLastUsed: < 60s → Just now", () => {
+  assert.equal(formatLastUsed(unixMsAgo(5), FROZEN_NOW), "Just now");
+});
+
+test("formatLastUsed: minutes / hours / days", () => {
+  assert.equal(formatLastUsed(unixMsAgo(120), FROZEN_NOW), "2 min ago");
+  assert.equal(formatLastUsed(unixMsAgo(7200), FROZEN_NOW), "2 h ago");
+  assert.equal(formatLastUsed(unixMsAgo(86_400 * 3), FROZEN_NOW), "3 d ago");
+});
+
+test("formatLastUsed: future timestamp (clock drift) → Just now", () => {
+  assert.equal(formatLastUsed(unixMsAgo(-30), FROZEN_NOW), "Just now");
+});

--- a/packages/web/src/dashboard/haConversationCardCore.ts
+++ b/packages/web/src/dashboard/haConversationCardCore.ts
@@ -1,0 +1,164 @@
+// haConversationCardCore — pure shape derivation for the /channels
+// "HA → Alfred (conversation)" setup card (#111 PR3).
+//
+// Card A in the Wave-C twofer with VoiceWakeWordsCard. This card is
+// mostly a documentation surface: it walks the principal through the
+// three-step install of the ssdavidai/alfred-ha HACS custom component,
+// then lists the channel tokens that have been minted for each HA
+// install. There is no runtime status to derive — HA is the side that
+// CALLS ctrl-api (POST /api/v1/channels/ha/turn), so the card's job is
+// to publish the install ritual and surface the persisted tokens.
+//
+// Backed by:
+//   * GET  /api/v1/channel-tokens?channel=ha-conversation     (PR #111 PR1)
+//   * POST /api/v1/channel-tokens/mint                        (PR #111 PR1)
+//   * POST /api/v1/channel-tokens/:id/revoke                  (PR #111 PR1)
+//
+// Import-free (no React, no Wasp) so the helpers unit-test under
+// node:test the same way the other ChannelsPage cores do.
+
+/** The single source of truth for "where is the HACS custom repo?".
+ *  Surfaced as a copyable string on the card. The principal pastes it
+ *  into HACS → ⋮ → Custom repositories → Repository. */
+export function buildHacsRepoUrl(): string {
+  return "https://github.com/ssdavidai/alfred-ha";
+}
+
+/** UUID v4 regex (loose — only checks shape + version nibble). HA's
+ *  built-in `instance_id` is a uuid4, which is the default we recommend.
+ *  Any v4-shaped string passes. Empty / whitespace fails. */
+const UUID_V4_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/** Slug regex for "human-readable HA install" labels (e.g. "home-kitchen"
+ *  or "vacation-house"). Mirrors the GitHub-slug / docker-name shape: the
+ *  characters that survive YAML + URL paths without quoting. */
+const SLUG_RE = /^[a-zA-Z0-9_-]+$/;
+
+/** Accept a uuid v4 OR a plain installation slug (`a-zA-Z0-9_-`,
+ *  8-64 chars). Returns the normalised value on success; null on
+ *  failure. Used by the mint-token form input to refuse footguns
+ *  (whitespace, control chars, accidental quoted strings) at the UI
+ *  layer rather than leaving it for ctrl-api to reject. */
+export function parseHaInstallId(input: string): string | null {
+  if (typeof input !== "string") return null;
+  const trimmed = input.trim();
+  if (trimmed.length === 0) return null;
+  if (UUID_V4_RE.test(trimmed)) return trimmed.toLowerCase();
+  if (trimmed.length < 8 || trimmed.length > 64) return null;
+  if (!SLUG_RE.test(trimmed)) return null;
+  return trimmed;
+}
+
+/** The public-safe channel-token shape we read off ctrl-api's
+ *  `GET /api/v1/channel-tokens?channel=ha-conversation`. Mirrors
+ *  `ChannelTokenMeta` in packages/ctrl/src/db/channelTokens.ts — but
+ *  duplicated here as a literal type so the web package doesn't have
+ *  to import from ctrl. */
+export interface ChannelTokenRow {
+  id: string;
+  channel: string;
+  label: string | null;
+  scope: Record<string, unknown> | null;
+  created_at: number;
+  last_used_at: number | null;
+  last_used_ip: string | null;
+  rotated_from: string | null;
+  revoked_at: number | null;
+}
+
+/** One row in the "Installed HA installs" table. The card's render
+ *  layer reads this shape directly. `installId` is read from the
+ *  channel-token's `scope.haInstanceId` (which the mint flow populates
+ *  by parsing the form input through `parseHaInstallId`); if the scope
+ *  is missing or malformed we fall back to the row id so the row is
+ *  never invisible. */
+export interface HaInstalledInstall {
+  /** The ULID of the channel-token row — used as a React key + the
+   *  argument to /channel-tokens/:id/revoke. */
+  tokenId: string;
+  /** The principal's identifier for this HA install. Read from
+   *  scope.haInstanceId; never null (falls back to tokenId). */
+  installId: string;
+  /** The human-friendly label the principal supplied at mint
+   *  (typically `ha:<installId>` per the migration's example). May be
+   *  null when an older mint omitted it. */
+  label: string | null;
+  /** Unix ms; null until the token is first used by HA. */
+  lastUsedAt: number | null;
+  /** Best-effort source IP recorded by ctrl-api on the most recent
+   *  authenticated request. Null when never used. */
+  lastUsedIp: string | null;
+}
+
+export interface HaInstallsSummary {
+  installs: HaInstalledInstall[];
+}
+
+/** Read the `haInstanceId` scope field defensively. The scope_json is
+ *  channel-defined free-form: a malformed string, a non-object, or a
+ *  missing key all fall back to null so the table renders something
+ *  rather than throwing. */
+function readInstallId(scope: Record<string, unknown> | null): string | null {
+  if (!scope || typeof scope !== "object") return null;
+  const v = (scope as Record<string, unknown>).haInstanceId;
+  if (typeof v === "string" && v.trim().length > 0) return v.trim();
+  return null;
+}
+
+/** Group ha-conversation channel-token rows into the install-table
+ *  shape the card renders. Filters out tokens for other channels (the
+ *  endpoint should already do this, but defence-in-depth is cheap),
+ *  filters out revoked tokens (their "row" is the audit, not the
+ *  table), and sorts by created_at descending so newest installs
+ *  appear at the top. */
+export function summariseInstalledHaTokens(
+  tokens: ChannelTokenRow[] | null | undefined,
+): HaInstallsSummary {
+  if (!Array.isArray(tokens)) return { installs: [] };
+  const filtered = tokens.filter(
+    (t) => t && t.channel === "ha-conversation" && t.revoked_at == null,
+  );
+  // Sort newest-first by created_at, with stable fallback on id.
+  const sorted = [...filtered].sort((a, b) => {
+    const ca = typeof a.created_at === "number" ? a.created_at : 0;
+    const cb = typeof b.created_at === "number" ? b.created_at : 0;
+    if (cb !== ca) return cb - ca;
+    return a.id.localeCompare(b.id);
+  });
+  const installs: HaInstalledInstall[] = sorted.map((t) => ({
+    tokenId: t.id,
+    installId: readInstallId(t.scope) ?? t.id,
+    label: t.label,
+    lastUsedAt: typeof t.last_used_at === "number" ? t.last_used_at : null,
+    lastUsedIp: typeof t.last_used_ip === "string" ? t.last_used_ip : null,
+  }));
+  return { installs };
+}
+
+/** Truncate a long install id for table-cell display. Keeps the head +
+ *  ellipsis + tail so the principal can tell two installs apart at a
+ *  glance without the cell overflowing. */
+export function truncateInstallId(value: string, max = 16): string {
+  if (typeof value !== "string") return "";
+  if (value.length <= max) return value;
+  const head = Math.max(4, Math.floor((max - 1) / 2));
+  const tail = Math.max(3, max - 1 - head);
+  return `${value.slice(0, head)}…${value.slice(value.length - tail)}`;
+}
+
+/** Format a unix-ms timestamp as a "Last used N ago" string. Null →
+ *  "Never". Now-vs-then comparison is done against a frozen `now` so
+ *  tests are deterministic. */
+export function formatLastUsed(
+  unixMs: number | null,
+  now: Date = new Date(),
+): string {
+  if (unixMs == null) return "Never";
+  const deltaSec = Math.floor((now.getTime() - unixMs) / 1000);
+  if (deltaSec < 0) return "Just now";
+  if (deltaSec < 60) return "Just now";
+  if (deltaSec < 3600) return `${Math.floor(deltaSec / 60)} min ago`;
+  if (deltaSec < 86_400) return `${Math.floor(deltaSec / 3600)} h ago`;
+  return `${Math.floor(deltaSec / 86_400)} d ago`;
+}

--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -2679,3 +2679,129 @@ export const deleteFile = async (
     path: `/api/v1/files/${encodeFilesPath(args.path)}`,
   });
 };
+
+// ============================================================
+// Wave C — HA conversation setup card (#111 PR3) and Voice
+// satellites / wake-words card (#112 PR3). Both cards land on
+// /channels; the HA card surfaces channel-token rows from
+// ctrl-api's shared channel_tokens table (PR #111 PR1), and the
+// voice card surfaces detected ESPHome satellites with graceful
+// 404 handling when the listener isn't enabled yet.
+// ============================================================
+
+/** Read the channel_tokens rows for `channel=ha-conversation`. Shape
+ *  comes from ctrl-api's GET /api/v1/channel-tokens (PR #111 PR1):
+ *  `{ tokens: ChannelTokenMeta[] }` where each meta omits the
+ *  token_hash and includes a public-safe `scope`. The web layer
+ *  passes through the rows verbatim; haConversationCardCore.ts
+ *  groups/sorts/filters into the install-table shape. */
+export const getHaInstalledTokens = async (_args: unknown, context: any) => {
+  const instance = await getUserInstance(context);
+  try {
+    return await proxyToTenant(instance, {
+      path: "/api/v1/channel-tokens",
+      query: { channel: "ha-conversation" },
+    });
+  } catch (e: any) {
+    // The shared channel-tokens surface lands in #111 PR1; the route
+    // is already on this branch, but tenants that haven't pulled the
+    // image yet will 404. Surface a graceful empty list so the card
+    // shows the "no installs yet" empty-state instead of an error.
+    if (e instanceof HttpError && e.statusCode === 404) {
+      return { tokens: [], unavailable: true };
+    }
+    throw e;
+  }
+};
+
+/** Mint a new ha-conversation channel token. The principal supplies
+ *  a free-form label (typically `ha:<installId>`) and the install id
+ *  (a uuid v4 or a slug) which we stash on `scope.haInstanceId` so
+ *  ctrl-api's validator can pin auth back to a specific HA install. */
+export const mintHaChannelToken = async (
+  args: { label?: string; installId?: string },
+  context: any,
+) => {
+  const label =
+    typeof args?.label === "string" && args.label.trim()
+      ? args.label.trim()
+      : null;
+  const installId =
+    typeof args?.installId === "string" && args.installId.trim()
+      ? args.installId.trim()
+      : null;
+  if (!installId) {
+    throw new HttpError(400, "installId required");
+  }
+  const instance = await getUserInstance(context);
+  try {
+    return await proxyToTenant(instance, {
+      method: "POST",
+      path: "/api/v1/channel-tokens/mint",
+      body: {
+        channel: "ha-conversation",
+        label: label ?? `ha:${installId}`,
+        scope: { haInstanceId: installId },
+      },
+    });
+  } catch (e: any) {
+    // PR #111 PR4 will surface a user-facing mint flow; until then,
+    // bubble a recognisable error so the card can show "Coming in
+    // PR4" without breaking the page.
+    if (e instanceof HttpError && e.statusCode === 404) {
+      throw new HttpError(
+        501,
+        "Mint surface not deployed yet (PR #111 PR4 lands the runtime mint).",
+      );
+    }
+    throw e;
+  }
+};
+
+/** Revoke (soft-delete) a channel token by id. The HA card uses this
+ *  to retire an install — the per-install bearer stops authenticating
+ *  on the next request. Idempotent on ctrl-api side. */
+export const revokeChannelToken = async (
+  args: { id?: string },
+  context: any,
+) => {
+  if (typeof args?.id !== "string" || !args.id.trim()) {
+    throw new HttpError(400, "id required");
+  }
+  const instance = await getUserInstance(context);
+  try {
+    return await proxyToTenant(instance, {
+      method: "POST",
+      path: `/api/v1/channel-tokens/${encodeURIComponent(args.id.trim())}/revoke`,
+    });
+  } catch (e: any) {
+    if (e instanceof HttpError && e.statusCode === 404) {
+      throw new HttpError(
+        501,
+        "Revoke surface not deployed yet (PR #111 PR4 lands the runtime mint).",
+      );
+    }
+    throw e;
+  }
+};
+
+/** Read the list of ESPHome satellites the voice-bridge has seen on
+ *  the local network. The listener landed in #112 PR1 but the
+ *  ctrl-api status endpoint is queued for #112 PR4 — when the route
+ *  isn't there yet, return `{ devices: [], unavailable: true }` so
+ *  the card surfaces "ESPHome listener disabled" copy instead of an
+ *  error toast. The card's job is to publish the catalogue + show
+ *  what's there; absence is a normal state. */
+export const getEsphomeDevices = async (_args: unknown, context: any) => {
+  const instance = await getUserInstance(context);
+  try {
+    return await proxyToTenant(instance, {
+      path: "/api/v1/channels/voice/esphome/devices",
+    });
+  } catch (e: any) {
+    if (e instanceof HttpError && e.statusCode === 404) {
+      return { devices: [], unavailable: true };
+    }
+    throw e;
+  }
+};

--- a/packages/web/src/dashboard/voiceWakeWordsCardCore.test.ts
+++ b/packages/web/src/dashboard/voiceWakeWordsCardCore.test.ts
@@ -1,0 +1,243 @@
+/**
+ * /channels — VoiceWakeWordsCard helper tests (#112 PR3).
+ *
+ * Covers:
+ *   • WAKE_WORD_CATALOGUE: 8 entries, all required fields present
+ *   • selectedWakeWordsToManifest: empty / micro-only / open-only / mixed
+ *   • selectedWakeWordsToManifest: unknown slugs silently ignored
+ *   • upstreamUrlForEntry: builds GitHub blob URL
+ *   • formatEsphomeDeviceRow: connected / disconnected / error rows
+ *   • formatEsphomeDeviceRow: missing model + wake-word fall back to —
+ *
+ * Run with:
+ *   cd packages/web && npx tsx --test src/dashboard/voiceWakeWordsCardCore.test.ts
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  WAKE_WORD_CATALOGUE,
+  WAKE_WORD_UPSTREAM_URL,
+  selectedWakeWordsToManifest,
+  upstreamUrlForEntry,
+  formatEsphomeDeviceRow,
+  type EsphomeDevice,
+} from "./voiceWakeWordsCardCore";
+
+const FROZEN_NOW = new Date("2026-05-29T12:00:00Z");
+
+// ---------------------------------------------------------------------------
+// WAKE_WORD_CATALOGUE: shape contract
+// ---------------------------------------------------------------------------
+
+test("catalogue: exactly 8 entries — matches task brief", () => {
+  assert.equal(WAKE_WORD_CATALOGUE.length, 8);
+});
+
+test("catalogue: every entry has slug / displayName / model / githubPath", () => {
+  for (const e of WAKE_WORD_CATALOGUE) {
+    assert.ok(typeof e.slug === "string" && e.slug.length > 0, "slug");
+    assert.ok(
+      typeof e.displayName === "string" && e.displayName.length > 0,
+      "displayName",
+    );
+    assert.ok(
+      e.model === "microWakeWord" || e.model === "openWakeWord",
+      "model",
+    );
+    assert.ok(
+      typeof e.githubPath === "string" && e.githubPath.length > 0,
+      "githubPath",
+    );
+    // sha256 is allowed to be null (unpinned) — that's the documented
+    // shape. We assert the field is present, null or string.
+    assert.ok(
+      e.sha256 === null || typeof e.sha256 === "string",
+      "sha256 must be string|null",
+    );
+  }
+});
+
+test("catalogue: slugs are unique", () => {
+  const slugs = WAKE_WORD_CATALOGUE.map((e) => e.slug);
+  assert.equal(new Set(slugs).size, slugs.length);
+});
+
+test("catalogue: covers BOTH model families", () => {
+  const models = new Set(WAKE_WORD_CATALOGUE.map((e) => e.model));
+  assert.ok(models.has("microWakeWord"));
+  assert.ok(models.has("openWakeWord"));
+});
+
+test("catalogue: every brief-listed wake word is present", () => {
+  // The Wave-C brief enumerates these eight specifically.
+  const required = [
+    "alexa",
+    "computer",
+    "hey_jarvis",
+    "hey_mycroft",
+    "hey_rhasspy",
+    "jarvis",
+    "ok_nabu",
+    "sherlock",
+  ];
+  const slugs = new Set(WAKE_WORD_CATALOGUE.map((e) => e.slug));
+  for (const s of required) {
+    assert.ok(slugs.has(s), `missing brief-listed slug ${s}`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// selectedWakeWordsToManifest: ESPHome YAML output
+// ---------------------------------------------------------------------------
+
+test("manifest: empty selection → instruction comment, no YAML", () => {
+  const out = selectedWakeWordsToManifest([]);
+  assert.match(out, /Select at least one wake word/);
+  assert.doesNotMatch(out, /micro_wake_word:/);
+});
+
+test("manifest: microWakeWord only → emits micro_wake_word block + use_wake_word", () => {
+  const out = selectedWakeWordsToManifest(["ok_nabu", "jarvis"]);
+  assert.match(out, /micro_wake_word:/);
+  assert.match(out, /- model: ok_nabu/);
+  assert.match(out, /- model: jarvis/);
+  assert.match(out, /voice_assistant:\n  use_wake_word: true/);
+  // No openWakeWord comment block since none were selected.
+  assert.doesNotMatch(out, /openWakeWord on the voice-bridge/);
+});
+
+test("manifest: openWakeWord only → comment block, no micro_wake_word", () => {
+  const out = selectedWakeWordsToManifest(["alexa", "hey_jarvis"]);
+  assert.doesNotMatch(out, /micro_wake_word:/);
+  assert.match(out, /openWakeWord on the voice-bridge/);
+  assert.match(out, /alexa/);
+  assert.match(out, /hey_jarvis/);
+  // Upstream URL appears for each openWakeWord entry.
+  assert.match(out, /github\.com\/fwartner/);
+});
+
+test("manifest: mixed selection → both blocks", () => {
+  const out = selectedWakeWordsToManifest(["ok_nabu", "alexa"]);
+  assert.match(out, /micro_wake_word:/);
+  assert.match(out, /- model: ok_nabu/);
+  assert.match(out, /openWakeWord on the voice-bridge/);
+  assert.match(out, /alexa/);
+});
+
+test("manifest: unknown slugs are silently ignored", () => {
+  const out = selectedWakeWordsToManifest(["ok_nabu", "no-such-wakeword"]);
+  assert.match(out, /- model: ok_nabu/);
+  assert.doesNotMatch(out, /no-such-wakeword/);
+});
+
+test("manifest: header references the upstream catalogue", () => {
+  const out = selectedWakeWordsToManifest(["ok_nabu"]);
+  assert.match(out, new RegExp(WAKE_WORD_UPSTREAM_URL.replace(/\./g, "\\.")));
+});
+
+// ---------------------------------------------------------------------------
+// upstreamUrlForEntry
+// ---------------------------------------------------------------------------
+
+test("upstreamUrlForEntry: returns a github.com blob URL", () => {
+  const entry = WAKE_WORD_CATALOGUE.find((e) => e.slug === "ok_nabu")!;
+  const url = upstreamUrlForEntry(entry);
+  assert.match(url, /^https:\/\/github\.com\/fwartner\/.*\/blob\/main\//);
+  assert.ok(url.endsWith(entry.githubPath));
+});
+
+// ---------------------------------------------------------------------------
+// formatEsphomeDeviceRow: status formatter
+// ---------------------------------------------------------------------------
+
+const BASE_DEVICE: EsphomeDevice = {
+  hostname: "voice-pe-living-room.local",
+  ip: "192.168.1.42",
+  lastSeenAt: FROZEN_NOW.getTime() - 30_000, // 30s ago
+  model: "voice-assistant-pe",
+  currentWakeWord: "ok_nabu",
+  status: "connected",
+  errorMessage: null,
+};
+
+test("formatEsphomeDeviceRow: connected → active pill + short host", () => {
+  const row = formatEsphomeDeviceRow(BASE_DEVICE, FROZEN_NOW);
+  assert.equal(row.pill, "active");
+  assert.equal(row.pillLabel, "Connected");
+  assert.equal(row.shortHost, "voice-pe-living-room");
+  assert.equal(row.modelLabel, "voice-assistant-pe");
+  assert.equal(row.wakeWordLabel, "ok_nabu");
+  assert.equal(row.lastSeenRelative, "Just now");
+  assert.equal(row.errorLine, null);
+});
+
+test("formatEsphomeDeviceRow: disconnected → available pill + Offline label", () => {
+  const row = formatEsphomeDeviceRow(
+    { ...BASE_DEVICE, status: "disconnected", lastSeenAt: null },
+    FROZEN_NOW,
+  );
+  assert.equal(row.pill, "available");
+  assert.equal(row.pillLabel, "Offline");
+  assert.equal(row.lastSeenRelative, "Never");
+  assert.equal(row.errorLine, null);
+});
+
+test("formatEsphomeDeviceRow: error → error pill + surfaced message", () => {
+  const row = formatEsphomeDeviceRow(
+    {
+      ...BASE_DEVICE,
+      status: "error",
+      errorMessage: "ESPHome refused encryption key",
+    },
+    FROZEN_NOW,
+  );
+  assert.equal(row.pill, "error");
+  assert.equal(row.pillLabel, "Error");
+  assert.equal(row.errorLine, "ESPHome refused encryption key");
+});
+
+test("formatEsphomeDeviceRow: error with null message → fallback line", () => {
+  const row = formatEsphomeDeviceRow(
+    { ...BASE_DEVICE, status: "error", errorMessage: null },
+    FROZEN_NOW,
+  );
+  assert.equal(row.pill, "error");
+  assert.match(row.errorLine ?? "", /no detail/);
+});
+
+test("formatEsphomeDeviceRow: missing model + wake word → em-dash fallback", () => {
+  const row = formatEsphomeDeviceRow(
+    { ...BASE_DEVICE, model: null, currentWakeWord: null },
+    FROZEN_NOW,
+  );
+  assert.equal(row.modelLabel, "—");
+  assert.equal(row.wakeWordLabel, "—");
+});
+
+test("formatEsphomeDeviceRow: hostname without .local left verbatim", () => {
+  const row = formatEsphomeDeviceRow(
+    { ...BASE_DEVICE, hostname: "192.168.1.42" },
+    FROZEN_NOW,
+  );
+  assert.equal(row.shortHost, "192.168.1.42");
+});
+
+test("formatEsphomeDeviceRow: lastSeenAt minutes/hours/days roll up", () => {
+  const min = formatEsphomeDeviceRow(
+    { ...BASE_DEVICE, lastSeenAt: FROZEN_NOW.getTime() - 120_000 },
+    FROZEN_NOW,
+  );
+  assert.equal(min.lastSeenRelative, "2 min ago");
+  const hr = formatEsphomeDeviceRow(
+    { ...BASE_DEVICE, lastSeenAt: FROZEN_NOW.getTime() - 7_200_000 },
+    FROZEN_NOW,
+  );
+  assert.equal(hr.lastSeenRelative, "2 h ago");
+  const day = formatEsphomeDeviceRow(
+    { ...BASE_DEVICE, lastSeenAt: FROZEN_NOW.getTime() - 86_400_000 * 3 },
+    FROZEN_NOW,
+  );
+  assert.equal(day.lastSeenRelative, "3 d ago");
+});

--- a/packages/web/src/dashboard/voiceWakeWordsCardCore.ts
+++ b/packages/web/src/dashboard/voiceWakeWordsCardCore.ts
@@ -1,0 +1,280 @@
+// voiceWakeWordsCardCore — pure derivation for the /channels
+// "Voice satellites & wake words" card (#112 PR3).
+//
+// Card B in the Wave-C twofer with HaConversationSetupCard. The
+// upstream catalogue lives at:
+//
+//   https://github.com/fwartner/home-assistant-wakewords-collection
+//
+// It's a community-curated repository of microWakeWord + openWakeWord
+// models. We bake a small allowlist of the eight most-used entries —
+// just metadata, no model bytes — so the principal can multi-select +
+// generate ESPHome YAML without leaving the page. A footer link points
+// at the upstream repo for browsing the long tail.
+//
+// Import-free (no React, no Wasp) so the helpers unit-test under
+// node:test the same way the other ChannelsPage cores do.
+
+export type WakeWordModel = "microWakeWord" | "openWakeWord";
+
+export interface WakeWordEntry {
+  /** Stable slug used as the React key + the YAML key when generating
+   *  ESPHome manifests. ASCII lower-snake-case. */
+  slug: string;
+  /** What the principal sees in the multi-select grid. */
+  displayName: string;
+  /** Where the model runs:
+   *   - microWakeWord runs on-device (ESP32-S3) — zero latency, free.
+   *   - openWakeWord runs on the voice-bridge — heavier accuracy, costs
+   *     a couple of CPU cores. The card surfaces this tradeoff. */
+  model: WakeWordModel;
+  /** Path within fwartner/home-assistant-wakewords-collection (relative
+   *  to the repo root). Used to build the "Open in upstream" link. */
+  githubPath: string;
+  /** sha256 of the model's primary `.tflite` (microWakeWord) or
+   *  `.onnx` (openWakeWord), lowercase hex. NULL when we haven't
+   *  pinned it yet — the catalogue ships pin-as-you-go so the PR
+   *  doesn't carry 8 weight-file SHAs the maintainer would have to
+   *  re-verify. The renderer surfaces "(unpinned — verify upstream)"
+   *  on null. */
+  sha256: string | null;
+}
+
+/** Eight most-used entries from
+ *  github.com/fwartner/home-assistant-wakewords-collection, chosen by
+ *  ★-count + canonical-ness. sha256s left null in this PR — the
+ *  catalogue is documentation-only here; voice-bridge / ESPHome pulls
+ *  the bytes itself from the upstream URL at flash-time. Pinning the
+ *  hashes is a separate housekeeping pass once the catalogue ships. */
+export const WAKE_WORD_CATALOGUE: ReadonlyArray<WakeWordEntry> = [
+  {
+    slug: "alexa",
+    displayName: "Alexa",
+    model: "openWakeWord",
+    githubPath: "openWakeWord/alexa/alexa_v0.1.onnx",
+    sha256: null,
+  },
+  {
+    slug: "computer",
+    displayName: "Computer",
+    model: "microWakeWord",
+    githubPath: "microWakeWord/computer.json",
+    sha256: null,
+  },
+  {
+    slug: "hey_jarvis",
+    displayName: "Hey Jarvis",
+    model: "openWakeWord",
+    githubPath: "openWakeWord/hey_jarvis/hey_jarvis_v0.1.onnx",
+    sha256: null,
+  },
+  {
+    slug: "hey_mycroft",
+    displayName: "Hey Mycroft",
+    model: "openWakeWord",
+    githubPath: "openWakeWord/hey_mycroft/hey_mycroft_v0.1.onnx",
+    sha256: null,
+  },
+  {
+    slug: "hey_rhasspy",
+    displayName: "Hey Rhasspy",
+    model: "openWakeWord",
+    githubPath: "openWakeWord/hey_rhasspy/hey_rhasspy_v0.1.onnx",
+    sha256: null,
+  },
+  {
+    slug: "jarvis",
+    displayName: "Jarvis",
+    model: "microWakeWord",
+    githubPath: "microWakeWord/jarvis.json",
+    sha256: null,
+  },
+  {
+    slug: "ok_nabu",
+    displayName: "Ok Nabu",
+    model: "microWakeWord",
+    githubPath: "microWakeWord/ok_nabu.json",
+    sha256: null,
+  },
+  {
+    slug: "sherlock",
+    displayName: "Sherlock",
+    model: "microWakeWord",
+    githubPath: "microWakeWord/sherlock.json",
+    sha256: null,
+  },
+];
+
+/** Upstream HACS-style URL root for the wake-words collection. */
+export const WAKE_WORD_UPSTREAM_URL =
+  "https://github.com/fwartner/home-assistant-wakewords-collection";
+
+/** Build a per-entry upstream link the principal can open in a new tab
+ *  to read the model card / training notes upstream maintains. */
+export function upstreamUrlForEntry(entry: WakeWordEntry): string {
+  return `${WAKE_WORD_UPSTREAM_URL}/blob/main/${entry.githubPath}`;
+}
+
+/** Given a list of selected slugs, return the ESPHome YAML snippet
+ *  the principal pastes into their satellite device's `.yaml`. Output:
+ *
+ *    micro_wake_word:
+ *      models:
+ *        - model: ok_nabu
+ *        - model: computer
+ *    voice_assistant:
+ *      use_wake_word: true
+ *
+ *  microWakeWord models are emitted under `micro_wake_word.models`
+ *  (one per line); openWakeWord models render as a YAML comment block
+ *  at the top, because openWakeWord runs on the voice-bridge, not the
+ *  device — the principal enables it through HA's Assist pipeline UI,
+ *  not through ESPHome YAML.
+ *
+ *  Unknown slugs are skipped silently — the UI only ever passes us
+ *  catalogue slugs, so this is belt-and-braces. */
+export function selectedWakeWordsToManifest(selected: string[]): string {
+  if (!Array.isArray(selected) || selected.length === 0) {
+    return "# Select at least one wake word above to generate ESPHome YAML.\n";
+  }
+  const slugSet = new Set(selected);
+  const micro = WAKE_WORD_CATALOGUE.filter(
+    (e) => e.model === "microWakeWord" && slugSet.has(e.slug),
+  );
+  const open = WAKE_WORD_CATALOGUE.filter(
+    (e) => e.model === "openWakeWord" && slugSet.has(e.slug),
+  );
+
+  const lines: string[] = [];
+  lines.push("# Generated by Alfred — paste under your ESPHome device YAML.");
+  lines.push("# Reference: " + WAKE_WORD_UPSTREAM_URL);
+  lines.push("");
+
+  if (micro.length > 0) {
+    lines.push("micro_wake_word:");
+    lines.push("  models:");
+    for (const e of micro) {
+      lines.push(`    - model: ${e.slug}`);
+    }
+    lines.push("");
+    lines.push("voice_assistant:");
+    lines.push("  use_wake_word: true");
+  }
+
+  if (open.length > 0) {
+    if (micro.length > 0) lines.push("");
+    lines.push(
+      "# The following models run as openWakeWord on the voice-bridge,",
+    );
+    lines.push(
+      "# not on this device. Enable them under HA → Settings → Voice",
+    );
+    lines.push("# Assistants → Wake word service → openWakeWord:");
+    for (const e of open) {
+      lines.push(`#   - ${e.slug}  (${upstreamUrlForEntry(e)})`);
+    }
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Detected ESPHome devices — surfaced by voice-bridge once #112 PR2's
+// ESPHome Native API listener is enabled. The shape mirrors what the
+// listener will publish to ctrl-api / GET /api/v1/channels/voice/
+// esphome/devices when that endpoint lands; for now ChannelsPage treats
+// a 404 as "feature off" and shows a hint to set ESPHOME_API_ENABLED=1.
+// ---------------------------------------------------------------------------
+
+export type EsphomeDeviceStatus = "connected" | "disconnected" | "error";
+
+export interface EsphomeDevice {
+  /** mDNS / .local hostname, e.g. `voice-pe-living-room.local`. */
+  hostname: string;
+  /** Last-seen IP. */
+  ip: string;
+  /** Unix ms of the most recent successful connection. */
+  lastSeenAt: number | null;
+  /** Free-form model string ESPHome publishes via API, e.g.
+   *  `voice-assistant-pe` or `m5stack-atom-echo`. */
+  model: string | null;
+  /** The wake-word the satellite is currently booted with. Null when
+   *  none is configured (HA Assist will use the cloud wake word). */
+  currentWakeWord: string | null;
+  /** Coarse health state. */
+  status: EsphomeDeviceStatus;
+  /** Verbatim message from the listener for "error" rows. */
+  errorMessage: string | null;
+}
+
+export interface EsphomeDeviceRowView {
+  /** Friendly hostname (just the bit before `.local`) or hostname
+   *  verbatim when there's no `.local` suffix. */
+  shortHost: string;
+  /** IP as supplied. */
+  ip: string;
+  /** "Just now" / "5 min ago" / "Never". Mirrors formatLastUsed in
+   *  haConversationCardCore but locally so this file unit-tests on
+   *  its own. */
+  lastSeenRelative: string;
+  /** Pretty label for the model field. */
+  modelLabel: string;
+  /** What to show in the "Wake word" column. Null falls back to the
+   *  literal "—" so the column never collapses. */
+  wakeWordLabel: string;
+  /** Pill tone for the row: green/yellow/red. */
+  pill: "active" | "available" | "error";
+  /** Pill text. */
+  pillLabel: string;
+  /** Optional error line under the row (only for `status: "error"`). */
+  errorLine: string | null;
+}
+
+function formatRelative(unixMs: number | null, now: Date): string {
+  if (unixMs == null) return "Never";
+  const deltaSec = Math.floor((now.getTime() - unixMs) / 1000);
+  if (deltaSec < 0 || deltaSec < 60) return "Just now";
+  if (deltaSec < 3600) return `${Math.floor(deltaSec / 60)} min ago`;
+  if (deltaSec < 86_400) return `${Math.floor(deltaSec / 3600)} h ago`;
+  return `${Math.floor(deltaSec / 86_400)} d ago`;
+}
+
+export function formatEsphomeDeviceRow(
+  device: EsphomeDevice,
+  now: Date = new Date(),
+): EsphomeDeviceRowView {
+  const shortHost = device.hostname.endsWith(".local")
+    ? device.hostname.slice(0, -".local".length)
+    : device.hostname;
+  const pill: "active" | "available" | "error" =
+    device.status === "connected"
+      ? "active"
+      : device.status === "error"
+        ? "error"
+        : "available";
+  const pillLabel =
+    device.status === "connected"
+      ? "Connected"
+      : device.status === "error"
+        ? "Error"
+        : "Offline";
+  return {
+    shortHost,
+    ip: device.ip,
+    lastSeenRelative: formatRelative(device.lastSeenAt, now),
+    modelLabel: device.model && device.model.trim() ? device.model : "—",
+    wakeWordLabel:
+      device.currentWakeWord && device.currentWakeWord.trim()
+        ? device.currentWakeWord
+        : "—",
+    pill,
+    pillLabel,
+    errorLine:
+      device.status === "error"
+        ? device.errorMessage && device.errorMessage.trim()
+          ? device.errorMessage
+          : "ESPHome connection failed (no detail)."
+        : null,
+  };
+}


### PR DESCRIPTION
Wave-C twofer bundling two `/channels` cards that share real estate.

## Card A — `HaConversationSetupCard` (#111 PR3)

Documentation-first surface for the install ritual the principal follows
ONCE per Home Assistant install:

  1. Install the HACS custom repository `ssdavidai/alfred-ha`.
  2. Add the integration in HA (Settings → Devices & Services → Alfred Black).
  3. Mint a per-install channel token, paste into HA.

```
┌──────────────────────────────────────────────────────────┐
│ Voice → HA → Alfred                          Connected  │
│ 2 HA installs paired                                     │
│ Pipe Home Assistant's Assist conversations to Alfred —  │
│ same memory, in the kitchen.                             │
│                                                          │
│ 1  Install the HACS custom repository                    │
│    [https://github.com/ssdavidai/alfred-ha     ] [Copy]  │
│ 2  Add the integration                                   │
│    Settings → Devices & Services → Add → Alfred Black    │
│ 3  Mint a channel token                                  │
│    [home-kitchen____________] [Mint token]               │
│    ┌──────────────────────────────────────────┐          │
│    │ One-time reveal — copy now               │          │
│    │ [ha_xxxxxxxxxxxxxxxxxxxxxx] [Copy][Hide] │          │
│    └──────────────────────────────────────────┘          │
│                                                          │
│ Installed HA installs                                    │
│ ── Install ID ─── Label ──── Last used ── IP ─ Action ── │
│    home-kitchen   ha:home    2 min ago    .5  Revoke     │
│    vacation_house ha:vac     Never        —   Revoke     │
└──────────────────────────────────────────────────────────┘
```

Backed by the shared `channel_tokens` surface that landed in #111 PR1
(`/api/v1/channel-tokens?channel=ha-conversation`, mint, revoke). Mint
+ revoke gracefully 404-fall-through to a "Coming in PR4" panel with a
manual `vault-cli` fallback so the card never breaks the page on a
tenant that hasn't pulled PR1's image.

## Card B — `VoiceWakeWordsCard` (#112 PR3)

Two-section card: detected ESPHome satellites + wake-word library.

```
┌──────────────────────────────────────────────────────────┐
│ Voice satellites                       1 on the network  │
│ ESPHome Voice PE · M5Stack Atom · S3-Box                 │
│ Wake words and satellites — the doors with no screens.   │
│                                                          │
│ Detected ESPHome devices                                 │
│ Hostname ─── IP ───── Last seen ─ Model ── Wake ─ Status │
│ voice-pe-kitchen .42  Just now    PE       ok_nabu  Conn │
│                                                          │
│ Wake-word library                                        │
│ microWakeWord on-device · openWakeWord on the bridge.    │
│ ┌─────────┐ ┌──────────┐ ┌────────────┐                  │
│ │ Alexa   │ │ Computer │ │ Hey Jarvis │  …               │
│ │ open    │ │ micro    │ │ open       │                  │
│ └─────────┘ └──────────┘ └────────────┘                  │
│ [Generate ESPHome YAML]  [Clear (3)]                     │
│                                                          │
│ Full catalogue + custom training:                        │
│ fwartner/home-assistant-wakewords-collection             │
└──────────────────────────────────────────────────────────┘
```

Selecting + clicking 'Generate ESPHome YAML' opens an inline panel
with a ready-to-paste YAML snippet:

```yaml
micro_wake_word:
  models:
    - model: ok_nabu
voice_assistant:
  use_wake_word: true

# The following models run as openWakeWord on the voice-bridge,
# not on this device. Enable them under HA → Settings → Voice…
#   - alexa  (github.com/fwartner/.../alexa_v0.1.onnx)
```

When `/api/v1/channels/voice/esphome/devices` 404s (the route lands in
#112 PR4), the section surfaces an enable-the-listener hint instead of
breaking — exact env var + restart command included.

## Wake-word catalogue

Catalogue: **github.com/fwartner/home-assistant-wakewords-collection**
(the upstream-most-popular HA wake-word collection covering both the
microWakeWord and openWakeWord families).

8 entries baked: Alexa · Computer · Hey Jarvis · Hey Mycroft ·
Hey Rhasspy · Jarvis · Ok Nabu · Sherlock — matches the brief exactly.

**sha256 hashes are intentionally null** for this PR. The catalogue is
documentation here; voice-bridge / ESPHome fetches the bytes itself
from the upstream URL at flash-time, and pinning the 8 hashes is a
separate housekeeping pass once the catalogue ships. The card surfaces
'unpinned' on each entry's metadata line so the principal can see at
a glance which models haven't been verified yet.

## Test count delta

- Baseline (pre-PR, dashboard core tests): **118 passing**
- After Card A core tests: **134 passing** (+16)
- After Card B core tests: **153 passing** (+19)

**Net delta: +35 tests, all passing.** Existing 118 tests unchanged.

```
ℹ tests 153
ℹ pass 153
ℹ fail 0
```

## Wiring constraints honoured

- Both cards placed at the END of `/channels` (HaCard from #110 PR3
  isn't in main yet — the comment in `ChannelsPage.tsx` notes that
  when it lands, the canonical alphabetical order is HaCard then
  HaConversationSetupCard, and a subsequent reflow will move them).
- **No ctrl-api changes** — runtime endpoints owned by #111 PR1/PR4
  and #112 PR1/PR2/PR4. All ops gracefully 404-fall-through so the
  card degrades to an empty-state with a clear "what's next" message.
- **No new migrations**, no docker-compose changes.
- 24 existing ctrl-api test failures untouched.
- All 118 pre-existing dashboard tests still pass.
- No real wake-word model bytes — just catalogue metadata + upstream
  links.

## Commits

  - `feat(web): HA conversation setup card on /channels (#111 PR3)`
  - `feat(web): voice satellites + wake-words card on /channels (#112 PR3)`

Two commits — one per card — so review is straightforward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)