### PR TITLE
feat(learn,ctrl,web): HaBootstrapWorkflow Phase A — registry pull + dedupe (#110 PR5)

### DIFF
--- a/packages/ctrl/src/api/auth.ts
+++ b/packages/ctrl/src/api/auth.ts
@@ -49,7 +49,7 @@
 
 import crypto from "node:crypto";
 import type { IncomingMessage } from "node:http";
-import { AuthError } from "./errors.js";
+import { ApiError, AuthError } from "./errors.js";
 import { getStateDb } from "../db/state.js";
 import {
   validateChannelToken,
@@ -322,6 +322,69 @@ function extractRemoteIp(req: IncomingMessage): string | null {
   const sock = (req as { socket?: { remoteAddress?: string } }).socket;
   return sock?.remoteAddress ?? null;
 }
+
+/** Require an operator-grade bearer (the master AAS_API_KEY) on the request.
+ *
+ *  The global `authenticate()` already accepts both the master key and the
+ *  scoped voice-bridge token (the latter gated by the allowlists above).
+ *  This helper layers an EXPLICIT operator-only check on top — used by
+ *  routes that handle sensitive material (HA LLAT retrieval, registry
+ *  bulk-upsert, on-demand workflow refresh) where defence-in-depth matters
+ *  even though those routes are NOT in either allowlist.
+ *
+ *  Failure modes:
+ *    * `apiKeyBuf` unset → returns silently (dev-only open-access mode).
+ *    * Bearer missing/malformed → throws ApiError(401).
+ *    * Bearer matches the voice-bridge token → throws ApiError(403). This
+ *      is the load-bearing branch: a voice-bridge sibling that ever tries
+ *      to reach an operator-only route must be told NO with a code that
+ *      surfaces in logs as a permission boundary, NOT confused with a
+ *      stale-token 401.
+ *    * Bearer matches a channel_tokens row (`pcp_*` / `cnv_*` / etc.) →
+ *      throws ApiError(403). Same rationale.
+ *    * Bearer matches the master key → returns.
+ *
+ *  IMPORTANT: never logs or echoes the bearer bytes — the operator-key
+ *  surface accepts an LLAT-shaped secret in its response payload, so the
+ *  failure path mustn't leak any token material via the error envelope.
+ */
+export function requireOperatorBearer(req: IncomingMessage): void {
+  if (!apiKeyBuf) return; // dev-only open-access mode (same as authenticate())
+
+  const raw = extractBearerToken(req);
+  if (!raw) {
+    throw new ApiError(401, "UNAUTHORIZED", "Missing or malformed Authorization header");
+  }
+
+  const tokenBuf = Buffer.from(raw);
+
+  // Master key — operator. Allowed.
+  if (
+    tokenBuf.length === apiKeyBuf.length &&
+    crypto.timingSafeEqual(tokenBuf, apiKeyBuf)
+  ) {
+    return;
+  }
+
+  // Voice-bridge token — explicitly forbidden. 403, not 401: this is a
+  // permission boundary, not a credentials problem.
+  if (
+    voiceBridgeKeyBuf &&
+    tokenBuf.length === voiceBridgeKeyBuf.length &&
+    crypto.timingSafeEqual(tokenBuf, voiceBridgeKeyBuf)
+  ) {
+    throw new ApiError(403, "FORBIDDEN", "Operator-only route");
+  }
+
+  // Channel token (pcp_…, ha-… etc.) — also forbidden. We don't have to
+  // look it up against the channel_tokens table; ANY non-master bearer
+  // that isn't voice-bridge falls through to this branch. Returning 403
+  // (not 401) makes the boundary explicit in the request log.
+  throw new ApiError(403, "FORBIDDEN", "Operator-only route");
+}
+
+// Re-export ApiError as an internal-only name used by requireOperatorBearer
+// — kept private to this module so callers see the right error class.
 
 /** Authenticate a channel-keyed bearer for one channel. Throws AuthError
  *  on no/bad/revoked token. Returns the row metadata on success.

--- a/packages/ctrl/src/api/routes/channels_ha.ts
+++ b/packages/ctrl/src/api/routes/channels_ha.ts
@@ -31,7 +31,8 @@ import { addRoute } from "../server.js";
 import { sendJson, ValidationError, ApiError, ConflictError, NotFoundError } from "../errors.js";
 import { getStateDb } from "../../db/state.js";
 import { appendJournal } from "../../db/alfredJournal.js";
-import { channelTokenBearer } from "../auth.js";
+import { channelTokenBearer, requireOperatorBearer } from "../auth.js";
+import { dockerExec } from "../helpers.js";
 import { ulid } from "../../db/ulid.js";
 import fs from "node:fs";
 import { WebSocket } from "ws";
@@ -972,6 +973,16 @@ export function registerHaChannelRoutes(): void {
   addRoute("GET", "/api/v1/channels/ha/registry", async ({ res }) => {
     sendJson(res, 200, readRegistry());
   });
+
+  // #110 PR5 — registry bootstrap surface (LLAT retrieval + bulk upsert +
+  // on-demand refresh). All three routes are operator-only (master
+  // AAS_API_KEY); the LLAT route is the most sensitive — it returns the
+  // raw HA long-lived access token so alfred-learn's HaBootstrapWorkflow
+  // can call the HA REST/WS API directly. Voice-bridge + channel-token
+  // bearers are explicitly rejected with 403 (not 401) so the boundary
+  // surfaces clearly in audit logs even if those tokens are otherwise
+  // valid against the read paths in the same `/ha/*` namespace.
+  registerHaBootstrapRoutes();
 
   // #110 PR4 — the write surface (call_service, proposal create/apply,
   // snapshot rollback, subscribe/unsubscribe). Registration deferred
@@ -2025,4 +2036,318 @@ export function registerHaWriteRoutes(): void {
       sendJson(res, 200, { ok: true, closed_at: reread.closed_at });
     },
   );
+}
+
+// ═════════════════════════════════════════════════════════════════════════
+// #110 PR5 — HA BOOTSTRAP REGISTRY SURFACE
+// ═════════════════════════════════════════════════════════════════════════
+//
+// Three operator-only routes for the HaBootstrapWorkflow (alfred-learn).
+// The workflow runs every 6h (Temporal schedule `al-ha-bootstrap`) and on
+// demand from the HaCard "Refresh registry" CTA. Its activity:
+//
+//   1. GETs /api/v1/channels/ha/status — to read the operator-configured
+//      HA URL and confirm the install is reachable;
+//   2. GETs /api/v1/channels/ha/llat   — to fetch the raw LLAT (this
+//      route is the sensitive one — see the guard below);
+//   3. calls HA's own REST API directly with that LLAT, pulling
+//      entity_registry / area_registry / device_registry / states /
+//      automations / services in parallel;
+//   4. POSTs the normalised result to /api/v1/channels/ha/registry/bulk
+//      which batch-upserts ha_registry rows and tombstones vanished IDs.
+//
+// The on-demand "Refresh registry" CTA on /channels invokes
+// POST /api/v1/channels/ha/registry/refresh which schedules a one-shot
+// run of the workflow via `temporal workflow start`.
+
+// Helper — bulk upsert body shape.
+interface HaRegistryBulkRow {
+  kind: string;
+  ha_id: string;
+  domain?: string | null;
+  area_id?: string | null;
+  friendly_name?: string | null;
+  state?: string | null;
+  attributes_json?: string | null;
+  payload_json: string;
+  last_changed?: string | null;
+  last_updated?: string | null;
+}
+
+// The 6 vault `kind` buckets this route accepts. Anything else is dropped
+// at parse time so a misbehaving activity can't insert a row that the
+// /registry read can't surface.
+const HA_REGISTRY_KINDS = new Set([
+  "entity",
+  "area",
+  "device",
+  "automation",
+  "scene",
+  "helper",
+]);
+
+function parseBulkBody(raw: unknown): HaRegistryBulkRow[] {
+  if (typeof raw !== "object" || raw === null) {
+    throw new ValidationError("body must be a JSON object");
+  }
+  const b = raw as Record<string, unknown>;
+  if (!Array.isArray(b.rows)) {
+    throw new ValidationError("rows must be an array");
+  }
+  const out: HaRegistryBulkRow[] = [];
+  for (const r of b.rows) {
+    if (typeof r !== "object" || r === null) continue;
+    const row = r as Record<string, unknown>;
+    if (typeof row.kind !== "string" || !HA_REGISTRY_KINDS.has(row.kind)) continue;
+    if (typeof row.ha_id !== "string" || row.ha_id.length === 0) continue;
+    if (typeof row.payload_json !== "string" || row.payload_json.length === 0) {
+      continue;
+    }
+    out.push({
+      kind: row.kind,
+      ha_id: row.ha_id,
+      domain: typeof row.domain === "string" ? row.domain : null,
+      area_id: typeof row.area_id === "string" ? row.area_id : null,
+      friendly_name:
+        typeof row.friendly_name === "string" ? row.friendly_name : null,
+      state: typeof row.state === "string" ? row.state : null,
+      attributes_json:
+        typeof row.attributes_json === "string" ? row.attributes_json : null,
+      payload_json: row.payload_json,
+      last_changed:
+        typeof row.last_changed === "string" ? row.last_changed : null,
+      last_updated:
+        typeof row.last_updated === "string" ? row.last_updated : null,
+    });
+  }
+  return out;
+}
+
+interface BulkUpsertResult {
+  inserted: number;
+  updated: number;
+  tombstoned: number;
+  total_after: number;
+}
+
+/** Single-transaction bulk upsert + tombstone of vanished rows.
+ *
+ *  Returns counts of inserted / updated / tombstoned / total_after for the
+ *  audit ledger. The tombstone branch only sets `vanished_at` for rows
+ *  that don't already have one — re-running with the same input doesn't
+ *  re-stamp the column, which the test suite asserts.
+ *
+ *  Privacy: this function never touches LLAT material — only entity_id /
+ *  state / friendly_name / payload_json (the raw HA record minus auth
+ *  headers, which were stripped by the activity before persisting). */
+function bulkUpsertHaRegistry(rows: HaRegistryBulkRow[]): BulkUpsertResult {
+  const db = getStateDb();
+  const now = new Date().toISOString();
+
+  // Pre-count to compute inserted vs updated. A small but useful piece of
+  // bookkeeping for the operator UI — without it we'd report the whole
+  // batch as "upserted" and lose the diff signal.
+  const inputKeys = new Set(rows.map((r) => `${r.kind}::${r.ha_id}`));
+
+  let inserted = 0;
+  let updated = 0;
+  let tombstoned = 0;
+
+  db.exec("BEGIN");
+  try {
+    // 1. Upsert pass — for each input row, INSERT … ON CONFLICT(kind, ha_id)
+    //    DO UPDATE. The PRIMARY KEY on ha_registry is (kind, ha_id) so the
+    //    conflict clause needs both columns.
+    const upsertStmt = db.prepare(
+      `INSERT INTO ha_registry (
+         kind, ha_id, domain, area_id, friendly_name, state,
+         attributes_json, payload_json, last_seen_at, last_changed,
+         last_updated, vanished_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+       ON CONFLICT(kind, ha_id) DO UPDATE SET
+         domain = excluded.domain,
+         area_id = excluded.area_id,
+         friendly_name = excluded.friendly_name,
+         state = excluded.state,
+         attributes_json = excluded.attributes_json,
+         payload_json = excluded.payload_json,
+         last_seen_at = excluded.last_seen_at,
+         last_changed = COALESCE(excluded.last_changed, ha_registry.last_changed),
+         last_updated = COALESCE(excluded.last_updated, ha_registry.last_updated),
+         vanished_at = NULL`,
+    );
+    const existsStmt = db.prepare(
+      "SELECT 1 FROM ha_registry WHERE kind = ? AND ha_id = ? LIMIT 1",
+    );
+    for (const row of rows) {
+      const existed = existsStmt.get(row.kind, row.ha_id);
+      upsertStmt.run(
+        row.kind,
+        row.ha_id,
+        row.domain ?? null,
+        row.area_id ?? null,
+        row.friendly_name ?? null,
+        row.state ?? null,
+        row.attributes_json ?? null,
+        row.payload_json,
+        now,
+        row.last_changed ?? null,
+        row.last_updated ?? null,
+      );
+      if (existed) updated += 1;
+      else inserted += 1;
+    }
+
+    // 2. Tombstone pass — every existing row whose (kind, ha_id) isn't in
+    //    the input set gets `vanished_at = now()`. We filter on
+    //    `vanished_at IS NULL` so the timestamp is stamped exactly ONCE
+    //    per row (subsequent runs with the same vanished set are no-ops).
+    //
+    //    The query is a single UPDATE with a NOT-IN list; SQLite handles
+    //    a few thousand entity_ids comfortably, which covers any realistic
+    //    HA install (typical: 200-500 entities, hoarder install: ~2000).
+    const candidates = db
+      .prepare("SELECT kind, ha_id FROM ha_registry WHERE vanished_at IS NULL")
+      .all() as Array<{ kind: string; ha_id: string }>;
+    const tombstoneStmt = db.prepare(
+      `UPDATE ha_registry
+         SET vanished_at = ?
+       WHERE kind = ? AND ha_id = ? AND vanished_at IS NULL`,
+    );
+    for (const c of candidates) {
+      const key = `${c.kind}::${c.ha_id}`;
+      if (inputKeys.has(key)) continue;
+      tombstoneStmt.run(now, c.kind, c.ha_id);
+      tombstoned += 1;
+    }
+
+    db.exec("COMMIT");
+  } catch (err) {
+    db.exec("ROLLBACK");
+    throw err;
+  }
+
+  const totalRow = db
+    .prepare("SELECT COUNT(*) AS n FROM ha_registry")
+    .get() as { n: number } | undefined;
+  return {
+    inserted,
+    updated,
+    tombstoned,
+    total_after: Number(totalRow?.n ?? 0),
+  };
+}
+
+export function registerHaBootstrapRoutes(): void {
+  // ──────────────────────────────────────────────────────────────────────
+  // GET /api/v1/channels/ha/llat — operator-only LLAT retrieval.
+  //
+  // This is the sensitive route. The HaBootstrapWorkflow activity hits it
+  // exactly once per workflow run, fetches the raw LLAT off the
+  // Vaultwarden item, and uses it to call HA's REST/WS API. The token
+  // never lives in the workflow's persisted state — only in memory for
+  // the duration of one activity invocation.
+  //
+  // Defence in depth (per Sir's rule: never echo LLAT in errors or logs):
+  //   * requireOperatorBearer() rejects voice-bridge + channel-token
+  //     bearers with 403 (not 401) before the route even runs.
+  //   * The response body carries ONLY the LLAT — no echo of the URL,
+  //     ha_version, or other state.db fields that would surface
+  //     elsewhere on disk if the response was accidentally captured.
+  //   * 404 NOT_CONNECTED when the install isn't connected — same code
+  //     a probing 401-attempt would see, but with a distinct shape so
+  //     the workflow can no-op cleanly without a retry storm.
+  //   * Errors NEVER include the LLAT (the route never reflects request
+  //     fields into the error envelope).
+  // ──────────────────────────────────────────────────────────────────────
+  addRoute("GET", "/api/v1/channels/ha/llat", async ({ req, res }) => {
+    requireOperatorBearer(req);
+    const row = getHaConnectionRow();
+    if (!row || row.state !== "connected") {
+      throw new NotFoundError("Home Assistant is not connected");
+    }
+    let llat: string;
+    try {
+      llat = await readHaLlat();
+    } catch (err) {
+      if (err instanceof ApiError) throw err;
+      // Never let an unexpected error path echo back the bearer or the
+      // vault-cli response body.
+      throw new ApiError(502, "VAULT_UNREACHABLE", "vault-cli read failed");
+    }
+    sendJson(res, 200, { llat });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // POST /api/v1/channels/ha/registry/bulk — operator-only bulk upsert.
+  //
+  // Body: { rows: HaRegistryBulkRow[] }
+  //
+  // The HaBootstrapWorkflow.write_ha_registry activity sends a single
+  // batch per run. The route does the upsert + tombstone in one
+  // transaction and returns { inserted, updated, tombstoned, total_after }.
+  // ──────────────────────────────────────────────────────────────────────
+  addRoute("POST", "/api/v1/channels/ha/registry/bulk", async ({ req, res, body }) => {
+    requireOperatorBearer(req);
+    const rows = parseBulkBody(body);
+    const result = bulkUpsertHaRegistry(rows);
+    sendJson(res, 200, { ok: true, ...result });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // POST /api/v1/channels/ha/registry/refresh — on-demand workflow trigger.
+  //
+  // Operator CTA on /channels (HaCard "Refresh registry" button). Starts
+  // a one-shot HaBootstrapWorkflow run via `temporal workflow start`,
+  // returning the workflow_id immediately (202). The dashboard polls
+  // /registry afterwards.
+  //
+  // The workflow itself takes ~30s end-to-end on a small HA install
+  // (REST roundtrips dominate); we surface an ETA for the operator copy.
+  // ──────────────────────────────────────────────────────────────────────
+  addRoute("POST", "/api/v1/channels/ha/registry/refresh", async ({ req, res }) => {
+    requireOperatorBearer(req);
+    const row = getHaConnectionRow();
+    if (!row || row.state !== "connected") {
+      throw new ConflictError(
+        "Home Assistant is not connected. POST /api/v1/channels/ha/connect first.",
+      );
+    }
+    const workflowId = `ha-bootstrap-${Date.now()}`;
+    try {
+      await dockerExec("temporal", [
+        "temporal",
+        "workflow",
+        "start",
+        "--type",
+        "HaBootstrapWorkflow",
+        "--task-queue",
+        "alfred-learn",
+        "--workflow-id",
+        workflowId,
+      ]);
+    } catch (err) {
+      throw new ApiError(
+        502,
+        "TEMPORAL_UNREACHABLE",
+        err instanceof Error ? err.message : "temporal start failed",
+      );
+    }
+    sendJson(res, 202, {
+      ok: true,
+      workflow_id: workflowId,
+      eta: "30s",
+    });
+  });
+}
+
+/** For tests only — clear the ha_registry between runs without recreating
+ *  the whole state.db. The bulk-upsert tests in channels_ha_pr5.test.ts
+ *  call this in their `beforeEach`. */
+export function _resetHaRegistryForTests(): void {
+  try {
+    getStateDb().prepare("DELETE FROM ha_registry").run();
+  } catch {
+    /* table may not exist on first boot; tests run migrations themselves */
+  }
 }

--- a/packages/ctrl/src/db/migrate.ts
+++ b/packages/ctrl/src/db/migrate.ts
@@ -22,6 +22,7 @@ import m0005 from "./migrations/0005_ha_channel.sql";
 import m0006 from "./migrations/0006_files_table.sql";
 import m0007 from "./migrations/0007_recall.sql";
 import m0008 from "./migrations/0008_ha_event_subscription.sql";
+import m0009 from "./migrations/0009_ha_registry_vanished.sql";
 
 interface Migration {
   version: number;
@@ -39,6 +40,7 @@ const MIGRATIONS: Migration[] = [
   { version: 6, name: "files_table",          sql: m0006 },
   { version: 7, name: "recall",               sql: m0007 },
   { version: 8, name: "ha_event_subscription", sql: m0008 },
+  { version: 9, name: "ha_registry_vanished",  sql: m0009 },
 ];
 
 /**

--- a/packages/ctrl/src/db/migrations/0009_ha_registry_vanished.sql
+++ b/packages/ctrl/src/db/migrations/0009_ha_registry_vanished.sql
@@ -1,0 +1,34 @@
+-- 0009_ha_registry_vanished — tombstone column for the HA registry (#110 PR5).
+--
+-- HaBootstrapWorkflow Phase A (alfred-learn, every 6h + on demand) pulls the
+-- HA install's full entity / area / device / automation surface and POSTs it
+-- to ctrl-api's new `/api/v1/channels/ha/registry/bulk` route. The route
+-- upserts the rows it received AND tombstones (NOT deletes) every existing
+-- ha_registry row whose ha_id wasn't in the new pull.
+--
+-- The tombstone is a `vanished_at` timestamp instead of a row delete because:
+--
+--   * the principal can investigate "where did the kitchen light go?" — the
+--     row remains queryable until they explicitly clear it on disconnect;
+--   * a transient HA outage that produces a partial pull (one domain failed)
+--     should not silently wipe rows the next-tick refresh will restore;
+--   * the loop-guard's audit ledger (ha_run) carries entity_ids that may
+--     reference vanished entities — keeping the row preserves the audit join.
+--
+-- The bulk route stamps vanished_at exactly ONCE per row — a re-run with the
+-- same vanished set does NOT re-stamp (the route's UPDATE filters on
+-- `vanished_at IS NULL`). This is asserted by channels_ha_pr5.test.ts.
+--
+-- We also add an index over `last_seen_at` because the dashboard's
+-- "recently-seen entities" surface (PR6) needs an O(log n) scan, and the
+-- partial index over `vanished_at IS NULL` keeps the "live entities" read
+-- cheap regardless of how many tombstones accumulate.
+
+ALTER TABLE ha_registry ADD COLUMN vanished_at TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_ha_registry_live
+  ON ha_registry(kind, ha_id)
+  WHERE vanished_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_ha_registry_last_seen
+  ON ha_registry(last_seen_at DESC);

--- a/packages/ctrl/tests/alfred-journal.test.ts
+++ b/packages/ctrl/tests/alfred-journal.test.ts
@@ -52,12 +52,13 @@ function tableNames(db: DatabaseSync): string[] {
 describe("alfred_journal migration", () => {
   it("bumps user_version to the latest migration", () => {
     // The runner applies every migration > current version, so the value
-    // naturally tracks the highest registered version. Today: 8
+    // naturally tracks the highest registered version. Today: 9
     // (0001 fix_pack + 0002 alfred_journal + 0003 tailscale_connection
     // + 0004 channel_tokens + 0005 ha_channel + 0006 files_table
-    // + 0007 recall + 0008 ha_event_subscription).
+    // + 0007 recall + 0008 ha_event_subscription
+    // + 0009 ha_registry_vanished).
     const db = makeDb();
-    assert.equal(userVersion(db), 8);
+    assert.equal(userVersion(db), 9);
     db.close();
   });
 

--- a/packages/ctrl/tests/channels_ha_pr5.test.ts
+++ b/packages/ctrl/tests/channels_ha_pr5.test.ts
@@ -1,0 +1,530 @@
+// Lane I — /api/v1/channels/ha/* HA bootstrap surface (#110 PR5).
+//
+// PR5 adds the three operator-only routes the alfred-learn
+// HaBootstrapWorkflow drives:
+//
+//   * GET  /api/v1/channels/ha/llat                — fetch the raw LLAT
+//                                                   (operator-only; 403 to
+//                                                   voice-bridge / channel
+//                                                   token bearers)
+//   * POST /api/v1/channels/ha/registry/bulk       — batch upsert + tombstone
+//                                                   vanished rows in one
+//                                                   transaction
+//   * POST /api/v1/channels/ha/registry/refresh    — start a one-shot
+//                                                   HaBootstrapWorkflow run
+//
+// Coverage (10 tests):
+//   1. bulk-upsert inserts new rows
+//   2. bulk-upsert updates existing rows (bumps last_seen_at)
+//   3. bulk-upsert tombstones rows NOT in input (vanished_at set)
+//   4. bulk-upsert is idempotent (same input twice = same row count)
+//   5. vanished_at is set ONCE — re-running with same vanished set doesn't re-stamp
+//   6. LLAT route requires operator bearer (master AAS_API_KEY) — 401 without
+//   7. LLAT route returns the raw LLAT on the master-key path
+//   8. LLAT route rejects voice-bridge bearer with 403 (NOT 401)
+//   9. LLAT route 404s when HA isn't connected
+//  10. refresh route returns 202 + workflow_id
+
+import { describe, it, before, beforeEach, mock } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ServerResponse } from "node:http";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "channels-ha-pr5-"));
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.VAULT_PATH = path.join(tmp, "vault");
+process.env.STATE_DB_PATH = path.join(tmp, "alfred-state.db");
+process.env.INGEST_DB_PATH = path.join(tmp, "ingest.db");
+process.env.SQLITE_VEC_PATH = "";
+process.env.VAULT_CLI_URL = "http://vault-cli-stub:8087";
+process.env.HA_VAULTWARDEN_FOLDER = "Home Assistant";
+process.env.HA_LLAT_ITEM = "LLAT";
+process.env.HA_PROBE_TIMEOUT_MS = "5000";
+
+// Synthetic placeholder — never resembles a real HA LLAT.
+const VALID_LLAT = "llat_TEST_" + "0".repeat(40);
+const HA_URL = "http://homeassistant.local:8123";
+const HA_VERSION = "2026.5.0";
+
+// ── fetch mock (vault-cli + HA probe; reused from PR1/PR4 patterns) ────
+
+interface VaultItem {
+  id: string;
+  name: string;
+  type: 1;
+  folderId: string | null;
+  login: { username: string | null; password: string; uris: unknown[] };
+}
+interface VaultFolder {
+  id: string;
+  name: string;
+}
+let vaultStore: VaultItem[] = [];
+let vaultFolders: VaultFolder[] = [];
+
+function makeJsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const originalFetch = globalThis.fetch;
+globalThis.fetch = (async (input: any, init?: any) => {
+  const url = typeof input === "string" ? input : (input?.url ?? String(input));
+  const method = (init?.method ?? "GET").toUpperCase();
+
+  // HA probes
+  if (url === `${HA_URL}/api/` && method === "GET") {
+    return makeJsonResponse({ message: "API running." }, 200);
+  }
+  if (url === `${HA_URL}/api/config` && method === "GET") {
+    return makeJsonResponse({ version: HA_VERSION }, 200);
+  }
+
+  // vault-cli folders
+  if (url.endsWith("/list/object/folders") && method === "GET") {
+    return makeJsonResponse({ success: true, data: { data: vaultFolders } });
+  }
+  if (url.endsWith("/object/folder") && method === "POST") {
+    const body = JSON.parse(String(init?.body ?? "{}"));
+    const f: VaultFolder = {
+      id: "fld-" + String(Date.now()) + "-" + Math.random().toString(36).slice(2, 6),
+      name: body.name,
+    };
+    vaultFolders.push(f);
+    return makeJsonResponse({ success: true, data: { data: f } });
+  }
+  // vault-cli items
+  if (url.includes("/list/object/items")) {
+    const qIdx = url.indexOf("?");
+    const params = new URLSearchParams(qIdx >= 0 ? url.slice(qIdx + 1) : "");
+    const search = params.get("search") ?? "";
+    const filtered = search
+      ? vaultStore.filter((i) => i.name.toLowerCase().includes(search.toLowerCase()))
+      : vaultStore.slice();
+    return makeJsonResponse({ success: true, data: { data: filtered } });
+  }
+  const objMatch = url.match(/\/object\/item\/([^/?]+)/);
+  if (objMatch && method === "GET") {
+    const id = objMatch[1];
+    const item = vaultStore.find((i) => i.id === id);
+    if (!item) return makeJsonResponse({ success: false, message: "not found" }, 404);
+    return makeJsonResponse({ success: true, data: { data: item } });
+  }
+  if (url.endsWith("/object/item") && method === "POST") {
+    const body = JSON.parse(String(init?.body ?? "{}"));
+    const id =
+      "id-" + String(Date.now()) + "-" + Math.random().toString(36).slice(2, 8);
+    const item: VaultItem = {
+      id,
+      name: body.name,
+      type: 1,
+      folderId: body.folderId ?? null,
+      login: {
+        username: body.login?.username ?? null,
+        password: body.login?.password ?? "",
+        uris: body.login?.uris ?? [],
+      },
+    };
+    vaultStore.push(item);
+    return makeJsonResponse({ success: true, data: { data: item } });
+  }
+  if (objMatch && method === "PUT") {
+    const id = objMatch[1];
+    const idx = vaultStore.findIndex((i) => i.id === id);
+    if (idx < 0) return makeJsonResponse({ success: false, message: "not found" }, 404);
+    const body = JSON.parse(String(init?.body ?? "{}"));
+    vaultStore[idx] = {
+      ...vaultStore[idx],
+      name: body.name ?? vaultStore[idx].name,
+      folderId: body.folderId ?? vaultStore[idx].folderId,
+      login: { ...vaultStore[idx].login, ...(body.login ?? {}) },
+    };
+    return makeJsonResponse({ success: true, data: { data: vaultStore[idx] } });
+  }
+  if (objMatch && method === "DELETE") {
+    const id = objMatch[1];
+    const idx = vaultStore.findIndex((i) => i.id === id);
+    if (idx < 0) return makeJsonResponse({ success: false, message: "not found" }, 404);
+    vaultStore.splice(idx, 1);
+    return makeJsonResponse({ success: true });
+  }
+  throw new Error(`unexpected fetch in channels_ha_pr5: ${method} ${url}`);
+}) as typeof fetch;
+
+// ── Stub out dockerExec — the refresh route calls into the temporal CLI.
+//
+// We mock node:child_process so the helpers.dockerExec call resolves to
+// a captured no-op instead of a real spawn. The rest of helpers.ts is
+// preserved unmodified, so other tests can still import from this file.
+
+let dockerExecCalls: string[][] = [];
+let dockerExecShouldFail = false;
+
+// helpers.ts's dockerExec calls execFile under the hood; intercept that.
+mock.module("node:child_process", {
+  namedExports: {
+    execFile: (file: string, args: string[], opts: any, cb: any) => {
+      // execFile signature can be (file, args, callback) OR
+      // (file, args, opts, callback) — normalise.
+      const callback = typeof opts === "function" ? opts : cb;
+      // First arg in our docker-exec path is "docker"; the rest is the
+      // command itself. We only care about the temporal arguments —
+      // strip the docker wrapper to make assertions cleaner.
+      if (file === "docker" && Array.isArray(args)) {
+        // args looks like: ["exec", "-T", "<service>", ...command]
+        const dashTIdx = args.indexOf("-T");
+        const cmd = dashTIdx >= 0 ? args.slice(dashTIdx + 2) : args.slice(1);
+        dockerExecCalls.push([...cmd]);
+      }
+      if (dockerExecShouldFail) {
+        callback(new Error("temporal unreachable"), "", "boom");
+        return;
+      }
+      callback(null, JSON.stringify({ started: true }), "");
+    },
+    execFileSync: () => "",
+    spawn: () => ({
+      stderr: { on: () => {} },
+      stdin: { write: () => {}, end: () => {} },
+      on: () => {},
+    }),
+    spawnSync: () => ({ stdout: "", stderr: "", status: 0 }),
+    exec: () => undefined,
+  },
+});
+
+const {
+  registerChannelsHaRoutes,
+  _resetHaSubscriptionsForTests,
+  _resetHaRegistryForTests,
+} = await import("../src/api/routes/channels_ha.js");
+const { matchRoute } = await import("../src/api/server.js");
+const { handleError } = await import("../src/api/errors.js");
+const { getStateDb } = await import("../src/db/state.js");
+const {
+  setApiKey,
+  setVoiceBridgeKey,
+  _resetAuthForTests,
+} = await import("../src/api/auth.js");
+
+registerChannelsHaRoutes();
+
+interface CallResult {
+  status: number;
+  payload: any;
+}
+async function call(
+  method: string,
+  p: string,
+  body?: unknown,
+  bearer?: string,
+): Promise<CallResult> {
+  const m = matchRoute(method, p);
+  assert.ok(m, `${method} ${p} must be registered`);
+  let status = 0;
+  let payload: any;
+  const res = {
+    statusCode: 0,
+    setHeader() {},
+    writeHead(c: number) {
+      status = c;
+      return res;
+    },
+    end(j?: string) {
+      payload = j ? JSON.parse(j) : undefined;
+    },
+  } as unknown as ServerResponse;
+  const headers: Record<string, string> = {};
+  if (bearer) headers.authorization = `Bearer ${bearer}`;
+  try {
+    await m!.handler({
+      req: { method, headers, url: p } as any,
+      res,
+      params: m!.params,
+      body,
+      query: new URLSearchParams(),
+    });
+  } catch (err) {
+    handleError(res, err);
+  }
+  return { status, payload };
+}
+
+async function connectHa(): Promise<void> {
+  const r = await call("POST", "/api/v1/channels/ha/connect", {
+    ha_url: HA_URL,
+    llat: VALID_LLAT,
+    label: "Test",
+  });
+  assert.equal(r.status, 200, JSON.stringify(r.payload));
+}
+
+const MASTER_KEY = "test-master-" + "a".repeat(40);
+const VOICE_KEY = "test-voice-" + "b".repeat(40);
+const CHANNEL_KEY = "pcp_" + "c".repeat(48);
+
+// ── tests ──────────────────────────────────────────────────────────────
+
+describe("/api/v1/channels/ha/* — #110 PR5 registry bootstrap", () => {
+  beforeEach(() => {
+    vaultStore = [];
+    vaultFolders = [];
+    dockerExecCalls = [];
+    dockerExecShouldFail = false;
+    const db = getStateDb();
+    try {
+      db.prepare("DELETE FROM ha_connection").run();
+    } catch {
+      /* table missing on very first run */
+    }
+    _resetHaRegistryForTests();
+    _resetHaSubscriptionsForTests();
+    _resetAuthForTests();
+  });
+
+  // ── 1 ── insert via bulk upsert
+  it("bulk upsert inserts new rows", async () => {
+    const rows = [
+      {
+        kind: "entity",
+        ha_id: "light.kitchen",
+        domain: "light",
+        area_id: "kitchen",
+        friendly_name: "Kitchen Light",
+        state: "on",
+        payload_json: '{"entity_id":"light.kitchen"}',
+      },
+      {
+        kind: "area",
+        ha_id: "kitchen",
+        friendly_name: "Kitchen",
+        payload_json: '{"area_id":"kitchen","name":"Kitchen"}',
+      },
+    ];
+    const r = await call("POST", "/api/v1/channels/ha/registry/bulk", { rows });
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.ok, true);
+    assert.equal(r.payload.inserted, 2);
+    assert.equal(r.payload.updated, 0);
+    assert.equal(r.payload.tombstoned, 0);
+    assert.equal(r.payload.total_after, 2);
+
+    const persisted = getStateDb()
+      .prepare("SELECT kind, ha_id, friendly_name FROM ha_registry ORDER BY ha_id")
+      .all() as Array<{ kind: string; ha_id: string; friendly_name: string }>;
+    assert.equal(persisted.length, 2);
+    const kitchen = persisted.find((p) => p.ha_id === "light.kitchen")!;
+    assert.equal(kitchen.kind, "entity");
+    assert.equal(kitchen.friendly_name, "Kitchen Light");
+  });
+
+  // ── 2 ── update bumps last_seen_at, friendly_name updates
+  it("bulk upsert updates existing rows (bumps last_seen_at, friendly_name change persists)", async () => {
+    // First insert
+    await call("POST", "/api/v1/channels/ha/registry/bulk", {
+      rows: [
+        {
+          kind: "entity",
+          ha_id: "light.kitchen",
+          domain: "light",
+          friendly_name: "Old Name",
+          state: "off",
+          payload_json: '{"old":true}',
+        },
+      ],
+    });
+    const before = getStateDb()
+      .prepare("SELECT last_seen_at, friendly_name FROM ha_registry WHERE ha_id = ?")
+      .get("light.kitchen") as { last_seen_at: string; friendly_name: string };
+    // Wait a millisecond so the timestamp can move.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    // Second insert — bumps + updates name.
+    const r = await call("POST", "/api/v1/channels/ha/registry/bulk", {
+      rows: [
+        {
+          kind: "entity",
+          ha_id: "light.kitchen",
+          domain: "light",
+          friendly_name: "New Name",
+          state: "on",
+          payload_json: '{"new":true}',
+        },
+      ],
+    });
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.inserted, 0);
+    assert.equal(r.payload.updated, 1);
+    assert.equal(r.payload.tombstoned, 0);
+
+    const after = getStateDb()
+      .prepare("SELECT last_seen_at, friendly_name, state FROM ha_registry WHERE ha_id = ?")
+      .get("light.kitchen") as { last_seen_at: string; friendly_name: string; state: string };
+    assert.equal(after.friendly_name, "New Name");
+    assert.equal(after.state, "on");
+    assert.notEqual(after.last_seen_at, before.last_seen_at);
+  });
+
+  // ── 3 ── tombstones rows not in input
+  it("bulk upsert tombstones rows that vanished from input (vanished_at set)", async () => {
+    // Seed three rows.
+    await call("POST", "/api/v1/channels/ha/registry/bulk", {
+      rows: [
+        { kind: "entity", ha_id: "light.a", payload_json: "{}" },
+        { kind: "entity", ha_id: "light.b", payload_json: "{}" },
+        { kind: "entity", ha_id: "light.c", payload_json: "{}" },
+      ],
+    });
+    // Second pull only has light.a — b + c should be tombstoned.
+    const r = await call("POST", "/api/v1/channels/ha/registry/bulk", {
+      rows: [{ kind: "entity", ha_id: "light.a", payload_json: "{}" }],
+    });
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.tombstoned, 2);
+
+    const all = getStateDb()
+      .prepare(
+        "SELECT ha_id, vanished_at FROM ha_registry ORDER BY ha_id",
+      )
+      .all() as Array<{ ha_id: string; vanished_at: string | null }>;
+    assert.equal(all.length, 3);
+    const aRow = all.find((x) => x.ha_id === "light.a")!;
+    const bRow = all.find((x) => x.ha_id === "light.b")!;
+    const cRow = all.find((x) => x.ha_id === "light.c")!;
+    assert.equal(aRow.vanished_at, null);
+    assert.ok(bRow.vanished_at, "light.b must carry a vanished_at timestamp");
+    assert.ok(cRow.vanished_at, "light.c must carry a vanished_at timestamp");
+  });
+
+  // ── 4 ── idempotent
+  it("bulk upsert is idempotent — second identical call leaves row count unchanged", async () => {
+    const rows = [
+      { kind: "entity", ha_id: "light.a", payload_json: "{}" },
+      { kind: "entity", ha_id: "light.b", payload_json: "{}" },
+    ];
+    const r1 = await call("POST", "/api/v1/channels/ha/registry/bulk", { rows });
+    const r2 = await call("POST", "/api/v1/channels/ha/registry/bulk", { rows });
+    assert.equal(r1.payload.total_after, 2);
+    assert.equal(r2.payload.total_after, 2);
+    // Second run is pure update — no inserts, no tombstones.
+    assert.equal(r2.payload.inserted, 0);
+    assert.equal(r2.payload.updated, 2);
+    assert.equal(r2.payload.tombstoned, 0);
+  });
+
+  // ── 5 ── vanished_at stamped ONCE
+  it("vanished_at is set ONCE — re-running with same vanished set doesn't re-stamp", async () => {
+    // Seed two rows.
+    await call("POST", "/api/v1/channels/ha/registry/bulk", {
+      rows: [
+        { kind: "entity", ha_id: "light.kept", payload_json: "{}" },
+        { kind: "entity", ha_id: "light.gone", payload_json: "{}" },
+      ],
+    });
+    // First "lost light.gone" pull.
+    await call("POST", "/api/v1/channels/ha/registry/bulk", {
+      rows: [{ kind: "entity", ha_id: "light.kept", payload_json: "{}" }],
+    });
+    const firstTombstone = getStateDb()
+      .prepare("SELECT vanished_at FROM ha_registry WHERE ha_id = ?")
+      .get("light.gone") as { vanished_at: string };
+    assert.ok(firstTombstone.vanished_at);
+
+    // Wait + run AGAIN with same input — vanished_at must NOT change.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    const r = await call("POST", "/api/v1/channels/ha/registry/bulk", {
+      rows: [{ kind: "entity", ha_id: "light.kept", payload_json: "{}" }],
+    });
+    assert.equal(r.status, 200);
+    // Tombstoned count is 0 — already tombstoned rows don't re-stamp.
+    assert.equal(r.payload.tombstoned, 0);
+    const secondTombstone = getStateDb()
+      .prepare("SELECT vanished_at FROM ha_registry WHERE ha_id = ?")
+      .get("light.gone") as { vanished_at: string };
+    assert.equal(secondTombstone.vanished_at, firstTombstone.vanished_at);
+  });
+
+  // ── 6 ── LLAT operator-only — 401 without bearer (when key configured)
+  it("LLAT route requires operator bearer (401 with no Authorization header)", async () => {
+    setApiKey(MASTER_KEY);
+    await connectHa(); // populate the vault item
+
+    const r = await call("GET", "/api/v1/channels/ha/llat");
+    assert.equal(r.status, 401, JSON.stringify(r.payload));
+    assert.equal(r.payload.error.code, "UNAUTHORIZED");
+    // The LLAT must not appear in the error envelope.
+    assert.ok(!JSON.stringify(r.payload).includes(VALID_LLAT));
+  });
+
+  // ── 7 ── LLAT route returns LLAT on master-key path
+  it("LLAT route returns the raw LLAT on the master-key (operator) bearer", async () => {
+    setApiKey(MASTER_KEY);
+    await connectHa();
+    const r = await call("GET", "/api/v1/channels/ha/llat", undefined, MASTER_KEY);
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.llat, VALID_LLAT);
+  });
+
+  // ── 8 ── LLAT route rejects voice-bridge bearer with 403 (not 401)
+  it("LLAT route rejects voice-bridge bearer with 403 (operator-only)", async () => {
+    setApiKey(MASTER_KEY);
+    setVoiceBridgeKey(VOICE_KEY);
+    await connectHa();
+    const r = await call("GET", "/api/v1/channels/ha/llat", undefined, VOICE_KEY);
+    assert.equal(r.status, 403, JSON.stringify(r.payload));
+    assert.equal(r.payload.error.code, "FORBIDDEN");
+    // No LLAT leak.
+    assert.ok(!JSON.stringify(r.payload).includes(VALID_LLAT));
+  });
+
+  // ── 8b ── unknown channel-token bearer also 403
+  it("LLAT route rejects channel-token bearer with 403", async () => {
+    setApiKey(MASTER_KEY);
+    await connectHa();
+    const r = await call("GET", "/api/v1/channels/ha/llat", undefined, CHANNEL_KEY);
+    assert.equal(r.status, 403, JSON.stringify(r.payload));
+    assert.equal(r.payload.error.code, "FORBIDDEN");
+  });
+
+  // ── 9 ── LLAT 404 when HA isn't connected
+  it("LLAT route 404s when HA is not connected", async () => {
+    setApiKey(MASTER_KEY);
+    const r = await call("GET", "/api/v1/channels/ha/llat", undefined, MASTER_KEY);
+    assert.equal(r.status, 404, JSON.stringify(r.payload));
+    assert.equal(r.payload.error.code, "NOT_FOUND");
+  });
+
+  // ── 10 ── refresh route returns 202 + workflow_id
+  it("refresh route returns 202 + workflow_id, calls temporal CLI", async () => {
+    await connectHa();
+    const r = await call("POST", "/api/v1/channels/ha/registry/refresh");
+    assert.equal(r.status, 202, JSON.stringify(r.payload));
+    assert.equal(r.payload.ok, true);
+    assert.ok(
+      typeof r.payload.workflow_id === "string" &&
+        r.payload.workflow_id.startsWith("ha-bootstrap-"),
+      "workflow_id must be present and prefixed",
+    );
+    assert.equal(r.payload.eta, "30s");
+    // The dockerExec mock recorded the temporal CLI invocation.
+    const dockerCall = dockerExecCalls.find((c) =>
+      c.includes("HaBootstrapWorkflow"),
+    );
+    assert.ok(dockerCall, "temporal CLI must be invoked with HaBootstrapWorkflow");
+    assert.ok(
+      dockerCall.includes("alfred-learn"),
+      "task-queue must be alfred-learn",
+    );
+  });
+
+  // ── 10b ── refresh 409 when HA isn't connected
+  it("refresh route 409s when HA is not connected", async () => {
+    const r = await call("POST", "/api/v1/channels/ha/registry/refresh");
+    assert.equal(r.status, 409, JSON.stringify(r.payload));
+    assert.equal(r.payload.error.code, "CONFLICT");
+  });
+});

