### PR TITLE
feat(learn,ctrl,web): HA gap detection + proposal generation Phase B+C (#110 PR6)

### DIFF
--- a/packages/ctrl/src/api/auth.ts
+++ b/packages/ctrl/src/api/auth.ts
@@ -132,6 +132,13 @@ const VOICE_BRIDGE_ALLOWLIST: ReadonlySet<string> = new Set([
   "GET:/api/v1/channels/ha/status",
   "GET:/api/v1/channels/ha/registry",
   "GET:/api/v1/channels/ha/automations",
+  // #110 PR6 — gap detection + proposal generation read surfaces.
+  // Voice CAN ask "what gaps does Alfred see?" / "what proposals are
+  // pending?" — but CANNOT trigger applyHaProposal (that stays through
+  // the MCP write surface so the loop-guard + snapshot pattern in
+  // PR4 still wraps every write).
+  "GET:/api/v1/channels/ha/gaps",
+  "GET:/api/v1/channels/ha/proposals",
   // ── Files store, read-only — issue #114 PR4 (voice-bridge files surface). ─
   // The voice agent surfaces four read-only `files__*` tools (list / stat /
   // read_text / search). list + usage have no path params; stat + blob carry

--- a/packages/ctrl/src/api/routes/channels_ha.ts
+++ b/packages/ctrl/src/api/routes/channels_ha.ts
@@ -2339,6 +2339,472 @@ export function registerHaBootstrapRoutes(): void {
       eta: "30s",
     });
   });
+
+  // #110 PR6 — Phase B (gap detection) + Phase C (proposal generation)
+  // bulk-upsert + read routes. The alfred-learn workflow drives:
+  //
+  //   POST /api/v1/channels/ha/gaps/bulk   — operator-only bulk upsert
+  //                                          (dedup by kind+area_id,
+  //                                          tombstone vanished gaps)
+  //   GET  /api/v1/channels/ha/gaps        — open + closed gap surfaces
+  //   GET  /api/v1/channels/ha/proposals   — pending + applied proposals
+  //   PATCH /api/v1/channels/ha/gap/:id/dismiss     — principal hides a gap
+  //   POST /api/v1/channels/ha/proposal/:id/reject  — principal kills a proposal
+  //
+  // The gap+proposal reads are voice-bridge readable; the bulk-write is
+  // operator-only and the dismiss/reject writes carry the channel-token
+  // chain (no `decision_ref` needed — dismiss/reject don't touch HA).
+  registerHaGapRoutes();
+}
+
+// ── PR6 routes — gap detection + proposal lifecycle ────────────────────
+
+// Bulk-upsert body shape. Mirrors the structure detect_gaps() returns
+// in alfred-learn.
+interface HaGapBulkInputRow {
+  kind: string;
+  summary: string;
+  severity: string;
+  area_id: string | null;
+  device_id: string | null;
+  discovered_at: string;
+  evidence: Record<string, unknown>;
+}
+
+// Stored shape (reflects the PR1 ha_gap schema: id/ts/kind/evidence/
+// fix_pack/proposal_ref/status/created_at). The optional spec fields
+// (area_id/device_id/summary/severity) ride inside `evidence` so we
+// don't need a new migration.
+interface HaGapStoredRow {
+  id: string;
+  ts: string;
+  kind: string;
+  evidence: string | null;
+  fix_pack: string | null;
+  proposal_ref: string | null;
+  status: string;
+  created_at: string;
+}
+
+// The 8 kinds Phase B emits. Anything else gets dropped at parse time
+// so a misbehaving activity can't push a row that the dashboard can't
+// surface.
+const HA_GAP_KINDS = new Set([
+  "no_morning_routine",
+  "no_bedtime_routine",
+  "no_motion_lighting",
+  "no_away_mode",
+  "no_security_camera_notification",
+  "no_vacation_mode",
+  "no_climate_schedule",
+  "no_party_mode",
+]);
+
+const HA_GAP_SEVERITIES = new Set(["low", "medium", "high"]);
+
+function parseGapBulkBody(raw: unknown): HaGapBulkInputRow[] {
+  if (typeof raw !== "object" || raw === null) {
+    throw new ValidationError("body must be a JSON object");
+  }
+  const b = raw as Record<string, unknown>;
+  if (!Array.isArray(b.rows)) {
+    throw new ValidationError("rows must be an array");
+  }
+  const out: HaGapBulkInputRow[] = [];
+  for (const r of b.rows) {
+    if (typeof r !== "object" || r === null) continue;
+    const row = r as Record<string, unknown>;
+    if (typeof row.kind !== "string" || !HA_GAP_KINDS.has(row.kind)) continue;
+    const summary = typeof row.summary === "string" ? row.summary : "";
+    if (summary.length === 0) continue;
+    const severity =
+      typeof row.severity === "string" && HA_GAP_SEVERITIES.has(row.severity)
+        ? row.severity
+        : "low";
+    const area_id = typeof row.area_id === "string" && row.area_id ? row.area_id : null;
+    const device_id =
+      typeof row.device_id === "string" && row.device_id ? row.device_id : null;
+    const discovered_at =
+      typeof row.discovered_at === "string" && row.discovered_at
+        ? row.discovered_at
+        : new Date().toISOString();
+    let evidence: Record<string, unknown> = {};
+    if (row.evidence && typeof row.evidence === "object") {
+      evidence = row.evidence as Record<string, unknown>;
+    }
+    out.push({
+      kind: row.kind,
+      summary,
+      severity,
+      area_id,
+      device_id,
+      discovered_at,
+      evidence,
+    });
+  }
+  return out;
+}
+
+/** Dedup key for upsert + tombstone passes — gap is the SAME gap iff
+ *  (kind, area_id) match. area_id=null is a valid first-class key (the
+ *  whole-home gaps like no_morning_routine fall here). */
+function gapDedupeKey(kind: string, area_id: string | null): string {
+  return `${kind}::${area_id ?? ""}`;
+}
+
+interface HaGapBulkResult {
+  inserted: number;
+  updated: number;
+  /** Gaps that vanished from input AND were still open → closed via
+   *  status='addressed'. */
+  addressed: number;
+  /** Convenience: 0 — dismiss is a principal action, never auto. */
+  dismissed: number;
+  /** The current open + addressed-this-call rows the workflow needs
+   *  to template proposals against. Each row carries its id + the
+   *  evidence-blob fields (kind, summary, severity, area_id…). */
+  gaps: Array<Record<string, unknown>>;
+}
+
+function decodeGapForResponse(
+  row: HaGapStoredRow,
+): Record<string, unknown> {
+  let evidence: Record<string, unknown> = {};
+  if (row.evidence) {
+    try {
+      const parsed = JSON.parse(row.evidence);
+      if (parsed && typeof parsed === "object") {
+        evidence = parsed as Record<string, unknown>;
+      }
+    } catch {
+      // best-effort — leave evidence empty
+    }
+  }
+  return {
+    id: row.id,
+    kind: row.kind,
+    summary: typeof evidence.summary === "string" ? evidence.summary : row.kind,
+    severity: typeof evidence.severity === "string" ? evidence.severity : "low",
+    area_id: typeof evidence.area_id === "string" ? evidence.area_id : null,
+    device_id: typeof evidence.device_id === "string" ? evidence.device_id : null,
+    discovered_at: row.ts,
+    evidence: typeof evidence.evidence === "object" ? evidence.evidence : evidence,
+    proposal_ref: row.proposal_ref,
+    status: row.status,
+  };
+}
+
+function bulkUpsertHaGaps(rows: HaGapBulkInputRow[]): HaGapBulkResult {
+  const db = getStateDb();
+  // We dedupe within the input batch by (kind, area_id) — the spec says
+  // we don't re-discover the same gap every 6h.
+  const seen = new Map<string, HaGapBulkInputRow>();
+  for (const r of rows) {
+    seen.set(gapDedupeKey(r.kind, r.area_id), r);
+  }
+  const inputRows = [...seen.values()];
+  const inputKeys = new Set(seen.keys());
+
+  let inserted = 0;
+  let updated = 0;
+  let addressed = 0;
+
+  db.exec("BEGIN");
+  try {
+    const existing = db
+      .prepare("SELECT id, kind, evidence, status, proposal_ref, ts FROM ha_gap")
+      .all() as Array<{
+      id: string;
+      kind: string;
+      evidence: string | null;
+      status: string;
+      proposal_ref: string | null;
+      ts: string;
+    }>;
+
+    // Index existing OPEN rows by (kind, area_id).
+    const openByKey = new Map<string, typeof existing[number]>();
+    for (const row of existing) {
+      if (row.status !== "open") continue;
+      let area_id: string | null = null;
+      if (row.evidence) {
+        try {
+          const ev = JSON.parse(row.evidence) as Record<string, unknown>;
+          if (typeof ev.area_id === "string") area_id = ev.area_id;
+        } catch {
+          // best-effort
+        }
+      }
+      openByKey.set(gapDedupeKey(row.kind, area_id), row);
+    }
+
+    const insertStmt = db.prepare(
+      `INSERT INTO ha_gap (id, ts, kind, evidence, fix_pack, status)
+       VALUES (?, ?, ?, ?, ?, 'open')`,
+    );
+    const updateStmt = db.prepare(
+      `UPDATE ha_gap
+          SET ts = ?, evidence = ?, fix_pack = ?
+        WHERE id = ?`,
+    );
+
+    for (const r of inputRows) {
+      const key = gapDedupeKey(r.kind, r.area_id);
+      const existing = openByKey.get(key);
+      // The evidence blob carries the spec fields the PR1 schema
+      // doesn't have a column for. Keys are flat — no nesting —
+      // so the dashboard `decodeGapForResponse` can lift them out
+      // without recursion.
+      const evidence = JSON.stringify({
+        summary: r.summary,
+        severity: r.severity,
+        area_id: r.area_id,
+        device_id: r.device_id,
+        evidence: r.evidence,
+      });
+      if (existing) {
+        updateStmt.run(r.discovered_at, evidence, r.kind, existing.id);
+        updated += 1;
+      } else {
+        insertStmt.run(ulid(), r.discovered_at, r.kind, evidence, r.kind);
+        inserted += 1;
+      }
+    }
+
+    // Tombstone open rows whose (kind, area_id) vanished from input
+    // → status='addressed' (the spec's "closed_at" semantic).
+    const addressedStmt = db.prepare(
+      `UPDATE ha_gap
+          SET status = 'addressed'
+        WHERE id = ? AND status = 'open'`,
+    );
+    for (const [key, row] of openByKey) {
+      if (inputKeys.has(key)) continue;
+      addressedStmt.run(row.id);
+      addressed += 1;
+    }
+
+    db.exec("COMMIT");
+  } catch (err) {
+    db.exec("ROLLBACK");
+    throw err;
+  }
+
+  // Re-read the still-open rows so Phase C has fresh `id` + status
+  // values to attach to its proposal POSTs.
+  const openRows = db
+    .prepare(
+      `SELECT id, ts, kind, evidence, fix_pack, proposal_ref, status, created_at
+         FROM ha_gap
+        WHERE status = 'open'
+        ORDER BY ts DESC`,
+    )
+    .all() as HaGapStoredRow[];
+  return {
+    inserted,
+    updated,
+    addressed,
+    dismissed: 0,
+    gaps: openRows.map(decodeGapForResponse),
+  };
+}
+
+function listHaGaps(): {
+  open: Array<Record<string, unknown>>;
+  closed: Array<Record<string, unknown>>;
+} {
+  const db = getStateDb();
+  let rows: HaGapStoredRow[] = [];
+  try {
+    rows = db
+      .prepare(
+        `SELECT id, ts, kind, evidence, fix_pack, proposal_ref, status, created_at
+           FROM ha_gap
+          ORDER BY ts DESC`,
+      )
+      .all() as HaGapStoredRow[];
+  } catch {
+    // ha_gap may not be present in an older test sandbox; treat as empty.
+    return { open: [], closed: [] };
+  }
+  const open: Array<Record<string, unknown>> = [];
+  const closed: Array<Record<string, unknown>> = [];
+  // Severity ranking for the sort.
+  const sev: Record<string, number> = { high: 0, medium: 1, low: 2 };
+  for (const r of rows) {
+    const view = decodeGapForResponse(r);
+    if (r.status === "open") {
+      open.push(view);
+    } else {
+      closed.push(view);
+    }
+  }
+  open.sort((a, b) => {
+    const da = sev[(a.severity as string) ?? "low"] ?? 2;
+    const db_ = sev[(b.severity as string) ?? "low"] ?? 2;
+    if (da !== db_) return da - db_;
+    return String(b.discovered_at).localeCompare(String(a.discovered_at));
+  });
+  closed.sort((a, b) =>
+    String(b.discovered_at).localeCompare(String(a.discovered_at)),
+  );
+  return { open, closed };
+}
+
+interface HaProposalListed {
+  id: string;
+  kind: string;
+  summary: string;
+  yaml: string;
+  gap_id: string | null;
+  status: string;
+  ts: string;
+  applied_at: string | null;
+}
+
+function listHaProposals(): {
+  pending: HaProposalListed[];
+  applied: HaProposalListed[];
+  other: HaProposalListed[];
+} {
+  const db = getStateDb();
+  let rows: Array<{
+    id: string;
+    ts: string;
+    scope: string;
+    summary: string;
+    payload_json: string;
+    status: string;
+    applied_at: string | null;
+  }> = [];
+  try {
+    rows = db
+      .prepare(
+        `SELECT id, ts, scope, summary, payload_json, status, applied_at
+           FROM ha_proposal
+          ORDER BY ts DESC`,
+      )
+      .all() as typeof rows;
+  } catch {
+    return { pending: [], applied: [], other: [] };
+  }
+  const pending: HaProposalListed[] = [];
+  const applied: HaProposalListed[] = [];
+  const other: HaProposalListed[] = [];
+  for (const r of rows) {
+    let yaml = "";
+    let gap_id: string | null = null;
+    try {
+      const p = JSON.parse(r.payload_json) as Record<string, unknown>;
+      if (typeof p.yaml === "string") yaml = p.yaml;
+      if (typeof p.gap_id === "string") gap_id = p.gap_id;
+    } catch {
+      // best-effort
+    }
+    const view: HaProposalListed = {
+      id: r.id,
+      kind: r.scope,
+      summary: r.summary,
+      yaml,
+      gap_id,
+      status: r.status,
+      ts: r.ts,
+      applied_at: r.applied_at,
+    };
+    if (r.status === "pending" || r.status === "approved") {
+      pending.push(view);
+    } else if (r.status === "applied") {
+      applied.push(view);
+    } else {
+      other.push(view);
+    }
+  }
+  return { pending, applied, other };
+}
+
+function dismissHaGapRow(id: string): { ok: boolean; status: string } {
+  const db = getStateDb();
+  const existing = db
+    .prepare("SELECT status FROM ha_gap WHERE id = ?")
+    .get(id) as { status: string } | undefined;
+  if (!existing) {
+    throw new NotFoundError(`ha_gap ${id} not found`);
+  }
+  if (existing.status === "dismissed") {
+    return { ok: true, status: "dismissed" };
+  }
+  if (existing.status === "addressed") {
+    throw new ConflictError(
+      `ha_gap ${id} is already addressed — nothing to dismiss`,
+    );
+  }
+  db.prepare("UPDATE ha_gap SET status = 'dismissed' WHERE id = ?").run(id);
+  return { ok: true, status: "dismissed" };
+}
+
+function rejectHaProposalRow(id: string): { ok: boolean; status: string } {
+  const db = getStateDb();
+  const existing = db
+    .prepare("SELECT status FROM ha_proposal WHERE id = ?")
+    .get(id) as { status: string } | undefined;
+  if (!existing) {
+    throw new NotFoundError(`ha_proposal ${id} not found`);
+  }
+  if (existing.status === "rejected") {
+    return { ok: true, status: "rejected" };
+  }
+  if (existing.status === "applied") {
+    throw new ConflictError(
+      `ha_proposal ${id} was already applied — cannot reject`,
+    );
+  }
+  const now = new Date().toISOString();
+  db.prepare(
+    "UPDATE ha_proposal SET status = 'rejected', updated_at = ? WHERE id = ?",
+  ).run(now, id);
+  return { ok: true, status: "rejected" };
+}
+
+export function registerHaGapRoutes(): void {
+  // POST /api/v1/channels/ha/gaps/bulk — operator-only Phase B sink.
+  addRoute("POST", "/api/v1/channels/ha/gaps/bulk", async ({ req, res, body }) => {
+    requireOperatorBearer(req);
+    const rows = parseGapBulkBody(body);
+    const result = bulkUpsertHaGaps(rows);
+    sendJson(res, 200, { ok: true, ...result });
+  });
+
+  // GET /api/v1/channels/ha/gaps — voice-bridge readable.
+  addRoute("GET", "/api/v1/channels/ha/gaps", async ({ res }) => {
+    sendJson(res, 200, listHaGaps());
+  });
+
+  // GET /api/v1/channels/ha/proposals — voice-bridge readable.
+  addRoute("GET", "/api/v1/channels/ha/proposals", async ({ res }) => {
+    sendJson(res, 200, listHaProposals());
+  });
+
+  // PATCH /api/v1/channels/ha/gap/:gap_id/dismiss — principal action.
+  // No decision_ref needed; dismiss never touches HA.
+  addRoute(
+    "PATCH",
+    "/api/v1/channels/ha/gap/:gap_id/dismiss",
+    async ({ res, params }) => {
+      const r = dismissHaGapRow(params.gap_id);
+      sendJson(res, 200, r);
+    },
+  );
+
+  // POST /api/v1/channels/ha/proposal/:proposal_id/reject — principal action.
+  // Same — no decision_ref because nothing reaches HA.
+  addRoute(
+    "POST",
+    "/api/v1/channels/ha/proposal/:proposal_id/reject",
+    async ({ res, params }) => {
+      const r = rejectHaProposalRow(params.proposal_id);
+      sendJson(res, 200, r);
+    },
+  );
 }
 
 /** For tests only — clear the ha_registry between runs without recreating
@@ -2349,5 +2815,19 @@ export function _resetHaRegistryForTests(): void {
     getStateDb().prepare("DELETE FROM ha_registry").run();
   } catch {
     /* table may not exist on first boot; tests run migrations themselves */
