### PR TITLE
feat(ctrl,learn): file dedupe + 90d cold archive (#114 PR5)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -461,6 +461,20 @@ services:
       # volume `:ro` and write only through POST /api/v1/files/upload.
       # Issue #114 PR 1; see docs/specs/issue-114-local-file-storage.md §5.1.
       - files_data:/files
+      # Store 5 cold archive (#114 PR 5) — companion volume for ZSTD-19
+      # compressed copies of any blob untouched for 90+ days. The daily
+      # FilesColdArchiveWorkflow (alfred-learn) drives the promotion via
+      # ctrl-api's POST /api/v1/files/cold-promote endpoint, which:
+      #   1. reads the live blob from /files
+      #   2. streams it through node:zlib.createZstdCompress at level 19
+      #   3. lands the compressed bytes at /cold-files/<ULID>.zst
+      #   4. atomically flips file_blobs.path to `cold:<ULID>` and
+      #      unlinks the live copy.
+      # GET /api/v1/files/blob/* transparently decompresses cold reads
+      # via createZstdDecompress — the principal sees the same shape on
+      # the read side either way. Only ctrl-api needs RW on this volume;
+      # no other service mounts it.
+      - files_cold_data:/cold-files
       # ctrl-api restarts sibling containers (worker ops, chore runs).
       - /var/run/docker.sock:/var/run/docker.sock
       # The host compose dir, bind-mounted RW. ctrl-api modules
@@ -1538,6 +1552,11 @@ volumes:
   # write only through POST /api/v1/files/upload. Issue #114 PR 1.
   # docs/specs/issue-114-local-file-storage.md.
   files_data:
+  # Store 5 cold archive (#114 PR 5) — companion to files_data, holds
+  # ZSTD-19 compressed copies of any blob untouched for 90+ days. ctrl-api
+  # is the sole consumer; nothing else mounts this volume. The blob layout
+  # is `<ULID>.zst`, one file per unique sha256 (file_blobs row).
+  files_cold_data:
   hermes_data:
   # Sealed builder runtime workspace — used by the codex-builder Hermes
   # profile only. Owned uid 10001 mode 0700 by the init container (PR 4).

--- a/packages/ctrl/Dockerfile
+++ b/packages/ctrl/Dockerfile
@@ -66,6 +66,12 @@ FROM node:22-slim AS runtime
 # v2 plugin is NOT packaged for Debian, so fetch the official plugin binary
 # into the CLI plugins dir. ctrl-api shells `docker compose` to restart
 # sibling containers via the bind-mounted docker socket.
+#
+# `zstd` (#114 PR 5) — the cold-archive read path uses node:zlib's streaming
+# zstd codec (Node >= 22.15), so the runtime does NOT shell out to /usr/bin/zstd
+# at request time. We install the CLI anyway so operators can inspect a cold
+# blob ad-hoc (`zstd -d /cold-files/<ULID>.zst -o /tmp/probe`) without having to
+# write a Node one-liner. ~150 KB image cost; worth it for the on-call ergonomics.
 ARG TARGETARCH
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
@@ -77,6 +83,7 @@ RUN apt-get update \
        python3-yaml \
        openssh-client \
        docker.io \
+       zstd \
   && rm -rf /var/lib/apt/lists/* \
   && case "${TARGETARCH}" in \
        amd64) DC_ARCH="x86_64" ;; \
@@ -114,7 +121,10 @@ EXPOSE 3100
 
 # alfred-state.db / ingest.db / cold.db (Store 3 archive) live on named volumes
 # mounted at these paths.
-VOLUME ["/state", "/ingest", "/cold"]
+#
+# /files (Store 5 live) + /cold-files (Store 5 cold, #114 PR 5) are mounted
+# from the `files_data` + `files_cold_data` named volumes by docker-compose.
+VOLUME ["/state", "/ingest", "/cold", "/files", "/cold-files"]
 
 # Node 22's node:sqlite is behind an experimental flag.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \

--- a/packages/ctrl/src/api/routes/files.ts
+++ b/packages/ctrl/src/api/routes/files.ts
@@ -54,6 +54,8 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import zlib from "node:zlib";
+import { pipeline } from "node:stream/promises";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { addRoute } from "../server.js";
 import { sendJson, ValidationError, NotFoundError, ApiError } from "../errors.js";
@@ -65,6 +67,28 @@ import { getStateDb } from "../../db/state.js";
  *  docker-compose mount lands `files_data` here `:rw`. Override via
  *  FILES_ROOT for tests. */
 const FILES_ROOT = process.env.FILES_ROOT ?? "/files";
+
+/** Root of the cold-archive volume inside the ctrl-api container.
+ *  The docker-compose mount lands `files_cold_data` here `:rw`. The
+ *  daily FilesColdArchiveWorkflow promotes unread (>=90d) files from
+ *  FILES_ROOT to FILES_COLD_ROOT, zstd-compressed at level 19.
+ *  Override via FILES_COLD_ROOT for tests. Issue #114 PR 5. */
+const FILES_COLD_ROOT = process.env.FILES_COLD_ROOT ?? "/cold-files";
+
+/** Cold-storage path prefix used in `files.path` + `file_blobs.path`
+ *  to mark a blob as living on the cold volume. The blob GET route
+ *  strips the prefix, resolves the remainder under FILES_COLD_ROOT,
+ *  appends `.zst`, and streams a transparent decompression on the way
+ *  out. */
+const COLD_PATH_PREFIX = "cold:";
+
+/** Age threshold for cold-archive promotion. Files whose
+ *  `last_accessed_at` (or `uploaded_at` if never accessed) is older
+ *  than this become eligible for the daily sweep. Override via
+ *  FILES_COLD_AFTER_MS for tests. Default: 90 days. */
+export const COLD_AFTER_MS = Number(
+  process.env.FILES_COLD_AFTER_MS ?? String(90 * 24 * 60 * 60 * 1000),
+);
 
 const MB = 1024 * 1024;
 const GB = 1024 * MB;
@@ -165,6 +189,34 @@ function resolveBlobPath(relPath: string): string {
   return abs;
 }
 
+/** Resolve a `cold:<ULID>` path to its absolute on-disk location under
+ *  FILES_COLD_ROOT. The on-disk filename is `<ULID>.zst`. Throws
+ *  ValidationError if the resolution would escape FILES_COLD_ROOT
+ *  (defence in depth — the cold blob name is principal-untrusted in
+ *  the rare case a malformed row sneaks through). Issue #114 PR 5. */
+function resolveColdBlobPath(coldPath: string): string {
+  if (!coldPath.startsWith(COLD_PATH_PREFIX)) {
+    throw new ValidationError(`not a cold path: ${coldPath}`);
+  }
+  const tail = coldPath.slice(COLD_PATH_PREFIX.length);
+  // The cold filename is just the ULID — no path separators allowed.
+  if (tail.includes("/") || tail.includes("\\") || tail.includes("..")) {
+    throw new ValidationError(`cold path tail must be a bare ULID: ${tail}`);
+  }
+  const root = path.resolve(FILES_COLD_ROOT);
+  const abs = path.resolve(root, `${tail}.zst`);
+  if (!abs.startsWith(root + path.sep)) {
+    throw new ValidationError("cold path escapes the cold files root");
+  }
+  return abs;
+}
+
+/** True iff the given `files.path` / `file_blobs.path` value lives on
+ *  the cold-archive volume (vs the live volume). */
+export function isColdPath(p: string): boolean {
+  return p.startsWith(COLD_PATH_PREFIX);
+}
+
 // ── DB helpers ─────────────────────────────────────────────────────────────
 
 interface FileRow {
@@ -179,6 +231,8 @@ interface FileRow {
   uploaded_at: number;
   last_accessed_at: number | null;
   deleted_at: number | null;
+  cold_promoted_at: number | null;
+  ref_count: number;
 }
 
 function rowFromDb(raw: Record<string, unknown>): FileRow {
@@ -197,17 +251,64 @@ function rowFromDb(raw: Record<string, unknown>): FileRow {
     last_accessed_at:
       raw.last_accessed_at == null ? null : Number(raw.last_accessed_at),
     deleted_at: raw.deleted_at == null ? null : Number(raw.deleted_at),
+    cold_promoted_at:
+      raw.cold_promoted_at == null ? null : Number(raw.cold_promoted_at),
+    ref_count: raw.ref_count == null ? 1 : Number(raw.ref_count),
   };
 }
 
-function liveUsage(): { used_bytes: number; count: number } {
-  const row = getStateDb()
+/**
+ * Per-tenant storage usage, computed from the deduped `file_blobs`
+ * table so two `files` rows with the same sha256 count their bytes
+ * ONCE. Live (= un-promoted) and cold (= promoted) storage are
+ * reported separately so the /usage UI can break down "what's on the
+ * hot volume" vs "what's been frozen to the cold volume". Issue #114
+ * PR 5.
+ *
+ * The `count` is the number of distinct sha256s in each bucket, NOT
+ * the number of `files.id` rows — the row count is the principal's
+ * count of distinct uploads, exposed separately as `file_count` on
+ * the /usage response.
+ */
+function tenantUsage(): {
+  live_bytes: number;
+  cold_bytes: number;
+  blob_count_live: number;
+  blob_count_cold: number;
+  file_count: number;
+} {
+  const db = getStateDb();
+  // Only `file_blobs` rows with at least one live (non-tombstoned)
+  // `files` row referencing them contribute to usage. Tombstoned rows
+  // already had their ref_count decremented at delete time; a
+  // ref_count of zero means the bytes have been (or will be) reaped
+  // by the deletion path and don't count.
+  const live = db
     .prepare(
       `SELECT COALESCE(SUM(size_bytes), 0) AS used, COUNT(*) AS count
-       FROM files WHERE deleted_at IS NULL`,
+         FROM file_blobs
+        WHERE cold_promoted_at IS NULL AND ref_count > 0`,
     )
     .get() as { used: number; count: number };
-  return { used_bytes: Number(row.used), count: Number(row.count) };
+  const cold = db
+    .prepare(
+      `SELECT COALESCE(SUM(size_bytes), 0) AS used, COUNT(*) AS count
+         FROM file_blobs
+        WHERE cold_promoted_at IS NOT NULL AND ref_count > 0`,
+    )
+    .get() as { used: number; count: number };
+  const fileCount = (
+    db
+      .prepare(`SELECT COUNT(*) AS c FROM files WHERE deleted_at IS NULL`)
+      .get() as { c: number }
+  ).c;
+  return {
+    live_bytes: Number(live.used),
+    cold_bytes: Number(cold.used),
+    blob_count_live: Number(live.count),
+    blob_count_cold: Number(cold.count),
+    file_count: Number(fileCount),
+  };
 }
 
 // ── multipart parser ───────────────────────────────────────────────────────
@@ -523,6 +624,7 @@ function rowToJson(row: FileRow): Record<string, unknown> {
     uploaded_at: row.uploaded_at,
     last_accessed_at: row.last_accessed_at,
     deleted_at: row.deleted_at,
+    cold_promoted_at: row.cold_promoted_at,
   };
 }
 
@@ -537,6 +639,13 @@ function ensureFilesRoot(): void {
     // is an mkdtemp dir.
     console.warn(
       `[files] could not ensure ${FILES_ROOT}: ${(err as Error).message}`,
+    );
+  }
+  try {
+    fs.mkdirSync(FILES_COLD_ROOT, { recursive: true });
+  } catch (err) {
+    console.warn(
+      `[files] could not ensure ${FILES_COLD_ROOT}: ${(err as Error).message}`,
     );
   }
 }
@@ -554,6 +663,27 @@ export function registerFilesRoutes(): void {
   // The `uploaded_by` actor defaults to `principal`; callers may
   // override via the `uploaded_by` field but PR 1 doesn't yet validate
   // it against a registry (PR 2 wires that to the MCP tool actor).
+  //
+  // Issue #114 PR 5 — content-addressed dedupe.
+  // ----------------------------------------------------------------
+  // Before inserting the `files` row we look up the sha256 in the
+  // `file_blobs` table. If a row exists we DO NOT write the bytes a
+  // second time: the new `files.id` points at the existing
+  // `file_blobs.path` (which may be a live `<ULID>/<safe-name>` or a
+  // promoted `cold:<ULID>`) and the canonical row's `ref_count` ticks
+  // up by one. Quota counts only unique sha256s (see `tenantUsage`),
+  // so the second upload of the same content costs zero principal
+  // bytes. The response shape is unchanged plus a `deduped` flag for
+  // observability.
+  //
+  // Race note. Two concurrent uploads of the same content can both
+  // pass the pre-flight `file_blobs` SELECT and both write the bytes
+  // to disk. We resolve that race AFTER both writes complete: the
+  // INSERT-or-IGNORE on `file_blobs` is the serialization point — the
+  // loser sees `changes()==0`, deletes its just-written ULID dir, and
+  // resolves its `files.path` to the winner's canonical path. Net
+  // outcome: exactly one set of bytes on disk, two `files` rows
+  // sharing it, ref_count=2.
   addRoute("POST", "/api/v1/files/upload", async ({ req, res }) => {
     const ct = String(req.headers["content-type"] ?? "");
     if (!ct.toLowerCase().startsWith("multipart/form-data")) {
@@ -568,8 +698,10 @@ export function registerFilesRoutes(): void {
 
     // Per-tenant hard quota pre-flight: bail before opening the write
     // stream so we don't even allocate the ULID dir on a doomed upload.
-    const before = liveUsage();
-    if (before.used_bytes >= QUOTA_HARD_BYTES) {
+    // PR 5 — only the unique-sha256 bytes count (live + cold).
+    const before = tenantUsage();
+    const usedBeforeBytes = before.live_bytes + before.cold_bytes;
+    if (usedBeforeBytes >= QUOTA_HARD_BYTES) {
       throw new ApiError(
         507,
         "QUOTA_EXCEEDED",
@@ -606,10 +738,29 @@ export function registerFilesRoutes(): void {
       throw err;
     }
 
-    // Post-write quota check: if the upload's tail pushes us past the
-    // hard cap, refuse + clean up. (We allow temporarily exceeding the
-    // soft cap; the principal sees that in `/usage`.)
-    if (before.used_bytes + parsed.size > QUOTA_HARD_BYTES) {
+    // ── dedupe check ────────────────────────────────────────────────
+    // After the body's been drained + sha256'd, look up the hash in
+    // `file_blobs`. We re-check the quota using the deduped size: a
+    // duplicate adds zero bytes to live storage so it should never be
+    // 507'd, even if the principal is right at the cap.
+    const db = getStateDb();
+    const existingBlob = db
+      .prepare(
+        `SELECT sha256, path, size_bytes, cold_promoted_at
+           FROM file_blobs WHERE sha256 = ?`,
+      )
+      .get(parsed.sha256) as
+      | {
+          sha256: string;
+          path: string;
+          size_bytes: number;
+          cold_promoted_at: number | null;
+        }
+      | undefined;
+
+    // Pure-new (no `file_blobs` row) quota gate: would this push us
+    // over the hard cap? Duplicates skip this check.
+    if (!existingBlob && usedBeforeBytes + parsed.size > QUOTA_HARD_BYTES) {
       try {
         fs.rmSync(ulidDir, { recursive: true, force: true });
       } catch {
@@ -630,10 +781,6 @@ export function registerFilesRoutes(): void {
       parsed.text.filename ||
       "file";
     const safeName = sanitizeFilename(declared);
-    const finalPath = path.join(ulidDir, safeName);
-    fs.renameSync(scratchPath, finalPath);
-
-    const relPath = path.posix.join(id, safeName);
     const contentType =
       parsed.contentType ||
       parsed.text.content_type ||
@@ -641,33 +788,84 @@ export function registerFilesRoutes(): void {
     const principalLabel = parsed.text.principal_label || null;
     const uploadedBy = parsed.text.uploaded_by || "principal";
     const now = Date.now();
-
-    // The principal-facing `original_filename` is `declared` — the
-    // explicit text-field override beats the multipart part's own
-    // filename header, mirroring the precedence we used for the
-    // on-disk safe-name above. Otherwise an uploader who passes both
-    // would see the row carry the part header (which they treat as
-    // a transport detail) instead of the value they intended.
     const originalFilename = declared;
 
-    getStateDb()
-      .prepare(
-        `INSERT INTO files
-          (id, path, size_bytes, sha256, content_type, original_filename,
-           principal_label, uploaded_by, uploaded_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      )
-      .run(
-        id,
-        relPath,
-        parsed.size,
-        parsed.sha256,
-        contentType,
-        originalFilename,
-        principalLabel,
-        uploadedBy,
-        now,
-      );
+    let relPath: string;
+    let deduped: boolean;
+
+    if (existingBlob) {
+      // ── dedupe path: the bytes already live on disk (or in the
+      // cold archive). Throw away our scratch copy, bump the
+      // canonical row's ref_count, and point the new `files.id`
+      // row at the existing path. The principal sees the SAME path
+      // they would have gotten if they uploaded for the first time —
+      // the dedupe is transparent on the read side.
+      try {
+        fs.rmSync(ulidDir, { recursive: true, force: true });
+      } catch {
+        /* best-effort */
+      }
+      db.prepare(
+        `UPDATE file_blobs SET ref_count = ref_count + 1 WHERE sha256 = ?`,
+      ).run(parsed.sha256);
+      relPath = existingBlob.path;
+      deduped = true;
+    } else {
+      // ── novel path: finalize the on-disk filename, then INSERT
+      // OR IGNORE into `file_blobs`. The IGNORE catches the race
+      // where two concurrent uploads of the same content both pass
+      // the dedupe-check above; whoever loses the INSERT race wins
+      // the cleanup duty (delete their just-written ULID dir, point
+      // at the canonical path, bump ref_count).
+      const finalPath = path.join(ulidDir, safeName);
+      fs.renameSync(scratchPath, finalPath);
+      const novelRelPath = path.posix.join(id, safeName);
+      const insert = db
+        .prepare(
+          `INSERT OR IGNORE INTO file_blobs
+            (sha256, path, size_bytes, ref_count, created_at)
+           VALUES (?, ?, ?, 1, ?)`,
+        )
+        .run(parsed.sha256, novelRelPath, parsed.size, now);
+      if (insert.changes === 0) {
+        // Concurrent-write race lost. Adopt the canonical row.
+        const canonical = db
+          .prepare(
+            `SELECT path FROM file_blobs WHERE sha256 = ?`,
+          )
+          .get(parsed.sha256) as { path: string } | undefined;
+        try {
+          fs.rmSync(ulidDir, { recursive: true, force: true });
+        } catch {
+          /* best-effort */
+        }
+        db.prepare(
+          `UPDATE file_blobs SET ref_count = ref_count + 1 WHERE sha256 = ?`,
+        ).run(parsed.sha256);
+        relPath = canonical?.path ?? novelRelPath;
+        deduped = true;
+      } else {
+        relPath = novelRelPath;
+        deduped = false;
+      }
+    }
+
+    db.prepare(
+      `INSERT INTO files
+        (id, path, size_bytes, sha256, content_type, original_filename,
+         principal_label, uploaded_by, uploaded_at, ref_count)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1)`,
+    ).run(
+      id,
+      relPath,
+      parsed.size,
+      parsed.sha256,
+      contentType,
+      originalFilename,
+      principalLabel,
+      uploadedBy,
+      now,
+    );
 
     sendJson(res, 201, {
       id,
@@ -679,6 +877,7 @@ export function registerFilesRoutes(): void {
       principal_label: principalLabel,
       uploaded_by: uploadedBy,
       uploaded_at: now,
+      deduped,
     });
   });
 
@@ -754,13 +953,29 @@ export function registerFilesRoutes(): void {
 
   // GET /api/v1/files/usage
   //
-  // Always-on observability. Reports the live total + count + both
-  // caps so the dashboard can decide when to show a warning band.
+  // Always-on observability. PR 5 changed two things:
+  //   * usage is computed from `file_blobs` (one row per unique
+  //     sha256) so two duplicate uploads count their bytes ONCE.
+  //   * the live/cold split is exposed so the /files dashboard can
+  //     show "X GB live + Y GB cold" — useful both for the storage
+  //     mental model and for sizing future cold-restore decisions.
+  //
+  // `used_bytes` + `count` are preserved as the PR 1 fields so
+  // existing callers (the /files page, MCP `files__usage`) keep
+  // working without a contract bump. `used_bytes` is the SUM of
+  // `live_bytes` + `cold_bytes`; `count` is `file_count`.
   addRoute("GET", "/api/v1/files/usage", async ({ res }) => {
-    const u = liveUsage();
+    const u = tenantUsage();
     sendJson(res, 200, {
-      used_bytes: u.used_bytes,
-      count: u.count,
+      // PR 1 compatibility surface (now the live+cold sum).
+      used_bytes: u.live_bytes + u.cold_bytes,
+      count: u.file_count,
+      // PR 5 surface — live vs cold breakdown.
+      live_bytes: u.live_bytes,
+      cold_bytes: u.cold_bytes,
+      blob_count_live: u.blob_count_live,
+      blob_count_cold: u.blob_count_cold,
+      file_count: u.file_count,
       soft_cap_bytes: QUOTA_SOFT_BYTES,
       hard_cap_bytes: QUOTA_HARD_BYTES,
       upload_soft_bytes: UPLOAD_SOFT_BYTES,
@@ -788,7 +1003,23 @@ export function registerFilesRoutes(): void {
   // GET /api/v1/files/blob/* — stream the raw bytes.
   //
   // Bumps `last_accessed_at` on every read so the principal can sort
-  // by recency in PR 3.
+  // by recency on the /files page AND so the cold-archive sweep can
+  // skip recently-touched files.
+  //
+  // Cold-aware (PR 5). If `files.path` starts with `cold:` the blob
+  // lives on the `files_cold_data` volume as `<ULID>.zst`. The
+  // decompression streams through `zlib.createZstdDecompress` so we
+  // never load a multi-MB file into memory — the inflated bytes go
+  // straight from the cold volume to the response socket. We can't
+  // pre-compute `Content-Length` (decompressed size != on-disk size)
+  // so we drop that header on cold reads and let the client read to
+  // EOF; the live path keeps its Content-Length for byte-range and
+  // download-progress goodness.
+  //
+  // A cold read does NOT auto-restore the blob to the live volume —
+  // the principal opts in via the explicit `POST /cold-restore/:file_id`
+  // route. Keeps the read path predictable: a cold read is a cold
+  // read until the operator says otherwise.
   addRoute("GET", "/api/v1/files/blob/*", async ({ res, params }) => {
     const relPath = params.path ?? "";
     if (!relPath) throw new ValidationError("path is required");
@@ -800,7 +1031,9 @@ export function registerFilesRoutes(): void {
       .get(relPath) as Record<string, unknown> | undefined;
     if (!raw) throw new NotFoundError(`file not found: ${relPath}`);
     const row = rowFromDb(raw);
-    const abs = resolveBlobPath(row.path);
+
+    const cold = isColdPath(row.path);
+    const abs = cold ? resolveColdBlobPath(row.path) : resolveBlobPath(row.path);
     if (!fs.existsSync(abs)) {
       // Row points at a missing blob — a real "this should never
       // happen", but if it does the principal deserves a clear 410.
@@ -810,11 +1043,22 @@ export function registerFilesRoutes(): void {
         `the row exists but the blob at ${row.path} is gone`,
       );
     }
-    const stat = fs.statSync(abs);
+
     const headers: Record<string, string | number> = {
       "Content-Type": row.content_type || "application/octet-stream",
-      "Content-Length": stat.size,
     };
+    if (!cold) {
+      // Hot path: we know the decompressed size; live blobs are
+      // stored verbatim so the on-disk size is the wire size.
+      const stat = fs.statSync(abs);
+      headers["Content-Length"] = stat.size;
+    } else {
+      // Cold path: the inflated stream is generated on the fly. We
+      // could pre-inflate to a temp file to learn the size, but that
+      // breaks the "never load into memory" invariant and costs an
+      // extra disk round trip. Drop the header instead.
+      headers["X-Cold-Blob"] = "1";
+    }
     if (row.original_filename) {
       // RFC 5987 / 6266 — use a UTF-8 encoded `filename*` so non-ASCII
       // characters survive the round trip without breaking older
@@ -828,7 +1072,11 @@ export function registerFilesRoutes(): void {
     db.prepare(
       `UPDATE files SET last_accessed_at = ? WHERE id = ?`,
     ).run(Date.now(), row.id);
-    streamBlobTo(res, abs);
+    if (cold) {
+      streamColdBlobTo(res, abs);
+    } else {
+      streamBlobTo(res, abs);
+    }
   });
 
   // PATCH /api/v1/files/* — update principal-owned metadata.
@@ -891,10 +1139,14 @@ export function registerFilesRoutes(): void {
 
   // DELETE /api/v1/files/* — soft delete.
   //
-  // Sets the tombstone column and unlinks the on-disk blob (the row
-  // and the ULID dir stay for the audit trail). PR 2 will tighten the
-  // ACL to "only the principal actor"; PR 1 accepts any authenticated
-  // caller.
+  // Sets the tombstone column. With dedupe (PR 5) the on-disk bytes
+  // are SHARED via `file_blobs`, so the unlink only happens when the
+  // canonical row's `ref_count` drops to zero — otherwise the other
+  // live `files.id` rows would suddenly point at a missing blob. The
+  // `files` row stays for the audit trail either way.
+  //
+  // Cold blobs are unlinked from FILES_COLD_ROOT instead of
+  // FILES_ROOT when their ref_count hits zero.
   addRoute("DELETE", "/api/v1/files/*", async ({ res, params }) => {
     const relPath = params.path ?? "";
     if (!relPath) throw new ValidationError("path is required");
@@ -906,17 +1158,410 @@ export function registerFilesRoutes(): void {
       .get(relPath) as Record<string, unknown> | undefined;
     if (!raw) throw new NotFoundError(`file not found: ${relPath}`);
     const row = rowFromDb(raw);
-    const abs = resolveBlobPath(row.path);
     const now = Date.now();
+    // Soft-delete the principal-facing row.
     db.prepare(`UPDATE files SET deleted_at = ? WHERE id = ?`).run(now, row.id);
-    try {
-      if (fs.existsSync(abs)) fs.unlinkSync(abs);
-    } catch (err) {
-      console.warn(
-        `[files] could not unlink ${abs}: ${(err as Error).message}`,
-      );
+    // Decrement the canonical blob's ref_count, then physically unlink
+    // only if it just hit zero. INSERT-or-IGNORE on upload guarantees
+    // exactly one `file_blobs` row per sha256, so this UPDATE +
+    // SELECT is race-free under SQLite's per-statement atomicity.
+    db.prepare(
+      `UPDATE file_blobs SET ref_count = ref_count - 1 WHERE sha256 = ?`,
+    ).run(row.sha256);
+    const blob = db
+      .prepare(
+        `SELECT path, ref_count, cold_promoted_at
+           FROM file_blobs WHERE sha256 = ?`,
+      )
+      .get(row.sha256) as
+      | { path: string; ref_count: number; cold_promoted_at: number | null }
+      | undefined;
+    if (blob && blob.ref_count <= 0) {
+      // Last reference dropped — reap the on-disk bytes + the
+      // canonical row. The ULID dir (live) or `<ULID>.zst` file
+      // (cold) is unlinked best-effort; the SQL state is the source
+      // of truth.
+      try {
+        if (isColdPath(blob.path)) {
+          const abs = resolveColdBlobPath(blob.path);
+          if (fs.existsSync(abs)) fs.unlinkSync(abs);
+        } else {
+          const abs = resolveBlobPath(blob.path);
+          if (fs.existsSync(abs)) fs.unlinkSync(abs);
+          // The ULID parent dir was the upload-namespace wrapper;
+          // remove it too if it's empty. Best-effort: a concurrent
+          // mkdir would race here harmlessly.
+          const parentDir = path.dirname(abs);
+          try {
+            fs.rmdirSync(parentDir);
+          } catch {
+            /* dir not empty / not ours / etc — fine. */
+          }
+        }
+      } catch (err) {
+        console.warn(
+          `[files] could not unlink ${blob.path}: ${(err as Error).message}`,
+        );
+      }
+      db.prepare(`DELETE FROM file_blobs WHERE sha256 = ?`).run(row.sha256);
     }
     sendJson(res, 200, { id: row.id, path: row.path, deleted_at: now });
+  });
+
+  // GET /api/v1/files/cold-candidates?older_than_ms=…
+  //
+  // Operator-facing list of files eligible for cold promotion (issue
+  // #114 PR 5). A row is a candidate when:
+  //
+  //   * `deleted_at IS NULL`              (not tombstoned)
+  //   * `cold_promoted_at IS NULL`        (not already promoted)
+  //   * `COALESCE(last_accessed_at, uploaded_at) < now - older_than_ms`
+  //
+  // The `older_than_ms` query arg defaults to COLD_AFTER_MS (90d). The
+  // daily FilesColdArchiveWorkflow consumes this surface, then loops
+  // POST /cold-promote/:file_id for each row.
+  //
+  // We deliberately project the per-file row (not the canonical
+  // `file_blobs` row) — multiple `files.id` rows can share a sha256
+  // via dedupe, and the workflow needs the per-row id to address the
+  // promote endpoint. The activity de-dupes on the workflow side.
+  addRoute("GET", "/api/v1/files/cold-candidates", async ({ res, query }) => {
+    const olderRaw = Number(
+      query.get("older_than_ms") ?? String(COLD_AFTER_MS),
+    );
+    const olderThanMs =
+      Number.isFinite(olderRaw) && olderRaw >= 0 ? olderRaw : COLD_AFTER_MS;
+    const limitRaw = Number(query.get("limit") ?? "500");
+    const limit =
+      Number.isFinite(limitRaw) && limitRaw > 0
+        ? Math.min(5000, Math.floor(limitRaw))
+        : 500;
+    const cutoff = Date.now() - olderThanMs;
+    const rows = getStateDb()
+      .prepare(
+        `SELECT * FROM files
+          WHERE deleted_at IS NULL
+            AND cold_promoted_at IS NULL
+            AND COALESCE(last_accessed_at, uploaded_at) < ?
+          ORDER BY COALESCE(last_accessed_at, uploaded_at) ASC
+          LIMIT ?`,
+      )
+      .all(cutoff, limit) as Record<string, unknown>[];
+    sendJson(res, 200, {
+      cutoff_ms: cutoff,
+      older_than_ms: olderThanMs,
+      items: rows.map((r) => rowToJson(rowFromDb(r))),
+      total: rows.length,
+    });
+  });
+
+  // POST /api/v1/files/cold-promote/:file_id
+  //
+  // Move ONE file from the live volume to the cold volume. Steps:
+  //
+  //   1. Look up the row + canonical `file_blobs` row by file_id.
+  //   2. Refuse if the blob is already cold, or if the row is
+  //      tombstoned, or if the live file is missing on disk.
+  //   3. Stream the live bytes through `zlib.createZstdCompress` at
+  //      level 19 into a temp file under FILES_COLD_ROOT. (We use a
+  //      temp + rename so a crash mid-promote never leaves a
+  //      half-written cold blob.)
+  //   4. Atomically swap: update `file_blobs.path` to `cold:<ULID>`
+  //      + `cold_promoted_at`, then update every live `files` row
+  //      that shares the sha256 to the cold path + `cold_promoted_at`
+  //      stamp, then unlink the live bytes.
+  //
+  // If step 4's DB write fails the temp file is cleaned up. If the
+  // unlink fails after the DB update the next sweep will skip the
+  // row (`cold_promoted_at IS NOT NULL`) and the orphan can be reaped
+  // by ops. Better that than rolling back the DB and re-promoting on
+  // every sweep tick.
+  addRoute("POST", "/api/v1/files/cold-promote/:file_id", async ({ res, params }) => {
+    const fileId = params.file_id ?? "";
+    if (!fileId) throw new ValidationError("file_id is required");
+    const db = getStateDb();
+    const raw = db
+      .prepare(`SELECT * FROM files WHERE id = ? LIMIT 1`)
+      .get(fileId) as Record<string, unknown> | undefined;
+    if (!raw) throw new NotFoundError(`file not found: ${fileId}`);
+    const row = rowFromDb(raw);
+    if (row.deleted_at != null) {
+      throw new ApiError(
+        409,
+        "TOMBSTONED",
+        `cannot promote a tombstoned file: ${fileId}`,
+      );
+    }
+    const blob = db
+      .prepare(`SELECT * FROM file_blobs WHERE sha256 = ?`)
+      .get(row.sha256) as
+      | {
+          sha256: string;
+          path: string;
+          size_bytes: number;
+          ref_count: number;
+          created_at: number;
+          cold_promoted_at: number | null;
+        }
+      | undefined;
+    if (!blob) {
+      throw new ApiError(
+        410,
+        "BLOB_INDEX_MISSING",
+        `file_blobs row missing for sha256 ${row.sha256}`,
+      );
+    }
+    if (blob.cold_promoted_at != null || isColdPath(blob.path)) {
+      // Already cold — idempotent no-op. Update the per-file row's
+      // cold_promoted_at + path in case it's drifted (the canonical
+      // blob is the source of truth).
+      db.prepare(
+        `UPDATE files SET path = ?, cold_promoted_at = ? WHERE sha256 = ? AND deleted_at IS NULL`,
+      ).run(blob.path, blob.cold_promoted_at ?? Date.now(), row.sha256);
+      sendJson(res, 200, {
+        id: row.id,
+        sha256: row.sha256,
+        path: blob.path,
+        cold_promoted_at: blob.cold_promoted_at,
+        already_cold: true,
+      });
+      return;
+    }
+    const liveAbs = resolveBlobPath(blob.path);
+    if (!fs.existsSync(liveAbs)) {
+      throw new ApiError(
+        410,
+        "BLOB_MISSING",
+        `the blob at ${blob.path} is gone (cannot promote)`,
+      );
+    }
+    // Derive the cold-volume ULID from the live path's first segment.
+    // The live path layout is `<ULID>/<safe-name>`; reuse the same
+    // ULID as the cold filename so the relationship is auditable.
+    const liveUlid = blob.path.split("/")[0];
+    if (!/^[0-9A-HJKMNP-TV-Z]{26}$/.test(liveUlid)) {
+      throw new ApiError(
+        500,
+        "INVALID_LIVE_PATH",
+        `live path does not start with a ULID: ${blob.path}`,
+      );
+    }
+    const coldRelPath = `${COLD_PATH_PREFIX}${liveUlid}`;
+    const coldFinalAbs = path.join(FILES_COLD_ROOT, `${liveUlid}.zst`);
+    const coldTempAbs = `${coldFinalAbs}.in-progress`;
+
+    // Stream zstd-compress live → temp file. createZstdCompress is
+    // a Transform stream, so `pipeline(read, compress, write)` keeps
+    // the data flowing chunk-by-chunk; nothing ever lives fully in
+    // memory.
+    const readStream = fs.createReadStream(liveAbs);
+    const compressor = (zlib as unknown as {
+      createZstdCompress: (opts?: unknown) => NodeJS.ReadWriteStream;
+      constants: Record<string, number>;
+    }).createZstdCompress({
+      params: {
+        // Level 19 is the strong-ratio knob; cold writes are
+        // one-shot so CPU spend is fine.
+        [(zlib as unknown as { constants: Record<string, number> }).constants
+          .ZSTD_c_compressionLevel ?? 0]: 19,
+      },
+    });
+    const writeStream = fs.createWriteStream(coldTempAbs);
+    try {
+      await pipeline(readStream, compressor, writeStream);
+    } catch (err) {
+      try {
+        if (fs.existsSync(coldTempAbs)) fs.unlinkSync(coldTempAbs);
+      } catch {
+        /* best-effort */
+      }
+      throw new ApiError(
+        500,
+        "COMPRESS_FAILED",
+        `zstd compression failed: ${(err as Error).message}`,
+      );
+    }
+    fs.renameSync(coldTempAbs, coldFinalAbs);
+
+    const promotedAt = Date.now();
+    const compressedSize = fs.statSync(coldFinalAbs).size;
+    // Atomic DB swap.
+    db.exec("BEGIN");
+    try {
+      db.prepare(
+        `UPDATE file_blobs
+            SET path = ?, cold_promoted_at = ?
+          WHERE sha256 = ?`,
+      ).run(coldRelPath, promotedAt, row.sha256);
+      db.prepare(
+        `UPDATE files
+            SET path = ?, cold_promoted_at = ?
+          WHERE sha256 = ? AND deleted_at IS NULL`,
+      ).run(coldRelPath, promotedAt, row.sha256);
+      db.exec("COMMIT");
+    } catch (err) {
+      db.exec("ROLLBACK");
+      try {
+        if (fs.existsSync(coldFinalAbs)) fs.unlinkSync(coldFinalAbs);
+      } catch {
+        /* best-effort */
+      }
+      throw err;
+    }
+    // Unlink the live bytes + the now-empty ULID dir. Best-effort
+    // after the DB has been flipped — if these fail the cold side is
+    // already authoritative.
+    try {
+      fs.unlinkSync(liveAbs);
+      const parentDir = path.dirname(liveAbs);
+      try {
+        fs.rmdirSync(parentDir);
+      } catch {
+        /* dir not empty / not ours / etc — fine. */
+      }
+    } catch (err) {
+      console.warn(
+        `[files] cold-promote: could not unlink live ${liveAbs}: ${(err as Error).message}`,
+      );
+    }
+    sendJson(res, 200, {
+      id: row.id,
+      sha256: row.sha256,
+      path: coldRelPath,
+      cold_promoted_at: promotedAt,
+      live_bytes: blob.size_bytes,
+      cold_bytes: compressedSize,
+      compression_ratio: blob.size_bytes
+        ? Number((blob.size_bytes / compressedSize).toFixed(3))
+        : null,
+    });
+  });
+
+  // POST /api/v1/files/cold-restore/:file_id
+  //
+  // Manually pull a file BACK to the live volume — the inverse of
+  // cold-promote. Steps mirror the promotion path: decompress the
+  // cold blob into a live temp file, then atomically flip the SQL
+  // path back to the live ULID layout and unlink the cold copy.
+  //
+  // This is operator-only; the read path (GET /blob/*) intentionally
+  // does NOT auto-restore on access so cold-promoted files stay cold
+  // until the operator explicitly opts in.
+  addRoute("POST", "/api/v1/files/cold-restore/:file_id", async ({ res, params }) => {
+    const fileId = params.file_id ?? "";
+    if (!fileId) throw new ValidationError("file_id is required");
+    const db = getStateDb();
+    const raw = db
+      .prepare(`SELECT * FROM files WHERE id = ? LIMIT 1`)
+      .get(fileId) as Record<string, unknown> | undefined;
+    if (!raw) throw new NotFoundError(`file not found: ${fileId}`);
+    const row = rowFromDb(raw);
+    if (row.deleted_at != null) {
+      throw new ApiError(
+        409,
+        "TOMBSTONED",
+        `cannot restore a tombstoned file: ${fileId}`,
+      );
+    }
+    const blob = db
+      .prepare(`SELECT * FROM file_blobs WHERE sha256 = ?`)
+      .get(row.sha256) as
+      | { sha256: string; path: string; size_bytes: number; cold_promoted_at: number | null }
+      | undefined;
+    if (!blob) {
+      throw new ApiError(
+        410,
+        "BLOB_INDEX_MISSING",
+        `file_blobs row missing for sha256 ${row.sha256}`,
+      );
+    }
+    if (!isColdPath(blob.path)) {
+      // Already live — idempotent no-op.
+      sendJson(res, 200, {
+        id: row.id,
+        sha256: row.sha256,
+        path: blob.path,
+        cold_promoted_at: null,
+        already_live: true,
+      });
+      return;
+    }
+    const coldAbs = resolveColdBlobPath(blob.path);
+    if (!fs.existsSync(coldAbs)) {
+      throw new ApiError(
+        410,
+        "BLOB_MISSING",
+        `the cold blob at ${blob.path} is gone (cannot restore)`,
+      );
+    }
+    const coldUlid = blob.path.slice(COLD_PATH_PREFIX.length);
+    // Reconstruct the live path by reusing the file's original name
+    // from the principal-facing row. If `original_filename` is null
+    // (a rare debug case), fall back to "file" — sanitize either way.
+    const safeName = sanitizeFilename(row.original_filename ?? "file");
+    const liveRelPath = path.posix.join(coldUlid, safeName);
+    const liveUlidDir = resolveBlobPath(coldUlid);
+    fs.mkdirSync(liveUlidDir, { recursive: true });
+    const liveFinalAbs = path.join(liveUlidDir, safeName);
+    const liveTempAbs = `${liveFinalAbs}.in-progress`;
+
+    const readStream = fs.createReadStream(coldAbs);
+    const decompressor = (zlib as unknown as {
+      createZstdDecompress: (opts?: unknown) => NodeJS.ReadWriteStream;
+    }).createZstdDecompress();
+    const writeStream = fs.createWriteStream(liveTempAbs);
+    try {
+      await pipeline(readStream, decompressor, writeStream);
+    } catch (err) {
+      try {
+        if (fs.existsSync(liveTempAbs)) fs.unlinkSync(liveTempAbs);
+      } catch {
+        /* best-effort */
+      }
+      throw new ApiError(
+        500,
+        "DECOMPRESS_FAILED",
+        `zstd decompression failed: ${(err as Error).message}`,
+      );
+    }
+    fs.renameSync(liveTempAbs, liveFinalAbs);
+
+    db.exec("BEGIN");
+    try {
+      db.prepare(
+        `UPDATE file_blobs
+            SET path = ?, cold_promoted_at = NULL
+          WHERE sha256 = ?`,
+      ).run(liveRelPath, row.sha256);
+      db.prepare(
+        `UPDATE files
+            SET path = ?, cold_promoted_at = NULL
+          WHERE sha256 = ? AND deleted_at IS NULL`,
+      ).run(liveRelPath, row.sha256);
+      db.exec("COMMIT");
+    } catch (err) {
+      db.exec("ROLLBACK");
+      try {
+        if (fs.existsSync(liveFinalAbs)) fs.unlinkSync(liveFinalAbs);
+      } catch {
+        /* best-effort */
+      }
+      throw err;
+    }
+    try {
+      fs.unlinkSync(coldAbs);
+    } catch (err) {
+      console.warn(
+        `[files] cold-restore: could not unlink cold ${coldAbs}: ${(err as Error).message}`,
+      );
+    }
+    sendJson(res, 200, {
+      id: row.id,
+      sha256: row.sha256,
+      path: liveRelPath,
+      cold_promoted_at: null,
+      restored_bytes: blob.size_bytes,
+    });
   });
 }
 
@@ -936,4 +1581,35 @@ function streamBlobTo(res: ServerResponse, abs: string): void {
     }
   });
   rs.pipe(res);
+}
+
+/** Stream the contents of a cold-archived `<ULID>.zst` blob to the
+ *  response, decompressing on the fly. The read + decompress + write
+ *  pipeline keeps everything chunked — the inflated bytes never sit
+ *  in a Node buffer at full size, so 100 MB cold reads stay within
+ *  the same memory budget as a 100 KB one. Issue #114 PR 5. */
+function streamColdBlobTo(res: ServerResponse, abs: string): void {
+  const rs = fs.createReadStream(abs);
+  const decompressor = (zlib as unknown as {
+    createZstdDecompress: (opts?: unknown) => NodeJS.ReadWriteStream;
+  }).createZstdDecompress();
+  rs.on("error", (err) => {
+    console.error(`[files] cold blob read error: ${(err as Error).message}`);
+    try {
+      res.end();
+    } catch {
+      /* noop */
+    }
+  });
+  decompressor.on("error", (err) => {
+    console.error(
+      `[files] cold blob decompress error: ${(err as Error).message}`,
+    );
+    try {
+      res.end();
+    } catch {
+      /* noop */
+    }
+  });
+  rs.pipe(decompressor).pipe(res);
 }

--- a/packages/ctrl/src/db/migrate.ts
+++ b/packages/ctrl/src/db/migrate.ts
@@ -23,6 +23,7 @@ import m0006 from "./migrations/0006_files_table.sql";
 import m0007 from "./migrations/0007_recall.sql";
 import m0008 from "./migrations/0008_ha_event_subscription.sql";
 import m0009 from "./migrations/0009_ha_registry_vanished.sql";
+import m0010 from "./migrations/0010_files_cold_archive.sql";
 
 interface Migration {
   version: number;
@@ -40,7 +41,8 @@ const MIGRATIONS: Migration[] = [
   { version: 6, name: "files_table",          sql: m0006 },
   { version: 7, name: "recall",               sql: m0007 },
   { version: 8, name: "ha_event_subscription", sql: m0008 },
-  { version: 9, name: "ha_registry_vanished",  sql: m0009 },
+  { version: 9, name: "ha_registry_vanished", sql: m0009 },
+  { version: 10, name: "files_cold_archive",  sql: m0010 },
 ];
 
 /**

--- a/packages/ctrl/src/db/migrations/0010_files_cold_archive.sql
+++ b/packages/ctrl/src/db/migrations/0010_files_cold_archive.sql
@@ -1,0 +1,162 @@
+-- 0010_files_cold_archive — issue #114 PR 5.
+--
+-- Two storage-efficiency upgrades sit on top of the PR 1 `files` table:
+--
+-- 1. **Dedupe at upload.** A new `file_blobs` table is added, one row
+--    per UNIQUE sha256. `files.id` rows then point at a physical blob
+--    indirectly via their sha256, so two uploads of the same content
+--    cost one set of bytes on disk. `file_blobs.ref_count` tracks how
+--    many live `files` rows share the underlying blob; the on-disk
+--    bytes are only unlinked when the count drops to zero.
+--
+-- 2. **Cold archive.** Files unaccessed for 90+ days are read off the
+--    `files_data` live volume, zstd-compressed at level 19, and
+--    written to the separate `files_cold_data` volume. The blob path
+--    flips from `<ULID>/<safe-name>` (live) to `cold:<ULID>` (the
+--    `cold:` prefix is the on-the-wire signal that ctrl-api's blob
+--    GET must transparently decompress on the way out). A new
+--    `cold_promoted_at` column on both `files` and `file_blobs`
+--    records when the move happened so /usage can break live vs cold.
+--
+-- Schema changes
+-- --------------
+-- PR 1's `files` table declared `path TEXT NOT NULL UNIQUE`. Dedupe
+-- requires two `files.id` rows to point at the SAME on-disk path
+-- (one shared blob), which violates that UNIQUE. We rebuild the
+-- `files` table without the UNIQUE constraint (SQLite has no ALTER
+-- TABLE … DROP CONSTRAINT, so the rename-create-copy-drop dance is
+-- the only path). Indexes are recreated identically afterwards.
+--
+-- Migration semantics
+-- -------------------
+-- Atomic backfill: every live row that already lives in `files`
+-- becomes one `file_blobs` row with `ref_count=N` (the count of
+-- live `files` rows sharing that sha256) and `cold_promoted_at=NULL`.
+-- Live `files` rows then have their `path` rewritten to the
+-- file_blobs canonical path so two pre-existing duplicates share
+-- the on-disk blob going forward. Soft-deleted rows keep their
+-- original path (tombstones, not lookups). On-disk cleanup of any
+-- now-orphaned duplicate blobs (rows that pre-existed PR 5 with
+-- the same sha256 but distinct paths) is left to a one-off operator
+-- command rather than running inside this transaction — deleting
+-- bytes inside a SQL migration is a footgun.
+
+-- ── 1. add the two new files columns ─────────────────────────────────
+ALTER TABLE files ADD COLUMN cold_promoted_at INTEGER;
+ALTER TABLE files ADD COLUMN ref_count INTEGER NOT NULL DEFAULT 1;
+
+-- ── 2. file_blobs table ─────────────────────────────────────────────────
+-- One row per unique sha256. The `path` is the on-disk location for
+-- live blobs (`<ULID>/<safe-name>`) or the cold-storage filename for
+-- promoted blobs (`cold:<ULID>`). `ref_count` is the count of live
+-- (deleted_at IS NULL) `files` rows that share this sha256.
+CREATE TABLE IF NOT EXISTS file_blobs (
+  sha256            TEXT PRIMARY KEY,
+  path              TEXT NOT NULL,
+  size_bytes        INTEGER NOT NULL,
+  ref_count         INTEGER NOT NULL DEFAULT 1,
+  created_at        INTEGER NOT NULL,
+  cold_promoted_at  INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_file_blobs_cold_promoted_at
+  ON file_blobs(cold_promoted_at);
+
+-- ── 3. backfill file_blobs from existing files rows ─────────────────────
+-- For each unique sha256, pick the first (by uploaded_at) live row's
+-- path as the canonical location. Compute ref_count as the count of
+-- live rows sharing that sha256. Soft-deleted rows do NOT count
+-- toward ref_count (matching the dedupe semantics in the upload
+-- route). If a sha256 exists ONLY on soft-deleted rows we skip it —
+-- the bytes can be reaped later, but the dedupe surface should not
+-- accidentally resurrect tombstoned content.
+INSERT OR IGNORE INTO file_blobs (sha256, path, size_bytes, ref_count, created_at, cold_promoted_at)
+SELECT
+  f.sha256,
+  (SELECT f2.path FROM files f2
+     WHERE f2.sha256 = f.sha256 AND f2.deleted_at IS NULL
+     ORDER BY f2.uploaded_at ASC LIMIT 1) AS path,
+  f.size_bytes,
+  (SELECT COUNT(*) FROM files f3
+     WHERE f3.sha256 = f.sha256 AND f3.deleted_at IS NULL) AS ref_count,
+  (SELECT MIN(f4.uploaded_at) FROM files f4
+     WHERE f4.sha256 = f.sha256) AS created_at,
+  NULL
+FROM files f
+WHERE f.deleted_at IS NULL
+GROUP BY f.sha256;
+
+-- ── 4. rebuild `files` without the UNIQUE constraint on `path` ─────────
+-- The PR 1 schema had `path TEXT NOT NULL UNIQUE`. Dedupe needs two
+-- `files.id` rows to share a `path`. SQLite has no ALTER TABLE DROP
+-- CONSTRAINT, so we do the canonical rename-create-copy-drop dance.
+-- All other columns + their semantics are identical.
+ALTER TABLE files RENAME TO files_old_0009;
+
+CREATE TABLE files (
+  id                 TEXT PRIMARY KEY,
+  path               TEXT NOT NULL,
+  size_bytes         INTEGER NOT NULL,
+  sha256             TEXT NOT NULL,
+  content_type       TEXT,
+  original_filename  TEXT,
+  principal_label    TEXT,
+  uploaded_by        TEXT NOT NULL,
+  uploaded_at        INTEGER NOT NULL,
+  last_accessed_at   INTEGER,
+  deleted_at         INTEGER,
+  cold_promoted_at   INTEGER,
+  ref_count          INTEGER NOT NULL DEFAULT 1
+);
+
+-- Copy live rows, rewriting `path` to the file_blobs canonical path
+-- (so post-migration two formerly-distinct dupes share one path
+-- going forward). Soft-deleted rows keep their original path.
+INSERT INTO files
+  (id, path, size_bytes, sha256, content_type, original_filename,
+   principal_label, uploaded_by, uploaded_at, last_accessed_at,
+   deleted_at, cold_promoted_at, ref_count)
+SELECT
+  f.id,
+  CASE
+    WHEN f.deleted_at IS NULL THEN COALESCE(
+      (SELECT b.path FROM file_blobs b WHERE b.sha256 = f.sha256),
+      f.path
+    )
+    ELSE f.path
+  END,
+  f.size_bytes,
+  f.sha256,
+  f.content_type,
+  f.original_filename,
+  f.principal_label,
+  f.uploaded_by,
+  f.uploaded_at,
+  f.last_accessed_at,
+  f.deleted_at,
+  f.cold_promoted_at,
+  f.ref_count
+FROM files_old_0009 f;
+
+DROP TABLE files_old_0009;
+
+-- Recreate the PR 1 indexes against the rebuilt table.
+CREATE INDEX IF NOT EXISTS idx_files_path
+  ON files(path)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_files_sha256
+  ON files(sha256);
+
+CREATE INDEX IF NOT EXISTS idx_files_uploaded_at
+  ON files(uploaded_at DESC);
+
+-- ── 5. files.last_accessed_at index for the cold-archive sweep ─────────
+-- The daily FilesColdArchiveWorkflow scans `files` for rows whose
+-- `last_accessed_at < now - 90d AND cold_promoted_at IS NULL AND
+-- deleted_at IS NULL`. Partial index keeps the lookup tight (cold +
+-- deleted rows never enter the candidate set so they don't need to
+-- be in the index).
+CREATE INDEX IF NOT EXISTS idx_files_last_accessed
+  ON files(last_accessed_at)
+  WHERE deleted_at IS NULL AND cold_promoted_at IS NULL;

--- a/packages/ctrl/tests/alfred-journal.test.ts
+++ b/packages/ctrl/tests/alfred-journal.test.ts
@@ -52,13 +52,13 @@ function tableNames(db: DatabaseSync): string[] {
 describe("alfred_journal migration", () => {
   it("bumps user_version to the latest migration", () => {
     // The runner applies every migration > current version, so the value
-    // naturally tracks the highest registered version. Today: 9
+    // naturally tracks the highest registered version. Today: 10
     // (0001 fix_pack + 0002 alfred_journal + 0003 tailscale_connection
     // + 0004 channel_tokens + 0005 ha_channel + 0006 files_table
     // + 0007 recall + 0008 ha_event_subscription
-    // + 0009 ha_registry_vanished).
+    // + 0009 ha_registry_vanished + 0010 files_cold_archive).
     const db = makeDb();
-    assert.equal(userVersion(db), 9);
+    assert.equal(userVersion(db), 10);
     db.close();
   });
 

--- a/packages/ctrl/tests/files-cold-archive.test.ts
+++ b/packages/ctrl/tests/files-cold-archive.test.ts
@@ -1,0 +1,564 @@
+// /api/v1/files/* — PR 5 cold-archive surface (issue #114).
+//
+// PR 5 adds three routes:
+//
+//   * GET  /api/v1/files/cold-candidates       — operator list of
+//     files eligible for cold promotion (un-accessed for >= 90 days).
+//   * POST /api/v1/files/cold-promote/:file_id — compress + move to
+//     the cold volume; atomically flips file_blobs.path to `cold:<ULID>`.
+//   * POST /api/v1/files/cold-restore/:file_id — decompress + move
+//     back to the live volume.
+//
+// And mutates GET /blob/* so a `cold:` row is served via transparent
+// streamed zstd decompression. A read of a cold file bumps
+// last_accessed_at but does NOT auto-restore — that's an explicit op.
+//
+// We exercise the routes through the same matchRoute + handleError
+// shim as files-routes.test.ts. The 90-day threshold is dialed all
+// the way down via FILES_COLD_AFTER_MS so we can manufacture
+// candidates without time-travel.
+
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import zlib from "node:zlib";
+import { PassThrough } from "node:stream";
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+// ── one-shot env wiring ────────────────────────────────────────────────────
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "files-cold-"));
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.VAULT_PATH = path.join(tmp, "vault");
+process.env.STATE_DB_PATH = path.join(tmp, "alfred-state.db");
+process.env.SQLITE_VEC_PATH = "";
+const FILES_ROOT = path.join(tmp, "files");
+const FILES_COLD_ROOT = path.join(tmp, "cold-files");
+process.env.FILES_ROOT = FILES_ROOT;
+process.env.FILES_COLD_ROOT = FILES_COLD_ROOT;
+// Tiny age threshold so we can hand-stamp a row's last_accessed_at
+// to "1 hour ago" and have it land in the candidates set.
+process.env.FILES_COLD_AFTER_MS = String(60 * 60 * 1000); // 1h
+process.env.FILES_QUOTA_HARD_BYTES = String(50 * 1024 * 1024);
+process.env.FILES_QUOTA_SOFT_BYTES = String(25 * 1024 * 1024);
+
+// ── module imports ────────────────────────────────────────────────────────
+
+const { matchRoute } = await import("../src/api/server.js");
+const { handleError } = await import("../src/api/errors.js");
+const { registerFilesRoutes } = await import("../src/api/routes/files.js");
+const { getStateDb } = await import("../src/db/state.js");
+registerFilesRoutes();
+
+// ── invokeRoute helper ────────────────────────────────────────────────────
+
+type InvokeOpts = {
+  body?: unknown;
+  headers?: Record<string, string>;
+  rawBodyChunks?: Buffer[];
+  url?: string;
+};
+
+async function invokeRoute(
+  method: string,
+  routePath: string,
+  opts: InvokeOpts = {},
+): Promise<{
+  status: number;
+  payload: any;
+  rawBody: Buffer;
+  headers: Record<string, string | number>;
+}> {
+  const matched = matchRoute(method, routePath);
+  assert.ok(matched, `${method} ${routePath} must be registered`);
+  let status = 0;
+  const bodyChunks: Buffer[] = [];
+  const responseHeaders: Record<string, string | number> = {};
+
+  const pt = new PassThrough();
+  pt.on("data", (chunk: Buffer) => bodyChunks.push(chunk));
+  const finished = new Promise<void>((resolve) => {
+    pt.on("end", () => resolve());
+    pt.on("finish", () => resolve());
+  });
+  const res = Object.assign(pt, {
+    statusCode: 0,
+    setHeader(k: string, v: string | number) {
+      responseHeaders[k] = v;
+    },
+    writeHead(code: number, hdrs?: Record<string, string | number>) {
+      status = code;
+      (res as any).statusCode = code;
+      if (hdrs) {
+        for (const [k, v] of Object.entries(hdrs)) responseHeaders[k] = v;
+      }
+      return res;
+    },
+  }) as unknown as ServerResponse & PassThrough;
+
+  let req: IncomingMessage;
+  const headers: Record<string, string> = {};
+  for (const [k, v] of Object.entries(opts.headers ?? {})) {
+    headers[k.toLowerCase()] = String(v);
+  }
+  if (opts.rawBodyChunks && opts.rawBodyChunks.length > 0) {
+    const ptIn = new PassThrough();
+    for (const c of opts.rawBodyChunks) ptIn.write(c);
+    ptIn.end();
+    req = Object.assign(ptIn, {
+      method,
+      url: opts.url ?? routePath,
+      headers,
+    }) as unknown as IncomingMessage;
+  } else {
+    req = {
+      method,
+      url: opts.url ?? routePath,
+      headers,
+      on() {
+        return req;
+      },
+      once() {
+        return req;
+      },
+    } as unknown as IncomingMessage;
+  }
+
+  let query = new URLSearchParams();
+  if (opts.url && opts.url.includes("?")) {
+    query = new URLSearchParams(opts.url.slice(opts.url.indexOf("?") + 1));
+  }
+
+  try {
+    await matched.handler({
+      req,
+      res,
+      params: matched.params,
+      body: opts.body,
+      query,
+    });
+  } catch (err) {
+    handleError(res, err);
+  }
+  await finished;
+  const rawBody = Buffer.concat(bodyChunks);
+  let payload: any = null;
+  if (
+    rawBody.length > 0 &&
+    (rawBody[0] === 0x7b || rawBody[0] === 0x5b)
+  ) {
+    try {
+      payload = JSON.parse(rawBody.toString("utf-8"));
+    } catch {
+      payload = null;
+    }
+  }
+  return { status, payload, rawBody, headers: responseHeaders };
+}
+
+// ── multipart helper ──────────────────────────────────────────────────────
+
+function buildMultipart(
+  fileContent: Buffer,
+  fileFilename: string,
+  fileMime: string,
+  textFields: Record<string, string> = {},
+): { boundary: string; body: Buffer } {
+  const boundary = `----alfred-test-${crypto.randomBytes(8).toString("hex")}`;
+  const chunks: Buffer[] = [];
+  for (const [name, value] of Object.entries(textFields)) {
+    chunks.push(Buffer.from(`--${boundary}\r\n`, "utf-8"));
+    chunks.push(
+      Buffer.from(
+        `Content-Disposition: form-data; name="${name}"\r\n\r\n`,
+        "utf-8",
+      ),
+    );
+    chunks.push(Buffer.from(value, "utf-8"));
+    chunks.push(Buffer.from("\r\n", "utf-8"));
+  }
+  chunks.push(Buffer.from(`--${boundary}\r\n`, "utf-8"));
+  chunks.push(
+    Buffer.from(
+      `Content-Disposition: form-data; name="file"; filename="${fileFilename}"\r\n`,
+      "utf-8",
+    ),
+  );
+  chunks.push(Buffer.from(`Content-Type: ${fileMime}\r\n\r\n`, "utf-8"));
+  chunks.push(fileContent);
+  chunks.push(Buffer.from(`\r\n--${boundary}--\r\n`, "utf-8"));
+  return { boundary, body: Buffer.concat(chunks) };
+}
+
+async function uploadBlob(
+  filename: string,
+  content: Buffer,
+  mime = "application/octet-stream",
+  fields: Record<string, string> = {},
+): Promise<any> {
+  const mp = buildMultipart(content, filename, mime, fields);
+  return await invokeRoute("POST", "/api/v1/files/upload", {
+    headers: {
+      "content-type": `multipart/form-data; boundary=${mp.boundary}`,
+      "content-length": String(mp.body.length),
+    },
+    rawBodyChunks: [mp.body],
+  });
+}
+
+/** Hand-stamp a `files` row's last_accessed_at so the cold sweep
+ *  picks it up. We use 2 hours ago vs the 1-hour FILES_COLD_AFTER_MS
+ *  test threshold so there's a clear margin. */
+function ageRow(id: string, msAgo = 2 * 60 * 60 * 1000): void {
+  const old = Date.now() - msAgo;
+  getStateDb()
+    .prepare(
+      `UPDATE files SET last_accessed_at = ?, uploaded_at = ? WHERE id = ?`,
+    )
+    .run(old, old, id);
+}
+
+// ── observed compression ratios are tracked for the PR summary ────────────
+const ratiosObserved: number[] = [];
+
+// ── tests ──────────────────────────────────────────────────────────────────
+
+describe("/api/v1/files/* — PR 5 cold archive", () => {
+  before(() => {
+    getStateDb();
+  });
+
+  beforeEach(() => {
+    const db = getStateDb();
+    db.exec("DELETE FROM files");
+    db.exec("DELETE FROM file_blobs");
+    for (const root of [FILES_ROOT, FILES_COLD_ROOT]) {
+      if (fs.existsSync(root)) {
+        for (const entry of fs.readdirSync(root)) {
+          try {
+            fs.rmSync(path.join(root, entry), {
+              recursive: true,
+              force: true,
+            });
+          } catch {
+            /* best-effort */
+          }
+        }
+      }
+    }
+  });
+
+  after(() => {
+    if (ratiosObserved.length > 0) {
+      const avg =
+        ratiosObserved.reduce((s, r) => s + r, 0) / ratiosObserved.length;
+      // Observability for the PR body — printed to stdout so the
+      // operator running these tests can eyeball the level-19 ZSTD
+      // payoff on the test fixtures.
+      // eslint-disable-next-line no-console
+      console.log(
+        `[files-cold-archive] observed compression ratio: avg=${avg.toFixed(2)}x across ${ratiosObserved.length} samples`,
+      );
+    }
+    try {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  it("cold-candidates returns ONLY files older than the threshold", async () => {
+    const fresh = await uploadBlob("fresh.txt", Buffer.from("just-now"));
+    const old = await uploadBlob("old.txt", Buffer.from("from-the-archives"));
+    ageRow(old.payload.id); // 2h ago, > 1h threshold
+
+    const r = await invokeRoute("GET", "/api/v1/files/cold-candidates", {
+      url: "/api/v1/files/cold-candidates",
+    });
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.total, 1);
+    assert.equal(r.payload.items[0].id, old.payload.id);
+    // The fresh upload must not appear.
+    assert.equal(
+      r.payload.items.find((it: any) => it.id === fresh.payload.id),
+      undefined,
+    );
+  });
+
+  it("cold-promote compresses + writes to cold volume + unlinks live", async () => {
+    // Use a highly-compressible payload so the level-19 ratio is
+    // meaningful (the small-payload baseline ratio is ~0.6x because
+    // zstd's frame header costs more than the input saves).
+    const content = Buffer.alloc(64 * 1024, "z"); // 64 KB of 'z'
+    const up = await uploadBlob("zeros.bin", content);
+    const liveAbs = path.join(FILES_ROOT, up.payload.path);
+    assert.ok(fs.existsSync(liveAbs), "live blob present pre-promote");
+
+    const promote = await invokeRoute(
+      "POST",
+      `/api/v1/files/cold-promote/${up.payload.id}`,
+    );
+    assert.equal(promote.status, 200);
+    assert.ok(promote.payload.cold_promoted_at);
+    assert.ok(promote.payload.path.startsWith("cold:"));
+
+    // The compressed file landed under FILES_COLD_ROOT as `<ULID>.zst`.
+    const ulid = promote.payload.path.slice("cold:".length);
+    const coldAbs = path.join(FILES_COLD_ROOT, `${ulid}.zst`);
+    assert.ok(fs.existsSync(coldAbs), "compressed blob on cold volume");
+
+    // Live blob is gone.
+    assert.equal(
+      fs.existsSync(liveAbs),
+      false,
+      "live bytes unlinked after promote",
+    );
+
+    // Compression ratio is reported. A 64KB run of 'z' compresses
+    // dramatically — record + a sanity check on the ratio.
+    assert.ok(promote.payload.compression_ratio > 1);
+    ratiosObserved.push(promote.payload.compression_ratio);
+  });
+
+  it("GET /blob/* on a cold file serves transparently decompressed bytes", async () => {
+    const content = Buffer.from(
+      "hello cold archive — please decompress me on the fly",
+    );
+    const up = await uploadBlob("cold-read.txt", content, "text/plain");
+    await invokeRoute("POST", `/api/v1/files/cold-promote/${up.payload.id}`);
+
+    // The path on the row is now `cold:<ULID>`; the dashboard / MCP
+    // tool / principal hits the SAME blob route.
+    const row = getStateDb()
+      .prepare(`SELECT path FROM files WHERE id = ?`)
+      .get(up.payload.id) as { path: string };
+    assert.ok(row.path.startsWith("cold:"));
+
+    const blob = await invokeRoute(
+      "GET",
+      `/api/v1/files/blob/${row.path}`,
+    );
+    assert.equal(blob.status, 200);
+    assert.equal(blob.rawBody.toString(), content.toString());
+    // Cold reads drop the Content-Length header (we don't know the
+    // inflated size up front) and add an X-Cold-Blob breadcrumb.
+    assert.equal(blob.headers["X-Cold-Blob"], "1");
+    assert.equal(blob.headers["Content-Length"], undefined);
+    // Content-Type still flows through.
+    assert.equal(blob.headers["Content-Type"], "text/plain");
+  });
+
+  it("cold read bumps last_accessed_at without auto-restoring", async () => {
+    const content = Buffer.from("read-me-cold");
+    const up = await uploadBlob("read-cold.bin", content);
+    await invokeRoute("POST", `/api/v1/files/cold-promote/${up.payload.id}`);
+
+    const before = getStateDb()
+      .prepare(`SELECT last_accessed_at, path FROM files WHERE id = ?`)
+      .get(up.payload.id) as { last_accessed_at: number; path: string };
+    const beforeStamp = before.last_accessed_at;
+    const beforePath = before.path;
+    assert.ok(beforePath.startsWith("cold:"));
+
+    // Force a 2 ms gap so the new stamp is strictly greater.
+    await new Promise((r) => setTimeout(r, 2));
+
+    const blob = await invokeRoute(
+      "GET",
+      `/api/v1/files/blob/${beforePath}`,
+    );
+    assert.equal(blob.status, 200);
+
+    const after = getStateDb()
+      .prepare(`SELECT last_accessed_at, path FROM files WHERE id = ?`)
+      .get(up.payload.id) as { last_accessed_at: number; path: string };
+    assert.ok(after.last_accessed_at > beforeStamp, "stamp bumped on read");
+    // Path stays `cold:` — read MUST NOT auto-restore.
+    assert.equal(after.path, beforePath, "cold read does not auto-restore");
+  });
+
+  it("cold-restore explicitly pulls a cold blob back to live", async () => {
+    const content = Buffer.from(
+      "restore me — should land back under <ULID>/<safe-name>",
+    );
+    const up = await uploadBlob("restore-me.txt", content, "text/plain");
+    const promote = await invokeRoute(
+      "POST",
+      `/api/v1/files/cold-promote/${up.payload.id}`,
+    );
+    assert.equal(promote.status, 200);
+
+    const restore = await invokeRoute(
+      "POST",
+      `/api/v1/files/cold-restore/${up.payload.id}`,
+    );
+    assert.equal(restore.status, 200);
+    assert.equal(restore.payload.cold_promoted_at, null);
+    assert.equal(
+      restore.payload.path.startsWith("cold:"),
+      false,
+      "restored path must be live, not cold:",
+    );
+
+    // The live volume now has the bytes back; the cold volume entry
+    // is gone.
+    const liveAbs = path.join(FILES_ROOT, restore.payload.path);
+    assert.ok(fs.existsSync(liveAbs));
+    assert.equal(fs.readFileSync(liveAbs).toString(), content.toString());
+
+    const coldEntries = fs.existsSync(FILES_COLD_ROOT)
+      ? fs.readdirSync(FILES_COLD_ROOT)
+      : [];
+    assert.equal(
+      coldEntries.length,
+      0,
+      "cold volume must be clean after restore",
+    );
+
+    // file_blobs.cold_promoted_at cleared.
+    const blob = getStateDb()
+      .prepare(
+        `SELECT cold_promoted_at, path FROM file_blobs WHERE sha256 = ?`,
+      )
+      .get(up.payload.sha256) as {
+      cold_promoted_at: number | null;
+      path: string;
+    };
+    assert.equal(blob.cold_promoted_at, null);
+    assert.equal(blob.path.startsWith("cold:"), false);
+  });
+
+  it("/usage breaks down live_bytes vs cold_bytes after promotion", async () => {
+    const a = Buffer.alloc(8 * 1024, "a");
+    const b = Buffer.alloc(8 * 1024, "b");
+    const rA = await uploadBlob("a.bin", a);
+    const rB = await uploadBlob("b.bin", b);
+
+    // Both live to start.
+    let usage = await invokeRoute("GET", "/api/v1/files/usage");
+    assert.equal(usage.payload.live_bytes, a.length + b.length);
+    assert.equal(usage.payload.cold_bytes, 0);
+
+    // Promote A.
+    const promote = await invokeRoute(
+      "POST",
+      `/api/v1/files/cold-promote/${rA.payload.id}`,
+    );
+    assert.equal(promote.status, 200);
+    ratiosObserved.push(promote.payload.compression_ratio);
+
+    usage = await invokeRoute("GET", "/api/v1/files/usage");
+    assert.equal(usage.payload.live_bytes, b.length);
+    assert.equal(usage.payload.cold_bytes, a.length);
+    assert.equal(usage.payload.blob_count_live, 1);
+    assert.equal(usage.payload.blob_count_cold, 1);
+    // The PR-1 compatibility surface still works (live + cold total).
+    assert.equal(usage.payload.used_bytes, a.length + b.length);
+    // file_count is the unchanged principal-facing row count.
+    assert.equal(usage.payload.file_count, 2);
+    // Use rB to silence the unused-warning.
+    assert.ok(rB.payload.id);
+  });
+
+  it("cold-promote on an already-cold file is an idempotent no-op", async () => {
+    const content = Buffer.from("already-cold");
+    const up = await uploadBlob("c.bin", content);
+    const first = await invokeRoute(
+      "POST",
+      `/api/v1/files/cold-promote/${up.payload.id}`,
+    );
+    assert.equal(first.status, 200);
+    const second = await invokeRoute(
+      "POST",
+      `/api/v1/files/cold-promote/${up.payload.id}`,
+    );
+    assert.equal(second.status, 200);
+    assert.equal(second.payload.already_cold, true);
+    // Cold volume still has exactly one `.zst` file.
+    const coldEntries = fs.readdirSync(FILES_COLD_ROOT);
+    assert.equal(coldEntries.length, 1);
+  });
+
+  it("cold-candidates respects older_than_ms override (for unit tests + custom sweeps)", async () => {
+    const fresh = await uploadBlob("fresh.txt", Buffer.from("now"));
+    const slightlyOld = await uploadBlob(
+      "old.txt",
+      Buffer.from("five-min-old"),
+    );
+    // Mark slightlyOld as 5 minutes old; default threshold (1h env)
+    // wouldn't pick it up.
+    const fiveMin = 5 * 60 * 1000;
+    getStateDb()
+      .prepare(`UPDATE files SET last_accessed_at = ? WHERE id = ?`)
+      .run(Date.now() - fiveMin - 1000, slightlyOld.payload.id);
+
+    // Default threshold (1h) — nothing.
+    let r = await invokeRoute("GET", "/api/v1/files/cold-candidates", {
+      url: "/api/v1/files/cold-candidates",
+    });
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.total, 0);
+
+    // Lower the threshold to 1 minute — picks up slightlyOld but
+    // not fresh.
+    r = await invokeRoute("GET", "/api/v1/files/cold-candidates", {
+      url: `/api/v1/files/cold-candidates?older_than_ms=${60 * 1000}`,
+    });
+    assert.equal(r.payload.total, 1);
+    assert.equal(r.payload.items[0].id, slightlyOld.payload.id);
+    assert.notEqual(r.payload.items[0].id, fresh.payload.id);
+  });
+
+  it("decompressed cold bytes match the originally-uploaded bytes (round trip)", async () => {
+    // Random binary payload — proves the round trip is byte-accurate
+    // (not just utf-8-accurate).
+    const content = crypto.randomBytes(32 * 1024); // 32 KB random
+    const up = await uploadBlob("rand.bin", content);
+    const promote = await invokeRoute(
+      "POST",
+      `/api/v1/files/cold-promote/${up.payload.id}`,
+    );
+    assert.equal(promote.status, 200);
+    // Random bytes don't compress well; ratio likely <1.0. Record
+    // anyway — important to show level-19 doesn't WORSEN dramatically.
+    ratiosObserved.push(promote.payload.compression_ratio);
+
+    const row = getStateDb()
+      .prepare(`SELECT path FROM files WHERE id = ?`)
+      .get(up.payload.id) as { path: string };
+    const blob = await invokeRoute("GET", `/api/v1/files/blob/${row.path}`);
+    assert.equal(blob.status, 200);
+    assert.equal(blob.rawBody.length, content.length);
+    assert.ok(blob.rawBody.equals(content), "round-trip is byte-exact");
+
+    // Sanity-check we used the zstd codec: read the on-disk file +
+    // verify the zstd magic number (0x28B52FFD little-endian).
+    const ulid = row.path.slice("cold:".length);
+    const coldAbs = path.join(FILES_COLD_ROOT, `${ulid}.zst`);
+    const head = fs.readFileSync(coldAbs).slice(0, 4);
+    assert.equal(head[0], 0x28, "zstd magic byte 0");
+    assert.equal(head[1], 0xb5, "zstd magic byte 1");
+    assert.equal(head[2], 0x2f, "zstd magic byte 2");
+    assert.equal(head[3], 0xfd, "zstd magic byte 3");
+  });
+
+  it("cold-promote refuses to promote a tombstoned file", async () => {
+    const up = await uploadBlob("ghost.bin", Buffer.from("ghost"));
+    const del = await invokeRoute(
+      "DELETE",
+      `/api/v1/files/${up.payload.path}`,
+    );
+    assert.equal(del.status, 200);
+    const promote = await invokeRoute(
+      "POST",
+      `/api/v1/files/cold-promote/${up.payload.id}`,
+    );
+    assert.equal(promote.status, 409);
+    assert.equal(promote.payload.error.code, "TOMBSTONED");
+    // Use `zlib` to silence the unused-import warning at the top.
+    assert.equal(typeof (zlib as any).createZstdCompress, "function");
+  });
+});

--- a/packages/ctrl/tests/files-dedupe.test.ts
+++ b/packages/ctrl/tests/files-dedupe.test.ts
@@ -1,0 +1,499 @@
+// /api/v1/files/* — PR 5 dedupe surface (issue #114).
+//
+// PR 5 adds:
+//
+//   * `file_blobs` table — one row per UNIQUE sha256, with ref_count.
+//   * Upload route looks up the sha256 BEFORE writing to disk; on
+//     hit, the bytes are not re-written and the response is flagged
+//     `deduped: true`.
+//   * DELETE decrements ref_count; the physical blob (+ ULID dir) is
+//     unlinked only when the count hits zero.
+//   * /usage reports a deduped total (live + cold) computed from
+//     `file_blobs`, not the `files.size_bytes` SUM.
+//
+// We exercise everything through the same matchRoute + handleError
+// shim as files-routes.test.ts (PR 1/PR 2), with the test bootstrap
+// pinned to an mkdtemp data dir so the on-disk state stays
+// hermetic.
+
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+// ── one-shot env wiring ────────────────────────────────────────────────────
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "files-dedupe-"));
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.VAULT_PATH = path.join(tmp, "vault");
+process.env.STATE_DB_PATH = path.join(tmp, "alfred-state.db");
+process.env.SQLITE_VEC_PATH = "";
+const FILES_ROOT = path.join(tmp, "files");
+const FILES_COLD_ROOT = path.join(tmp, "cold-files");
+process.env.FILES_ROOT = FILES_ROOT;
+process.env.FILES_COLD_ROOT = FILES_COLD_ROOT;
+// Tight quota so the quota-exceeded test below stays fast.
+process.env.FILES_QUOTA_HARD_BYTES = String(1024 * 1024);
+process.env.FILES_QUOTA_SOFT_BYTES = String(512 * 1024);
+
+// ── module imports (after env is set) ──────────────────────────────────────
+
+const { matchRoute } = await import("../src/api/server.js");
+const { handleError } = await import("../src/api/errors.js");
+const { registerFilesRoutes } = await import("../src/api/routes/files.js");
+const { getStateDb } = await import("../src/db/state.js");
+registerFilesRoutes();
+
+// ── invokeRoute helper (mirrors files-routes.test.ts) ─────────────────────
+
+type InvokeOpts = {
+  body?: unknown;
+  headers?: Record<string, string>;
+  rawBodyChunks?: Buffer[];
+  url?: string;
+};
+
+async function invokeRoute(
+  method: string,
+  routePath: string,
+  opts: InvokeOpts = {},
+): Promise<{
+  status: number;
+  payload: any;
+  rawBody: Buffer;
+  headers: Record<string, string | number>;
+}> {
+  const matched = matchRoute(method, routePath);
+  assert.ok(matched, `${method} ${routePath} must be registered`);
+  let status = 0;
+  const bodyChunks: Buffer[] = [];
+  const responseHeaders: Record<string, string | number> = {};
+
+  const pt = new PassThrough();
+  pt.on("data", (chunk: Buffer) => bodyChunks.push(chunk));
+  const finished = new Promise<void>((resolve) => {
+    pt.on("end", () => resolve());
+    pt.on("finish", () => resolve());
+  });
+  const res = Object.assign(pt, {
+    statusCode: 0,
+    setHeader(k: string, v: string | number) {
+      responseHeaders[k] = v;
+    },
+    writeHead(code: number, hdrs?: Record<string, string | number>) {
+      status = code;
+      (res as any).statusCode = code;
+      if (hdrs) {
+        for (const [k, v] of Object.entries(hdrs)) responseHeaders[k] = v;
+      }
+      return res;
+    },
+  }) as unknown as ServerResponse & PassThrough;
+
+  let req: IncomingMessage;
+  const headers: Record<string, string> = {};
+  for (const [k, v] of Object.entries(opts.headers ?? {})) {
+    headers[k.toLowerCase()] = String(v);
+  }
+  if (opts.rawBodyChunks && opts.rawBodyChunks.length > 0) {
+    const ptIn = new PassThrough();
+    for (const c of opts.rawBodyChunks) ptIn.write(c);
+    ptIn.end();
+    req = Object.assign(ptIn, {
+      method,
+      url: opts.url ?? routePath,
+      headers,
+    }) as unknown as IncomingMessage;
+  } else {
+    req = {
+      method,
+      url: opts.url ?? routePath,
+      headers,
+      on() {
+        return req;
+      },
+      once() {
+        return req;
+      },
+    } as unknown as IncomingMessage;
+  }
+
+  let query = new URLSearchParams();
+  if (opts.url && opts.url.includes("?")) {
+    query = new URLSearchParams(opts.url.slice(opts.url.indexOf("?") + 1));
+  }
+
+  try {
+    await matched.handler({
+      req,
+      res,
+      params: matched.params,
+      body: opts.body,
+      query,
+    });
+  } catch (err) {
+    handleError(res, err);
+  }
+  await finished;
+  const rawBody = Buffer.concat(bodyChunks);
+  let payload: any = null;
+  if (
+    rawBody.length > 0 &&
+    (rawBody[0] === 0x7b || rawBody[0] === 0x5b)
+  ) {
+    try {
+      payload = JSON.parse(rawBody.toString("utf-8"));
+    } catch {
+      payload = null;
+    }
+  }
+  return { status, payload, rawBody, headers: responseHeaders };
+}
+
+// ── multipart helper ──────────────────────────────────────────────────────
+
+function buildMultipart(
+  fileContent: Buffer,
+  fileFilename: string,
+  fileMime: string,
+  textFields: Record<string, string> = {},
+): { boundary: string; body: Buffer } {
+  const boundary = `----alfred-test-${crypto.randomBytes(8).toString("hex")}`;
+  const chunks: Buffer[] = [];
+  for (const [name, value] of Object.entries(textFields)) {
+    chunks.push(Buffer.from(`--${boundary}\r\n`, "utf-8"));
+    chunks.push(
+      Buffer.from(
+        `Content-Disposition: form-data; name="${name}"\r\n\r\n`,
+        "utf-8",
+      ),
+    );
+    chunks.push(Buffer.from(value, "utf-8"));
+    chunks.push(Buffer.from("\r\n", "utf-8"));
+  }
+  chunks.push(Buffer.from(`--${boundary}\r\n`, "utf-8"));
+  chunks.push(
+    Buffer.from(
+      `Content-Disposition: form-data; name="file"; filename="${fileFilename}"\r\n`,
+      "utf-8",
+    ),
+  );
+  chunks.push(Buffer.from(`Content-Type: ${fileMime}\r\n\r\n`, "utf-8"));
+  chunks.push(fileContent);
+  chunks.push(Buffer.from(`\r\n--${boundary}--\r\n`, "utf-8"));
+  return { boundary, body: Buffer.concat(chunks) };
+}
+
+async function uploadBlob(
+  filename: string,
+  content: Buffer,
+  mime = "application/octet-stream",
+  fields: Record<string, string> = {},
+): Promise<any> {
+  const mp = buildMultipart(content, filename, mime, fields);
+  return await invokeRoute("POST", "/api/v1/files/upload", {
+    headers: {
+      "content-type": `multipart/form-data; boundary=${mp.boundary}`,
+      "content-length": String(mp.body.length),
+    },
+    rawBodyChunks: [mp.body],
+  });
+}
+
+// ── tests ──────────────────────────────────────────────────────────────────
+
+describe("/api/v1/files/* — PR 5 dedupe", () => {
+  before(() => {
+    getStateDb();
+  });
+
+  beforeEach(() => {
+    const db = getStateDb();
+    db.exec("DELETE FROM files");
+    db.exec("DELETE FROM file_blobs");
+    for (const root of [FILES_ROOT, FILES_COLD_ROOT]) {
+      if (fs.existsSync(root)) {
+        for (const entry of fs.readdirSync(root)) {
+          try {
+            fs.rmSync(path.join(root, entry), { recursive: true, force: true });
+          } catch {
+            /* best-effort */
+          }
+        }
+      }
+    }
+  });
+
+  after(() => {
+    try {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  it("two uploads of the same bytes share one path + ref_count=2 + deduped flag", async () => {
+    const content = Buffer.from("identical payload — should dedupe");
+    const r1 = await uploadBlob("first.bin", content);
+    assert.equal(r1.status, 201);
+    assert.equal(r1.payload.deduped, false, "first upload is novel");
+    const r2 = await uploadBlob("second.bin", content);
+    assert.equal(r2.status, 201);
+    assert.equal(r2.payload.deduped, true, "second upload sees the dedupe");
+    // Same on-disk path returned.
+    assert.equal(r2.payload.path, r1.payload.path);
+    // Distinct file_ids.
+    assert.notEqual(r2.payload.id, r1.payload.id);
+    // Same sha256.
+    assert.equal(r2.payload.sha256, r1.payload.sha256);
+    // file_blobs row carries ref_count=2.
+    const blob = getStateDb()
+      .prepare(`SELECT ref_count, path FROM file_blobs WHERE sha256 = ?`)
+      .get(r1.payload.sha256) as { ref_count: number; path: string };
+    assert.equal(blob.ref_count, 2);
+    assert.equal(blob.path, r1.payload.path);
+    // Only ONE on-disk blob exists.
+    const ulidDirs = fs
+      .readdirSync(FILES_ROOT)
+      .filter((d) => !d.startsWith("."));
+    assert.equal(ulidDirs.length, 1, "dedupe must not write the bytes twice");
+  });
+
+  it("deleting one of two duplicate files keeps the blob alive for the other", async () => {
+    const content = Buffer.from("byte-share");
+    const r1 = await uploadBlob("a.bin", content);
+    const r2 = await uploadBlob("b.bin", content);
+    assert.equal(r2.payload.deduped, true);
+
+    // Delete the first.
+    const del = await invokeRoute("DELETE", `/api/v1/files/${r1.payload.path}`);
+    assert.equal(del.status, 200);
+
+    // file_blobs row still here, ref_count == 1.
+    const blob = getStateDb()
+      .prepare(`SELECT ref_count FROM file_blobs WHERE sha256 = ?`)
+      .get(r1.payload.sha256) as { ref_count: number };
+    assert.equal(blob.ref_count, 1);
+
+    // Disk blob still present — the second file is readable via /blob/*.
+    const blobResp = await invokeRoute(
+      "GET",
+      `/api/v1/files/blob/${r2.payload.path}`,
+    );
+    assert.equal(blobResp.status, 200);
+    assert.equal(blobResp.rawBody.toString(), content.toString());
+  });
+
+  it("deleting both duplicates physically removes the blob + file_blobs row", async () => {
+    const content = Buffer.from("doomed-shared");
+    const r1 = await uploadBlob("a.bin", content);
+    const r2 = await uploadBlob("b.bin", content);
+    const absPath = path.join(FILES_ROOT, r1.payload.path);
+    assert.ok(fs.existsSync(absPath));
+
+    const del1 = await invokeRoute(
+      "DELETE",
+      `/api/v1/files/${r1.payload.path}`,
+    );
+    assert.equal(del1.status, 200);
+    assert.ok(fs.existsSync(absPath), "still here after first delete");
+
+    const del2 = await invokeRoute(
+      "DELETE",
+      `/api/v1/files/${r2.payload.path}`,
+    );
+    assert.equal(del2.status, 200);
+    assert.equal(
+      fs.existsSync(absPath),
+      false,
+      "physically gone after both refs dropped",
+    );
+    // file_blobs row gone too.
+    const blob = getStateDb()
+      .prepare(`SELECT * FROM file_blobs WHERE sha256 = ?`)
+      .get(r1.payload.sha256) as Record<string, unknown> | undefined;
+    assert.equal(blob, undefined);
+  });
+
+  it("/usage counts unique sha256s — duplicates don't double up", async () => {
+    const a = Buffer.from("unique-a-payload");
+    const b = Buffer.from("unique-b-payload-larger-x");
+    await uploadBlob("a.bin", a);
+    await uploadBlob("dup-of-a.bin", a); // dedupe
+    await uploadBlob("b.bin", b);
+
+    const usage = await invokeRoute("GET", "/api/v1/files/usage");
+    assert.equal(usage.status, 200);
+    // Two unique sha256s — used_bytes = a.length + b.length.
+    assert.equal(usage.payload.used_bytes, a.length + b.length);
+    assert.equal(usage.payload.live_bytes, a.length + b.length);
+    assert.equal(usage.payload.cold_bytes, 0);
+    // Three principal-facing files.
+    assert.equal(usage.payload.file_count, 3);
+    // Two distinct live blobs.
+    assert.equal(usage.payload.blob_count_live, 2);
+    assert.equal(usage.payload.blob_count_cold, 0);
+  });
+
+  it("dedupes on sha256 even when content_type differs between uploads", async () => {
+    const content = Buffer.from("same-bytes-different-ct");
+    const r1 = await uploadBlob("doc.txt", content, "text/plain");
+    const r2 = await uploadBlob(
+      "doc.octet",
+      content,
+      "application/octet-stream",
+    );
+    assert.equal(r2.payload.deduped, true);
+    assert.equal(r2.payload.path, r1.payload.path);
+    // Each `files` row keeps its declared content_type — dedupe is
+    // about the bytes, not the metadata.
+    assert.equal(r1.payload.content_type, "text/plain");
+    assert.equal(r2.payload.content_type, "application/octet-stream");
+  });
+
+  it("concurrent uploads of the same bytes — only one disk write, exactly one file_blobs row", async () => {
+    // Fire 5 uploads of the same content with Promise.all. The race
+    // resolution path inside the upload handler must pick exactly one
+    // winner; the other 4 must dedupe to the canonical path.
+    const content = Buffer.from(`race-${crypto.randomBytes(16).toString("hex")}`);
+    const results = await Promise.all(
+      [0, 1, 2, 3, 4].map((i) => uploadBlob(`r${i}.bin`, content)),
+    );
+    for (const r of results) {
+      assert.equal(r.status, 201);
+    }
+    // Exactly one file_blobs row, ref_count=5.
+    const blobs = getStateDb()
+      .prepare(`SELECT sha256, ref_count, path FROM file_blobs`)
+      .all() as { sha256: string; ref_count: number; path: string }[];
+    assert.equal(blobs.length, 1);
+    assert.equal(blobs[0].ref_count, 5);
+    // All 5 `files.id` rows share the same canonical path.
+    const distinctPaths = new Set(results.map((r) => r.payload.path));
+    assert.equal(distinctPaths.size, 1);
+    // Exactly one ULID dir survived (the rest were cleaned up).
+    const ulidDirs = fs
+      .readdirSync(FILES_ROOT)
+      .filter((d) => !d.startsWith("."));
+    assert.equal(
+      ulidDirs.length,
+      1,
+      "race resolution must leave exactly one set of bytes on disk",
+    );
+  });
+
+  it("tombstoned files don't block dedupe of a new upload of the same bytes", async () => {
+    // Upload once, delete it, upload again — the new upload should
+    // see no `file_blobs` row (it's been reaped) and write fresh
+    // bytes with deduped=false.
+    const content = Buffer.from("zombie-resurrect-me");
+    const r1 = await uploadBlob("v1.bin", content);
+    const del = await invokeRoute("DELETE", `/api/v1/files/${r1.payload.path}`);
+    assert.equal(del.status, 200);
+    // Blob row should be gone (ref_count went to 0 on the only
+    // outstanding reference).
+    const before = getStateDb()
+      .prepare(`SELECT * FROM file_blobs WHERE sha256 = ?`)
+      .get(r1.payload.sha256) as Record<string, unknown> | undefined;
+    assert.equal(before, undefined);
+    // Re-upload: should be novel, not deduped.
+    const r2 = await uploadBlob("v2.bin", content);
+    assert.equal(r2.status, 201);
+    assert.equal(r2.payload.deduped, false);
+    // file_blobs has a fresh row with ref_count=1.
+    const after = getStateDb()
+      .prepare(`SELECT ref_count FROM file_blobs WHERE sha256 = ?`)
+      .get(r1.payload.sha256) as { ref_count: number };
+    assert.equal(after.ref_count, 1);
+  });
+
+  it("dedupe upload skips the hard-quota check (dup adds zero bytes)", async () => {
+    // Tight quota: 1 MiB hard. Fill with 600 KiB unique content,
+    // then re-upload the same 600 KiB — total live remains 600 KiB,
+    // so the second upload must succeed even though `used + size`
+    // (612K + 612K) would naively blow the cap.
+    const fat = Buffer.alloc(600 * 1024, "z");
+    const r1 = await uploadBlob("fat.bin", fat);
+    assert.equal(r1.status, 201);
+    const r2 = await uploadBlob("fat-dup.bin", fat);
+    assert.equal(
+      r2.status,
+      201,
+      "dedupe must skip the post-write quota check",
+    );
+    assert.equal(r2.payload.deduped, true);
+  });
+
+  it("ref_count on `files` rows always inserts as 1 (per-row tracker)", async () => {
+    const content = Buffer.from("per-row-counter");
+    const r1 = await uploadBlob("a.bin", content);
+    const r2 = await uploadBlob("b.bin", content);
+    const rows = getStateDb()
+      .prepare(`SELECT ref_count FROM files WHERE id IN (?, ?)`)
+      .all(r1.payload.id, r2.payload.id) as { ref_count: number }[];
+    assert.equal(rows.length, 2);
+    for (const r of rows) {
+      assert.equal(
+        r.ref_count,
+        1,
+        "files.ref_count is per-row (the SHA-level ref count lives on file_blobs)",
+      );
+    }
+  });
+
+  it("blob-level usage is reported separately for live and cold buckets", async () => {
+    const a = Buffer.from("aaa-live");
+    const b = Buffer.from("bbb-live-larger");
+    await uploadBlob("a.bin", a);
+    const rB = await uploadBlob("b.bin", b);
+
+    // Pre-promotion: both blobs are live.
+    let usage = await invokeRoute("GET", "/api/v1/files/usage");
+    assert.equal(usage.payload.live_bytes, a.length + b.length);
+    assert.equal(usage.payload.cold_bytes, 0);
+    assert.equal(usage.payload.blob_count_live, 2);
+
+    // Promote b → cold.
+    const promote = await invokeRoute(
+      "POST",
+      `/api/v1/files/cold-promote/${rB.payload.id}`,
+    );
+    assert.equal(promote.status, 200);
+    assert.ok(promote.payload.cold_promoted_at);
+
+    // Post-promotion: a is live, b is cold; total bytes unchanged in
+    // the principal's view but the buckets split.
+    usage = await invokeRoute("GET", "/api/v1/files/usage");
+    assert.equal(usage.payload.live_bytes, a.length);
+    assert.equal(usage.payload.cold_bytes, b.length);
+    assert.equal(usage.payload.blob_count_live, 1);
+    assert.equal(usage.payload.blob_count_cold, 1);
+  });
+
+  it("dedupe response shape is forward-compatible with the PR 1 surface", async () => {
+    // Every existing field that PR 1 / PR 2 callers depend on must
+    // still be present (the dashboard reads them, the MCP tools
+    // wrap them). PR 5 only ADDS `deduped` + `cold_promoted_at`.
+    const r = await uploadBlob("forward-compat.bin", Buffer.from("hello"));
+    const required = [
+      "id",
+      "path",
+      "size_bytes",
+      "sha256",
+      "content_type",
+      "original_filename",
+      "principal_label",
+      "uploaded_by",
+      "uploaded_at",
+      "deduped",
+    ];
+    for (const k of required) {
+      assert.ok(k in r.payload, `response is missing ${k}`);
+    }
+    assert.equal(typeof r.payload.deduped, "boolean");
+  });
+});

--- a/packages/ctrl/tests/files-routes.test.ts
+++ b/packages/ctrl/tests/files-routes.test.ts
@@ -248,10 +248,13 @@ describe("/api/v1/files/* — PR 1", () => {
   });
 
   beforeEach(() => {
-    // Clear the files table + the on-disk blobs between tests so each
-    // case sees a quiet starting state.
+    // Clear the files + file_blobs tables + the on-disk blobs between
+    // tests so each case sees a quiet starting state. (PR 5 added the
+    // file_blobs companion table that holds the actual size totals
+    // for /usage.)
     const db = getStateDb();
     db.exec("DELETE FROM files");
+    db.exec("DELETE FROM file_blobs");
     if (fs.existsSync(FILES_ROOT)) {
       for (const entry of fs.readdirSync(FILES_ROOT)) {
         try {
@@ -382,11 +385,14 @@ describe("/api/v1/files/* — PR 1", () => {
 
     it("507 QUOTA_EXCEEDED when the upload would blow the hard cap", async () => {
       // FILES_QUOTA_HARD_BYTES = 1 MiB; one 600 KiB upload fits, the
-      // next 600 KiB pushes us over.
-      const half = Buffer.alloc(600 * 1024, "a");
-      const r1 = await uploadBlob("first.bin", half, "application/octet-stream");
+      // next DISTINCT-CONTENT 600 KiB pushes us over. PR 5 dedupes by
+      // sha256 so the bytes have to be different — use Buffer.alloc
+      // with two different fill characters.
+      const first = Buffer.alloc(600 * 1024, "a");
+      const second = Buffer.alloc(600 * 1024, "b");
+      const r1 = await uploadBlob("first.bin", first, "application/octet-stream");
       assert.equal(r1.status, 201);
-      const r2 = await uploadBlob("second.bin", half, "application/octet-stream");
+      const r2 = await uploadBlob("second.bin", second, "application/octet-stream");
       assert.equal(r2.status, 507);
       assert.equal(r2.payload.error.code, "QUOTA_EXCEEDED");
       // Verify the failed upload's scratch dir was cleaned up.

--- a/packages/ctrl/tests/migrate.test.ts
+++ b/packages/ctrl/tests/migrate.test.ts
@@ -36,13 +36,13 @@ describe("state.db migration runner", () => {
     const db = new DatabaseSync(":memory:");
     db.exec(schema);
     const v = runMigrations(db);
-    // Latest version moves as new migrations land. Today: 9
+    // Latest version moves as new migrations land. Today: 10
     // (0001_fix_pack + 0002_alfred_journal + 0003_tailscale_connection
     // + 0004_channel_tokens + 0005_ha_channel + 0006_files_table
     // + 0007_recall + 0008_ha_event_subscription
-    // + 0009_ha_registry_vanished).
-    assert.equal(v, 9, "migrated to latest version");
-    assert.equal(userVersion(db), 9);
+    // + 0009_ha_registry_vanished + 0010_files_cold_archive).
+    assert.equal(v, 10, "migrated to latest version");
+    assert.equal(userVersion(db), 10);
     assert.ok(cols(db, "observation").includes("processed_at"), "0001: processed_at present after migrate");
     // 0002: alfred_journal + alfred_principal tables present.
     const tables = (
@@ -137,6 +137,78 @@ describe("state.db migration runner", () => {
       "0009: ha_registry.vanished_at column added",
     );
 
+    // 0010: file_blobs table + files.cold_promoted_at / ref_count
+    // columns + idx_files_last_accessed (issue #114 PR 5).
+    assert.ok(
+      tables.includes("file_blobs"),
+      "0010: file_blobs table created",
+    );
+    const blobCols = cols(db, "file_blobs");
+    for (const required of [
+      "sha256",
+      "path",
+      "size_bytes",
+      "ref_count",
+      "created_at",
+      "cold_promoted_at",
+    ]) {
+      assert.ok(
+        blobCols.includes(required),
+        `0010: file_blobs.${required} present`,
+      );
+    }
+    const fileCols = cols(db, "files");
+    assert.ok(
+      fileCols.includes("cold_promoted_at"),
+      "0010: files.cold_promoted_at present",
+    );
+    assert.ok(
+      fileCols.includes("ref_count"),
+      "0010: files.ref_count present",
+    );
+    // The PR 1 UNIQUE constraint on files.path is gone (dedupe needs
+    // two files.id rows to point at the same path). Verify the
+    // constraint was dropped: inserting two rows with the same path
+    // must succeed.
+    const filesNow = Date.now();
+    db.prepare(
+      `INSERT INTO files
+        (id, path, size_bytes, sha256, content_type, original_filename,
+         principal_label, uploaded_by, uploaded_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      "01HFTEST0000000000000000A",
+      "01HFTEST/dup.bin",
+      4,
+      "abc",
+      null,
+      "dup.bin",
+      null,
+      "principal",
+      filesNow,
+    );
+    assert.doesNotThrow(() =>
+      db
+        .prepare(
+          `INSERT INTO files
+            (id, path, size_bytes, sha256, content_type, original_filename,
+             principal_label, uploaded_by, uploaded_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          "01HFTEST0000000000000000B",
+          "01HFTEST/dup.bin",
+          4,
+          "abc",
+          null,
+          "dup.bin",
+          null,
+          "principal",
+          filesNow,
+        ),
+      "0010: files.path UNIQUE constraint dropped — dedupe needs shared paths",
+    );
+
     db.close();
   });
 
@@ -145,7 +217,7 @@ describe("state.db migration runner", () => {
     db.exec(schema);
     runMigrations(db);
     const v2 = runMigrations(db);
-    assert.equal(v2, 9);
+    assert.equal(v2, 10);
     assert.equal(
       cols(db, "observation").filter((c) => c === "processed_at").length,
       1,

--- a/packages/learn/scripts/register_schedules.py
+++ b/packages/learn/scripts/register_schedules.py
@@ -401,6 +401,23 @@ CALENDAR_SCHEDULES = [
             minute=[ScheduleRange(start=0)],
         ),
     },
+    {
+        # #114 PR 5 — daily cold-archive sweep for Store 5 (files).
+        # Walks the principal's files table for blobs untouched in
+        # >=90 days, hands each one to ctrl-api's
+        # POST /api/v1/files/cold-promote endpoint (zstd-19 compress
+        # → write to `files_cold_data` → unlink live → atomic SQL
+        # flip). Runs at 03:00 LOCAL — low-traffic window, sits
+        # comfortably between nightly_maintenance and the morning
+        # briefing. The sweep is per-entry-isolated so one bad file
+        # never wedges the rest of the run.
+        "id": "al-files-cold-archive",
+        "workflow": "FilesColdArchiveWorkflow",
+        "calendar": ScheduleCalendarSpec(
+            hour=[ScheduleRange(start=3)],
+            minute=[ScheduleRange(start=0)],
+        ),
+    },
 ]
 
 

--- a/packages/learn/src/activities/files_cold_archive.py
+++ b/packages/learn/src/activities/files_cold_archive.py
@@ -1,0 +1,122 @@
+"""files_cold_archive — activities for the daily cold-promotion sweep.
+
+Background
+----------
+
+Issue #114 PR 5 ships a cold-storage tier for Store 5 (files): a
+separate ``files_cold_data`` named volume on the tenant host with
+ZSTD-compressed copies of any blob that hasn't been touched in 90+
+days. Live ``files_data`` keeps the recent hot path tight; the cold
+tier preserves the bytes at a fraction of the disk cost.
+
+The promotion + restore steps themselves live in ctrl-api (Lane III
+of the PR plan); ctrl-api owns the filesystem and the
+``alfred-state.db`` writes. This module is the alfred-learn glue:
+two thin activities that the daily ``FilesColdArchiveWorkflow``
+chains together to drive the sweep.
+
+Activities
+----------
+
+* ``find_cold_candidates(older_than_ms)`` — GET
+  ``/api/v1/files/cold-candidates?older_than_ms=…`` on ctrl-api,
+  return the list of (file_id, sha256, size_bytes, …) rows that are
+  eligible for promotion. ctrl-api applies the threshold + ordering
+  for us; the activity is a pure pass-through.
+
+* ``promote_to_cold(file_id)`` — POST
+  ``/api/v1/files/cold-promote/:file_id`` on ctrl-api. Returns the
+  per-row promotion summary (live + cold bytes, ratio). Failures
+  bubble out so the workflow per-entry try/except can isolate them.
+
+We deliberately do NOT have the workflow read the
+``state.db`` directly. ctrl-api is the sole writer of the
+files/file_blobs schema; learn writes through HTTP, exactly the
+discipline ``StateClient`` / ``VaultClient`` already follow.
+
+Environment
+-----------
+
+* ``ALFRED_CTRL_URL`` — the tenant ctrl-api base URL (the same
+  variable ``StateClient`` consumes). Defaults to ``http://alfred-ctrl:3100``.
+* ``AAS_API_KEY`` — the operator bearer token. Required.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import httpx
+from temporalio import activity
+
+logger = logging.getLogger("alfred-learn")
+
+
+# Same env knob StateClient / VaultClient honour.
+_DEFAULT_CTRL_URL = "http://alfred-ctrl:3100"
+
+
+def _ctrl_base_url() -> str:
+    return os.environ.get("ALFRED_CTRL_URL", _DEFAULT_CTRL_URL)
+
+
+def _auth_headers() -> dict[str, str]:
+    key = os.environ.get("AAS_API_KEY", "")
+    return {"Authorization": f"Bearer {key}"} if key else {}
+
+
+@activity.defn
+async def find_cold_candidates(older_than_ms: int) -> list[dict[str, Any]]:
+    """Pull the eligible-for-cold-promotion list from ctrl-api.
+
+    ``older_than_ms`` is the threshold: files whose
+    ``COALESCE(last_accessed_at, uploaded_at) < now - older_than_ms``
+    are returned. The default workflow tick passes 90 days; tests
+    and one-off sweeps can override.
+
+    The response shape from ctrl-api is::
+
+        {
+          "cutoff_ms": <int>,
+          "older_than_ms": <int>,
+          "total": <int>,
+          "items": [ { ...full FileRow row... }, ... ]
+        }
+
+    We hand the workflow the ``items`` list directly.
+    """
+    url = f"{_ctrl_base_url()}/api/v1/files/cold-candidates"
+    params = {"older_than_ms": int(older_than_ms)}
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.get(url, params=params, headers=_auth_headers())
+        resp.raise_for_status()
+        payload = resp.json()
+    items = payload.get("items", []) or []
+    logger.info(
+        "files_cold_archive: %d candidates (older_than_ms=%d, cutoff_ms=%s)",
+        len(items),
+        older_than_ms,
+        payload.get("cutoff_ms"),
+    )
+    return list(items)
+
+
+@activity.defn
+async def promote_to_cold(file_id: str) -> dict[str, Any]:
+    """Move one file from live storage to the cold archive.
+
+    Returns the ctrl-api response payload so the workflow can roll up
+    aggregate stats (bytes saved, ratio, etc.). 4xx/5xx bubble out as
+    HTTPStatusError — the workflow's per-entry try/except will
+    catch + log; one bad file mustn't strand the rest of the run.
+
+    The promote endpoint is idempotent: if the file is already cold,
+    ctrl-api returns the same 200 + ``already_cold=True``. We do not
+    treat that as a failure.
+    """
+    url = f"{_ctrl_base_url()}/api/v1/files/cold-promote/{file_id}"
+    async with httpx.AsyncClient(timeout=120.0) as client:
+        resp = await client.post(url, headers=_auth_headers())
+        resp.raise_for_status()
+        return resp.json()

--- a/packages/learn/src/worker.py
+++ b/packages/learn/src/worker.py
@@ -28,6 +28,9 @@ from src.workflows.plane_sync import PlaneSyncWorkflow
 from src.workflows.plane_reverse_sync import PlaneReverseSyncWorkflow
 from src.workflows.plane_reconciliation import PlaneReconciliationWorkflow
 from src.workflows.fleet_audit import FleetAuditWorkflow
+from src.workflows.files_cold_archive import (
+    FilesColdArchiveWorkflow,
+)
 from src.workflows.composio_reconnect_cleanup import (
     ComposioReconnectCleanupWorkflow,
 )
@@ -401,6 +404,15 @@ from src.activities.composio_reconnect import (
     verify_new_connection_active,
 )
 
+# Files cold-archive sweep (#114 PR 5) — daily promotion of unaccessed
+# blobs from `files_data` (live volume) to `files_cold_data` (ZSTD-19
+# compressed). ctrl-api owns the compression + atomic SQL flip; the
+# workflow is pure orchestration over these two activities.
+from src.activities.files_cold_archive import (
+    find_cold_candidates,
+    promote_to_cold,
+)
+
 # Phase 2 #23: the openclaw .bak-* session reaper activity
 # (sweep_openclaw_bak_sessions) was DELETED — Hermes' SQLite
 # SessionStore removes the O(N) readdir leak it existed to mop up.
@@ -711,6 +723,7 @@ _STATIC_WORKFLOWS = [
     PlaneReconciliationWorkflow,
     FleetAuditWorkflow,
     ComposioReconnectCleanupWorkflow,
+    FilesColdArchiveWorkflow,
     # OpenclawSessionSweepWorkflow removed — Phase 2 #23.
     # StewardWorkflow kept registered as a tombstone (#52): no longer
     # scheduled per-matter, but callable ad-hoc and harmless to register.
@@ -985,6 +998,9 @@ ALL_ACTIVITIES = [
     verify_new_connection_active,
     delete_old_connection,
     remove_ledger_entry,
+    # Files cold-archive sweep (#114 PR 5)
+    find_cold_candidates,
+    promote_to_cold,
     # sweep_openclaw_bak_sessions removed — Phase 2 #23.
     # Plane reverse sync (#536 B7)
     plane_reverse_sync_is_enabled,

--- a/packages/learn/src/workflows/files_cold_archive.py
+++ b/packages/learn/src/workflows/files_cold_archive.py
@@ -1,0 +1,194 @@
+"""FilesColdArchiveWorkflow — daily cold-promotion sweep for Store 5.
+
+Background
+----------
+
+Issue #114 PR 5 adds a cold-archive tier to the principal-facing
+files store: a separate ``files_cold_data`` volume, ZSTD-19
+compressed, that holds blobs untouched for 90+ days.
+
+This workflow runs once a day at 03:00 (low traffic — sits between
+nightly_maintenance at 03:00 and decision_patterns also at 03:00,
+but no overlap because the sweep is read-mostly + per-entry
+isolated). It:
+
+  1. Reads the list of eligible files from ctrl-api via
+     ``find_cold_candidates``.
+  2. Loops each one through ``promote_to_cold``, isolating per-file
+     failures so one bad file never wedges the rest of the run.
+  3. Returns a roll-up: how many candidates, how many promoted, how
+     many bytes lifted off the live volume + landed on the cold
+     volume, and the average compression ratio.
+
+Design notes
+------------
+
+* Pure orchestration. All ctrl-api interaction lives in
+  ``src.activities.files_cold_archive``; the workflow never imports
+  httpx or touches the filesystem.
+* Per-entry try/except boundary: one Composio-style API failure on
+  one file can never poison the rest of the sweep.
+* Idempotent + overlap-safe. The sweep is content-addressed; an
+  already-cold file is a no-op on ctrl-api's side.
+* Takes one optional argument ``older_than_ms`` so an operator can
+  hand-run a tighter sweep without re-deploying.
+
+Schedule
+--------
+
+Registered as ``al-files-cold-archive`` in
+``packages/learn/scripts/register_schedules.py``, daily at
+03:00 LOCAL.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import timedelta
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+with workflow.unsafe.imports_passed_through():
+    from src.activities.files_cold_archive import (
+        find_cold_candidates,
+        promote_to_cold,
+    )
+
+
+# 90 days in milliseconds — the default cold-promotion threshold.
+DEFAULT_COLD_AFTER_MS = 90 * 24 * 60 * 60 * 1000
+
+
+@dataclass
+class FilesColdArchiveResult:
+    candidates_total: int = 0
+    promoted: list[str] = field(default_factory=list)
+    already_cold: list[str] = field(default_factory=list)
+    live_bytes_freed: int = 0
+    cold_bytes_written: int = 0
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def compression_ratio(self) -> float | None:
+        if self.cold_bytes_written <= 0:
+            return None
+        return round(self.live_bytes_freed / self.cold_bytes_written, 3)
+
+
+@workflow.defn(name="FilesColdArchiveWorkflow")
+class FilesColdArchiveWorkflow:
+    """Promote unaccessed files to the cold archive once a day.
+
+    Per the PR 5 contract:
+
+      * Cold-eligible = ``deleted_at IS NULL`` AND
+        ``cold_promoted_at IS NULL`` AND
+        ``COALESCE(last_accessed_at, uploaded_at) < now - older_than_ms``.
+      * ``older_than_ms`` defaults to 90d (``DEFAULT_COLD_AFTER_MS``);
+        ad-hoc runs can override for testing.
+      * Each file is promoted via ctrl-api's
+        ``POST /api/v1/files/cold-promote/:file_id``. ctrl-api owns
+        the compression + the atomic SQL flip; the workflow just
+        chains the activity.
+    """
+
+    @workflow.run
+    async def run(
+        self, older_than_ms: int = DEFAULT_COLD_AFTER_MS,
+    ) -> FilesColdArchiveResult:
+        workflow.logger.info(
+            "files_cold_archive.start older_than_ms=%d",
+            older_than_ms,
+        )
+        result = FilesColdArchiveResult()
+
+        # ── pull candidates ───────────────────────────────────────────────
+        try:
+            candidates = await workflow.execute_activity(
+                find_cold_candidates,
+                args=[int(older_than_ms)],
+                start_to_close_timeout=timedelta(seconds=30),
+                retry_policy=RetryPolicy(
+                    maximum_attempts=3,
+                    initial_interval=timedelta(seconds=2),
+                    backoff_coefficient=2.0,
+                    maximum_interval=timedelta(seconds=10),
+                ),
+            )
+        except Exception as exc:  # noqa: BLE001
+            result.errors.append(f"find_cold_candidates failed: {exc}")
+            workflow.logger.error(
+                "files_cold_archive: candidate fetch failed: %s", exc,
+            )
+            return result
+
+        result.candidates_total = len(candidates)
+        if not candidates:
+            workflow.logger.info(
+                "files_cold_archive: no candidates — nothing to do"
+            )
+            return result
+
+        # ── per-entry promotion loop ──────────────────────────────────────
+        for entry in candidates:
+            file_id = str(entry.get("id") or "")
+            size_bytes = int(entry.get("size_bytes") or 0)
+            if not file_id:
+                result.errors.append(
+                    f"skipping entry with no id: {entry!r}"
+                )
+                continue
+
+            try:
+                promote_resp = await workflow.execute_activity(
+                    promote_to_cold,
+                    args=[file_id],
+                    # Generous timeout: 90 days of single-file data could
+                    # be hundreds of MB; zstd level 19 is the CPU sink
+                    # but tenant-VM CPUs are not turbocharged.
+                    start_to_close_timeout=timedelta(minutes=10),
+                    retry_policy=RetryPolicy(
+                        # One retry — the compression + atomic swap is
+                        # already idempotent on ctrl-api's side. Re-running
+                        # against an already-cold file is a no-op.
+                        maximum_attempts=2,
+                        initial_interval=timedelta(seconds=5),
+                        backoff_coefficient=2.0,
+                        maximum_interval=timedelta(seconds=20),
+                    ),
+                )
+            except Exception as exc:  # noqa: BLE001
+                # Per-file failure — log, accumulate, keep going.
+                result.errors.append(
+                    f"promote_to_cold({file_id}) failed: {exc}"
+                )
+                workflow.logger.warning(
+                    "files_cold_archive: promote failed for %s — leaving "
+                    "for next sweep (%s)",
+                    file_id, exc,
+                )
+                continue
+
+            if promote_resp.get("already_cold"):
+                result.already_cold.append(file_id)
+                continue
+
+            result.promoted.append(file_id)
+            result.live_bytes_freed += int(
+                promote_resp.get("live_bytes") or size_bytes
+            )
+            result.cold_bytes_written += int(
+                promote_resp.get("cold_bytes") or 0
+            )
+
+        workflow.logger.info(
+            "files_cold_archive.done candidates=%d promoted=%d "
+            "already_cold=%d live_freed=%d cold_written=%d errors=%d",
+            result.candidates_total,
+            len(result.promoted),
+            len(result.already_cold),
+            result.live_bytes_freed,
+            result.cold_bytes_written,
+            len(result.errors),
+        )
+        return result

--- a/packages/learn/tests/test_files_cold_archive.py
+++ b/packages/learn/tests/test_files_cold_archive.py
@@ -1,0 +1,385 @@
+"""Tests for FilesColdArchiveWorkflow + files_cold_archive activities.
+
+The workflow runs daily at 03:00 LOCAL and drains all
+``last_accessed_at`` >= 90 days files from the live volume into
+ZSTD-compressed copies on the cold volume. ctrl-api owns the
+compression + atomic SQL flip; the workflow is pure orchestration.
+
+These tests cover:
+
+  * Activities (``find_cold_candidates``, ``promote_to_cold``) in
+    isolation with the httpx call stubbed at the transport level so
+    no network I/O happens.
+  * The workflow via ``WorkflowEnvironment.start_time_skipping()``
+    with stub activities — exercises:
+      - empty-candidate-list no-op
+      - happy-path promotion across multiple files
+      - per-entry try/except boundary on a failing promote
+      - already-cold accounting (a no-op response is NOT counted as a
+        new promotion)
+      - aggregate bytes-saved + compression-ratio roll-up
+
+Mirrors the discipline ``test_composio_reconnect_cleanup.py`` already
+follows for the other Temporal-scheduled sweep.
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Any
+
+import httpx
+import pytest
+from temporalio import activity
+from temporalio.client import Client
+from temporalio.testing import ActivityEnvironment, WorkflowEnvironment
+from temporalio.worker import Worker
+
+from src.activities.files_cold_archive import (
+    find_cold_candidates,
+    promote_to_cold,
+)
+from src.workflows.files_cold_archive import (
+    DEFAULT_COLD_AFTER_MS,
+    FilesColdArchiveResult,
+    FilesColdArchiveWorkflow,
+)
+
+
+# ---------------------------------------------------------------------------
+# Activity isolation tests — stub httpx so no network I/O happens.
+# ---------------------------------------------------------------------------
+
+
+class _StubTransport(httpx.AsyncBaseTransport):
+    """Captures every request + returns the next queued response."""
+
+    def __init__(self) -> None:
+        self.queued: list[httpx.Response] = []
+        self.requests: list[httpx.Request] = []
+
+    def queue(
+        self,
+        status: int = 200,
+        json_payload: dict[str, Any] | None = None,
+    ) -> None:
+        self.queued.append(
+            httpx.Response(status, json=json_payload or {})
+        )
+
+    async def handle_async_request(  # type: ignore[override]
+        self, request: httpx.Request,
+    ) -> httpx.Response:
+        self.requests.append(request)
+        if not self.queued:
+            return httpx.Response(500, json={"error": "no stub queued"})
+        return self.queued.pop(0)
+
+
+@pytest.fixture
+def stub_transport(monkeypatch):
+    """Patch httpx.AsyncClient to use a deterministic stub transport.
+
+    Each test gets a fresh transport so cross-test interference is
+    impossible.
+    """
+    transport = _StubTransport()
+
+    real_init = httpx.AsyncClient.__init__
+
+    def patched_init(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        kwargs["transport"] = transport
+        real_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(httpx.AsyncClient, "__init__", patched_init)
+    monkeypatch.setenv("ALFRED_CTRL_URL", "http://stub-ctrl:3100")
+    monkeypatch.setenv("AAS_API_KEY", "test-key")
+    return transport
+
+
+class TestFindColdCandidates:
+    def test_returns_items_list(self, stub_transport):
+        stub_transport.queue(
+            200,
+            {
+                "cutoff_ms": 100,
+                "older_than_ms": 90,
+                "total": 2,
+                "items": [
+                    {"id": "01HF0000000000000000000001", "size_bytes": 1024},
+                    {"id": "01HF0000000000000000000002", "size_bytes": 2048},
+                ],
+            },
+        )
+        env = ActivityEnvironment()
+        items = asyncio.run(env.run(find_cold_candidates, 90))
+        assert len(items) == 2
+        assert items[0]["id"] == "01HF0000000000000000000001"
+        # The bearer header was set from AAS_API_KEY.
+        req = stub_transport.requests[0]
+        assert req.headers.get("authorization") == "Bearer test-key"
+        # The older_than_ms query parameter rode along.
+        assert "older_than_ms=90" in str(req.url)
+
+    def test_empty_items_returns_empty_list(self, stub_transport):
+        stub_transport.queue(
+            200, {"cutoff_ms": 0, "older_than_ms": 0, "total": 0, "items": []}
+        )
+        env = ActivityEnvironment()
+        items = asyncio.run(env.run(find_cold_candidates, 1))
+        assert items == []
+
+    def test_5xx_bubbles_out(self, stub_transport):
+        stub_transport.queue(503, {"error": "downstream broken"})
+        env = ActivityEnvironment()
+        with pytest.raises(httpx.HTTPStatusError):
+            asyncio.run(env.run(find_cold_candidates, 1))
+
+
+class TestPromoteToCold:
+    def test_returns_payload(self, stub_transport):
+        stub_transport.queue(
+            200,
+            {
+                "id": "01HF0000000000000000000001",
+                "sha256": "abc",
+                "path": "cold:01HF0000000000000000000001",
+                "cold_promoted_at": 12345,
+                "live_bytes": 1024,
+                "cold_bytes": 256,
+                "compression_ratio": 4.0,
+            },
+        )
+        env = ActivityEnvironment()
+        resp = asyncio.run(
+            env.run(promote_to_cold, "01HF0000000000000000000001")
+        )
+        assert resp["live_bytes"] == 1024
+        assert resp["cold_bytes"] == 256
+        assert resp["path"].startswith("cold:")
+        # Path was built from the file_id.
+        req = stub_transport.requests[0]
+        assert "/api/v1/files/cold-promote/01HF0000000000000000000001" in str(
+            req.url
+        )
+
+    def test_4xx_bubbles_out(self, stub_transport):
+        stub_transport.queue(409, {"error": {"code": "TOMBSTONED"}})
+        env = ActivityEnvironment()
+        with pytest.raises(httpx.HTTPStatusError):
+            asyncio.run(env.run(promote_to_cold, "tombstoned-id"))
+
+
+# ---------------------------------------------------------------------------
+# Workflow tests — stub activities so no httpx call happens at all.
+# ---------------------------------------------------------------------------
+
+
+_CALL_LOG: list[tuple[str, Any]] = []
+
+
+def _reset_call_log() -> None:
+    _CALL_LOG.clear()
+
+
+def _make_stubs(
+    *,
+    candidates: list[dict[str, Any]],
+    promote_outcomes: dict[str, dict[str, Any]] | None = None,
+    promote_raises: set[str] | None = None,
+):
+    """Build a (find, promote) activity pair backed by deterministic stubs.
+
+    ``promote_outcomes`` maps file_id → response dict; defaults to a
+    happy 2x-ratio response.
+    ``promote_raises`` is a set of file_ids the promote stub should
+    raise for, to exercise the per-entry try/except.
+    """
+    promote_outcomes = promote_outcomes or {}
+    promote_raises = promote_raises or set()
+
+    @activity.defn(name="find_cold_candidates")
+    async def stub_find(older_than_ms: int) -> list[dict[str, Any]]:
+        _CALL_LOG.append(("find", older_than_ms))
+        return list(candidates)
+
+    @activity.defn(name="promote_to_cold")
+    async def stub_promote(file_id: str) -> dict[str, Any]:
+        _CALL_LOG.append(("promote", file_id))
+        if file_id in promote_raises:
+            raise RuntimeError(f"simulated failure for {file_id}")
+        if file_id in promote_outcomes:
+            return promote_outcomes[file_id]
+        # Default: 2x ratio + 1KB cold.
+        return {
+            "id": file_id,
+            "path": f"cold:{file_id}",
+            "cold_promoted_at": 12345,
+            "live_bytes": 2048,
+            "cold_bytes": 1024,
+            "compression_ratio": 2.0,
+        }
+
+    return [stub_find, stub_promote]
+
+
+async def _run_workflow(
+    stubs, older_than_ms: int = DEFAULT_COLD_AFTER_MS,
+) -> FilesColdArchiveResult:
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        client: Client = env.client
+        tq = f"files-cold-archive-test-{uuid.uuid4()}"
+        worker = Worker(
+            client,
+            task_queue=tq,
+            workflows=[FilesColdArchiveWorkflow],
+            activities=stubs,
+        )
+        async with worker:
+            result = await client.execute_workflow(
+                FilesColdArchiveWorkflow.run,
+                older_than_ms,
+                id=f"files-cold-archive-run-{uuid.uuid4()}",
+                task_queue=tq,
+            )
+    return result
+
+
+class TestEmptyCandidates:
+    def test_no_op(self):
+        _reset_call_log()
+        stubs = _make_stubs(candidates=[])
+        result = asyncio.run(_run_workflow(stubs))
+        assert result.candidates_total == 0
+        assert result.promoted == []
+        assert result.errors == []
+        # Only the find call happened — no promote loop.
+        verbs = [c[0] for c in _CALL_LOG]
+        assert verbs == ["find"]
+
+
+class TestHappyPath:
+    def test_promotes_each_candidate_and_rolls_up_bytes(self):
+        _reset_call_log()
+        candidates = [
+            {"id": "f-1", "size_bytes": 2048},
+            {"id": "f-2", "size_bytes": 4096},
+        ]
+        promote_outcomes = {
+            "f-1": {
+                "id": "f-1",
+                "path": "cold:f-1",
+                "cold_promoted_at": 1,
+                "live_bytes": 2048,
+                "cold_bytes": 512,
+                "compression_ratio": 4.0,
+            },
+            "f-2": {
+                "id": "f-2",
+                "path": "cold:f-2",
+                "cold_promoted_at": 2,
+                "live_bytes": 4096,
+                "cold_bytes": 2048,
+                "compression_ratio": 2.0,
+            },
+        }
+        stubs = _make_stubs(
+            candidates=candidates, promote_outcomes=promote_outcomes,
+        )
+        result = asyncio.run(_run_workflow(stubs))
+        assert result.candidates_total == 2
+        assert sorted(result.promoted) == ["f-1", "f-2"]
+        assert result.live_bytes_freed == 2048 + 4096
+        assert result.cold_bytes_written == 512 + 2048
+        # Average compression ratio is 6144/2560 = 2.4x.
+        ratio = result.compression_ratio
+        assert ratio is not None
+        assert abs(ratio - 2.4) < 0.01
+        assert result.errors == []
+
+
+class TestPerEntryFailureIsolation:
+    def test_one_failed_promote_does_not_strand_the_others(self):
+        _reset_call_log()
+        candidates = [
+            {"id": "f-good-1", "size_bytes": 1024},
+            {"id": "f-bad", "size_bytes": 2048},
+            {"id": "f-good-2", "size_bytes": 4096},
+        ]
+        stubs = _make_stubs(
+            candidates=candidates,
+            promote_raises={"f-bad"},
+        )
+        result = asyncio.run(_run_workflow(stubs))
+        assert result.candidates_total == 3
+        # Both good files promoted; the bad one is in errors but did
+        # not poison the run.
+        assert sorted(result.promoted) == ["f-good-1", "f-good-2"]
+        assert len(result.errors) == 1
+        assert "f-bad" in result.errors[0]
+
+
+class TestAlreadyColdAccounting:
+    def test_already_cold_is_not_counted_as_a_new_promotion(self):
+        _reset_call_log()
+        candidates = [
+            {"id": "f-fresh", "size_bytes": 2048},
+            {"id": "f-already", "size_bytes": 1024},
+        ]
+        promote_outcomes = {
+            "f-already": {
+                "id": "f-already",
+                "path": "cold:f-already",
+                "cold_promoted_at": 99,
+                "already_cold": True,
+            },
+            "f-fresh": {
+                "id": "f-fresh",
+                "path": "cold:f-fresh",
+                "cold_promoted_at": 100,
+                "live_bytes": 2048,
+                "cold_bytes": 1024,
+                "compression_ratio": 2.0,
+            },
+        }
+        stubs = _make_stubs(
+            candidates=candidates, promote_outcomes=promote_outcomes,
+        )
+        result = asyncio.run(_run_workflow(stubs))
+        assert result.promoted == ["f-fresh"]
+        assert result.already_cold == ["f-already"]
+        # Bytes accounting only includes the actually-promoted file.
+        assert result.live_bytes_freed == 2048
+        assert result.cold_bytes_written == 1024
+
+
+class TestFindFailureShortCircuits:
+    def test_find_failure_returns_with_an_error_no_promote_attempts(self):
+        _reset_call_log()
+
+        @activity.defn(name="find_cold_candidates")
+        async def boom_find(older_than_ms: int) -> list[dict[str, Any]]:
+            raise RuntimeError("simulated find failure")
+
+        @activity.defn(name="promote_to_cold")
+        async def stub_promote(file_id: str) -> dict[str, Any]:
+            _CALL_LOG.append(("promote", file_id))
+            return {}
+
+        result = asyncio.run(_run_workflow([boom_find, stub_promote]))
+        assert result.candidates_total == 0
+        assert result.promoted == []
+        assert any("find_cold_candidates failed" in e for e in result.errors)
+        # No promote attempts after a find failure.
+        assert [c for c in _CALL_LOG if c[0] == "promote"] == []
+
+
+class TestThresholdPassThrough:
+    def test_workflow_passes_older_than_ms_to_the_find_activity(self):
+        _reset_call_log()
+        stubs = _make_stubs(candidates=[])
+        custom_threshold = 60 * 60 * 1000  # 1h
+        asyncio.run(_run_workflow(stubs, older_than_ms=custom_threshold))
+        # The find call sees the workflow's input verbatim.
+        find_calls = [c for c in _CALL_LOG if c[0] == "find"]
+        assert find_calls == [("find", custom_threshold)]


### PR DESCRIPTION
Closes the storage-efficiency lane of #114. Two upgrades on top of PR 1's `files` store; PR 4's read tools and the /files page work unchanged.

## What

### 1. Content-addressed dedupe at upload

A new `file_blobs` table (one row per unique `sha256`, with `ref_count`) sits between `files.id` and the on-disk bytes. The upload handler:

1. Streams the body to a scratch dir, sha256'ing on the fly (PR 1 behaviour).
2. AFTER the hash is known, looks up `file_blobs` for that sha256.
3. On hit: cleans up the scratch dir (the bytes already exist on disk), bumps the canonical row's `ref_count`, and points the new `files.id` row at the existing canonical `path`. Response carries `{deduped: true}`.
4. On miss: finalizes the live path, `INSERT OR IGNORE INTO file_blobs` (the IGNORE catches concurrent-upload races — the loser cleans up its just-written dir, adopts the canonical path, bumps ref_count). Response carries `{deduped: false}`.

DELETE decrements the `file_blobs.ref_count`; the on-disk bytes (+ canonical row) only physically reap when ref_count hits zero. /usage reports `used_bytes = SUM(file_blobs.size_bytes) WHERE ref_count > 0` so two duplicate uploads cost ONE set of bytes against the quota.

### 2. 90-day cold archive

A new `files_cold_data` named volume holds ZSTD-19 compressed copies of any blob untouched for >= 90 days.

- `POST /api/v1/files/cold-promote/:file_id` — streams the live blob through `zlib.createZstdCompress({ level: 19 })` into `/cold-files/<ULID>.zst.in-progress`, renames to final, then atomic SQL flip (`file_blobs.path = "cold:<ULID>"` + `cold_promoted_at = now()`; matching `files` rows updated in the same transaction), then unlinks the live copy. Multi-MB files never materialize in memory (streaming Transform).
- `GET /api/v1/files/blob/*` — when the path starts with `cold:` the route resolves under `FILES_COLD_ROOT`, pipes through `createZstdDecompress`, drops `Content-Length` (inflated size unknown), adds `X-Cold-Blob: 1` breadcrumb. Cold reads bump `last_accessed_at` but do NOT auto-restore — explicit opt-in via `POST /cold-restore/:file_id` is the only path back to live.
- `GET /api/v1/files/cold-candidates?older_than_ms=...` — operator list (default 90d) for the workflow.

Daily `FilesColdArchiveWorkflow` (alfred-learn, 03:00 LOCAL) runs `find_cold_candidates → loop(promote_to_cold)` with per-entry try/except so one bad file doesn't strand the rest of the sweep.

### Migration 0010

Adds the new table + the two new `files` columns (`cold_promoted_at`, `ref_count`), and — because dedupe needs two `files.id` rows to share a `path` — rebuilds `files` without the PR 1 `UNIQUE(path)` constraint (SQLite rename-create-copy-drop). Existing rows backfill into `file_blobs` with `ref_count = COUNT(live files sharing sha256)` and live rows have their path rewritten to the canonical blob path so pre-existing dupes start sharing bytes immediately.

### Compose + Dockerfile

- New `files_cold_data` volume mounted `:rw` at `/cold-files` on ctrl-api ONLY. No other service touches it.
- Dockerfile installs `zstd` apt package for operator-debugging ergonomics (the runtime uses node:zlib's streaming codec, not the CLI).

## Tests

| Surface | New tests |
|---|---|
| `packages/ctrl/tests/files-dedupe.test.ts` | 11 |
| `packages/ctrl/tests/files-cold-archive.test.ts` | 10 |
| `packages/learn/tests/test_files_cold_archive.py` | 11 (5 activity isolation + 6 workflow orchestration) |
| `packages/ctrl/tests/migrate.test.ts` + `alfred-journal.test.ts` | extended for v10 + the new schema |

`ctrl-api` full suite: **774 pass / 0 fail / 1 skipped (775 total)**. Pre-existing baseline was zero after #146, and this PR preserves it.

`learn` smoke (files_cold_archive + composio_reconnect_cleanup + ha_bootstrap): **59 pass**.

## Observed compression ratio

Average across the cold-archive test fixtures: **~1374x** (heavily skewed by the highly-compressible `Buffer.alloc(64KB, 'z')` case — ZSTD-19 shrinks that to ~50 bytes; the random-binary 32 KB fixture sits at ~1.0x, expected entropy floor).

## What this does NOT do

- Garbage-collecting pre-PR-5 orphaned duplicate blobs on disk. The migration `file_blobs` backfill picks one canonical path per sha256 and rewrites the live `files.path` to match, but does NOT delete the now-unreferenced blob copies — that's a one-off operator command (intentionally not in a SQL migration; deleting bytes inside a transaction is a footgun).
- An "auto-restore on read" path. Cold reads stay cold. The principal opts in via `/cold-restore/:file_id` when they expect to read repeatedly.
- A /files dashboard UI for the cold/live split. The `/usage` response carries `live_bytes` / `cold_bytes` / `blob_count_*`; the dashboard render is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)