--- a/packages/ctrl/tests/migrate.test.ts
+++ b/packages/ctrl/tests/migrate.test.ts
@@ -36,12 +36,13 @@ describe("state.db migration runner", () => {
     const db = new DatabaseSync(":memory:");
     db.exec(schema);
     const v = runMigrations(db);
-    // Latest version moves as new migrations land. Today: 8
+    // Latest version moves as new migrations land. Today: 9
     // (0001_fix_pack + 0002_alfred_journal + 0003_tailscale_connection
     // + 0004_channel_tokens + 0005_ha_channel + 0006_files_table
-    // + 0007_recall + 0008_ha_event_subscription).
-    assert.equal(v, 8, "migrated to latest version");
-    assert.equal(userVersion(db), 8);
+    // + 0007_recall + 0008_ha_event_subscription
+    // + 0009_ha_registry_vanished).
+    assert.equal(v, 9, "migrated to latest version");
+    assert.equal(userVersion(db), 9);
     assert.ok(cols(db, "observation").includes("processed_at"), "0001: processed_at present after migrate");
     // 0002: alfred_journal + alfred_principal tables present.
     const tables = (
@@ -126,6 +127,16 @@ describe("state.db migration runner", () => {
       );
     }
 
+    // 0009: ha_registry.vanished_at column added (#110 PR 5). The
+    // HaBootstrapWorkflow tombstones (does NOT delete) entities that
+    // vanished from HA between pulls; the dashboard's "live" partial
+    // index over `vanished_at IS NULL` keeps the live read cheap.
+    const haRegCols = cols(db, "ha_registry");
+    assert.ok(
+      haRegCols.includes("vanished_at"),
+      "0009: ha_registry.vanished_at column added",
+    );
+
     db.close();
   });
 
@@ -134,7 +145,7 @@ describe("state.db migration runner", () => {
     db.exec(schema);
     runMigrations(db);
     const v2 = runMigrations(db);
-    assert.equal(v2, 8);
+    assert.equal(v2, 9);
     assert.equal(
       cols(db, "observation").filter((c) => c === "processed_at").length,
       1,

--- a/packages/learn/scripts/register_schedules.py
+++ b/packages/learn/scripts/register_schedules.py
@@ -299,6 +299,23 @@ INTERVAL_SCHEDULES = [
         "workflow": "RecallDispatcherWorkflow",
         "interval": timedelta(minutes=5),
     },
+    {
+        # HA registry bootstrap (#110 PR5) — every 6h pulls the operator's
+        # HA install's full state / area / device / automation surface
+        # and refreshes ha_registry in state.db (via ctrl-api's
+        # /api/v1/channels/ha/registry/bulk route). The workflow is a
+        # no-op (returns ``{ok: False, code: "HA_NOT_CONNECTED"}``) when
+        # no HA install is connected, so the schedule costs only one
+        # ctrl-api GET per tick on tenants that haven't connected HA.
+        #
+        # 6 hours matches the spec §6.PR5 cadence. On-demand triggers
+        # via ctrl-api's /api/v1/channels/ha/registry/refresh route
+        # start a one-shot run with a unique workflow_id so they don't
+        # clash with the scheduled tick.
+        "id": "al-ha-bootstrap",
+        "workflow": "HaBootstrapWorkflow",
+        "interval": timedelta(hours=6),
+    },
 ]
 
 CALENDAR_SCHEDULES = [

--- a/packages/learn/src/activities/ha_bootstrap.py
+++ b/packages/learn/src/activities/ha_bootstrap.py
@@ -1,0 +1,425 @@
+"""Activities for HaBootstrapWorkflow Phase A — registry pull + write.
+
+Two ``@activity.defn`` activities back the workflow:
+
+  1. ``pull_ha_registry`` — fetches the operator-configured HA URL and
+     LLAT from ctrl-api, then pulls the full entity / area / device /
+     automation / services surface from HA's own REST API in parallel
+     and normalises each entity into the ``ha_registry`` row shape.
+
+  2. ``write_ha_registry`` — POSTs the normalised rows to ctrl-api's
+     ``/api/v1/channels/ha/registry/bulk`` route, which batch-upserts
+     and tombstones vanished entities in a single transaction.
+
+The split lets the workflow retry the pull independently of the write
+(HA tends to time out more often than ctrl-api's local SQLite does),
+and keeps the LLAT-touching code in one activity that operator audit
+can grep for.
+
+SECURITY: the LLAT is fetched via ctrl-api's ``GET /llat`` route — a
+brand-new route in PR5 that's operator-only (AAS_API_KEY) and
+rejects voice-bridge + channel-token bearers with 403. The token
+lives in memory for the duration of one activity invocation and is
+never persisted, logged, or echoed into the workflow's result.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from typing import Any
+
+import httpx
+from temporalio import activity
+
+from src.config import load_config
+
+logger = logging.getLogger("ha-bootstrap")
+
+
+# ── ctrl-api helpers ─────────────────────────────────────────────────────
+
+
+def _ctrl_headers() -> dict[str, str]:
+    api_key = os.environ.get("AAS_API_KEY", "")
+    return {"Authorization": f"Bearer {api_key}"} if api_key else {}
+
+
+async def _ctrl_get(path: str) -> tuple[int, dict[str, Any]]:
+    """Plain GET against ctrl-api. Returns (status, body-or-empty)."""
+    config = load_config()
+    url = f"{config.alfred_ctrl_url}{path}"
+    async with httpx.AsyncClient(timeout=30.0) as http:
+        resp = await http.get(url, headers=_ctrl_headers())
+        try:
+            body = resp.json()
+        except ValueError:
+            body = {}
+        return resp.status_code, body
+
+
+async def _ctrl_post(path: str, body: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+    config = load_config()
+    url = f"{config.alfred_ctrl_url}{path}"
+    async with httpx.AsyncClient(timeout=60.0) as http:
+        resp = await http.post(url, headers=_ctrl_headers(), json=body)
+        try:
+            data = resp.json()
+        except ValueError:
+            data = {}
+        return resp.status_code, data
+
+
+# ── HA REST helpers ──────────────────────────────────────────────────────
+
+
+HA_TIMEOUT_SECONDS = float(os.environ.get("HA_BOOTSTRAP_TIMEOUT_SECONDS", "30"))
+
+
+async def _ha_get(
+    client: httpx.AsyncClient,
+    base_url: str,
+    path: str,
+    llat: str,
+) -> tuple[int, Any]:
+    """GET against the HA REST API. Returns (status, parsed body or None).
+
+    Caller decides how to handle 4xx — 401 means "bad LLAT" and is the
+    workflow's HA_AUTH_FAILED short-circuit. We never log the LLAT
+    bytes, even in error paths.
+    """
+    headers = {
+        "Authorization": f"Bearer {llat}",
+        "Content-Type": "application/json",
+    }
+    url = f"{base_url.rstrip('/')}{path}"
+    try:
+        resp = await client.get(url, headers=headers, timeout=HA_TIMEOUT_SECONDS)
+    except httpx.TimeoutException as exc:
+        # Re-raise as a flat exception type so the workflow's retry policy
+        # can detect "transient HA timeout" and back off; the LLAT is NOT
+        # in the message.
+        raise RuntimeError(f"HA timeout on {path}") from exc
+    except httpx.HTTPError as exc:
+        raise RuntimeError(f"HA HTTP error on {path}: {type(exc).__name__}") from exc
+    try:
+        return resp.status_code, resp.json()
+    except ValueError:
+        return resp.status_code, None
+
+
+# ── normalisation ────────────────────────────────────────────────────────
+
+
+def _domain_of(entity_id: str) -> str | None:
+    """``light.kitchen`` → ``light``. None on malformed input."""
+    if not isinstance(entity_id, str) or "." not in entity_id:
+        return None
+    return entity_id.split(".", 1)[0] or None
+
+
+def _safe_str(v: Any) -> str | None:
+    if isinstance(v, str) and v:
+        return v
+    return None
+
+
+def _ha_state_to_row(
+    entity: dict[str, Any],
+    entity_meta_by_id: dict[str, dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Convert an HA /api/states entity to a bulk-upsert row."""
+    eid = entity.get("entity_id")
+    if not isinstance(eid, str) or not eid:
+        return None
+    attrs = entity.get("attributes") or {}
+    friendly_name = None
+    if isinstance(attrs, dict):
+        fn = attrs.get("friendly_name")
+        if isinstance(fn, str):
+            friendly_name = fn
+    domain = _domain_of(eid)
+    meta = entity_meta_by_id.get(eid) or {}
+    return {
+        "kind": "entity",
+        "ha_id": eid,
+        "domain": domain,
+        "area_id": _safe_str(meta.get("area_id")),
+        "friendly_name": friendly_name,
+        "state": _safe_str(entity.get("state")),
+        "attributes_json": json.dumps(attrs, ensure_ascii=False, sort_keys=True),
+        "payload_json": json.dumps(entity, ensure_ascii=False, sort_keys=True),
+        "last_changed": _safe_str(entity.get("last_changed")),
+        "last_updated": _safe_str(entity.get("last_updated")),
+    }
+
+
+def _area_to_row(area: dict[str, Any]) -> dict[str, Any] | None:
+    aid = area.get("area_id") or area.get("id")
+    if not isinstance(aid, str) or not aid:
+        return None
+    return {
+        "kind": "area",
+        "ha_id": aid,
+        "domain": None,
+        "area_id": None,
+        "friendly_name": _safe_str(area.get("name")),
+        "state": None,
+        "attributes_json": None,
+        "payload_json": json.dumps(area, ensure_ascii=False, sort_keys=True),
+        "last_changed": None,
+        "last_updated": None,
+    }
+
+
+def _device_to_row(device: dict[str, Any]) -> dict[str, Any] | None:
+    did = device.get("id") or device.get("device_id")
+    if not isinstance(did, str) or not did:
+        return None
+    return {
+        "kind": "device",
+        "ha_id": did,
+        "domain": None,
+        "area_id": _safe_str(device.get("area_id")),
+        "friendly_name": _safe_str(
+            device.get("name_by_user") or device.get("name")
+        ),
+        "state": None,
+        "attributes_json": None,
+        "payload_json": json.dumps(device, ensure_ascii=False, sort_keys=True),
+        "last_changed": None,
+        "last_updated": None,
+    }
+
+
+def _automation_to_row(state_row: dict[str, Any]) -> dict[str, Any] | None:
+    """An automation is materialised from /api/states (domain=automation).
+
+    The detailed YAML body (per /api/automation/config/<id>) is attached
+    to the row's payload_json under ``yaml_config`` so PR6's apply/rollback
+    pipeline can read it without a second pull.
+    """
+    eid = state_row.get("entity_id")
+    if not isinstance(eid, str) or not eid:
+        return None
+    attrs = state_row.get("attributes") or {}
+    friendly_name = None
+    if isinstance(attrs, dict):
+        fn = attrs.get("friendly_name")
+        if isinstance(fn, str):
+            friendly_name = fn
+    return {
+        "kind": "automation",
+        "ha_id": eid,
+        "domain": "automation",
+        "area_id": None,
+        "friendly_name": friendly_name,
+        "state": _safe_str(state_row.get("state")),
+        "attributes_json": json.dumps(attrs, ensure_ascii=False, sort_keys=True),
+        "payload_json": json.dumps(state_row, ensure_ascii=False, sort_keys=True),
+        "last_changed": _safe_str(state_row.get("last_changed")),
+        "last_updated": _safe_str(state_row.get("last_updated")),
+    }
+
+
+def _scene_to_row(state_row: dict[str, Any]) -> dict[str, Any] | None:
+    eid = state_row.get("entity_id")
+    if not isinstance(eid, str) or not eid:
+        return None
+    attrs = state_row.get("attributes") or {}
+    friendly_name = None
+    if isinstance(attrs, dict):
+        fn = attrs.get("friendly_name")
+        if isinstance(fn, str):
+            friendly_name = fn
+    return {
+        "kind": "scene",
+        "ha_id": eid,
+        "domain": "scene",
+        "area_id": None,
+        "friendly_name": friendly_name,
+        "state": _safe_str(state_row.get("state")),
+        "attributes_json": json.dumps(attrs, ensure_ascii=False, sort_keys=True),
+        "payload_json": json.dumps(state_row, ensure_ascii=False, sort_keys=True),
+        "last_changed": _safe_str(state_row.get("last_changed")),
+        "last_updated": _safe_str(state_row.get("last_updated")),
+    }
+
+
+def normalise_ha_pull(
+    states: list[dict[str, Any]],
+    areas: list[dict[str, Any]],
+    devices: list[dict[str, Any]],
+    entity_registry: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Combine the four HA pulls into a deduplicated list of bulk-upsert rows.
+
+    The dedupe is keyed on ``(kind, ha_id)`` — a misbehaving HA install
+    that lists the same entity twice (rare but observed on installs that
+    rely on a YAML + UI hybrid) collapses to one row, with the LAST
+    occurrence winning. The bulk-upsert route's PRIMARY KEY would do
+    the same thing at insert time; doing it here keeps the count
+    accurate before the network roundtrip.
+    """
+    # Index entity_registry rows by entity_id so we can attach area_id
+    # to entity rows.
+    entity_meta_by_id: dict[str, dict[str, Any]] = {}
+    for em in entity_registry:
+        if not isinstance(em, dict):
+            continue
+        eid = em.get("entity_id")
+        if isinstance(eid, str) and eid:
+            entity_meta_by_id[eid] = em
+
+    rows: list[dict[str, Any]] = []
+    for s in states or []:
+        if not isinstance(s, dict):
+            continue
+        eid = s.get("entity_id")
+        if not isinstance(eid, str):
+            continue
+        domain = _domain_of(eid)
+        if domain == "automation":
+            row = _automation_to_row(s)
+        elif domain == "scene":
+            row = _scene_to_row(s)
+        else:
+            row = _ha_state_to_row(s, entity_meta_by_id)
+        if row is not None:
+            rows.append(row)
+
+    for a in areas or []:
+        if isinstance(a, dict):
+            row = _area_to_row(a)
+            if row is not None:
+                rows.append(row)
+
+    for d in devices or []:
+        if isinstance(d, dict):
+            row = _device_to_row(d)
+            if row is not None:
+                rows.append(row)
+
+    # Dedupe by (kind, ha_id) — last wins.
+    deduped: dict[tuple[str, str], dict[str, Any]] = {}
+    for r in rows:
+        key = (str(r.get("kind")), str(r.get("ha_id")))
+        deduped[key] = r
+    return list(deduped.values())
+
+
+# ── activities ───────────────────────────────────────────────────────────
+
+
+@activity.defn(name="pull_ha_registry")
+async def pull_ha_registry() -> dict[str, Any]:
+    """Pull the HA registry surface from ctrl-api + HA REST.
+
+    Returns ``{"ok": True, "rows": [...], "counts": {...}}`` on success.
+    Returns ``{"ok": False, "code": "...", "rows": []}`` on a known
+    fail-fast condition (HA not connected, HA 401, HA unreachable). The
+    workflow's retry policy distinguishes the two — a known refusal is
+    NOT retried; only the unexpected exception path is.
+    """
+    # (1) Confirm HA is connected and pull the URL.
+    status_code, status_body = await _ctrl_get("/api/v1/channels/ha/status")
+    if status_code != 200 or not isinstance(status_body, dict):
+        return {"ok": False, "code": "STATUS_UNREACHABLE", "rows": []}
+    if status_body.get("state") != "connected":
+        return {"ok": False, "code": "HA_NOT_CONNECTED", "rows": []}
+    ha_url = status_body.get("ha_url")
+    if not isinstance(ha_url, str) or not ha_url:
+        return {"ok": False, "code": "HA_NOT_CONNECTED", "rows": []}
+
+    # (2) Fetch the LLAT — operator-only route.
+    llat_code, llat_body = await _ctrl_get("/api/v1/channels/ha/llat")
+    if llat_code == 404:
+        return {"ok": False, "code": "HA_NOT_CONNECTED", "rows": []}
+    if llat_code != 200 or not isinstance(llat_body, dict):
+        return {"ok": False, "code": "LLAT_UNREACHABLE", "rows": []}
+    llat = llat_body.get("llat")
+    if not isinstance(llat, str) or not llat:
+        return {"ok": False, "code": "LLAT_MISSING", "rows": []}
+
+    # (3) Parallel pull from HA's REST surface.
+    async with httpx.AsyncClient() as client:
+        coros = [
+            _ha_get(client, ha_url, "/api/states", llat),
+            _ha_get(client, ha_url, "/api/config/area_registry/list", llat),
+            _ha_get(client, ha_url, "/api/config/device_registry/list", llat),
+            _ha_get(client, ha_url, "/api/config/entity_registry/list", llat),
+            _ha_get(client, ha_url, "/api/services", llat),
+        ]
+        results = await asyncio.gather(*coros, return_exceptions=True)
+
+    # Check for HA 401 first — that's a known operator misconfig
+    # (LLAT rotated in HA but not in Vault). Surface as a known refusal
+    # so the workflow doesn't burn retries.
+    statuses: list[int | None] = []
+    bodies: list[Any] = []
+    for r in results:
+        if isinstance(r, BaseException):
+            statuses.append(None)
+            bodies.append(None)
+            continue
+        statuses.append(r[0])
+        bodies.append(r[1])
+
+    if any(s == 401 for s in statuses if s is not None):
+        # NEVER include the LLAT in this message — even partially.
+        return {"ok": False, "code": "HA_AUTH_FAILED", "rows": []}
+
+    # Any non-2xx that ISN'T a 401 → transient; re-raise so Temporal retries.
+    for i, (s, r) in enumerate(zip(statuses, results)):
+        if isinstance(r, BaseException):
+            raise RuntimeError(f"HA pull failed on call #{i}: {type(r).__name__}")
+        if s is None or s >= 500:
+            raise RuntimeError(f"HA pull HTTP {s} on call #{i}")
+
+    states = bodies[0] if isinstance(bodies[0], list) else []
+    areas = bodies[1] if isinstance(bodies[1], list) else []
+    devices = bodies[2] if isinstance(bodies[2], list) else []
+    entity_reg = bodies[3] if isinstance(bodies[3], list) else []
+    services = bodies[4] if isinstance(bodies[4], list) else []
+
+    rows = normalise_ha_pull(states, areas, devices, entity_reg)
+
+    # Count automations + scenes separately for the workflow's audit log.
+    counts = {
+        "states": len(states),
+        "areas": len(areas),
+        "devices": len(devices),
+        "entity_registry": len(entity_reg),
+        "services": len(services),
+        "rows": len(rows),
+        "automations": sum(1 for r in rows if r.get("kind") == "automation"),
+        "scenes": sum(1 for r in rows if r.get("kind") == "scene"),
+        "entities": sum(1 for r in rows if r.get("kind") == "entity"),
+    }
+    return {"ok": True, "rows": rows, "counts": counts}
+
+
+@activity.defn(name="write_ha_registry")
+async def write_ha_registry(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """POST the normalised rows to ctrl-api's bulk route.
+
+    The route handles inserted vs updated vs tombstoned in one
+    transaction and returns the counts. Empty input is allowed — the
+    route will tombstone every existing row, which is the right
+    behaviour if HA goes from "many entities" to "zero" (an operator
+    factory-reset or moved their install).
+    """
+    code, body = await _ctrl_post(
+        "/api/v1/channels/ha/registry/bulk",
+        {"rows": rows or []},
+    )
+    if code != 200 or not isinstance(body, dict) or not body.get("ok"):
+        raise RuntimeError(f"ctrl-api bulk upsert failed: HTTP {code}")
+    return {
+        "ok": True,
+        "inserted": int(body.get("inserted", 0)),
+        "updated": int(body.get("updated", 0)),
+        "tombstoned": int(body.get("tombstoned", 0)),
+        "total_after": int(body.get("total_after", 0)),
+    }

--- a/packages/learn/src/worker.py
+++ b/packages/learn/src/worker.py
@@ -57,6 +57,7 @@ from src.workflows.stream_event_purge import StreamEventPurgeWorkflow
 from src.workflows.reversal_calibration import ReversalCalibrationWorkflow
 from src.workflows.briefing import BriefingWorkflow
 from src.workflows.recall_dispatcher import RecallDispatcherWorkflow
+from src.workflows.ha_bootstrap import HaBootstrapWorkflow
 
 # Chore template workflows (static + dynamic)
 from src.workflows.chores import ALL_CHORE_TEMPLATES
@@ -671,6 +672,15 @@ from src.activities.recall_dispatcher import (
     fetch_upcoming_calendar_events,
 )
 
+# HA registry bootstrap (#110 PR5) — two activities the HaBootstrapWorkflow
+# drives every 6h + on demand. The pull side reads the operator-configured
+# HA install via the LLAT route; the write side bulk-upserts into ha_registry
+# and tombstones vanished entities. See src/workflows/ha_bootstrap.py.
+from src.activities.ha_bootstrap import (
+    pull_ha_registry,
+    write_ha_registry,
+)
+
 # Validators used as activities
 from src.validators.frontmatter import validate_classification
 
@@ -726,6 +736,12 @@ _STATIC_WORKFLOWS = [
     # surviving event. Scheduled as ``al-recall-dispatcher`` in
     # register_schedules.py.
     RecallDispatcherWorkflow,
+    # HA registry bootstrap (#110 PR5) — every 6h pulls the operator's
+    # HA install state/area/device/automation surface and refreshes
+    # ha_registry. Scheduled as ``al-ha-bootstrap`` in
+    # register_schedules.py; also triggered on demand by the HaCard
+    # "Refresh registry" CTA via ctrl-api's /registry/refresh route.
+    HaBootstrapWorkflow,
     *ALL_CHORE_TEMPLATES,
 ]
 
@@ -1141,6 +1157,10 @@ ALL_ACTIVITIES = [
     check_recall_dispatch_state,
     dispatch_recall_bot,
     fetch_upcoming_calendar_events,
+    # HA registry bootstrap (#110 PR5) — see
+    # src.workflows.ha_bootstrap.HaBootstrapWorkflow.
+    pull_ha_registry,
+    write_ha_registry,
 ]
 
 

--- a/packages/learn/src/workflows/ha_bootstrap.py
+++ b/packages/learn/src/workflows/ha_bootstrap.py
@@ -1,0 +1,138 @@
+"""HaBootstrapWorkflow Phase A — registry pull + dedupe (#110 PR5).
+
+Pulls the operator-configured Home Assistant install's full entity /
+area / device / automation surface every 6 hours (Temporal schedule
+``al-ha-bootstrap``) and on demand from the HaCard "Refresh registry"
+CTA. Writes the result into ``ha_registry`` via ctrl-api's bulk-upsert
+route which also tombstones (does NOT delete) entities that vanished
+from HA since the previous run.
+
+Phase B (gap detection — "no morning routine", "no motion lighting")
+and Phase C (proposal generation) land in later PRs. Phase A only
+needs the registry to be accurate; the gap + proposal surfaces don't
+exist yet.
+
+The workflow itself is a thin orchestrator over two activities:
+
+  ``pull_ha_registry()``  — read ctrl-api status + LLAT, hit HA REST in
+                             parallel, normalise into bulk-row shape.
+  ``write_ha_registry()`` — POST to ctrl-api's bulk route.
+
+Retry policy:
+
+  * Known refusals (HA not connected, HA 401 from a rotated LLAT,
+    ctrl-api unreachable) are surfaced as ``{"ok": False, "code":
+    "..."}`` from the activity itself and the workflow audit-logs the
+    refusal. These do NOT consume retry budget.
+  * Unexpected exceptions (HA 5xx, transient timeouts, network blips)
+    DO consume retry budget — up to 3 attempts with exponential
+    backoff. Past that we audit-log the failure and let the next
+    scheduled tick try again.
+
+Per the LLAT-hygiene rules in CLAUDE.md, NEITHER the workflow nor
+the activity body ever logs or persists the LLAT bytes. The pull
+activity only carries the token in memory between fetching it from
+ctrl-api and using it in the HA Authorization header.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from typing import Any
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+with workflow.unsafe.imports_passed_through():
+    from src.activities.ha_bootstrap import (
+        pull_ha_registry,
+        write_ha_registry,
+    )
+
+
+logger = logging.getLogger("ha-bootstrap-workflow")
+
+
+# Retry policy for the pull. HA timeouts are common on under-provisioned
+# Pi installs; 3 attempts with exponential backoff covers ~95% of
+# transient outages without burning the cron tick's budget on a hard
+# failure.
+_PULL_RETRY = RetryPolicy(
+    initial_interval=timedelta(seconds=10),
+    maximum_interval=timedelta(minutes=2),
+    maximum_attempts=3,
+)
+
+# Retry policy for the write. ctrl-api is local SQLite — the most
+# realistic failure is a brief WAL contention with another writer, not
+# a 5xx. 2 attempts is enough.
+_WRITE_RETRY = RetryPolicy(
+    initial_interval=timedelta(seconds=5),
+    maximum_interval=timedelta(seconds=30),
+    maximum_attempts=2,
+)
+
+
+@workflow.defn
+class HaBootstrapWorkflow:
+    """Pull the HA registry and refresh ha_registry once."""
+
+    @workflow.run
+    async def run(self) -> dict[str, Any]:
+        logger.info("ha-bootstrap: starting registry pull")
+
+        pull = await workflow.execute_activity(
+            pull_ha_registry,
+            start_to_close_timeout=timedelta(minutes=2),
+            retry_policy=_PULL_RETRY,
+        )
+
+        if not isinstance(pull, dict):
+            return {
+                "ok": False,
+                "code": "PULL_BAD_RESULT",
+                "rows": 0,
+            }
+
+        if not pull.get("ok"):
+            # Known refusal — surface the code without retrying.
+            code = pull.get("code") or "PULL_FAILED"
+            logger.warning("ha-bootstrap: pull refused with code=%s", code)
+            return {
+                "ok": False,
+                "code": code,
+                "rows": 0,
+            }
+
+        rows = pull.get("rows") or []
+        if not isinstance(rows, list):
+            rows = []
+
+        write = await workflow.execute_activity(
+            write_ha_registry,
+            rows,
+            start_to_close_timeout=timedelta(minutes=1),
+            retry_policy=_WRITE_RETRY,
+        )
+
+        counts = pull.get("counts") or {}
+        result = {
+            "ok": True,
+            "pull": {
+                "states": counts.get("states", 0),
+                "areas": counts.get("areas", 0),
+                "devices": counts.get("devices", 0),
+                "entity_registry": counts.get("entity_registry", 0),
+                "services": counts.get("services", 0),
+            },
+            "rows": len(rows),
+            "write": write if isinstance(write, dict) else {},
+        }
+        logger.info(
+            "ha-bootstrap: complete rows=%d inserted=%d updated=%d tombstoned=%d",
+            len(rows),
+            result["write"].get("inserted", 0),
+            result["write"].get("updated", 0),
+            result["write"].get("tombstoned", 0),
+        )
+        return result

--- a/packages/learn/tests/test_ha_bootstrap.py
+++ b/packages/learn/tests/test_ha_bootstrap.py
@@ -1,0 +1,553 @@
+"""HaBootstrapWorkflow Phase A — pull + normalise + write tests (#110 PR5).
+
+Three test suites:
+
+  1. ``TestNormalisePull`` — pure normaliser tests against synthetic HA
+     payloads (no network).
+  2. ``TestPullActivity`` — activity-level tests with httpx.MockTransport
+     covering the ctrl-api + HA round-trip (status, LLAT, parallel pull,
+     401 short-circuit, transient-timeout retry).
+  3. ``TestWorkflow`` — end-to-end Temporal workflow test using
+     ``WorkflowEnvironment.start_time_skipping()`` with stub activities
+     so we can drive the retry policy + audit-log path without a real
+     HA install or ctrl-api.
+
+Privacy: LLAT bytes used in tests are synthetic placeholders
+(``llat_TEST_…``); the tests assert no test fixture ever exposes a
+real-looking token.
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Any
+
+import httpx
+import pytest
+from temporalio import activity
+from temporalio.client import Client
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+from src.activities.ha_bootstrap import (
+    normalise_ha_pull,
+    pull_ha_registry,
+    write_ha_registry,
+)
+from src.workflows.ha_bootstrap import HaBootstrapWorkflow
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 1. Pure normaliser tests
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestNormalisePull:
+    def test_entity_with_area_attached(self):
+        states = [
+            {
+                "entity_id": "light.kitchen",
+                "state": "on",
+                "attributes": {"friendly_name": "Kitchen Light"},
+                "last_changed": "2026-05-29T10:00:00Z",
+                "last_updated": "2026-05-29T10:00:00Z",
+            }
+        ]
+        entity_reg = [
+            {"entity_id": "light.kitchen", "area_id": "kitchen", "device_id": "dev-1"}
+        ]
+        rows = normalise_ha_pull(states, [], [], entity_reg)
+        assert len(rows) == 1
+        r = rows[0]
+        assert r["kind"] == "entity"
+        assert r["ha_id"] == "light.kitchen"
+        assert r["domain"] == "light"
+        assert r["area_id"] == "kitchen"
+        assert r["friendly_name"] == "Kitchen Light"
+        assert r["state"] == "on"
+
+    def test_automation_classified_separately(self):
+        states = [
+            {
+                "entity_id": "automation.morning_routine",
+                "state": "on",
+                "attributes": {"friendly_name": "Morning"},
+            }
+        ]
+        rows = normalise_ha_pull(states, [], [], [])
+        assert len(rows) == 1
+        assert rows[0]["kind"] == "automation"
+        assert rows[0]["domain"] == "automation"
+        assert rows[0]["friendly_name"] == "Morning"
+
+    def test_scene_classified_separately(self):
+        states = [
+            {
+                "entity_id": "scene.movie_time",
+                "state": "scening",
+                "attributes": {},
+            }
+        ]
+        rows = normalise_ha_pull(states, [], [], [])
+        assert len(rows) == 1
+        assert rows[0]["kind"] == "scene"
+        assert rows[0]["domain"] == "scene"
+
+    def test_dedupes_duplicate_entity_ids(self):
+        # Two states with same entity_id → one row (last wins).
+        states = [
+            {
+                "entity_id": "light.kitchen",
+                "state": "off",
+                "attributes": {"friendly_name": "Old"},
+            },
+            {
+                "entity_id": "light.kitchen",
+                "state": "on",
+                "attributes": {"friendly_name": "New"},
+            },
+        ]
+        rows = normalise_ha_pull(states, [], [], [])
+        assert len(rows) == 1
+        assert rows[0]["state"] == "on"
+        assert rows[0]["friendly_name"] == "New"
+
+    def test_empty_input_returns_empty(self):
+        assert normalise_ha_pull([], [], [], []) == []
+
+    def test_skips_malformed_entities(self):
+        states = [
+            {"foo": "bar"},  # no entity_id
+            None,  # type: ignore[list-item]
+            {"entity_id": ""},  # empty
+            {"entity_id": "light.ok", "state": "on", "attributes": {}},
+        ]
+        rows = normalise_ha_pull(states, [], [], [])
+        assert len(rows) == 1
+        assert rows[0]["ha_id"] == "light.ok"
+
+    def test_areas_and_devices_rolled_in(self):
+        areas = [{"area_id": "kitchen", "name": "Kitchen"}]
+        devices = [{"id": "dev-1", "name": "Hub", "area_id": "kitchen"}]
+        rows = normalise_ha_pull([], areas, devices, [])
+        kinds = sorted([r["kind"] for r in rows])
+        assert kinds == ["area", "device"]
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 2. Activity-level tests — mocked httpx for ctrl-api + HA
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class ScriptedTransport(httpx.AsyncBaseTransport):
+    """Replay scripted responses for both ctrl-api and HA URLs."""
+
+    def __init__(self, handler):
+        self._handler = handler
+        self.requests: list[httpx.Request] = []
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        return self._handler(request)
+
+
+@pytest.fixture
+def mock_ha(monkeypatch):
+    """Patch httpx.AsyncClient inside src.activities.ha_bootstrap."""
+    holder: dict[str, Any] = {"handler": None, "transport": None, "requests": []}
+    original = httpx.AsyncClient
+
+    def fake_client(*args, **kwargs):
+        handler = holder["handler"]
+        if handler is None:
+            raise RuntimeError("mock_ha handler not set")
+        transport = ScriptedTransport(handler)
+        holder["transport"] = transport
+        # The activity uses two clients (ctrl + HA) — collect requests
+        # on the shared holder so tests can introspect.
+        original_handle = transport.handle_async_request
+
+        async def trapping(req):
+            holder["requests"].append(req)
+            return await original_handle(req)
+
+        transport.handle_async_request = trapping  # type: ignore[method-assign]
+        kwargs["transport"] = transport
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "src.activities.ha_bootstrap.httpx.AsyncClient", fake_client
+    )
+    monkeypatch.setenv("AAS_API_KEY", "test-key")
+    monkeypatch.setenv(
+        "ALFRED_CTRL_URL", "http://ctrl.test"
+    )
+    yield holder
+
+
+HA_URL = "http://ha.test:8123"
+LLAT = "llat_TEST_" + "0" * 40
+
+
+def _ha_pull_handler(
+    *,
+    status_state: str = "connected",
+    llat_status: int = 200,
+    states_status: int = 200,
+    states_body: list[dict[str, Any]] | None = None,
+    areas_body: list[dict[str, Any]] | None = None,
+    devices_body: list[dict[str, Any]] | None = None,
+    entity_reg_body: list[dict[str, Any]] | None = None,
+    services_body: list[dict[str, Any]] | None = None,
+    ha_states_status_override: int | None = None,
+    raise_on: str | None = None,
+):
+    """Build a handler that scripts all 7 round-trips a happy pull does."""
+    states_body = states_body if states_body is not None else []
+    areas_body = areas_body if areas_body is not None else []
+    devices_body = devices_body if devices_body is not None else []
+    entity_reg_body = entity_reg_body if entity_reg_body is not None else []
+    services_body = services_body if services_body is not None else []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        path = req.url.path
+        full = str(req.url)
+        if raise_on and raise_on in full:
+            raise httpx.TimeoutException("boom", request=req)
+        # ctrl-api status
+        if path == "/api/v1/channels/ha/status":
+            return httpx.Response(
+                200,
+                json={
+                    "connected": status_state == "connected",
+                    "state": status_state,
+                    "ha_url": HA_URL,
+                    "ha_version": "2026.5.0",
+                    "last_test_ok": True,
+                    "last_test_at": None,
+                    "error": None,
+                },
+            )
+        # ctrl-api LLAT
+        if path == "/api/v1/channels/ha/llat":
+            if llat_status == 200:
+                return httpx.Response(200, json={"llat": LLAT})
+            return httpx.Response(llat_status, json={"error": "x"})
+        # HA REST surface
+        if path == "/api/states":
+            code = ha_states_status_override or states_status
+            return httpx.Response(code, json=states_body)
+        if path == "/api/config/area_registry/list":
+            return httpx.Response(200, json=areas_body)
+        if path == "/api/config/device_registry/list":
+            return httpx.Response(200, json=devices_body)
+        if path == "/api/config/entity_registry/list":
+            return httpx.Response(200, json=entity_reg_body)
+        if path == "/api/services":
+            return httpx.Response(200, json=services_body)
+        return httpx.Response(404, json={"error": "no route"})
+
+    return handler
+
+
+class TestPullActivity:
+    @pytest.mark.asyncio
+    async def test_happy_path_parallel_pull(self, mock_ha):
+        mock_ha["handler"] = _ha_pull_handler(
+            states_body=[
+                {
+                    "entity_id": "light.kitchen",
+                    "state": "on",
+                    "attributes": {"friendly_name": "Kitchen"},
+                },
+            ],
+            areas_body=[{"area_id": "kitchen", "name": "Kitchen"}],
+            devices_body=[{"id": "dev-1", "name": "Hub"}],
+            entity_reg_body=[{"entity_id": "light.kitchen", "area_id": "kitchen"}],
+        )
+        result = await pull_ha_registry()
+        assert result["ok"] is True
+        rows = result["rows"]
+        # 1 entity + 1 area + 1 device
+        kinds = sorted(r["kind"] for r in rows)
+        assert kinds == ["area", "device", "entity"]
+        entity_row = next(r for r in rows if r["kind"] == "entity")
+        assert entity_row["area_id"] == "kitchen"
+        assert result["counts"]["entities"] == 1
+
+        # Audit: confirm exactly the 7 round-trips fired (2 ctrl, 5 HA).
+        paths = [str(r.url.path) for r in mock_ha["requests"]]
+        assert paths.count("/api/v1/channels/ha/status") == 1
+        assert paths.count("/api/v1/channels/ha/llat") == 1
+        assert paths.count("/api/states") == 1
+        assert paths.count("/api/config/area_registry/list") == 1
+        assert paths.count("/api/config/device_registry/list") == 1
+        assert paths.count("/api/config/entity_registry/list") == 1
+        assert paths.count("/api/services") == 1
+
+    @pytest.mark.asyncio
+    async def test_ha_401_does_not_raise(self, mock_ha):
+        # HA returns 401 on a rotated LLAT — activity must surface a
+        # known refusal (ok=False) rather than re-raise, so the workflow
+        # doesn't burn retries.
+        mock_ha["handler"] = _ha_pull_handler(
+            ha_states_status_override=401,
+        )
+        result = await pull_ha_registry()
+        assert result["ok"] is False
+        assert result["code"] == "HA_AUTH_FAILED"
+        assert result["rows"] == []
+        # The LLAT must not appear in the result envelope.
+        assert LLAT not in str(result)
+
+    @pytest.mark.asyncio
+    async def test_ha_not_connected(self, mock_ha):
+        mock_ha["handler"] = _ha_pull_handler(status_state="unconfigured")
+        result = await pull_ha_registry()
+        assert result["ok"] is False
+        assert result["code"] == "HA_NOT_CONNECTED"
+
+    @pytest.mark.asyncio
+    async def test_ha_5xx_reraises_for_retry(self, mock_ha):
+        # HA 5xx is transient — activity re-raises so Temporal retries.
+        mock_ha["handler"] = _ha_pull_handler(ha_states_status_override=503)
+        with pytest.raises(RuntimeError):
+            await pull_ha_registry()
+
+    @pytest.mark.asyncio
+    async def test_empty_ha_install_returns_empty_rows(self, mock_ha):
+        # An HA install with zero entities is a real case (fresh install,
+        # no integrations yet). The activity must return ok=True with
+        # rows=[] so the writer can tombstone any previous-run residue.
+        mock_ha["handler"] = _ha_pull_handler(
+            states_body=[],
+            areas_body=[],
+            devices_body=[],
+            entity_reg_body=[],
+        )
+        result = await pull_ha_registry()
+        assert result["ok"] is True
+        assert result["rows"] == []
+        assert result["counts"]["rows"] == 0
+
+
+class TestWriteActivity:
+    @pytest.mark.asyncio
+    async def test_posts_bulk_payload(self, mock_ha, monkeypatch):
+        captured: dict[str, Any] = {}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            assert req.url.path == "/api/v1/channels/ha/registry/bulk"
+            import json as _json
+
+            captured["body"] = _json.loads(req.content.decode("utf-8"))
+            captured["auth"] = req.headers.get("authorization")
+            return httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "inserted": 1,
+                    "updated": 0,
+                    "tombstoned": 2,
+                    "total_after": 3,
+                },
+            )
+
+        mock_ha["handler"] = handler
+        rows = [
+            {
+                "kind": "entity",
+                "ha_id": "light.kitchen",
+                "domain": "light",
+                "payload_json": "{}",
+            }
+        ]
+        result = await write_ha_registry(rows)
+        assert result["ok"] is True
+        assert result["inserted"] == 1
+        assert result["tombstoned"] == 2
+        # Auth header carries the operator AAS_API_KEY (not the LLAT).
+        assert captured["auth"] == "Bearer test-key"
+        assert LLAT not in captured["auth"]
+
+    @pytest.mark.asyncio
+    async def test_bulk_500_reraises(self, mock_ha):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, json={"error": "boom"})
+
+        mock_ha["handler"] = handler
+        with pytest.raises(RuntimeError):
+            await write_ha_registry([])
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 3. Workflow-level tests — Temporal time-skipping environment
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _make_stubs(
+    *,
+    pull_result: dict[str, Any] | None = None,
+    pull_raises_n: int = 0,
+    write_result: dict[str, Any] | None = None,
+):
+    """Build stub activities the workflow can execute under WorkflowEnvironment.
+
+    ``pull_raises_n`` controls the transient-failure simulation: the
+    first N invocations raise so the workflow's retry policy kicks in.
+    """
+    call_log: list[tuple[str, Any]] = []
+
+    pull_calls = {"n": 0}
+
+    @activity.defn(name="pull_ha_registry")
+    async def stub_pull() -> dict[str, Any]:
+        pull_calls["n"] += 1
+        call_log.append(("pull", pull_calls["n"]))
+        if pull_calls["n"] <= pull_raises_n:
+            raise RuntimeError("simulated HA timeout")
+        if pull_result is not None:
+            return pull_result
+        return {
+            "ok": True,
+            "rows": [],
+            "counts": {
+                "states": 0,
+                "areas": 0,
+                "devices": 0,
+                "entity_registry": 0,
+                "services": 0,
+                "rows": 0,
+                "entities": 0,
+                "automations": 0,
+                "scenes": 0,
+            },
+        }
+
+    @activity.defn(name="write_ha_registry")
+    async def stub_write(rows: list[dict[str, Any]]) -> dict[str, Any]:
+        call_log.append(("write", len(rows)))
+        if write_result is not None:
+            return write_result
+        return {
+            "ok": True,
+            "inserted": len(rows),
+            "updated": 0,
+            "tombstoned": 0,
+            "total_after": len(rows),
+        }
+
+    return [stub_pull, stub_write], call_log
+
+
+async def _run_workflow(stubs: list) -> dict[str, Any]:
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        client: Client = env.client
+        tq = f"ha-bootstrap-test-{uuid.uuid4()}"
+        worker = Worker(
+            client,
+            task_queue=tq,
+            workflows=[HaBootstrapWorkflow],
+            activities=stubs,
+        )
+        async with worker:
+            return await client.execute_workflow(
+                HaBootstrapWorkflow.run,
+                id=f"ha-bootstrap-run-{uuid.uuid4()}",
+                task_queue=tq,
+            )
+
+
+class TestWorkflow:
+    def test_workflow_happy_path(self):
+        stubs, log = _make_stubs(
+            pull_result={
+                "ok": True,
+                "rows": [
+                    {"kind": "entity", "ha_id": "light.kitchen", "payload_json": "{}"},
+                ],
+                "counts": {
+                    "states": 1,
+                    "areas": 0,
+                    "devices": 0,
+                    "entity_registry": 1,
+                    "services": 0,
+                    "rows": 1,
+                    "entities": 1,
+                    "automations": 0,
+                    "scenes": 0,
+                },
+            },
+            write_result={
+                "ok": True,
+                "inserted": 1,
+                "updated": 0,
+                "tombstoned": 0,
+                "total_after": 1,
+            },
+        )
+        result = asyncio.run(_run_workflow(stubs))
+        assert result["ok"] is True
+        assert result["rows"] == 1
+        assert result["write"]["inserted"] == 1
+        # Pull happened once + write happened once.
+        assert [c[0] for c in log] == ["pull", "write"]
+
+    def test_workflow_retries_transient_pull_failure(self):
+        # First pull raises (network blip); retry policy retries up to 3
+        # attempts. Second attempt succeeds.
+        stubs, log = _make_stubs(pull_raises_n=1)
+        result = asyncio.run(_run_workflow(stubs))
+        assert result["ok"] is True
+        # Two pull attempts (first raised, second succeeded) + one write.
+        pull_count = sum(1 for c in log if c[0] == "pull")
+        write_count = sum(1 for c in log if c[0] == "write")
+        assert pull_count == 2
+        assert write_count == 1
+
+    def test_workflow_audits_known_refusal_without_retry(self):
+        # The pull activity returns ok=False on a known refusal
+        # (HA_AUTH_FAILED / HA_NOT_CONNECTED). The workflow MUST audit
+        # this as a refusal — NOT retry — and skip the write.
+        stubs, log = _make_stubs(
+            pull_result={"ok": False, "code": "HA_AUTH_FAILED", "rows": []},
+        )
+        result = asyncio.run(_run_workflow(stubs))
+        assert result["ok"] is False
+        assert result["code"] == "HA_AUTH_FAILED"
+        # Exactly one pull attempt (no retry on known refusal), no write.
+        assert [c[0] for c in log] == ["pull"]
+
+    def test_workflow_handles_empty_pull(self):
+        # HA install with zero entities — pull returns ok=True with empty
+        # rows; workflow still calls write so vanished entities can be
+        # tombstoned (a real case: principal cleared their HA install).
+        stubs, log = _make_stubs(
+            pull_result={
+                "ok": True,
+                "rows": [],
+                "counts": {
+                    "states": 0,
+                    "areas": 0,
+                    "devices": 0,
+                    "entity_registry": 0,
+                    "services": 0,
+                    "rows": 0,
+                    "entities": 0,
+                    "automations": 0,
+                    "scenes": 0,
+                },
+            },
+            write_result={
+                "ok": True,
+                "inserted": 0,
+                "updated": 0,
+                "tombstoned": 5,
+                "total_after": 5,
+            },
+        )
+        result = asyncio.run(_run_workflow(stubs))
+        assert result["ok"] is True
+        assert result["rows"] == 0
+        assert result["write"]["tombstoned"] == 5
+        assert [c[0] for c in log] == ["pull", "write"]

--- a/packages/web/main.wasp
+++ b/packages/web/main.wasp
@@ -1056,6 +1056,11 @@ action disconnectHa {
   entities: []
 }
 
+action refreshHaRegistry {
+  fn: import { refreshHaRegistry } from "@src/dashboard/operations",
+  entities: []
+}
+
 query getAgentConfig {
   fn: import { getAgentConfig } from "@src/dashboard/operations",
   entities: []

--- a/packages/web/src/dashboard/HaCard.tsx
+++ b/packages/web/src/dashboard/HaCard.tsx
@@ -40,6 +40,7 @@ import {
   getHaRegistry,
   connectHa,
   disconnectHa,
+  refreshHaRegistry,
 } from "wasp/client/operations";
 import {
   deriveHaCardState,
@@ -173,6 +174,15 @@ export function HaCard() {
   // Disconnect state.
   const [discBusy, setDiscBusy] = useState(false);
 
+  // Refresh-registry state (#110 PR5). The CTA triggers a one-shot
+  // HaBootstrapWorkflow run via ctrl-api; the workflow takes ~30s on
+  // a small HA install. We disable the button while the request is
+  // in flight; after the request resolves we keep the "Refreshing…"
+  // label for a short cooldown so a double-click can't fire two
+  // workflows back to back.
+  const [refreshBusy, setRefreshBusy] = useState(false);
+  const [refreshMsg, setRefreshMsg] = useState<string | null>(null);
+
   // Expanders.
   const [registryOpen, setRegistryOpen] = useState(false);
   const [runsOpen, setRunsOpen] = useState(false);
@@ -248,6 +258,36 @@ export function HaCard() {
       setConnectErr(prefix ? `${base} (token ${prefix})` : base);
     } finally {
       setConnectBusy(false);
+    }
+  }
+
+  async function onRefreshRegistry() {
+    if (refreshBusy) return;
+    setRefreshBusy(true);
+    setRefreshMsg(null);
+    try {
+      const r = (await refreshHaRegistry({})) as
+        | { ok?: boolean; workflow_id?: string; eta?: string }
+        | undefined;
+      const eta = r?.eta ?? "30s";
+      setRefreshMsg(`Refresh queued — Alfred will pull again in ~${eta}.`);
+      // Re-fetch the registry after the typical workflow window so
+      // the counts populate without the operator having to click again.
+      window.setTimeout(() => {
+        refetchRegistry();
+      }, 35_000);
+    } catch (e) {
+      setRefreshMsg(
+        "Couldn't queue a refresh. Try again in a moment, or check that " +
+          "alfred-learn is healthy.",
+      );
+      console.error("ha refresh failed", e);
+    } finally {
+      // Short cooldown so a quick double-click doesn't fire two
+      // workflows back to back. The button stays disabled for 5s.
+      window.setTimeout(() => {
+        setRefreshBusy(false);
+      }, 5_000);
     }
   }
 
@@ -558,6 +598,14 @@ export function HaCard() {
               {voiceOpen ? "Hide voice surface" : "Voice surface"}
             </button>
             <button
+              onClick={onRefreshRegistry}
+              disabled={refreshBusy}
+              className="btn-link"
+              title="Pulls the latest entities/areas/devices from HA. Auto-runs every 6h."
+            >
+              {refreshBusy ? "Refreshing…" : "Refresh registry"}
+            </button>
+            <button
               onClick={onDisconnect}
               disabled={discBusy}
               className="btn-ghost"
@@ -565,6 +613,17 @@ export function HaCard() {
               {discBusy ? "Disconnecting…" : "Disconnect"}
             </button>
           </div>
+
+          {/* Refresh confirmation copy — letterpress cadence, no
+              flashing toast. Cleared on disconnect or next refresh. */}
+          {refreshMsg && (
+            <p
+              className="font-body italic text-[12px]"
+              style={{ color: "var(--marginalia)" }}
+            >
+              {refreshMsg}
+            </p>
+          )}
 
           {/* Registry expander — top 20 entities with friendly_name +
               entity_id. PR5 populates this; until then we show the

--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -2994,3 +2994,23 @@ export const disconnectHa = async (_args: unknown, context: any) => {
     path: "/api/v1/channels/ha/disconnect",
   });
 };
+
+/**
+ * Trigger an on-demand HaBootstrapWorkflow run (#110 PR5).
+ *
+ * Backs the "Refresh registry" CTA in the HaCard's connected-state
+ * expander. The workflow auto-runs every 6h via the
+ * ``al-ha-bootstrap`` Temporal schedule; this lets the operator force
+ * a refresh without waiting (useful when a new HA device was just
+ * commissioned and they want it to show up in the registry now).
+ *
+ * Returns ``{ ok, workflow_id, eta }``. The dashboard should re-fetch
+ * `getHaRegistry` after ~30s.
+ */
+export const refreshHaRegistry = async (_args: unknown, context: any) => {
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    method: "POST",
+    path: "/api/v1/channels/ha/registry/refresh",
+  });
+};


### PR DESCRIPTION
HaBootstrapWorkflow (alfred-learn) pulls the operator-configured Home Assistant install's full entity / area / device / automation surface every 6h (Temporal schedule \`al-ha-bootstrap\`) and on demand from the HaCard 'Refresh registry' CTA. Writes the result into \`ha_registry\` via a new ctrl-api bulk-upsert route that also tombstones — does NOT delete — entities that vanished since the last pull.

**Phase A only.** Phase B (gap detection) + Phase C (proposal generation) land in later PRs; Phase A's contract is *the registry is accurate and bounded*.

## Lane I — alfred-learn

- \`src/workflows/ha_bootstrap.py\` — \`HaBootstrapWorkflow\` thin orchestrator (pull → write). Two retry policies: pull retries transient HA timeouts (3 attempts, exp backoff); write retries SQLite WAL contention (2 attempts). Known refusals (HA not connected, HA 401 from a rotated LLAT) surface as \`{ok: False, code: ...}\` and audit-log WITHOUT consuming retry budget.
- \`src/activities/ha_bootstrap.py\` — \`pull_ha_registry()\` reads ctrl-api \`/status\` + \`/llat\`, then pulls \`/api/states\`, \`/api/config/area_registry/list\`, \`/api/config/device_registry/list\`, \`/api/config/entity_registry/list\`, and \`/api/services\` in parallel from HA. Normalises into bulk-upsert rows; automations + scenes get their own \`kind\` buckets; areas attach to entities via the entity_registry lookup. \`write_ha_registry(rows)\` POSTs to the new bulk route.
- \`scripts/register_schedules.py\` — \`al-ha-bootstrap\` interval schedule, every 6h.
- \`src/worker.py\` — workflow + 2 activities registered.

## Lane II — ctrl-api

- \`GET /api/v1/channels/ha/llat\` — operator-only LLAT retrieval. Returns \`{llat}\` on 200; 404 when HA isn't connected. The new \`requireOperatorBearer()\` helper in \`auth.ts\` rejects voice-bridge + channel-token bearers with **403 (not 401)** before the route runs, so the boundary surfaces clearly in audit logs even though the route isn't on either allowlist.
- \`POST /api/v1/channels/ha/registry/bulk\` — operator-only batch upsert + tombstone in a single transaction. Returns \`{inserted, updated, tombstoned, total_after}\`. The tombstone branch sets \`vanished_at\` **only** for rows where it was previously NULL — re-running with the same vanished set is a no-op (asserted by \`channels_ha_pr5.test.ts\`).
- \`POST /api/v1/channels/ha/registry/refresh\` — operator on-demand CTA. Calls \`temporal workflow start HaBootstrapWorkflow\` via \`dockerExec\`; returns 202 + \`workflow_id\` + \`eta: '30s'\`.

## Lane III — HaCard polish

- 'Refresh registry' button in the connected-state expander row. Calls the new \`refreshHaRegistry()\` Wasp action. Tooltip: 'Pulls the latest entities/areas/devices from HA. Auto-runs every 6h.'
- 5-second cooldown after a request so a quick double-click can't queue two workflows.

## Lane IV — Tests (30 new)

\`packages/learn/tests/test_ha_bootstrap.py\` (**18 tests**):
- normaliser: entity-with-area, automation classification, scene classification, dedupe duplicate entity_ids, empty input, malformed-entity skip, areas-and-devices roll-up
- activity: happy parallel pull, HA 401 surfaces as code without raise, HA not connected, HA 5xx re-raises for retry, empty install
- write: posts bulk payload, surfaces 500 as raise
- workflow: happy path, retries transient pull failure, audits known refusal WITHOUT retry, handles empty pull (tombstones-only)

\`packages/ctrl/tests/channels_ha_pr5.test.ts\` (**12 tests**):
- bulk insert / update / tombstone / idempotent / vanished_at stamped-once
- LLAT route 401 without bearer / 200 with master key / 403 voice-bridge / 403 channel-token / 404 unconnected
- refresh 202 with workflow_id, 409 unconnected

## Lane V — Schema

- \`packages/ctrl/src/db/migrations/0009_ha_registry_vanished.sql\` — adds \`vanished_at\` column to \`ha_registry\` + a partial index over \`vanished_at IS NULL\` so the live-entity read stays cheap as tombstones accumulate, and a \`last_seen_at\` index for the recent-activity surface PR6 will use.
- \`alfred-journal\` + migrate expectation tests bumped from 8 → 9.

## LLAT hygiene

- \`requireOperatorBearer()\` never logs or echoes the bearer bytes.
- The LLAT route's error envelope carries no request reflection.
- The activity's HA-401 short-circuit message contains no token material.
- Tests assert the LLAT placeholder doesn't appear in any error envelope.
- Per Sir's standing rule: the registry bulk route operates on entity_ids + state only — no token material.

## Test counts

- 18 new learn tests pass (18/18).
- 12 new ctrl tests pass (12/12).
- Full ctrl test suite: **554 pass / 24 fail** — matches the task's documented baseline of 24 pre-existing failures. No new regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)