+  }
+}
+
+/** For tests only — clear ha_gap + ha_proposal between runs. */
+export function _resetHaGapsForTests(): void {
+  try {
+    getStateDb().prepare("DELETE FROM ha_gap").run();
+  } catch {
+    // table may not exist; tests own migrations
+  }
+  try {
+    getStateDb().prepare("DELETE FROM ha_proposal").run();
+  } catch {
+    // table may not exist; tests own migrations
   }
 }

--- a/packages/ctrl/tests/channels_ha_gaps.test.ts
+++ b/packages/ctrl/tests/channels_ha_gaps.test.ts
@@ -1,0 +1,336 @@
+// Lane II — /api/v1/channels/ha/* HA gap + proposal surfaces (#110 PR6).
+//
+// PR6 adds five routes plus voice-bridge allowlist entries for the two
+// reads:
+//
+//   POST  /api/v1/channels/ha/gaps/bulk                    — operator-only
+//   GET   /api/v1/channels/ha/gaps                         — voice readable
+//   GET   /api/v1/channels/ha/proposals                    — voice readable
+//   PATCH /api/v1/channels/ha/gap/:id/dismiss              — principal action
+//   POST  /api/v1/channels/ha/proposal/:id/reject          — principal action
+//
+// The bulk route dedupes by (kind, area_id) so a 6h refresh doesn't
+// re-discover the same gap; rows whose (kind, area_id) vanish from the
+// input get status='addressed' (the spec's closed_at semantic, ridden
+// inside the ha_gap.status column since PR1 didn't ship a closed_at
+// column).
+//
+// Coverage (10 tests):
+//   1. bulk upsert inserts new gap rows
+//   2. bulk upsert is idempotent on (kind, area_id)
+//   3. bulk upsert tombstones vanished gaps (status → addressed)
+//   4. bulk upsert returns the open rows for Phase C
+//   5. GET /gaps returns open + closed sorted by severity then ts
+//   6. GET /proposals returns pending + applied + other
+//   7. dismissed gap excluded from open in subsequent GET /gaps
+//   8. PATCH dismiss on unknown gap returns 404
+//   9. POST reject on pending proposal returns 200, status flips
+//  10. bulk POST without operator bearer returns 401 (when key set)
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ServerResponse } from "node:http";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "channels-ha-pr6-"));
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.VAULT_PATH = path.join(tmp, "vault");
+process.env.STATE_DB_PATH = path.join(tmp, "alfred-state.db");
+process.env.INGEST_DB_PATH = path.join(tmp, "ingest.db");
+process.env.SQLITE_VEC_PATH = "";
+process.env.HA_VAULTWARDEN_FOLDER = "Home Assistant";
+process.env.HA_LLAT_ITEM = "LLAT";
+
+const {
+  registerChannelsHaRoutes,
+  _resetHaGapsForTests,
+} = await import("../src/api/routes/channels_ha.js");
+const { matchRoute } = await import("../src/api/server.js");
+const { handleError } = await import("../src/api/errors.js");
+const { getStateDb } = await import("../src/db/state.js");
+const { setApiKey, setVoiceBridgeKey, _resetAuthForTests } = await import(
+  "../src/api/auth.js"
+);
+
+registerChannelsHaRoutes();
+
+interface CallResult {
+  status: number;
+  payload: any;
+}
+async function call(
+  method: string,
+  p: string,
+  body?: unknown,
+  bearer?: string,
+): Promise<CallResult> {
+  const m = matchRoute(method, p);
+  assert.ok(m, `${method} ${p} must be registered`);
+  let status = 0;
+  let payload: any;
+  const res = {
+    statusCode: 0,
+    setHeader() {},
+    writeHead(c: number) {
+      status = c;
+      return res;
+    },
+    end(j?: string) {
+      payload = j ? JSON.parse(j) : undefined;
+    },
+  } as unknown as ServerResponse;
+  const headers: Record<string, string> = {};
+  if (bearer) headers.authorization = `Bearer ${bearer}`;
+  try {
+    await m!.handler({
+      req: { method, headers, url: p } as any,
+      res,
+      params: m!.params,
+      body,
+      query: new URLSearchParams(),
+    });
+  } catch (err) {
+    handleError(res, err);
+  }
+  return { status, payload };
+}
+
+const MASTER_KEY = "test-master-" + "a".repeat(40);
+
+const morningGap = {
+  kind: "no_morning_routine",
+  summary: "No morning lighting routine.",
+  severity: "medium",
+  area_id: null,
+  device_id: null,
+  discovered_at: "2026-05-29T00:00:00Z",
+  evidence: { light_count: 3 },
+};
+
+const motionHallGap = {
+  kind: "no_motion_lighting",
+  summary: "Motion sensor in Hallway isn't wired.",
+  severity: "low",
+  area_id: "hallway",
+  device_id: null,
+  discovered_at: "2026-05-29T00:00:00Z",
+  evidence: { sensor: "binary_sensor.hall" },
+};
+
+const motionBathGap = {
+  kind: "no_motion_lighting",
+  summary: "Motion sensor in Bathroom isn't wired.",
+  severity: "low",
+  area_id: "bathroom",
+  device_id: null,
+  discovered_at: "2026-05-29T00:00:00Z",
+  evidence: { sensor: "binary_sensor.bath" },
+};
+
+const cameraGap = {
+  kind: "no_security_camera_notification",
+  summary: "Cameras + motion sensors live.",
+  severity: "high",
+  area_id: null,
+  device_id: null,
+  discovered_at: "2026-05-29T00:00:00Z",
+  evidence: { camera_count: 2 },
+};
+
+describe("/api/v1/channels/ha/* — #110 PR6 gap + proposal surfaces", () => {
+  beforeEach(() => {
+    _resetHaGapsForTests();
+    _resetAuthForTests();
+  });
+
+  it("bulk upsert inserts new gap rows", async () => {
+    const r = await call("POST", "/api/v1/channels/ha/gaps/bulk", {
+      rows: [morningGap, motionHallGap, motionBathGap],
+    });
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.ok, true);
+    assert.equal(r.payload.inserted, 3);
+    assert.equal(r.payload.updated, 0);
+    assert.equal(r.payload.addressed, 0);
+    assert.equal(r.payload.gaps.length, 3);
+    // Each returned gap has a server-minted id and the decoded fields.
+    const morning = r.payload.gaps.find(
+      (g: any) => g.kind === "no_morning_routine",
+    );
+    assert.ok(morning?.id);
+    assert.equal(morning.severity, "medium");
+    assert.equal(morning.area_id, null);
+  });
+
+  it("bulk upsert is idempotent — second identical batch updates instead of inserting", async () => {
+    await call("POST", "/api/v1/channels/ha/gaps/bulk", {
+      rows: [morningGap, motionHallGap],
+    });
+    const r = await call("POST", "/api/v1/channels/ha/gaps/bulk", {
+      rows: [morningGap, motionHallGap],
+    });
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.inserted, 0);
+    assert.equal(r.payload.updated, 2);
+    assert.equal(r.payload.addressed, 0);
+    const allRows = getStateDb()
+      .prepare("SELECT id FROM ha_gap")
+      .all() as Array<{ id: string }>;
+    assert.equal(allRows.length, 2);
+  });
+
+  it("bulk upsert tombstones vanished gaps (status → addressed)", async () => {
+    // Seed two areas with motion gaps + one whole-home gap.
+    await call("POST", "/api/v1/channels/ha/gaps/bulk", {
+      rows: [morningGap, motionHallGap, motionBathGap],
+    });
+    // Second pass — only the morning gap survives; both motion gaps vanish.
+    const r = await call("POST", "/api/v1/channels/ha/gaps/bulk", {
+      rows: [morningGap],
+    });
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.addressed, 2);
+    const statuses = getStateDb()
+      .prepare(
+        "SELECT kind, evidence, status FROM ha_gap ORDER BY status, kind",
+      )
+      .all() as Array<{ kind: string; evidence: string | null; status: string }>;
+    const addressed = statuses.filter((s) => s.status === "addressed");
+    assert.equal(addressed.length, 2);
+    const open = statuses.filter((s) => s.status === "open");
+    assert.equal(open.length, 1);
+    assert.equal(open[0].kind, "no_morning_routine");
+  });
+
+  it("bulk upsert returns the open rows for Phase C", async () => {
+    const r = await call("POST", "/api/v1/channels/ha/gaps/bulk", {
+      rows: [morningGap, cameraGap, motionHallGap],
+    });
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.gaps.length, 3);
+    // Each row carries an id so Phase C can attach it to the proposal.
+    for (const g of r.payload.gaps) {
+      assert.ok(typeof g.id === "string" && g.id.length > 0);
+    }
+  });
+
+  it("GET /gaps returns open + closed sorted by severity then ts", async () => {
+    // Seed: high-camera, medium-morning, low-motion-hall, low-motion-bath.
+    await call("POST", "/api/v1/channels/ha/gaps/bulk", {
+      rows: [
+        morningGap,
+        { ...cameraGap, discovered_at: "2026-05-29T01:00:00Z" },
+        motionHallGap,
+        motionBathGap,
+      ],
+    });
+    const r = await call("GET", "/api/v1/channels/ha/gaps");
+    assert.equal(r.status, 200);
+    assert.ok(Array.isArray(r.payload.open));
+    assert.ok(Array.isArray(r.payload.closed));
+    assert.equal(r.payload.open.length, 4);
+    // Sort: high first, then medium, then low.
+    assert.equal(r.payload.open[0].severity, "high");
+    assert.equal(r.payload.open[1].severity, "medium");
+    // Two low gaps last.
+    assert.equal(r.payload.open[2].severity, "low");
+    assert.equal(r.payload.open[3].severity, "low");
+  });
+
+  it("GET /proposals returns pending + applied + other buckets", async () => {
+    // Seed a proposal via the existing POST /proposal route.
+    const create = await call("POST", "/api/v1/channels/ha/proposal", {
+      kind: "no_morning_routine",
+      summary: "Wake the lights at sunrise.",
+      yaml: "alias: x\ntrigger: []\naction: []\n",
+    });
+    assert.equal(create.status, 200, JSON.stringify(create.payload));
+    const r = await call("GET", "/api/v1/channels/ha/proposals");
+    assert.equal(r.status, 200);
+    assert.ok(Array.isArray(r.payload.pending));
+    assert.equal(r.payload.pending.length, 1);
+    assert.equal(r.payload.pending[0].kind, "no_morning_routine");
+    assert.equal(r.payload.pending[0].summary, "Wake the lights at sunrise.");
+    assert.ok(r.payload.pending[0].yaml.includes("alias:"));
+    assert.equal(r.payload.applied.length, 0);
+  });
+
+  it("dismissed gap is excluded from open in subsequent GET /gaps", async () => {
+    const bulk = await call("POST", "/api/v1/channels/ha/gaps/bulk", {
+      rows: [morningGap, motionHallGap],
+    });
+    const morningId = bulk.payload.gaps.find(
+      (g: any) => g.kind === "no_morning_routine",
+    ).id;
+    const dismiss = await call(
+      "PATCH",
+      `/api/v1/channels/ha/gap/${morningId}/dismiss`,
+    );
+    assert.equal(dismiss.status, 200, JSON.stringify(dismiss.payload));
+    assert.equal(dismiss.payload.status, "dismissed");
+    const list = await call("GET", "/api/v1/channels/ha/gaps");
+    assert.equal(list.status, 200);
+    assert.equal(list.payload.open.length, 1);
+    assert.equal(list.payload.open[0].kind, "no_motion_lighting");
+    // Closed bucket carries the dismissed row.
+    assert.equal(list.payload.closed.length, 1);
+    assert.equal(list.payload.closed[0].kind, "no_morning_routine");
+    assert.equal(list.payload.closed[0].status, "dismissed");
+  });
+
+  it("PATCH dismiss on unknown gap returns 404", async () => {
+    const r = await call(
+      "PATCH",
+      "/api/v1/channels/ha/gap/01HX0000000000000000000000/dismiss",
+    );
+    assert.equal(r.status, 404);
+    assert.equal(r.payload.error.code, "NOT_FOUND");
+  });
+
+  it("POST reject on pending proposal flips status, idempotent", async () => {
+    const create = await call("POST", "/api/v1/channels/ha/proposal", {
+      kind: "no_party_mode",
+      summary: "Add party mode.",
+      yaml: "alias: y\ntrigger: []\naction: []\n",
+    });
+    const id = create.payload.proposal_id;
+    const r = await call(
+      "POST",
+      `/api/v1/channels/ha/proposal/${id}/reject`,
+    );
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.status, "rejected");
+    // Idempotent — second reject on a rejected proposal is 200, not 409.
+    const r2 = await call(
+      "POST",
+      `/api/v1/channels/ha/proposal/${id}/reject`,
+    );
+    assert.equal(r2.status, 200);
+    assert.equal(r2.payload.status, "rejected");
+
+    const list = await call("GET", "/api/v1/channels/ha/proposals");
+    assert.equal(list.payload.pending.length, 0);
+    assert.equal(list.payload.other.length, 1);
+    assert.equal(list.payload.other[0].status, "rejected");
+  });
+
+  it("bulk POST without operator bearer returns 401 when key is set", async () => {
+    setApiKey(MASTER_KEY);
+    const r = await call("POST", "/api/v1/channels/ha/gaps/bulk", {
+      rows: [morningGap],
+    });
+    assert.equal(r.status, 401);
+    assert.equal(r.payload.error.code, "UNAUTHORIZED");
+
+    // With the master key, the route succeeds.
+    const ok = await call(
+      "POST",
+      "/api/v1/channels/ha/gaps/bulk",
+      { rows: [morningGap] },
+      MASTER_KEY,
+    );
+    assert.equal(ok.status, 200);
+  });
+});

