### PR TITLE
feat(learn,ctrl): Recall.ai auto-dispatcher (#113 PR4)

### DIFF
--- a/packages/ctrl/src/api/routes/channels_recall.ts
+++ b/packages/ctrl/src/api/routes/channels_recall.ts
@@ -1,4 +1,4 @@
-// /api/v1/channels/recall/* — Recall.ai channel routes (#113 PR2).
+// /api/v1/channels/recall/* — Recall.ai channel routes (#113 PR2 + PR4).
 //
 // Recall.ai replaces the retired Vexa stack (#113 PR1) as the per-meeting
 // bot transport. Everything Sir needs to configure — API key, region, bot
@@ -9,19 +9,21 @@
 //
 // This file ships the ctrl-api half of the card-driven contract per spec
 // §5.1.1, plus the inbound Svix-signed webhook target per spec §5.4.
-// The 7 outbound routes are bearer-authed via the global AAS_API_KEY
+// The 7+ outbound routes are bearer-authed via the global AAS_API_KEY
 // gate (same as every other /channels/* route except the webhook target).
 //
 // Surface:
 //
-//   POST /api/v1/channels/recall/validate-key       — paste+round-trip test
-//   GET  /api/v1/channels/recall/config             — current dials
-//   PATCH /api/v1/channels/recall/config            — update dials
-//   GET  /api/v1/channels/recall/usage              — month-to-date rollup
-//   GET  /api/v1/channels/recall/bots/active        — non-terminal bots
-//   DELETE /api/v1/channels/recall/bots/:bot_id     — mid-meeting terminate
-//   POST /api/v1/channels/recall/webhook-test       — synthetic delivery
-//   POST /api/v1/webhooks/recall                    — Svix-signed inbound
+//   POST /api/v1/channels/recall/validate-key            — paste+round-trip test
+//   GET  /api/v1/channels/recall/config                  — current dials
+//   PATCH /api/v1/channels/recall/config                 — update dials
+//   GET  /api/v1/channels/recall/usage                   — month-to-date rollup
+//   GET  /api/v1/channels/recall/bots/active             — non-terminal bots
+//   POST /api/v1/channels/recall/bots                    — dispatch a bot (PR4)
+//   DELETE /api/v1/channels/recall/bots/:bot_id          — mid-meeting terminate
+//   POST /api/v1/channels/recall/bots/:bot_id/leave      — graceful leave (PR4)
+//   POST /api/v1/channels/recall/webhook-test            — synthetic delivery
+//   POST /api/v1/webhooks/recall                         — Svix-signed inbound
 //
 // Persistence: state.db tables recall_config / recall_bot / recall_event
 // (migration 0007_recall.sql). The card-side surface (PR3a/PR3b) reads
@@ -57,6 +59,50 @@ const VALID_RESPOND_MODES = ["off", "on_mention", "always"] as const;
 
 function recallBaseUrl(region: string): string {
   return RECALL_REGION_HOSTS[region] ?? RECALL_REGION_HOSTS["us-east-1"];
+}
+
+// ── meeting URL validation ────────────────────────────────────────────────
+//
+// PR4 — POST /bots accepts a meeting URL the dispatcher (alfred-learn)
+// or the card pulled out of a calendar event. We confirm the URL is
+// shaped like one of the three platforms Recall actually supports
+// today: Zoom, Google Meet, Microsoft Teams. Anything else gets a 400
+// so a stray "join here" link in a description doesn't try to spin
+// up a bot Recall would refuse anyway.
+//
+// Patterns are deliberately loose — Recall does the canonical
+// resolution (e.g. zoom.us/j/... with a passcode encoded into the
+// link). We only confirm the host *family* matches one of the three.
+const MEETING_HOST_PATTERNS: Array<{ name: string; re: RegExp }> = [
+  { name: "zoom", re: /\b(?:[a-z0-9-]+\.)?zoom\.(?:us|com)\b/i },
+  { name: "meet", re: /\bmeet\.google\.com\b/i },
+  { name: "teams", re: /\bteams\.(?:microsoft|live)\.com\b/i },
+];
+
+interface MeetingUrlInfo {
+  platform: "zoom" | "meet" | "teams";
+  normalized: string;
+}
+
+export function classifyMeetingUrl(url: string): MeetingUrlInfo | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url.trim());
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    return null;
+  }
+  for (const { name, re } of MEETING_HOST_PATTERNS) {
+    if (re.test(parsed.host)) {
+      return {
+        platform: name as MeetingUrlInfo["platform"],
+        normalized: parsed.toString(),
+      };
+    }
+  }
+  return null;
 }
 
 // ── recall_config row helpers ─────────────────────────────────────────────
@@ -633,6 +679,7 @@ export const _recallInternals = {
   getOrSeedConfig,
   statusFromEvent,
   parseConfigPatch,
+  classifyMeetingUrl,
 };
 
 // ── Routes ────────────────────────────────────────────────────────────────
@@ -780,6 +827,301 @@ export function registerChannelsRecallRoutes(): void {
         transcript_url: string | null;
       }>;
       sendJson(res, 200, { bots: rows });
