### PR TITLE
feat(ctrl,web): channel-token mint/list/revoke/rotate (#111 PR4)

### DIFF
--- a/packages/ctrl/src/api/routes/channels_tokens.ts
+++ b/packages/ctrl/src/api/routes/channels_tokens.ts
@@ -1,0 +1,239 @@
+// Canonical REST surface for channel-token management — `/api/v1/channels/tokens/*`.
+//
+// Background. The shared channel_tokens table is the per-channel
+// bearer-token store every external surface (HA conversation, HA Voice,
+// Paperclip, future Matter/HomeKit) authenticates against. PR1 (#111)
+// shipped the table + DB helpers + an early route surface at
+// /api/v1/channel-tokens/* (POST /mint, GET /, POST /:id/revoke,
+// POST /:id/rotate). That surface stays for back-compat — existing
+// fleet bearers + the legacy HaConversationSetupCard call it — but it
+// is not the canonical REST shape.
+//
+// This module (#111 PR4) lands the canonical surface:
+//
+//   POST   /api/v1/channels/tokens          mint
+//   GET    /api/v1/channels/tokens          list (?channel= optional filter)
+//   GET    /api/v1/channels/tokens/:id      get one row
+//   DELETE /api/v1/channels/tokens/:id      revoke (soft-delete)
+//   POST   /api/v1/channels/tokens/:id/rotate   rotate (one-time raw)
+//
+// The shape is REST-uniform: the resource is at the path root, methods
+// pick the operation. Same table, same DB helpers, same one-time-raw
+// privacy posture as the legacy surface.
+//
+// Auth: all five endpoints are gated by the master AAS_API_KEY via the
+// global authenticate() middleware. These are operator-facing tooling,
+// not external surfaces. The TOKENS THIS MODULE MINTS are what external
+// surfaces (HA, Paperclip, …) actually validate against via
+// channelTokenBearer().
+//
+// PRIVACY contract (every response shape obeys this):
+//   * `raw_token` appears EXACTLY ONCE — in the mint and rotate responses.
+//   * `token_hash` is NEVER returned by any endpoint. It is sha256(raw),
+//     stored at mint time, used only for the auth-path lookup.
+//   * GET/list responses carry the public-safe ChannelTokenMeta view only.
+
+import { addRoute } from "../server.js";
+import { sendJson, ValidationError, NotFoundError } from "../errors.js";
+import { getStateDb } from "../../db/state.js";
+import {
+  mintChannelToken,
+  listChannelTokens,
+  revokeChannelToken,
+  rotateChannelToken,
+  getChannelTokenMeta,
+  type ChannelTokenMeta,
+} from "../../db/channelTokens.js";
+
+/** Channels this route surface accepts at mint time. Anything else is a
+ *  400 — keeps a typo from fragmenting the audit trail with
+ *  `channel='ha_conversation'` vs `channel='ha-conversation'`. Update in
+ *  lockstep with `generateRawToken`'s prefix arm in db/channelTokens.ts. */
+const KNOWN_CHANNELS: ReadonlySet<string> = new Set([
+  "ha-conversation",
+  "ha-voice",
+  "paperclip-heartbeat",
+]);
+
+interface MintBody {
+  channel: string;
+  label?: string | null;
+  scope?: Record<string, unknown> | null;
+}
+
+function parseMintBody(raw: unknown): MintBody {
+  if (typeof raw !== "object" || raw === null) {
+    throw new ValidationError("body must be a JSON object");
+  }
+  const b = raw as Record<string, unknown>;
+  if (typeof b.channel !== "string" || b.channel.length === 0) {
+    throw new ValidationError("channel must be a non-empty string");
+  }
+  if (!KNOWN_CHANNELS.has(b.channel)) {
+    throw new ValidationError(
+      `channel must be one of ${[...KNOWN_CHANNELS].join(", ")}`,
+    );
+  }
+  let label: string | null = null;
+  if (b.label !== undefined && b.label !== null) {
+    if (typeof b.label !== "string") {
+      throw new ValidationError("label must be a string or omitted");
+    }
+    label = b.label;
+  }
+  let scope: Record<string, unknown> | null = null;
+  if (b.scope !== undefined && b.scope !== null) {
+    if (typeof b.scope !== "object" || Array.isArray(b.scope)) {
+      throw new ValidationError("scope must be a JSON object or omitted");
+    }
+    scope = b.scope as Record<string, unknown>;
+  }
+  return { channel: b.channel, label, scope };
+}
+
+/** Flatten the public-safe meta into the wire shape used by GET/list
+ *  responses. Mirrors ChannelTokenMeta with `scope` renamed to
+ *  `scope_json` on the wire so downstream consumers (the Wasp web layer,
+ *  the legacy `vault-cli channel-token list` tooling) can rely on the
+ *  same field name across both route surfaces. token_hash is NEVER
+ *  exposed — the only mapping is hash → row inside auth.ts. */
+function metaToWire(meta: ChannelTokenMeta): Record<string, unknown> {
+  return {
+    id: meta.id,
+    channel: meta.channel,
+    label: meta.label,
+    scope_json: meta.scope,
+    created_at: meta.created_at,
+    last_used_at: meta.last_used_at,
+    last_used_ip: meta.last_used_ip,
+    rotated_from: meta.rotated_from,
+    revoked_at: meta.revoked_at,
+  };
+}
+
+export function registerChannelsTokensRoutes(): void {
+  // POST /api/v1/channels/tokens — mint. Generates a raw token via
+  // mintChannelToken() (which under the hood uses 24 random bytes →
+  // hex + channel-specific prefix — `ha_…` for HA, `pcp_…` for
+  // Paperclip — for at-a-glance log identification; 192 bits of
+  // entropy either way) and stores sha256(raw) in token_hash. The raw
+  // token is returned EXACTLY ONCE in `raw_token`; subsequent reads of
+  // this row will never re-expose it.
+  addRoute("POST", "/api/v1/channels/tokens", async ({ res, body }) => {
+    const parsed = parseMintBody(body);
+    const result = mintChannelToken(getStateDb(), {
+      channel: parsed.channel,
+      label: parsed.label,
+      scope: parsed.scope,
+    });
+    sendJson(res, 201, {
+      id: result.meta.id,
+      channel: result.meta.channel,
+      label: result.meta.label,
+      raw_token: result.raw,
+      scope_json: result.meta.scope,
+      created_at: result.meta.created_at,
+    });
+  });
+
+  // GET /api/v1/channels/tokens?channel=<filter>&include_revoked=false
+  // — operator list. Returns the public-safe view. With no `channel`
+  // filter the list spans every channel; with `channel=ha-conversation`
+  // (et al.) it scopes. `include_revoked=true` surfaces tombstones for
+  // audit views; the default is active-only so the HA card's install
+  // table doesn't paint stale rows.
+  addRoute("GET", "/api/v1/channels/tokens", async ({ res, query }) => {
+    const includeRevoked =
+      query.get("include_revoked") === "true" ||
+      query.get("include_revoked") === "1";
+    const channelFilter = query.get("channel");
+    let metas: ChannelTokenMeta[];
+    if (channelFilter) {
+      // Unknown-channel filter returns an empty list (not a 400) — the
+      // operator may be probing for an as-yet-unused channel surface.
+      metas = listChannelTokens(getStateDb(), channelFilter, {
+        includeRevoked,
+      });
+    } else {
+      // No filter → list every channel. We do this channel-by-channel
+      // rather than a raw SELECT because listChannelTokens centralises
+      // the public-safe row projection (no token_hash).
+      const all: ChannelTokenMeta[] = [];
+      for (const channel of KNOWN_CHANNELS) {
+        all.push(
+          ...listChannelTokens(getStateDb(), channel, { includeRevoked }),
+        );
+      }
+      // Newest first across channels.
+      all.sort((a, b) => b.created_at - a.created_at);
+      metas = all;
+    }
+    sendJson(res, 200, { tokens: metas.map(metaToWire) });
+  });
+
+  // GET /api/v1/channels/tokens/:id — single row, same shape as the
+  // list rows. NotFound for unknown ids — the operator gets a clear
+  // 404 rather than a generic empty list.
+  addRoute(
+    "GET",
+    "/api/v1/channels/tokens/:id",
+    async ({ res, params }) => {
+      const id = params.id;
+      if (!id) throw new ValidationError("id is required");
+      const meta = getChannelTokenMeta(getStateDb(), id);
+      if (!meta) throw new NotFoundError(`channel_token ${id} not found`);
+      sendJson(res, 200, metaToWire(meta));
+    },
+  );
+
+  // DELETE /api/v1/channels/tokens/:id — soft-revoke. Sets
+  // `revoked_at = now()`. Idempotent: a second DELETE is a no-op (the
+  // existing `revoked_at` stays). Returns `{ok, revoked_at}`. The next
+  // request from the now-revoked token gets 401 via channelTokenBearer.
+  addRoute(
+    "DELETE",
+    "/api/v1/channels/tokens/:id",
+    async ({ res, params }) => {
+      const id = params.id;
+      if (!id) throw new ValidationError("id is required");
+      const meta = revokeChannelToken(getStateDb(), id);
+      if (!meta) throw new NotFoundError(`channel_token ${id} not found`);
+      sendJson(res, 200, { ok: true, revoked_at: meta.revoked_at });
+    },
+  );
+
+  // POST /api/v1/channels/tokens/:id/rotate — mint a fresh token in
+  // the same channel (carrying label + scope), set `rotated_from = :id`,
+  // and return the new row + new `raw_token` (one-time).
+  //
+  // GRACE WINDOW. The old row is deliberately NOT auto-revoked here.
+  // channelTokenBearer accepts ANY non-revoked row matching
+  // (channel, sha256(raw)), so during the operator-controlled cutover
+  // BOTH the old and the new tokens keep authenticating — the consuming
+  // surface (an HA install, a Paperclip agent, …) can be re-pointed at
+  // the new bearer at the operator's pace. When the operator confirms
+  // the new bearer is installed they DELETE the old row separately.
+  // This is the "rotate, then explicit revoke" two-step that mirrors
+  // how SSH key rotation is run in production.
+  addRoute(
+    "POST",
+    "/api/v1/channels/tokens/:id/rotate",
+    async ({ res, params }) => {
+      const id = params.id;
+      if (!id) throw new ValidationError("id is required");
+      const existing = getChannelTokenMeta(getStateDb(), id);
+      if (!existing) throw new NotFoundError(`channel_token ${id} not found`);
+      const fresh = rotateChannelToken(getStateDb(), id);
+      if (!fresh) throw new NotFoundError(`channel_token ${id} not found`);
+      sendJson(res, 201, {
+        id: fresh.meta.id,
+        channel: fresh.meta.channel,
+        label: fresh.meta.label,
+        raw_token: fresh.raw,
+        scope_json: fresh.meta.scope,
+        created_at: fresh.meta.created_at,
+        rotated_from: id,
+      });
+    },
+  );
+}

--- a/packages/ctrl/src/api/server.ts
+++ b/packages/ctrl/src/api/server.ts
@@ -63,6 +63,7 @@ import {
 } from "./routes/channels_recall.js";
 import { registerHaChannelRoutes } from "./routes/channels_ha.js";
 import { registerChannelTokenRoutes } from "./routes/channel_tokens.js";
+import { registerChannelsTokensRoutes } from "./routes/channels_tokens.js";
 import { registerComposioWebhookRoutes } from "./routes/composioWebhook.js";
 import { registerAlfredJournalRoutes } from "./routes/alfredJournal.js";
 import { registerAlfredDeliverRoutes } from "./routes/alfredDeliver.js";
@@ -196,6 +197,14 @@ export function createApiServer(): http.Server {
   // (#111 PR1, Sir's decision Q2). HA-conversation tokens land here; HA
   // Voice (#112) joins next; Paperclip migrates onto it later.
   registerChannelTokenRoutes();
+  // /api/v1/channels/tokens/* — canonical REST surface for the same
+  // shared bearer-token table (#111 PR4). REST-uniform: resource at the
+  // path root, methods pick the operation
+  // (POST mint, GET list, GET :id, DELETE revoke, POST :id/rotate).
+  // The legacy /api/v1/channel-tokens/* surface stays registered above
+  // so existing fleet bearers + the first cut of the HA card keep
+  // working; new web-layer callers (PR4 web operations) use this surface.
+  registerChannelsTokensRoutes();
   registerComposioWebhookRoutes();
   // The one-Alfred continuity layer — alfred_journal + principal mapping
   // (the persistence + lookup surface) plus alfred-deliver (the unified

--- a/packages/ctrl/tests/channels_tokens.test.ts
+++ b/packages/ctrl/tests/channels_tokens.test.ts
@@ -1,0 +1,531 @@
+// /api/v1/channels/tokens/* — canonical REST surface (#111 PR4).
+//
+// What's under test
+// -----------------
+// The five HTTP routes added by registerChannelsTokensRoutes:
+//
+//   POST   /api/v1/channels/tokens                  mint
+//   GET    /api/v1/channels/tokens                  list
+//   GET    /api/v1/channels/tokens/:id              get one
+//   DELETE /api/v1/channels/tokens/:id              revoke
+//   POST   /api/v1/channels/tokens/:id/rotate       rotate
+//
+// Companion to channel_tokens.test.ts (legacy /channel-tokens/* surface)
+// and channels_ha_turn.test.ts (channelTokenBearer integration). The DB
+// helpers are covered by channel_tokens.test.ts; this file focuses on
+// the wire shape + the surrounding invariants of the new REST surface.
+
+import { describe, it, beforeEach, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ServerResponse } from "node:http";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "channels-tokens-"));
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.STATE_DB_PATH = path.join(tmp, "alfred-state.db");
+process.env.VAULT_PATH = path.join(tmp, "vault");
+process.env.SQLITE_VEC_PATH = "";
+
+const { getStateDb } = await import("../src/db/state.js");
+const {
+  mintChannelToken,
+  validateChannelToken,
+  hashToken,
+} = await import("../src/db/channelTokens.js");
+const { matchRoute } = await import("../src/api/server.js");
+const { handleError, AuthError } = await import("../src/api/errors.js");
+const { authenticate, setApiKey, _resetAuthForTests, channelTokenBearer } =
+  await import("../src/api/auth.js");
+const { registerChannelsTokensRoutes } = await import(
+  "../src/api/routes/channels_tokens.js"
+);
+const { registerHaChannelRoutes } = await import(
+  "../src/api/routes/channels_ha.js"
+);
+registerChannelsTokensRoutes();
+// channels_ha registers POST /api/v1/channels/ha/turn — we use it to
+// regression-test that channelTokenBearer 401s a revoked token through
+// the new DELETE path.
+registerHaChannelRoutes();
+
+interface InvokeOpts {
+  body?: unknown;
+  query?: string;
+  params?: Record<string, string>;
+  headers?: Record<string, string>;
+}
+
+async function invokeRoute(
+  method: string,
+  p: string,
+  opts: InvokeOpts = {},
+): Promise<{ status: number; payload: any }> {
+  const pathOnly = p.split("?")[0];
+  // The route key for matchRoute is the literal pattern path
+  // (`/api/v1/channels/tokens/:id`). For ":id"-style patterns the
+  // helper falls back to `opts.params`. For concrete paths we let
+  // matchRoute do the parameter extraction so the test catches a
+  // typo in the route registration (the same failure mode the
+  // channel_tokens.test.ts suite uses).
+  const m = matchRoute(method, pathOnly);
+  assert.ok(m, `${method} ${pathOnly} must be registered`);
+  let status = 0;
+  let payload: any;
+  const res = {
+    setHeader() {},
+    writeHead(c: number) {
+      status = c;
+      return res;
+    },
+    end(j?: string) {
+      payload = j ? JSON.parse(j) : undefined;
+    },
+  } as unknown as ServerResponse;
+  try {
+    await m!.handler({
+      req: {
+        method,
+        url: p,
+        headers: opts.headers ?? {},
+        socket: { remoteAddress: "10.0.0.42" },
+      } as any,
+      res,
+      params: opts.params ?? m!.params,
+      body: opts.body,
+      query: new URLSearchParams(opts.query ?? ""),
+    });
+  } catch (err) {
+    handleError(res, err);
+  }
+  return { status, payload };
+}
+
+function clearTokens(): void {
+  getStateDb().exec("DELETE FROM channel_tokens");
+}
+
+async function mintViaRoute(
+  channel: string,
+  label?: string,
+  scope?: Record<string, unknown>,
+): Promise<{ id: string; raw_token: string; payload: any }> {
+  const r = await invokeRoute("POST", "/api/v1/channels/tokens", {
+    body: { channel, label, scope },
+  });
+  assert.equal(r.status, 201, `mint should 201; got ${r.status}`);
+  return { id: r.payload.id, raw_token: r.payload.raw_token, payload: r.payload };
+}
+
+describe("/api/v1/channels/tokens — operator surface (#111 PR4)", () => {
+  beforeEach(() => {
+    clearTokens();
+  });
+
+  // ---- mint ----------------------------------------------------------
+
+  it("mint requires AAS_API_KEY (authenticate() rejects when no bearer)", () => {
+    // The route handler itself does NOT call channelTokenBearer — the
+    // master-key gate sits in front of every /api/v1/* path in
+    // server.ts via authenticate(). Test the gate directly so we don't
+    // need to spin up an http server: with the key set, an empty-
+    // Authorization request is rejected exactly like the runtime
+    // would reject the mint call.
+    setApiKey("master-secret-test-key");
+    try {
+      assert.throws(
+        () =>
+          authenticate(
+            { headers: {} } as any,
+            { method: "POST", pathname: "/api/v1/channels/tokens" },
+          ),
+        (err: unknown) => err instanceof AuthError,
+      );
+      // Sanity: a request with the right master key passes.
+      assert.doesNotThrow(() =>
+        authenticate(
+          {
+            headers: { authorization: "Bearer master-secret-test-key" },
+          } as any,
+          { method: "POST", pathname: "/api/v1/channels/tokens" },
+        ),
+      );
+    } finally {
+      _resetAuthForTests();
+    }
+  });
+
+  it("mint returns raw_token ONCE; subsequent reads never re-expose it", async () => {
+    const mint = await mintViaRoute(
+      "ha-conversation",
+      "ha:home-uuid-1",
+      { haInstanceId: "home-uuid-1" },
+    );
+    // The mint response carries raw_token (one-time field) + all the
+    // public-safe fields the operator UI surfaces.
+    assert.ok(
+      typeof mint.payload.raw_token === "string" &&
+        mint.payload.raw_token.length > 0,
+      "raw_token present on mint",
+    );
+    assert.equal(mint.payload.channel, "ha-conversation");
+    assert.equal(mint.payload.label, "ha:home-uuid-1");
+    assert.deepEqual(mint.payload.scope_json, { haInstanceId: "home-uuid-1" });
+    assert.ok(mint.payload.id, "id present");
+    assert.ok(
+      typeof mint.payload.created_at === "number",
+      "created_at present",
+    );
+    // GET /:id — raw_token MUST NOT come back.
+    const one = await invokeRoute(
+      "GET",
+      `/api/v1/channels/tokens/${mint.id}`,
+    );
+    assert.equal(one.status, 200);
+    assert.equal(
+      one.payload.raw_token,
+      undefined,
+      "GET /:id never re-exposes raw_token",
+    );
+    assert.equal(
+      one.payload.token,
+      undefined,
+      "GET /:id never re-exposes a legacy `token` field either",
+    );
+  });
+
+  it("response shapes NEVER include token_hash", async () => {
+    await mintViaRoute("ha-conversation", "ha:a");
+    await mintViaRoute("ha-voice", "voice:a");
+    // mint response
+    const mintB = await mintViaRoute("paperclip-heartbeat", "pcp:b");
+    assert.equal(mintB.payload.token_hash, undefined);
+    // list response — both filtered and unfiltered
+    const list = await invokeRoute("GET", "/api/v1/channels/tokens", {
+      query: "channel=ha-conversation",
+    });
+    assert.equal(list.status, 200);
+    for (const t of list.payload.tokens) {
+      assert.equal(t.token_hash, undefined);
+      assert.equal(t.raw_token, undefined);
+    }
+    const all = await invokeRoute("GET", "/api/v1/channels/tokens");
+    assert.equal(all.status, 200);
+    for (const t of all.payload.tokens) {
+      assert.equal(t.token_hash, undefined);
+      assert.equal(t.raw_token, undefined);
+    }
+    // GET /:id
+    const single = await invokeRoute(
+      "GET",
+      `/api/v1/channels/tokens/${mintB.id}`,
+    );
+    assert.equal(single.payload.token_hash, undefined);
+  });
+
+  // ---- list ----------------------------------------------------------
+
+  it("list is filtered by `channel` query parameter", async () => {
+    await mintViaRoute("ha-conversation");
+    await mintViaRoute("ha-conversation");
+    await mintViaRoute("ha-voice");
+    const haConv = await invokeRoute("GET", "/api/v1/channels/tokens", {
+      query: "channel=ha-conversation",
+    });
+    assert.equal(haConv.status, 200);
+    assert.equal(haConv.payload.tokens.length, 2);
+    for (const t of haConv.payload.tokens) {
+      assert.equal(t.channel, "ha-conversation");
+    }
+    const haVoice = await invokeRoute("GET", "/api/v1/channels/tokens", {
+      query: "channel=ha-voice",
+    });
+    assert.equal(haVoice.payload.tokens.length, 1);
+    // No filter → spans every channel.
+    const all = await invokeRoute("GET", "/api/v1/channels/tokens");
+    assert.equal(all.payload.tokens.length, 3);
+  });
+
+  it("scope_json round-trips through mint + list + get", async () => {
+    const scope = {
+      haInstanceId: "kitchen-tablet",
+      nested: { count: 3, allowed: true },
+    };
+    const m = await mintViaRoute("ha-conversation", "ha:kitchen", scope);
+    assert.deepEqual(m.payload.scope_json, scope);
+    const single = await invokeRoute(
+      "GET",
+      `/api/v1/channels/tokens/${m.id}`,
+    );
+    assert.deepEqual(single.payload.scope_json, scope);
+    const list = await invokeRoute("GET", "/api/v1/channels/tokens", {
+      query: "channel=ha-conversation",
+    });
+    const row = list.payload.tokens.find((t: any) => t.id === m.id);
+    assert.deepEqual(row.scope_json, scope);
+  });
+
+  it("label persists across mint → list → get", async () => {
+    const m = await mintViaRoute("ha-voice", "ha-voice:greatroom");
+    assert.equal(m.payload.label, "ha-voice:greatroom");
+    const one = await invokeRoute(
+      "GET",
+      `/api/v1/channels/tokens/${m.id}`,
+    );
+    assert.equal(one.payload.label, "ha-voice:greatroom");
+  });
+
+  // ---- revoke (DELETE) ----------------------------------------------
+
+  it("DELETE /:id sets revoked_at and returns {ok, revoked_at}", async () => {
+    const m = await mintViaRoute("ha-conversation");
+    const before = await invokeRoute(
+      "GET",
+      `/api/v1/channels/tokens/${m.id}`,
+    );
+    assert.equal(before.payload.revoked_at, null);
+    const del = await invokeRoute("DELETE", `/api/v1/channels/tokens/${m.id}`);
+    assert.equal(del.status, 200);
+    assert.equal(del.payload.ok, true);
+    assert.ok(
+      typeof del.payload.revoked_at === "number" && del.payload.revoked_at > 0,
+      "revoked_at populated",
+    );
+    const after = await invokeRoute(
+      "GET",
+      `/api/v1/channels/tokens/${m.id}`,
+    );
+    assert.equal(after.payload.revoked_at, del.payload.revoked_at);
+  });
+
+  it("a revoked token is rejected by channelTokenBearer (regression)", async () => {
+    // End-to-end: mint via the new route, hit a real channel route
+    // (POST /api/v1/channels/ha/turn) with the raw, revoke via the
+    // new DELETE route, hit /turn again — second call must 401. This
+    // catches a regression where revoke_at would be set on the wrong
+    // row, or channelTokenBearer would cache.
+    const m = await mintViaRoute(
+      "ha-conversation",
+      "ha:test",
+      { haInstanceId: "test-uuid" },
+    );
+    // Direct channelTokenBearer probe — cheaper than invoking /turn,
+    // and tests the auth path we actually care about.
+    const stillValid = validateChannelToken(
+      getStateDb(),
+      "ha-conversation",
+      m.raw_token,
+    );
+    assert.ok(stillValid, "raw token validates pre-revoke");
+    const del = await invokeRoute("DELETE", `/api/v1/channels/tokens/${m.id}`);
+    assert.equal(del.status, 200);
+    const afterRevoke = validateChannelToken(
+      getStateDb(),
+      "ha-conversation",
+      m.raw_token,
+    );
+    assert.equal(afterRevoke, null, "revoked token no longer validates");
+    // And channelTokenBearer surfaces that as a 401:
+    assert.throws(
+      () =>
+        channelTokenBearer(
+          {
+            headers: { authorization: `Bearer ${m.raw_token}` },
+            socket: { remoteAddress: "10.0.0.99" },
+          } as any,
+          "ha-conversation",
+        ),
+      (err: unknown) => err instanceof AuthError,
+    );
+  });
+
+  // ---- rotate -------------------------------------------------------
+
+  it("rotate mints fresh row + sets rotated_from + carries label/scope", async () => {
+    const original = await mintViaRoute(
+      "ha-conversation",
+      "ha:home",
+      { haInstanceId: "home" },
+    );
+    const rot = await invokeRoute(
+      "POST",
+      "/api/v1/channels/tokens/:id/rotate",
+      { params: { id: original.id } },
+    );
+    assert.equal(rot.status, 201);
+    assert.ok(rot.payload.raw_token, "new raw_token in response");
+    assert.notEqual(
+      rot.payload.raw_token,
+      original.raw_token,
+      "rotated token differs",
+    );
+    assert.notEqual(rot.payload.id, original.id, "new id");
+    assert.equal(rot.payload.rotated_from, original.id);
+    assert.equal(rot.payload.channel, "ha-conversation");
+    assert.equal(rot.payload.label, "ha:home", "label carried forward");
+    assert.deepEqual(
+      rot.payload.scope_json,
+      { haInstanceId: "home" },
+      "scope carried forward",
+    );
+    // Both old and new validate (60s grace — operator decides when to
+    // revoke the old). We assert this directly via validateChannelToken
+    // because the grace window predates an explicit DELETE on the old
+    // row; channelTokenBearer is hash-lookup, not time-bound.
+    const oldStill = validateChannelToken(
+      getStateDb(),
+      "ha-conversation",
+      original.raw_token,
+    );
+    assert.ok(oldStill, "old token still valid during grace window");
+    const newAlso = validateChannelToken(
+      getStateDb(),
+      "ha-conversation",
+      rot.payload.raw_token,
+    );
+    assert.ok(newAlso, "new token valid");
+    // After operator-controlled cutover (DELETE the old row), only the
+    // new token validates.
+    const del = await invokeRoute(
+      "DELETE",
+      `/api/v1/channels/tokens/${original.id}`,
+    );
+    assert.equal(del.status, 200);
+    const oldAfter = validateChannelToken(
+      getStateDb(),
+      "ha-conversation",
+      original.raw_token,
+    );
+    assert.equal(oldAfter, null, "old token rejected post-revoke");
+    const newAfter = validateChannelToken(
+      getStateDb(),
+      "ha-conversation",
+      rot.payload.raw_token,
+    );
+    assert.ok(newAfter, "new token still validates post-cutover");
+  });
+
+  it("last_used_at + last_used_ip are bumped on channelTokenBearer hit", async () => {
+    const m = await mintViaRoute("ha-conversation");
+    const before = await invokeRoute(
+      "GET",
+      `/api/v1/channels/tokens/${m.id}`,
+    );
+    assert.equal(before.payload.last_used_at, null);
+    assert.equal(before.payload.last_used_ip, null);
+    // Walk the channelTokenBearer path with a concrete remoteAddress.
+    channelTokenBearer(
+      {
+        headers: { authorization: `Bearer ${m.raw_token}` },
+        socket: { remoteAddress: "192.0.2.17" },
+      } as any,
+      "ha-conversation",
+    );
+    const after = await invokeRoute(
+      "GET",
+      `/api/v1/channels/tokens/${m.id}`,
+    );
+    assert.ok(
+      typeof after.payload.last_used_at === "number" &&
+        after.payload.last_used_at > 0,
+      "last_used_at bumped",
+    );
+    assert.equal(after.payload.last_used_ip, "192.0.2.17");
+  });
+
+  // ---- validation / error shapes ------------------------------------
+
+  it("mint with missing channel → 400 VALIDATION_ERROR", async () => {
+    const r = await invokeRoute("POST", "/api/v1/channels/tokens", {
+      body: { label: "no-channel" },
+    });
+    assert.equal(r.status, 400);
+    assert.equal(r.payload.error.code, "VALIDATION_ERROR");
+  });
+
+  it("mint with unknown channel → 400 (only 3 channels are allowed)", async () => {
+    const r = await invokeRoute("POST", "/api/v1/channels/tokens", {
+      body: { channel: "made-up-channel", label: "x" },
+    });
+    assert.equal(r.status, 400);
+    assert.equal(r.payload.error.code, "VALIDATION_ERROR");
+    assert.ok(
+      /must be one of/.test(r.payload.error.message),
+      "error message enumerates known channels",
+    );
+    // Triple-check the 3 known channels documented in the contract
+    // mint without 400:
+    for (const c of ["ha-conversation", "ha-voice", "paperclip-heartbeat"]) {
+      const ok = await invokeRoute("POST", "/api/v1/channels/tokens", {
+        body: { channel: c },
+      });
+      assert.equal(ok.status, 201, `channel=${c} should mint cleanly`);
+    }
+  });
+
+  it("DELETE /:id on a non-existent id → 404", async () => {
+    const r = await invokeRoute(
+      "DELETE",
+      "/api/v1/channels/tokens/01HZZZZZZZZZZZZZZZZZZZZZZZ",
+      { params: { id: "01HZZZZZZZZZZZZZZZZZZZZZZZ" } },
+    );
+    assert.equal(r.status, 404);
+    assert.equal(r.payload.error.code, "NOT_FOUND");
+  });
+
+  it("GET /:id on a non-existent id → 404", async () => {
+    const r = await invokeRoute(
+      "GET",
+      "/api/v1/channels/tokens/01HZZZZZZZZZZZZZZZZZZZZZZZ",
+      { params: { id: "01HZZZZZZZZZZZZZZZZZZZZZZZ" } },
+    );
+    assert.equal(r.status, 404);
+    assert.equal(r.payload.error.code, "NOT_FOUND");
+  });
+
+  it("POST /:id/rotate on a non-existent id → 404", async () => {
+    const r = await invokeRoute(
+      "POST",
+      "/api/v1/channels/tokens/01HZZZZZZZZZZZZZZZZZZZZZZZ/rotate",
+      { params: { id: "01HZZZZZZZZZZZZZZZZZZZZZZZ" } },
+    );
+    assert.equal(r.status, 404);
+  });
+
+  it("mint persists the row as sha256(raw_token) — never the raw bytes", async () => {
+    const m = await mintViaRoute("ha-conversation", "ha:hash-check");
+    const row = getStateDb()
+      .prepare(
+        "SELECT token_hash FROM channel_tokens WHERE id = ?",
+      )
+      .get(m.id) as { token_hash: string } | undefined;
+    assert.ok(row, "row exists");
+    assert.equal(
+      row!.token_hash,
+      hashToken(m.raw_token),
+      "stored hash is sha256(raw_token)",
+    );
+    // And the raw bytes never appear anywhere in the channel_tokens
+    // table:
+    const allRows = getStateDb()
+      .prepare("SELECT * FROM channel_tokens")
+      .all() as Array<Record<string, unknown>>;
+    for (const r of allRows) {
+      for (const v of Object.values(r)) {
+        if (typeof v === "string") {
+          assert.notEqual(
+            v,
+            m.raw_token,
+            "raw_token must never appear verbatim in the DB",
+          );
+        }
+      }
+    }
+  });
+
+  after(() => {
+    // Don't leak the master-key into other test files in this process.
+    _resetAuthForTests();
+  });
+});

