### PR TITLE
fix(web): drop explicit return type on getRecallChannelStatus

### DIFF
--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -709,7 +709,7 @@ async function safeProxy(
 export const getRecallChannelStatus = async (
   _args: unknown,
   context: any,
-): Promise<RecallCompositeStatus> => {
+) => {
   const instance = await getUserInstance(context);
 
   // Three parallel reads — config + usage + active_bots.


### PR DESCRIPTION
The `getRecallChannelStatus` op (added in PR #136) declared an explicit
`Promise<RecallCompositeStatus>` return type. Wasp's SDK build chokes on it:

\`\`\`
server/operations/queries/index.ts(609,14): error TS2322:
  Type '(args: unknown, context: { user: AuthUser; }) => Promise<Payload>'
  is not assignable to type
  '(args: unknown, context: { user: AuthUser; }) => Promise<RecallCompositeStatus>'.
\`\`\`

Removing the annotation lets Wasp infer it from the body — no runtime
change. Caught when build-web went red on the post-#136 main SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)