### PR TITLE
feat(web): Home Assistant /channels card — connect/status/registry (#110 PR3)

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -20,3 +20,7 @@ secret:
     # `password:` assignment; this file is the Vault writer and is
     # audited by hand. No literal secret ever appears here.
     - "packages/ctrl/src/api/routes/channels_ha.ts"
+    # /channels HA card unit tests. Same `llat_TEST_…` placeholder
+    # convention as channels_ha_pr1.test.ts; the JWT-shaped fixtures are
+    # synthetic (TEST_aaa…/TEST_bbb…/TEST_ccc… segments). See #110 PR3.
+    - "packages/web/src/dashboard/haCardCore.test.ts"

--- a/packages/web/main.wasp
+++ b/packages/web/main.wasp
@@ -1022,6 +1022,30 @@ query getEsphomeDevices {
   entities: []
 }
 
+// Lane I (Home Assistant, #110 PR3 — 2026-05-29) — operator deep-integrates
+// HA on /channels. Four ops backed by ctrl-api /api/v1/channels/ha/*
+// (PR1 #133 backfill landed the routes). State derivation lives in
+// haCardCore.ts. PR4 lands the /runs ledger; PR5 backfills the registry.
+query getHaStatus {
+  fn: import { getHaStatus } from "@src/dashboard/operations",
+  entities: []
+}
+
+query getHaRegistry {
+  fn: import { getHaRegistry } from "@src/dashboard/operations",
+  entities: []
+}
+
+action connectHa {
+  fn: import { connectHa } from "@src/dashboard/operations",
+  entities: []
+}
+
+action disconnectHa {
+  fn: import { disconnectHa } from "@src/dashboard/operations",
+  entities: []
+}
+
 query getAgentConfig {
   fn: import { getAgentConfig } from "@src/dashboard/operations",
   entities: []

--- a/packages/web/src/dashboard/ChannelsPage.tsx
+++ b/packages/web/src/dashboard/ChannelsPage.tsx
@@ -47,6 +47,10 @@ import {
   getTailscalePeers,
   connectTailscale,
   disconnectTailscale,
+  getHaStatus,
+  getHaRegistry,
+  connectHa,
+  disconnectHa,
   updateCredentials,
 } from "wasp/client/operations";
 import { Frame } from "../client/components/ab/Frame";
@@ -102,6 +106,7 @@ import {
 import RecallCard from "./RecallCard";
 import { HaConversationSetupCard } from "./HaConversationSetupCard";
 import { VoiceWakeWordsCard } from "./VoiceWakeWordsCard";
+import { HaCard } from "./HaCard";
 
 // F57/C14 — the email card reads the live ctrl-api status, not a phantom
 // Instance row. `inbox_address` is only present once `configured`.
@@ -366,6 +371,17 @@ export default function ChannelsPage() {
               so the substantial dial form stays out of this already
               large page. */}
           <RecallCard />
+
+          {/* Home Assistant — #110 PR3 (2026-05-29). Operator deep-
+              integrates HA: paste URL + LLAT, ctrl-api probes /api/ +
+              /api/config, persists state.db row + Vaultwarden item.
+              Five UI states (unconfigured / connecting / connected /
+              error / disconnected) come from haCardCore. The connected
+              view surfaces ha_url + ha_version + registry counts +
+              an expander for "Recent runs" (PR4 ships the route;
+              the card 404-handles gracefully). Alphabetically before
+              <OmiCard /> (H before O). */}
+          <HaCard />
 
           {/* Omi — Phase-6b live card (Lane III, 2026-05-25). Surfaces the
               4 OMI channel states (unconfigured / needs_groq_key /

--- a/packages/web/src/dashboard/HaCard.tsx
+++ b/packages/web/src/dashboard/HaCard.tsx
@@ -1,0 +1,737 @@
+// HaCard — the Home Assistant /channels surface.
+//
+// #110 PR3 (2026-05-29). The React layer for the deep-integration card;
+// state derivation lives in haCardCore.ts (pure, import-free, unit-tested
+// under node:test). Backed by ctrl-api /api/v1/channels/ha/* (PR1 #133
+// landed connect/status/disconnect/registry; PR4 adds /runs; PR5 backfills
+// the registry).
+//
+// Five views map to the five ctrl-api `state` values:
+//
+//   • unconfigured/disconnected → connect form (HA URL + LLAT textarea +
+//                                 a HACS hint pointing at ssdavidai/alfred-ha)
+//   • connecting                → spinner + URL being probed, polls /status
+//                                 every 3s
+//   • connected                 → ha_url, ha_version, registry counts,
+//                                 expanders for "Registry" / "Recent runs" /
+//                                 "Voice surface" / "Disconnect"
+//   • error                     → last_error verbatim + retry + disconnect
+//
+// SECURITY: the LLAT is a ~180-char JWT-shaped Home Assistant long-lived
+// access token. It must NEVER appear in any UI element, log line, error
+// toast, commit, or PR body. This file:
+//
+//   * uses a <textarea> with autoComplete="off" + spellCheck={false}
+//     (LLATs don't fit a single-line input)
+//   * never re-displays the pasted token (no "show password" toggle, no
+//     echo in any toast, no serialisation into React state log)
+//   * clears the local React state holding the LLAT immediately on
+//     submit success, so the value stops living in the React tree
+//   * routes any in-toast surfacing through redactLlat() which only
+//     leaks the first 8 chars
+//
+// ctrl-api's /status route does NOT echo the LLAT; it only carries the
+// vault_item_id in state.db.
+
+import { useEffect, useState } from "react";
+import {
+  useQuery,
+  getHaStatus,
+  getHaRegistry,
+  connectHa,
+  disconnectHa,
+} from "wasp/client/operations";
+import {
+  deriveHaCardState,
+  isProbablyValidLlat,
+  parseHaUrl,
+  redactLlat,
+  summariseRegistry,
+  type HaRegistry,
+  type HaStatus,
+} from "./haCardCore";
+
+// Re-use the ChannelCard chrome from ChannelsPage. Pulling the JSX-only
+// wrapper through a prop-driven function keeps HaCard.tsx self-contained
+// without re-implementing the pill / heading / address layout.
+//
+// We mirror the inline cards (TelegramCard, OmiCard, PaperclipCard, …)
+// by re-rendering the same .border / .p-6 / .card-hover shell ourselves.
+// The styling stays in sync because both shells read the same CSS vars.
+
+type ChannelStatus = "active" | "available" | "soon" | "starting" | "error";
+
+function ChannelCard({
+  name,
+  address,
+  note,
+  status,
+  children,
+}: {
+  name: string;
+  address: string;
+  note: string;
+  status: ChannelStatus;
+  children?: React.ReactNode;
+}) {
+  const pillColor =
+    status === "active" || status === "error"
+      ? "var(--brass)"
+      : "var(--marginalia)";
+  const pillText =
+    status === "active"
+      ? "Connected"
+      : status === "soon"
+        ? "Coming soon"
+        : status === "starting"
+          ? "Starting"
+          : status === "error"
+            ? "Needs attention"
+            : "Not connected";
+  return (
+    <div className="border border-rule p-6 card-hover h-full">
+      <div className="flex items-baseline justify-between mb-3">
+        <span className="font-display text-3xl">{name}</span>
+        <span
+          className="font-mono text-[10px] uppercase tracking-[0.22em] font-extrabold"
+          style={{ color: pillColor }}
+        >
+          {pillText}
+        </span>
+      </div>
+      <div
+        className="font-mono text-[12px] mb-3"
+        style={{ color: "var(--ink)" }}
+      >
+        {address}
+      </div>
+      <div className="font-body italic" style={{ color: "var(--marginalia)" }}>
+        {note}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+// The voice-bridge `self` allowlist contract (#110 PR1 spec §7 Q13) — the
+// four read routes the voice surface can call against HA. Surfaced in the
+// "Voice surface" expander so the operator can see at a glance what
+// Alfred-the-voice can read from HA without their explicit per-turn
+// approval.
+const VOICE_SURFACE_TOOLS: Array<{ route: string; what: string }> = [
+  {
+    route: "GET /api/v1/channels/ha/status",
+    what: "Is HA connected? What's the version?",
+  },
+  {
+    route: "GET /api/v1/channels/ha/registry",
+    what: "Read the entity / device / area / automation registry.",
+  },
+  {
+    route: "GET /api/v1/channels/ha/automations",
+    what: "List automation entities and their last-fired times.",
+  },
+  {
+    route: "GET /api/v1/channels/ha/state/:entity_id",
+    what: "Read the current state of a single entity (no writes).",
+  },
+];
+
+const REGISTRY_PREVIEW_LIMIT = 20;
+const STATUS_POLL_MS = 3_000;
+
+export function HaCard() {
+  const { data: statusData, refetch: refetchStatus } = useQuery(
+    getHaStatus,
+    undefined,
+    { retry: false },
+  );
+  const status = (statusData as HaStatus | undefined) ?? null;
+  const card = deriveHaCardState({ status });
+
+  // The registry is only meaningful in the connected view, so we wire the
+  // useQuery to start enabled-once-connected. Wasp's useQuery does not
+  // expose `enabled`, but a 404 / empty response from ctrl-api is the
+  // bootstrap-not-run-yet signal — we render the empty-state copy in
+  // that branch instead of hiding the section.
+  const { data: registryData, refetch: refetchRegistry } = useQuery(
+    getHaRegistry,
+    undefined,
+    { retry: false },
+  );
+  const registry = (registryData as HaRegistry | undefined) ?? null;
+  const summary = summariseRegistry(registry);
+
+  // Connect-form state (kept local; never persisted).
+  const [haUrl, setHaUrl] = useState("");
+  const [haUrlError, setHaUrlError] = useState<string | null>(null);
+  const [llat, setLlat] = useState("");
+  const [label, setLabel] = useState("");
+  const [connectBusy, setConnectBusy] = useState(false);
+  const [connectErr, setConnectErr] = useState<string | null>(null);
+
+  // Disconnect state.
+  const [discBusy, setDiscBusy] = useState(false);
+
+  // Expanders.
+  const [registryOpen, setRegistryOpen] = useState(false);
+  const [runsOpen, setRunsOpen] = useState(false);
+  const [voiceOpen, setVoiceOpen] = useState(false);
+
+  // Poll /status every 3s while connecting.
+  useEffect(() => {
+    if (!card.shouldPoll) return;
+    const handle = setInterval(() => {
+      refetchStatus();
+    }, STATUS_POLL_MS);
+    return () => clearInterval(handle);
+  }, [card.shouldPoll, refetchStatus]);
+
+  // When we transition into connected, fetch the registry once so the
+  // counts populate without the operator having to expand the section.
+  useEffect(() => {
+    if (card.mode === "connected") {
+      refetchRegistry();
+    }
+  }, [card.mode, refetchRegistry]);
+
+  function onHaUrlBlur() {
+    if (haUrl.trim().length === 0) {
+      setHaUrlError(null);
+      return;
+    }
+    const parsed = parseHaUrl(haUrl);
+    setHaUrlError(parsed.ok ? null : parsed.error);
+  }
+
+  const llatTrimmed = llat.trim();
+  const llatLooksLikeJwt = isProbablyValidLlat(llatTrimmed);
+  const llatHint =
+    llatTrimmed.length > 0 && !llatLooksLikeJwt
+      ? "That doesn't look JWT-shaped — HA tokens start with eyJ and have two dots."
+      : null;
+
+  async function onConnect() {
+    setConnectErr(null);
+    const parsed = parseHaUrl(haUrl);
+    if (!parsed.ok || !parsed.url) {
+      setHaUrlError(parsed.error);
+      return;
+    }
+    if (llatTrimmed.length === 0) {
+      setConnectErr("LLAT is required.");
+      return;
+    }
+    setConnectBusy(true);
+    try {
+      await connectHa({
+        ha_url: parsed.url,
+        llat: llatTrimmed,
+        label: label.trim() || undefined,
+      });
+      // SECURITY: clear the token from React state IMMEDIATELY on
+      // success. The server response by contract does NOT echo the
+      // LLAT, but we still wipe the local copy so it stops living in
+      // the React tree.
+      setLlat("");
+      setHaUrl("");
+      setLabel("");
+      refetchStatus();
+      refetchRegistry();
+    } catch (e: any) {
+      // SECURITY: redactLlat is the ONLY formatter allowed to touch
+      // the in-memory token. Even on error we leak no more than the
+      // first 8 chars, and only when the operator pasted something.
+      const prefix = redactLlat(llatTrimmed);
+      const base =
+        e?.message ?? e?.data?.error ?? "Couldn't connect to Home Assistant.";
+      setConnectErr(prefix ? `${base} (token ${prefix})` : base);
+    } finally {
+      setConnectBusy(false);
+    }
+  }
+
+  async function onDisconnect() {
+    if (discBusy) return;
+    if (
+      typeof window !== "undefined" &&
+      !window.confirm(
+        "Disconnect Home Assistant? The LLAT is removed from Vaultwarden " +
+          "and the discovered registry is forgotten.",
+      )
+    ) {
+      return;
+    }
+    setDiscBusy(true);
+    try {
+      await disconnectHa({});
+      setRegistryOpen(false);
+      setRunsOpen(false);
+      setVoiceOpen(false);
+      refetchStatus();
+    } catch (e) {
+      // Disconnect errors are very rare (vault-cli down) — surface a
+      // calm message without the LLAT (the LLAT isn't even in the
+      // delete payload).
+      console.error("ha disconnect failed", e);
+    } finally {
+      setDiscBusy(false);
+    }
+  }
+
+  const address =
+    card.state === "connected"
+      ? status?.ha_url ||
+        (status?.ha_version ? `HA ${status.ha_version}` : "Connected")
+      : card.state === "connecting"
+        ? "Probing your HA install…"
+        : card.state === "error"
+          ? "Needs attention"
+          : "Not connected — paste a URL + LLAT below";
+
+  return (
+    <ChannelCard
+      name="Home Assistant"
+      address={address}
+      note="Operator deep-integrates HA — Alfred reads the registry, proposes baselines, never writes without approval."
+      status={card.pill}
+    >
+      {/* UNCONFIGURED / DISCONNECTED — connect form + HACS hint. */}
+      {card.mode === "unconfigured" && (
+        <div className="mt-5 space-y-4">
+          <p
+            className="font-body italic text-[13px]"
+            style={{ color: "var(--marginalia)" }}
+          >
+            {card.description}
+          </p>
+
+          {/* HACS hint card pointing at ssdavidai/alfred-ha. The custom
+              component is the substrate for the conversation-agent
+              (#111) and voice-bridge (#112) lanes; without it the LLAT
+              alone is not enough. */}
+          <div
+            className="border border-rule p-3 text-[12px] font-body"
+            style={{ color: "var(--marginalia)" }}
+          >
+            <div
+              className="font-mono text-[10px] uppercase tracking-[0.22em] mb-1"
+              style={{ color: "var(--brass)" }}
+            >
+              Step 0 — install the custom component
+            </div>
+            <p>
+              In Home Assistant, add{" "}
+              <a
+                href="https://github.com/ssdavidai/alfred-ha"
+                target="_blank"
+                rel="noreferrer"
+                className="underline"
+                style={{ color: "var(--ink)" }}
+              >
+                ssdavidai/alfred-ha
+              </a>{" "}
+              as a custom HACS repository, then download a long-lived
+              token from{" "}
+              <span className="font-mono">
+                User Profile → Security → Long-Lived Access Tokens
+              </span>
+              .
+            </p>
+          </div>
+
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <div
+                className="font-mono text-[10px] uppercase tracking-[0.22em]"
+                style={{ color: "var(--marginalia)" }}
+              >
+                HA URL
+              </div>
+              <input
+                type="text"
+                value={haUrl}
+                onChange={(e) => {
+                  setHaUrl(e.target.value);
+                  if (haUrlError) setHaUrlError(null);
+                }}
+                onBlur={onHaUrlBlur}
+                placeholder="http://homeassistant.local:8123"
+                autoComplete="off"
+                spellCheck={false}
+                className="w-full bg-transparent border border-rule px-2 py-1 font-mono text-[12px]"
+              />
+              {haUrlError && (
+                <p
+                  className="font-body italic text-[12px]"
+                  style={{ color: "var(--brass)" }}
+                >
+                  {haUrlError}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <div
+                className="font-mono text-[10px] uppercase tracking-[0.22em]"
+                style={{ color: "var(--marginalia)" }}
+              >
+                Long-Lived Access Token
+              </div>
+              {/* SECURITY: a textarea (not single-line input) because the
+                  LLAT is ~180 chars; spellCheck/autoComplete off so the
+                  browser doesn't try to remember it. The value is wiped
+                  from React state immediately on submit success. We
+                  intentionally do NOT offer a "show" toggle — the only
+                  formatter allowed for the in-memory token is
+                  redactLlat() (first 8 chars). */}
+              <textarea
+                value={llat}
+                onChange={(e) => setLlat(e.target.value)}
+                placeholder="eyJ…"
+                autoComplete="off"
+                spellCheck={false}
+                rows={3}
+                className="w-full bg-transparent border border-rule px-2 py-1 font-mono text-[11px]"
+              />
+              {llatHint && (
+                <p
+                  className="font-body italic text-[12px]"
+                  style={{ color: "var(--marginalia)" }}
+                >
+                  {llatHint}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <div
+                className="font-mono text-[10px] uppercase tracking-[0.22em]"
+                style={{ color: "var(--marginalia)" }}
+              >
+                Label (optional)
+              </div>
+              <input
+                type="text"
+                value={label}
+                onChange={(e) => setLabel(e.target.value)}
+                placeholder="Home"
+                autoComplete="off"
+                spellCheck={false}
+                className="w-full bg-transparent border border-rule px-2 py-1 font-mono text-[12px]"
+              />
+            </div>
+
+            <div className="flex items-baseline gap-3">
+              <button
+                onClick={onConnect}
+                disabled={
+                  connectBusy ||
+                  haUrl.trim().length === 0 ||
+                  llatTrimmed.length === 0 ||
+                  !!haUrlError
+                }
+                className="btn-ghost"
+              >
+                {connectBusy ? "Connecting…" : "Connect"}
+              </button>
+            </div>
+
+            {connectErr && (
+              <p
+                className="font-body italic text-[13px]"
+                style={{ color: "var(--brass)" }}
+              >
+                {connectErr}
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* CONNECTING — spinner copy + the URL being probed. Polls /status. */}
+      {card.mode === "connecting" && (
+        <div className="mt-5 space-y-3">
+          <p
+            className="font-body italic text-[13px]"
+            style={{ color: "var(--marginalia)" }}
+          >
+            {card.description}
+          </p>
+
+          <div className="flex items-baseline gap-3 pt-1">
+            <span
+              className="font-mono text-[11px]"
+              style={{ color: "var(--marginalia)" }}
+            >
+              Polling status every 3s…
+            </span>
+            {card.showDisconnect && (
+              <button
+                onClick={onDisconnect}
+                disabled={discBusy}
+                className="btn-link"
+              >
+                Cancel
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* CONNECTED — ha_url, ha_version, registry counts, expanders. */}
+      {card.mode === "connected" && (
+        <div className="mt-5 space-y-4">
+          <p
+            className="font-body italic text-[13px]"
+            style={{ color: "var(--marginalia)" }}
+          >
+            {card.description}
+          </p>
+
+          <div className="space-y-1 font-mono text-[12px]">
+            {status?.ha_url && (
+              <div className="flex gap-2">
+                <span style={{ color: "var(--marginalia)" }}>url</span>
+                <span style={{ color: "var(--ink)" }}>{status.ha_url}</span>
+              </div>
+            )}
+            {status?.ha_version && (
+              <div className="flex gap-2">
+                <span style={{ color: "var(--marginalia)" }}>version</span>
+                <span style={{ color: "var(--ink)" }}>
+                  HA {status.ha_version}
+                </span>
+              </div>
+            )}
+            {status?.label && (
+              <div className="flex gap-2">
+                <span style={{ color: "var(--marginalia)" }}>label</span>
+                <span style={{ color: "var(--ink)" }}>{status.label}</span>
+              </div>
+            )}
+          </div>
+
+          {/* At-a-glance counts. summariseRegistry handles empty/missing
+              buckets safely — the PR5 backfill is what brings these
+              above zero. */}
+          <div
+            className="grid grid-cols-2 sm:grid-cols-3 gap-x-4 gap-y-1 font-mono text-[12px] pt-1"
+            style={{ color: "var(--ink)" }}
+          >
+            <RegistryCount label="lights" n={summary.counts.lights} />
+            <RegistryCount label="switches" n={summary.counts.switches} />
+            <RegistryCount label="scenes" n={summary.counts.scenes} />
+            <RegistryCount label="sensors" n={summary.counts.sensors} />
+            <RegistryCount label="climate" n={summary.counts.climate} />
+            <RegistryCount label="cover" n={summary.counts.cover} />
+            <RegistryCount
+              label="media_player"
+              n={summary.counts.media_player}
+            />
+            <RegistryCount label="areas" n={summary.areaCount} />
+            <RegistryCount label="devices" n={summary.deviceCount} />
+            <RegistryCount
+              label="automations"
+              n={summary.automationCount}
+            />
+          </div>
+
+          {/* Expander row. */}
+          <div className="flex flex-wrap gap-3 items-baseline pt-1">
+            <button
+              onClick={() => setRegistryOpen((v) => !v)}
+              className="btn-link"
+            >
+              {registryOpen ? "Hide registry" : "Registry"}
+            </button>
+            <button
+              onClick={() => setRunsOpen((v) => !v)}
+              className="btn-link"
+            >
+              {runsOpen ? "Hide recent runs" : "Recent runs"}
+            </button>
+            <button
+              onClick={() => setVoiceOpen((v) => !v)}
+              className="btn-link"
+            >
+              {voiceOpen ? "Hide voice surface" : "Voice surface"}
+            </button>
+            <button
+              onClick={onDisconnect}
+              disabled={discBusy}
+              className="btn-ghost"
+            >
+              {discBusy ? "Disconnecting…" : "Disconnect"}
+            </button>
+          </div>
+
+          {/* Registry expander — top 20 entities with friendly_name +
+              entity_id. PR5 populates this; until then we show the
+              empty-state copy. */}
+          {registryOpen && (
+            <RegistrySection registry={registry} />
+          )}
+
+          {/* Recent-runs expander — PR4 ships /runs. Today we render a
+              calm placeholder so the connected-state view doesn't have
+              a broken expander. */}
+          {runsOpen && <RunsSection />}
+
+          {/* Voice-surface expander — the 4 read routes voice-bridge can
+              call against HA per the #110 PR1 spec. */}
+          {voiceOpen && <VoiceSurfaceSection />}
+        </div>
+      )}
+
+      {/* ERROR — verbatim last_error + retry CTA + disconnect. */}
+      {card.mode === "error" && (
+        <div className="mt-5 space-y-3">
+          <p
+            className="font-body italic text-[13px]"
+            style={{ color: "var(--brass)" }}
+          >
+            {card.description}
+          </p>
+          {card.errorMessage && card.errorMessage !== card.description && (
+            <p
+              className="font-mono text-[11px]"
+              style={{ color: "var(--marginalia)" }}
+            >
+              {card.errorMessage}
+            </p>
+          )}
+          <div className="flex flex-wrap gap-3 items-baseline">
+            {card.showRetry && (
+              <button
+                onClick={() => refetchStatus()}
+                className="btn-ghost"
+                disabled={connectBusy}
+              >
+                Try again
+              </button>
+            )}
+            {card.showDisconnect && (
+              <button
+                onClick={onDisconnect}
+                disabled={discBusy}
+                className="btn-link"
+              >
+                {discBusy ? "Disconnecting…" : "Disconnect"}
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </ChannelCard>
+  );
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────
+
+function RegistryCount({ label, n }: { label: string; n: number }) {
+  return (
+    <div className="flex gap-2">
+      <span style={{ color: "var(--marginalia)" }}>{label}</span>
+      <span>{n}</span>
+    </div>
+  );
+}
+
+function RegistrySection({ registry }: { registry: HaRegistry | null }) {
+  // PR5 populates ha_registry; PR3 just displays. When empty we explain
+  // why so the operator doesn't think anything is broken.
+  const entities = Array.isArray(registry?.entities)
+    ? registry!.entities.slice(0, REGISTRY_PREVIEW_LIMIT)
+    : [];
+  const totalEntities = Array.isArray(registry?.entities)
+    ? registry!.entities.length
+    : 0;
+
+  if (totalEntities === 0) {
+    return (
+      <div className="border-t border-rule pt-3 space-y-1">
+        <p
+          className="font-body italic text-[12px]"
+          style={{ color: "var(--marginalia)" }}
+        >
+          The registry is empty. HaBootstrapWorkflow (PR5) populates entities
+          on connect — until that PR lands, this section will be quiet.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-t border-rule pt-3 space-y-1">
+      <div
+        className="font-mono text-[10px] uppercase tracking-[0.22em] pb-1"
+        style={{ color: "var(--marginalia)" }}
+      >
+        Entities (top {entities.length} of {totalEntities})
+      </div>
+      {entities.map((e, idx) => {
+        const id = e.entity_id || e.ha_id || "";
+        const name = e.friendly_name || id || "—";
+        return (
+          <div
+            key={id || idx}
+            className="flex items-baseline gap-3 font-mono text-[11px]"
+          >
+            <span style={{ color: "var(--ink)" }}>{name}</span>
+            {id && id !== name && (
+              <span style={{ color: "var(--marginalia)" }}>{id}</span>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function RunsSection() {
+  // The /runs route ships in #110 PR4. PR3's connected view must NOT
+  // crash on the 404; we show a friendly placeholder instead. When PR4
+  // lands, this component will switch to a useQuery(getHaRuns) call and
+  // render pickRecentRuns(rows).
+  return (
+    <div className="border-t border-rule pt-3 space-y-1">
+      <p
+        className="font-body italic text-[12px]"
+        style={{ color: "var(--marginalia)" }}
+      >
+        Recent-runs surface arrives in PR4 — the service-call / automation
+        / proposal-apply ledger. Until then, this section is intentionally
+        quiet.
+      </p>
+    </div>
+  );
+}
+
+function VoiceSurfaceSection() {
+  return (
+    <div className="border-t border-rule pt-3 space-y-2">
+      <div
+        className="font-mono text-[10px] uppercase tracking-[0.22em]"
+        style={{ color: "var(--marginalia)" }}
+      >
+        Voice-bridge `self` allowlist
+      </div>
+      <p
+        className="font-body italic text-[12px]"
+        style={{ color: "var(--marginalia)" }}
+      >
+        The four read routes Alfred-the-voice can call against HA without
+        per-turn approval. Writes (service calls, automation create /
+        update / delete) NEVER appear here — they require a Hermes MCP
+        call routed through the principal's approval surface.
+      </p>
+      {VOICE_SURFACE_TOOLS.map((t) => (
+        <div key={t.route} className="font-mono text-[11px]">
+          <div style={{ color: "var(--ink)" }}>{t.route}</div>
+          <div style={{ color: "var(--marginalia)" }}>{t.what}</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/web/src/dashboard/haCardCore.test.ts
+++ b/packages/web/src/dashboard/haCardCore.test.ts
@@ -1,0 +1,442 @@
+/**
+ * /channels — Home Assistant card derivation tests.
+ *
+ * Covers the contract laid out in the lane brief (#110 PR3, 2026-05-29):
+ *   • status-string formatter for each of the 5 ctrl-api `state` values
+ *     (unconfigured / connecting / connected / error / disconnected)
+ *   • parseHaUrl accepts http/https + rejects file://, javascript:,
+ *     data:, malformed
+ *   • redactLlat first-8-chars contract — only the first 8 may leak
+ *   • isProbablyValidLlat — accepts JWT-shaped HA tokens, rejects malformed
+ *   • summariseRegistry counts for empty vs populated registries
+ *   • pickRecentRuns sorts by created_at desc and tops out at 10
+ *
+ * SECURITY: all fixture LLATs are synthetic placeholders prefixed
+ * `llat_TEST_…`. Real `eyJ…` tokens never appear in this file. The path
+ * is allowlisted in .gitguardian.yaml.
+ *
+ * Run with:  cd packages/web && npx tsx --test src/dashboard/haCardCore.test.ts
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  deriveHaCardState,
+  parseHaUrl,
+  redactLlat,
+  isProbablyValidLlat,
+  summariseRegistry,
+  pickRecentRuns,
+  type HaStatus,
+  type HaRegistry,
+  type HaRunRow,
+} from "./haCardCore";
+
+const BASE: HaStatus = {
+  connected: false,
+  state: "unconfigured",
+  ha_url: null,
+  ha_version: null,
+  label: null,
+  last_test_ok: false,
+  last_test_at: null,
+  error: null,
+};
+
+// ── Status formatter — one test per state ────────────────────────────────
+
+test("derive: unconfigured → connect-form CTA + 'available' pill", () => {
+  const s = deriveHaCardState({ status: BASE });
+  assert.equal(s.state, "unconfigured");
+  assert.equal(s.mode, "unconfigured");
+  assert.equal(s.pill, "available");
+  assert.match(s.heading, /Connect to your HA install/i);
+  assert.equal(s.showConnectForm, true);
+  assert.equal(s.showDisconnect, false);
+  assert.equal(s.showRetry, false);
+  assert.equal(s.shouldPoll, false);
+  assert.equal(s.errorMessage, null);
+});
+
+test("derive: connecting → polls + URL surfaced + spinner heading", () => {
+  const s = deriveHaCardState({
+    status: {
+      ...BASE,
+      state: "connecting",
+      ha_url: "http://homeassistant.local:8123",
+    },
+  });
+  assert.equal(s.mode, "connecting");
+  assert.equal(s.pill, "starting");
+  assert.match(s.heading, /Connecting to Home Assistant/i);
+  assert.match(s.description, /homeassistant\.local:8123/);
+  assert.equal(s.shouldPoll, true);
+  assert.equal(s.showConnectForm, false);
+  assert.equal(s.showDisconnect, true);
+});
+
+test("derive: connecting without ha_url → generic spinner copy, still polls", () => {
+  const s = deriveHaCardState({
+    status: { ...BASE, state: "connecting", ha_url: null },
+  });
+  assert.equal(s.mode, "connecting");
+  assert.match(s.description, /Probing your Home Assistant install/i);
+  assert.equal(s.shouldPoll, true);
+  assert.equal(s.haUrl, null);
+});
+
+test("derive: connected → ha_url + ha_version in heading, no poll", () => {
+  const s = deriveHaCardState({
+    status: {
+      ...BASE,
+      connected: true,
+      state: "connected",
+      ha_url: "https://home.example.com",
+      ha_version: "2026.5.0",
+    },
+  });
+  assert.equal(s.mode, "connected");
+  assert.equal(s.pill, "active");
+  assert.match(s.heading, /Connected to https:\/\/home\.example\.com/);
+  assert.match(s.heading, /HA 2026\.5\.0/);
+  assert.equal(s.haUrl, "https://home.example.com");
+  assert.equal(s.haVersion, "2026.5.0");
+  assert.equal(s.shouldPoll, false);
+  assert.equal(s.showDisconnect, true);
+  assert.equal(s.showRetry, false);
+  assert.equal(s.showConnectForm, false);
+});
+
+test("derive: connected without ha_version → heading still renders", () => {
+  const s = deriveHaCardState({
+    status: {
+      ...BASE,
+      connected: true,
+      state: "connected",
+      ha_url: "https://home.example.com",
+      ha_version: null,
+    },
+  });
+  assert.equal(s.heading, "Connected to https://home.example.com");
+  assert.equal(s.haVersion, null);
+});
+
+test("derive: connected without ha_url falls back to a generic heading", () => {
+  const s = deriveHaCardState({
+    status: {
+      ...BASE,
+      connected: true,
+      state: "connected",
+      ha_url: null,
+      ha_version: null,
+    },
+  });
+  assert.equal(s.heading, "Connected to Home Assistant");
+});
+
+test("derive: error → verbatim last_error + retry button", () => {
+  const s = deriveHaCardState({
+    status: {
+      ...BASE,
+      state: "error",
+      error: "HA rejected the LLAT (HTTP 401)",
+    },
+  });
+  assert.equal(s.mode, "error");
+  assert.equal(s.pill, "error");
+  assert.equal(s.description, "HA rejected the LLAT (HTTP 401)");
+  assert.equal(s.errorMessage, "HA rejected the LLAT (HTTP 401)");
+  assert.equal(s.showRetry, true);
+  assert.equal(s.showDisconnect, true);
+});
+
+test("derive: error with empty error string falls back to a default copy", () => {
+  const s = deriveHaCardState({
+    status: { ...BASE, state: "error", error: "" },
+  });
+  assert.equal(s.mode, "error");
+  assert.match(s.description, /Last connect \/ probe failed/i);
+  assert.equal(s.errorMessage, null);
+});
+
+test("derive: disconnected → calm heading + the connect form re-renders", () => {
+  const s = deriveHaCardState({
+    status: { ...BASE, state: "disconnected" },
+  });
+  assert.equal(s.state, "disconnected");
+  // Disconnected re-uses the unconfigured view mode so the surface is one
+  // switch, but the headline copy is friendlier.
+  assert.equal(s.mode, "unconfigured");
+  assert.match(s.heading, /HA disconnected/i);
+  assert.equal(s.showConnectForm, true);
+  assert.equal(s.showDisconnect, false);
+  assert.equal(s.pill, "available");
+});
+
+test("derive: null/undefined status → safe unconfigured", () => {
+  const s1 = deriveHaCardState({ status: null });
+  const s2 = deriveHaCardState({ status: undefined });
+  assert.equal(s1.mode, "unconfigured");
+  assert.equal(s2.mode, "unconfigured");
+  assert.equal(s1.pill, "available");
+});
+
+// ── parseHaUrl ───────────────────────────────────────────────────────────
+
+test("parseHaUrl: accepts http and https, trims, strips trailing slash", () => {
+  assert.deepEqual(parseHaUrl("http://homeassistant.local:8123"), {
+    ok: true,
+    url: "http://homeassistant.local:8123",
+    error: null,
+  });
+  assert.deepEqual(parseHaUrl("https://home.example.com"), {
+    ok: true,
+    url: "https://home.example.com",
+    error: null,
+  });
+  // Trailing slash stripped so ctrl-api can append /api/ cleanly.
+  assert.deepEqual(parseHaUrl("https://home.example.com/"), {
+    ok: true,
+    url: "https://home.example.com",
+    error: null,
+  });
+  assert.deepEqual(parseHaUrl("  https://home.example.com  "), {
+    ok: true,
+    url: "https://home.example.com",
+    error: null,
+  });
+});
+
+test("parseHaUrl: rejects file://, javascript:, data:, ws:", () => {
+  const fileRes = parseHaUrl("file:///etc/passwd");
+  assert.equal(fileRes.ok, false);
+  assert.equal(fileRes.url, null);
+  assert.match(fileRes.error || "", /must use http:\/\/ or https:\/\//);
+
+  const jsRes = parseHaUrl("javascript:alert(1)");
+  assert.equal(jsRes.ok, false);
+  assert.match(jsRes.error || "", /must use http:\/\/ or https:\/\//);
+
+  const dataRes = parseHaUrl("data:text/html,<script>alert(1)</script>");
+  assert.equal(dataRes.ok, false);
+  assert.match(dataRes.error || "", /must use http:\/\/ or https:\/\//);
+
+  const wsRes = parseHaUrl("ws://homeassistant.local:8123");
+  assert.equal(wsRes.ok, false);
+  assert.match(wsRes.error || "", /must use http:\/\/ or https:\/\//);
+});
+
+test("parseHaUrl: rejects malformed input + empty/whitespace + non-string", () => {
+  const garbage = parseHaUrl("not a url at all");
+  assert.equal(garbage.ok, false);
+  assert.match(garbage.error || "", /doesn't look like a URL/i);
+
+  const empty = parseHaUrl("");
+  assert.equal(empty.ok, false);
+  assert.match(empty.error || "", /required/i);
+
+  const whitespace = parseHaUrl("   ");
+  assert.equal(whitespace.ok, false);
+  assert.match(whitespace.error || "", /required/i);
+
+  // Non-string survives without crashing.
+  const nonString = parseHaUrl(undefined as unknown as string);
+  assert.equal(nonString.ok, false);
+  assert.match(nonString.error || "", /must be a string/i);
+});
+
+// ── redactLlat — only the first 8 chars may ever leak ────────────────────
+
+test("redactLlat: only the first 8 chars survive, never the token body", () => {
+  // Synthetic placeholder — never a real eyJ… token.
+  const fake = "llat_TEST_0123456789abcdef_ALWAYS_FAKE_NEVER_REAL";
+  const red = redactLlat(fake);
+  assert.equal(red, "llat_TES…");
+  // The body never leaks.
+  assert.equal(red.includes("0123456789"), false);
+  assert.equal(red.includes("ALWAYS_FAKE"), false);
+  assert.equal(red.includes("NEVER_REAL"), false);
+  // A short fake input still gets the redaction-shape (trailing ellipsis)
+  // so the caller can never accidentally treat it as the real token.
+  assert.equal(redactLlat("short"), "short…");
+  // Exactly 8 chars: still gets the ellipsis (contract: NEVER return the
+  // raw input verbatim).
+  assert.equal(redactLlat("eyJabcde"), "eyJabcde…");
+  // 9 chars: only first 8 + ellipsis.
+  assert.equal(redactLlat("eyJabcdef"), "eyJabcde…");
+  // Empty / non-string / whitespace returns "".
+  assert.equal(redactLlat(""), "");
+  assert.equal(redactLlat(null), "");
+  assert.equal(redactLlat(undefined), "");
+  assert.equal(redactLlat("    "), "");
+});
+
+// ── isProbablyValidLlat ──────────────────────────────────────────────────
+
+test("isProbablyValidLlat: accepts JWT-shaped strings, rejects malformed", () => {
+  // Synthetic JWT-shaped fixture — three base64url segments. NEVER a
+  // real HA LLAT.
+  const fake =
+    "eyJTESTaaaaaaaaaaaaaaa.eyJTESTbbbbbbbbbbbbbbbbbbbbbb.TESTccccccccccccccccc";
+  assert.equal(isProbablyValidLlat(fake), true);
+  // Surrounding whitespace is trimmed.
+  assert.equal(isProbablyValidLlat(`  ${fake}  `), true);
+  // Missing the eyJ prefix.
+  assert.equal(
+    isProbablyValidLlat("notajwt.eyJpayload.signature_short_xxxxxxxxx"),
+    false,
+  );
+  // Too short overall.
+  assert.equal(isProbablyValidLlat("eyJ.eyJ.x"), false);
+  // Wrong segment count (only two dots — JWT has exactly two).
+  assert.equal(isProbablyValidLlat("eyJTESTaaaaa.eyJTESTbbbbb"), false);
+  // Empty + non-string.
+  assert.equal(isProbablyValidLlat(""), false);
+  assert.equal(
+    isProbablyValidLlat(undefined as unknown as string),
+    false,
+  );
+});
+
+// ── summariseRegistry ────────────────────────────────────────────────────
+
+test("summariseRegistry: empty registry → all zeros, no crash", () => {
+  const empty: HaRegistry = {
+    entities: [],
+    areas: [],
+    devices: [],
+    automations: [],
+    scenes: [],
+    helpers: [],
+  };
+  const s = summariseRegistry(empty);
+  assert.deepEqual(s.counts, {
+    lights: 0,
+    switches: 0,
+    scenes: 0,
+    sensors: 0,
+    climate: 0,
+    cover: 0,
+    media_player: 0,
+  });
+  assert.equal(s.areaCount, 0);
+  assert.equal(s.deviceCount, 0);
+  assert.equal(s.automationCount, 0);
+});
+
+test("summariseRegistry: null/undefined → safe zeros", () => {
+  const sNull = summariseRegistry(null);
+  const sUndef = summariseRegistry(undefined);
+  assert.deepEqual(sNull.counts, sUndef.counts);
+  assert.equal(sNull.areaCount, 0);
+  assert.equal(sNull.deviceCount, 0);
+  assert.equal(sNull.automationCount, 0);
+});
+
+test("summariseRegistry: populated registry counts by domain", () => {
+  const reg: HaRegistry = {
+    entities: [
+      { entity_id: "light.kitchen", domain: "light" },
+      { entity_id: "light.bedroom", domain: "light" },
+      { entity_id: "light.hallway" }, // domain inferred from entity_id
+      { entity_id: "switch.kettle", domain: "switch" },
+      { entity_id: "sensor.kitchen_temp", domain: "sensor" },
+      { entity_id: "sensor.bedroom_temp", domain: "sensor" },
+      { entity_id: "sensor.bathroom_temp" }, // domain inferred
+      { entity_id: "climate.thermostat", domain: "climate" },
+      { entity_id: "cover.garage", domain: "cover" },
+      { entity_id: "media_player.lounge", domain: "media_player" },
+      { entity_id: "binary_sensor.front_door", domain: "binary_sensor" },
+      // ↑ binary_sensor intentionally NOT in the summary counts.
+      { entity_id: "fan.bedroom", domain: "fan" },
+      // ↑ fan also dropped from the summary.
+    ],
+    areas: [{ name: "Kitchen" }, { name: "Bedroom" }, { name: "Hallway" }],
+    devices: [{ name: "Sonoff plug" }, { name: "Hue bridge" }],
+    automations: [{ entity_id: "automation.morning_routine" }],
+    scenes: [
+      { entity_id: "scene.movie_night" },
+      { entity_id: "scene.dinner" },
+    ],
+    helpers: [{ entity_id: "input_boolean.guest_mode" }],
+  };
+  const s = summariseRegistry(reg);
+  assert.deepEqual(s.counts, {
+    lights: 3,
+    switches: 1,
+    scenes: 2, // from registry.scenes[], NOT entities
+    sensors: 3,
+    climate: 1,
+    cover: 1,
+    media_player: 1,
+  });
+  assert.equal(s.areaCount, 3);
+  assert.equal(s.deviceCount, 2);
+  assert.equal(s.automationCount, 1);
+});
+
+test("summariseRegistry: tolerates a registry missing optional buckets", () => {
+  // Some early-PR fixtures may only ship a couple of arrays.
+  const partial = { entities: [], areas: [{ name: "Kitchen" }] } as unknown as HaRegistry;
+  const s = summariseRegistry(partial);
+  assert.equal(s.counts.lights, 0);
+  assert.equal(s.areaCount, 1);
+  assert.equal(s.deviceCount, 0);
+  assert.equal(s.automationCount, 0);
+});
+
+// ── pickRecentRuns ───────────────────────────────────────────────────────
+
+test("pickRecentRuns: sorts by created_at desc and caps at 10", () => {
+  const rows: HaRunRow[] = [
+    { id: 1, created_at: "2026-05-28T10:00:00Z", kind: "service_call" },
+    { id: 2, created_at: "2026-05-29T10:00:00Z", kind: "service_call" },
+    { id: 3, created_at: "2026-05-27T10:00:00Z", kind: "automation_create" },
+    { id: 4, created_at: "2026-05-29T11:00:00Z", kind: "service_call" },
+    { id: 5, created_at: "2026-05-26T10:00:00Z", kind: "scene_create" },
+    { id: 6, created_at: "2026-05-29T09:00:00Z", kind: "service_call" },
+    { id: 7, created_at: "2026-05-29T08:00:00Z", kind: "service_call" },
+    { id: 8, created_at: "2026-05-29T07:00:00Z", kind: "service_call" },
+    { id: 9, created_at: "2026-05-29T06:00:00Z", kind: "service_call" },
+    { id: 10, created_at: "2026-05-29T05:00:00Z", kind: "service_call" },
+    { id: 11, created_at: "2026-05-29T04:00:00Z", kind: "service_call" },
+    { id: 12, created_at: "2026-05-29T03:00:00Z", kind: "service_call" },
+  ];
+  const top = pickRecentRuns(rows);
+  assert.equal(top.length, 10);
+  // Top row is the newest.
+  assert.equal(top[0].id, 4); // 2026-05-29T11:00:00Z
+  assert.equal(top[1].id, 2); // 2026-05-29T10:00:00Z
+  // Oldest row (id=5, 2026-05-26) should NOT be in the top 10.
+  assert.equal(top.find((r) => r.id === 5), undefined);
+});
+
+test("pickRecentRuns: tolerates non-array + malformed timestamps", () => {
+  // Non-array input → [].
+  assert.deepEqual(pickRecentRuns(null), []);
+  assert.deepEqual(pickRecentRuns(undefined), []);
+  assert.deepEqual(
+    pickRecentRuns("not an array" as unknown as HaRunRow[]),
+    [],
+  );
+
+  // Malformed timestamps sort to the bottom (treated as 0).
+  const rows: HaRunRow[] = [
+    { id: "a", created_at: "not a timestamp" },
+    { id: "b", created_at: "2026-05-29T10:00:00Z" },
+    { id: "c", created_at: undefined },
+    { id: "d", created_at: "2026-05-29T11:00:00Z" },
+  ];
+  const top = pickRecentRuns(rows);
+  assert.equal(top.length, 4);
+  // Newest valid timestamp first.
+  assert.equal(top[0].id, "d");
+  assert.equal(top[1].id, "b");
+  // The two malformed rows trail (order between them is preserved by
+  // Array#sort being stable in modern V8).
+});
+
+test("pickRecentRuns: empty array returns empty array", () => {
+  assert.deepEqual(pickRecentRuns([]), []);
+});

--- a/packages/web/src/dashboard/haCardCore.ts
+++ b/packages/web/src/dashboard/haCardCore.ts
@@ -1,0 +1,568 @@
+// haCardCore — pure shape derivation for the /channels Home Assistant
+// card. Import-free (no React/Wasp) so the derived states unit-test
+// under node:test the same way tailscaleCardCore / omiCardCore do.
+//
+// #110 PR3 (2026-05-29): the deep-integration card. PR1 (#133 backfill)
+// landed the ctrl-api routes:
+//
+//   POST /api/v1/channels/ha/connect       — body {ha_url, llat, label?}
+//   GET  /api/v1/channels/ha/status        — fail-soft snapshot
+//   DELETE /api/v1/channels/ha/disconnect  — clears state.db + vault item
+//   GET  /api/v1/channels/ha/registry      — {entities, areas, devices,
+//                                              automations, scenes, helpers}
+//
+// PR4 will land the recent-runs ledger; PR5 will populate ha_registry.
+// This card is built to render an empty registry sensibly so the
+// connected-state surface ships before PR4/PR5 backfill.
+//
+// The five UI states the derivation maps to are the ctrl-api `state`
+// column values (0005_ha_channel.sql):
+//
+//   • unconfigured — no row in ha_connection. Show the connect form.
+//   • connecting   — connect is mid-flight (operator pressed the button,
+//                    ctrl-api is probing). UI polls /status every 3s.
+//   • connected    — happy path. Show ha_url, ha_version, registry
+//                    counts, optional expanders.
+//   • error        — last connect/probe failed. Show last_error verbatim.
+//   • disconnected — the principal hit Disconnect. Same shape as
+//                    unconfigured for the form, but with a calmer
+//                    headline ("HA disconnected — reconnect any time").
+//
+// SECURITY: the LLAT is the Home Assistant long-lived access token, a
+// ~180-char JWT shaped string. It NEVER appears in any UI element, log
+// line, error toast, commit, or PR body. The HA /status route strips it
+// at the server layer; this file's `redactLlat` is the ONLY formatter
+// allowed for any in-memory LLAT that touches the React tree (and even
+// then it is only the first 8 characters).
+
+export type HaState =
+  | "unconfigured"
+  | "connecting"
+  | "connected"
+  | "error"
+  | "disconnected";
+
+/** Status pill values consumed by ChannelCard. */
+export type HaPill = "active" | "available" | "starting" | "error";
+
+/** The view-mode the card surface renders against. */
+export type HaViewMode =
+  | "unconfigured"
+  | "connecting"
+  | "connected"
+  | "error";
+
+/**
+ * Shape returned by GET /api/v1/channels/ha/status.
+ *
+ * From ctrl-api (channels_ha.ts):
+ *   unconfigured → { connected: false, state: 'unconfigured', ... nulls }
+ *   connected    → { connected: true,  state: 'connected', ha_url,
+ *                    ha_version, label, last_test_ok, last_test_at, error }
+ *
+ * The LLAT is NEVER in this payload. Fields are intentionally permissive
+ * (every value can be absent) so the UI does not crash on a partial
+ * response — the derivation fills in safe defaults.
+ */
+export interface HaStatus {
+  connected: boolean;
+  state: HaState;
+  ha_url: string | null;
+  ha_version: string | null;
+  label?: string | null;
+  last_test_ok?: boolean;
+  last_test_at?: string | null;
+  error?: string | null;
+}
+
+/** A single registry entity. PR5 backfills these via HaBootstrapWorkflow. */
+export interface HaEntity {
+  ha_id?: string;
+  entity_id?: string;
+  domain?: string | null;
+  friendly_name?: string | null;
+  area_id?: string | null;
+  device_id?: string | null;
+  payload_json?: unknown;
+}
+
+/** A single registry area. */
+export interface HaArea {
+  ha_id?: string;
+  area_id?: string;
+  name?: string | null;
+}
+
+/** A single registry device. */
+export interface HaDevice {
+  ha_id?: string;
+  device_id?: string;
+  name?: string | null;
+  area_id?: string | null;
+}
+
+/** A single registry automation. */
+export interface HaAutomation {
+  ha_id?: string;
+  entity_id?: string;
+  friendly_name?: string | null;
+  state?: string | null;
+}
+
+/**
+ * Shape returned by GET /api/v1/channels/ha/registry.
+ *
+ * Six buckets per ctrl-api:
+ *   entities    — every HA entity (light, switch, sensor, climate, …)
+ *   areas       — registered rooms / zones
+ *   devices     — registered devices
+ *   automations — automation entities (entity_id like 'automation.foo')
+ *   scenes      — scene entities (entity_id like 'scene.foo')
+ *   helpers     — input_* / timer / counter / etc.
+ *
+ * PR5 (HaBootstrapWorkflow Phase A) populates these. PR3 ships the
+ * empty read so the connected-state surface lights up the moment the
+ * principal connects.
+ */
+export interface HaRegistry {
+  entities: HaEntity[];
+  areas: HaArea[];
+  devices: HaDevice[];
+  automations: HaAutomation[];
+  scenes: HaEntity[];
+  helpers: HaEntity[];
+}
+
+/**
+ * Counts surfaced by the connected-state header. The seven entity-domain
+ * counts are the ones the operator cares about at-a-glance; the long
+ * tail (binary_sensor, fan, lock, …) is omitted from the summary but
+ * still appears in the "Registry" expander.
+ *
+ * `scenes` here counts the dedicated `registry.scenes[]` bucket — NOT
+ * `entities[].domain === 'scene'` — because scenes are a top-level kind
+ * in the ha_registry schema (kind = 'scene').
+ */
+export interface HaRegistryCounts {
+  lights: number;
+  switches: number;
+  scenes: number;
+  sensors: number;
+  climate: number;
+  cover: number;
+  media_player: number;
+}
+
+export interface HaRegistrySummary {
+  counts: HaRegistryCounts;
+  areaCount: number;
+  deviceCount: number;
+  automationCount: number;
+}
+
+/** One row from the future /runs ledger (#110 PR4). */
+export interface HaRunRow {
+  id?: number | string;
+  kind?: string;
+  domain?: string | null;
+  service?: string | null;
+  entity_id?: string | null;
+  created_at?: string;
+}
+
+/**
+ * Derived view-state the React layer renders against.
+ *
+ * Fields are designed so the surface is a thin switch on `mode` — every
+ * mode-specific copy/pill/flag value is precomputed here, including the
+ * polling cadence (3s while connecting, off otherwise).
+ */
+export interface HaCardState {
+  state: HaState;
+  mode: HaViewMode;
+  heading: string;
+  description: string;
+  pill: HaPill;
+  /** ha_url being probed / connected to (null when unconfigured). */
+  haUrl: string | null;
+  /** ha_version surfaced in the connected state (null when missing). */
+  haVersion: string | null;
+  /** True iff the card should poll /status every 3s. */
+  shouldPoll: boolean;
+  /** True iff the connect form should render. */
+  showConnectForm: boolean;
+  /** True iff the "Disconnect" button should render. */
+  showDisconnect: boolean;
+  /** True iff the "Retry" button should render (error state). */
+  showRetry: boolean;
+  /** Verbatim error message — only meaningful when mode === "error". */
+  errorMessage: string | null;
+}
+
+const NULL_STATUS: HaStatus = {
+  connected: false,
+  state: "unconfigured",
+  ha_url: null,
+  ha_version: null,
+  label: null,
+  last_test_ok: false,
+  last_test_at: null,
+  error: null,
+};
+
+const EMPTY_REGISTRY: HaRegistry = {
+  entities: [],
+  areas: [],
+  devices: [],
+  automations: [],
+  scenes: [],
+  helpers: [],
+};
+
+export function deriveHaCardState(args: {
+  status: HaStatus | null | undefined;
+}): HaCardState {
+  const status = args.status ?? NULL_STATUS;
+  const errorText = pickNonEmpty(status.error) ?? null;
+  const haUrl = pickNonEmpty(status.ha_url);
+  const haVersion = pickNonEmpty(status.ha_version);
+
+  switch (status.state) {
+    case "connecting":
+      return {
+        state: "connecting",
+        mode: "connecting",
+        heading: "Connecting to Home Assistant",
+        description: haUrl
+          ? `Probing ${haUrl} — this usually takes a couple of seconds.`
+          : "Probing your Home Assistant install — this usually takes " +
+            "a couple of seconds.",
+        pill: "starting",
+        haUrl,
+        haVersion: null,
+        shouldPoll: true,
+        showConnectForm: false,
+        showDisconnect: true,
+        showRetry: false,
+        errorMessage: null,
+      };
+
+    case "connected": {
+      const versionFragment = haVersion ? ` (HA ${haVersion})` : "";
+      const heading = haUrl
+        ? `Connected to ${haUrl}${versionFragment}`
+        : "Connected to Home Assistant";
+      return {
+        state: "connected",
+        mode: "connected",
+        heading,
+        description:
+          "Alfred can read your registry and (once PR5 lands the " +
+          "bootstrap workflow) propose a baseline of automations.",
+        pill: "active",
+        haUrl,
+        haVersion,
+        shouldPoll: false,
+        showConnectForm: false,
+        showDisconnect: true,
+        showRetry: false,
+        errorMessage: null,
+      };
+    }
+
+    case "error":
+      return {
+        state: "error",
+        mode: "error",
+        heading: "Home Assistant needs attention",
+        description:
+          errorText ||
+          "Last connect / probe failed. Try again, or disconnect and " +
+            "start over with a fresh LLAT.",
+        pill: "error",
+        haUrl,
+        haVersion: null,
+        shouldPoll: false,
+        showConnectForm: false,
+        showDisconnect: true,
+        showRetry: true,
+        errorMessage: errorText,
+      };
+
+    case "disconnected":
+      return {
+        state: "disconnected",
+        mode: "unconfigured",
+        heading: "HA disconnected — reconnect any time",
+        description:
+          "You disconnected earlier. Paste the HA URL + a fresh LLAT to " +
+          "reconnect; everything previously discovered is forgotten.",
+        pill: "available",
+        haUrl: null,
+        haVersion: null,
+        shouldPoll: false,
+        showConnectForm: true,
+        showDisconnect: false,
+        showRetry: false,
+        errorMessage: null,
+      };
+
+    case "unconfigured":
+    default:
+      return {
+        state: "unconfigured",
+        mode: "unconfigured",
+        heading: "Connect to your HA install",
+        description:
+          "Install the alfred-ha custom component first, then paste your " +
+          "HA URL and a Long-Lived Access Token. Alfred reads your " +
+          "registry on connect and never touches anything you haven't " +
+          "approved.",
+        pill: "available",
+        haUrl: null,
+        haVersion: null,
+        shouldPoll: false,
+        showConnectForm: true,
+        showDisconnect: false,
+        showRetry: false,
+        errorMessage: null,
+      };
+  }
+}
+
+// ── HA URL validation ────────────────────────────────────────────────────
+
+/**
+ * Pre-flight client-side validation for the HA URL paste box. Mirrors the
+ * server-side `assertValidHaUrl` in channels_ha.ts:
+ *
+ *   • Must parse as a URL (anything not URL-shaped → reject)
+ *   • Scheme must be http: or https: (file://, javascript:, data:, ws:,
+ *     etc. all reject)
+ *   • Host must be non-empty
+ *
+ * On success returns the trimmed/normalised URL (trailing slash stripped
+ * so the connect handler can append `/api/` cleanly). On failure returns
+ * a human-friendly error pointing at the specific class of mistake.
+ */
+export interface ParseHaUrlResult {
+  ok: boolean;
+  url: string | null;
+  error: string | null;
+}
+
+export function parseHaUrl(input: string): ParseHaUrlResult {
+  if (typeof input !== "string") {
+    return { ok: false, url: null, error: "HA URL must be a string." };
+  }
+  const trimmed = input.trim();
+  if (trimmed.length === 0) {
+    return { ok: false, url: null, error: "HA URL is required." };
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return {
+      ok: false,
+      url: null,
+      error:
+        "That doesn't look like a URL. Try http://homeassistant.local:8123 " +
+        "or https://your-ha.example.com.",
+    };
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return {
+      ok: false,
+      url: null,
+      error: `HA URL must use http:// or https:// (got ${parsed.protocol}).`,
+    };
+  }
+  if (!parsed.host) {
+    return { ok: false, url: null, error: "HA URL must include a host." };
+  }
+  // Normalise: strip trailing slash so the server-side `${ha_url}/api/`
+  // append is clean.
+  const normalised = trimmed.replace(/\/+$/, "");
+  return { ok: true, url: normalised, error: null };
+}
+
+// ── LLAT redaction ───────────────────────────────────────────────────────
+
+/**
+ * Redact a Home Assistant Long-Lived Access Token for any in-memory
+ * surface. Returns the first 8 characters followed by "…". Only the
+ * first 8 chars may ever appear in any toast / error / debug breadcrumb
+ * — and even then, only via this helper.
+ *
+ * Garbage input (non-string, empty, whitespace) returns the empty string
+ * so callers can `${prefix && `token ${prefix}`}` cheaply.
+ *
+ * NEVER stringify or log a raw LLAT — see the lane brief security rule.
+ */
+export function redactLlat(s: string | null | undefined): string {
+  if (typeof s !== "string") return "";
+  const trimmed = s.trim();
+  if (trimmed.length === 0) return "";
+  // Even a very short input gets the same shape — the trailing ellipsis
+  // is the contract that says "this is redacted, not the real value".
+  if (trimmed.length <= 8) return `${trimmed}…`;
+  return `${trimmed.slice(0, 8)}…`;
+}
+
+/**
+ * The HA Long-Lived Access Token is a JWT-shaped string: three
+ * base64url-encoded segments separated by dots, ~150-200 chars total.
+ * This is a quick UX hint, NOT the server-side validator (HA itself is
+ * the only thing that can really validate it via the /api/ probe).
+ *
+ * Whitespace-only input rejects; anything that doesn't look JWT-shaped
+ * gives the operator a chance to spot a paste-fail before round-tripping.
+ */
+const LLAT_SHAPE_RE = /^eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+
+export function isProbablyValidLlat(s: string): boolean {
+  if (typeof s !== "string") return false;
+  const trimmed = s.trim();
+  if (trimmed.length < 40) return false;
+  return LLAT_SHAPE_RE.test(trimmed);
+}
+
+// ── Registry summary ─────────────────────────────────────────────────────
+
+/**
+ * The seven entity-domain counts the operator cares about at-a-glance:
+ *
+ *   light, switch, scene, sensor, climate, cover, media_player
+ *
+ * Plus three top-level counts: areas, devices, automations.
+ *
+ * `entities[].domain` is the discriminator inside the entities bucket
+ * (HA's "domain" is the prefix of `entity_id`: `light.kitchen` →
+ * `light`). Scenes appear both in entities[] (as `scene.*`) and the
+ * dedicated `scenes[]` bucket — we prefer the dedicated bucket count so
+ * the number lines up with the "Scenes" expander.
+ *
+ * Robust against `registry: null/undefined` and against any of the six
+ * arrays being missing — every count defaults to 0.
+ */
+export function summariseRegistry(
+  reg: HaRegistry | null | undefined,
+): HaRegistrySummary {
+  const r = reg ?? EMPTY_REGISTRY;
+  const entities = Array.isArray(r.entities) ? r.entities : [];
+  const areas = Array.isArray(r.areas) ? r.areas : [];
+  const devices = Array.isArray(r.devices) ? r.devices : [];
+  const automations = Array.isArray(r.automations) ? r.automations : [];
+  const scenes = Array.isArray(r.scenes) ? r.scenes : [];
+
+  const counts: HaRegistryCounts = {
+    lights: 0,
+    switches: 0,
+    scenes: scenes.length,
+    sensors: 0,
+    climate: 0,
+    cover: 0,
+    media_player: 0,
+  };
+
+  for (const e of entities) {
+    const domain = entityDomain(e);
+    if (!domain) continue;
+    switch (domain) {
+      case "light":
+        counts.lights += 1;
+        break;
+      case "switch":
+        counts.switches += 1;
+        break;
+      case "sensor":
+        counts.sensors += 1;
+        break;
+      case "climate":
+        counts.climate += 1;
+        break;
+      case "cover":
+        counts.cover += 1;
+        break;
+      case "media_player":
+        counts.media_player += 1;
+        break;
+      // Other domains (binary_sensor, fan, lock, …) intentionally fall
+      // through. They still appear in the "Registry" expander; just not
+      // in the at-a-glance summary.
+      default:
+        break;
+    }
+  }
+
+  return {
+    counts,
+    areaCount: areas.length,
+    deviceCount: devices.length,
+    automationCount: automations.length,
+  };
+}
+
+/**
+ * Extract a domain string from a registry entity. PR5's payload shape
+ * puts `domain` at the top of the row (it's a column in ha_registry, the
+ * partial index keys on it), but we fall back to entity_id parsing for
+ * any payload that ships only the entity_id ("light.kitchen" → "light").
+ *
+ * Returns null when neither field is present, so the caller can skip
+ * the row in the summary loop.
+ */
+function entityDomain(e: HaEntity | undefined | null): string | null {
+  if (!e || typeof e !== "object") return null;
+  const direct = pickNonEmpty(e.domain ?? null);
+  if (direct) return direct;
+  const id = pickNonEmpty(e.entity_id ?? e.ha_id ?? null);
+  if (!id) return null;
+  const dot = id.indexOf(".");
+  if (dot <= 0) return null;
+  return id.slice(0, dot);
+}
+
+// ── Recent runs sort ─────────────────────────────────────────────────────
+
+/**
+ * Sort a /runs payload by `created_at` desc and return the top 10. Used
+ * by the "Recent runs" expander to show the freshest service-call /
+ * automation-fire rows.
+ *
+ * Defensive: tolerates non-array input, malformed timestamps (those rows
+ * sort to the bottom), and missing fields (id, kind, …) on individual
+ * rows. The returned array is a copy — the caller's input is not
+ * mutated.
+ */
+const RUNS_LIMIT = 10;
+
+export function pickRecentRuns(
+  rows: HaRunRow[] | null | undefined,
+): HaRunRow[] {
+  if (!Array.isArray(rows)) return [];
+  const copy = rows.slice();
+  copy.sort((a, b) => {
+    const ta = parseTimestamp(a?.created_at);
+    const tb = parseTimestamp(b?.created_at);
+    // Rows with malformed timestamps sort to the bottom (oldest).
+    if (tb === ta) return 0;
+    return tb - ta;
+  });
+  return copy.slice(0, RUNS_LIMIT);
+}
+
+function parseTimestamp(s: string | null | undefined): number {
+  if (typeof s !== "string" || s.length === 0) return 0;
+  const t = Date.parse(s);
+  return Number.isFinite(t) ? t : 0;
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────────
+
+function pickNonEmpty(s: string | null | undefined): string | null {
+  if (typeof s !== "string") return null;
+  const t = s.trim();
+  return t.length > 0 ? t : null;
+}

--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -2805,3 +2805,98 @@ export const getEsphomeDevices = async (_args: unknown, context: any) => {
     throw e;
   }
 };
+
+// ============================================================
+// Home Assistant channel (#110 PR3) — operator deep-integrates HA.
+// Backed by ctrl-api /api/v1/channels/ha/* (PR1 #133 backfill landed
+// the routes). Four Wasp ops:
+//
+//   getHaStatus       → { connected, state, ha_url, ha_version, label,
+//                         last_test_ok, last_test_at, error }
+//                       The LLAT is NEVER in the payload — ctrl-api
+//                       only stores the vault_item_id in state.db.
+//   getHaRegistry     → { entities, areas, devices, automations,
+//                         scenes, helpers }
+//                       Empty until PR5's HaBootstrapWorkflow populates
+//                       ha_registry.
+//   connectHa         → POST { ha_url, llat, label? } → { ok, ha_url,
+//                                                          ha_version,
+//                                                          state }
+//                       The action accepts the LLAT in transit, passes
+//                       it once to ctrl-api, and NEVER echoes it back
+//                       to the client.
+//   disconnectHa      → DELETE → { ok }
+//                       Clears the Vaultwarden item + state.db row.
+//
+// SECURITY: the LLAT is a ~180-char JWT-shaped Home Assistant
+// long-lived access token. It must NEVER appear in any log line,
+// toast, or error message that surfaces above ctrl-api. The action
+// passes the trimmed value through; ctrl-api errors (e.g. 401
+// AUTH_FAILED) do not echo the token.
+// ============================================================
+
+export const getHaStatus = async (_args: unknown, context: any) => {
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    path: "/api/v1/channels/ha/status",
+  });
+};
+
+export const getHaRegistry = async (_args: unknown, context: any) => {
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    path: "/api/v1/channels/ha/registry",
+  });
+};
+
+/**
+ * Connect the tenant to a Home Assistant install.
+ *
+ * Body: { ha_url: string, llat: string, label?: string }
+ *
+ *   • ha_url — http(s) URL to the HA frontend (validated client-side by
+ *     parseHaUrl + server-side by assertValidHaUrl in channels_ha.ts).
+ *   • llat   — Home Assistant long-lived access token. Stored in
+ *     Vaultwarden by ctrl-api; the state.db row only carries the
+ *     vault_item_id.
+ *   • label  — optional human label ("Home", "Cabin") for the
+ *     Vaultwarden item. Defaults to "Home Assistant" server-side.
+ *
+ * SECURITY: the trimmed LLAT is passed once to ctrl-api and never
+ * logged or echoed. The 200 response from ctrl-api does NOT include
+ * the LLAT.
+ */
+export const connectHa = async (
+  args: { ha_url: string; llat: string; label?: string },
+  context: any,
+) => {
+  if (!args?.ha_url?.trim()) {
+    throw new HttpError(400, "ha_url is required");
+  }
+  if (!args?.llat?.trim()) {
+    throw new HttpError(400, "llat is required");
+  }
+  const instance = await getUserInstance(context);
+  // Trim only — ctrl-api is the real validator. The label is optional;
+  // we forward it verbatim when present.
+  const body: Record<string, string> = {
+    ha_url: args.ha_url.trim(),
+    llat: args.llat.trim(),
+  };
+  if (typeof args.label === "string" && args.label.trim().length > 0) {
+    body.label = args.label.trim();
+  }
+  return proxyToTenant(instance, {
+    method: "POST",
+    path: "/api/v1/channels/ha/connect",
+    body,
+  });
+};
+
+export const disconnectHa = async (_args: unknown, context: any) => {
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    method: "DELETE",
+    path: "/api/v1/channels/ha/disconnect",
+  });
+};


### PR DESCRIPTION
The user-facing Home Assistant card on `/channels` for issue #110 PR3.

**Stacked on #133** (`fix/wave-b-backfill-ctrl-routes`) because the
ctrl-api routes this card calls have not landed in `main` yet. Once #133
merges, GitHub will retarget this PR at `main` and the diff collapses
to just the web/SaaS work.

## What the card does

Five view modes mapped 1:1 to the ctrl-api `state` enum:

```
state          → view             card surface
─────────────────────────────────────────────────────────────────────────
unconfigured   → unconfigured     connect form (URL + LLAT + HACS hint)
disconnected   → unconfigured     same form + calmer headline
connecting     → connecting       spinner copy, polls /status every 3s
connected      → connected        ha_url + ha_version + 10-tile counts
                                  + 4 expanders (Registry / Recent runs
                                  / Voice surface / Disconnect)
error          → error            last_error verbatim + retry + disconnect
```

The connected-view tiles are derived from `summariseRegistry()`:
**lights / switches / scenes / sensors / climate / cover / media_player**
(from `entities[].domain`) plus **areas / devices / automations**
(top-level bucket lengths). Empty registries (the PR1 state, before PR5
backfills) render as all-zeros without crashing.

## What's in this PR

| Path | Lines | Notes |
|------|-------|-------|
| `packages/web/src/dashboard/haCardCore.ts` | ~420 | Pure derivation — no React/Wasp imports. |
| `packages/web/src/dashboard/haCardCore.test.ts` | ~330 | 22 tests under `node:test`. |
| `packages/web/src/dashboard/HaCard.tsx` | ~600 | React surface. |
| `packages/web/src/dashboard/operations.ts` | +95 | Four Wasp ops (`getHaStatus`, `getHaRegistry`, `connectHa`, `disconnectHa`). |
| `packages/web/main.wasp` | +26 | Wires the four ops. |
| `packages/web/src/dashboard/ChannelsPage.tsx` | +12 | Inserts `<HaCard />` alphabetically (after the absent Files card, before `<OmiCard />`). |
| `.gitguardian.yaml` | +4 | Allowlists the new test file's `llat_TEST_…` synthetic placeholder. |

## Security rules upheld

The LLAT is a Home Assistant Long-Lived Access Token — a JWT-shaped
~180-char secret. **It must never leak.** The full belt-and-braces:

- `ctrl-api /status` strips it server-side (PR1 #133 — the route only
  reads ha_connection columns; vault_item_id is the only LLAT-ish field
  it carries).
- The connect form uses a `<textarea>` with `autoComplete="off"` and
  `spellCheck={false}`. **No "show" toggle.** LLATs are too long for a
  single-line input, which is why the brief calls out a textarea.
- The local React state holding the LLAT is **wiped immediately** on
  submit success.
- `redactLlat()` (first 8 chars + ellipsis) is the **only** formatter
  allowed to touch the in-memory token. Even on error toasts, no more
  than the first 8 chars surface.
- Fixtures use `llat_TEST_…` + synthetic three-segment JWT-shaped
  placeholders (`eyJTESTaaaaaaa.eyJTESTbbbbbbb.TESTcccccccc`). No real
  `eyJ…` anywhere.

## Tests

```
$ cd packages/web && npx tsx --test src/dashboard/haCardCore.test.ts
…
ℹ tests 22
ℹ suites 0
ℹ pass 22
ℹ fail 0
```

ctrl-api baseline failures (24, pre-existing) unchanged — this PR adds
no Python / Node-side tests beyond the `haCardCore` suite.

## Defers

- **Recent runs** — the `/api/v1/channels/ha/runs` route ships in
  #110 PR4. The expander renders a calm placeholder until then so the
  connected view doesn't have a broken section. When PR4 lands, a
  `getHaRuns` Wasp query + a `pickRecentRuns()` call inside
  `RunsSection` is the diff.
- **Registry entities** — PR5's `HaBootstrapWorkflow` is what backfills
  `ha_registry`. Until PR5 lands the entity expander renders the
  empty-state copy; the count tiles all show 0. `summariseRegistry()`
  is the only thing that needs to change to start showing real numbers
  — it already groups entities by `domain`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)