+    },
+  );
+
+  // POST /api/v1/channels/recall/bots — dispatch a Recall bot (#113 PR4).
+  //
+  // Body: { meeting_url: string, bot_name?: string,
+  //         calendar_event_id?: string, scheduled_join_time?: string }
+  //
+  // Posts to Recall's POST /api/v2/bot create-bot endpoint with the
+  // configured bot_name, recording_config defaults, and an optional
+  // `join_at` if `scheduled_join_time` is in the future. The full
+  // Recall payload is persisted verbatim into recall_bot.json so we can
+  // re-derive any field later (transcript URL surfacing, etc.) without a
+  // migration.
+  //
+  // Two consumers:
+  //   1. The alfred-learn RecallDispatcherWorkflow (PR4) walks the
+  //      principal's calendar and POSTs here for each policy-passing
+  //      meeting.
+  //   2. The /channels Recall card's manual "Send bot now" button
+  //      (PR3a) POSTs here with just the meeting URL.
+  //
+  // Idempotence: if the request carries `calendar_event_id` and a
+  // recall_bot row already exists for it in a non-terminal state, we
+  // 200 the existing row instead of creating a second Recall bot. The
+  // dispatcher uses this as its dedupe surface; the card's manual path
+  // bypasses it (no calendar_event_id sent).
+  addRoute(
+    "POST",
+    "/api/v1/channels/recall/bots",
+    async ({ res, body }) => {
+      const b = (body ?? {}) as Record<string, unknown>;
+      if (typeof b.meeting_url !== "string" || b.meeting_url.trim().length === 0) {
+        throw new ValidationError("meeting_url (non-empty string) is required");
+      }
+      const meetingInfo = classifyMeetingUrl(b.meeting_url);
+      if (!meetingInfo) {
+        throw new ValidationError(
+          "meeting_url must point at zoom.us, meet.google.com, or teams.microsoft.com",
+        );
+      }
+      let calendarEventId: string | null = null;
+      if (b.calendar_event_id !== undefined && b.calendar_event_id !== null) {
+        if (
+          typeof b.calendar_event_id !== "string" ||
+          b.calendar_event_id.length > 256
+        ) {
+          throw new ValidationError(
+            "calendar_event_id must be a string ≤256 chars",
+          );
+        }
+        calendarEventId = b.calendar_event_id.trim() || null;
+      }
+      let scheduledJoinTime: string | null = null;
+      if (b.scheduled_join_time !== undefined && b.scheduled_join_time !== null) {
+        if (typeof b.scheduled_join_time !== "string") {
+          throw new ValidationError(
+            "scheduled_join_time must be an ISO 8601 string",
+          );
+        }
+        const ts = Date.parse(b.scheduled_join_time);
+        if (!Number.isFinite(ts)) {
+          throw new ValidationError(
+            "scheduled_join_time must be a valid ISO 8601 datetime",
+          );
+        }
+        scheduledJoinTime = new Date(ts).toISOString();
+      }
+      const apiKey = process.env.RECALL_API_KEY?.trim();
+      if (!apiKey) {
+        throw new ApiError(
+          503,
+          "NOT_CONFIGURED",
+          "RECALL_API_KEY is not set on this tenant",
+        );
+      }
+      const db = getStateDb();
+      const cfg = getOrSeedConfig(db);
+
+      // Idempotence on calendar_event_id — if the dispatcher already
+      // created a bot for this meeting, return the existing row.
+      if (calendarEventId) {
+        const existing = db
+          .prepare(
+            `SELECT id, status, json
+               FROM recall_bot
+              WHERE calendar_event_id = ?
+                AND status NOT IN ('done','fail')
+              ORDER BY created_at DESC
+              LIMIT 1`,
+          )
+          .get(calendarEventId) as
+          | { id: string; status: string; json: string }
+          | undefined;
+        if (existing) {
+          sendJson(res, 200, {
+            bot_id: existing.id,
+            status: existing.status,
+            recall_url: null,
+            note: "existing bot for this calendar_event_id",
+          });
+          return;
+        }
+      }
+
+      const botName =
+        typeof b.bot_name === "string" && b.bot_name.trim().length > 0
+          ? b.bot_name.trim().slice(0, 200)
+          : cfg.bot_name;
+
+      const recallBody: Record<string, unknown> = {
+        meeting_url: meetingInfo.normalized,
+        bot_name: botName,
+        recording_config: {
+          transcript: { provider: { meeting_captions: {} } },
+        },
+      };
+      if (scheduledJoinTime) {
+        recallBody.join_at = scheduledJoinTime;
+      }
+
+      const base = recallBaseUrl(cfg.region);
+      const url = `${base}/api/v2/bot`;
+      let resp: Response;
+      try {
+        resp = await fetch(url, {
+          method: "POST",
+          headers: {
+            Authorization: `Token ${apiKey}`,
+            "Content-Type": "application/json",
+            Accept: "application/json",
+          },
+          body: JSON.stringify(recallBody),
+          signal: AbortSignal.timeout(15_000),
+        });
+      } catch (err) {
+        // Never include the API key in the surfaced message — only the
+        // request error.
+        throw new ApiError(
+          502,
+          "RECALL_UNREACHABLE",
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+      if (!resp.ok) {
+        let detail = "";
+        try {
+          detail = (await resp.text()).slice(0, 200);
+        } catch {
+          /* swallow */
+        }
+        // Prefix-only key fingerprint for log correlation; the key
+        // itself never leaves the env.
+        const keyPrefix = apiKey.slice(0, 6);
+        console.warn(
+          `[recall] create-bot HTTP ${resp.status} (key ${keyPrefix}…): ${detail}`,
+        );
+        throw new ApiError(
+          resp.status === 401 || resp.status === 403 ? 503 : 502,
+          resp.status === 401 || resp.status === 403
+            ? "NOT_CONFIGURED"
+            : "RECALL_REJECTED",
+          `Recall returned HTTP ${resp.status}${detail ? ` — ${detail}` : ""}`,
+        );
+      }
+      let payload: Record<string, unknown> = {};
+      try {
+        payload = (await resp.json()) as Record<string, unknown>;
+      } catch {
+        // Recall returned 2xx with a non-JSON body. Treat as a soft
+        // failure — we have no bot_id to persist.
+        throw new ApiError(
+          502,
+          "RECALL_REJECTED",
+          "Recall returned a non-JSON success body",
+        );
+      }
+      const botId =
+        typeof payload.id === "string"
+          ? payload.id
+          : typeof payload.bot_id === "string"
+            ? payload.bot_id
+            : null;
+      if (!botId) {
+        throw new ApiError(
+          502,
+          "RECALL_REJECTED",
+          "Recall response did not include a bot id",
+        );
+      }
+      const recallUrl =
+        typeof payload.recording_url === "string"
+          ? payload.recording_url
+          : typeof payload.url === "string"
+            ? payload.url
+            : null;
+      const now = Date.now();
+      db.prepare(
+        `INSERT INTO recall_bot (id, calendar_event_id, meeting_url, status, created_at, json)
+           VALUES (?, ?, ?, 'requested', ?, ?)`,
+      ).run(
+        botId,
+        calendarEventId,
+        meetingInfo.normalized,
+        now,
+        JSON.stringify(payload),
+      );
+      sendJson(res, 200, {
+        bot_id: botId,
+        status: "requested",
+        recall_url: recallUrl,
+      });
+    },
+  );
+
+  // POST /api/v1/channels/recall/bots/:bot_id/leave — graceful leave (#113 PR4).
+  //
+  // Semantically identical to the DELETE route (Recall's API exposes
+  // exactly one "remove bot from call" verb) but matches the spec's
+  // POST-leave wording and gives the dispatcher / card a verb that
+  // reads naturally in their own code paths ("send bot home" vs
+  // "delete bot").
+  addRoute(
+    "POST",
+    "/api/v1/channels/recall/bots/:bot_id/leave",
+    async ({ res, params }) => {
+      const botId = params.bot_id;
+      if (!botId || botId.length > 200) {
+        throw new ValidationError("bot_id must be a non-empty string ≤200 chars");
+      }
+      const apiKey = process.env.RECALL_API_KEY?.trim();
+      if (!apiKey) {
+        throw new ApiError(
+          503,
+          "NOT_CONFIGURED",
+          "RECALL_API_KEY is not set on this tenant",
+        );
+      }
+      const db = getStateDb();
+      const cfg = getOrSeedConfig(db);
+      const base = recallBaseUrl(cfg.region);
+      const url = `${base}/api/v1/bot/${encodeURIComponent(botId)}/`;
+      let resp: Response;
+      try {
+        resp = await fetch(url, {
+          method: "DELETE",
+          headers: {
+            Authorization: `Token ${apiKey}`,
+            Accept: "application/json",
+          },
+          signal: AbortSignal.timeout(10_000),
+        });
+      } catch (err) {
+        throw new ApiError(
+          502,
+          "RECALL_UNREACHABLE",
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+      if (resp.status === 404) {
+        db.prepare(
+          `UPDATE recall_bot
+              SET status = 'done',
+                  left_at = COALESCE(left_at, ?)
+            WHERE id = ? AND status NOT IN ('done','fail')`,
+        ).run(Date.now(), botId);
+        sendJson(res, 200, {
+          ok: true,
+          bot_id: botId,
+          status: "done",
+          note: "Recall reported 404; local row marked done",
+        });
+        return;
+      }
+      if (!resp.ok) {
+        let detail = "";
+        try {
+          detail = (await resp.text()).slice(0, 200);
+        } catch {
+          /* swallow */
+        }
+        throw new ApiError(
+          502,
+          "RECALL_REJECTED",
+          `Recall returned HTTP ${resp.status}${detail ? ` — ${detail}` : ""}`,
+        );
+      }
+      const now = Date.now();
+      db.prepare(
+        `UPDATE recall_bot
+            SET status = CASE WHEN status IN ('done','fail') THEN status ELSE 'leaving' END,
+                left_at = COALESCE(left_at, ?)
+          WHERE id = ?`,
+      ).run(now, botId);
+      sendJson(res, 200, { ok: true, bot_id: botId, status: "leaving" });
     },
   );
 

--- a/packages/ctrl/tests/channels_recall_dispatch.test.ts
+++ b/packages/ctrl/tests/channels_recall_dispatch.test.ts
@@ -1,0 +1,506 @@
+// channels_recall_dispatch — POST /bots + POST /bots/:id/leave + webhook
+// state flip + GET /bots/active (#113 PR4).
+//
+// This file ships the ctrl-api half of the PR4 task spec. The Recall.ai
+// API is stubbed at the global fetch boundary the same way as
+// channels_recall.test.ts — we never reach out to recall.ai. The
+// state.db migration 0007_recall has already created the recall_*
+// tables by the time `getStateDb()` returns.
+//
+// Cases (per PR4 spec):
+//   1. POST /bots with valid Zoom URL → 200 + bot_id + recall_bot row inserted
+//   2. POST /bots with valid Meet URL → 200 + row inserted
+//   3. POST /bots with valid Teams URL → 200 + row inserted
+//   4. POST /bots with invalid URL → 400 VALIDATION_ERROR
+//   5. POST /bots without RECALL_API_KEY → 503 NOT_CONFIGURED
+//   6. POST /bots Recall returns 401 → 503 (NOT_CONFIGURED on auth failures)
+//   7. POST /bots Recall returns 422 → 502 RECALL_REJECTED
+//   8. POST /bots is idempotent on calendar_event_id (no second Recall call)
+//   9. POST /bots respects bot_name override (sent to Recall in body)
+//  10. POST /bots/:id/leave flips local row to "leaving"
+//  11. POST /bots/:id/leave with 404 from Recall marks row "done"
+//  12. POST /bots/:id/leave without API key → 503
+//  13. Webhook bot.in_call_recording flips status to in_meeting
+//  14. Webhook bot.done flips status to done + stamps left_at
+//  15. GET /bots/active returns inserted bot
+
+import { describe, it, before, beforeEach, after } from "node:test";
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ServerResponse } from "node:http";
+
+// ── fixture dir ───────────────────────────────────────────────────────────
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "channels-recall-dispatch-"));
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.VAULT_PATH = path.join(tmp, "vault");
+process.env.STATE_DB_PATH = path.join(tmp, "alfred-state.db");
+process.env.SQLITE_VEC_PATH = "";
+process.env.DOMAIN = "test.alfred.black";
+process.env.AAS_HOST = "127.0.0.1";
+process.env.AAS_PORT = "3100";
+delete process.env.RECALL_API_KEY;
+delete process.env.RECALL_WEBHOOK_SECRET;
+
+// ── Recall stub ───────────────────────────────────────────────────────────
+
+interface RecallStub {
+  createBotStatus: number;
+  createBotBody: unknown;
+  // capture the last create-bot request so tests can assert the body
+  lastCreateBody: unknown | null;
+  // for the leave/delete path
+  deleteBotStatus: number;
+}
+
+const originalFetch = globalThis.fetch;
+
+const recallStub: RecallStub = {
+  createBotStatus: 200,
+  createBotBody: { id: "bot-default", recording_url: "https://recall.example/bot-default" },
+  lastCreateBody: null,
+  deleteBotStatus: 200,
+};
+
+function makeJsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+globalThis.fetch = (async (input: any, init?: any) => {
+  const url = typeof input === "string" ? input : (input?.url ?? String(input));
+  const method = (init?.method ?? "GET").toUpperCase();
+
+  // Recall POST /api/v2/bot — create-bot
+  if (
+    method === "POST" &&
+    /\/api\/v2\/bot$/.test(url) &&
+    /recall\.ai/.test(url)
+  ) {
+    try {
+      recallStub.lastCreateBody = init?.body
+        ? JSON.parse(String(init.body))
+        : null;
+    } catch {
+      recallStub.lastCreateBody = init?.body;
+    }
+    return makeJsonResponse(recallStub.createBotBody, recallStub.createBotStatus);
+  }
+  // Recall DELETE /api/v1/bot/:id/ — leave path
+  if (
+    method === "DELETE" &&
+    /\/api\/v1\/bot\/[^/]+\/?$/.test(url) &&
+    /recall\.ai/.test(url)
+  ) {
+    const status = recallStub.deleteBotStatus;
+    if (status === 204) return new Response(null, { status });
+    return makeJsonResponse({}, status);
+  }
+  throw new Error(`unexpected fetch in dispatch test: ${method} ${url}`);
+}) as typeof fetch;
+
+// ── module imports (after env + fetch are set) ─────────────────────────────
+
+const { matchRoute } = await import("../src/api/server.js");
+const { handleError } = await import("../src/api/errors.js");
+const {
+  registerChannelsRecallRoutes,
+  registerRecallWebhookRoute,
+  _recallInternals,
+} = await import("../src/api/routes/channels_recall.js");
+const { getStateDb } = await import("../src/db/state.js");
+registerChannelsRecallRoutes();
+registerRecallWebhookRoute();
+
+async function invokeRoute(
+  method: string,
+  p: string,
+  body?: unknown,
+  headers: Record<string, string> = {},
+): Promise<{ status: number; payload: any }> {
+  const m = matchRoute(method, p);
+  assert.ok(m, `${method} ${p} must be registered`);
+  let status = 0;
+  let payload: any;
+  const res = {
+    statusCode: 0,
+    setHeader() {},
+    writeHead(c: number) {
+      status = c;
+      return res;
+    },
+    end(j?: string) {
+      payload = j ? JSON.parse(j) : undefined;
+    },
+  } as unknown as ServerResponse;
+  try {
+    await m!.handler({
+      req: { method, url: p, headers } as any,
+      res,
+      params: m!.params,
+      body,
+      query: new URLSearchParams(),
+    });
+  } catch (err) {
+    handleError(res, err);
+  }
+  return { status, payload };
+}
+
+// ── DB helpers ─────────────────────────────────────────────────────────────
+
+function clearDb() {
+  const db = getStateDb();
+  db.exec("DELETE FROM recall_event");
+  db.exec("DELETE FROM recall_bot");
+  db.exec("DELETE FROM recall_config");
+}
+
+function getBotRow(id: string) {
+  const db = getStateDb();
+  return db.prepare(`SELECT * FROM recall_bot WHERE id = ?`).get(id) as
+    | Record<string, any>
+    | undefined;
+}
+
+// ── webhook signing ───────────────────────────────────────────────────────
+
+const WEBHOOK_SECRET = "test-recall-secret";
+
+function signSvix(
+  rawBody: Buffer,
+  opts: { secret?: string; ts?: number; id?: string } = {},
+): Record<string, string> {
+  const secret = opts.secret ?? WEBHOOK_SECRET;
+  const ts = opts.ts ?? Math.floor(Date.now() / 1000);
+  const id = opts.id ?? `evt-${ts}`;
+  const secretBytes = secret.startsWith("whsec_")
+    ? Buffer.from(secret.slice("whsec_".length), "base64")
+    : Buffer.from(secret, "utf-8");
+  const signed = Buffer.concat([
+    Buffer.from(`${id}.${ts}.`, "utf-8"),
+    rawBody,
+  ]);
+  const v1 = crypto
+    .createHmac("sha256", secretBytes)
+    .update(signed)
+    .digest("base64");
+  return {
+    "content-type": "application/json",
+    "svix-id": id,
+    "svix-timestamp": String(ts),
+    "svix-signature": `v1,${v1}`,
+  };
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────
+
+describe("/api/v1/channels/recall — dispatcher routes (#113 PR4)", () => {
+  before(() => {
+    getStateDb();
+  });
+
+  beforeEach(() => {
+    clearDb();
+    recallStub.createBotStatus = 200;
+    recallStub.createBotBody = {
+      id: "bot-default",
+      recording_url: "https://recall.example/bot-default",
+    };
+    recallStub.lastCreateBody = null;
+    recallStub.deleteBotStatus = 200;
+    delete process.env.RECALL_API_KEY;
+    delete process.env.RECALL_WEBHOOK_SECRET;
+  });
+
+  after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe("classifyMeetingUrl (pure)", () => {
+    it("recognises a zoom.us URL", () => {
+      const r = _recallInternals.classifyMeetingUrl("https://zoom.us/j/123");
+      assert.equal(r?.platform, "zoom");
+    });
+    it("recognises a subdomain zoom URL", () => {
+      const r = _recallInternals.classifyMeetingUrl(
+        "https://acme.zoom.us/j/123?pwd=x",
+      );
+      assert.equal(r?.platform, "zoom");
+    });
+    it("recognises a meet.google.com URL", () => {
+      const r = _recallInternals.classifyMeetingUrl("https://meet.google.com/abc-defg-hij");
+      assert.equal(r?.platform, "meet");
+    });
+    it("recognises a teams.microsoft.com URL", () => {
+      const r = _recallInternals.classifyMeetingUrl(
+        "https://teams.microsoft.com/l/meetup-join/abc",
+      );
+      assert.equal(r?.platform, "teams");
+    });
+    it("rejects a random URL", () => {
+      assert.equal(
+        _recallInternals.classifyMeetingUrl("https://example.com/foo"),
+        null,
+      );
+    });
+    it("rejects a non-URL", () => {
+      assert.equal(_recallInternals.classifyMeetingUrl("not a url"), null);
+    });
+  });
+
+  describe("POST /api/v1/channels/recall/bots", () => {
+    it("creates a bot with a valid Zoom URL → 200 + recall_bot row", async () => {
+      process.env.RECALL_API_KEY = "rec_test_key";
+      recallStub.createBotBody = {
+        id: "bot-abc-001",
+        recording_url: "https://recall.example/bot-abc-001",
+      };
+      const r = await invokeRoute("POST", "/api/v1/channels/recall/bots", {
+        meeting_url: "https://zoom.us/j/123456",
+      });
+      assert.equal(r.status, 200);
+      assert.equal(r.payload.bot_id, "bot-abc-001");
+      assert.equal(r.payload.status, "requested");
+      assert.equal(r.payload.recall_url, "https://recall.example/bot-abc-001");
+      const row = getBotRow("bot-abc-001");
+      assert.ok(row, "recall_bot row must be inserted");
+      assert.equal(row!.status, "requested");
+      assert.equal(row!.meeting_url, "https://zoom.us/j/123456");
+    });
+
+    it("accepts a Meet URL", async () => {
+      process.env.RECALL_API_KEY = "rec_test_key";
+      recallStub.createBotBody = { id: "bot-meet-1" };
+      const r = await invokeRoute("POST", "/api/v1/channels/recall/bots", {
+        meeting_url: "https://meet.google.com/abc-defg-hij",
+      });
+      assert.equal(r.status, 200);
+      assert.equal(r.payload.bot_id, "bot-meet-1");
+    });
+
+    it("accepts a Teams URL", async () => {
+      process.env.RECALL_API_KEY = "rec_test_key";
+      recallStub.createBotBody = { id: "bot-teams-1" };
+      const r = await invokeRoute("POST", "/api/v1/channels/recall/bots", {
+        meeting_url: "https://teams.microsoft.com/l/meetup-join/abc",
+      });
+      assert.equal(r.status, 200);
+      assert.equal(r.payload.bot_id, "bot-teams-1");
+    });
+
+    it("400 VALIDATION_ERROR on an unknown meeting URL", async () => {
+      process.env.RECALL_API_KEY = "rec_test_key";
+      const r = await invokeRoute("POST", "/api/v1/channels/recall/bots", {
+        meeting_url: "https://example.com/foo",
+      });
+      assert.equal(r.status, 400);
+      assert.equal(r.payload.error.code, "VALIDATION_ERROR");
+    });
+
+    it("400 VALIDATION_ERROR when meeting_url is missing", async () => {
+      process.env.RECALL_API_KEY = "rec_test_key";
+      const r = await invokeRoute("POST", "/api/v1/channels/recall/bots", {});
+      assert.equal(r.status, 400);
+      assert.equal(r.payload.error.code, "VALIDATION_ERROR");
+    });
+
+    it("503 NOT_CONFIGURED when RECALL_API_KEY is absent", async () => {
+      const r = await invokeRoute("POST", "/api/v1/channels/recall/bots", {
+        meeting_url: "https://zoom.us/j/1",
+      });
+      assert.equal(r.status, 503);
+      assert.equal(r.payload.error.code, "NOT_CONFIGURED");
+    });
+
+    it("Recall 401 surfaces as 503 NOT_CONFIGURED", async () => {
+      process.env.RECALL_API_KEY = "rec_test_key";
+      recallStub.createBotStatus = 401;
+      recallStub.createBotBody = { detail: "Invalid token." };
+      const r = await invokeRoute("POST", "/api/v1/channels/recall/bots", {
+        meeting_url: "https://zoom.us/j/1",
+      });
+      assert.equal(r.status, 503);
+      assert.equal(r.payload.error.code, "NOT_CONFIGURED");
+    });
+
+    it("Recall 422 surfaces as 502 RECALL_REJECTED", async () => {
+      process.env.RECALL_API_KEY = "rec_test_key";
+      recallStub.createBotStatus = 422;
+      recallStub.createBotBody = { detail: "Unsupported meeting URL" };
+      const r = await invokeRoute("POST", "/api/v1/channels/recall/bots", {
+        meeting_url: "https://zoom.us/j/1",
+      });
+      assert.equal(r.status, 502);
+      assert.equal(r.payload.error.code, "RECALL_REJECTED");
+    });
+
+    it("idempotent on calendar_event_id — second POST returns existing row", async () => {
+      process.env.RECALL_API_KEY = "rec_test_key";
+      recallStub.createBotBody = { id: "bot-cal-1" };
+      const a = await invokeRoute("POST", "/api/v1/channels/recall/bots", {
+        meeting_url: "https://zoom.us/j/1",
+        calendar_event_id: "gcal-evt-42",
+      });
+      assert.equal(a.status, 200);
+      assert.equal(a.payload.bot_id, "bot-cal-1");
+
+      // Second call would *try* to create bot-cal-2 if not for dedupe.
+      recallStub.createBotBody = { id: "bot-cal-2" };
+      recallStub.lastCreateBody = null;
+      const b = await invokeRoute("POST", "/api/v1/channels/recall/bots", {
+        meeting_url: "https://zoom.us/j/1",
+        calendar_event_id: "gcal-evt-42",
+      });
+      assert.equal(b.status, 200);
+      assert.equal(b.payload.bot_id, "bot-cal-1", "must return existing bot");
+      assert.equal(
+        recallStub.lastCreateBody,
+        null,
+        "must NOT have re-called Recall create-bot",
+      );
+    });
+
+    it("respects bot_name override (sent verbatim to Recall)", async () => {
+      process.env.RECALL_API_KEY = "rec_test_key";
+      recallStub.createBotBody = { id: "bot-name-1" };
+      await invokeRoute("POST", "/api/v1/channels/recall/bots", {
+        meeting_url: "https://zoom.us/j/2",
+        bot_name: "Cratchit",
+      });
+      const body = recallStub.lastCreateBody as Record<string, any>;
+      assert.equal(body?.bot_name, "Cratchit");
+      assert.equal(body?.meeting_url, "https://zoom.us/j/2");
+    });
+
+    it("400 VALIDATION_ERROR on a malformed scheduled_join_time", async () => {
+      process.env.RECALL_API_KEY = "rec_test_key";
+      const r = await invokeRoute("POST", "/api/v1/channels/recall/bots", {
+        meeting_url: "https://zoom.us/j/1",
+        scheduled_join_time: "not a date",
+      });
+      assert.equal(r.status, 400);
+      assert.equal(r.payload.error.code, "VALIDATION_ERROR");
+    });
+  });
+
+  describe("POST /api/v1/channels/recall/bots/:bot_id/leave", () => {
+    it("flips an in-flight row to 'leaving'", async () => {
+      process.env.RECALL_API_KEY = "rec_test_key";
+      const db = getStateDb();
+      db.prepare(
+        `INSERT INTO recall_bot (id, status, created_at, json) VALUES (?, 'in_meeting', ?, '{}')`,
+      ).run("bot-leave-1", Date.now());
+      const r = await invokeRoute(
+        "POST",
+        "/api/v1/channels/recall/bots/bot-leave-1/leave",
+      );
+      assert.equal(r.status, 200);
+      assert.equal(r.payload.status, "leaving");
+      const row = getBotRow("bot-leave-1");
+      assert.equal(row!.status, "leaving");
+      assert.ok(row!.left_at);
+    });
+
+    it("404 from Recall marks the local row 'done'", async () => {
+      process.env.RECALL_API_KEY = "rec_test_key";
+      const db = getStateDb();
+      db.prepare(
+        `INSERT INTO recall_bot (id, status, created_at, json) VALUES (?, 'in_meeting', ?, '{}')`,
+      ).run("bot-leave-404", Date.now());
+      recallStub.deleteBotStatus = 404;
+      const r = await invokeRoute(
+        "POST",
+        "/api/v1/channels/recall/bots/bot-leave-404/leave",
+      );
+      assert.equal(r.status, 200);
+      assert.equal(r.payload.status, "done");
+      const row = getBotRow("bot-leave-404");
+      assert.equal(row!.status, "done");
+    });
+
+    it("503 NOT_CONFIGURED without RECALL_API_KEY", async () => {
+      const r = await invokeRoute(
+        "POST",
+        "/api/v1/channels/recall/bots/anything/leave",
+      );
+      assert.equal(r.status, 503);
+      assert.equal(r.payload.error.code, "NOT_CONFIGURED");
+    });
+  });
+
+  describe("webhook event flips status", () => {
+    it("bot.in_call_recording → in_meeting + stamps joined_at", async () => {
+      process.env.RECALL_WEBHOOK_SECRET = WEBHOOK_SECRET;
+      const db = getStateDb();
+      db.prepare(
+        `INSERT INTO recall_bot (id, status, created_at, json) VALUES (?, 'requested', ?, '{}')`,
+      ).run("bot-wh-1", Date.now());
+
+      const payload = { event: "bot.in_call_recording", data: { bot_id: "bot-wh-1" } };
+      const rawBody = Buffer.from(JSON.stringify(payload));
+      const headers = signSvix(rawBody);
+      const r = await invokeRoute(
+        "POST",
+        "/api/v1/webhooks/recall",
+        rawBody,
+        headers,
+      );
+      assert.equal(r.status, 200);
+      assert.equal(r.payload.ok, true);
+      assert.equal(r.payload.new_status, "in_meeting");
+      const row = getBotRow("bot-wh-1");
+      assert.equal(row!.status, "in_meeting");
+      assert.ok(row!.joined_at);
+    });
+
+    it("bot.done → done + stamps left_at", async () => {
+      process.env.RECALL_WEBHOOK_SECRET = WEBHOOK_SECRET;
+      const db = getStateDb();
+      const t0 = Date.now() - 1000;
+      db.prepare(
+        `INSERT INTO recall_bot (id, status, created_at, joined_at, json) VALUES (?, 'in_meeting', ?, ?, '{}')`,
+      ).run("bot-wh-2", t0, t0);
+
+      const payload = { event: "bot.done", data: { bot: { id: "bot-wh-2" } } };
+      const rawBody = Buffer.from(JSON.stringify(payload));
+      const headers = signSvix(rawBody);
+      const r = await invokeRoute(
+        "POST",
+        "/api/v1/webhooks/recall",
+        rawBody,
+        headers,
+      );
+      assert.equal(r.status, 200);
+      assert.equal(r.payload.new_status, "done");
+      const row = getBotRow("bot-wh-2");
+      assert.equal(row!.status, "done");
+      assert.ok(row!.left_at);
+    });
+  });
+
+  describe("GET /api/v1/channels/recall/bots/active", () => {
+    it("returns the inserted bot when status is non-terminal", async () => {
+      process.env.RECALL_API_KEY = "rec_test_key";
+      recallStub.createBotBody = { id: "bot-active-1" };
+      await invokeRoute("POST", "/api/v1/channels/recall/bots", {
+        meeting_url: "https://zoom.us/j/777",
+        calendar_event_id: "gcal-active",
+      });
+      const r = await invokeRoute(
+        "GET",
+        "/api/v1/channels/recall/bots/active",
+      );
+      assert.equal(r.status, 200);
+      assert.ok(Array.isArray(r.payload.bots));
+      assert.equal(r.payload.bots.length, 1);
+      assert.equal(r.payload.bots[0].id, "bot-active-1");
+      assert.equal(r.payload.bots[0].calendar_event_id, "gcal-active");
+    });
+  });
+});

--- a/packages/learn/scripts/register_schedules.py
+++ b/packages/learn/scripts/register_schedules.py
@@ -284,6 +284,21 @@ INTERVAL_SCHEDULES = [
         "workflow": "DecayWatcherWorkflow",
         "interval": timedelta(hours=6),
     },
+    {
+        # Recall.ai dispatcher (#113 PR4) — every 5 min reads the
+        # principal's Google Calendar for the next 15 min, applies
+        # the operator-configured auto_join_policy (off /
+        # principal_attendee / all), dedupes against
+        # already-dispatched calendar_event_ids, refuses dispatches
+        # that would blow the monthly_hours_cap, and POSTs to
+        # ctrl-api's create-bot route for each surviving event. The
+        # workflow is a no-op when auto_join_policy=off, so leaving
+        # the schedule registered on tenants that haven't enabled
+        # Recall costs only one ctrl-api GET per tick.
+        "id": "al-recall-dispatcher",
+        "workflow": "RecallDispatcherWorkflow",
+        "interval": timedelta(minutes=5),
+    },
 ]
 
 CALENDAR_SCHEDULES = [

--- a/packages/learn/src/activities/recall_dispatcher.py
+++ b/packages/learn/src/activities/recall_dispatcher.py
@@ -1,0 +1,523 @@
+"""Activities for the Recall.ai auto-dispatcher (#113 PR4).
+
+The dispatcher walks the principal's calendar every five minutes and
+asks ctrl-api to spin up a Recall bot for each meeting whose host /
+attendee shape matches the operator's ``auto_join_policy``. Three
+activities + a small helper module:
+
+  1. ``fetch_upcoming_calendar_events`` — pulls the next N minutes of
+     events via ``POST /api/v1/integrations/execute`` with
+     ``GOOGLECALENDAR_LIST_EVENTS``. Extracts ``meeting_url`` from each
+     event's hangoutLink, conferenceData, location, or description.
+     Returns a normalised list the workflow + the policy gate can read
+     without re-parsing.
+
+  2. ``check_recall_dispatch_state`` — pulls the current Recall config,
+     the month-to-date usage, and the set of already-dispatched
+     calendar_event_ids. The workflow uses the result to (a) read the
+     policy, (b) refuse dispatch when the projected cap would be
+     blown, (c) dedupe against bots already requested for the same
+     event.
+
+  3. ``dispatch_recall_bot`` — POSTs to ``/api/v1/channels/recall/bots``
+     with the meeting URL, the configured bot name, the calendar event
+     id (so the route can dedupe on its end too), and an optional
+     ``scheduled_join_time``. The ctrl-api side already inserts the
+     ``recall_bot`` row; we just return the response envelope so the
+     workflow can log per-meeting outcomes.
+
+Policy gate (the workflow code calls this — kept pure so tests can drive
+it without Temporal) reads the recall_config's ``auto_join_policy``
+column. The DB stores three canonical values (migration 0007_recall):
+
+  ``off``                — never auto-dispatch
+  ``principal_attendee`` — only when the principal is an attendee
+                           and a meeting URL is present
+  ``all``                — every event with a meeting URL
+
+These names are the ones in the schema today; the PR4 spec uses
+"off / manual_only / calendar_only / all_meetings" interchangeably,
+which map as:
+
+  ``off``           ←→ off / manual_only        — no dispatch
+  ``principal_attendee`` ←→ calendar_only        — dispatch on principal-attended events
+  ``all``           ←→ all_meetings              — dispatch on any event with URL
+
+The gate canonicalises whatever the config carries and refuses anything
+unknown (defensive — the PATCH route validates on the way in, but a
+hand-edited row shouldn't take the dispatcher down).
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterable
+
+import httpx
+from temporalio import activity
+
+from src.config import load_config
+
+logger = logging.getLogger("recall-dispatcher")
+
+
+# ── ctrl-api helpers ─────────────────────────────────────────────────────
+
+
+async def _ctrl_get(
+    path: str, params: dict[str, str] | None = None
+) -> dict[str, Any]:
+    config = load_config()
+    api_key = os.environ.get("AAS_API_KEY", "")
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    url = f"{config.alfred_ctrl_url}{path}"
+    async with httpx.AsyncClient(timeout=30.0) as http:
+        resp = await http.get(url, headers=headers, params=params or {})
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def _ctrl_post(
+    path: str, body: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    config = load_config()
+    api_key = os.environ.get("AAS_API_KEY", "")
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    url = f"{config.alfred_ctrl_url}{path}"
+    async with httpx.AsyncClient(timeout=60.0) as http:
+        resp = await http.post(url, headers=headers, json=body or {})
+        # The ctrl-api error envelope is a JSON {error: {code, message}}.
+        # Re-raise on 5xx so Temporal retries; 4xx is the route refusing
+        # work and is surfaced verbatim so the dispatcher can log + skip.
+        if resp.status_code >= 500:
+            resp.raise_for_status()
+        try:
+            return {"_status": resp.status_code, **(resp.json() or {})}
+        except ValueError:
+            return {"_status": resp.status_code, "error": "non-JSON body"}
+
+
+# ── meeting URL extraction ───────────────────────────────────────────────
+
+
+# Three host families Recall actually accepts (matches ctrl-api's
+# classifyMeetingUrl). We tolerate either the full link or the host
+# pattern showing up anywhere in the description / location field.
+_MEETING_HOST_RE = re.compile(
+    r"https?://[^\s>'\"]*?"
+    r"(?:zoom\.(?:us|com)|meet\.google\.com|teams\.(?:microsoft|live)\.com)"
+    r"[^\s>'\"]*",
+    re.IGNORECASE,
+)
+
+
+def extract_meeting_url(event: dict[str, Any]) -> str | None:
+    """Return the first plausible meeting URL on a Google Calendar event.
+
+    Check order: ``hangoutLink`` (set when the event was created with a
+    Meet conference) → ``conferenceData.entryPoints[].uri`` → the
+    location field → the description (free-text). The first hit wins;
+    later fields are not consulted.
+    """
+    if not isinstance(event, dict):
+        return None
+    # 1. hangoutLink — set automatically for any Meet-created event.
+    link = event.get("hangoutLink") or event.get("hangout_link")
+    if isinstance(link, str) and link.strip():
+        return link.strip()
+    # 2. conferenceData.entryPoints
+    conf = event.get("conferenceData") or event.get("conference_data") or {}
+    if isinstance(conf, dict):
+        for ep in conf.get("entryPoints") or conf.get("entry_points") or []:
+            if not isinstance(ep, dict):
+                continue
+            uri = ep.get("uri") or ep.get("url")
+            if isinstance(uri, str) and uri.strip():
+                m = _MEETING_HOST_RE.search(uri)
+                if m:
+                    return m.group(0)
+    # 3. location
+    loc = event.get("location")
+    if isinstance(loc, str):
+        m = _MEETING_HOST_RE.search(loc)
+        if m:
+            return m.group(0)
+    # 4. description
+    desc = event.get("description")
+    if isinstance(desc, str):
+        m = _MEETING_HOST_RE.search(desc)
+        if m:
+            return m.group(0)
+    return None
+
+
+def event_start_iso(event: dict[str, Any]) -> str | None:
+    """Pull a usable ISO 8601 start time out of a Google Calendar event."""
+    start = event.get("start")
+    if isinstance(start, dict):
+        for key in ("dateTime", "date_time", "date"):
+            v = start.get(key)
+            if isinstance(v, str) and v.strip():
+                return v.strip()
+    if isinstance(start, str) and start.strip():
+        return start.strip()
+    return None
+
+
+def principal_is_attendee(
+    event: dict[str, Any], principal_email: str | None
+) -> bool:
+    """Return True iff the principal's email appears as a non-declined attendee.
+
+    Two acceptance paths:
+      * the event's organizer is the principal (Sir owns it)
+      * one of the attendees matches the principal's email and the
+        response status isn't ``declined``
+
+    When the principal email is unknown (env var missing) the function
+    defaults to True — better to dispatch on Sir's behalf than silently
+    skip on a config gap. The dispatcher logs that fallback path.
+    """
+    if not principal_email:
+        return True
+    principal_email = principal_email.lower().strip()
+
+    organizer = event.get("organizer")
+    if isinstance(organizer, dict):
+        email = organizer.get("email")
+        if isinstance(email, str) and email.lower().strip() == principal_email:
+            return True
+        # 'self' is sometimes set on the organizer block.
+        if organizer.get("self") is True:
+            return True
+
+    creator = event.get("creator")
+    if isinstance(creator, dict) and creator.get("self") is True:
+        return True
+
+    for a in event.get("attendees") or []:
+        if not isinstance(a, dict):
+            continue
+        email = a.get("email")
+        if not isinstance(email, str):
+            continue
+        if email.lower().strip() != principal_email:
+            continue
+        status = (a.get("responseStatus") or a.get("response_status") or "").lower()
+        if status == "declined":
+            return False
+        return True
+    return False
+
+
+# ── policy gate (pure) ────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class NormalisedEvent:
+    """A calendar event reduced to what the dispatcher actually needs."""
+
+    calendar_event_id: str
+    meeting_url: str | None
+    start_iso: str | None
+    summary: str
+    principal_is_attendee: bool
+
+    @classmethod
+    def from_raw(
+        cls, raw: dict[str, Any], principal_email: str | None
+    ) -> "NormalisedEvent | None":
+        if not isinstance(raw, dict):
+            return None
+        cid = raw.get("id") or raw.get("iCalUID") or raw.get("icaluid")
+        if not isinstance(cid, str) or not cid.strip():
+            return None
+        return cls(
+            calendar_event_id=cid.strip(),
+            meeting_url=extract_meeting_url(raw),
+            start_iso=event_start_iso(raw),
+            summary=(raw.get("summary") or "")[:200],
+            principal_is_attendee=principal_is_attendee(raw, principal_email),
+        )
+
+
+# Canonical policy values stored in recall_config.auto_join_policy.
+_POLICY_OFF = {"off", "manual_only"}
+_POLICY_ATTENDEE = {"principal_attendee", "calendar_only"}
+_POLICY_ALL = {"all", "all_meetings"}
+
+
+def should_dispatch(
+    event: NormalisedEvent, policy: str
+) -> tuple[bool, str]:
+    """Return ``(dispatch?, reason)`` for one normalised event.
+
+    The reason is the short string the dispatcher logs to explain
+    skips — useful when Sir reads the worker logs at 3am wondering why
+    the bot didn't show up.
+    """
+    pol = (policy or "").strip().lower()
+    if pol in _POLICY_OFF:
+        return False, f"policy={pol} → no auto-dispatch"
+    if not event.meeting_url:
+        return False, "no meeting_url on event"
+    if pol in _POLICY_ATTENDEE:
+        if event.principal_is_attendee:
+            return True, "policy=principal_attendee + principal is attendee"
+        return False, "policy=principal_attendee + principal not on invite"
+    if pol in _POLICY_ALL:
+        return True, "policy=all + meeting_url present"
+    # Unknown policy — refuse rather than guess.
+    return False, f"unknown auto_join_policy={policy!r}"
+
+
+# ── activities ────────────────────────────────────────────────────────────
+
+
+@activity.defn
+async def fetch_upcoming_calendar_events(
+    window_minutes: int = 15,
+) -> list[dict[str, Any]]:
+    """Pull upcoming events from the principal's Google Calendar.
+
+    Window: ``now - 5min`` to ``now + window_minutes`` — the 5-minute
+    backstop catches meetings that just started (Recall takes ~30s to
+    actually join, and the bot should still get there before the
+    standup ends).
+
+    Returns NormalisedEvent payloads as plain dicts so they survive
+    the Temporal activity boundary. Events without a calendar event id
+    are dropped (we can't dedupe without one). Each returned dict has
+    the keys: ``calendar_event_id``, ``meeting_url``,
+    ``start_iso``, ``summary``, ``principal_is_attendee``.
+    """
+    if not isinstance(window_minutes, int) or window_minutes <= 0:
+        window_minutes = 15
+
+    now = datetime.now(timezone.utc)
+    time_min = (now - timedelta(minutes=5)).isoformat()
+    time_max = (now + timedelta(minutes=window_minutes)).isoformat()
+
+    try:
+        result = await _ctrl_post(
+            "/api/v1/integrations/execute",
+            body={
+                "action": "GOOGLECALENDAR_EVENTS_LIST",
+                "arguments": {
+                    "calendar_id": "primary",
+                    "time_min": time_min,
+                    "time_max": time_max,
+                    "max_results": 50,
+                    "single_events": True,
+                    "order_by": "startTime",
+                },
+            },
+        )
+    except Exception as exc:  # noqa: BLE001
+        # The workflow is on a 5-min beat; any single failure should be
+        # tolerated — Temporal retries are configured at the workflow
+        # level. We log + return empty so the workflow doesn't crash.
+        logger.warning("fetch_upcoming_calendar_events: pull failed: %s", exc)
+        return []
+
+    err = result.get("error") if isinstance(result, dict) else None
+    data = result.get("data") if isinstance(result, dict) else None
+    items = []
+    if isinstance(data, dict):
+        items = data.get("items") or data.get("event_list") or []
+    if err or not isinstance(items, list):
+        logger.info("fetch_upcoming_calendar_events: no items (err=%s)", str(err)[:200])
+        return []
+
+    principal_email = (
+        os.environ.get("OWNER_EMAIL") or os.environ.get("PRINCIPAL_EMAIL") or ""
+    )
+
+    out: list[dict[str, Any]] = []
+    for raw in items:
+        norm = NormalisedEvent.from_raw(raw, principal_email or None)
+        if not norm:
+            continue
+        out.append(
+            {
+                "calendar_event_id": norm.calendar_event_id,
+                "meeting_url": norm.meeting_url,
+                "start_iso": norm.start_iso,
+                "summary": norm.summary,
+                "principal_is_attendee": norm.principal_is_attendee,
+            }
+        )
+    return out
+
+
+@activity.defn
+async def check_recall_dispatch_state() -> dict[str, Any]:
+    """Pull config + usage + active bots in one activity.
+
+    Returned shape:
+
+      {
+        "policy": str,
+        "bot_name": str,
+        "leave_after_minutes": int,
+        "monthly_hours_cap": int,
+        "bot_minutes_used": int,
+        "dispatched_event_ids": [str, ...],
+      }
+
+    On any single sub-call failure we return ``{"policy": "off", ...}``
+    so the workflow defaults to "don't dispatch" rather than spinning
+    a bot off a half-loaded config snapshot.
+    """
+    default = {
+        "policy": "off",
+        "bot_name": "Alfred",
+        "leave_after_minutes": 90,
+        "monthly_hours_cap": 60,
+        "bot_minutes_used": 0,
+        "dispatched_event_ids": [],
+    }
+    try:
+        config = await _ctrl_get("/api/v1/channels/recall/config")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("check_recall_dispatch_state: config fetch failed: %s", exc)
+        return default
+    try:
+        usage = await _ctrl_get("/api/v1/channels/recall/usage")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("check_recall_dispatch_state: usage fetch failed: %s", exc)
+        usage = {"this_month_hours": 0.0}
+    try:
+        active = await _ctrl_get("/api/v1/channels/recall/bots/active")
+        bots = active.get("bots") if isinstance(active, dict) else []
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("check_recall_dispatch_state: bots fetch failed: %s", exc)
+        bots = []
+
+    dispatched_event_ids: list[str] = []
+    if isinstance(bots, list):
+        for b in bots:
+            cid = b.get("calendar_event_id") if isinstance(b, dict) else None
+            if isinstance(cid, str) and cid.strip():
+                dispatched_event_ids.append(cid.strip())
+
+    # `this_month_hours` is a float; turn into minutes-int for arithmetic.
+    used_hours = (
+        usage.get("this_month_hours") if isinstance(usage, dict) else 0
+    ) or 0
+    try:
+        bot_minutes_used = int(round(float(used_hours) * 60))
+    except (TypeError, ValueError):
+        bot_minutes_used = 0
+
+    return {
+        "policy": str(config.get("auto_join_policy") or "off"),
+        "bot_name": str(config.get("bot_name") or "Alfred"),
+        "leave_after_minutes": int(config.get("leave_after_minutes") or 90),
+        "monthly_hours_cap": int(config.get("monthly_hours_cap") or 60),
+        "bot_minutes_used": bot_minutes_used,
+        "dispatched_event_ids": dispatched_event_ids,
+    }
+
+
+@activity.defn
+async def dispatch_recall_bot(
+    meeting_url: str,
+    bot_name: str | None = None,
+    calendar_event_id: str | None = None,
+    scheduled_join_time: str | None = None,
+) -> dict[str, Any]:
+    """POST to ctrl-api's create-bot route and surface the envelope.
+
+    Return shape:
+
+      {
+        "ok": bool,
+        "status_code": int,
+        "bot_id": str | None,
+        "recall_url": str | None,
+        "error": str | None,
+        "calendar_event_id": str | None,
+      }
+
+    On a 4xx ``ok=False`` is returned with the error body; on a 5xx the
+    activity raises so Temporal retries.
+    """
+    if not isinstance(meeting_url, str) or not meeting_url.strip():
+        return {
+            "ok": False,
+            "status_code": 0,
+            "error": "meeting_url is required",
+            "calendar_event_id": calendar_event_id,
+        }
+    body: dict[str, Any] = {"meeting_url": meeting_url.strip()}
+    if bot_name:
+        body["bot_name"] = bot_name
+    if calendar_event_id:
+        body["calendar_event_id"] = calendar_event_id
+    if scheduled_join_time:
+        body["scheduled_join_time"] = scheduled_join_time
+
+    result = await _ctrl_post("/api/v1/channels/recall/bots", body=body)
+    status = int(result.get("_status") or 0)
+    err = result.get("error")
+    if status >= 400 or err:
+        # ctrl-api returns {error: {code, message}} on the 4xx envelope.
+        reason = err
+        if isinstance(err, dict):
+            reason = err.get("message") or err.get("code") or repr(err)
+        return {
+            "ok": False,
+            "status_code": status,
+            "bot_id": None,
+            "recall_url": None,
+            "error": str(reason) if reason is not None else f"HTTP {status}",
+            "calendar_event_id": calendar_event_id,
+        }
+    return {
+        "ok": True,
+        "status_code": status,
+        "bot_id": result.get("bot_id"),
+        "recall_url": result.get("recall_url"),
+        "error": None,
+        "calendar_event_id": calendar_event_id,
+    }
+
+
+# Exported so workflow/tests can drive the gate without instantiating
+# the dataclass themselves.
+def filter_dispatch_candidates(
+    events: Iterable[dict[str, Any]],
+    policy: str,
+    already_dispatched: Iterable[str],
+) -> list[tuple[dict[str, Any], str]]:
+    """Apply the policy + dedupe filter to a raw event list.
+
+    Returns ``[(event_dict, reason), ...]`` for the events that should
+    be dispatched, in calendar order.
+    """
+    seen = {x for x in already_dispatched if isinstance(x, str)}
+    out: list[tuple[dict[str, Any], str]] = []
+    for ev in events:
+        if not isinstance(ev, dict):
+            continue
+        cid = ev.get("calendar_event_id")
+        if not isinstance(cid, str) or not cid:
+            continue
+        if cid in seen:
+            continue
+        norm = NormalisedEvent(
+            calendar_event_id=cid,
+            meeting_url=ev.get("meeting_url"),
+            start_iso=ev.get("start_iso"),
+            summary=ev.get("summary") or "",
+            principal_is_attendee=bool(ev.get("principal_is_attendee", True)),
+        )
+        ok, reason = should_dispatch(norm, policy)
+        if ok:
+            out.append((ev, reason))
+            seen.add(cid)
+    return out

--- a/packages/learn/src/worker.py
+++ b/packages/learn/src/worker.py
@@ -56,6 +56,7 @@ from src.workflows.signal_router import (
 from src.workflows.stream_event_purge import StreamEventPurgeWorkflow
 from src.workflows.reversal_calibration import ReversalCalibrationWorkflow
 from src.workflows.briefing import BriefingWorkflow
+from src.workflows.recall_dispatcher import RecallDispatcherWorkflow
 
 # Chore template workflows (static + dynamic)
 from src.workflows.chores import ALL_CHORE_TEMPLATES
@@ -661,6 +662,15 @@ from src.activities.briefing import (
     list_active_matters_for_briefing,
 )
 
+# Recall.ai meeting-bot dispatcher (#113 PR4) — three activities the
+# RecallDispatcherWorkflow drives every 5 min. ``filter_dispatch_candidates``
+# is the pure helper; it's not an @activity.defn and is not registered here.
+from src.activities.recall_dispatcher import (
+    check_recall_dispatch_state,
+    dispatch_recall_bot,
+    fetch_upcoming_calendar_events,
+)
+
 # Validators used as activities
 from src.validators.frontmatter import validate_classification
 
@@ -711,6 +721,11 @@ _STATIC_WORKFLOWS = [
     StreamEventPurgeWorkflow,
     ReversalCalibrationWorkflow,
     BriefingWorkflow,
+    # Recall.ai meeting-bot dispatcher (#113 PR4) — every 5 min reads
+    # the calendar, applies the policy gate, dispatches a bot per
+    # surviving event. Scheduled as ``al-recall-dispatcher`` in
+    # register_schedules.py.
+    RecallDispatcherWorkflow,
     *ALL_CHORE_TEMPLATES,
 ]
 
@@ -1121,6 +1136,11 @@ ALL_ACTIVITIES = [
     get_prior_briefing,
     briefing_visit_matter,
     compose_and_write_briefing,
+    # Recall.ai meeting-bot dispatcher (#113 PR4) — see
+    # src.workflows.recall_dispatcher.RecallDispatcherWorkflow.
+    check_recall_dispatch_state,
+    dispatch_recall_bot,
+    fetch_upcoming_calendar_events,
 ]
 
 

--- a/packages/learn/src/workflows/recall_dispatcher.py
+++ b/packages/learn/src/workflows/recall_dispatcher.py
@@ -1,0 +1,153 @@
+"""RecallDispatcherWorkflow — calendar-driven Recall.ai bot dispatch.
+
+Runs every 5 minutes (Temporal schedule ``al-recall-dispatcher``,
+registered alongside the rest of the interval schedules). On each
+tick:
+
+  1. Read the recall_config + month-to-date usage + the set of
+     calendar_event_ids that already have a non-terminal bot.
+  2. Pull the next 15 minutes of calendar events via Composio
+     (GOOGLECALENDAR_LIST_EVENTS).
+  3. Apply the policy gate (off / principal_attendee / all). Filter to
+     events with a meeting URL the principal hasn't already had a bot
+     dispatched for.
+  4. Check the monthly cap — if projected (used + leave_after_minutes)
+     would exceed ``monthly_hours_cap * 60`` minutes, refuse the
+     dispatch and log a skip.
+  5. POST each surviving event to ctrl-api's create-bot route. The
+     ctrl-api side also dedupes on calendar_event_id, so a torn run
+     can't double-dispatch.
+
+The workflow is idempotent: re-running the same tick produces no extra
+bots because (a) ctrl-api dedupes by calendar_event_id, and (b) the
+dispatcher reads the active-bots list each tick and skips IDs already
+seen there.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from typing import Any
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+with workflow.unsafe.imports_passed_through():
+    from src.activities.recall_dispatcher import (
+        check_recall_dispatch_state,
+        dispatch_recall_bot,
+        fetch_upcoming_calendar_events,
+        filter_dispatch_candidates,
+    )
+
+
+logger = logging.getLogger("recall-dispatcher-workflow")
+
+
+_FETCH_RETRY = RetryPolicy(
+    initial_interval=timedelta(seconds=10),
+    maximum_interval=timedelta(minutes=2),
+    maximum_attempts=3,
+)
+
+_DISPATCH_RETRY = RetryPolicy(
+    initial_interval=timedelta(seconds=15),
+    maximum_interval=timedelta(minutes=2),
+    # 1 retry only — Recall create-bot is non-idempotent on its own
+    # (no client-side request id), so we lean on ctrl-api's
+    # calendar_event_id dedupe instead of more aggressive retries.
+    maximum_attempts=2,
+)
+
+
+@workflow.defn
+class RecallDispatcherWorkflow:
+    @workflow.run
+    async def run(self, window_minutes: int = 15) -> dict[str, Any]:
+        state = await workflow.execute_activity(
+            check_recall_dispatch_state,
+            start_to_close_timeout=timedelta(seconds=60),
+            retry_policy=_FETCH_RETRY,
+        )
+        policy = str(state.get("policy") or "off").lower()
+        if policy in ("off", "manual_only"):
+            return {
+                "ok": True,
+                "skipped": "policy_off",
+                "policy": policy,
+                "dispatched": 0,
+            }
+
+        # Monthly cap — refuse the entire tick if even one more bot of
+        # the configured leave_after_minutes would push us past the cap.
+        # The whole tick rather than per-event because every event in
+        # this tick will trigger the same projection.
+        cap_minutes = int(state.get("monthly_hours_cap") or 60) * 60
+        used = int(state.get("bot_minutes_used") or 0)
+        leave_after = int(state.get("leave_after_minutes") or 90)
+        if used + leave_after > cap_minutes:
+            logger.warning(
+                "recall_dispatcher: monthly cap exceeded "
+                "(used=%dmin + leave_after=%dmin > cap=%dmin); skipping",
+                used,
+                leave_after,
+                cap_minutes,
+            )
+            return {
+                "ok": True,
+                "skipped": "monthly_cap",
+                "policy": policy,
+                "bot_minutes_used": used,
+                "leave_after_minutes": leave_after,
+                "monthly_cap_minutes": cap_minutes,
+                "dispatched": 0,
+            }
+
+        events = await workflow.execute_activity(
+            fetch_upcoming_calendar_events,
+            window_minutes,
+            start_to_close_timeout=timedelta(minutes=2),
+            retry_policy=_FETCH_RETRY,
+        )
+        if not isinstance(events, list) or not events:
+            return {
+                "ok": True,
+                "skipped": "no_events",
+                "policy": policy,
+                "dispatched": 0,
+            }
+
+        already = state.get("dispatched_event_ids") or []
+        candidates = filter_dispatch_candidates(events, policy, already)
+        if not candidates:
+            return {
+                "ok": True,
+                "policy": policy,
+                "candidates": 0,
+                "dispatched": 0,
+            }
+
+        bot_name = state.get("bot_name") or "Alfred"
+        outcomes: list[dict[str, Any]] = []
+        for ev, _reason in candidates:
+            outcome = await workflow.execute_activity(
+                dispatch_recall_bot,
+                args=[
+                    ev.get("meeting_url"),
+                    bot_name,
+                    ev.get("calendar_event_id"),
+                    ev.get("start_iso"),
+                ],
+                start_to_close_timeout=timedelta(seconds=60),
+                retry_policy=_DISPATCH_RETRY,
+            )
+            outcomes.append(outcome if isinstance(outcome, dict) else {})
+
+        dispatched = sum(1 for o in outcomes if o.get("ok"))
+        return {
+            "ok": True,
+            "policy": policy,
+            "candidates": len(candidates),
+            "dispatched": dispatched,
+            "outcomes": outcomes,
+        }

--- a/packages/learn/tests/test_recall_dispatcher.py
+++ b/packages/learn/tests/test_recall_dispatcher.py
@@ -1,0 +1,476 @@
+"""Recall.ai dispatcher — policy gate, dedupe, cap check, calendar tolerance.
+
+Tests the pure helpers + the policy gate first (no Temporal needed),
+then the activity layer with httpx.MockTransport so the workflow's
+ctrl-api round-trips are fully exercised without a live ctrl-api.
+The Temporal workflow itself is integration-tested separately;
+unit-test coverage targets the load-bearing dispatch logic.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from src.activities.recall_dispatcher import (
+    NormalisedEvent,
+    check_recall_dispatch_state,
+    dispatch_recall_bot,
+    extract_meeting_url,
+    fetch_upcoming_calendar_events,
+    filter_dispatch_candidates,
+    principal_is_attendee,
+    should_dispatch,
+)
+
+
+# ---------------------------------------------------------------------------
+# meeting URL extraction
+# ---------------------------------------------------------------------------
+
+
+class TestExtractMeetingUrl:
+    def test_picks_hangout_link_first(self):
+        ev = {
+            "hangoutLink": "https://meet.google.com/abc-defg-hij",
+            "description": "Backup: https://zoom.us/j/999",
+        }
+        # hangoutLink wins over a description link.
+        assert extract_meeting_url(ev) == "https://meet.google.com/abc-defg-hij"
+
+    def test_falls_back_to_conference_data(self):
+        ev = {
+            "conferenceData": {
+                "entryPoints": [
+                    {"entryPointType": "video", "uri": "https://zoom.us/j/123456"},
+                ],
+            },
+        }
+        assert extract_meeting_url(ev) == "https://zoom.us/j/123456"
+
+    def test_extracts_from_location(self):
+        ev = {"location": "Coffee shop. Or https://meet.google.com/xyz-abc-def"}
+        assert extract_meeting_url(ev) == "https://meet.google.com/xyz-abc-def"
+
+    def test_extracts_from_description(self):
+        ev = {
+            "description": "Standup at https://teams.microsoft.com/l/meetup-join/xyz at 10am",
+        }
+        assert (
+            extract_meeting_url(ev)
+            == "https://teams.microsoft.com/l/meetup-join/xyz"
+        )
+
+    def test_returns_none_when_no_link(self):
+        ev = {"description": "Coffee at the office"}
+        assert extract_meeting_url(ev) is None
+
+    def test_handles_non_dict(self):
+        assert extract_meeting_url(None) is None  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# principal_is_attendee
+# ---------------------------------------------------------------------------
+
+
+class TestPrincipalIsAttendee:
+    def test_true_when_organizer_matches(self):
+        ev = {"organizer": {"email": "sir@alfred.black"}}
+        assert principal_is_attendee(ev, "sir@alfred.black") is True
+
+    def test_true_when_self_flag_set(self):
+        ev = {"organizer": {"email": "someone@else.com", "self": True}}
+        assert principal_is_attendee(ev, "sir@alfred.black") is True
+
+    def test_true_when_attendee_match(self):
+        ev = {
+            "attendees": [
+                {"email": "sir@alfred.black", "responseStatus": "accepted"},
+                {"email": "other@example.com"},
+            ],
+        }
+        assert principal_is_attendee(ev, "sir@alfred.black") is True
+
+    def test_false_when_declined(self):
+        ev = {
+            "attendees": [
+                {"email": "sir@alfred.black", "responseStatus": "declined"},
+            ],
+        }
+        assert principal_is_attendee(ev, "sir@alfred.black") is False
+
+    def test_false_when_principal_not_present(self):
+        ev = {
+            "attendees": [
+                {"email": "alice@example.com", "responseStatus": "accepted"},
+            ],
+        }
+        assert principal_is_attendee(ev, "sir@alfred.black") is False
+
+    def test_true_when_principal_email_unknown(self):
+        # Fallback path — better to dispatch than silently skip on a
+        # config gap.
+        ev = {"attendees": [{"email": "alice@example.com"}]}
+        assert principal_is_attendee(ev, None) is True
+
+
+# ---------------------------------------------------------------------------
+# Policy gate matrix
+# ---------------------------------------------------------------------------
+
+
+def _ev(
+    cid: str = "ev-1",
+    meeting_url: str | None = "https://zoom.us/j/1",
+    is_attendee: bool = True,
+) -> NormalisedEvent:
+    return NormalisedEvent(
+        calendar_event_id=cid,
+        meeting_url=meeting_url,
+        start_iso="2026-05-30T10:00:00Z",
+        summary="Test",
+        principal_is_attendee=is_attendee,
+    )
+
+
+class TestPolicyGate:
+    @pytest.mark.parametrize("policy", ["off", "manual_only", "OFF", "Manual_Only"])
+    def test_off_never_dispatches(self, policy):
+        ok, reason = should_dispatch(_ev(), policy)
+        assert ok is False
+        assert "no auto-dispatch" in reason
+
+    def test_unknown_policy_refuses(self):
+        ok, reason = should_dispatch(_ev(), "wat")
+        assert ok is False
+        assert "unknown" in reason.lower()
+
+    def test_no_meeting_url_skipped(self):
+        ok, reason = should_dispatch(_ev(meeting_url=None), "all")
+        assert ok is False
+        assert reason == "no meeting_url on event"
+
+    def test_principal_attendee_dispatches_when_attending(self):
+        ok, _ = should_dispatch(_ev(is_attendee=True), "principal_attendee")
+        assert ok is True
+
+    def test_principal_attendee_skips_when_not_attending(self):
+        ok, reason = should_dispatch(_ev(is_attendee=False), "principal_attendee")
+        assert ok is False
+        assert "not on invite" in reason
+
+    def test_calendar_only_alias_for_principal_attendee(self):
+        # Spec alias: "calendar_only" is the same gate as principal_attendee.
+        ok, _ = should_dispatch(_ev(is_attendee=True), "calendar_only")
+        assert ok is True
+        ok2, _ = should_dispatch(_ev(is_attendee=False), "calendar_only")
+        assert ok2 is False
+
+    def test_all_dispatches_with_url(self):
+        ok, _ = should_dispatch(_ev(is_attendee=False), "all")
+        assert ok is True
+
+    def test_all_meetings_alias(self):
+        ok, _ = should_dispatch(_ev(is_attendee=False), "all_meetings")
+        assert ok is True
+
+
+# ---------------------------------------------------------------------------
+# Dedupe via filter_dispatch_candidates
+# ---------------------------------------------------------------------------
+
+
+class TestFilterDispatchCandidates:
+    def _raw(self, cid: str, url: str | None = "https://zoom.us/j/1") -> dict[str, Any]:
+        return {
+            "calendar_event_id": cid,
+            "meeting_url": url,
+            "start_iso": "2026-05-30T10:00:00Z",
+            "summary": "Test",
+            "principal_is_attendee": True,
+        }
+
+    def test_skips_already_dispatched(self):
+        events = [self._raw("a"), self._raw("b")]
+        candidates = filter_dispatch_candidates(events, "all", ["a"])
+        ids = [ev["calendar_event_id"] for ev, _ in candidates]
+        assert ids == ["b"]
+
+    def test_internal_dedupe_within_one_pass(self):
+        # Two events with the same calendar_event_id (e.g. recurring
+        # instance + override) should only get one dispatch.
+        events = [self._raw("dup"), self._raw("dup")]
+        candidates = filter_dispatch_candidates(events, "all", [])
+        assert len(candidates) == 1
+
+    def test_filters_no_meeting_url(self):
+        events = [self._raw("a", url=None), self._raw("b")]
+        candidates = filter_dispatch_candidates(events, "all", [])
+        ids = [ev["calendar_event_id"] for ev, _ in candidates]
+        assert ids == ["b"]
+
+    def test_policy_off_returns_empty(self):
+        events = [self._raw("a"), self._raw("b")]
+        candidates = filter_dispatch_candidates(events, "off", [])
+        assert candidates == []
+
+    def test_skips_events_without_calendar_id(self):
+        events = [
+            {"meeting_url": "https://zoom.us/j/1"},
+            self._raw("ok"),
+        ]
+        candidates = filter_dispatch_candidates(events, "all", [])
+        ids = [ev["calendar_event_id"] for ev, _ in candidates]
+        assert ids == ["ok"]
+
+
+# ---------------------------------------------------------------------------
+# Activity-level tests — mocked ctrl-api transport
+# ---------------------------------------------------------------------------
+
+
+class ScriptedTransport(httpx.AsyncBaseTransport):
+    """Replay scripted responses; capture every request."""
+
+    def __init__(self, handler):
+        self._handler = handler
+        self.requests: list[httpx.Request] = []
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        return self._handler(request)
+
+
+@pytest.fixture
+def mock_ctrl(monkeypatch):
+    """Patch httpx.AsyncClient inside src.activities.recall_dispatcher.
+
+    Yields a holder where the test installs a per-test handler. The
+    handler is called with each request and must return an httpx.Response.
+    """
+    holder: dict[str, Any] = {"handler": None, "transport": None}
+
+    original = httpx.AsyncClient
+
+    def fake_client(*args, **kwargs):
+        handler = holder["handler"]
+        if handler is None:
+            raise RuntimeError("mock_ctrl handler not set for this test")
+        transport = ScriptedTransport(handler)
+        holder["transport"] = transport
+        # Pass through everything but transport.
+        kwargs["transport"] = transport
+        # We never actually network — strip base_url because MockTransport
+        # respects whatever URL the caller passes in.
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "src.activities.recall_dispatcher.httpx.AsyncClient",
+        fake_client,
+    )
+    monkeypatch.setenv("AAS_API_KEY", "test-key")
+    yield holder
+
+
+class TestCheckRecallDispatchState:
+    @pytest.mark.asyncio
+    async def test_happy_path(self, mock_ctrl):
+        responses = {
+            "/api/v1/channels/recall/config": {
+                "auto_join_policy": "principal_attendee",
+                "bot_name": "Alfred",
+                "leave_after_minutes": 90,
+                "monthly_hours_cap": 60,
+            },
+            "/api/v1/channels/recall/usage": {"this_month_hours": 12.5},
+            "/api/v1/channels/recall/bots/active": {
+                "bots": [
+                    {"id": "bot-1", "calendar_event_id": "gcal-1"},
+                    {"id": "bot-2", "calendar_event_id": "gcal-2"},
+                    {"id": "bot-3", "calendar_event_id": None},
+                ],
+            },
+        }
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            body = responses.get(req.url.path)
+            if body is None:
+                return httpx.Response(404, json={"error": "not found"})
+            return httpx.Response(200, json=body)
+
+        mock_ctrl["handler"] = handler
+
+        state = await check_recall_dispatch_state()
+        assert state["policy"] == "principal_attendee"
+        assert state["bot_name"] == "Alfred"
+        assert state["leave_after_minutes"] == 90
+        assert state["monthly_hours_cap"] == 60
+        assert state["bot_minutes_used"] == 750  # 12.5h * 60
+        assert sorted(state["dispatched_event_ids"]) == ["gcal-1", "gcal-2"]
+
+    @pytest.mark.asyncio
+    async def test_config_fetch_failure_defaults_off(self, mock_ctrl):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, json={"error": {"code": "BOOM"}})
+
+        mock_ctrl["handler"] = handler
+        state = await check_recall_dispatch_state()
+        assert state["policy"] == "off"
+
+
+class TestFetchUpcomingCalendarEvents:
+    @pytest.mark.asyncio
+    async def test_pulls_and_normalises(self, mock_ctrl, monkeypatch):
+        monkeypatch.setenv("OWNER_EMAIL", "sir@alfred.black")
+        items = [
+            {
+                "id": "gcal-evt-1",
+                "summary": "Standup",
+                "hangoutLink": "https://meet.google.com/abc-defg-hij",
+                "start": {"dateTime": "2026-05-30T10:00:00Z"},
+                "attendees": [
+                    {"email": "sir@alfred.black", "responseStatus": "accepted"},
+                ],
+            },
+            {
+                "id": "gcal-evt-2",
+                "summary": "Lunch (no meeting URL)",
+                "start": {"dateTime": "2026-05-30T12:00:00Z"},
+            },
+        ]
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            assert req.url.path == "/api/v1/integrations/execute"
+            payload = json.loads(req.content.decode("utf-8"))
+            assert payload["action"] == "GOOGLECALENDAR_EVENTS_LIST"
+            return httpx.Response(
+                200, json={"data": {"items": items}},
+            )
+
+        mock_ctrl["handler"] = handler
+        result = await fetch_upcoming_calendar_events(15)
+        assert len(result) == 2
+        first = result[0]
+        assert first["calendar_event_id"] == "gcal-evt-1"
+        assert first["meeting_url"] == "https://meet.google.com/abc-defg-hij"
+        assert first["principal_is_attendee"] is True
+        # Second event has no URL but is still returned (gate decides skip).
+        assert result[1]["meeting_url"] is None
+
+    @pytest.mark.asyncio
+    async def test_tolerates_pull_failure(self, mock_ctrl):
+        def handler(req: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("boom")
+
+        mock_ctrl["handler"] = handler
+        # Activity must NOT raise — workflow retries are at the workflow
+        # layer; this activity is best-effort.
+        result = await fetch_upcoming_calendar_events(15)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_handles_no_items(self, mock_ctrl):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"data": {"items": []}})
+
+        mock_ctrl["handler"] = handler
+        result = await fetch_upcoming_calendar_events(15)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_skips_events_without_id(self, mock_ctrl):
+        items = [
+            # missing id
+            {"summary": "ghost", "hangoutLink": "https://zoom.us/j/1"},
+            # valid
+            {
+                "id": "ok",
+                "summary": "ok",
+                "hangoutLink": "https://zoom.us/j/2",
+            },
+        ]
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"data": {"items": items}})
+
+        mock_ctrl["handler"] = handler
+        result = await fetch_upcoming_calendar_events(15)
+        assert [r["calendar_event_id"] for r in result] == ["ok"]
+
+
+class TestDispatchRecallBot:
+    @pytest.mark.asyncio
+    async def test_happy_path(self, mock_ctrl):
+        captured: dict[str, Any] = {}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            assert req.url.path == "/api/v1/channels/recall/bots"
+            captured["body"] = json.loads(req.content.decode("utf-8"))
+            return httpx.Response(
+                200,
+                json={
+                    "bot_id": "bot-abc",
+                    "status": "requested",
+                    "recall_url": "https://recall.example/bot-abc",
+                },
+            )
+
+        mock_ctrl["handler"] = handler
+        out = await dispatch_recall_bot(
+            meeting_url="https://zoom.us/j/123",
+            bot_name="Alfred",
+            calendar_event_id="gcal-77",
+        )
+        assert out["ok"] is True
+        assert out["bot_id"] == "bot-abc"
+        assert out["status_code"] == 200
+        assert captured["body"]["meeting_url"] == "https://zoom.us/j/123"
+        assert captured["body"]["calendar_event_id"] == "gcal-77"
+        assert captured["body"]["bot_name"] == "Alfred"
+
+    @pytest.mark.asyncio
+    async def test_400_returns_ok_false(self, mock_ctrl):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                400,
+                json={"error": {"code": "VALIDATION_ERROR", "message": "bad url"}},
+            )
+
+        mock_ctrl["handler"] = handler
+        out = await dispatch_recall_bot(
+            meeting_url="https://example.com",
+            calendar_event_id="gcal-1",
+        )
+        assert out["ok"] is False
+        assert out["status_code"] == 400
+        assert "bad url" in (out["error"] or "")
+
+    @pytest.mark.asyncio
+    async def test_503_returns_ok_false(self, mock_ctrl):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                503,
+                json={"error": {"code": "NOT_CONFIGURED", "message": "no key"}},
+            )
+
+        mock_ctrl["handler"] = handler
+        # 5xx raises; the activity surfaces the httpx exception so
+        # Temporal can retry the activity.
+        with pytest.raises(httpx.HTTPStatusError):
+            await dispatch_recall_bot(
+                meeting_url="https://zoom.us/j/1",
+            )
+
+    @pytest.mark.asyncio
+    async def test_empty_url_short_circuits(self, mock_ctrl):
+        # No network call should happen.
+        mock_ctrl["handler"] = lambda req: pytest.fail(
+            "should not have networked"
+        )
+        out = await dispatch_recall_bot(meeting_url="")
+        assert out["ok"] is False
+        assert "required" in out["error"]

--- a/packages/web/main.wasp
+++ b/packages/web/main.wasp
@@ -992,6 +992,16 @@ action terminateRecallBot {
   entities: []
 }
 
+// Lane III (#113 PR4) — operator-facing "Send bot now" button on the
+// /channels Recall card. POSTs to ctrl-api's create-bot route with a
+// pasted meeting URL and (optionally) a friendly bot name override.
+// ctrl-api dedupes if calendar_event_id is supplied; the manual path
+// does not supply one (the card just hands over the URL).
+action dispatchRecallBot {
+  fn: import { dispatchRecallBot } from "@src/dashboard/operations",
+  entities: []
+}
+
 // Wave C — HA conversation setup card (#111 PR3). Reads the shared
 // `channel_tokens` table for rows with `channel='ha-conversation'`
 // (one row per HA install). Mint + revoke proxy to the same shared

--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -826,6 +826,37 @@ export const terminateRecallBot = async (
   });
 };
 
+/** Manually dispatch a Recall bot for a meeting URL (#113 PR4).
+ *
+ *  Card-side "Send bot now" CTA. The bot_name override is optional —
+ *  ctrl-api falls back to the configured default if omitted. The card
+ *  does NOT supply a calendar_event_id because this is the
+ *  ad-hoc, off-calendar path; the dispatcher workflow supplies one
+ *  for the automated path and ctrl-api uses it for dedupe. */
+export const dispatchRecallBot = async (
+  args: { meeting_url: string; bot_name?: string },
+  context: any,
+) => {
+  if (
+    typeof args?.meeting_url !== "string" ||
+    args.meeting_url.trim().length === 0
+  ) {
+    throw new HttpError(400, "meeting_url required");
+  }
+  const body: Record<string, string> = {
+    meeting_url: args.meeting_url.trim(),
+  };
+  if (typeof args.bot_name === "string" && args.bot_name.trim().length > 0) {
+    body.bot_name = args.bot_name.trim();
+  }
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    method: "POST",
+    path: "/api/v1/channels/recall/bots",
+    body,
+  });
+};
+
 // ============================================================
 // Dashboard Home
 // ============================================================


### PR DESCRIPTION
## Summary

Adds the Recall.ai auto-dispatcher for #113 PR4. Every 5 minutes the
new `RecallDispatcherWorkflow` walks the principal's Google Calendar,
applies the operator's `auto_join_policy`, dedupes against bots
already requested for the same `calendar_event_id`, refuses dispatches
that would blow the monthly cap, and POSTs to a new ctrl-api
create-bot route.

The principal never visits recall.ai. The card-side surface from PR2
(#129) + PR3 (#136) already exposes config + active bots + manual
terminate; this PR fills in the automatic side and the manual
"Send bot now" CTA.

## Lanes shipped

### Lane I — alfred-learn
* `packages/learn/src/workflows/recall_dispatcher.py` — `RecallDispatcherWorkflow`
* `packages/learn/src/activities/recall_dispatcher.py` — three @activity.defn
  helpers plus the pure `should_dispatch` / `filter_dispatch_candidates`
  policy gate:
  * `fetch_upcoming_calendar_events(window_minutes=15)` — Composio
    GOOGLECALENDAR_EVENTS_LIST pull with 5-min lookback so just-started
    meetings still get a bot. Extracts meeting URL from `hangoutLink`,
    `conferenceData.entryPoints`, `location`, or `description` in that
    order.
  * `check_recall_dispatch_state()` — one round-trip per ctrl-api
    endpoint (config / usage / active-bots) composed into a single
    state dict the workflow uses for policy + dedupe + cap.
  * `dispatch_recall_bot(meeting_url, bot_name?, calendar_event_id?,
    scheduled_join_time?)` — wraps the new POST /bots route, surfaces
    a 4xx as `{ok:false, error}` and lets 5xx raise so Temporal retries.

### Lane II — ctrl-api
* `POST /api/v1/channels/recall/bots` — accepts a Zoom/Meet/Teams URL
  (anything else → 400), reads `RECALL_API_KEY` from env, POSTs to
  Recall's `/api/v2/bot` create-bot endpoint, inserts a `recall_bot`
  row with the full Recall payload. **Idempotent on
  `calendar_event_id`** — second POST for the same event returns the
  existing row without calling Recall again.
* `POST /api/v1/channels/recall/bots/:bot_id/leave` — graceful-leave
  verb (DELETE remains for symmetry with PR2 spec wording).
* `classifyMeetingUrl(url)` — pure helper exported for tests. Hosts
  accepted: `zoom.us` (incl. subdomains), `meet.google.com`,
  `teams.microsoft.com`, `teams.live.com`.
* Webhook handler (already shipped in PR2) already maps
  `bot.in_call_recording → in_meeting` and `bot.done → done`; this PR
  adds tests proving the contract holds.

### Lane III — Wasp wiring
* `dispatchRecallBot({meeting_url, bot_name?})` operation + main.wasp
  declaration. The card's "Send bot now" CTA calls this.

### Lane IV — tests
* `packages/ctrl/tests/channels_recall_dispatch.test.ts` — **23 cases**:
  * `classifyMeetingUrl` matrix (zoom subdomain, meet, teams, rejects, non-URL)
  * POST /bots happy + idempotence + url rejection + 401/422/503 paths
  * `bot_name` override → sent verbatim to Recall
  * `scheduled_join_time` validation
  * POST /bots/:id/leave + 404 → done path + 503 path
  * Webhook `bot.in_call_recording` → in_meeting, `bot.done` → done
  * GET /bots/active surfaces the inserted bot
* `packages/learn/tests/test_recall_dispatcher.py` — **38 cases**:
  * URL extraction matrix (hangoutLink wins, conferenceData fallback,
    location regex, description regex, no-link returns None)
  * `principal_is_attendee` (organizer match, self flag, attendee
    accepted, declined → false, no principal email → True fallback)
  * Policy gate matrix — `off / manual_only / OFF / Manual_Only` all skip,
    unknown policy refuses, no `meeting_url` skipped, `principal_attendee`
    + `calendar_only` honour attendee state, `all` + `all_meetings` dispatch
    on any URL.
  * Dedupe — already-dispatched skipped, duplicate IDs in one pass
    deduped, no `calendar_event_id` skipped.
  * Cap pre-check via `check_recall_dispatch_state` — config-failure
    defaults to `policy=off`.
  * Calendar fetch failure tolerated (returns `[]`, workflow doesn't
    crash).
  * `dispatch_recall_bot` — 400/503 paths + empty-URL short-circuit.

### Lane V — schedule
* `al-recall-dispatcher` (every 5 min) added to `INTERVAL_SCHEDULES` in
  `packages/learn/scripts/register_schedules.py`.

## Policy matrix (one-liner)

`off`/`manual_only` → no auto-dispatch; `principal_attendee`/`calendar_only` → dispatch iff event has meeting URL **and** principal is non-declined attendee; `all`/`all_meetings` → dispatch on any event with a meeting URL; unknown policy → refuse + log.

## Test results

* ctrl-api new tests: **23/23 passing**.
* learn new tests: **38/38 passing**.
* Full learn suite: 2211 passed (no regressions in deselect-slow run).
* Full ctrl-api suite: 27 failures, all pre-existing baseline
  (admin/agents/voice-routes/migrations all fail on `system.ts`'s
  `execFileSync` import under Node 25 ESM, and `bumps user_version` /
  `runMigrations adds processed_at` assert `user_version=6` while the
  recall migration already shipped as 0007 in #129 — not introduced
  here). No recall-related failures.

## Schema

No new migration. `recall_config` / `recall_bot` / `recall_event` already
shipped in `0007_recall.sql` (#113 PR2 / #129).

## Security

Recall API key read from `process.env.RECALL_API_KEY` (set via existing
PR3a paste flow). Error logs include only the first 6 chars of the key
prefix; the key itself never leaves the env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)