--- a/packages/learn/src/activities/ha_gap_detection.py
+++ b/packages/learn/src/activities/ha_gap_detection.py
@@ -1,0 +1,1132 @@
+"""HaBootstrapWorkflow Phase B + C — gap detection + proposal generation (#110 PR6).
+
+Phase A (#110 PR5) populates ``ha_registry`` every 6h. Phase B reads
+that registry, scans for the 8 baseline patterns the spec lists, and
+emits an ``ha_gap`` row per missing capability. Phase C then templates
+a concrete ``ha_proposal`` row (YAML automation) per open gap so the
+principal can click "Apply" on the HaCard.
+
+The 8 gap kinds (per spec):
+
+  1. ``no_morning_routine`` — no automation lights up the house in
+     6am–9am, neither via ``sun.below_horizon`` nor ``time`` trigger.
+  2. ``no_bedtime_routine`` — no automation turns lights off + locks
+     doors with a ``time`` trigger after 22:00.
+  3. ``no_motion_lighting`` — ``binary_sensor.*motion*`` exists in an
+     area but no automation in that area triggers on it.
+  4. ``no_away_mode`` — ``device_tracker.*`` exists but no automation
+     triggers on ``not_home``.
+  5. ``no_security_camera_notification`` — ``camera.*`` entities exist
+     but no automation pushes a notification on motion.
+  6. ``no_vacation_mode`` — no ``input_boolean`` named ``vacation*``
+     or ``away*`` with associated lighting-randomization automation.
+  7. ``no_climate_schedule`` — ``climate.*`` exists but no automation
+     adjusts setpoint by time-of-day.
+  8. ``no_party_mode`` — no ``input_boolean`` named ``party*`` with
+     scene activation.
+
+The functions in this module are intentionally PURE (no I/O, no
+network, no LLM). The workflow side wraps them as
+``@activity.defn`` entry points that fetch the registry from
+ctrl-api, run detect/generate, and POST the rows back. Keeping the
+core logic pure means we can unit-test every gap kind under
+``pytest`` without a Temporal harness or a fake HTTP server.
+
+Privacy: the YAML templates use ``area_id`` placeholders pulled
+straight from ``ha_registry.area_id`` (no PII), and never reflect
+any user-supplied attribute body. ``decision_ref`` minting happens
+in ctrl-api at apply-time, not here.
+
+Storage contract (no migration in PR6 — re-uses the PR1 schema):
+
+  ``ha_gap`` columns:
+    * ``id``           — ulid, minted at insert time
+    * ``ts``           — discovered_at (ISO-8601)
+    * ``kind``         — one of the 8 kinds above
+    * ``evidence``     — JSON string carrying area_id / device_id /
+                         summary / severity / extra context (the
+                         columns the spec asks for that aren't in
+                         the PR1 schema — they ride here)
+    * ``fix_pack``     — baseline pack id (== ``kind`` today)
+    * ``proposal_ref`` — set to the ``ha_proposal.id`` once Phase C
+                         emits one
+    * ``status``       — open|addressed|dismissed
+    * ``created_at``   — DB default
+
+The detector returns a list of ``HaGapRow`` typed dicts; the
+generator returns ``HaProposalRow`` dicts. Both shapes match what
+ctrl-api's bulk-upsert + proposal-create routes accept.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import uuid
+from datetime import datetime, timezone
+from typing import Any, TypedDict
+
+import httpx
+from temporalio import activity
+
+from src.config import load_config
+
+logger = logging.getLogger("ha-gap-detection")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Types — kept narrow on purpose. The detector returns plain dicts so
+# the workflow can JSON-serialise straight to ctrl-api without a
+# pydantic dance.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class HaGapRow(TypedDict, total=False):
+    kind: str
+    summary: str
+    severity: str
+    area_id: str | None
+    device_id: str | None
+    discovered_at: str
+    evidence: dict[str, Any]
+
+
+class HaProposalRow(TypedDict, total=False):
+    kind: str
+    summary: str
+    yaml: str
+    gap_id: str | None
+
+
+# Registry shape we accept — same shape ctrl-api's GET /registry
+# returns. Each list is a list of payload dicts (the raw HA records).
+class HaRegistry(TypedDict, total=False):
+    entities: list[dict[str, Any]]
+    areas: list[dict[str, Any]]
+    devices: list[dict[str, Any]]
+    automations: list[dict[str, Any]]
+    scenes: list[dict[str, Any]]
+    helpers: list[dict[str, Any]]
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Helpers — registry shape normalisation
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _entities(reg: HaRegistry) -> list[dict[str, Any]]:
+    e = reg.get("entities")
+    return e if isinstance(e, list) else []
+
+
+def _areas(reg: HaRegistry) -> list[dict[str, Any]]:
+    a = reg.get("areas")
+    return a if isinstance(a, list) else []
+
+
+def _devices(reg: HaRegistry) -> list[dict[str, Any]]:
+    d = reg.get("devices")
+    return d if isinstance(d, list) else []
+
+
+def _automations(reg: HaRegistry) -> list[dict[str, Any]]:
+    a = reg.get("automations")
+    return a if isinstance(a, list) else []
+
+
+def _helpers(reg: HaRegistry) -> list[dict[str, Any]]:
+    h = reg.get("helpers")
+    return h if isinstance(h, list) else []
+
+
+def _entity_id(record: dict[str, Any]) -> str:
+    eid = record.get("entity_id") or record.get("ha_id")
+    return eid if isinstance(eid, str) else ""
+
+
+def _domain_of(entity_id: str) -> str:
+    if "." not in entity_id:
+        return ""
+    return entity_id.split(".", 1)[0]
+
+
+def _attrs(record: dict[str, Any]) -> dict[str, Any]:
+    a = record.get("attributes")
+    return a if isinstance(a, dict) else {}
+
+
+def _entities_by_domain(reg: HaRegistry, domain: str) -> list[dict[str, Any]]:
+    out = []
+    for e in _entities(reg):
+        if not isinstance(e, dict):
+            continue
+        eid = _entity_id(e)
+        if _domain_of(eid) == domain:
+            out.append(e)
+    return out
+
+
+def _area_of(record: dict[str, Any]) -> str | None:
+    aid = record.get("area_id")
+    if isinstance(aid, str) and aid:
+        return aid
+    return None
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Automation introspection — every gap detector reduces to "is there an
+# automation that does X?". We give them a single shared inspection
+# layer over the automation list.
+#
+# An automation is a dict with at least ``entity_id`` (automation.foo);
+# its triggers + actions can live in the top-level ``attributes`` or
+# under a ``yaml_config`` blob (the PR5 normaliser stashes
+# ``/api/config/automation/config/<id>`` there when available). We try
+# both paths.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _automation_blocks(auto: dict[str, Any]) -> dict[str, Any]:
+    """Return a dict with normalised triggers/actions/conditions lists."""
+    blocks: dict[str, list[Any]] = {
+        "triggers": [],
+        "actions": [],
+        "conditions": [],
+    }
+
+    # YAML config attached by PR5 normaliser.
+    yaml_config = auto.get("yaml_config")
+    if isinstance(yaml_config, dict):
+        for src_key, dst_key in (
+            ("trigger", "triggers"),
+            ("triggers", "triggers"),
+            ("action", "actions"),
+            ("actions", "actions"),
+            ("condition", "conditions"),
+            ("conditions", "conditions"),
+        ):
+            v = yaml_config.get(src_key)
+            if isinstance(v, list):
+                blocks[dst_key].extend(v)
+            elif isinstance(v, dict):
+                blocks[dst_key].append(v)
+
+    # Some HA versions surface "trigger"/"action" under attributes.
+    attrs = _attrs(auto)
+    for src_key, dst_key in (
+        ("trigger", "triggers"),
+        ("triggers", "triggers"),
+        ("action", "actions"),
+        ("actions", "actions"),
+    ):
+        v = attrs.get(src_key)
+        if isinstance(v, list):
+            blocks[dst_key].extend(v)
+
+    # Friendly area hint sits at the top of the row (HA's UI lets you
+    # assign an automation to an area for organisation).
+    return blocks
+
+
+def _automation_area_ids(auto: dict[str, Any]) -> set[str]:
+    """All area_id hints we can read off an automation row.
+
+    HA's automation YAML lets ``target: { area_id: kitchen }`` appear in
+    any action block. We collect all of them — a single automation can
+    be "in" multiple areas.
+    """
+    ids: set[str] = set()
+    direct = _area_of(auto)
+    if direct:
+        ids.add(direct)
+
+    blocks = _automation_blocks(auto)
+    for action in blocks["actions"]:
+        if not isinstance(action, dict):
+            continue
+        target = action.get("target")
+        if isinstance(target, dict):
+            aid = target.get("area_id")
+            if isinstance(aid, str):
+                ids.add(aid)
+            elif isinstance(aid, list):
+                for v in aid:
+                    if isinstance(v, str):
+                        ids.add(v)
+        # Top-level area_id on the action block.
+        aid = action.get("area_id")
+        if isinstance(aid, str):
+            ids.add(aid)
+    return ids
+
+
+def _automation_trigger_kinds(auto: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return all trigger blocks as a flat list."""
+    blocks = _automation_blocks(auto)
+    return [t for t in blocks["triggers"] if isinstance(t, dict)]
+
+
+def _automation_action_services(auto: dict[str, Any]) -> list[str]:
+    """Return all ``service`` strings referenced anywhere in actions.
+
+    ``light.turn_on``, ``notify.mobile_app_iphone``, ``lock.lock`` —
+    flat list, preserves order, includes duplicates.
+    """
+    out: list[str] = []
+    blocks = _automation_blocks(auto)
+    for action in blocks["actions"]:
+        if not isinstance(action, dict):
+            continue
+        svc = action.get("service")
+        if isinstance(svc, str):
+            out.append(svc)
+        # Some YAMLs use {service: light.turn_on, target: ...}; some
+        # use the script-style {action: light.turn_on}.
+        alt = action.get("action")
+        if isinstance(alt, str) and "." in alt:
+            out.append(alt)
+    return out
+
+
+def _trigger_references_entity(
+    trigger: dict[str, Any], entity_id: str,
+) -> bool:
+    """True iff trigger watches the given entity_id (state platform)."""
+    plat = trigger.get("platform") or trigger.get("trigger")
+    if plat != "state":
+        return False
+    eid = trigger.get("entity_id")
+    if isinstance(eid, str):
+        return eid == entity_id
+    if isinstance(eid, list):
+        return entity_id in eid
+    return False
+
+
+def _trigger_is_sun(trigger: dict[str, Any]) -> bool:
+    plat = trigger.get("platform") or trigger.get("trigger")
+    return plat == "sun"
+
+
+def _trigger_is_time(trigger: dict[str, Any]) -> bool:
+    plat = trigger.get("platform") or trigger.get("trigger")
+    return plat == "time"
+
+
+def _trigger_time_at(trigger: dict[str, Any]) -> str | None:
+    at = trigger.get("at")
+    if isinstance(at, str):
+        return at
+    if isinstance(at, list) and at and isinstance(at[0], str):
+        return at[0]
+    return None
+
+
+def _hour_of(time_str: str | None) -> int | None:
+    """Parse "HH:MM[:SS]" → integer hour. None on malformed."""
+    if not isinstance(time_str, str):
+        return None
+    m = re.match(r"^(\d{1,2}):(\d{2})", time_str.strip())
+    if not m:
+        return None
+    h = int(m.group(1))
+    if 0 <= h <= 23:
+        return h
+    return None
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Gap detectors — one per kind. Each returns a list[HaGapRow] (may be
+# empty). detect_gaps() chains them all.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _gap_no_morning_routine(reg: HaRegistry) -> list[HaGapRow]:
+    """Gap if no automation turns lights on in 6am-9am or near sunrise."""
+    autos = _automations(reg)
+    lights = _entities_by_domain(reg, "light")
+    if not lights:
+        # No lights at all — not a fixable gap, skip.
+        return []
+
+    for auto in autos:
+        triggers = _automation_trigger_kinds(auto)
+        services = _automation_action_services(auto)
+        has_light_turn_on = any(
+            s == "light.turn_on" or s == "scene.turn_on" for s in services
+        )
+        if not has_light_turn_on:
+            continue
+        for trig in triggers:
+            if _trigger_is_sun(trig):
+                event = trig.get("event") or ""
+                if event in ("sunrise", "sunset"):
+                    if event == "sunrise":
+                        return []
+                # sun.below_horizon is technically a state trigger but
+                # HA's modern YAML uses `platform: sun` with event.
+                continue
+            if _trigger_is_time(trig):
+                at = _trigger_time_at(trig)
+                h = _hour_of(at)
+                if h is not None and 6 <= h < 9:
+                    return []
+
+    # No qualifying automation — surface the gap once. We don't
+    # localise per-area; morning is whole-home.
+    return [
+        HaGapRow(
+            kind="no_morning_routine",
+            summary="No morning lighting routine — lights aren't woken at sunrise.",
+            severity="medium",
+            area_id=None,
+            device_id=None,
+            evidence={"light_count": len(lights)},
+        )
+    ]
+
+
+def _gap_no_bedtime_routine(reg: HaRegistry) -> list[HaGapRow]:
+    """Gap if no time-triggered automation after 22:00 turns lights off + locks doors."""
+    autos = _automations(reg)
+    has_lights = bool(_entities_by_domain(reg, "light"))
+    has_locks = bool(_entities_by_domain(reg, "lock"))
+    if not has_lights and not has_locks:
+        return []
+
+    for auto in autos:
+        triggers = _automation_trigger_kinds(auto)
+        services = _automation_action_services(auto)
+        has_late_time_trigger = False
+        for trig in triggers:
+            if _trigger_is_time(trig):
+                h = _hour_of(_trigger_time_at(trig))
+                if h is not None and (h >= 22 or h <= 2):
+                    has_late_time_trigger = True
+                    break
+        if not has_late_time_trigger:
+            continue
+
+        turns_lights_off = any(s == "light.turn_off" for s in services)
+        locks_doors = any(s == "lock.lock" for s in services)
+        # If lights exist, we want light-off; if locks exist, we want lock.
+        ok = True
+        if has_lights and not turns_lights_off:
+            ok = False
+        if has_locks and not locks_doors:
+            ok = False
+        if ok:
+            return []
+
+    return [
+        HaGapRow(
+            kind="no_bedtime_routine",
+            summary="No bedtime routine — lights stay on and doors aren't auto-locked at night.",
+            severity="medium",
+            area_id=None,
+            device_id=None,
+            evidence={"has_lights": has_lights, "has_locks": has_locks},
+        )
+    ]
+
+
+_MOTION_AREA_KEYWORDS = ("hall", "bath", "corridor", "landing", "entry", "foyer", "stair")
+
+
+def _is_motion_sensor(entity: dict[str, Any]) -> bool:
+    eid = _entity_id(entity)
+    if _domain_of(eid) != "binary_sensor":
+        return False
+    if "motion" in eid.lower():
+        return True
+    attrs = _attrs(entity)
+    dc = attrs.get("device_class")
+    if isinstance(dc, str) and dc == "motion":
+        return True
+    return False
+
+
+def _gap_no_motion_lighting(reg: HaRegistry) -> list[HaGapRow]:
+    """Gap PER AREA: motion sensor exists but no automation triggers off it.
+
+    Restricted to the canonical "passing-through" areas (hallway,
+    bathroom, foyer, …) — kitchens and bedrooms typically don't want
+    motion-on lights because the principal is doing intentional work
+    there.
+    """
+    autos = _automations(reg)
+    area_id_to_name: dict[str, str] = {}
+    for a in _areas(reg):
+        if not isinstance(a, dict):
+            continue
+        aid = a.get("ha_id") or a.get("area_id") or a.get("id")
+        nm = a.get("name") or a.get("friendly_name") or aid
+        if isinstance(aid, str):
+            area_id_to_name[aid] = nm if isinstance(nm, str) else aid
+
+    gaps: list[HaGapRow] = []
+    seen_areas: set[str] = set()
+
+    for sensor in _entities(reg):
+        if not isinstance(sensor, dict):
+            continue
+        if not _is_motion_sensor(sensor):
+            continue
+        area_id = _area_of(sensor)
+        if not area_id:
+            continue
+        if area_id in seen_areas:
+            continue
+        # Only flag the "passing through" areas.
+        name = (area_id_to_name.get(area_id) or area_id).lower()
+        if not any(k in name or k in area_id.lower() for k in _MOTION_AREA_KEYWORDS):
+            continue
+        seen_areas.add(area_id)
+
+        # Is there an automation in this area that's triggered by this
+        # sensor and turns a light on?
+        eid = _entity_id(sensor)
+        covered = False
+        for auto in autos:
+            triggers = _automation_trigger_kinds(auto)
+            if not any(_trigger_references_entity(t, eid) for t in triggers):
+                continue
+            services = _automation_action_services(auto)
+            if any(s in ("light.turn_on", "scene.turn_on", "switch.turn_on") for s in services):
+                covered = True
+                break
+        if covered:
+            continue
+
+        gaps.append(
+            HaGapRow(
+                kind="no_motion_lighting",
+                summary=(
+                    f"Motion sensor in {area_id_to_name.get(area_id, area_id)} "
+                    f"isn't wired to a light — dark walks at night."
+                ),
+                severity="low",
+                area_id=area_id,
+                device_id=None,
+                evidence={"sensor": eid, "area": area_id_to_name.get(area_id, area_id)},
+            )
+        )
+    return gaps
+
+
+def _gap_no_away_mode(reg: HaRegistry) -> list[HaGapRow]:
+    """Gap if device_tracker.* exists but no automation triggers on not_home."""
+    trackers = _entities_by_domain(reg, "device_tracker")
+    if not trackers:
+        return []
+
+    autos = _automations(reg)
+    for auto in autos:
+        triggers = _automation_trigger_kinds(auto)
+        for trig in triggers:
+            plat = trig.get("platform") or trig.get("trigger")
+            if plat != "state":
+                continue
+            to = trig.get("to") or trig.get("to_state")
+            if to == "not_home":
+                return []
+            # numeric_state / zone-leave variant.
+            eid = trig.get("entity_id")
+            entities = eid if isinstance(eid, list) else [eid] if isinstance(eid, str) else []
+            if any(
+                isinstance(e, str) and e.startswith("device_tracker.")
+                for e in entities
+            ):
+                # Found a device_tracker watcher — count it.
+                return []
+
+    return [
+        HaGapRow(
+            kind="no_away_mode",
+            summary="No away-mode automation — Alfred can't dim or lock when the house empties.",
+            severity="medium",
+            area_id=None,
+            device_id=None,
+            evidence={"tracker_count": len(trackers)},
+        )
+    ]
+
+
+def _gap_no_security_camera_notification(reg: HaRegistry) -> list[HaGapRow]:
+    """Gap if camera.* exists but no automation notifies on motion."""
+    cameras = _entities_by_domain(reg, "camera")
+    if not cameras:
+        return []
+
+    motion_sensors = [
+        e for e in _entities(reg) if isinstance(e, dict) and _is_motion_sensor(e)
+    ]
+    if not motion_sensors:
+        return []
+
+    autos = _automations(reg)
+    motion_ids = {_entity_id(s) for s in motion_sensors}
+    for auto in autos:
+        triggers = _automation_trigger_kinds(auto)
+        triggered_by_motion = False
+        for trig in triggers:
+            eid = trig.get("entity_id")
+            if isinstance(eid, str) and eid in motion_ids:
+                triggered_by_motion = True
+                break
+            if isinstance(eid, list) and any(e in motion_ids for e in eid):
+                triggered_by_motion = True
+                break
+        if not triggered_by_motion:
+            continue
+        services = _automation_action_services(auto)
+        if any(s.startswith("notify.") or s == "persistent_notification.create" for s in services):
+            return []
+
+    return [
+        HaGapRow(
+            kind="no_security_camera_notification",
+            summary="Cameras + motion sensors live, but no notification fires on motion.",
+            severity="high",
+            area_id=None,
+            device_id=None,
+            evidence={"camera_count": len(cameras), "motion_sensor_count": len(motion_sensors)},
+        )
+    ]
+
+
+def _input_boolean_names(reg: HaRegistry) -> list[str]:
+    """All input_boolean entity ids (e.g. ``input_boolean.vacation_mode``)."""
+    names: list[str] = []
+    for e in _entities(reg):
+        if not isinstance(e, dict):
+            continue
+        eid = _entity_id(e)
+        if _domain_of(eid) == "input_boolean":
+            names.append(eid)
+    for h in _helpers(reg):
+        if not isinstance(h, dict):
+            continue
+        eid = _entity_id(h)
+        if _domain_of(eid) == "input_boolean":
+            names.append(eid)
+    return names
+
+
+def _gap_no_vacation_mode(reg: HaRegistry) -> list[HaGapRow]:
+    """Gap if no input_boolean named vacation*|away* exists with light-randomisation."""
+    bools = _input_boolean_names(reg)
+    has_vacation_helper = any(
+        ("vacation" in b.split(".", 1)[1].lower() if "." in b else False)
+        or ("away" in b.split(".", 1)[1].lower() if "." in b else False)
+        for b in bools
+    )
+    lights = _entities_by_domain(reg, "light")
+    if not lights:
+        return []
+    if not has_vacation_helper:
+        return [
+            HaGapRow(
+                kind="no_vacation_mode",
+                summary="No vacation mode — lights won't randomise when you're away.",
+                severity="low",
+                area_id=None,
+                device_id=None,
+                evidence={"light_count": len(lights), "input_booleans_present": bools},
+            )
+        ]
+    # Helper exists — is any automation triggered by it AND randomising lights?
+    autos = _automations(reg)
+    vacation_ids = {b for b in bools if "vacation" in b.lower() or "away" in b.lower()}
+    for auto in autos:
+        triggers = _automation_trigger_kinds(auto)
+        if not any(
+            isinstance(t.get("entity_id"), str) and t.get("entity_id") in vacation_ids
+            for t in triggers
+        ):
+            continue
+        services = _automation_action_services(auto)
+        if any(s in ("light.turn_on", "scene.turn_on") for s in services):
+            return []
+    return [
+        HaGapRow(
+            kind="no_vacation_mode",
+            summary="Vacation helper exists but isn't wired to randomise lights.",
+            severity="low",
+            area_id=None,
+            device_id=None,
+            evidence={"input_booleans_present": list(vacation_ids)},
+        )
+    ]
+
+
+def _gap_no_climate_schedule(reg: HaRegistry) -> list[HaGapRow]:
+    """Gap if climate.* exists but no automation adjusts setpoint by time-of-day."""
+    climates = _entities_by_domain(reg, "climate")
+    if not climates:
+        return []
+    autos = _automations(reg)
+    for auto in autos:
+        triggers = _automation_trigger_kinds(auto)
+        has_time_trigger = any(_trigger_is_time(t) for t in triggers)
+        if not has_time_trigger:
+            continue
+        services = _automation_action_services(auto)
+        if any(
+            s in (
+                "climate.set_temperature",
+                "climate.set_hvac_mode",
+                "climate.set_preset_mode",
+            )
+            for s in services
+        ):
+            return []
+    return [
+        HaGapRow(
+            kind="no_climate_schedule",
+            summary="Climate runs flat — no time-of-day setpoint adjustment.",
+            severity="low",
+            area_id=None,
+            device_id=None,
+            evidence={"climate_count": len(climates)},
+        )
+    ]
+
+
+def _gap_no_party_mode(reg: HaRegistry) -> list[HaGapRow]:
+    """Gap if no input_boolean named party* with scene activation."""
+    bools = _input_boolean_names(reg)
+    party_bools = [b for b in bools if "party" in b.lower()]
+    scenes = reg.get("scenes") or []
+    if not isinstance(scenes, list):
+        scenes = []
+    # If you have no scenes at all, party-mode is hard to template, but
+    # we still surface the gap so the operator sees the option.
+    if not party_bools:
+        return [
+            HaGapRow(
+                kind="no_party_mode",
+                summary="No party mode — single tap to turn the house into a party.",
+                severity="low",
+                area_id=None,
+                device_id=None,
+                evidence={"scene_count": len(scenes)},
+            )
+        ]
+    # Helper exists — is an automation triggered by it activating a scene?
+    autos = _automations(reg)
+    party_ids = set(party_bools)
+    for auto in autos:
+        triggers = _automation_trigger_kinds(auto)
+        if not any(
+            isinstance(t.get("entity_id"), str) and t.get("entity_id") in party_ids
+            for t in triggers
+        ):
+            continue
+        services = _automation_action_services(auto)
+        if "scene.turn_on" in services:
+            return []
+    return [
+        HaGapRow(
+            kind="no_party_mode",
+            summary="Party helper exists but no scene activates from it.",
+            severity="low",
+            area_id=None,
+            device_id=None,
+            evidence={"input_booleans_present": list(party_ids)},
+        )
+    ]
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Public — detect_gaps + generate_proposal
+# ─────────────────────────────────────────────────────────────────────────
+
+
+_DETECTORS = (
+    _gap_no_morning_routine,
+    _gap_no_bedtime_routine,
+    _gap_no_motion_lighting,
+    _gap_no_away_mode,
+    _gap_no_security_camera_notification,
+    _gap_no_vacation_mode,
+    _gap_no_climate_schedule,
+    _gap_no_party_mode,
+)
+
+
+def detect_gaps(registry: HaRegistry) -> list[HaGapRow]:
+    """Run all 8 baseline-pattern detectors against the registry.
+
+    Returns a list of HaGapRow dicts — one per missing capability.
+    Each row carries the discovery timestamp so ctrl-api can dedupe.
+    Empty registries → empty list (nothing to detect).
+    """
+    if not isinstance(registry, dict):
+        return []
+    now = _utc_now_iso()
+    gaps: list[HaGapRow] = []
+    for detector in _DETECTORS:
+        try:
+            results = detector(registry)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "ha-gap-detection: detector %s crashed: %s",
+                detector.__name__,
+                exc,
+            )
+            continue
+        for r in results:
+            r["discovered_at"] = now
+            gaps.append(r)
+    return gaps
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# YAML templates — one per gap kind. Kept inline (no jinja, no external
+# files) so the image size stays flat. Each template is plain ASCII;
+# the principal can customise post-apply.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _yaml_morning() -> str:
+    return (
+        "alias: 'Alfred · Morning lighting'\n"
+        "description: 'Wakes lights gently at sunrise.'\n"
+        "trigger:\n"
+        "  - platform: sun\n"
+        "    event: sunrise\n"
+        "    offset: '-00:30:00'\n"
+        "action:\n"
+        "  - service: light.turn_on\n"
+        "    target:\n"
+        "      entity_id: all\n"
+        "    data:\n"
+        "      brightness_pct: 60\n"
+        "      transition: 300\n"
+        "mode: single\n"
+    )
+
+
+def _yaml_bedtime() -> str:
+    return (
+        "alias: 'Alfred · Bedtime'\n"
+        "description: 'Lights off + doors locked at 22:30.'\n"
+        "trigger:\n"
+        "  - platform: time\n"
+        "    at: '22:30:00'\n"
+        "action:\n"
+        "  - service: light.turn_off\n"
+        "    target:\n"
+        "      entity_id: all\n"
+        "  - service: lock.lock\n"
+        "    target:\n"
+        "      entity_id: all\n"
+        "mode: single\n"
+    )
+
+
+def _yaml_motion_lighting(area_id: str | None) -> str:
+    target = (
+        f"      area_id: {area_id}\n"
+        if isinstance(area_id, str) and area_id
+        else "      entity_id: all\n"
+    )
+    area_label = area_id or "area"
+    return (
+        f"alias: 'Alfred · Motion lighting · {area_label}'\n"
+        "description: 'Turn the light on when motion is detected.'\n"
+        "trigger:\n"
+        "  - platform: state\n"
+        "    entity_id: binary_sensor.motion\n"
+        "    to: 'on'\n"
+        "action:\n"
+        "  - service: light.turn_on\n"
+        "    target:\n"
+        f"{target}"
+        "    data:\n"
+        "      brightness_pct: 80\n"
+        "      transition: 1\n"
+        "mode: single\n"
+    )
+
+
+def _yaml_away_mode() -> str:
+    return (
+        "alias: 'Alfred · Away mode'\n"
+        "description: 'Dim lights + lock doors when everyone leaves.'\n"
+        "trigger:\n"
+        "  - platform: state\n"
+        "    entity_id: group.family\n"
+        "    to: 'not_home'\n"
+        "action:\n"
+        "  - service: light.turn_off\n"
+        "    target:\n"
+        "      entity_id: all\n"
+        "  - service: lock.lock\n"
+        "    target:\n"
+        "      entity_id: all\n"
+        "mode: single\n"
+    )
+
+
+def _yaml_security_notify() -> str:
+    return (
+        "alias: 'Alfred · Camera motion notify'\n"
+        "description: 'Push a notification when motion fires near a camera.'\n"
+        "trigger:\n"
+        "  - platform: state\n"
+        "    entity_id: binary_sensor.motion\n"
+        "    to: 'on'\n"
+        "action:\n"
+        "  - service: notify.mobile_app\n"
+        "    data:\n"
+        "      title: 'Motion at home'\n"
+        "      message: 'Camera saw movement.'\n"
+        "mode: single\n"
+    )
+
+
+def _yaml_vacation_mode() -> str:
+    return (
+        "alias: 'Alfred · Vacation lighting'\n"
+        "description: 'Randomise lights while vacation mode is on.'\n"
+        "trigger:\n"
+        "  - platform: state\n"
+        "    entity_id: input_boolean.vacation_mode\n"
+        "    to: 'on'\n"
+        "action:\n"
+        "  - service: light.turn_on\n"
+        "    target:\n"
+        "      entity_id: all\n"
+        "    data:\n"
+        "      brightness_pct: 50\n"
+        "  - delay:\n"
+        "      minutes: 90\n"
+        "  - service: light.turn_off\n"
+        "    target:\n"
+        "      entity_id: all\n"
+        "mode: restart\n"
+    )
+
+
+def _yaml_climate_schedule() -> str:
+    return (
+        "alias: 'Alfred · Climate schedule'\n"
+        "description: 'Adjust setpoint by time of day.'\n"
+        "trigger:\n"
+        "  - platform: time\n"
+        "    at: '06:30:00'\n"
+        "    id: morning\n"
+        "  - platform: time\n"
+        "    at: '22:00:00'\n"
+        "    id: night\n"
+        "action:\n"
+        "  - choose:\n"
+        "      - conditions:\n"
+        "          - condition: trigger\n"
+        "            id: morning\n"
+        "        sequence:\n"
+        "          - service: climate.set_temperature\n"
+        "            data:\n"
+        "              temperature: 21\n"
+        "      - conditions:\n"
+        "          - condition: trigger\n"
+        "            id: night\n"
+        "        sequence:\n"
+        "          - service: climate.set_temperature\n"
+        "            data:\n"
+        "              temperature: 18\n"
+        "mode: single\n"
+    )
+
+
+def _yaml_party_mode() -> str:
+    return (
+        "alias: 'Alfred · Party mode'\n"
+        "description: 'One tap turns the house into a party.'\n"
+        "trigger:\n"
+        "  - platform: state\n"
+        "    entity_id: input_boolean.party_mode\n"
+        "    to: 'on'\n"
+        "action:\n"
+        "  - service: scene.turn_on\n"
+        "    target:\n"
+        "      entity_id: scene.party\n"
+        "mode: single\n"
+    )
+
+
+_YAML_BY_KIND = {
+    "no_morning_routine": lambda gap: _yaml_morning(),
+    "no_bedtime_routine": lambda gap: _yaml_bedtime(),
+    "no_motion_lighting": lambda gap: _yaml_motion_lighting(gap.get("area_id")),
+    "no_away_mode": lambda gap: _yaml_away_mode(),
+    "no_security_camera_notification": lambda gap: _yaml_security_notify(),
+    "no_vacation_mode": lambda gap: _yaml_vacation_mode(),
+    "no_climate_schedule": lambda gap: _yaml_climate_schedule(),
+    "no_party_mode": lambda gap: _yaml_party_mode(),
+}
+
+
+def generate_proposal(gap: HaGapRow) -> HaProposalRow:
+    """Template a concrete ha_proposal row from one gap row.
+
+    Returns ``{kind, summary, yaml, gap_id}``. The ``gap_id`` is the
+    ulid the bulk-upsert route minted; the workflow passes it through
+    from the bulk-upsert response (or None for ad-hoc generation).
+
+    Raises ``ValueError`` on an unknown gap kind.
+    """
+    kind = gap.get("kind", "")
+    if kind not in _YAML_BY_KIND:
+        raise ValueError(f"unknown gap kind: {kind!r}")
+    yaml = _YAML_BY_KIND[kind](gap)
+    summary = gap.get("summary") or kind
+    return HaProposalRow(
+        kind=kind,
+        summary=summary,
+        yaml=yaml,
+        gap_id=gap.get("id") if isinstance(gap.get("id"), str) else None,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Activities — Phase B + Phase C entry points wired into the workflow.
+#
+# Both are thin orchestrators over ctrl-api (read registry, write
+# gaps, write proposals). The detect/generate work happens in the
+# pure functions above so the activities can be re-tried freely
+# without re-running the actual detection logic on stale state.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _ctrl_headers() -> dict[str, str]:
+    api_key = os.environ.get("AAS_API_KEY", "")
+    return {"Authorization": f"Bearer {api_key}"} if api_key else {}
+
+
+async def _ctrl_get(path: str) -> tuple[int, dict[str, Any]]:
+    config = load_config()
+    url = f"{config.alfred_ctrl_url}{path}"
+    async with httpx.AsyncClient(timeout=30.0) as http:
+        resp = await http.get(url, headers=_ctrl_headers())
+        try:
+            body = resp.json()
+        except ValueError:
+            body = {}
+        return resp.status_code, body
+
+
+async def _ctrl_post(path: str, body: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+    config = load_config()
+    url = f"{config.alfred_ctrl_url}{path}"
+    async with httpx.AsyncClient(timeout=60.0) as http:
+        resp = await http.post(url, headers=_ctrl_headers(), json=body)
+        try:
+            data = resp.json()
+        except ValueError:
+            data = {}
+        return resp.status_code, data
+
+
+@activity.defn(name="detect_ha_gaps")
+async def detect_ha_gaps() -> dict[str, Any]:
+    """Phase B: read ctrl-api's registry, run detect_gaps, bulk-upsert gaps.
+
+    Returns ``{"ok": True, "gaps": [...], "inserted": N, "addressed": M,
+    "dismissed": K}`` on success, or ``{"ok": False, "code": "..."}`` on
+    a known failure path.
+
+    The ``gaps`` list in the response carries the server-minted ``id``
+    values so the caller (Phase C) can attach them to the proposal
+    rows it generates next.
+    """
+    code, body = await _ctrl_get("/api/v1/channels/ha/registry")
+    if code != 200 or not isinstance(body, dict):
+        return {"ok": False, "code": "REGISTRY_UNREACHABLE", "gaps": []}
+
+    registry: HaRegistry = body  # type: ignore[assignment]
+    gaps = detect_gaps(registry)
+
+    upsert_code, upsert_body = await _ctrl_post(
+        "/api/v1/channels/ha/gaps/bulk",
+        {"rows": gaps},
+    )
+    if upsert_code != 200 or not isinstance(upsert_body, dict) or not upsert_body.get("ok"):
+        return {"ok": False, "code": "GAP_BULK_FAILED", "gaps": []}
+
+    return {
+        "ok": True,
+        "gaps": upsert_body.get("gaps") or [],
+        "inserted": int(upsert_body.get("inserted", 0)),
+        "updated": int(upsert_body.get("updated", 0)),
+        "addressed": int(upsert_body.get("addressed", 0)),
+        "dismissed": int(upsert_body.get("dismissed", 0)),
+    }
+
+
+@activity.defn(name="generate_ha_proposals")
+async def generate_ha_proposals(gaps: list[dict[str, Any]]) -> dict[str, Any]:
+    """Phase C: template a proposal per open gap, POST each to ctrl-api.
+
+    Already-applied or already-addressed gaps are skipped — the bulk
+    route also filters them, but we double-check on this side so a
+    flaky network doesn't queue two proposals for the same gap.
+
+    Returns ``{"ok": True, "created": N, "skipped": M}``.
+    """
+    if not isinstance(gaps, list):
+        return {"ok": False, "code": "BAD_GAPS_INPUT", "created": 0, "skipped": 0}
+
+    created = 0
+    skipped = 0
+    for gap in gaps:
+        if not isinstance(gap, dict):
+            skipped += 1
+            continue
+        status = gap.get("status")
+        if status and status != "open":
+            skipped += 1
+            continue
+        if gap.get("proposal_ref"):
+            skipped += 1
+            continue
+        try:
+            proposal = generate_proposal(gap)  # type: ignore[arg-type]
+        except ValueError as exc:
+            logger.warning("generate_ha_proposals: skipping gap: %s", exc)
+            skipped += 1
+            continue
+        # Stamp the FK link to the gap row.
+        body = {
+            "kind": proposal["kind"],
+            "summary": proposal["summary"],
+            "yaml": proposal["yaml"],
+        }
+        gap_id = gap.get("id")
+        if isinstance(gap_id, str) and gap_id:
+            body["gap_id"] = gap_id
+        code, resp = await _ctrl_post("/api/v1/channels/ha/proposal", body)
+        if code != 200 or not isinstance(resp, dict) or not resp.get("ok"):
+            logger.warning(
+                "generate_ha_proposals: proposal POST failed kind=%s code=%s",
+                proposal.get("kind"),
+                code,
+            )
+            skipped += 1
+            continue
+        created += 1
+
+    return {"ok": True, "created": created, "skipped": skipped}
+
+
+# Used by tests to mint a deterministic ID-less gap; not part of the
+# activity surface itself.
+def _mint_gap_id() -> str:  # pragma: no cover - trivial
+    return uuid.uuid4().hex

--- a/packages/learn/src/worker.py
+++ b/packages/learn/src/worker.py
@@ -693,6 +693,16 @@ from src.activities.ha_bootstrap import (
     write_ha_registry,
 )
 
+# HA gap detection + proposal generation (#110 PR6) — Phase B + Phase C
+# of HaBootstrapWorkflow. detect_ha_gaps re-reads the registry, runs
+# the 8 baseline detectors, and bulk-upserts ha_gap. generate_ha_proposals
+# templates a concrete YAML automation per open gap and POSTs each to
+# ctrl-api as a `pending` ha_proposal.
+from src.activities.ha_gap_detection import (
+    detect_ha_gaps,
+    generate_ha_proposals,
+)
+
 # Validators used as activities
 from src.validators.frontmatter import validate_classification
 
@@ -1177,6 +1187,10 @@ ALL_ACTIVITIES = [
     # src.workflows.ha_bootstrap.HaBootstrapWorkflow.
     pull_ha_registry,
     write_ha_registry,
+    # HA gap detection + proposal generation (#110 PR6) — Phase B + C
+    # run inside the same HaBootstrapWorkflow after Phase A's write.
+    detect_ha_gaps,
+    generate_ha_proposals,
 ]
 
 

--- a/packages/learn/src/workflows/ha_bootstrap.py
+++ b/packages/learn/src/workflows/ha_bootstrap.py
@@ -1,4 +1,4 @@
-"""HaBootstrapWorkflow Phase A — registry pull + dedupe (#110 PR5).
+"""HaBootstrapWorkflow Phase A + B + C — registry pull + gap + proposal (#110 PR5/PR6).
 
 Pulls the operator-configured Home Assistant install's full entity /
 area / device / automation surface every 6 hours (Temporal schedule
@@ -7,16 +7,24 @@ CTA. Writes the result into ``ha_registry`` via ctrl-api's bulk-upsert
 route which also tombstones (does NOT delete) entities that vanished
 from HA since the previous run.
 
-Phase B (gap detection — "no morning routine", "no motion lighting")
-and Phase C (proposal generation) land in later PRs. Phase A only
-needs the registry to be accurate; the gap + proposal surfaces don't
-exist yet.
+Phase B (PR6, this file) — once the registry refresh completes, scan
+the registry for missing baseline patterns ("no morning routine", "no
+motion lighting", …) and write rows into ``ha_gap``.
 
-The workflow itself is a thin orchestrator over two activities:
+Phase C (PR6, this file) — for each newly-opened gap, template a
+concrete ``ha_proposal`` row (YAML automation pasted into the
+principal's vault as ``pending``). The existing PR4 apply route is
+what the principal clicks on the HaCard to ship it.
 
-  ``pull_ha_registry()``  — read ctrl-api status + LLAT, hit HA REST in
-                             parallel, normalise into bulk-row shape.
-  ``write_ha_registry()`` — POST to ctrl-api's bulk route.
+The workflow itself is a thin orchestrator over the activities:
+
+  ``pull_ha_registry()``    — read ctrl-api status + LLAT, hit HA REST
+                               in parallel, normalise into bulk-row shape.
+  ``write_ha_registry()``   — POST to ctrl-api's bulk route.
+  ``detect_ha_gaps()``      — (PR6 Phase B) re-read the registry and
+                               upsert gap rows.
+  ``generate_ha_proposals()`` — (PR6 Phase C) template a YAML proposal
+                               per open gap.
 
 Retry policy:
 
@@ -48,6 +56,10 @@ with workflow.unsafe.imports_passed_through():
         pull_ha_registry,
         write_ha_registry,
     )
+    from src.activities.ha_gap_detection import (
+        detect_ha_gaps,
+        generate_ha_proposals,
+    )
 
 
 logger = logging.getLogger("ha-bootstrap-workflow")
@@ -67,6 +79,14 @@ _PULL_RETRY = RetryPolicy(
 # realistic failure is a brief WAL contention with another writer, not
 # a 5xx. 2 attempts is enough.
 _WRITE_RETRY = RetryPolicy(
+    initial_interval=timedelta(seconds=5),
+    maximum_interval=timedelta(seconds=30),
+    maximum_attempts=2,
+)
+
+# Retry policy for Phase B + Phase C. Same ctrl-api WAL-contention
+# concern as the write — 2 attempts is enough.
+_GAP_RETRY = RetryPolicy(
     initial_interval=timedelta(seconds=5),
     maximum_interval=timedelta(seconds=30),
     maximum_attempts=2,
@@ -116,7 +136,7 @@ class HaBootstrapWorkflow:
         )
 
         counts = pull.get("counts") or {}
-        result = {
+        result: dict[str, Any] = {
             "ok": True,
             "pull": {
                 "states": counts.get("states", 0),
@@ -129,10 +149,74 @@ class HaBootstrapWorkflow:
             "write": write if isinstance(write, dict) else {},
         }
         logger.info(
-            "ha-bootstrap: complete rows=%d inserted=%d updated=%d tombstoned=%d",
+            "ha-bootstrap: phase A complete rows=%d inserted=%d updated=%d tombstoned=%d",
             len(rows),
             result["write"].get("inserted", 0),
             result["write"].get("updated", 0),
             result["write"].get("tombstoned", 0),
+        )
+
+        # ── Phase B — gap detection ─────────────────────────────────────
+        #
+        # Now that the registry is fresh, scan it for the 8 baseline
+        # patterns. A registry-empty install (operator just connected and
+        # hasn't pulled yet) safely produces zero gaps because every
+        # detector early-exits when no relevant entities exist.
+        gaps_result = await workflow.execute_activity(
+            detect_ha_gaps,
+            start_to_close_timeout=timedelta(minutes=1),
+            retry_policy=_GAP_RETRY,
+        )
+        if not isinstance(gaps_result, dict) or not gaps_result.get("ok"):
+            code = (gaps_result or {}).get("code", "GAP_PHASE_FAILED")
+            logger.warning("ha-bootstrap: phase B failed with code=%s", code)
+            result["gap_phase"] = {"ok": False, "code": code}
+            return result
+
+        gap_rows = gaps_result.get("gaps") or []
+        result["gap_phase"] = {
+            "ok": True,
+            "gap_count": len(gap_rows),
+            "inserted": gaps_result.get("inserted", 0),
+            "updated": gaps_result.get("updated", 0),
+        }
+        logger.info(
+            "ha-bootstrap: phase B complete gaps=%d inserted=%d",
+            len(gap_rows),
+            gaps_result.get("inserted", 0),
+        )
+
+        # ── Phase C — proposal generation ───────────────────────────────
+        #
+        # Generate a proposal per open gap that doesn't already have one.
+        # The activity is idempotent — re-running with the same gap list
+        # safely skips gaps that already have a `proposal_ref`.
+        if not gap_rows:
+            result["proposal_phase"] = {"ok": True, "created": 0, "skipped": 0}
+            return result
+
+        prop_result = await workflow.execute_activity(
+            generate_ha_proposals,
+            gap_rows,
+            start_to_close_timeout=timedelta(minutes=2),
+            retry_policy=_GAP_RETRY,
+        )
+        if not isinstance(prop_result, dict) or not prop_result.get("ok"):
+            code = (prop_result or {}).get("code", "PROPOSAL_PHASE_FAILED")
+            logger.warning(
+                "ha-bootstrap: phase C failed with code=%s", code
+            )
+            result["proposal_phase"] = {"ok": False, "code": code}
+            return result
+
+        result["proposal_phase"] = {
+            "ok": True,
+            "created": prop_result.get("created", 0),
+            "skipped": prop_result.get("skipped", 0),
+        }
+        logger.info(
+            "ha-bootstrap: phase C complete created=%d skipped=%d",
+            prop_result.get("created", 0),
+            prop_result.get("skipped", 0),
         )
         return result

--- a/packages/learn/tests/test_ha_bootstrap.py
+++ b/packages/learn/tests/test_ha_bootstrap.py
@@ -390,6 +390,8 @@ def _make_stubs(
     pull_result: dict[str, Any] | None = None,
     pull_raises_n: int = 0,
     write_result: dict[str, Any] | None = None,
+    detect_result: dict[str, Any] | None = None,
+    proposals_result: dict[str, Any] | None = None,
 ):
     """Build stub activities the workflow can execute under WorkflowEnvironment.
 
@@ -437,7 +439,31 @@ def _make_stubs(
             "total_after": len(rows),
         }
 
-    return [stub_pull, stub_write], call_log
+    # PR6 — Phase B + Phase C stubs. The default is "no gaps emitted"
+    # which means no proposals get queued either; tests that want to
+    # exercise the gap+proposal path can replace the stubs.
+    @activity.defn(name="detect_ha_gaps")
+    async def stub_detect() -> dict[str, Any]:
+        call_log.append(("detect", 0))
+        if detect_result is not None:
+            return detect_result
+        return {
+            "ok": True,
+            "gaps": [],
+            "inserted": 0,
+            "updated": 0,
+            "addressed": 0,
+            "dismissed": 0,
+        }
+
+    @activity.defn(name="generate_ha_proposals")
+    async def stub_proposals(gaps: list[dict[str, Any]]) -> dict[str, Any]:
+        call_log.append(("proposals", len(gaps)))
+        if proposals_result is not None:
+            return proposals_result
+        return {"ok": True, "created": 0, "skipped": 0}
+
+    return [stub_pull, stub_write, stub_detect, stub_proposals], call_log
 
 
 async def _run_workflow(stubs: list) -> dict[str, Any]:
@@ -490,8 +516,14 @@ class TestWorkflow:
         assert result["ok"] is True
         assert result["rows"] == 1
         assert result["write"]["inserted"] == 1
-        # Pull happened once + write happened once.
-        assert [c[0] for c in log] == ["pull", "write"]
+        # Pull happened once + write happened once + detect (Phase B)
+        # ran once. With an empty gap list, the proposal phase (C) is
+        # short-circuited.
+        steps = [c[0] for c in log]
+        assert steps[:2] == ["pull", "write"]
+        assert "detect" in steps
+        # No gaps emitted by the stub → Phase C is skipped.
+        assert "proposals" not in steps
 
     def test_workflow_retries_transient_pull_failure(self):
         # First pull raises (network blip); retry policy retries up to 3
@@ -550,4 +582,52 @@ class TestWorkflow:
         assert result["ok"] is True
         assert result["rows"] == 0
         assert result["write"]["tombstoned"] == 5
-        assert [c[0] for c in log] == ["pull", "write"]
+        # PR6 — Phase B always runs after a successful write, even with
+        # zero rows (the registry may have just been cleared and the gap
+        # detector should re-evaluate accordingly).
+        steps = [c[0] for c in log]
+        assert steps[:2] == ["pull", "write"]
+        assert "detect" in steps
+
+    def test_workflow_runs_phase_b_and_c_when_gaps_present(self):
+        # Phase B emits two gaps → Phase C runs against them.
+        stubs, log = _make_stubs(
+            detect_result={
+                "ok": True,
+                "gaps": [
+                    {
+                        "id": "01HX0000000000000000000001",
+                        "kind": "no_morning_routine",
+                        "summary": "No morning lighting.",
+                        "severity": "medium",
+                        "area_id": None,
+                        "status": "open",
+                    },
+                    {
+                        "id": "01HX0000000000000000000002",
+                        "kind": "no_motion_lighting",
+                        "summary": "No motion light in hallway.",
+                        "severity": "low",
+                        "area_id": "hallway",
+                        "status": "open",
+                    },
+                ],
+                "inserted": 2,
+                "updated": 0,
+                "addressed": 0,
+                "dismissed": 0,
+            },
+            proposals_result={"ok": True, "created": 2, "skipped": 0},
+        )
+        result = asyncio.run(_run_workflow(stubs))
+        assert result["ok"] is True
+        assert result["gap_phase"]["ok"] is True
+        assert result["gap_phase"]["gap_count"] == 2
+        assert result["proposal_phase"]["ok"] is True
+        assert result["proposal_phase"]["created"] == 2
+        steps = [c[0] for c in log]
+        # Pull → write → detect → proposals, in that order.
+        assert steps == ["pull", "write", "detect", "proposals"]
+        # Phase C received the two gaps from Phase B.
+        prop_invocation = next(c for c in log if c[0] == "proposals")
+        assert prop_invocation[1] == 2

--- a/packages/learn/tests/test_ha_gap_detection.py
+++ b/packages/learn/tests/test_ha_gap_detection.py
@@ -1,0 +1,611 @@
+"""HaBootstrapWorkflow Phase B — gap detection tests (#110 PR6).
+
+24+ test cases across the 8 baseline gap kinds (3 per kind: present /
+absent / edge). The detectors are pure functions over the registry
+shape — no Temporal, no httpx, no LLM.
+
+Each fixture builds a minimal HaRegistry dict and asserts which gap
+rows ``detect_gaps`` emits. The fixtures are deliberately compact so a
+human reviewer can scan the "what does this gap mean" semantics next
+to the assertion.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from src.activities.ha_gap_detection import detect_gaps
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Fixture helpers
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _entity(
+    entity_id: str,
+    *,
+    area_id: str | None = None,
+    attributes: dict[str, Any] | None = None,
+    state: str = "on",
+) -> dict[str, Any]:
+    return {
+        "entity_id": entity_id,
+        "state": state,
+        "area_id": area_id,
+        "attributes": attributes or {},
+    }
+
+
+def _area(area_id: str, name: str) -> dict[str, Any]:
+    return {"ha_id": area_id, "area_id": area_id, "name": name}
+
+
+def _automation(
+    entity_id: str,
+    *,
+    yaml_config: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    a: dict[str, Any] = {
+        "entity_id": entity_id,
+        "state": "on",
+        "attributes": {"friendly_name": entity_id.split(".", 1)[1]},
+    }
+    if yaml_config is not None:
+        a["yaml_config"] = yaml_config
+    return a
+
+
+def _registry(
+    *,
+    entities: list[dict[str, Any]] | None = None,
+    areas: list[dict[str, Any]] | None = None,
+    automations: list[dict[str, Any]] | None = None,
+    helpers: list[dict[str, Any]] | None = None,
+    scenes: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "entities": entities or [],
+        "areas": areas or [],
+        "devices": [],
+        "automations": automations or [],
+        "scenes": scenes or [],
+        "helpers": helpers or [],
+    }
+
+
+def _kinds(rows: list[dict[str, Any]]) -> set[str]:
+    return {r["kind"] for r in rows}
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 1. no_morning_routine
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestMorningRoutine:
+    def test_present_sun_trigger_covers(self) -> None:
+        reg = _registry(
+            entities=[_entity("light.kitchen", area_id="kitchen")],
+            automations=[
+                _automation(
+                    "automation.morning",
+                    yaml_config={
+                        "trigger": [{"platform": "sun", "event": "sunrise"}],
+                        "action": [
+                            {
+                                "service": "light.turn_on",
+                                "target": {"entity_id": "light.kitchen"},
+                            }
+                        ],
+                    },
+                )
+            ],
+        )
+        gaps = detect_gaps(reg)
+        assert "no_morning_routine" not in _kinds(gaps)
+
+    def test_absent_no_automation(self) -> None:
+        reg = _registry(
+            entities=[_entity("light.kitchen", area_id="kitchen")],
+        )
+        gaps = detect_gaps(reg)
+        assert "no_morning_routine" in _kinds(gaps)
+        morning = [g for g in gaps if g["kind"] == "no_morning_routine"][0]
+        assert morning["severity"] == "medium"
+
+    def test_edge_late_time_doesnt_count(self) -> None:
+        """A time trigger at 11:00 is NOT a morning routine — gap stands."""
+        reg = _registry(
+            entities=[_entity("light.kitchen", area_id="kitchen")],
+            automations=[
+                _automation(
+                    "automation.late",
+                    yaml_config={
+                        "trigger": [{"platform": "time", "at": "11:00:00"}],
+                        "action": [{"service": "light.turn_on"}],
+                    },
+                )
+            ],
+        )
+        gaps = detect_gaps(reg)
+        assert "no_morning_routine" in _kinds(gaps)
+
+    def test_edge_time_in_window_covers(self) -> None:
+        """07:30 time trigger covers the morning window."""
+        reg = _registry(
+            entities=[_entity("light.kitchen", area_id="kitchen")],
+            automations=[
+                _automation(
+                    "automation.morn",
+                    yaml_config={
+                        "trigger": [{"platform": "time", "at": "07:30:00"}],
+                        "action": [{"service": "light.turn_on"}],
+                    },
+                )
+            ],
+        )
+        gaps = detect_gaps(reg)
+        assert "no_morning_routine" not in _kinds(gaps)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 2. no_bedtime_routine
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestBedtimeRoutine:
+    def test_present_lights_off_lock(self) -> None:
+        reg = _registry(
+            entities=[
+                _entity("light.kitchen", area_id="kitchen"),
+                _entity("lock.front", area_id="hall"),
+            ],
+            automations=[
+                _automation(
+                    "automation.bedtime",
+                    yaml_config={
+                        "trigger": [{"platform": "time", "at": "22:30:00"}],
+                        "action": [
+                            {"service": "light.turn_off"},
+                            {"service": "lock.lock"},
+                        ],
+                    },
+                )
+            ],
+        )
+        gaps = detect_gaps(reg)
+        assert "no_bedtime_routine" not in _kinds(gaps)
+
+    def test_absent_no_late_automation(self) -> None:
+        reg = _registry(
+            entities=[
+                _entity("light.kitchen", area_id="kitchen"),
+                _entity("lock.front", area_id="hall"),
+            ],
+        )
+        gaps = detect_gaps(reg)
+        assert "no_bedtime_routine" in _kinds(gaps)
+
+    def test_edge_time_too_early(self) -> None:
+        """A 20:00 trigger is NOT bedtime (must be 22:00+)."""
+        reg = _registry(
+            entities=[_entity("light.kitchen", area_id="kitchen")],
+            automations=[
+                _automation(
+                    "automation.early",
+                    yaml_config={
+                        "trigger": [{"platform": "time", "at": "20:00:00"}],
+                        "action": [{"service": "light.turn_off"}],
+                    },
+                )
+            ],
+        )
+        gaps = detect_gaps(reg)
+        assert "no_bedtime_routine" in _kinds(gaps)
+
+    def test_edge_late_but_no_lock_when_locks_present(self) -> None:
+        """Late trigger turns lights off but no lock action → gap stands."""
+        reg = _registry(
+            entities=[
+                _entity("light.kitchen", area_id="kitchen"),
+                _entity("lock.front", area_id="hall"),
+            ],
+            automations=[
+                _automation(
+                    "automation.late",
+                    yaml_config={
+                        "trigger": [{"platform": "time", "at": "23:00:00"}],
+                        "action": [{"service": "light.turn_off"}],
+                    },
+                )
+            ],
+        )
+        gaps = detect_gaps(reg)
+        assert "no_bedtime_routine" in _kinds(gaps)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 3. no_motion_lighting (per-area)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestMotionLighting:
+    def test_present_hallway_covered(self) -> None:
+        reg = _registry(
+            areas=[_area("hallway", "Hallway")],
+            entities=[
+                _entity(
+                    "binary_sensor.hallway_motion",
+                    area_id="hallway",
+                    attributes={"device_class": "motion"},
+                ),
+                _entity("light.hallway", area_id="hallway"),
+            ],
+            automations=[
+                _automation(
+                    "automation.hallway_motion",
+                    yaml_config={
+                        "trigger": [
+                            {
+                                "platform": "state",
+                                "entity_id": "binary_sensor.hallway_motion",
+                                "to": "on",
+                            }
+                        ],
+                        "action": [
+                            {
+                                "service": "light.turn_on",
+                                "target": {"area_id": "hallway"},
+                            }
+                        ],
+                    },
+                )
+            ],
+        )
+        gaps = detect_gaps(reg)
+        assert "no_motion_lighting" not in _kinds(gaps)
+
+    def test_absent_hallway_sensor_uncovered(self) -> None:
+        reg = _registry(
+            areas=[_area("hallway", "Hallway")],
+            entities=[
+                _entity(
+                    "binary_sensor.hallway_motion",
+                    area_id="hallway",
+                    attributes={"device_class": "motion"},
+                )
+            ],
+        )
+        gaps = detect_gaps(reg)
+        assert "no_motion_lighting" in _kinds(gaps)
+        motion = [g for g in gaps if g["kind"] == "no_motion_lighting"][0]
+        assert motion["area_id"] == "hallway"
+
+    def test_edge_kitchen_motion_does_NOT_flag(self) -> None:
+        """Kitchens aren't in the motion-area allowlist — no flag."""
+        reg = _registry(
+            areas=[_area("kitchen", "Kitchen")],
+            entities=[
+                _entity(
+                    "binary_sensor.kitchen_motion",
+                    area_id="kitchen",
+                    attributes={"device_class": "motion"},
+                )
+            ],
+        )
+        gaps = detect_gaps(reg)
+        assert "no_motion_lighting" not in _kinds(gaps)
+
+    def test_edge_bathroom_motion_DOES_flag(self) -> None:
+        reg = _registry(
+            areas=[_area("bathroom", "Bathroom")],
+            entities=[
+                _entity(
+                    "binary_sensor.bathroom_motion",
+                    area_id="bathroom",
+                    attributes={"device_class": "motion"},
+                )
+            ],
+        )
+        gaps = detect_gaps(reg)
+        assert "no_motion_lighting" in _kinds(gaps)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 4. no_away_mode
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestAwayMode:
+    def test_present_not_home_trigger(self) -> None:
+        reg = _registry(
+            entities=[
+                _entity("device_tracker.phone", state="home"),
+                _entity("light.kitchen"),
+            ],
+            automations=[
+                _automation(
+                    "automation.away",
+                    yaml_config={
+                        "trigger": [
+                            {
+                                "platform": "state",
+                                "entity_id": "device_tracker.phone",
+                                "to": "not_home",
+                            }
+                        ],
+                        "action": [{"service": "light.turn_off"}],
+                    },
+                )
+            ],
+        )
+        gaps = detect_gaps(reg)
+        assert "no_away_mode" not in _kinds(gaps)
+
+    def test_absent_no_tracker_watcher(self) -> None:
+        reg = _registry(
+            entities=[_entity("device_tracker.phone", state="home")],
+        )
+        gaps = detect_gaps(reg)
+        assert "no_away_mode" in _kinds(gaps)
+
+    def test_edge_no_trackers_no_gap(self) -> None:
+        """No device_tracker → away-mode gap is not surfaced (no signal)."""
+        reg = _registry(
+            entities=[_entity("light.kitchen", area_id="kitchen")],
+        )
+        gaps = detect_gaps(reg)
+        assert "no_away_mode" not in _kinds(gaps)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 5. no_security_camera_notification
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestCameraNotification:
+    def test_present_notify_on_motion(self) -> None:
+        reg = _registry(
+            entities=[
+                _entity("camera.front_door"),
+                _entity(
+                    "binary_sensor.front_motion",
+                    attributes={"device_class": "motion"},
+                ),
+            ],
+            automations=[
+                _automation(
+                    "automation.notify",
+                    yaml_config={
+                        "trigger": [
+                            {
+                                "platform": "state",
+                                "entity_id": "binary_sensor.front_motion",
+                                "to": "on",
+                            }
+                        ],
+                        "action": [
+                            {"service": "notify.mobile_app_iphone"}
+                        ],
+                    },
+                )
+            ],
+        )
+        gaps = detect_gaps(reg)
+        assert "no_security_camera_notification" not in _kinds(gaps)
+
+    def test_absent_no_notification(self) -> None:
+        reg = _registry(
+            entities=[
+                _entity("camera.front_door"),
+                _entity(
+                    "binary_sensor.front_motion",
+                    attributes={"device_class": "motion"},
+                ),
+            ],
+        )
+        gaps = detect_gaps(reg)
+        assert "no_security_camera_notification" in _kinds(gaps)
+        row = [
+            g
+            for g in gaps
+            if g["kind"] == "no_security_camera_notification"
+        ][0]
+        assert row["severity"] == "high"
+
+    def test_edge_camera_but_no_motion_sensor_no_gap(self) -> None:
+        reg = _registry(
+            entities=[_entity("camera.front_door")],
+        )
+        gaps = detect_gaps(reg)
+        assert "no_security_camera_notification" not in _kinds(gaps)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 6. no_vacation_mode
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestVacationMode:
+    def test_present_helper_and_automation(self) -> None:
+        reg = _registry(
+            entities=[
+                _entity("light.kitchen"),
+                _entity("input_boolean.vacation_mode", state="off"),
+            ],
+            automations=[
+                _automation(
+                    "automation.vacation",
+                    yaml_config={
+                        "trigger": [
+                            {
+                                "platform": "state",
+                                "entity_id": "input_boolean.vacation_mode",
+                                "to": "on",
+                            }
+                        ],
+                        "action": [{"service": "light.turn_on"}],
+                    },
+                )
+            ],
+        )
+        gaps = detect_gaps(reg)
+        assert "no_vacation_mode" not in _kinds(gaps)
+
+    def test_absent_no_helper(self) -> None:
+        reg = _registry(
+            entities=[_entity("light.kitchen")],
+        )
+        gaps = detect_gaps(reg)
+        assert "no_vacation_mode" in _kinds(gaps)
+
+    def test_edge_helper_but_no_automation(self) -> None:
+        reg = _registry(
+            entities=[
+                _entity("light.kitchen"),
+                _entity("input_boolean.vacation_mode", state="off"),
+            ],
+        )
+        gaps = detect_gaps(reg)
+        assert "no_vacation_mode" in _kinds(gaps)
+
+    def test_edge_no_lights_no_gap(self) -> None:
+        """Without lights there's nothing to randomise — gap is irrelevant."""
+        reg = _registry()
+        gaps = detect_gaps(reg)
+        assert "no_vacation_mode" not in _kinds(gaps)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 7. no_climate_schedule
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestClimateSchedule:
+    def test_present_time_trigger_sets_temp(self) -> None:
+        reg = _registry(
+            entities=[_entity("climate.living_room")],
+            automations=[
+                _automation(
+                    "automation.climate",
+                    yaml_config={
+                        "trigger": [{"platform": "time", "at": "06:30:00"}],
+                        "action": [{"service": "climate.set_temperature"}],
+                    },
+                )
+            ],
+        )
+        gaps = detect_gaps(reg)
+        assert "no_climate_schedule" not in _kinds(gaps)
+
+    def test_absent_no_climate_automation(self) -> None:
+        reg = _registry(
+            entities=[_entity("climate.living_room")],
+        )
+        gaps = detect_gaps(reg)
+        assert "no_climate_schedule" in _kinds(gaps)
+
+    def test_edge_no_climate_entity_no_gap(self) -> None:
+        reg = _registry(
+            entities=[_entity("light.kitchen")],
+        )
+        gaps = detect_gaps(reg)
+        assert "no_climate_schedule" not in _kinds(gaps)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 8. no_party_mode
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestPartyMode:
+    def test_present_helper_with_scene(self) -> None:
+        reg = _registry(
+            entities=[
+                _entity("input_boolean.party_mode", state="off"),
+            ],
+            scenes=[{"entity_id": "scene.party", "ha_id": "scene.party"}],
+            automations=[
+                _automation(
+                    "automation.party",
+                    yaml_config={
+                        "trigger": [
+                            {
+                                "platform": "state",
+                                "entity_id": "input_boolean.party_mode",
+                                "to": "on",
+                            }
+                        ],
+                        "action": [{"service": "scene.turn_on"}],
+                    },
+                )
+            ],
+        )
+        gaps = detect_gaps(reg)
+        assert "no_party_mode" not in _kinds(gaps)
+
+    def test_absent_no_helper(self) -> None:
+        reg = _registry()
+        gaps = detect_gaps(reg)
+        assert "no_party_mode" in _kinds(gaps)
+        row = [g for g in gaps if g["kind"] == "no_party_mode"][0]
+        assert row["severity"] == "low"
+
+    def test_edge_helper_but_no_scene_automation(self) -> None:
+        reg = _registry(
+            entities=[_entity("input_boolean.party_lights", state="off")],
+        )
+        gaps = detect_gaps(reg)
+        assert "no_party_mode" in _kinds(gaps)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Cross-cutting
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestDetectGapsCrossCutting:
+    def test_empty_registry_returns_empty(self) -> None:
+        gaps = detect_gaps({})
+        # Some detectors that gate on "no relevant entities" don't emit;
+        # others (party-mode for example) DO emit even when empty. Make
+        # sure we always return a list and never raise.
+        assert isinstance(gaps, list)
+
+    def test_each_gap_has_discovered_at(self) -> None:
+        reg = _registry()
+        gaps = detect_gaps(reg)
+        for g in gaps:
+            assert isinstance(g.get("discovered_at"), str)
+            assert g["discovered_at"].endswith("Z")
+
+    def test_none_input_returns_empty(self) -> None:
+        # type: ignore[arg-type]
+        gaps = detect_gaps(None)  # type: ignore[arg-type]
+        assert gaps == []
+
+    def test_motion_lighting_devices_to_multiple_areas(self) -> None:
+        reg = _registry(
+            areas=[_area("hallway", "Hallway"), _area("bathroom", "Bathroom")],
+            entities=[
+                _entity(
+                    "binary_sensor.hallway_motion",
+                    area_id="hallway",
+                    attributes={"device_class": "motion"},
+                ),
+                _entity(
+                    "binary_sensor.bathroom_motion",
+                    area_id="bathroom",
+                    attributes={"device_class": "motion"},
+                ),
+            ],
+        )
+        gaps = detect_gaps(reg)
+        motion_areas = sorted(
+            g["area_id"]
+            for g in gaps
+            if g["kind"] == "no_motion_lighting"
+        )
+        assert motion_areas == ["bathroom", "hallway"]

--- a/packages/learn/tests/test_ha_proposal_generation.py
+++ b/packages/learn/tests/test_ha_proposal_generation.py
@@ -1,0 +1,103 @@
+"""HaBootstrapWorkflow Phase C — proposal generation tests (#110 PR6).
+
+8 tests — one per gap kind — assert that ``generate_proposal()``
+emits a valid YAML automation for each of the 8 baseline gaps.
+
+We don't bring a full YAML parser as a dependency (the file is plain
+ASCII templates kept inline in the activity module). Each test:
+
+  1. Calls ``generate_proposal()`` with a synthetic ``HaGapRow``.
+  2. Asserts the returned dict has the required keys.
+  3. Asserts the YAML body carries the load-bearing service / trigger
+     fragments the spec asks for.
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.activities.ha_gap_detection import generate_proposal
+
+
+def _gap(kind: str, **kwargs):
+    base = {
+        "kind": kind,
+        "summary": f"{kind} summary",
+        "severity": "medium",
+        "area_id": None,
+        "device_id": None,
+        "discovered_at": "2026-05-29T00:00:00Z",
+        "evidence": {},
+    }
+    base.update(kwargs)
+    return base
+
+
+class TestProposalGeneration:
+    def test_morning(self) -> None:
+        p = generate_proposal(_gap("no_morning_routine"))
+        assert p["kind"] == "no_morning_routine"
+        assert "platform: sun" in p["yaml"]
+        assert "event: sunrise" in p["yaml"]
+        assert "light.turn_on" in p["yaml"]
+        assert "alias:" in p["yaml"]
+        assert "mode: single" in p["yaml"]
+
+    def test_bedtime(self) -> None:
+        p = generate_proposal(_gap("no_bedtime_routine"))
+        assert p["kind"] == "no_bedtime_routine"
+        assert "platform: time" in p["yaml"]
+        assert "light.turn_off" in p["yaml"]
+        assert "lock.lock" in p["yaml"]
+
+    def test_motion_lighting_with_area(self) -> None:
+        p = generate_proposal(_gap("no_motion_lighting", area_id="hallway"))
+        assert p["kind"] == "no_motion_lighting"
+        assert "binary_sensor" in p["yaml"]
+        assert "light.turn_on" in p["yaml"]
+        assert "area_id: hallway" in p["yaml"]
+
+    def test_motion_lighting_no_area_falls_back(self) -> None:
+        p = generate_proposal(_gap("no_motion_lighting", area_id=None))
+        # Should still produce a valid YAML; the target falls back to
+        # entity_id: all when there's no area to scope on.
+        assert "light.turn_on" in p["yaml"]
+        assert "entity_id: all" in p["yaml"]
+
+    def test_away_mode(self) -> None:
+        p = generate_proposal(_gap("no_away_mode"))
+        assert p["kind"] == "no_away_mode"
+        assert "not_home" in p["yaml"]
+        assert "light.turn_off" in p["yaml"]
+        assert "lock.lock" in p["yaml"]
+
+    def test_security_camera_notify(self) -> None:
+        p = generate_proposal(_gap("no_security_camera_notification"))
+        assert p["kind"] == "no_security_camera_notification"
+        assert "notify." in p["yaml"]
+        assert "Camera" in p["yaml"] or "Motion" in p["yaml"]
+
+    def test_vacation_mode(self) -> None:
+        p = generate_proposal(_gap("no_vacation_mode"))
+        assert p["kind"] == "no_vacation_mode"
+        assert "input_boolean.vacation" in p["yaml"]
+        assert "light.turn_on" in p["yaml"]
+
+    def test_climate_schedule(self) -> None:
+        p = generate_proposal(_gap("no_climate_schedule"))
+        assert p["kind"] == "no_climate_schedule"
+        assert "climate.set_temperature" in p["yaml"]
+        assert "platform: time" in p["yaml"]
+
+    def test_party_mode(self) -> None:
+        p = generate_proposal(_gap("no_party_mode"))
+        assert p["kind"] == "no_party_mode"
+        assert "input_boolean.party" in p["yaml"]
+        assert "scene.turn_on" in p["yaml"]
+
+    def test_unknown_kind_raises(self) -> None:
+        with pytest.raises(ValueError):
+            generate_proposal(_gap("no_such_gap"))
+
+    def test_summary_persists(self) -> None:
+        p = generate_proposal(_gap("no_morning_routine", summary="Custom copy"))
+        assert p["summary"] == "Custom copy"

--- a/packages/web/main.wasp
+++ b/packages/web/main.wasp
@@ -1061,6 +1061,36 @@ action refreshHaRegistry {
   entities: []
 }
 
+// #110 PR6 — gap detection + proposal generation read/write surface.
+// The HaBootstrapWorkflow Phase B + C run inside the same workflow
+// the "Refresh registry" CTA above triggers; these five ops let the
+// HaCard read the resulting ha_gap / ha_proposal rows and take
+// principal action on them.
+query getHaGaps {
+  fn: import { getHaGaps } from "@src/dashboard/operations",
+  entities: []
+}
+
+query getHaProposals {
+  fn: import { getHaProposals } from "@src/dashboard/operations",
+  entities: []
+}
+
+action applyHaProposal {
+  fn: import { applyHaProposal } from "@src/dashboard/operations",
+  entities: []
+}
+
+action dismissHaGap {
+  fn: import { dismissHaGap } from "@src/dashboard/operations",
+  entities: []
+}
+
+action rejectHaProposal {
+  fn: import { rejectHaProposal } from "@src/dashboard/operations",
+  entities: []
+}
+
 query getAgentConfig {
   fn: import { getAgentConfig } from "@src/dashboard/operations",
   entities: []

--- a/packages/web/src/dashboard/HaCard.tsx
+++ b/packages/web/src/dashboard/HaCard.tsx
@@ -33,21 +33,35 @@
 // ctrl-api's /status route does NOT echo the LLAT; it only carries the
 // vault_item_id in state.db.
 
-import { useEffect, useState } from "react";
+import { useEffect, useReducer, useState } from "react";
 import {
   useQuery,
   getHaStatus,
   getHaRegistry,
+  getHaGaps,
+  getHaProposals,
   connectHa,
   disconnectHa,
   refreshHaRegistry,
+  applyHaProposal,
+  dismissHaGap,
+  rejectHaProposal,
 } from "wasp/client/operations";
 import {
   deriveHaCardState,
   isProbablyValidLlat,
+  labelForGapKind,
   parseHaUrl,
+  proposalModalReduce,
+  PROPOSAL_MODAL_CLOSED,
   redactLlat,
+  summariseGaps,
+  summariseProposals,
   summariseRegistry,
+  type HaGapRow,
+  type HaGapsResponse,
+  type HaProposalRow,
+  type HaProposalsResponse,
   type HaRegistry,
   type HaStatus,
 } from "./haCardCore";
@@ -162,6 +176,36 @@ export function HaCard() {
   );
   const registry = (registryData as HaRegistry | undefined) ?? null;
   const summary = summariseRegistry(registry);
+
+  // #110 PR6 — gaps + proposals. Empty {open:[],closed:[]} / {pending:[]…}
+  // shape on cold start; the polling cadence is driven by the refresh CTA
+  // (we refetch ~35s after a refresh queues, same window as the registry).
+  const { data: gapsData, refetch: refetchGaps } = useQuery(
+    getHaGaps,
+    undefined,
+    { retry: false },
+  );
+  const gaps = (gapsData as HaGapsResponse | undefined) ?? null;
+  const gapSummary = summariseGaps(gaps);
+
+  const { data: proposalsData, refetch: refetchProposals } = useQuery(
+    getHaProposals,
+    undefined,
+    { retry: false },
+  );
+  const proposals =
+    (proposalsData as HaProposalsResponse | undefined) ?? null;
+  const proposalSummary = summariseProposals(proposals);
+
+  // Proposal modal — reducer-driven so the state machine is unit-tested
+  // (proposalModalReduce in haCardCore.ts).
+  const [modal, dispatchModal] = useReducer(
+    proposalModalReduce,
+    PROPOSAL_MODAL_CLOSED,
+  );
+
+  // Per-gap dismiss spinners — keyed by gap id.
+  const [gapBusy, setGapBusy] = useState<Set<string>>(new Set());
 
   // Connect-form state (kept local; never persisted).
   const [haUrl, setHaUrl] = useState("");
@@ -288,6 +332,73 @@ export function HaCard() {
       window.setTimeout(() => {
         setRefreshBusy(false);
       }, 5_000);
+    }
+  }
+
+  async function onDismissGap(gap: HaGapRow) {
+    const id = gap.id;
+    if (!id) return;
+    if (gapBusy.has(id)) return;
+    setGapBusy((prev) => {
+      const next = new Set(prev);
+      next.add(id);
+      return next;
+    });
+    try {
+      await dismissHaGap({ gapId: id });
+      refetchGaps();
+    } catch (e) {
+      console.error("ha gap dismiss failed", e);
+    } finally {
+      setGapBusy((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+    }
+  }
+
+  function onOpenProposalForGap(gap: HaGapRow) {
+    // Look up the proposal whose gap_id matches; fall back to a
+    // matching-kind proposal if Phase C hasn't refreshed the FK yet.
+    if (!proposals) return;
+    const byGap = proposals.pending.find((p) => p.gap_id === gap.id);
+    if (byGap) {
+      dispatchModal({ type: "OPEN", proposal: byGap });
+      return;
+    }
+    const byKind = proposals.pending.find((p) => p.kind === gap.kind);
+    if (byKind) {
+      dispatchModal({ type: "OPEN", proposal: byKind });
+    }
+  }
+
+  async function onApplyProposal() {
+    if (!modal.proposal) return;
+    dispatchModal({ type: "APPLY" });
+    try {
+      await applyHaProposal({ proposalId: modal.proposal.id });
+      dispatchModal({ type: "APPLY_OK" });
+      refetchProposals();
+      refetchGaps();
+    } catch (e: any) {
+      const message =
+        e?.message ?? e?.data?.error ?? "Couldn't apply that proposal.";
+      dispatchModal({ type: "FAIL", error: String(message) });
+    }
+  }
+
+  async function onRejectProposal() {
+    if (!modal.proposal) return;
+    dispatchModal({ type: "REJECT" });
+    try {
+      await rejectHaProposal({ proposalId: modal.proposal.id });
+      dispatchModal({ type: "REJECT_OK" });
+      refetchProposals();
+    } catch (e: any) {
+      const message =
+        e?.message ?? e?.data?.error ?? "Couldn't reject that proposal.";
+      dispatchModal({ type: "FAIL", error: String(message) });
     }
   }
 
@@ -640,7 +751,36 @@ export function HaCard() {
           {/* Voice-surface expander — the 4 read routes voice-bridge can
               call against HA per the #110 PR1 spec. */}
           {voiceOpen && <VoiceSurfaceSection />}
+
+          {/* #110 PR6 — Alfred-sees-these-gaps section. Always rendered
+              in the connected view; an empty registry still shows the
+              calm "Alfred is still listening" copy via summariseGaps. */}
+          <GapsSection
+            gaps={gaps}
+            summary={gapSummary}
+            busy={gapBusy}
+            onOpenProposal={onOpenProposalForGap}
+            onDismiss={onDismissGap}
+          />
+
+          {/* #110 PR6 — Pending proposals section. */}
+          <ProposalsSection
+            proposals={proposals}
+            summary={proposalSummary}
+            onOpen={(p) => dispatchModal({ type: "OPEN", proposal: p })}
+          />
         </div>
+      )}
+
+      {/* Proposal modal — letterpress overlay with YAML preview + apply/reject CTAs. */}
+      {modal.mode !== "closed" && modal.proposal && (
+        <ProposalModal
+          state={modal}
+          onApply={onApplyProposal}
+          onReject={onRejectProposal}
+          onClose={() => dispatchModal({ type: "CLOSE" })}
+          onRetry={() => dispatchModal({ type: "RETRY" })}
+        />
       )}
 
       {/* ERROR — verbatim last_error + retry CTA + disconnect. */}
@@ -763,6 +903,301 @@ function RunsSection() {
         / proposal-apply ledger. Until then, this section is intentionally
         quiet.
       </p>
+    </div>
+  );
+}
+
+function GapsSection({
+  gaps,
+  summary,
+  busy,
+  onOpenProposal,
+  onDismiss,
+}: {
+  gaps: HaGapsResponse | null;
+  summary: ReturnType<typeof summariseGaps>;
+  busy: Set<string>;
+  onOpenProposal: (gap: HaGapRow) => void;
+  onDismiss: (gap: HaGapRow) => void;
+}) {
+  const open = Array.isArray(gaps?.open) ? gaps!.open : [];
+  if (summary.totalOpen === 0 && summary.totalClosed === 0) {
+    return (
+      <div className="border-t border-rule pt-3 space-y-1">
+        <div
+          className="font-mono text-[10px] uppercase tracking-[0.22em] pb-1"
+          style={{ color: "var(--marginalia)" }}
+        >
+          Alfred sees these gaps
+        </div>
+        <p
+          className="font-body italic text-[12px]"
+          style={{ color: "var(--marginalia)" }}
+        >
+          Nothing yet — Alfred re-runs the audit every 6h. The next pass
+          will surface any missing baselines.
+        </p>
+      </div>
+    );
+  }
+  return (
+    <div className="border-t border-rule pt-3 space-y-2">
+      <div
+        className="font-mono text-[10px] uppercase tracking-[0.22em]"
+        style={{ color: "var(--marginalia)" }}
+      >
+        Alfred sees these gaps ({summary.totalOpen} open
+        {summary.highCount > 0 ? `, ${summary.highCount} high` : ""})
+      </div>
+      {open.map((gap) => {
+        const id = gap.id ?? "";
+        const sev = gap.severity ?? "low";
+        const sevColor =
+          sev === "high"
+            ? "var(--brass)"
+            : sev === "medium"
+              ? "var(--ink)"
+              : "var(--marginalia)";
+        return (
+          <div
+            key={id || `${gap.kind}-${gap.area_id ?? ""}`}
+            className="flex items-baseline gap-3 font-mono text-[11px]"
+          >
+            <span style={{ color: sevColor }}>{labelForGapKind(gap.kind)}</span>
+            <span
+              className="flex-1 italic"
+              style={{ color: "var(--marginalia)" }}
+            >
+              {gap.summary}
+            </span>
+            <button
+              onClick={() => onOpenProposal(gap)}
+              className="btn-link"
+              title="Open the templated proposal for this gap."
+            >
+              Open proposal
+            </button>
+            <button
+              onClick={() => onDismiss(gap)}
+              disabled={!id || busy.has(id)}
+              className="btn-link"
+              title="Hide this gap. Alfred won't re-surface it."
+            >
+              {busy.has(id) ? "Dismissing…" : "Dismiss"}
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function ProposalsSection({
+  proposals,
+  summary,
+  onOpen,
+}: {
+  proposals: HaProposalsResponse | null;
+  summary: ReturnType<typeof summariseProposals>;
+  onOpen: (p: HaProposalRow) => void;
+}) {
+  const pending = Array.isArray(proposals?.pending) ? proposals!.pending : [];
+  if (pending.length === 0 && summary.appliedCount === 0) {
+    return null;
+  }
+  return (
+    <div className="border-t border-rule pt-3 space-y-2">
+      <div
+        className="font-mono text-[10px] uppercase tracking-[0.22em]"
+        style={{ color: "var(--marginalia)" }}
+      >
+        Pending proposals ({pending.length}
+        {summary.appliedCount > 0
+          ? ` · ${summary.appliedCount} applied`
+          : ""}
+        )
+      </div>
+      {pending.length === 0 ? (
+        <p
+          className="font-body italic text-[12px]"
+          style={{ color: "var(--marginalia)" }}
+        >
+          No pending proposals. Alfred queues a new one as gaps come back.
+        </p>
+      ) : (
+        pending.map((p) => (
+          <div
+            key={p.id}
+            className="flex items-baseline gap-3 font-mono text-[11px]"
+          >
+            <span style={{ color: "var(--ink)" }}>{labelForGapKind(p.kind)}</span>
+            <span
+              className="flex-1 italic"
+              style={{ color: "var(--marginalia)" }}
+            >
+              {p.summary}
+            </span>
+            <button
+              onClick={() => onOpen(p)}
+              className="btn-link"
+              title="View YAML preview, apply, or reject."
+            >
+              Review
+            </button>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}
+
+function ProposalModal({
+  state,
+  onApply,
+  onReject,
+  onClose,
+  onRetry,
+}: {
+  state: ReturnType<typeof proposalModalReduce>;
+  onApply: () => void;
+  onReject: () => void;
+  onClose: () => void;
+  onRetry: () => void;
+}) {
+  // The state machine guarantees state.proposal is non-null when mode
+  // is anything other than "closed".
+  const p = state.proposal;
+  if (!p) return null;
+  const mode = state.mode;
+  const errorMsg = state.error;
+  const busy = mode === "applying" || mode === "rejecting";
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="ha-proposal-title"
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0,0,0,0.4)",
+        zIndex: 50,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: "1rem",
+      }}
+      onClick={() => {
+        if (!busy) onClose();
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="border border-rule"
+        style={{
+          background: "var(--paper)",
+          padding: "1.25rem",
+          maxWidth: "640px",
+          width: "100%",
+          maxHeight: "80vh",
+          overflowY: "auto",
+        }}
+      >
+        <div
+          id="ha-proposal-title"
+          className="font-display text-2xl mb-2"
+          style={{ color: "var(--ink)" }}
+        >
+          {labelForGapKind(p.kind)}
+        </div>
+        <p
+          className="font-body italic text-[13px] mb-3"
+          style={{ color: "var(--marginalia)" }}
+        >
+          {p.summary}
+        </p>
+        <pre
+          className="font-mono text-[11px] border border-rule p-3 mb-3"
+          style={{
+            color: "var(--ink)",
+            background: "transparent",
+            whiteSpace: "pre-wrap",
+            wordBreak: "break-word",
+          }}
+        >
+          {p.yaml}
+        </pre>
+
+        {mode === "applied" && (
+          <p
+            className="font-body italic text-[13px] mb-2"
+            style={{ color: "var(--ink)" }}
+          >
+            Applied. Alfred snapshotted the previous automation; you can
+            roll back from the Recent runs ledger.
+          </p>
+        )}
+        {mode === "rejected" && (
+          <p
+            className="font-body italic text-[13px] mb-2"
+            style={{ color: "var(--marginalia)" }}
+          >
+            Rejected. Alfred won't re-queue this one until you ask.
+          </p>
+        )}
+        {mode === "error" && errorMsg && (
+          <p
+            className="font-body italic text-[13px] mb-2"
+            style={{ color: "var(--brass)" }}
+          >
+            {errorMsg}
+          </p>
+        )}
+
+        <div className="flex flex-wrap gap-3 items-baseline pt-2">
+          {(mode === "viewing" || mode === "error") && (
+            <>
+              <button
+                onClick={onApply}
+                disabled={busy}
+                className="btn-ghost"
+              >
+                Apply
+              </button>
+              <button
+                onClick={onReject}
+                disabled={busy}
+                className="btn-link"
+              >
+                Reject
+              </button>
+            </>
+          )}
+          {mode === "applying" && (
+            <span
+              className="font-mono text-[11px]"
+              style={{ color: "var(--marginalia)" }}
+            >
+              Applying…
+            </span>
+          )}
+          {mode === "rejecting" && (
+            <span
+              className="font-mono text-[11px]"
+              style={{ color: "var(--marginalia)" }}
+            >
+              Rejecting…
+            </span>
+          )}
+          {mode === "error" && (
+            <button onClick={onRetry} className="btn-link">
+              Try again
+            </button>
+          )}
+          <button onClick={onClose} disabled={busy} className="btn-link">
+            Close
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/packages/web/src/dashboard/haCardCore.test.ts
+++ b/packages/web/src/dashboard/haCardCore.test.ts
@@ -28,9 +28,17 @@ import {
   isProbablyValidLlat,
   summariseRegistry,
   pickRecentRuns,
+  summariseGaps,
+  summariseProposals,
+  labelForGapKind,
+  proposalModalReduce,
+  PROPOSAL_MODAL_CLOSED,
   type HaStatus,
   type HaRegistry,
   type HaRunRow,
+  type HaGapsResponse,
+  type HaProposalsResponse,
+  type HaProposalRow,
 } from "./haCardCore";
 
 const BASE: HaStatus = {
@@ -439,4 +447,149 @@ test("pickRecentRuns: tolerates non-array + malformed timestamps", () => {
 
 test("pickRecentRuns: empty array returns empty array", () => {
   assert.deepEqual(pickRecentRuns([]), []);
+});
+
+// ── PR6 — summariseGaps + summariseProposals + modal reducer ────────────
+
+test("summariseGaps: empty/null input → all-zero summary", () => {
+  const s = summariseGaps(null);
+  assert.equal(s.totalOpen, 0);
+  assert.equal(s.totalClosed, 0);
+  assert.equal(s.highCount, 0);
+  assert.equal(s.mediumCount, 0);
+  assert.equal(s.lowCount, 0);
+  assert.deepEqual(s.topOpen, []);
+});
+
+test("summariseGaps: counts by severity, slices top 5", () => {
+  const resp: HaGapsResponse = {
+    open: [
+      { id: "1", kind: "no_security_camera_notification", summary: "x", severity: "high" },
+      { id: "2", kind: "no_morning_routine", summary: "x", severity: "medium" },
+      { id: "3", kind: "no_motion_lighting", summary: "x", severity: "low" },
+      { id: "4", kind: "no_motion_lighting", summary: "x", severity: "low" },
+      { id: "5", kind: "no_motion_lighting", summary: "x", severity: "low" },
+      { id: "6", kind: "no_motion_lighting", summary: "x", severity: "low" },
+    ],
+    closed: [
+      { id: "7", kind: "no_party_mode", summary: "x", severity: "low" },
+    ],
+  };
+  const s = summariseGaps(resp);
+  assert.equal(s.totalOpen, 6);
+  assert.equal(s.totalClosed, 1);
+  assert.equal(s.highCount, 1);
+  assert.equal(s.mediumCount, 1);
+  assert.equal(s.lowCount, 4);
+  assert.equal(s.topOpen.length, 5);
+});
+
+test("summariseProposals: handles empty + counts pending/applied", () => {
+  assert.deepEqual(
+    summariseProposals(null),
+    { pendingCount: 0, appliedCount: 0, topPending: [] },
+  );
+  const resp: HaProposalsResponse = {
+    pending: [
+      { id: "a", kind: "no_morning_routine", summary: "x", yaml: "x", status: "pending" },
+      { id: "b", kind: "no_bedtime_routine", summary: "x", yaml: "x", status: "pending" },
+    ],
+    applied: [
+      { id: "c", kind: "no_away_mode", summary: "x", yaml: "x", status: "applied" },
+    ],
+    other: [],
+  };
+  const s = summariseProposals(resp);
+  assert.equal(s.pendingCount, 2);
+  assert.equal(s.appliedCount, 1);
+  assert.equal(s.topPending.length, 2);
+});
+
+test("labelForGapKind: maps known kinds, falls back to raw kind", () => {
+  assert.equal(labelForGapKind("no_morning_routine"), "Morning lighting");
+  assert.equal(labelForGapKind("no_motion_lighting"), "Motion lighting");
+  assert.equal(labelForGapKind("no_party_mode"), "Party mode");
+  assert.equal(labelForGapKind("future_kind_alfred_invents"), "future_kind_alfred_invents");
+  assert.equal(labelForGapKind(null), "Gap");
+  assert.equal(labelForGapKind(undefined), "Gap");
+});
+
+// ── Proposal modal state machine ─────────────────────────────────────────
+
+const SAMPLE_PROPOSAL: HaProposalRow = {
+  id: "p1",
+  kind: "no_morning_routine",
+  summary: "Wake the lights.",
+  yaml: "alias: x\ntrigger: []\naction: []\n",
+  status: "pending",
+};
+
+test("proposalModalReduce: OPEN takes closed → viewing with proposal", () => {
+  const next = proposalModalReduce(PROPOSAL_MODAL_CLOSED, {
+    type: "OPEN",
+    proposal: SAMPLE_PROPOSAL,
+  });
+  assert.equal(next.mode, "viewing");
+  assert.equal(next.proposal?.id, "p1");
+  assert.equal(next.error, null);
+});
+
+test("proposalModalReduce: APPLY → applying → APPLY_OK → applied", () => {
+  const opened = proposalModalReduce(PROPOSAL_MODAL_CLOSED, {
+    type: "OPEN",
+    proposal: SAMPLE_PROPOSAL,
+  });
+  const applying = proposalModalReduce(opened, { type: "APPLY" });
+  assert.equal(applying.mode, "applying");
+  const applied = proposalModalReduce(applying, { type: "APPLY_OK" });
+  assert.equal(applied.mode, "applied");
+});
+
+test("proposalModalReduce: REJECT → rejecting → REJECT_OK → rejected", () => {
+  const opened = proposalModalReduce(PROPOSAL_MODAL_CLOSED, {
+    type: "OPEN",
+    proposal: SAMPLE_PROPOSAL,
+  });
+  const rejecting = proposalModalReduce(opened, { type: "REJECT" });
+  assert.equal(rejecting.mode, "rejecting");
+  const rejected = proposalModalReduce(rejecting, { type: "REJECT_OK" });
+  assert.equal(rejected.mode, "rejected");
+});
+
+test("proposalModalReduce: FAIL preserves proposal + RETRY returns to viewing", () => {
+  const opened = proposalModalReduce(PROPOSAL_MODAL_CLOSED, {
+    type: "OPEN",
+    proposal: SAMPLE_PROPOSAL,
+  });
+  const applying = proposalModalReduce(opened, { type: "APPLY" });
+  const failed = proposalModalReduce(applying, {
+    type: "FAIL",
+    error: "HA timed out",
+  });
+  assert.equal(failed.mode, "error");
+  assert.equal(failed.error, "HA timed out");
+  assert.equal(failed.proposal?.id, "p1");
+
+  const retried = proposalModalReduce(failed, { type: "RETRY" });
+  assert.equal(retried.mode, "viewing");
+  assert.equal(retried.error, null);
+});
+
+test("proposalModalReduce: CLOSE always returns the closed state", () => {
+  const opened = proposalModalReduce(PROPOSAL_MODAL_CLOSED, {
+    type: "OPEN",
+    proposal: SAMPLE_PROPOSAL,
+  });
+  const closed = proposalModalReduce(opened, { type: "CLOSE" });
+  assert.equal(closed, PROPOSAL_MODAL_CLOSED);
+});
+
+test("proposalModalReduce: out-of-order events are no-ops", () => {
+  // APPLY_OK without preceding APPLY: state stays unchanged.
+  const opened = proposalModalReduce(PROPOSAL_MODAL_CLOSED, {
+    type: "OPEN",
+    proposal: SAMPLE_PROPOSAL,
+  });
+  const same = proposalModalReduce(opened, { type: "APPLY_OK" });
+  assert.equal(same, opened);
 });

--- a/packages/web/src/dashboard/haCardCore.ts
+++ b/packages/web/src/dashboard/haCardCore.ts
@@ -566,3 +566,197 @@ function pickNonEmpty(s: string | null | undefined): string | null {
   const t = s.trim();
   return t.length > 0 ? t : null;
 }
+
+// ── PR6 — gaps + proposals ───────────────────────────────────────────────
+
+/** A single ha_gap row as returned by GET /api/v1/channels/ha/gaps. */
+export interface HaGapRow {
+  id?: string;
+  kind: string;
+  summary: string;
+  severity?: "low" | "medium" | "high" | string;
+  area_id?: string | null;
+  device_id?: string | null;
+  discovered_at?: string;
+  proposal_ref?: string | null;
+  status?: string;
+}
+
+export interface HaGapsResponse {
+  open: HaGapRow[];
+  closed: HaGapRow[];
+}
+
+/** A single ha_proposal row as returned by GET /api/v1/channels/ha/proposals. */
+export interface HaProposalRow {
+  id: string;
+  kind: string;
+  summary: string;
+  yaml: string;
+  gap_id?: string | null;
+  status: string;
+  ts?: string;
+  applied_at?: string | null;
+}
+
+export interface HaProposalsResponse {
+  pending: HaProposalRow[];
+  applied: HaProposalRow[];
+  other: HaProposalRow[];
+}
+
+/** The 8 baseline kinds Phase B can emit. */
+export const HA_GAP_KIND_LABELS: Record<string, string> = {
+  no_morning_routine: "Morning lighting",
+  no_bedtime_routine: "Bedtime routine",
+  no_motion_lighting: "Motion lighting",
+  no_away_mode: "Away mode",
+  no_security_camera_notification: "Camera notify",
+  no_vacation_mode: "Vacation mode",
+  no_climate_schedule: "Climate schedule",
+  no_party_mode: "Party mode",
+};
+
+export function labelForGapKind(kind: string | null | undefined): string {
+  if (typeof kind !== "string") return "Gap";
+  return HA_GAP_KIND_LABELS[kind] ?? kind;
+}
+
+export interface HaGapSummary {
+  totalOpen: number;
+  totalClosed: number;
+  highCount: number;
+  mediumCount: number;
+  lowCount: number;
+  /** Top 5 open gaps already pre-sorted by the server (high → low,
+   *  then discovered_at desc). */
+  topOpen: HaGapRow[];
+}
+
+export function summariseGaps(
+  resp: HaGapsResponse | null | undefined,
+): HaGapSummary {
+  const open = Array.isArray(resp?.open) ? resp!.open : [];
+  const closed = Array.isArray(resp?.closed) ? resp!.closed : [];
+  let high = 0;
+  let medium = 0;
+  let low = 0;
+  for (const g of open) {
+    switch (g.severity) {
+      case "high":
+        high += 1;
+        break;
+      case "medium":
+        medium += 1;
+        break;
+      default:
+        low += 1;
+        break;
+    }
+  }
+  return {
+    totalOpen: open.length,
+    totalClosed: closed.length,
+    highCount: high,
+    mediumCount: medium,
+    lowCount: low,
+    topOpen: open.slice(0, 5),
+  };
+}
+
+export interface HaProposalSummary {
+  pendingCount: number;
+  appliedCount: number;
+  topPending: HaProposalRow[];
+}
+
+export function summariseProposals(
+  resp: HaProposalsResponse | null | undefined,
+): HaProposalSummary {
+  const pending = Array.isArray(resp?.pending) ? resp!.pending : [];
+  const applied = Array.isArray(resp?.applied) ? resp!.applied : [];
+  return {
+    pendingCount: pending.length,
+    appliedCount: applied.length,
+    topPending: pending.slice(0, 5),
+  };
+}
+
+// ── Proposal-modal state machine ─────────────────────────────────────────
+//
+// The modal renders against one of four states:
+//   • closed       — no proposal selected
+//   • viewing      — proposal loaded, [Apply] + [Reject] live
+//   • applying     — Apply CTA pressed, request in flight
+//   • applied      — request resolved ok, calm "Done" copy + Close CTA
+//   • error        — request failed, surface the error + Retry CTA
+//
+// The pure transition function below is unit-tested; the React
+// component just wires the events.
+
+export type HaProposalModalMode =
+  | "closed"
+  | "viewing"
+  | "applying"
+  | "applied"
+  | "rejecting"
+  | "rejected"
+  | "error";
+
+export interface HaProposalModalState {
+  mode: HaProposalModalMode;
+  proposal: HaProposalRow | null;
+  error: string | null;
+}
+
+export type HaProposalModalEvent =
+  | { type: "OPEN"; proposal: HaProposalRow }
+  | { type: "APPLY" }
+  | { type: "REJECT" }
+  | { type: "APPLY_OK" }
+  | { type: "REJECT_OK" }
+  | { type: "FAIL"; error: string }
+  | { type: "RETRY" }
+  | { type: "CLOSE" };
+
+export const PROPOSAL_MODAL_CLOSED: HaProposalModalState = {
+  mode: "closed",
+  proposal: null,
+  error: null,
+};
+
+export function proposalModalReduce(
+  state: HaProposalModalState,
+  event: HaProposalModalEvent,
+): HaProposalModalState {
+  switch (event.type) {
+    case "OPEN":
+      return { mode: "viewing", proposal: event.proposal, error: null };
+    case "APPLY":
+      if (state.mode !== "viewing" && state.mode !== "error") return state;
+      return { ...state, mode: "applying", error: null };
+    case "REJECT":
+      if (state.mode !== "viewing" && state.mode !== "error") return state;
+      return { ...state, mode: "rejecting", error: null };
+    case "APPLY_OK":
+      if (state.mode !== "applying") return state;
+      return { ...state, mode: "applied", error: null };
+    case "REJECT_OK":
+      if (state.mode !== "rejecting") return state;
+      return { ...state, mode: "rejected", error: null };
+    case "FAIL":
+      // Stay open for the operator to retry / close. Pre-apply error
+      // (from viewing) keeps the proposal mounted.
+      return { ...state, mode: "error", error: event.error };
+    case "RETRY":
+      if (state.mode !== "error") return state;
+      // Return to viewing — the React layer decides whether the next
+      // press is Apply or Reject based on which button the operator
+      // clicks.
+      return { ...state, mode: "viewing", error: null };
+    case "CLOSE":
+      return PROPOSAL_MODAL_CLOSED;
+    default:
+      return state;
+  }
+}

--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -3014,3 +3014,135 @@ export const refreshHaRegistry = async (_args: unknown, context: any) => {
     path: "/api/v1/channels/ha/registry/refresh",
   });
 };
+
+// ============================================================
+// Home Assistant — gap detection + proposal generation (#110 PR6).
+// HaBootstrapWorkflow Phase B + C surface their results through these
+// five ops:
+//
+//   getHaGaps         → { open: [...], closed: [...] }
+//                       Both halves of the audit ledger sorted by
+//                       severity then discovered_at desc.
+//   getHaProposals    → { pending: [...], applied: [...], other: [...] }
+//                       The pending list is what the HaCard "Pending
+//                       proposals" section iterates over.
+//   applyHaProposal   → POST proposal apply with a server-minted
+//                       decision_ref. Routes through PR4's existing
+//                       /proposal/:id/apply (loop guard + snapshot).
+//   dismissHaGap      → PATCH gap with dismissed_at semantic.
+//                       No HA write.
+//   rejectHaProposal  → POST proposal reject (no HA write).
+//
+// Voice cannot trigger applyHaProposal — write actions stay through
+// alfred__act_on_decision per the voice-bridge contract. The voice
+// surface CAN call getHaGaps + getHaProposals (read-only).
+// ============================================================
+
+export const getHaGaps = async (_args: unknown, context: any) => {
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    path: "/api/v1/channels/ha/gaps",
+  });
+};
+
+export const getHaProposals = async (_args: unknown, context: any) => {
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    path: "/api/v1/channels/ha/proposals",
+  });
+};
+
+/**
+ * Apply an HA proposal through the PR4 loop-guard + snapshot pattern.
+ *
+ * The PR4 route requires a `decision_ref` (formatted ulid). We mint
+ * it server-side here so the principal doesn't have to think about
+ * it. The same value goes into the ha_proposal row + the ha_run row,
+ * closing the audit loop.
+ *
+ * Body the client passes:  { proposalId: string, automationId?: string }
+ *
+ * Voice cannot reach this op — Wasp auth + the voice-bridge token
+ * scope both forbid it.
+ */
+export const applyHaProposal = async (
+  args: { proposalId: string; automationId?: string },
+  context: any,
+) => {
+  if (!args?.proposalId?.trim()) {
+    throw new HttpError(400, "proposalId is required");
+  }
+  const instance = await getUserInstance(context);
+  // Mint a decision_ref — same shape PR4's assertDecisionRef expects
+  // (ULID-ish: 26 chars, Crockford base32). Use crypto.randomUUID and
+  // strip dashes to get a 32-char alphanumeric — PR4 accepts either
+  // shape via its format-gate. For maximum compat we just generate a
+  // ULID-shaped string using timestamp + random.
+  const decision_ref = mintDecisionRef();
+  const body: Record<string, string> = {
+    decision_ref,
+  };
+  if (typeof args.automationId === "string" && args.automationId.trim()) {
+    body.automation_id = args.automationId.trim();
+  }
+  return proxyToTenant(instance, {
+    method: "POST",
+    path: `/api/v1/channels/ha/proposal/${encodeURIComponent(
+      args.proposalId.trim(),
+    )}/apply`,
+    body,
+  });
+};
+
+export const dismissHaGap = async (
+  args: { gapId: string },
+  context: any,
+) => {
+  if (!args?.gapId?.trim()) {
+    throw new HttpError(400, "gapId is required");
+  }
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    method: "PATCH",
+    path: `/api/v1/channels/ha/gap/${encodeURIComponent(args.gapId.trim())}/dismiss`,
+  });
+};
+
+export const rejectHaProposal = async (
+  args: { proposalId: string },
+  context: any,
+) => {
+  if (!args?.proposalId?.trim()) {
+    throw new HttpError(400, "proposalId is required");
+  }
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    method: "POST",
+    path: `/api/v1/channels/ha/proposal/${encodeURIComponent(
+      args.proposalId.trim(),
+    )}/reject`,
+  });
+};
+
+// ── decision_ref minter ──────────────────────────────────────────────────
+//
+// Crockford base32, 26 chars — the ULID shape PR4's
+// `assertDecisionRef` accepts. We don't need cryptographic ULID
+// monotonicity here (one proposal-apply per user click), so a simple
+// timestamp + random suffix is fine.
+const _ULID_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+function mintDecisionRef(): string {
+  const now = Date.now();
+  let timeChars = "";
+  let t = now;
+  for (let i = 0; i < 10; i++) {
+    timeChars = _ULID_ALPHABET[t & 31] + timeChars;
+    t = Math.floor(t / 32);
+  }
+  let randChars = "";
+  for (let i = 0; i < 16; i++) {
+    randChars += _ULID_ALPHABET[Math.floor(Math.random() * 32)];
+  }
+  return timeChars + randChars;
+}


### PR DESCRIPTION
Builds on PR5's HaBootstrapWorkflow Phase A (registry pull). Closes Phase B + Phase C of #110.

## What ships

### Phase B — gap detection (alfred-learn)
Pure-function detectors over the registry shape, one per baseline pattern:
- `no_morning_routine` — no automation lights up the house in 6am–9am
- `no_bedtime_routine` — no time-triggered light-off + lock-doors after 22:00
- `no_motion_lighting` — per-area (hallway/bathroom/foyer/...) motion sensor without a wired light
- `no_away_mode` — `device_tracker.*` exists but no `not_home` automation
- `no_security_camera_notification` — cameras + motion but no notify
- `no_vacation_mode` — no `input_boolean.vacation*` with light randomisation
- `no_climate_schedule` — `climate.*` exists but no time-of-day setpoint
- `no_party_mode` — no `input_boolean.party*` with scene activation

### Phase C — proposal generation
Inline YAML templates per gap kind. The principal clicks Apply on the HaCard which routes through PR4's `/proposal/:id/apply` (loop-guard + snapshot pattern preserved).

### ctrl-api routes
All colocated in `registerHaGapRoutes`:
- `POST /api/v1/channels/ha/gaps/bulk` — operator-only, dedup by `(kind, area_id)`, tombstone vanished gaps to `addressed`.
- `GET /api/v1/channels/ha/gaps` — voice-bridge readable.
- `GET /api/v1/channels/ha/proposals` — voice-bridge readable.
- `PATCH /api/v1/channels/ha/gap/:id/dismiss` — principal hide.
- `POST /api/v1/channels/ha/proposal/:id/reject` — principal reject.

### Storage
No new migration — `ha_gap` (PR1 schema) carries the spec's extra fields (`area_id` / `summary` / `severity` / `device_id`) inside the existing `evidence` column as a JSON blob.

### Voice-bridge
`/gaps` + `/proposals` added to `VOICE_BRIDGE_ALLOWLIST` so the voice agent can answer "what gaps does Alfred see?" without gaining write capability. `applyHaProposal` stays through the `alfred__act_on_decision` MCP write surface per the voice-bridge contract.

### Web (HaCard)
- "Alfred sees these gaps" — table from `/gaps`, severity-sorted (high → medium → low → discovered_at desc), each row carries Open proposal + Dismiss CTAs.
- "Pending proposals" — table from `/proposals`, opens a modal with YAML preview + Apply / Reject buttons.
- Proposal-modal state machine extracted to `haCardCore.proposalModalReduce` for unit-testability.

## Tests

| Suite | Count | Result |
|---|---:|---|
| `test_ha_gap_detection.py` (gap detectors, pure) | 32 | pass |
| `test_ha_proposal_generation.py` (YAML templates) | 11 | pass |
| `channels_ha_gaps.test.ts` (ctrl routes) | 10 | pass |
| `haCardCore.test.ts` (PR6 additions) | 10 | pass |
| `test_ha_bootstrap.py` (workflow stubs + Phase B/C chain) | +1 test | pass |
| **alfred-learn full suite** | **2284** | pass (101 skipped, 0 failed) |
| **alfred-ctrl full suite** | **785** | pass (1 skipped, 0 failed) |

## Image-size impact
The 8 inline YAML templates total ~2.7 KB. The full `ha_gap_detection.py` module adds ~38 KB of Python source. Worker image growth is well under 0.1 MB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)