### PR TITLE
ci+test(ctrl): naming guard + clear baseline ctrl-api failures

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -22,6 +22,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  test-naming-guard:
+    # Cheap fail-fast guard against the glob-escape bug PR #133 fixed: the
+    # ctrl/web test runners glob `tests/*.test.ts` (suffix convention). A file
+    # named `test_foo.ts` (prefix convention) is silently invisible to the
+    # runner — that's how #110 PR1's whole batch of HA-channel tests shipped
+    # without running. This step rejects the prefix shape so the regression
+    # cannot recur.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Reject tests/test_*.ts naming (must be *.test.ts)
+        run: |
+          bad=$(find packages/ctrl/tests packages/web/src -name 'test_*.ts' -not -name '*.test.ts' 2>/dev/null || true)
+          if [ -n "$bad" ]; then
+            echo "FAIL — these test files use the prefix-naming convention which the runner glob skips:"
+            echo "$bad"
+            echo "Rename to *.test.ts (suffix convention) so they actually run."
+            exit 1
+          fi
+
   build-ctrl:
     runs-on: ubuntu-latest
     steps:

--- a/packages/ctrl/tests/admin.test.ts
+++ b/packages/ctrl/tests/admin.test.ts
@@ -16,6 +16,11 @@ const execFileFn = mock.fn((...args: any[]) => {
 mock.module("node:child_process", {
   namedExports: {
     execFile: execFileFn,
+    // execFileSync is imported by src/api/routes/system.ts (ssh-keygen
+    // path). The mock loader rejects any named-export the module's source
+    // imports if it isn't listed here, so we must keep this stub even
+    // though these tests don't exercise the ssh-keygen surface.
+    execFileSync: mock.fn(() => ""),
     spawn: mock.fn(() => ({
       stderr: { on: mock.fn() },
       stdin: { write: mock.fn(), end: mock.fn() },

--- a/packages/ctrl/tests/agents.test.ts
+++ b/packages/ctrl/tests/agents.test.ts
@@ -35,7 +35,9 @@ const spawnFn = mock.fn(() => {
 });
 
 mock.module("node:child_process", {
-  namedExports: { execFile: execFileFn, spawn: spawnFn },
+  // execFileSync is imported by src/api/routes/system.ts; must be listed
+  // even though these tests don't exercise the ssh-keygen surface.
+  namedExports: { execFile: execFileFn, execFileSync: mock.fn(() => ""), spawn: spawnFn },
 });
 
 // node:fs mock (readConfig uses python3/execFile, but admin routes may need fs)

--- a/packages/ctrl/tests/context.test.ts
+++ b/packages/ctrl/tests/context.test.ts
@@ -24,6 +24,10 @@ const execFileFn = mock.fn((...args: any[]) => {
 mock.module("node:child_process", {
   namedExports: {
     execFile: execFileFn,
+    // execFileSync is imported by src/api/routes/system.ts (ssh-keygen
+    // path, unused here) — must be listed or the mock loader 500s the
+    // whole module import.
+    execFileSync: mock.fn(() => ""),
     spawn: mock.fn(() => ({
       stderr: { on: mock.fn() },
       stdin: { write: mock.fn(), end: mock.fn() },

--- a/packages/ctrl/tests/cross-tenant.test.ts
+++ b/packages/ctrl/tests/cross-tenant.test.ts
@@ -68,6 +68,10 @@ mock.module("node:child_process", {
       const cb = _args[_args.length - 1];
       if (typeof cb === "function") cb(null, "{}", "");
     }),
+    // execFileSync is imported by src/api/routes/system.ts (ssh-keygen
+    // path, unused here) — must be listed or the mock loader 500s the
+    // whole module import.
+    execFileSync: mock.fn(() => ""),
     spawn: mock.fn(() => ({
       stderr: { on: mock.fn() },
       stdin: { write: mock.fn(), end: mock.fn() },

--- a/packages/ctrl/tests/dispatch-signal-terminal.test.ts
+++ b/packages/ctrl/tests/dispatch-signal-terminal.test.ts
@@ -134,10 +134,19 @@ describe("delegate-dispatch mints re-routed signal as TERMINAL (#216)", () => {
     assert.equal(status, 200, `dispatch must 200, got ${status}: ${JSON.stringify(payload)}`);
     assert.equal(payload.status, "dispatched");
 
-    // Existing assertions (carry forward — F2 + Gap 4 contract).
+    // Existing assertions (carry forward — F2 contract).
     const rec = readNeedsAttention(NA_LEGACY);
     assert.equal(rec!.frontmatter.status, "dispatched", "NA must be flipped to dispatched");
-    assert.ok(payload.decision_record_path, "decision mirror must be minted");
+    // #218 round 2 (bb868daf): when /dispatch is called WITH decision_origin
+    // (the DecisionRouter caller path — exactly what this test simulates),
+    // the mirror mint is intentionally suppressed to avoid the 1/min minting
+    // loop. Gap 4 mirror minting still applies when /dispatch is called
+    // WITHOUT decision_origin — covered by the next assertion further down
+    // and by the second `it()` block.
+    assert.equal(
+      payload.decision_record_path, null,
+      "with decision_origin set, mirror mint MUST be suppressed (#218 round 2)",
+    );
 
     // NEW assertion (#216): the re-routed signal MUST be terminal —
     // status="routed_agent" — so SignalRouterWorkflow's `unrouted`

--- a/packages/ctrl/tests/integrations-auto-config-no-schedule.test.ts
+++ b/packages/ctrl/tests/integrations-auto-config-no-schedule.test.ts
@@ -264,6 +264,8 @@ mock.module("node:child_process", {
       stdin: { write: mock.fn(), end: mock.fn() },
       on: mock.fn(),
     })),
+    // execFileSync needed by src/api/routes/system.ts (ssh-keygen, unused here).
+    execFileSync: mock.fn(() => ""),
   },
 });
 

--- a/packages/ctrl/tests/integrations-disconnect.test.ts
+++ b/packages/ctrl/tests/integrations-disconnect.test.ts
@@ -218,6 +218,10 @@ mock.module("node:child_process", {
       const cb = args[args.length - 1] as Function;
       cb(null, "{}", "");
     }),
+    // execFileSync is imported by src/api/routes/system.ts (ssh-keygen
+    // path, unused here) — must be listed or the mock loader 500s the
+    // whole module import.
+    execFileSync: mock.fn(() => ""),
     spawn: mock.fn(() => ({
       stderr: { on: mock.fn() },
       stdin: { write: mock.fn(), end: mock.fn() },

--- a/packages/ctrl/tests/integrations-gmail-revoke-token.test.ts
+++ b/packages/ctrl/tests/integrations-gmail-revoke-token.test.ts
@@ -48,7 +48,8 @@ const fsMock: any = {
   promises: { mkdir: async () => undefined, writeFile: async () => undefined },
 };
 mock.module("node:fs", { defaultExport: fsMock, namedExports: { ...fsMock } });
-mock.module("node:child_process", { namedExports: { execFile: (...a: any[]) => { (a[a.length - 1] as Function)(null, "{}", ""); }, spawn: () => ({ stderr: { on() {} }, stdin: { write() {}, end() {} }, on() {} }) } });
+// execFileSync needed by src/api/routes/system.ts (ssh-keygen path, unused here).
+mock.module("node:child_process", { namedExports: { execFile: (...a: any[]) => { (a[a.length - 1] as Function)(null, "{}", ""); }, execFileSync: () => "", spawn: () => ({ stderr: { on() {} }, stdin: { write() {}, end() {} }, on() {} }) } });
 
 process.env.COMPOSIO_API_KEY = "test-composio-key";
 process.env.COMPOSIO_USER_ID = "alfred-test-user";

--- a/packages/ctrl/tests/integrations-reconnect.test.ts
+++ b/packages/ctrl/tests/integrations-reconnect.test.ts
@@ -177,6 +177,8 @@ mock.module("node:child_process", {
       const cb = args[args.length - 1] as Function;
       cb(null, "{}", "");
     }),
+    // execFileSync needed by src/api/routes/system.ts (ssh-keygen, unused here).
+    execFileSync: mock.fn(() => ""),
     spawn: mock.fn(() => ({
       stderr: { on: mock.fn() },
       stdin: { write: mock.fn(), end: mock.fn() },

--- a/packages/ctrl/tests/integrations-regenerate-skills.test.ts
+++ b/packages/ctrl/tests/integrations-regenerate-skills.test.ts
@@ -147,6 +147,8 @@ mock.module("node:child_process", {
       const cb = args[args.length - 1] as Function;
       cb(null, "{}", "");
     }),
+    // execFileSync needed by src/api/routes/system.ts (ssh-keygen, unused here).
+    execFileSync: mock.fn(() => ""),
     spawn: mock.fn(() => ({
       stderr: { on: mock.fn() },
       stdin: { write: mock.fn(), end: mock.fn() },

--- a/packages/ctrl/tests/integrations-revoke-stream-sweep.test.ts
+++ b/packages/ctrl/tests/integrations-revoke-stream-sweep.test.ts
@@ -47,7 +47,8 @@ const fsMock: any = {
   promises: { mkdir: async () => undefined, writeFile: async () => undefined },
 };
 mock.module("node:fs", { defaultExport: fsMock, namedExports: { ...fsMock } });
-mock.module("node:child_process", { namedExports: { execFile: (...a: any[]) => { (a[a.length - 1] as Function)(null, "{}", ""); }, spawn: () => ({ stderr: { on() {} }, stdin: { write() {}, end() {} }, on() {} }) } });
+// execFileSync needed by src/api/routes/system.ts (ssh-keygen path, unused here).
+mock.module("node:child_process", { namedExports: { execFile: (...a: any[]) => { (a[a.length - 1] as Function)(null, "{}", ""); }, execFileSync: () => "", spawn: () => ({ stderr: { on() {} }, stdin: { write() {}, end() {} }, on() {} }) } });
 
 process.env.COMPOSIO_API_KEY = "test-composio-key";
 process.env.COMPOSIO_USER_ID = "alfred-test-user";

--- a/packages/ctrl/tests/integrations-stream-badge-durable.test.ts
+++ b/packages/ctrl/tests/integrations-stream-badge-durable.test.ts
@@ -48,7 +48,8 @@ const fsMock: any = {
   promises: { mkdir: async () => undefined, writeFile: async () => undefined },
 };
 mock.module("node:fs", { defaultExport: fsMock, namedExports: { ...fsMock } });
-mock.module("node:child_process", { namedExports: { execFile: (...a: any[]) => { (a[a.length - 1] as Function)(null, "{}", ""); }, spawn: () => ({ stderr: { on() {} }, stdin: { write() {}, end() {} }, on() {} }) } });
+// execFileSync needed by src/api/routes/system.ts (ssh-keygen path, unused here).
+mock.module("node:child_process", { namedExports: { execFile: (...a: any[]) => { (a[a.length - 1] as Function)(null, "{}", ""); }, execFileSync: () => "", spawn: () => ({ stderr: { on() {} }, stdin: { write() {}, end() {} }, on() {} }) } });
 
 process.env.COMPOSIO_API_KEY = "test-composio-key";
 process.env.COMPOSIO_USER_ID = "alfred-test-user";

--- a/packages/ctrl/tests/onboarding_quality_gate.test.ts
+++ b/packages/ctrl/tests/onboarding_quality_gate.test.ts
@@ -20,6 +20,8 @@ const execFileFn = mock.fn((...args: any[]) => {
 mock.module("node:child_process", {
   namedExports: {
     execFile: execFileFn,
+    // execFileSync needed by src/api/routes/system.ts (ssh-keygen, unused here).
+    execFileSync: mock.fn(() => ""),
     spawn: mock.fn(() => ({ stderr: { on: mock.fn() }, stdin: { write: mock.fn(), end: mock.fn() }, on: mock.fn() })),
   },
 });

--- a/packages/ctrl/tests/onboarding_quality_report.test.ts
+++ b/packages/ctrl/tests/onboarding_quality_report.test.ts
@@ -15,6 +15,8 @@ const execFileFn = mock.fn((...args: any[]) => {
 mock.module("node:child_process", {
   namedExports: {
     execFile: execFileFn,
+    // execFileSync needed by src/api/routes/system.ts (ssh-keygen, unused here).
+    execFileSync: mock.fn(() => ""),
     spawn: mock.fn(() => ({ stderr: { on: mock.fn() }, stdin: { write: mock.fn(), end: mock.fn() }, on: mock.fn() })),
   },
 });

--- a/packages/ctrl/tests/plane-comment.test.ts
+++ b/packages/ctrl/tests/plane-comment.test.ts
@@ -19,6 +19,8 @@ const execFileFn = mock.fn((...args: any[]) => {
 mock.module("node:child_process", {
   namedExports: {
     execFile: execFileFn,
+    // execFileSync needed by src/api/routes/system.ts (ssh-keygen, unused here).
+    execFileSync: mock.fn(() => ""),
     spawn: mock.fn(() => ({
       stderr: { on: mock.fn() },
       stdin: { write: mock.fn(), end: mock.fn() },

--- a/packages/ctrl/tests/plane-read.test.ts
+++ b/packages/ctrl/tests/plane-read.test.ts
@@ -15,6 +15,8 @@ const execFileFn = mock.fn((...args: any[]) => {
 mock.module("node:child_process", {
   namedExports: {
     execFile: execFileFn,
+    // execFileSync needed by src/api/routes/system.ts (ssh-keygen, unused here).
+    execFileSync: mock.fn(() => ""),
     spawn: mock.fn(() => ({
       stderr: { on: mock.fn() },
       stdin: { write: mock.fn(), end: mock.fn() },

--- a/packages/ctrl/tests/plane-self-comments-path.test.ts
+++ b/packages/ctrl/tests/plane-self-comments-path.test.ts
@@ -84,6 +84,8 @@ mock.module("node:child_process", {
       const cb = args[args.length - 1] as Function;
       cb(null, '{"id":"x"}', "");
     }),
+    // execFileSync needed by src/api/routes/system.ts (ssh-keygen, unused here).
+    execFileSync: mock.fn(() => ""),
     spawn: mock.fn(() => ({ stderr: { on: mock.fn() }, stdin: { write: mock.fn(), end: mock.fn() }, on: mock.fn() })),
   },
 });

--- a/packages/ctrl/tests/sure-mutate-path.test.ts
+++ b/packages/ctrl/tests/sure-mutate-path.test.ts
@@ -29,6 +29,8 @@ const execFileFn = mock.fn((...args: any[]) => {
 mock.module("node:child_process", {
   namedExports: {
     execFile: execFileFn,
+    // execFileSync needed by src/api/routes/system.ts (ssh-keygen, unused here).
+    execFileSync: mock.fn(() => ""),
     spawn: mock.fn(() => ({
       stdout: { on: mock.fn() },
       stderr: { on: mock.fn() },

--- a/packages/ctrl/tests/sure-mutate.test.ts
+++ b/packages/ctrl/tests/sure-mutate.test.ts
@@ -22,6 +22,8 @@ const execFileFn = mock.fn((...args: any[]) => {
 mock.module("node:child_process", {
   namedExports: {
     execFile: execFileFn,
+    // execFileSync needed by src/api/routes/system.ts (ssh-keygen, unused here).
+    execFileSync: mock.fn(() => ""),
     spawn: mock.fn(() => ({
       stdout: { on: mock.fn() },
       stderr: { on: mock.fn() },

--- a/packages/ctrl/tests/vault-delete-not-found.test.ts
+++ b/packages/ctrl/tests/vault-delete-not-found.test.ts
@@ -55,6 +55,8 @@ const execFileFn = mock.fn((...args: any[]) => {
 mock.module("node:child_process", {
   namedExports: {
     execFile: execFileFn,
+    // execFileSync needed by src/api/routes/system.ts (ssh-keygen, unused here).
+    execFileSync: mock.fn(() => ""),
     spawn: mock.fn(() => ({
       stderr: { on: mock.fn() },
       stdin: { write: mock.fn(), end: mock.fn() },

--- a/packages/ctrl/tests/vault-patch-not-found.test.ts
+++ b/packages/ctrl/tests/vault-patch-not-found.test.ts
@@ -45,6 +45,8 @@ const execFileFn = mock.fn((...args: any[]) => {
 mock.module("node:child_process", {
   namedExports: {
     execFile: execFileFn,
+    // execFileSync needed by src/api/routes/system.ts (ssh-keygen, unused here).
+    execFileSync: mock.fn(() => ""),
     spawn: mock.fn(() => ({
       stderr: { on: mock.fn() },
       stdin: { write: mock.fn(), end: mock.fn() },

--- a/packages/ctrl/tests/vault.test.ts
+++ b/packages/ctrl/tests/vault.test.ts
@@ -18,6 +18,8 @@ const execFileFn = mock.fn((...args: any[]) => {
 mock.module("node:child_process", {
   namedExports: {
     execFile: execFileFn,
+    // execFileSync needed by src/api/routes/system.ts (ssh-keygen, unused here).
+    execFileSync: mock.fn(() => ""),
     spawn: mock.fn(() => ({ stderr: { on: mock.fn() }, stdin: { write: mock.fn(), end: mock.fn() }, on: mock.fn() })),
   },
 });

--- a/packages/ctrl/tests/voice-routes.test.ts
+++ b/packages/ctrl/tests/voice-routes.test.ts
@@ -38,11 +38,39 @@ import realFs from "node:fs";
 // no-op, but defer to the real fs for anything else (tsx loader still
 // needs it to read source files).
 
+// State the fakes read from on each call, mutated per-test in `beforeEach`.
+interface FakeState {
+  composeService: "missing" | "running" | "starting" | "unhealthy";
+  envText: string; // contents of the hermes-main /.env
+  composeEnvText: string; // contents of COMPOSE_DIR/.env (OPENAI_API_KEY + allowlist)
+  logsTail: string; // tail of voice-bridge container logs (used in error state)
+}
+
+const fake: FakeState = {
+  composeService: "missing",
+  envText: "",
+  composeEnvText: "",
+  logsTail: "",
+};
+
+// fs.readFileSync is called by voice.ts's `readComposeEnvKey()` to read
+// COMPOSE_DIR/.env directly (OPENAI_API_KEY + voice allowlist). Intercept
+// that one path and serve `fake.composeEnvText`; defer to real fs for
+// anything else (tsx loader, source files).
+const realReadFileSync = realFs.readFileSync;
+const readFileSyncFn = mock.fn((p: any, opts?: any) => {
+  if (typeof p === "string" && p.endsWith("/.env")) {
+    return fake.composeEnvText;
+  }
+  return realReadFileSync(p, opts);
+});
+
 const fsMock = {
   ...realFs,
   mkdirSync: mock.fn(() => undefined),
   writeFileSync: mock.fn(() => undefined),
   appendFileSync: mock.fn(() => undefined),
+  readFileSync: readFileSyncFn,
 };
 
 mock.module("node:fs", {
@@ -54,21 +82,9 @@ mock.module("node:fs", {
     mkdirSync: fsMock.mkdirSync,
     writeFileSync: fsMock.writeFileSync,
     appendFileSync: fsMock.appendFileSync,
+    readFileSync: readFileSyncFn,
   },
 });
-
-// State the fakes read from on each call, mutated per-test in `beforeEach`.
-interface FakeState {
-  composeService: "missing" | "running" | "starting" | "unhealthy";
-  envText: string; // contents of the hermes-main /.env
-  logsTail: string; // tail of voice-bridge container logs (used in error state)
-}
-
-const fake: FakeState = {
-  composeService: "missing",
-  envText: "",
-  logsTail: "",
-};
 
 // dockerComposeCmd(["ps","voice-bridge","--format","json"]) is the
 // compose_service_exists probe. When the service is absent, `docker
@@ -199,6 +215,7 @@ after(async () => {
 beforeEach(() => {
   fake.composeService = "missing";
   fake.envText = "";
+  fake.composeEnvText = "";
   fake.logsTail = "";
   dockerComposeCmdFn.mock.resetCalls();
   dockerExecFn.mock.resetCalls();
@@ -282,6 +299,10 @@ describe("GET /api/v1/channels/voice/status", () => {
       "TWILIO_ACCOUNT_SID=AC00000000000000000000000000000000\n" +
       "TWILIO_AUTH_TOKEN=00000000000000000000000000000000\n" +
       "TWILIO_PHONE_NUMBER=+15550100\n";
+    // PR #42 made OPENAI_API_KEY a gate for state="configured_running"
+    // (voice-bridge needs it to talk to gpt-realtime). Without it, /status
+    // resolves to state="unconfigured" with openai_key_set=false.
+    fake.composeEnvText = "OPENAI_API_KEY=sk-test-dummy\n";
     const { status, data } = await get("/api/v1/channels/voice/status");
     assert.equal(status, 200);
     assert.equal(data.compose_service_exists, true);
@@ -294,6 +315,9 @@ describe("GET /api/v1/channels/voice/status", () => {
   it("reports state=error with a non-null error string when the service is unhealthy", async () => {
     fake.composeService = "unhealthy";
     fake.envText = "TWILIO_PHONE_NUMBER=+15550100\n";
+    // PR #42: OPENAI_API_KEY required for state="error" too (otherwise the
+    // openai-key-missing path swallows it as state="unconfigured").
+    fake.composeEnvText = "OPENAI_API_KEY=sk-test-dummy\n";
     fake.logsTail =
       "voice-bridge | ERROR: media stream websocket connection refused\n";
     const { status, data } = await get("/api/v1/channels/voice/status");


### PR DESCRIPTION
Two cleanups, one PR per the commit split.

## 1. CI guard — reject tests/test_*.ts naming

PR #110 PR1 shipped a whole batch of HA-channel routes whose tests never actually ran in CI. The file was named `tests/test_channels_ha_pr1.ts` (prefix convention); the runner globs `tests/*.test.ts` (suffix), so the test file was silently invisible. PR #133 fixed the rename. This PR adds a `test-naming-guard` job to `.github/workflows/ci-check.yml` that fails the moment any `packages/ctrl/tests/test_*.ts` or `packages/web/src/test_*.ts` file lands. Cheap, no install, fail-fast.

## 2. Clear baseline ctrl-api failures — 24 → 0

`cd packages/ctrl && npm test` had been reporting 24 failures as "baseline" for the entire session. Investigation revealed three real categories, not 24 separate issues.

### A. Module-mock contract drift (20 files)

`mock.module("node:child_process", { namedExports: ... })` from `node:test` rejects any named import the consumer module makes if it isn't listed. A recent change added `import { execFileSync } from "node:child_process"` to `src/api/routes/system.ts` (the `/ssh-keys` keygen path). Every test that imports `server.ts` transitively imports `system.ts`, and every one that mocks `node:child_process` without listing `execFileSync` failed at file-load time with `SyntaxError: ... does not provide an export named 'execFileSync'`.

Fix: stub `execFileSync: mock.fn(() => "")` (or `() => ""`) in each mock block. The tests don't exercise the ssh-keygen path, so a no-op is correct.

Files touched (all under `packages/ctrl/tests/`):
- `admin.test.ts`, `agents.test.ts`, `context.test.ts`, `cross-tenant.test.ts`
- `integrations-disconnect.test.ts`, `integrations-gmail-revoke-token.test.ts`, `integrations-auto-config-no-schedule.test.ts`, `integrations-reconnect.test.ts`, `integrations-regenerate-skills.test.ts`, `integrations-revoke-stream-sweep.test.ts`, `integrations-stream-badge-durable.test.ts`
- `onboarding_quality_gate.test.ts`, `onboarding_quality_report.test.ts`
- `plane-comment.test.ts`, `plane-read.test.ts`, `plane-self-comments-path.test.ts`
- `sure-mutate.test.ts`, `sure-mutate-path.test.ts`
- `vault.test.ts`, `vault-delete-not-found.test.ts`, `vault-patch-not-found.test.ts`

### B. voice-routes.test.ts — 2 sub-tests, stale assertion

PR #42 added `openai_key_set` as a gate (no `OPENAI_API_KEY` in `${COMPOSE_DIR}/.env` → `state="unconfigured"`), but the two tests asserting `state="configured_running"` and `state="error"` were not updated to seed the key. Fix: add a `composeEnvText` field to `FakeState`, intercept `fs.readFileSync(...'/.env')` to serve it, and seed `OPENAI_API_KEY=sk-test-dummy` in the two affected cases.

### C. dispatch-signal-terminal.test.ts — 1 sub-test, stale assertion

Test asserted `payload.decision_record_path` was truthy after `POST /api/v1/admin/needs-attention/:id/dispatch` with `decision_origin` set. PR #218 round 2 (commit bb868daf) intentionally suppresses mirror minting when `decision_origin` is set — that's the DecisionRouter caller path, and minting was the cause of the 1/min minting loop. Fix: flip to assert mirror IS suppressed when `decision_origin` is set. The file's actual subject (the #216 terminal-status guarantee) is unaffected.

## Disposition table

| Test (file or sub-test) | Disposition |
|---|---|
| 20 file-level failures (see list in A above) | **updated** — added `execFileSync` to the mock's `namedExports` |
| `voice-routes.test.ts` :: `state=configured_running` | **updated** — seed `OPENAI_API_KEY` in `composeEnvText` |
| `voice-routes.test.ts` :: `state=error` | **updated** — same |
| `dispatch-signal-terminal.test.ts` :: `legacy POST /needs-attention/:id/dispatch leaves the signal in a router-skip state` | **updated** — flip assertion to match #218 round 2 contract |

Zero tests skipped. Zero `TODO/fix` markers left. Zero source under test changed (the source was already correct; the tests were stale).

## Before / after

```
BEFORE:  742 tests · 718 pass · 24 fail · 1 skipped (pre-existing)
AFTER:   742 tests · 741 pass ·  0 fail · 1 skipped (pre-existing)
```

`node build.mjs` (the bundle CI check) verified green. The CI guard's logic verified locally by synthesising a `test_guard_canary.ts` file and confirming the `find` returns it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)