### PR TITLE
fix(web): widen channel-token Wasp op return types for SDK build

### DIFF
--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -2757,7 +2757,10 @@ function wireRowToCardRow(r: ChannelTokenWireRow) {
  *  shipped in #111 PR4. Returns `{ tokens: ChannelTokenRow[] }` — the
  *  card's haConversationCardCore.ts reads `t.scope.haInstanceId`, so
  *  we normalise the wire's `scope_json` → `scope` here. */
-export const getHaInstalledTokens = async (_args: unknown, context: any) => {
+export const getHaInstalledTokens = async (
+  _args: unknown,
+  context: any,
+): Promise<any> => {
   const instance = await getUserInstance(context);
   try {
     const raw = (await proxyToTenant(instance, {
@@ -2792,7 +2795,7 @@ export const getHaInstalledTokens = async (_args: unknown, context: any) => {
 export const mintHaChannelToken = async (
   args: { label?: string; installId?: string },
   context: any,
-) => {
+): Promise<any> => {
   const label =
     typeof args?.label === "string" && args.label.trim()
       ? args.label.trim()


### PR DESCRIPTION
Same family as #139. PR #140 (channel-token mint surface) added
\`mintHaChannelToken\` and \`getHaInstalledTokens\` returning specific
object literals. Wasp's SDK build wraps every op with a
\`Promise<Payload>\` return constraint that can't widen back to the
inferred narrow shape — \`wasp build\` fails on every main SHA since
#140 merged.

Annotating return as \`Promise<any>\` matches Wasp's contract. The
ctrl-api response shape on the wire is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)