--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -2689,24 +2689,59 @@ export const deleteFile = async (
 // 404 handling when the listener isn't enabled yet.
 // ============================================================
 
-/** Read the channel_tokens rows for `channel=ha-conversation`. Shape
- *  comes from ctrl-api's GET /api/v1/channel-tokens (PR #111 PR1):
- *  `{ tokens: ChannelTokenMeta[] }` where each meta omits the
- *  token_hash and includes a public-safe `scope`. The web layer
- *  passes through the rows verbatim; haConversationCardCore.ts
- *  groups/sorts/filters into the install-table shape. */
+/** Public-safe row shape returned by /api/v1/channels/tokens/* (#111
+ *  PR4). The ctrl-api wire format names the JSON-typed scope field
+ *  `scope_json` (mirroring the column name); the card's core helpers
+ *  read `scope`. We normalise at the boundary so the existing card
+ *  doesn't need to change. */
+interface ChannelTokenWireRow {
+  id: string;
+  channel: string;
+  label: string | null;
+  scope_json: Record<string, unknown> | null;
+  created_at: number;
+  last_used_at: number | null;
+  last_used_ip: string | null;
+  rotated_from: string | null;
+  revoked_at: number | null;
+}
+
+function wireRowToCardRow(r: ChannelTokenWireRow) {
+  return {
+    id: r.id,
+    channel: r.channel,
+    label: r.label,
+    scope: r.scope_json,
+    created_at: r.created_at,
+    last_used_at: r.last_used_at,
+    last_used_ip: r.last_used_ip,
+    rotated_from: r.rotated_from,
+    revoked_at: r.revoked_at,
+  };
+}
+
+/** Read the channel_tokens rows for `channel=ha-conversation`. Backed
+ *  by ctrl-api's canonical REST surface
+ *    GET /api/v1/channels/tokens?channel=ha-conversation
+ *  shipped in #111 PR4. Returns `{ tokens: ChannelTokenRow[] }` — the
+ *  card's haConversationCardCore.ts reads `t.scope.haInstanceId`, so
+ *  we normalise the wire's `scope_json` → `scope` here. */
 export const getHaInstalledTokens = async (_args: unknown, context: any) => {
   const instance = await getUserInstance(context);
   try {
-    return await proxyToTenant(instance, {
-      path: "/api/v1/channel-tokens",
+    const raw = (await proxyToTenant(instance, {
+      path: "/api/v1/channels/tokens",
       query: { channel: "ha-conversation" },
-    });
+    })) as { tokens?: ChannelTokenWireRow[] };
+    const tokens = Array.isArray(raw?.tokens)
+      ? raw.tokens.map(wireRowToCardRow)
+      : [];
+    return { tokens };
   } catch (e: any) {
-    // The shared channel-tokens surface lands in #111 PR1; the route
-    // is already on this branch, but tenants that haven't pulled the
-    // image yet will 404. Surface a graceful empty list so the card
-    // shows the "no installs yet" empty-state instead of an error.
+    // ctrl-api images predating PR4 will 404 the new path. Surface a
+    // graceful empty list so the card paints "no installs yet" instead
+    // of an error toast. The card has its own `unavailable` rendering
+    // for this signal.
     if (e instanceof HttpError && e.statusCode === 404) {
       return { tokens: [], unavailable: true };
     }
@@ -2717,7 +2752,12 @@ export const getHaInstalledTokens = async (_args: unknown, context: any) => {
 /** Mint a new ha-conversation channel token. The principal supplies
  *  a free-form label (typically `ha:<installId>`) and the install id
  *  (a uuid v4 or a slug) which we stash on `scope.haInstanceId` so
- *  ctrl-api's validator can pin auth back to a specific HA install. */
+ *  ctrl-api's validator can pin auth back to a specific HA install.
+ *
+ *  Backed by POST /api/v1/channels/tokens (#111 PR4). The card reads
+ *  `r.token` (legacy field name from the PR1 surface); we re-shape
+ *  the canonical `raw_token` response field to `token` at this layer
+ *  so the merged card (#137) keeps compiling unchanged. */
 export const mintHaChannelToken = async (
   args: { label?: string; installId?: string },
   context: any,
@@ -2735,23 +2775,40 @@ export const mintHaChannelToken = async (
   }
   const instance = await getUserInstance(context);
   try {
-    return await proxyToTenant(instance, {
+    const raw = (await proxyToTenant(instance, {
       method: "POST",
-      path: "/api/v1/channel-tokens/mint",
+      path: "/api/v1/channels/tokens",
       body: {
         channel: "ha-conversation",
         label: label ?? `ha:${installId}`,
         scope: { haInstanceId: installId },
       },
-    });
+    })) as {
+      id: string;
+      raw_token: string;
+      label: string | null;
+      created_at: number;
+      scope_json: Record<string, unknown> | null;
+    };
+    // Two-name response: `raw_token` matches the PR4 ctrl-api spec;
+    // `token` is the field the merged HaConversationSetupCard already
+    // reads. Both point at the same one-time string. `meta.id` mirrors
+    // the legacy mint shape so any other caller that grabs the id off
+    // `meta` (e.g. a CLI consumer) keeps working.
+    return {
+      id: raw.id,
+      label: raw.label,
+      created_at: raw.created_at,
+      raw_token: raw.raw_token,
+      token: raw.raw_token,
+      scope: raw.scope_json,
+      meta: { id: raw.id, label: raw.label, created_at: raw.created_at },
+    };
   } catch (e: any) {
-    // PR #111 PR4 will surface a user-facing mint flow; until then,
-    // bubble a recognisable error so the card can show "Coming in
-    // PR4" without breaking the page.
     if (e instanceof HttpError && e.statusCode === 404) {
       throw new HttpError(
         501,
-        "Mint surface not deployed yet (PR #111 PR4 lands the runtime mint).",
+        "Mint surface not deployed yet — ctrl-api image predates #111 PR4.",
       );
     }
     throw e;
@@ -2760,7 +2817,10 @@ export const mintHaChannelToken = async (
 
 /** Revoke (soft-delete) a channel token by id. The HA card uses this
  *  to retire an install — the per-install bearer stops authenticating
- *  on the next request. Idempotent on ctrl-api side. */
+ *  on the next request via channelTokenBearer. Idempotent at the
+ *  ctrl-api layer (revoking a revoked row is a no-op that still
+ *  returns 200). Backed by DELETE /api/v1/channels/tokens/:id (#111
+ *  PR4). */
 export const revokeChannelToken = async (
   args: { id?: string },
   context: any,
@@ -2771,14 +2831,14 @@ export const revokeChannelToken = async (
   const instance = await getUserInstance(context);
   try {
     return await proxyToTenant(instance, {
-      method: "POST",
-      path: `/api/v1/channel-tokens/${encodeURIComponent(args.id.trim())}/revoke`,
+      method: "DELETE",
+      path: `/api/v1/channels/tokens/${encodeURIComponent(args.id.trim())}`,
     });
   } catch (e: any) {
     if (e instanceof HttpError && e.statusCode === 404) {
       throw new HttpError(
         501,
-        "Revoke surface not deployed yet (PR #111 PR4 lands the runtime mint).",
+        "Revoke surface not deployed yet — ctrl-api image predates #111 PR4.",
       );
     }
     throw e;


### PR DESCRIPTION
## What this lands

The canonical REST surface for the shared `channel_tokens` table (the bearer-token store every external surface authenticates against), plus the Wasp wiring that points the merged `HaConversationSetupCard` (#137) at it.

## ctrl-api routes (new file `packages/ctrl/src/api/routes/channels_tokens.ts`)

| Method | Path | Purpose |
|--------|------|---------|
| `POST` | `/api/v1/channels/tokens` | mint — returns `raw_token` ONCE |
| `GET` | `/api/v1/channels/tokens?channel=...` | list (optional channel filter, `include_revoked=true` for audit) |
| `GET` | `/api/v1/channels/tokens/:id` | single row |
| `DELETE` | `/api/v1/channels/tokens/:id` | soft-revoke; sets `revoked_at = now()` |
| `POST` | `/api/v1/channels/tokens/:id/rotate` | mint fresh row + carry label/scope + set `rotated_from`; returns new `raw_token` ONCE |

**Auth.** All five are gated by the master `AAS_API_KEY` via the global `authenticate()` middleware. These are operator-facing routes. The TOKENS THIS MODULE MINTS are what external surfaces (HA conversation, HA voice, Paperclip heartbeat) actually validate against via `channelTokenBearer()`.

**Privacy contract.**
- `raw_token` appears EXACTLY ONCE — in the mint and rotate responses.
- `token_hash` is NEVER returned by any endpoint. It's `sha256(raw)`, stored at mint time, used only for the auth-path lookup.
- The channel discriminator pins auth — a leaked HA token cannot be replayed against a different channel.

**Rotate's grace window.** Rotate creates a fresh row carrying `label` + `scope`, sets `rotated_from = :id` on the new row, and leaves the old row active. Both validate via `channelTokenBearer` until the operator separately `DELETE`s the old row. This is the SSH-key-rotation pattern: rotate, install on the consuming side, revoke.

## Wasp wiring (`packages/web/src/dashboard/operations.ts`)

The placeholder ops shipped with #137 now route to the real ctrl-api surface:

- `getHaInstalledTokens` → `GET /api/v1/channels/tokens?channel=ha-conversation`
- `mintHaChannelToken(label, installId)` → `POST /api/v1/channels/tokens` with `scope.haInstanceId`
- `revokeChannelToken(id)` → `DELETE /api/v1/channels/tokens/:id`

The action signatures are unchanged, so `HaConversationSetupCard` doesn't need a recompile. The mint response carries both `raw_token` (the canonical name in the spec) and `token` (the legacy field the merged card reads), and remaps `scope_json` → `scope` to match the card's expected row shape.

## Back-compat

The legacy `/api/v1/channel-tokens/*` surface (#111 PR1) stays registered — existing fleet bearers + the `vault-cli channel-token` operator tooling keep working. It's just no longer the canonical write path.

## Tests

16 new tests in `packages/ctrl/tests/channels_tokens.test.ts` covering the full contract:

1. mint auth gate (`authenticate()` rejects without bearer; passes with master key)
2. mint returns `raw_token` ONCE; subsequent reads never re-expose it
3. response shapes NEVER carry `token_hash` (mint / list / get / filter / unfiltered)
4. list filtered by `channel` query (and unfiltered spans every channel)
5. `scope_json` round-trips through mint → list → get
6. label persists across mint → list → get
7. DELETE `/:id` sets `revoked_at` and returns `{ok, revoked_at}`
8. **Regression:** a revoked token is rejected by `channelTokenBearer` (the cross-route invariant)
9. rotate mints fresh row + `rotated_from` + carries label/scope; both validate during grace; only new after explicit DELETE
10. `last_used_at` + `last_used_ip` bumped on `channelTokenBearer` hit
11. mint with missing channel → 400
12. mint with unknown channel → 400 (only 3 allowed: `ha-conversation`, `ha-voice`, `paperclip-heartbeat`)
13. DELETE on non-existent id → 404
14. GET on non-existent id → 404
15. rotate on non-existent id → 404
16. raw token never appears verbatim in the DB; only `sha256(raw_token)` is stored

**All 16 pass.** Baseline 27 ctrl-api failures (pre-existing, see migration drift from #122 / #137 etc.) stay at 27 — zero new regressions.

```
Before:  501 tests, 473 pass, 27 fail
After:   517 tests, 489 pass, 27 fail
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)