### PR TITLE
feat(voice-bridge,ctrl,web): HA voice pipeline live wiring + Wyoming fallback (#112 PR5)

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -158,7 +158,9 @@ sms.{$DOMAIN} {
 	reverse_proxy hermes:8080
 }
 
-# Voice — Twilio Media Streams WebSocket endpoint for the voice-bridge.
+# Voice — Twilio Media Streams WebSocket endpoint + voice-bridge HTTP
+# control surface for Home Assistant's REST integration.
+#
 # Hermes has no native phone-call adapter (upstream issue #409), so
 # realtime audio bridges through a separate service that translates
 # Twilio mulaw <-> OpenAI gpt-realtime. The bridge's :9000 listener
@@ -166,6 +168,19 @@ sms.{$DOMAIN} {
 # console, set the number's "A CALL COMES IN" webhook to a TwiML <Stream>
 # pointing at `wss://voice.{$DOMAIN}/voice/<id>?sig=...`. Caddy auto-issues
 # the LE cert + handles the WS upgrade transparently.
+#
+# Issue #112 PR5 adds three HTTP endpoints on the same :9000 listener that
+# Home Assistant's REST integration can hit over TLS via this hostname:
+#
+#   GET /esphome/devices   — list HA installs paired with the bridge
+#   GET /wyoming/status    — Wyoming Protocol fallback readiness
+#   GET /health, /metrics  — pre-existing operator endpoints
+#
+# These are unauthenticated on voice-bridge itself (boundary lives at
+# ctrl-api, which is the only caller of /esphome/devices + /wyoming/status
+# in production). The voice subdomain stays DNS-only at Cloudflare
+# (orange cloud off) — see the comment above the apex block for the
+# WSS-upgrade rationale.
 voice.{$DOMAIN} {
 	encode zstd gzip
 	reverse_proxy voice-bridge:9000

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -720,6 +720,15 @@ services:
       # (none today) would set this explicitly.
       ESPHOME_TENANT_SEED: "${ESPHOME_TENANT_SEED:-}"
       ESPHOME_FRIENDLY_NAME: "${ESPHOME_FRIENDLY_NAME:-Alfred}"
+      # ── Wyoming Protocol fallback (issue #112 PR5) ──────────────────
+      # Off by default — most tenants route HA → us via the ESPHome
+      # Native API (PR1/PR2) which has a shorter audio path. Flip to
+      # WYOMING_ENABLED=1 on tenants whose HA install can't reach :6053
+      # over the LAN (HA-OS / HA-Cloud) but CAN reach the Wyoming server
+      # on the tailnet. Same brain factory, different transport.
+      WYOMING_ENABLED: "${WYOMING_ENABLED:-0}"
+      WYOMING_PORT: "10300"
+      WYOMING_BIND: "0.0.0.0"
     ports:
       # ESPHome Native API. Plain TCP — not HTTP — so Caddy can't terminate
       # it; HA's ESPHome integration expects no TLS on :6053 (the
@@ -733,6 +742,13 @@ services:
       # devices on the same LAN. End-to-end setup steps:
       # packages/voice-bridge/docs/ha-pipeline-setup.md.
       - "127.0.0.1:6053:6053"
+      # Wyoming Protocol fallback (#112 PR5). Also localhost-only — HA's
+      # Wyoming integration reaches it the same way as the ESPHome listener
+      # (via the Tailscale sidecar's `tailscale serve --bg 10300` when the
+      # operator enables it). Bound iff WYOMING_ENABLED=1; the listener
+      # itself only boots when the env flag is set, so leaving the port
+      # mapping on with the flag off is a no-op.
+      - "127.0.0.1:10300:10300"
     healthcheck:
       test: ["CMD-SHELL", "node -e \"require('http').get('http://127.0.0.1:9000/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))\""]
       interval: 30s

--- a/packages/ctrl/src/api/routes/voice_esphome.ts
+++ b/packages/ctrl/src/api/routes/voice_esphome.ts
@@ -1,0 +1,543 @@
+// voice_esphome.ts — ESPHome-side voice routes (#112 PR5).
+//
+//   GET  /api/v1/channels/voice/esphome/devices       — proxy voice-bridge's
+//                                                       /esphome/devices
+//   POST /api/v1/channels/voice/esphome/devices/test  — operator-side probe
+//                                                       of a real ESPHome
+//                                                       satellite IP
+//   GET  /api/v1/channels/voice/wyoming/status        — proxy voice-bridge's
+//                                                       /wyoming/status
+//
+// All three are operator-only (master AAS_API_KEY bearer). The voice-bridge
+// listener is on the docker bridge network so ctrl-api can reach it directly
+// at http://voice-bridge:9000.
+//
+// `/devices/test` is the special one: it opens a real outbound ESPHome
+// Native API TCP connection to a satellite the operator pastes the IP for,
+// runs Hello → DeviceInfo → ListEntities, looks for a voice_assistant entity,
+// and returns a structured diagnosis the dashboard can render. This is the
+// "is the satellite YAML actually configured to route voice to us?" check —
+// catches the common misconfigurations:
+//
+//   - the satellite is on the right LAN but has no `voice_assistant:` block
+//   - `use_wake_word: true` but no `micro_wake_word:` block (silent failure)
+//   - sample rate / format mismatch
+//   - the satellite's ESPHome version is old enough that it doesn't speak
+//     API 1.10 (we advertise 1.10; ESPHome ≤2024.7 speaks 1.9)
+//
+// All probes use a 5s connect + 5s read timeout — the operator's typing
+// a UI form, they shouldn't be waiting half a minute on a wrong IP.
+
+import net from "node:net";
+
+import { addRoute } from "../server.js";
+import { sendJson, ValidationError, ApiError } from "../errors.js";
+import { requireOperatorBearer } from "../auth.js";
+
+// Where voice-bridge's HTTP control surface lives. The voice-bridge is on
+// the same docker-compose network as ctrl-api; the service name resolves
+// over the docker DNS. The env override lets the operator point at a
+// remote bridge during the rare case of a multi-host deploy.
+const VOICE_BRIDGE_URL =
+  process.env.VOICE_BRIDGE_INTERNAL_URL ?? "http://voice-bridge:9000";
+const VOICE_BRIDGE_FETCH_TIMEOUT_MS = 4000;
+
+// ESPHome Native API constants — duplicated here rather than imported from
+// voice-bridge because the ctrl-api bundle doesn't depend on voice-bridge
+// (different package, different esbuild build context).
+const ESPHOME_PREAMBLE = 0x00;
+const MSG_HelloRequest = 1;
+const MSG_HelloResponse = 2;
+const MSG_ConnectRequest = 3;
+const MSG_ConnectResponse = 4;
+const MSG_DisconnectRequest = 5;
+const MSG_DeviceInfoRequest = 9;
+const MSG_DeviceInfoResponse = 10;
+const MSG_ListEntitiesRequest = 11;
+const MSG_ListEntitiesDoneResponse = 19;
+const MSG_ListEntitiesVoiceAssistantResponse = 58;
+
+const DEFAULT_PROBE_TIMEOUT_MS = 5000;
+
+// ── Probe-side ESPHome codec ─────────────────────────────────────────────
+// Tiny hand-rolled subset; same wire shape as voice-bridge's
+// esphome-protocol.ts but inlined so this file has no cross-package import.
+
+function encodeVarint(value: number): Buffer {
+  const out: number[] = [];
+  let v = value;
+  while (v >= 0x80) {
+    out.push((v & 0x7f) | 0x80);
+    v >>>= 7;
+  }
+  out.push(v & 0x7f);
+  return Buffer.from(out);
+}
+
+function decodeVarint(buf: Buffer, offset: number): { value: number; next: number } {
+  let value = 0;
+  let shift = 0;
+  let i = offset;
+  while (i < buf.length) {
+    const b = buf[i++];
+    value |= (b & 0x7f) << shift;
+    if ((b & 0x80) === 0) return { value: value >>> 0, next: i };
+    shift += 7;
+    if (shift >= 35) throw new Error("varint too long");
+  }
+  throw new Error("varint truncated");
+}
+
+function tag(fieldNumber: number, wireType: number): Buffer {
+  return encodeVarint((fieldNumber << 3) | wireType);
+}
+
+function writeStringField(fieldNumber: number, value: string): Buffer {
+  if (value === "") return Buffer.alloc(0);
+  const bytes = Buffer.from(value, "utf8");
+  return Buffer.concat([tag(fieldNumber, 2), encodeVarint(bytes.length), bytes]);
+}
+
+function writeUint32Field(fieldNumber: number, value: number): Buffer {
+  if (value === 0) return Buffer.alloc(0);
+  return Buffer.concat([tag(fieldNumber, 0), encodeVarint(value >>> 0)]);
+}
+
+function encodeFrame(messageType: number, payload: Buffer): Buffer {
+  return Buffer.concat([
+    Buffer.from([ESPHOME_PREAMBLE]),
+    encodeVarint(payload.length),
+    encodeVarint(messageType),
+    payload,
+  ]);
+}
+
+interface DecodedFrame {
+  messageType: number;
+  payload: Buffer;
+  bytesConsumed: number;
+}
+
+function tryDecodeFrame(buf: Buffer): DecodedFrame | null {
+  if (buf.length === 0) return null;
+  if (buf[0] !== ESPHOME_PREAMBLE) {
+    throw new Error(`unexpected preamble 0x${buf[0].toString(16)}`);
+  }
+  try {
+    const { value: len, next: afterLen } = decodeVarint(buf, 1);
+    const { value: mt, next: afterType } = decodeVarint(buf, afterLen);
+    const end = afterType + len;
+    if (buf.length < end) return null;
+    return {
+      messageType: mt,
+      payload: buf.subarray(afterType, end),
+      bytesConsumed: end,
+    };
+  } catch (err) {
+    if (err instanceof Error && err.message === "varint truncated") return null;
+    throw err;
+  }
+}
+
+type DecodedFields = Record<number, number | Buffer | Array<number | Buffer>>;
+
+function decodeFields(payload: Buffer): DecodedFields {
+  const out: DecodedFields = {};
+  let off = 0;
+  while (off < payload.length) {
+    const { value: tagValue, next: afterTag } = decodeVarint(payload, off);
+    const fieldNumber = tagValue >>> 3;
+    const wireType = tagValue & 0x07;
+    off = afterTag;
+    let parsed: number | Buffer;
+    if (wireType === 0) {
+      const { value, next } = decodeVarint(payload, off);
+      parsed = value;
+      off = next;
+    } else if (wireType === 2) {
+      const { value: len, next } = decodeVarint(payload, off);
+      parsed = payload.subarray(next, next + len);
+      off = next + len;
+    } else {
+      // Unsupported wire types — bail. We only need varint + length-delimited
+      // for the messages we read here.
+      throw new Error(`probe: unsupported wire type ${wireType}`);
+    }
+    const existing = out[fieldNumber];
+    if (existing === undefined) out[fieldNumber] = parsed;
+    else if (Array.isArray(existing)) existing.push(parsed);
+    else out[fieldNumber] = [existing, parsed];
+  }
+  return out;
+}
+
+function fieldAsString(fields: DecodedFields, n: number): string {
+  const v = fields[n];
+  if (v === undefined) return "";
+  if (Buffer.isBuffer(v)) return v.toString("utf8");
+  return "";
+}
+
+function fieldAsUint(fields: DecodedFields, n: number): number {
+  const v = fields[n];
+  if (v === undefined) return 0;
+  if (typeof v === "number") return v;
+  return 0;
+}
+
+// ── Probe runner ─────────────────────────────────────────────────────────
+// One TCP connection per probe. We open, run Hello → DeviceInfo →
+// ListEntities, collect responses, then close cleanly via DisconnectRequest.
+
+interface EsphomeProbeResult {
+  reachable: boolean;
+  /** Verbatim message from the satellite's HelloResponse `server_info`
+   * field — typically the ESPHome version + board. Empty when probe
+   * failed before HelloResponse. */
+  server_info: string;
+  /** The satellite's reported esphome_version (DeviceInfoResponse field 4).
+   * Empty when probe failed before DeviceInfo. */
+  esphome_version: string;
+  /** The satellite's reported MAC, lower-case `aa:bb:cc:dd:ee:ff`. */
+  mac_address: string;
+  /** Friendly name, e.g. "Voice PE Living Room". */
+  friendly_name: string;
+  /** Did the satellite advertise a `voice_assistant:` entity in
+   * ListEntitiesResponse? */
+  voice_assistant_present: boolean;
+  /** Free-form codec descriptor. PR5 only checks "pcm16 mono @ 16 kHz" is
+   * what the satellite expects on the wire; voice-bridge's
+   * EsphomeVoiceSession always speaks that codec, so any deviation here is
+   * a configuration warning, not a hard fail. */
+  codec: string;
+  /** Operator-readable recommendations. Empty array on a clean run. */
+  recommendations: string[];
+  /** On probe failure: terse one-line diagnosis. Null on success. */
+  error: string | null;
+}
+
+async function probeEsphomeDevice(opts: {
+  ip: string;
+  /** Optional override — default 6053. Tests use it to point at a fake
+   * satellite on a random high port without monkey-patching net. */
+  port?: number;
+  timeoutMs?: number;
+}): Promise<EsphomeProbeResult> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS;
+  const ip = opts.ip;
+  const port = opts.port ?? 6053;
+
+  const result: EsphomeProbeResult = {
+    reachable: false,
+    server_info: "",
+    esphome_version: "",
+    mac_address: "",
+    friendly_name: "",
+    voice_assistant_present: false,
+    codec: "",
+    recommendations: [],
+    error: null,
+  };
+
+  const socket = new net.Socket();
+  let buffer = Buffer.alloc(0);
+  let helloDone = false;
+  let connectDone = false;
+  let deviceInfoDone = false;
+  let listDone = false;
+
+  const done = new Promise<void>((resolve) => {
+    let resolved = false;
+    function finish(): void {
+      if (resolved) return;
+      resolved = true;
+      try {
+        socket.destroy();
+      } catch {
+        /* ignore */
+      }
+      resolve();
+    }
+
+    const timer = setTimeout(() => {
+      if (!result.error) {
+        if (!helloDone) result.error = "connect-timeout";
+        else if (!deviceInfoDone) result.error = "device-info-timeout";
+        else if (!listDone) result.error = "list-entities-timeout";
+        else result.error = "probe-timeout";
+      }
+      finish();
+    }, timeoutMs);
+
+    socket.on("connect", () => {
+      result.reachable = true;
+      // Send HelloRequest. client_info + major/minor versions.
+      const helloPayload = Buffer.concat([
+        writeStringField(1, "alfred-ctrl-probe"),
+        writeUint32Field(2, 1),
+        writeUint32Field(3, 10),
+      ]);
+      socket.write(encodeFrame(MSG_HelloRequest, helloPayload));
+    });
+
+    socket.on("error", (err) => {
+      result.error = err.message;
+      clearTimeout(timer);
+      finish();
+    });
+
+    socket.on("data", (chunk: Buffer) => {
+      buffer = buffer.length === 0 ? chunk : Buffer.concat([buffer, chunk]);
+      let frame: DecodedFrame | null;
+      try {
+        while ((frame = tryDecodeFrame(buffer))) {
+          buffer = buffer.subarray(frame.bytesConsumed);
+          handleFrame(frame.messageType, frame.payload);
+        }
+      } catch (err) {
+        result.error = err instanceof Error ? err.message : String(err);
+        clearTimeout(timer);
+        finish();
+      }
+      if (listDone) {
+        clearTimeout(timer);
+        // Polite disconnect — the satellite stays paired to its real HA.
+        try {
+          socket.write(encodeFrame(MSG_DisconnectRequest, Buffer.alloc(0)));
+        } catch {
+          /* ignore */
+        }
+        setTimeout(finish, 50);
+      }
+    });
+
+    socket.on("close", () => {
+      clearTimeout(timer);
+      finish();
+    });
+
+    function handleFrame(messageType: number, payload: Buffer): void {
+      switch (messageType) {
+        case MSG_HelloResponse: {
+          const fields = decodeFields(payload);
+          result.server_info = fieldAsString(fields, 3);
+          helloDone = true;
+          // Real ESPHome devices typically require ConnectRequest even
+          // before they answer DeviceInfo. Send an empty-password
+          // ConnectRequest — if the satellite requires a password we'll
+          // get invalid_password=true back and downgrade gracefully.
+          socket.write(encodeFrame(MSG_ConnectRequest, Buffer.alloc(0)));
+          return;
+        }
+        case MSG_ConnectResponse: {
+          const fields = decodeFields(payload);
+          const invalid = fieldAsUint(fields, 1) !== 0;
+          if (invalid) {
+            result.recommendations.push(
+              "Satellite's ESPHome API password is set — set HA_VOICE_API_TOKEN " +
+                "in /opt/alfred/.env so voice-bridge can connect back, or remove " +
+                "the password from the satellite YAML.",
+            );
+            // Don't bail — DeviceInfo + ListEntities still work post-pair
+            // on most firmware versions; carry on best-effort.
+          }
+          connectDone = true;
+          socket.write(encodeFrame(MSG_DeviceInfoRequest, Buffer.alloc(0)));
+          return;
+        }
+        case MSG_DeviceInfoResponse: {
+          const fields = decodeFields(payload);
+          // field 3 = mac_address, 4 = esphome_version, 13 = friendly_name
+          result.mac_address = fieldAsString(fields, 3);
+          result.esphome_version = fieldAsString(fields, 4);
+          result.friendly_name = fieldAsString(fields, 13);
+          deviceInfoDone = true;
+          socket.write(encodeFrame(MSG_ListEntitiesRequest, Buffer.alloc(0)));
+          return;
+        }
+        case MSG_ListEntitiesVoiceAssistantResponse: {
+          // PR5 doesn't try to parse the full voice_assistant entity shape —
+          // its mere presence is the signal. PR6 will decode the FlagsBits
+          // field to surface USE_VAD / supports announcements etc.
+          result.voice_assistant_present = true;
+          // We assume the codec because the ESPHome firmware hard-codes it
+          // — voice_assistant only ever speaks pcm16 mono @ 16 kHz.
+          result.codec = "pcm16 mono @ 16 kHz (assumed from voice_assistant)";
+          return;
+        }
+        case MSG_ListEntitiesDoneResponse: {
+          listDone = true;
+          return;
+        }
+        default: {
+          // Other entity types (light, sensor, button) flow through the
+          // same ListEntities loop. Ignore them — we only care about
+          // voice_assistant.
+          return;
+        }
+      }
+    }
+  });
+
+  try {
+    socket.connect({ port, host: ip });
+  } catch (err) {
+    result.error = err instanceof Error ? err.message : String(err);
+  }
+  await done;
+
+  // Post-probe recommendations.
+  if (!result.reachable) {
+    if (!result.error) result.error = "unreachable";
+    result.recommendations.push(
+      `Could not open TCP to ${ip}:6053 — check the IP is on a network this VM can reach (same LAN or Tailscale).`,
+    );
+  } else if (!result.voice_assistant_present && listDone) {
+    result.recommendations.push(
+      "Device responded but has no `voice_assistant:` block in its ESPHome YAML — add one and reflash.",
+    );
+  }
+  if (result.esphome_version && /^2024\.([0-6])\./.test(result.esphome_version)) {
+    result.recommendations.push(
+      `ESPHome ${result.esphome_version} is older than 2024.7; voice-bridge advertises API 1.10 which needs 2024.8+. Update + reflash.`,
+    );
+  }
+
+  return result;
+}
+
+// ── voice-bridge HTTP control proxy ──────────────────────────────────────
+
+async function getVoiceBridgeJson(path: string): Promise<unknown> {
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(),
+    VOICE_BRIDGE_FETCH_TIMEOUT_MS,
+  );
+  try {
+    const resp = await fetch(`${VOICE_BRIDGE_URL}${path}`, {
+      signal: controller.signal,
+    });
+    if (!resp.ok) {
+      throw new Error(`voice-bridge ${path} → HTTP ${resp.status}`);
+    }
+    return await resp.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ── Route registration ──────────────────────────────────────────────────
+
+export function registerVoiceEsphomeRoutes(): void {
+  // GET /api/v1/channels/voice/esphome/devices — list HA installs that have
+  // paired with the bridge. Fail-soft: if voice-bridge isn't running we
+  // surface `{devices: [], unavailable: true}` so the UI renders the
+  // "ESPHome listener disabled" hint instead of an error toast.
+  addRoute(
+    "GET",
+    "/api/v1/channels/voice/esphome/devices",
+    async ({ req, res }) => {
+      requireOperatorBearer(req);
+      try {
+        const data = await getVoiceBridgeJson("/esphome/devices");
+        sendJson(res, 200, data);
+      } catch (err) {
+        // Surface as unavailable rather than 500 so the dashboard handles
+        // the "listener off" case in the same code path as the 404 the
+        // pre-PR5 stub returned. The card already special-cases
+        // `unavailable: true`.
+        const message = err instanceof Error ? err.message : String(err);
+        sendJson(res, 200, {
+          enabled: false,
+          listener_address: null,
+          devices: [],
+          unavailable: true,
+          error: message,
+        });
+      }
+    },
+  );
+
+  // POST /api/v1/channels/voice/esphome/devices/test
+  //   body: { ip: string, hostname?: string, timeoutMs?: number }
+  //   200 :  { ok, info: <EsphomeProbeResult>, hostname? }
+  addRoute(
+    "POST",
+    "/api/v1/channels/voice/esphome/devices/test",
+    async ({ req, res, body }) => {
+      requireOperatorBearer(req);
+      const b = (body ?? {}) as Record<string, unknown>;
+      const ip = typeof b.ip === "string" ? b.ip.trim() : "";
+      const hostname = typeof b.hostname === "string" ? b.hostname.trim() : "";
+      const timeoutMs =
+        typeof b.timeoutMs === "number" && b.timeoutMs > 0 && b.timeoutMs < 30_000
+          ? b.timeoutMs
+          : DEFAULT_PROBE_TIMEOUT_MS;
+      // Loose IPv4/IPv6/hostname check — net.connect will reject garbage
+      // anyway. We reject only the empty case + obvious scheme-prefixed
+      // mistakes (the dashboard form sometimes leaks "http://" prefixes).
+      if (!ip) {
+        throw new ValidationError("ip is required");
+      }
+      if (/^[a-z]+:\/\//i.test(ip)) {
+        throw new ValidationError(
+          "ip must be a bare IP / hostname — no scheme prefix",
+        );
+      }
+      const info = await probeEsphomeDevice({ ip, timeoutMs });
+      const ok =
+        info.reachable && info.voice_assistant_present && info.error === null;
+      sendJson(res, 200, {
+        ok,
+        info,
+        hostname: hostname || null,
+      });
+    },
+  );
+
+  // GET /api/v1/channels/voice/wyoming/status — surface Wyoming-fallback
+  // readiness. Useful for the dashboard's "voice protocol" diagnostic
+  // tile + for support fanouts ("is wyoming on for tenant X?").
+  addRoute(
+    "GET",
+    "/api/v1/channels/voice/wyoming/status",
+    async ({ req, res }) => {
+      requireOperatorBearer(req);
+      try {
+        const data = await getVoiceBridgeJson("/wyoming/status");
+        sendJson(res, 200, data);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        sendJson(res, 200, {
+          enabled: false,
+          port: null,
+          bind: null,
+          last_handshake_at: null,
+          unavailable: true,
+          error: message,
+        });
+      }
+    },
+  );
+}
+
+// Exported for tests.
+export {
+  probeEsphomeDevice,
+  encodeFrame,
+  tryDecodeFrame,
+  decodeFields,
+  fieldAsString,
+  fieldAsUint,
+  MSG_HelloRequest,
+  MSG_HelloResponse,
+  MSG_ConnectRequest,
+  MSG_ConnectResponse,
+  MSG_DeviceInfoRequest,
+  MSG_DeviceInfoResponse,
+  MSG_ListEntitiesRequest,
+  MSG_ListEntitiesDoneResponse,
+  MSG_ListEntitiesVoiceAssistantResponse,
+};
+export type { EsphomeProbeResult };

--- a/packages/ctrl/src/api/server.ts
+++ b/packages/ctrl/src/api/server.ts
@@ -55,6 +55,7 @@ import { registerTelegramRoutes } from "./routes/telegram.js";
 import { registerSlackRoutes } from "./routes/slack.js";
 import { registerSmsRoutes } from "./routes/sms.js";
 import { registerVoiceRoutes } from "./routes/voice.js";
+import { registerVoiceEsphomeRoutes } from "./routes/voice_esphome.js";
 import { registerOmiChannelRoutes } from "./routes/channels_omi.js";
 import { registerPaperclipChannelRoutes } from "./routes/channels_paperclip.js";
 import {
@@ -181,6 +182,12 @@ export function createApiServer(): http.Server {
   registerSlackRoutes();
   registerSmsRoutes();
   registerVoiceRoutes();
+  // /api/v1/channels/voice/esphome/* + /wyoming/status — #112 PR5. Live
+  // wiring of the ESPHome listener + Wyoming fallback for the dashboard's
+  // VoiceWakeWordsCard. Read routes proxy to voice-bridge over the docker
+  // network; POST /devices/test opens a real outbound ESPHome Native API
+  // probe against the satellite IP the operator pastes in.
+  registerVoiceEsphomeRoutes();
   registerOmiChannelRoutes();
   registerPaperclipChannelRoutes();
   // /api/v1/channels/recall/* + /api/v1/webhooks/recall — Recall.ai

--- a/packages/ctrl/tests/voice_esphome.test.ts
+++ b/packages/ctrl/tests/voice_esphome.test.ts
@@ -1,0 +1,391 @@
+// voice_esphome.test.ts — coverage for /api/v1/channels/voice/esphome/*
+// (#112 PR5). Same shape as channels_ha_pr1.test.ts: stub out the network
+// surface (here, a fake ESPHome satellite over TCP), drive the route
+// handlers in-process via `matchRoute`, assert on the parsed response.
+//
+// Coverage:
+//   1. probeEsphomeDevice — happy path against a fake satellite that
+//      advertises a voice_assistant entity. `voice_assistant_present:true`,
+//      no recommendations, ok:true.
+//   2. probeEsphomeDevice — satellite responds but has NO voice_assistant
+//      entity → ok:false + the "no voice_assistant: block" recommendation.
+//   3. probeEsphomeDevice — satellite IP is closed (TCP refused) →
+//      reachable:false + the unreachable recommendation.
+//   4. probeEsphomeDevice — older ESPHome version (2024.5) gets the
+//      upgrade recommendation appended.
+//   5. POST /devices/test — bad body (missing ip) → ValidationError.
+//   6. POST /devices/test — body with scheme prefix → ValidationError.
+//   7. GET /devices — voice-bridge unavailable falls through to {devices:[],
+//      unavailable:true} (matches the dashboard's expected shape).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import net from "node:net";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Same pattern as channels_ha_pr1.test.ts — set the data-dir env vars
+// BEFORE we await-import the SUT so its top-level module bodies (which
+// eagerly read these paths) land in tmp instead of /alfred-data.
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "voice-esphome-pr5-"));
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.VAULT_PATH = path.join(tmp, "vault");
+process.env.STATE_DB_PATH = path.join(tmp, "alfred-state.db");
+process.env.INGEST_DB_PATH = path.join(tmp, "ingest.db");
+process.env.SQLITE_VEC_PATH = "";
+
+// ── ESPHome satellite stub (re-uses the codec the SUT inlines) ─────────
+// We avoid importing voice_esphome's encoder/decoder so the stub remains
+// independent of the SUT under test — same trick channels_ha_pr1 uses
+// for its HA mock.
+
+function encVarint(value: number): Buffer {
+  const out: number[] = [];
+  let v = value;
+  while (v >= 0x80) {
+    out.push((v & 0x7f) | 0x80);
+    v >>>= 7;
+  }
+  out.push(v & 0x7f);
+  return Buffer.from(out);
+}
+
+function decVarint(buf: Buffer, off: number): { value: number; next: number } {
+  let value = 0;
+  let shift = 0;
+  let i = off;
+  while (i < buf.length) {
+    const b = buf[i++];
+    value |= (b & 0x7f) << shift;
+    if ((b & 0x80) === 0) return { value: value >>> 0, next: i };
+    shift += 7;
+  }
+  throw new Error("varint truncated");
+}
+
+function tagBytes(fieldNumber: number, wireType: number): Buffer {
+  return encVarint((fieldNumber << 3) | wireType);
+}
+
+function strField(n: number, s: string): Buffer {
+  const b = Buffer.from(s, "utf-8");
+  return Buffer.concat([tagBytes(n, 2), encVarint(b.length), b]);
+}
+
+function encFrame(mt: number, payload: Buffer): Buffer {
+  return Buffer.concat([
+    Buffer.from([0x00]),
+    encVarint(payload.length),
+    encVarint(mt),
+    payload,
+  ]);
+}
+
+const SAT_MSG = {
+  HelloRequest: 1,
+  HelloResponse: 2,
+  ConnectRequest: 3,
+  ConnectResponse: 4,
+  DisconnectRequest: 5,
+  DeviceInfoRequest: 9,
+  DeviceInfoResponse: 10,
+  ListEntitiesRequest: 11,
+  ListEntitiesDoneResponse: 19,
+  ListEntitiesVoiceAssistantResponse: 58,
+};
+
+interface FakeSatelliteOpts {
+  esphomeVersion: string;
+  hasVoiceAssistant: boolean;
+  friendlyName?: string;
+  mac?: string;
+}
+
+async function startFakeSatellite(
+  opts: FakeSatelliteOpts,
+): Promise<{ port: number; close: () => Promise<void> }> {
+  const server = net.createServer((sock) => {
+    let buf = Buffer.alloc(0);
+    sock.on("data", (chunk) => {
+      buf = Buffer.concat([buf, chunk]);
+      while (buf.length > 0) {
+        if (buf[0] !== 0x00) {
+          sock.destroy();
+          return;
+        }
+        let len: number;
+        let mt: number;
+        let payloadStart: number;
+        try {
+          const a = decVarint(buf, 1);
+          const b = decVarint(buf, a.next);
+          len = a.value;
+          mt = b.value;
+          payloadStart = b.next;
+        } catch {
+          return; // partial frame, wait
+        }
+        if (buf.length < payloadStart + len) return;
+        buf = buf.subarray(payloadStart + len);
+        switch (mt) {
+          case SAT_MSG.HelloRequest: {
+            const payload = Buffer.concat([
+              strField(3, `ESPHome ${opts.esphomeVersion} (fake)`),
+              strField(4, "alfred-voice-pe"),
+            ]);
+            sock.write(encFrame(SAT_MSG.HelloResponse, payload));
+            break;
+          }
+          case SAT_MSG.ConnectRequest: {
+            sock.write(encFrame(SAT_MSG.ConnectResponse, Buffer.alloc(0)));
+            break;
+          }
+          case SAT_MSG.DeviceInfoRequest: {
+            const payload = Buffer.concat([
+              strField(3, opts.mac ?? "aa:bb:cc:11:22:33"),
+              strField(4, opts.esphomeVersion),
+              strField(13, opts.friendlyName ?? "Voice PE Living Room"),
+            ]);
+            sock.write(encFrame(SAT_MSG.DeviceInfoResponse, payload));
+            break;
+          }
+          case SAT_MSG.ListEntitiesRequest: {
+            if (opts.hasVoiceAssistant) {
+              sock.write(
+                encFrame(
+                  SAT_MSG.ListEntitiesVoiceAssistantResponse,
+                  strField(1, "voice_assistant"),
+                ),
+              );
+            }
+            sock.write(
+              encFrame(SAT_MSG.ListEntitiesDoneResponse, Buffer.alloc(0)),
+            );
+            break;
+          }
+          case SAT_MSG.DisconnectRequest: {
+            sock.end();
+            break;
+          }
+          default:
+            break;
+        }
+      }
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.removeListener("error", reject);
+      resolve();
+    });
+  });
+  const port = (server.address() as net.AddressInfo).port;
+  return {
+    port,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}
+
+// Import the SUT after we've stubbed the network surface.
+const { probeEsphomeDevice, registerVoiceEsphomeRoutes } = await import(
+  "../src/api/routes/voice_esphome.js"
+);
+const { matchRoute } = await import("../src/api/server.js");
+const { handleError } = await import("../src/api/errors.js");
+const { setApiKey, _resetAuthForTests } = await import("../src/api/auth.js");
+
+registerVoiceEsphomeRoutes();
+
+const MASTER_KEY = "test-master-" + "x".repeat(40);
+
+interface CallResult {
+  status: number;
+  payload: any;
+}
+
+async function call(
+  method: string,
+  p: string,
+  body?: unknown,
+  token: string | undefined = MASTER_KEY,
+): Promise<CallResult> {
+  const m = matchRoute(method, p);
+  assert.ok(m, `${method} ${p} must be registered`);
+  let status = 0;
+  let payload: any;
+  const res = {
+    statusCode: 0,
+    setHeader() {},
+    writeHead(c: number) {
+      status = c;
+      return res;
+    },
+    end(j?: string) {
+      payload = j ? JSON.parse(j) : undefined;
+    },
+  } as any;
+  try {
+    await m!.handler({
+      req: {
+        method,
+        url: p,
+        headers: token ? { authorization: `Bearer ${token}` } : {},
+      } as any,
+      res,
+      params: m!.params,
+      body,
+      query: new URLSearchParams(),
+    });
+  } catch (err) {
+    handleError(res, err);
+  }
+  return { status, payload };
+}
+
+// The SUT accepts an optional `port` arg; tests use it to point at our
+// fake satellite on a random high port instead of the real :6053.
+async function probeAgainstFake(port: number, opts: { timeoutMs?: number } = {}) {
+  const result = await probeEsphomeDevice({
+    ip: "127.0.0.1",
+    port,
+    timeoutMs: opts.timeoutMs ?? 3000,
+  });
+  return { result };
+}
+
+test("probeEsphomeDevice — happy path: voice_assistant entity present, ok:true", async () => {
+  const fake = await startFakeSatellite({
+    esphomeVersion: "2024.10.3",
+    hasVoiceAssistant: true,
+  });
+  try {
+    const { result } = await probeAgainstFake(fake.port);
+    assert.equal(result.reachable, true, "tcp connect succeeded");
+    assert.equal(result.error, null, "no probe error");
+    assert.equal(result.voice_assistant_present, true);
+    assert.equal(result.esphome_version, "2024.10.3");
+    assert.equal(result.friendly_name, "Voice PE Living Room");
+    assert.equal(result.mac_address, "aa:bb:cc:11:22:33");
+    assert.deepEqual(result.recommendations, []);
+  } finally {
+    await fake.close();
+  }
+});
+
+test("probeEsphomeDevice — no voice_assistant block surfaces a recommendation", async () => {
+  const fake = await startFakeSatellite({
+    esphomeVersion: "2024.10.3",
+    hasVoiceAssistant: false,
+  });
+  try {
+    const { result } = await probeAgainstFake(fake.port);
+    assert.equal(result.reachable, true);
+    assert.equal(result.voice_assistant_present, false);
+    const matched = result.recommendations.find((r) =>
+      r.includes("voice_assistant:"),
+    );
+    assert.ok(
+      matched,
+      "should recommend adding a voice_assistant: block; got " +
+        JSON.stringify(result.recommendations),
+    );
+  } finally {
+    await fake.close();
+  }
+});
+
+test("probeEsphomeDevice — unreachable IP surfaces reachable:false + recommendation", async () => {
+  // Dial a port that's definitely not listening (port 1, which on most
+  // systems immediately returns ECONNREFUSED). Faster than depending on
+  // a connect timeout — the test stays under 100ms.
+  const result = await probeEsphomeDevice({
+    ip: "127.0.0.1",
+    port: 1,
+    timeoutMs: 1500,
+  });
+  assert.equal(result.reachable, false);
+  assert.ok(result.error, "error string set");
+  const recommendation = result.recommendations.find((r) =>
+    r.includes("Could not open TCP"),
+  );
+  assert.ok(
+    recommendation,
+    "should suggest checking IP/network reachability",
+  );
+});
+
+test("probeEsphomeDevice — old ESPHome version is flagged for upgrade", async () => {
+  const fake = await startFakeSatellite({
+    esphomeVersion: "2024.5.0",
+    hasVoiceAssistant: true,
+  });
+  try {
+    const { result } = await probeAgainstFake(fake.port);
+    assert.equal(result.reachable, true);
+    assert.equal(result.voice_assistant_present, true);
+    const matched = result.recommendations.find((r) =>
+      r.includes("older than 2024.7"),
+    );
+    assert.ok(
+      matched,
+      "should recommend upgrading the satellite; got " +
+        JSON.stringify(result.recommendations),
+    );
+  } finally {
+    await fake.close();
+  }
+});
+
+// ── Route-level tests ───────────────────────────────────────────────────
+
+test("POST /devices/test — empty body rejects with ValidationError (ip required)", async () => {
+  _resetAuthForTests();
+  setApiKey(MASTER_KEY);
+  const r = await call(
+    "POST",
+    "/api/v1/channels/voice/esphome/devices/test",
+    {},
+  );
+  assert.equal(r.status, 400, JSON.stringify(r.payload));
+  assert.match(JSON.stringify(r.payload), /ip is required/);
+});
+
+test("POST /devices/test — body with scheme prefix is rejected", async () => {
+  _resetAuthForTests();
+  setApiKey(MASTER_KEY);
+  const r = await call(
+    "POST",
+    "/api/v1/channels/voice/esphome/devices/test",
+    { ip: "http://192.168.1.50" },
+  );
+  assert.equal(r.status, 400, JSON.stringify(r.payload));
+  assert.match(JSON.stringify(r.payload), /scheme prefix/);
+});
+
+test("GET /esphome/devices — voice-bridge unreachable returns unavailable:true", async () => {
+  _resetAuthForTests();
+  setApiKey(MASTER_KEY);
+  // Point VOICE_BRIDGE_INTERNAL_URL at an unreachable host BEFORE the
+  // route module gets reloaded — but in this test pattern the module is
+  // already imported, so we drive the fail path by patching `fetch`. The
+  // SUT's `getVoiceBridgeJson` uses the global fetch.
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    throw new Error("connect ECONNREFUSED 172.18.0.42:9000");
+  }) as typeof fetch;
+  try {
+    const r = await call("GET", "/api/v1/channels/voice/esphome/devices");
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.unavailable, true);
+    assert.equal(r.payload.enabled, false);
+    assert.deepEqual(r.payload.devices, []);
+    assert.match(r.payload.error, /ECONNREFUSED/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/packages/voice-bridge/docs/ha-pipeline-setup.md
+++ b/packages/voice-bridge/docs/ha-pipeline-setup.md
@@ -253,3 +253,110 @@ Failure to reach `:6053` from HA surfaces as
 `Failed to connect to esphome:6053 → connection refused` in HA's ESPHome
 integration logs — that's the topology test. Re-read the
 "Reachability" table above and confirm your topology is correct.
+
+### Operator-side smoke test (issue #112 PR5)
+
+From your laptop, while on the tailnet, you can probe a satellite IP
+without leaving the shell:
+
+```bash
+# Probe a specific satellite — opens an ESPHome Native API connection,
+# runs Hello → DeviceInfo → ListEntities, looks for `voice_assistant:`,
+# reports back with recommendations.
+curl -s -X POST \
+     -H "Authorization: Bearer $AAS_API_KEY" \
+     -H "Content-Type: application/json" \
+     -d '{"ip":"192.168.1.50","hostname":"voice-pe-living-room.local"}' \
+     https://home.alfred.black/api/v1/channels/voice/esphome/devices/test \
+| jq .
+
+# Output shape:
+# {
+#   "ok": true,
+#   "info": {
+#     "reachable": true,
+#     "esphome_version": "2024.10.3",
+#     "voice_assistant_present": true,
+#     "codec": "pcm16 mono @ 16 kHz (assumed from voice_assistant)",
+#     "recommendations": []
+#   },
+#   "hostname": "voice-pe-living-room.local"
+# }
+
+# List HA installs that have paired with voice-bridge so far:
+curl -s -H "Authorization: Bearer $AAS_API_KEY" \
+     https://home.alfred.black/api/v1/channels/voice/esphome/devices | jq .
+
+# Wyoming-fallback readiness — `enabled: true` iff WYOMING_ENABLED=1
+# was set when voice-bridge last booted:
+curl -s -H "Authorization: Bearer $AAS_API_KEY" \
+     https://home.alfred.black/api/v1/channels/voice/wyoming/status | jq .
+```
+
+The same routes power the `/channels` dashboard's **Voice satellites**
+card — the `[Test]` button next to each detected device calls the same
+probe and renders the recommendations inline.
+
+There's also a CLI helper for the bare ESPHome Native API probe (skips
+ctrl-api entirely — useful when you're SSH'd into the VM and don't have
+`$AAS_API_KEY` handy):
+
+```bash
+packages/voice-bridge/scripts/smoke-esphome-device.sh --ip 192.168.1.50
+```
+
+---
+
+## Alternative — the Wyoming Protocol route
+
+The default path above uses the **ESPHome Native API** (`:6053`). Issue
+#112 PR5 adds a parallel **Wyoming Protocol** listener on `:10300` that
+HA's `wyoming` integration calls into. The voice-bridge supports both —
+they terminate at the same brain — so the operator picks whichever
+matches their HA install.
+
+When to pick which:
+
+| Path | Pros | Cons |
+| --- | --- | --- |
+| **ESPHome Native API** (default) | Shorter audio path (~30 ms latency saving), wake word stays on-device for free, no extra HA-side config. | Requires HA to reach `:6053` over the LAN OR the tailnet. HA-OS / HA-Cloud installs that can't reach :6053 hit a wall. |
+| **Wyoming Protocol** (`:10300`, opt-in) | Works wherever HA's `wyoming` integration works — including HA-Cloud / HA-OS where the ESPHome Native API path is closed. Speaks the same JSONL grammar as Whisper / Piper, so HA treats us like any other satellite worker. | One extra serialisation round-trip per turn; HA owns the wake/STT/intent/TTS pipeline so the wake word + STT happen HA-side first. |
+
+Enable on a tenant:
+
+```bash
+# /opt/alfred/.env
+WYOMING_ENABLED=1
+```
+
+Then restart `voice-bridge`:
+
+```bash
+docker compose --profile voice restart voice-bridge
+```
+
+In HA: `Settings → Add-ons / Integrations → Wyoming Protocol → Add`.
+Use the same hostname you'd point ESPHome at (typically the tailnet name
+or `voice.<your-domain>` if you've set up the Caddy reverse-proxy). HA
+will probe the listener with a Wyoming `describe` event; our reply
+advertises a `satellite` service at 16 kHz pcm16 mono on both mic and
+sound directions. HA wires us as the satellite + the conversation agent
+in one step.
+
+The wake-word selection card on `/channels` still applies — the
+microWakeWord entries run on-device (whether you came in via ESPHome
+Native or via Wyoming through a Pi running `wyoming-satellite`); the
+openWakeWord entries run on the voice-bridge regardless of transport.
+
+### Wake-word handling differences
+
+- **ESPHome Native path**: wake stays on the ESP32-S3, voice-bridge
+  receives a `VoiceAssistantRequest(start=true, wake_word_phrase=...)`
+  with the phrase already detected. We don't run wake detection at all.
+- **Wyoming path**: HA's Assist pipeline runs wake detection first
+  (either via its `openwakeword` add-on or per-satellite firmware), then
+  forwards post-wake audio to us as a `audio-start` → `audio-chunk*` →
+  `audio-stop` stream. We never see the wake word itself.
+
+Either way the principal's experience is identical — say the wake word,
+ask a question, get a Received-Pronunciation butler reply.

--- a/packages/voice-bridge/scripts/smoke-esphome-device.sh
+++ b/packages/voice-bridge/scripts/smoke-esphome-device.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# smoke-esphome-device.sh — bare ESPHome Native API probe.
+#
+# Same diagnosis ctrl-api's POST /api/v1/channels/voice/esphome/devices/test
+# runs, but spawned from a laptop without ctrl-api in the loop. Useful when:
+#
+#   - You're SSH'd into the tenant VM and the master AAS_API_KEY isn't to
+#     hand.
+#   - You want to confirm "is :6053 even reachable from this host?" without
+#     going through Caddy.
+#   - You're debugging an integration outage and ctrl-api itself isn't
+#     up — this script only depends on `node` + the voice-bridge dist.
+#
+# Usage:
+#
+#   packages/voice-bridge/scripts/smoke-esphome-device.sh --ip 192.168.1.50
+#   packages/voice-bridge/scripts/smoke-esphome-device.sh --ip voice-pe.local --port 6053
+#
+# Exits 0 + prints OK on a healthy probe, exits non-zero + prints a one-
+# line diagnosis on failure. Doesn't write anything. Doesn't keep state.
+
+set -euo pipefail
+
+IP=""
+PORT="6053"
+TIMEOUT_MS="5000"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --ip)
+      IP="${2:-}"
+      shift 2
+      ;;
+    --port)
+      PORT="${2:-}"
+      shift 2
+      ;;
+    --timeout-ms)
+      TIMEOUT_MS="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      cat <<EOF
+smoke-esphome-device.sh — bare ESPHome Native API probe.
+
+Usage:
+  $(basename "$0") --ip <ip-or-hostname> [--port 6053] [--timeout-ms 5000]
+
+Prints OK on success or a one-line diagnosis on failure.
+EOF
+      exit 0
+      ;;
+    *)
+      echo "unknown arg: $1" >&2
+      echo "see --help" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$IP" ]]; then
+  echo "error: --ip is required" >&2
+  exit 2
+fi
+
+# We embed a tiny Node script rather than depending on the voice-bridge
+# dist — keeps this runnable on a fresh VM checkout without `npm install`.
+# Same wire shape as packages/voice-bridge/src/esphome-protocol.ts.
+node --input-type=module -e "
+const net = await import('node:net');
+const ip = process.argv[1];
+const port = Number(process.argv[2]);
+const timeoutMs = Number(process.argv[3]);
+
+function encVarint(v) {
+  const out = [];
+  while (v >= 0x80) { out.push((v & 0x7f) | 0x80); v >>>= 7; }
+  out.push(v & 0x7f);
+  return Buffer.from(out);
+}
+function decVarint(buf, off) {
+  let value = 0, shift = 0, i = off;
+  while (i < buf.length) {
+    const b = buf[i++];
+    value |= (b & 0x7f) << shift;
+    if ((b & 0x80) === 0) return { value: value >>> 0, next: i };
+    shift += 7;
+  }
+  throw new Error('varint truncated');
+}
+function tagBytes(n, w) { return encVarint((n << 3) | w); }
+function strField(n, s) {
+  const b = Buffer.from(s, 'utf-8');
+  return Buffer.concat([tagBytes(n, 2), encVarint(b.length), b]);
+}
+function uintField(n, v) {
+  if (v === 0) return Buffer.alloc(0);
+  return Buffer.concat([tagBytes(n, 0), encVarint(v)]);
+}
+function encFrame(mt, payload) {
+  return Buffer.concat([Buffer.from([0x00]), encVarint(payload.length), encVarint(mt), payload]);
+}
+function tryDecode(buf) {
+  if (buf.length === 0) return null;
+  if (buf[0] !== 0x00) throw new Error('unexpected preamble 0x' + buf[0].toString(16));
+  try {
+    const a = decVarint(buf, 1);
+    const b = decVarint(buf, a.next);
+    const end = b.next + a.value;
+    if (buf.length < end) return null;
+    return { messageType: b.value, payload: buf.subarray(b.next, end), bytesConsumed: end };
+  } catch (e) {
+    if (e.message === 'varint truncated') return null;
+    throw e;
+  }
+}
+function decFields(payload) {
+  const out = {}; let off = 0;
+  while (off < payload.length) {
+    const t = decVarint(payload, off); const fieldN = t.value >>> 3; const wireType = t.value & 0x07; off = t.next;
+    if (wireType === 0) { const v = decVarint(payload, off); out[fieldN] = v.value; off = v.next; }
+    else if (wireType === 2) { const len = decVarint(payload, off); const bytes = payload.subarray(len.next, len.next + len.value); off = len.next + len.value; out[fieldN] = bytes; }
+    else { break; }
+  }
+  return out;
+}
+function asStr(f, n) { const v = f[n]; return Buffer.isBuffer(v) ? v.toString('utf8') : ''; }
+
+const MSG = { Hello: 1, HelloR: 2, Conn: 3, ConnR: 4, Disc: 5, DevI: 9, DevIR: 10, List: 11, ListD: 19, ListVA: 58 };
+
+const sock = new net.Socket();
+let buf = Buffer.alloc(0);
+let helloDone = false, devDone = false, listDone = false, voicePresent = false;
+let serverInfo = '', espVer = '', macAddr = '', friendlyName = '';
+
+const timer = setTimeout(() => {
+  console.error('FAIL probe-timeout (helloDone=' + helloDone + ' devDone=' + devDone + ' listDone=' + listDone + ')');
+  sock.destroy();
+  process.exit(3);
+}, timeoutMs);
+
+sock.on('connect', () => {
+  const payload = Buffer.concat([
+    strField(1, 'alfred-smoke-probe'),
+    uintField(2, 1),
+    uintField(3, 10),
+  ]);
+  sock.write(encFrame(MSG.Hello, payload));
+});
+
+sock.on('error', (err) => {
+  clearTimeout(timer);
+  console.error('FAIL connect-error ' + err.message);
+  process.exit(4);
+});
+
+sock.on('data', (chunk) => {
+  buf = buf.length === 0 ? chunk : Buffer.concat([buf, chunk]);
+  let frame;
+  while ((frame = tryDecode(buf))) {
+    buf = buf.subarray(frame.bytesConsumed);
+    if (frame.messageType === MSG.HelloR) {
+      helloDone = true;
+      const f = decFields(frame.payload);
+      serverInfo = asStr(f, 3);
+      sock.write(encFrame(MSG.Conn, Buffer.alloc(0)));
+    } else if (frame.messageType === MSG.ConnR) {
+      sock.write(encFrame(MSG.DevI, Buffer.alloc(0)));
+    } else if (frame.messageType === MSG.DevIR) {
+      devDone = true;
+      const f = decFields(frame.payload);
+      macAddr = asStr(f, 3);
+      espVer = asStr(f, 4);
+      friendlyName = asStr(f, 13);
+      sock.write(encFrame(MSG.List, Buffer.alloc(0)));
+    } else if (frame.messageType === MSG.ListVA) {
+      voicePresent = true;
+    } else if (frame.messageType === MSG.ListD) {
+      listDone = true;
+      clearTimeout(timer);
+      sock.write(encFrame(MSG.Disc, Buffer.alloc(0)));
+      setTimeout(() => sock.destroy(), 50);
+    }
+  }
+});
+
+sock.on('close', () => {
+  if (!listDone) return; // error handlers already exited
+  if (!voicePresent) {
+    console.log('FAIL no-voice-assistant esphome_version=' + espVer + ' friendly_name=' + friendlyName);
+    process.exit(5);
+  }
+  console.log('OK ' + ip + ':' + port + ' esphome_version=' + espVer + ' mac=' + macAddr + ' friendly_name=' + friendlyName + ' voice_assistant=present');
+  process.exit(0);
+});
+
+sock.connect({ port, host: ip });
+" -- "$IP" "$PORT" "$TIMEOUT_MS"

--- a/packages/voice-bridge/src/config.ts
+++ b/packages/voice-bridge/src/config.ts
@@ -105,6 +105,21 @@ export const config = {
   // synthetic ESPHome device. Falls back to os.hostname() in computeIdentity.
   esphomeTenantSeed: optional("ESPHOME_TENANT_SEED", ""),
   esphomeFriendlyName: optional("ESPHOME_FRIENDLY_NAME", "Alfred"),
+
+  // ── Wyoming Protocol fallback (issue #112, PR5) ─────────────────────────
+  // HA's Wyoming integration speaks a different on-wire shape than the
+  // ESPHome Native API — JSONL events over a TCP socket on :10300. We
+  // implement the satellite-side surface so HA can route a full Assist
+  // pipeline through us without going via mDNS-discovered ESPHome.
+  //
+  // OFF by default (WYOMING_ENABLED=0) because the ESPHome Native API path
+  // is shorter end-to-end. Flip to "1" on tenants whose HA install can't
+  // reach :6053 over the LAN (HA-OS / HA-Cloud) but CAN reach a Wyoming
+  // server on the same tailnet. See packages/voice-bridge/docs/
+  // ha-pipeline-setup.md for the trade-off.
+  wyomingEnabled: optional("WYOMING_ENABLED", "0") === "1",
+  wyomingPort: Number(optional("WYOMING_PORT", "10300")),
+  wyomingBind: optional("WYOMING_BIND", "0.0.0.0"),
 } as const;
 
 export type Config = typeof config;

--- a/packages/voice-bridge/src/esphome-server.ts
+++ b/packages/voice-bridge/src/esphome-server.ts
@@ -252,6 +252,10 @@ export interface EsphomeServerOptions {
    * mock so they can assert the bridge bytes without standing up the full
    * OpenAI Realtime client. */
   voiceSessionFactory?: VoiceSessionFactory;
+  /** Optional device registry. Production wires the server-level singleton
+   * so the HTTP control surface can list known clients; tests omit and the
+   * connection still works (registry calls become no-ops). */
+  registry?: EsphomeDeviceRegistry;
 }
 
 /** Hooks the EsphomeConnection exposes to a voice-assistant session. */
@@ -296,6 +300,131 @@ interface SessionState {
   voiceAssistantSubscribed: boolean;
 }
 
+// ── Known-devices registry (PR5) ─────────────────────────────────────────────
+// PR5 surfaces "which HA installs / ESPHome integrations have paired with
+// this voice-bridge" to the /channels dashboard via ctrl-api. We track one
+// entry per inbound connection — keyed on remote IP + clientInfo (the
+// HelloRequest's `client_info` field, which HA sets to e.g.
+// "Home Assistant 2026.5.2") so the same HA install reconnecting after a
+// network blip dedupes onto one row rather than spawning a new ghost.
+//
+// Devices NEVER expire from the registry — last_seen_at is what the UI uses
+// to colour-code rows. The registry is process-local; restarting voice-bridge
+// re-discovers HA installs as they reconnect (HA's ESPHome integration
+// retries forever, so this is fine in practice).
+
+export interface KnownEsphomeDevice {
+  /** Stable id — `${ip}|${clientInfo}` or `${ip}` when client info is empty.
+   * Used by the dashboard as the React key. */
+  id: string;
+  /** Last-known remote IP. May be a docker-bridge IP when HA's running on
+   * the same VM via the tailscale sidecar route. */
+  ip: string;
+  /** HelloRequest.client_info — empty until the connection has handshaken. */
+  clientInfo: string;
+  /** Unix ms of the most recent inbound frame on this connection. */
+  lastSeenAt: number;
+  /** True iff a connection from this device is currently open. We flip
+   * back to false on socket close — older entries with a stale
+   * lastSeenAt + connected=false render as "Offline" in the UI. */
+  connected: boolean;
+  /** True iff the most recent connection completed the ConnectRequest
+   * handshake (i.e. survived auth). When `password` was unset this is
+   * always true on connect. */
+  authorized: boolean;
+  /** True iff HA has subscribed to voice-assistant events. The card uses
+   * this as a tri-state pill ("Paired" / "Listening" / "Idle"). */
+  voiceSubscribed: boolean;
+  /** Total inbound frames observed across the lifetime of this entry —
+   * useful for "is the satellite actually talking to us?" diagnostics. */
+  framesIn: number;
+  /** Total voice-assistant turns we've handled for this device. */
+  turnsHandled: number;
+}
+
+/**
+ * Process-local registry of paired ESPHome clients (= HA installs).
+ *
+ * The EsphomeServer creates one and passes it down to every EsphomeConnection;
+ * each connection notifies the registry on key lifecycle events (open,
+ * handshake, voice-subscribe, frame-in, close). The HTTP control surface in
+ * server.ts reads from it via getKnownDevices().
+ */
+export class EsphomeDeviceRegistry {
+  private byId = new Map<string, KnownEsphomeDevice>();
+
+  /** Called from EsphomeConnection on socket-open + after HelloRequest is
+   * parsed (so we have clientInfo). Returns the entry's id for subsequent
+   * mutations on this connection. */
+  observe(remote: { ip: string; clientInfo: string }): string {
+    const id = makeDeviceId(remote.ip, remote.clientInfo);
+    const now = Date.now();
+    const existing = this.byId.get(id);
+    if (existing) {
+      existing.lastSeenAt = now;
+      existing.connected = true;
+      // clientInfo upgrades from "" → known string when HelloRequest lands.
+      if (remote.clientInfo) existing.clientInfo = remote.clientInfo;
+      return id;
+    }
+    this.byId.set(id, {
+      id,
+      ip: remote.ip,
+      clientInfo: remote.clientInfo,
+      lastSeenAt: now,
+      connected: true,
+      authorized: false,
+      voiceSubscribed: false,
+      framesIn: 0,
+      turnsHandled: 0,
+    });
+    return id;
+  }
+
+  markAuthorized(id: string): void {
+    const e = this.byId.get(id);
+    if (e) e.authorized = true;
+  }
+
+  markVoiceSubscribed(id: string, subscribed: boolean): void {
+    const e = this.byId.get(id);
+    if (e) e.voiceSubscribed = subscribed;
+  }
+
+  tickFrame(id: string): void {
+    const e = this.byId.get(id);
+    if (!e) return;
+    e.framesIn += 1;
+    e.lastSeenAt = Date.now();
+  }
+
+  tickTurn(id: string): void {
+    const e = this.byId.get(id);
+    if (e) e.turnsHandled += 1;
+  }
+
+  markClosed(id: string): void {
+    const e = this.byId.get(id);
+    if (e) e.connected = false;
+  }
+
+  list(): KnownEsphomeDevice[] {
+    // Most-recently-seen first — that's the order the UI wants.
+    return [...this.byId.values()].sort((a, b) => b.lastSeenAt - a.lastSeenAt);
+  }
+
+  /** Test helper. Clears all observed devices. NOT part of the public
+   * runtime surface. */
+  _resetForTests(): void {
+    this.byId.clear();
+  }
+}
+
+function makeDeviceId(ip: string, clientInfo: string): string {
+  const c = clientInfo.trim();
+  return c.length > 0 ? `${ip}|${c}` : ip;
+}
+
 function defaultLog(msg: string, extra?: Record<string, unknown>): void {
   if (extra) console.log(`[esphome] ${msg}`, extra);
   else console.log(`[esphome] ${msg}`);
@@ -314,18 +443,30 @@ export class EsphomeConnection {
    * connection in PR2 — concurrent turns from one HA satellite are not a
    * thing the upstream pipeline emits. */
   private voiceSession: VoiceSessionHandle | null = null;
+  /** Registry id assigned on first HelloRequest. Null until then; we don't
+   * register the bare TCP accept because pre-Hello there's no clientInfo
+   * yet, and registering on accept would spawn duplicate rows for short-
+   * lived port scans. */
+  private deviceId: string | null = null;
+  /** Captured remote IP — `socket.remoteAddress` is nullable post-close. */
+  private readonly remoteIp: string;
 
   constructor(
     private readonly socket: net.Socket,
     private readonly opts: EsphomeServerOptions,
   ) {
-    const remote = socket.remoteAddress ?? "?";
+    this.remoteIp = socket.remoteAddress ?? "?";
     const log = opts.log ?? defaultLog;
-    log("connection accepted", { remote });
+    log("connection accepted", { remote: this.remoteIp });
     socket.on("data", (chunk) => this.onData(chunk));
-    socket.on("error", (err) => log("socket error", { remote, err: err.message }));
+    socket.on("error", (err) =>
+      log("socket error", { remote: this.remoteIp, err: err.message }),
+    );
     socket.on("close", () => {
-      log("connection closed", { remote });
+      log("connection closed", { remote: this.remoteIp });
+      if (this.deviceId && this.opts.registry) {
+        this.opts.registry.markClosed(this.deviceId);
+      }
       if (this.voiceSession) {
         try {
           this.voiceSession.close("connection-closed");
@@ -380,6 +521,14 @@ export class EsphomeConnection {
           clientMinor: fieldAsUint(fields, 3),
         });
         this.state.helloSeen = true;
+        // First handshake — register in the device registry so the /channels
+        // card sees this HA install.
+        if (this.opts.registry) {
+          this.deviceId = this.opts.registry.observe({
+            ip: this.remoteIp,
+            clientInfo,
+          });
+        }
         const resp = buildHelloResponse({
           // We advertise API 1.10 — matches what aioesphomeapi expects from
           // current HA Core. Anything newer would risk HA trying to use
@@ -402,6 +551,9 @@ export class EsphomeConnection {
         if (!invalid) {
           this.state.connected = true;
           this.state.authorized = true;
+          if (this.deviceId && this.opts.registry) {
+            this.opts.registry.markAuthorized(this.deviceId);
+          }
         }
         return;
       }
@@ -465,6 +617,9 @@ export class EsphomeConnection {
         const flags = fieldAsUint(fields, 2);
         log("SubscribeVoiceAssistantRequest", { subscribe, flags });
         this.state.voiceAssistantSubscribed = subscribe;
+        if (this.deviceId && this.opts.registry) {
+          this.opts.registry.markVoiceSubscribed(this.deviceId, subscribe);
+        }
         return;
       }
       case MessageType.VoiceAssistantRequest: {
@@ -490,6 +645,9 @@ export class EsphomeConnection {
             this.voiceSession = null;
           }
           return;
+        }
+        if (this.deviceId && this.opts.registry) {
+          this.opts.registry.tickTurn(this.deviceId);
         }
         if (this.voiceSession) {
           // Already running. Per the spec we never have two concurrent turns
@@ -559,6 +717,9 @@ export class EsphomeConnection {
         const dataField = fields[1];
         const data = Buffer.isBuffer(dataField) ? dataField : Buffer.alloc(0);
         const end = fieldAsBool(fields, 2);
+        if (this.deviceId && this.opts.registry) {
+          this.opts.registry.tickFrame(this.deviceId);
+        }
         this.voiceSession.onInboundAudio(data, end);
         return;
       }
@@ -628,6 +789,9 @@ export interface StartEsphomeServerOptions {
   /** Inject a different voice session factory — production omits and gets
    * the default OpenAI Realtime bridge; tests inject a mock. */
   voiceSessionFactory?: VoiceSessionFactory;
+  /** Optional registry. When omitted, startEsphomeServer creates one
+   * internally so handle.getKnownDevices() always returns something. */
+  registry?: EsphomeDeviceRegistry;
 }
 
 export interface EsphomeServerHandle {
@@ -637,10 +801,19 @@ export interface EsphomeServerHandle {
   /** Resolved port after bind — useful when port=0 in tests. */
   boundPort(): number;
   close(): Promise<void>;
+  /** Return the snapshot of known ESPHome client connections (HA installs)
+   * that have handshaken with this listener. PR5 — the HTTP control
+   * surface in server.ts surfaces this to ctrl-api. */
+  getKnownDevices(): KnownEsphomeDevice[];
+  /** Direct registry handle — production wires this into ctrl-api so the
+   * /test endpoint can observe outgoing-connection probes too. Tests use
+   * it to clear state between cases. */
+  registry: EsphomeDeviceRegistry;
 }
 
 export function startEsphomeServer(opts: StartEsphomeServerOptions): EsphomeServerHandle {
   const log = opts.log ?? defaultLog;
+  const registry = opts.registry ?? new EsphomeDeviceRegistry();
   const server = net.createServer((socket) => {
     socket.setNoDelay(true);
     new EsphomeConnection(socket, {
@@ -648,6 +821,7 @@ export function startEsphomeServer(opts: StartEsphomeServerOptions): EsphomeServ
       password: opts.password,
       log: opts.log,
       voiceSessionFactory: opts.voiceSessionFactory,
+      registry,
     });
   });
   server.on("error", (err) => log("server error", { err: err.message }));
@@ -673,6 +847,8 @@ export function startEsphomeServer(opts: StartEsphomeServerOptions): EsphomeServ
       new Promise<void>((resolve, reject) => {
         server.close((err) => (err ? reject(err) : resolve()));
       }),
+    getKnownDevices: () => registry.list(),
+    registry,
   };
 }
 

--- a/packages/voice-bridge/src/server.ts
+++ b/packages/voice-bridge/src/server.ts
@@ -28,9 +28,15 @@ import { config } from "./config.js";
 import { VoiceCall } from "./voice-call.js";
 import { handleTwimlInbound, TWIML_INBOUND_PATH } from "./twiml.js";
 import { connectAllMcp } from "./mcp-clients.js";
-import { computeIdentity, startEsphomeServer } from "./esphome-server.js";
+import {
+  computeIdentity,
+  startEsphomeServer,
+  type EsphomeServerHandle,
+  type KnownEsphomeDevice,
+} from "./esphome-server.js";
 import { announceEsphomeMdns } from "./esphome-mdns.js";
 import { EsphomeVoiceSession } from "./esphome-session.js";
+import { startWyomingServer, type WyomingServerHandle } from "./wyoming-server.js";
 
 export function verifySig(tenantId: string, sig: string | null | undefined): boolean {
   if (!sig) return false;
@@ -78,6 +84,24 @@ function renderMetrics(): string {
   );
 }
 
+// Boot-time handles captured by the ESPHome + Wyoming initialisers below.
+// The HTTP control routes (`/esphome/devices`, `/wyoming/status`) read
+// from these. Initially null — surface as `{enabled: false, ...}` to the
+// caller until the listeners come up.
+let esphomeHandle: EsphomeServerHandle | null = null;
+let wyomingHandle: WyomingServerHandle | null = null;
+
+/** Public shape returned by `GET /esphome/devices`. Kept in this file to
+ * keep ctrl-api proxying simple — both sides import this type later if
+ * needed; for now the wire shape is the contract. */
+export interface EsphomeDevicesPayload {
+  enabled: boolean;
+  /** "0.0.0.0:6053" — informational so the dashboard can render a hint
+   * when listener_address has been re-bound. */
+  listener_address: string | null;
+  devices: KnownEsphomeDevice[];
+}
+
 const httpServer = http.createServer((req, res) => {
   if (req.url === "/health") {
     res.writeHead(200, { "Content-Type": "application/json" });
@@ -87,6 +111,39 @@ const httpServer = http.createServer((req, res) => {
   if (req.url === "/metrics") {
     res.writeHead(200, { "Content-Type": "text/plain; version=0.0.4" });
     res.end(renderMetrics());
+    return;
+  }
+  // ── PR5 control surface ──────────────────────────────────────────────
+  // ctrl-api hits these over the internal docker network so the operator
+  // dashboard can render which HA installs have paired + whether the
+  // Wyoming fallback is hot. Both are GET-only — there is no remote write
+  // to the voice-bridge from here. Authentication is the docker network
+  // boundary; both ports stay bound to localhost / docker-bridge only.
+  if (req.url === "/esphome/devices") {
+    const payload: EsphomeDevicesPayload = esphomeHandle
+      ? {
+          enabled: true,
+          listener_address: `${config.esphomeApiBind}:${config.esphomeApiPort}`,
+          devices: esphomeHandle.getKnownDevices(),
+        }
+      : {
+          enabled: false,
+          listener_address: null,
+          devices: [],
+        };
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(payload));
+    return;
+  }
+  if (req.url === "/wyoming/status") {
+    const payload = {
+      enabled: !!wyomingHandle,
+      port: wyomingHandle ? config.wyomingPort : null,
+      bind: wyomingHandle ? config.wyomingBind : null,
+      last_handshake_at: wyomingHandle?.lastHandshakeAt() ?? null,
+    };
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(payload));
     return;
   }
   // Twilio "A CALL COMES IN" webhook — returns TwiML pointing at the
@@ -183,6 +240,7 @@ if (config.esphomeApiEnabled) {
     // env. See esphome-server.ts's import block for the long form.
     voiceSessionFactory: (opts) => new EsphomeVoiceSession(opts),
   });
+  esphomeHandle = handle;
   handle.ready
     .then(() =>
       announceEsphomeMdns({
@@ -193,6 +251,28 @@ if (config.esphomeApiEnabled) {
     .catch((err) => {
       console.error("[esphome] startup failed (continuing without HA leg):", err);
     });
+
+  // PR5 — Wyoming Protocol fallback. Same brain factory, different transport
+  // shape. Boots iff WYOMING_ENABLED=1; defaults off because most tenants
+  // use ESPHome Native and the extra listener is dead weight otherwise.
+  if (config.wyomingEnabled) {
+    const wyHandle = startWyomingServer({
+      port: config.wyomingPort,
+      bindHost: config.wyomingBind,
+      identity,
+      voiceSessionFactory: (opts) => new EsphomeVoiceSession(opts),
+    });
+    wyomingHandle = wyHandle;
+    wyHandle.ready.catch((err) => {
+      console.error(
+        "[wyoming] startup failed (continuing without Wyoming fallback):",
+        err,
+      );
+      wyomingHandle = null;
+    });
+  } else {
+    console.log("[wyoming] WYOMING_ENABLED!=1 — Wyoming fallback disabled");
+  }
 } else {
   console.log("[esphome] ESPHOME_API_ENABLED!=1 — HA voice leg disabled");
 }

--- a/packages/voice-bridge/src/wyoming-server.test.ts
+++ b/packages/voice-bridge/src/wyoming-server.test.ts
@@ -1,0 +1,491 @@
+// wyoming-server.test.ts — coverage for the Wyoming Protocol fallback
+// (#112 PR5). The Wyoming spec lives at https://github.com/rhasspy/wyoming;
+// we exercise the subset HA's `wyoming` integration calls into a satellite
+// service:
+//
+//   1.  Encoder round-trips through the parser (event-only, no payload)
+//   2.  Encoder round-trips through the parser (event + binary payload)
+//   3.  Parser handles split frames across TCP chunks
+//   4.  `describe` triggers an `info` reply with the right service shape
+//   5.  `audio-start` → `audio-chunk` x N → `audio-stop` ends the session
+//   6.  `audio-chunk` arriving before `audio-start` triggers a Wyoming error
+//      event (NOT a silent drop). This deviates from the upstream spec —
+//      Wyoming's reference impl drops silently. We surface it so HA's
+//      misconfigured pipelines are visible in the operator-facing log
+//      stream. Documented in the test name + this comment.
+//   7.  `synthesize` is rejected with a typed error (we're a satellite, not
+//      a TTS). HA gracefully falls back to its other configured TTS.
+//   8.  The brain emitting `VoiceAssistantAudio` (PR2 wire) translates to
+//      `audio-start` → `audio-chunk` → `audio-stop` on the Wyoming socket.
+//   9.  Parser rejects a header that isn't JSON (protocol violation).
+//   10. `lastHandshakeAt` updates after the first inbound frame.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import net from "node:net";
+
+// env must be set BEFORE importing config-bearing modules; the SUT does not
+// read env at import time but its sibling config.ts does.
+process.env.OPENAI_API_KEY = process.env.OPENAI_API_KEY ?? "sk-test-dummy";
+process.env.VOICE_BRIDGE_INTERNAL_TOKEN =
+  process.env.VOICE_BRIDGE_INTERNAL_TOKEN ?? "test-internal-token";
+
+import {
+  encodeWyomingEvent,
+  WyomingFrameParser,
+  WyomingEventType,
+  buildWyomingInfo,
+  startWyomingServer,
+  type WyomingEvent,
+} from "./wyoming-server.js";
+import {
+  computeIdentity,
+  buildVoiceAssistantAudio,
+  buildVoiceAssistantEventResponse,
+  type VoiceSessionConnection,
+  type VoiceSessionHandle,
+} from "./esphome-server.js";
+import { MessageType, VoiceAssistantEvent } from "./esphome-protocol.js";
+
+// ── Encoder / parser round-trips ─────────────────────────────────────────
+
+test("wyoming: encoder/parser round-trip for a header-only event", () => {
+  const wire = encodeWyomingEvent({ type: WyomingEventType.Describe });
+  const parser = new WyomingFrameParser();
+  const events = parser.push(wire);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].type, WyomingEventType.Describe);
+  assert.equal(events[0].payload, undefined);
+  assert.equal(parser.pendingBytes(), 0);
+});
+
+test("wyoming: encoder/parser round-trip for an event with binary payload", () => {
+  const audio = Buffer.from([0x01, 0x02, 0x03, 0x04, 0xff, 0x7f]);
+  const wire = encodeWyomingEvent({
+    type: WyomingEventType.AudioChunk,
+    data: { rate: 16000, width: 2, channels: 1 },
+    payload: audio,
+  });
+  const parser = new WyomingFrameParser();
+  const events = parser.push(wire);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].type, WyomingEventType.AudioChunk);
+  assert.ok(events[0].payload);
+  assert.deepEqual(Array.from(events[0].payload!), Array.from(audio));
+  const data = events[0].data as { rate: number; width: number; channels: number };
+  assert.equal(data.rate, 16000);
+  assert.equal(data.width, 2);
+  assert.equal(data.channels, 1);
+});
+
+test("wyoming: parser yields events across split TCP chunks", () => {
+  const e1 = encodeWyomingEvent({ type: WyomingEventType.Describe });
+  const e2 = encodeWyomingEvent({
+    type: WyomingEventType.AudioStart,
+    data: { rate: 16000, width: 2, channels: 1 },
+  });
+  const all = Buffer.concat([e1, e2]);
+  const parser = new WyomingFrameParser();
+  // Split mid-header to exercise the partial-header branch.
+  const split = 10;
+  const events1 = parser.push(all.subarray(0, split));
+  const events2 = parser.push(all.subarray(split));
+  const combined = [...events1, ...events2];
+  assert.equal(combined.length, 2);
+  assert.equal(combined[0].type, WyomingEventType.Describe);
+  assert.equal(combined[1].type, WyomingEventType.AudioStart);
+  assert.equal(parser.pendingBytes(), 0);
+});
+
+test("wyoming: parser rejects a non-JSON header", () => {
+  const parser = new WyomingFrameParser();
+  const bad = Buffer.from("not-valid-json\n", "utf-8");
+  assert.throws(
+    () => parser.push(bad),
+    /not valid JSON/,
+  );
+});
+
+// ── Info response ────────────────────────────────────────────────────────
+
+test("wyoming: info response advertises a satellite with 16 kHz pcm16 mono", () => {
+  const identity = computeIdentity({ tenantSeed: "wyoming-test-A" });
+  const info = buildWyomingInfo({ identity });
+  assert.ok(info.satellite, "satellite section present");
+  const sat = info.satellite as Record<string, unknown>;
+  assert.equal(sat.installed, true);
+  assert.equal((sat.snd_format as { rate: number }).rate, 16000);
+  assert.equal((sat.mic_format as { rate: number }).rate, 16000);
+  assert.equal((sat.snd_format as { width: number }).width, 2);
+  assert.equal((sat.mic_format as { channels: number }).channels, 1);
+  assert.equal(sat.name, identity.friendlyName);
+});
+
+// ── End-to-end: drive a real socket ──────────────────────────────────────
+
+// Helper — open a TCP connection to a Wyoming server, send events, collect
+// the reply within `collectMs`. Same shape as esphome-server.test.ts's
+// `exchange()`.
+async function exchange(
+  port: number,
+  outgoing: WyomingEvent[],
+  opts: { collectMs?: number } = {},
+): Promise<WyomingEvent[]> {
+  const collectMs = opts.collectMs ?? 200;
+  const sock = net.connect(port, "127.0.0.1");
+  await new Promise<void>((resolve, reject) => {
+    sock.once("connect", resolve);
+    sock.once("error", reject);
+  });
+  const parser = new WyomingFrameParser();
+  const received: WyomingEvent[] = [];
+  sock.on("data", (chunk: Buffer) => {
+    for (const e of parser.push(chunk)) received.push(e);
+  });
+  for (const out of outgoing) sock.write(encodeWyomingEvent(out));
+  await new Promise<void>((resolve) => setTimeout(resolve, collectMs));
+  sock.destroy();
+  return received;
+}
+
+function makeRecordingSession(
+  capture: { inbound: Array<{ data: Buffer; end: boolean }>; closed: string[] },
+): VoiceSessionHandle & { _emit: (mt: number, p: Buffer) => void } {
+  // We need access to the connection hook so we can simulate the brain
+  // emitting outbound frames. The factory we register below captures it
+  // into `connRef` and the test calls it through `session._emit`.
+  return {
+    onInboundAudio(chunk: Buffer, end: boolean) {
+      capture.inbound.push({ data: Buffer.from(chunk), end });
+    },
+    onInboundEvent() {
+      /* no-op for these tests */
+    },
+    close(reason: string) {
+      capture.closed.push(reason);
+    },
+    _emit() {
+      /* set by factory below */
+    },
+  };
+}
+
+test("wyoming: audio-start → audio-chunk* → audio-stop drives a session end-to-end", async () => {
+  const identity = computeIdentity({ tenantSeed: "wyoming-test-B" });
+  const capture = { inbound: [] as Array<{ data: Buffer; end: boolean }>, closed: [] as string[] };
+  const handle = startWyomingServer({
+    port: 0,
+    bindHost: "127.0.0.1",
+    identity,
+    voiceSessionFactory: () => makeRecordingSession(capture),
+    log: () => {},
+  });
+  await handle.ready;
+  const port = handle.boundPort();
+
+  try {
+    const chunk1 = Buffer.alloc(640, 0x10);
+    const chunk2 = Buffer.alloc(640, 0x20);
+    await exchange(
+      port,
+      [
+        {
+          type: WyomingEventType.AudioStart,
+          data: { rate: 16000, width: 2, channels: 1 },
+        },
+        {
+          type: WyomingEventType.AudioChunk,
+          data: { rate: 16000, width: 2, channels: 1 },
+          payload: chunk1,
+        },
+        {
+          type: WyomingEventType.AudioChunk,
+          data: { rate: 16000, width: 2, channels: 1 },
+          payload: chunk2,
+        },
+        { type: WyomingEventType.AudioStop, data: { timestamp: 1 } },
+      ],
+      { collectMs: 250 },
+    );
+    // After audio-stop, the session must have observed exactly 3 inbound
+    // calls (two chunks + one end-of-mic marker).
+    assert.equal(capture.inbound.length, 3, "two chunks + one end-mic call");
+    assert.equal(capture.inbound[0].data.length, 640);
+    assert.equal(capture.inbound[1].data.length, 640);
+    assert.equal(capture.inbound[2].end, true);
+    assert.equal(capture.inbound[2].data.length, 0);
+  } finally {
+    await handle.close();
+  }
+});
+
+test("wyoming: audio-chunk without audio-start emits an error event (PR5 deviation)", async () => {
+  const identity = computeIdentity({ tenantSeed: "wyoming-test-C" });
+  const handle = startWyomingServer({
+    port: 0,
+    bindHost: "127.0.0.1",
+    identity,
+    voiceSessionFactory: () =>
+      makeRecordingSession({ inbound: [], closed: [] }),
+    log: () => {},
+  });
+  await handle.ready;
+  const port = handle.boundPort();
+  try {
+    const replies = await exchange(
+      port,
+      [
+        {
+          type: WyomingEventType.AudioChunk,
+          data: { rate: 16000, width: 2, channels: 1 },
+          payload: Buffer.alloc(640),
+        },
+      ],
+      { collectMs: 150 },
+    );
+    // Should see exactly one `error` event with the no-active-session code.
+    const errors = replies.filter((e) => e.type === WyomingEventType.Error);
+    assert.equal(errors.length, 1, "exactly one error event");
+    const data = errors[0].data as { code: string };
+    assert.equal(data.code, "no-active-session");
+  } finally {
+    await handle.close();
+  }
+});
+
+test("wyoming: synthesize is rejected with tts-not-supported", async () => {
+  const identity = computeIdentity({ tenantSeed: "wyoming-test-D" });
+  const handle = startWyomingServer({
+    port: 0,
+    bindHost: "127.0.0.1",
+    identity,
+    voiceSessionFactory: () =>
+      makeRecordingSession({ inbound: [], closed: [] }),
+    log: () => {},
+  });
+  await handle.ready;
+  const port = handle.boundPort();
+  try {
+    const replies = await exchange(
+      port,
+      [
+        {
+          type: WyomingEventType.Synthesize,
+          data: { text: "the rain in spain stays mainly in the plain" },
+        },
+      ],
+      { collectMs: 150 },
+    );
+    const errors = replies.filter((e) => e.type === WyomingEventType.Error);
+    assert.equal(errors.length, 1);
+    const data = errors[0].data as { code: string };
+    assert.equal(data.code, "tts-not-supported");
+  } finally {
+    await handle.close();
+  }
+});
+
+test("wyoming: describe triggers an info reply with satellite shape", async () => {
+  const identity = computeIdentity({ tenantSeed: "wyoming-test-E" });
+  const handle = startWyomingServer({
+    port: 0,
+    bindHost: "127.0.0.1",
+    identity,
+    voiceSessionFactory: () =>
+      makeRecordingSession({ inbound: [], closed: [] }),
+    log: () => {},
+  });
+  await handle.ready;
+  const port = handle.boundPort();
+  try {
+    const replies = await exchange(
+      port,
+      [{ type: WyomingEventType.Describe }],
+      { collectMs: 150 },
+    );
+    const infos = replies.filter((e) => e.type === WyomingEventType.Info);
+    assert.equal(infos.length, 1, "exactly one info reply");
+    const data = infos[0].data as { satellite: { name: string; installed: boolean } };
+    assert.ok(data.satellite, "info carries a satellite section");
+    assert.equal(data.satellite.name, identity.friendlyName);
+    assert.equal(data.satellite.installed, true);
+  } finally {
+    await handle.close();
+  }
+});
+
+test("wyoming: brain emitting VoiceAssistantAudio translates to audio-start + audio-chunk + audio-stop", async () => {
+  // This test uses a factory that captures the connection hook so we can
+  // pretend to be the brain emitting outbound frames.
+  const identity = computeIdentity({ tenantSeed: "wyoming-test-F" });
+  // Wrapped in a holder so the closure assignment doesn't get narrowed
+  // to `never` by TS's control-flow analysis across the await boundaries.
+  const captured: { conn: VoiceSessionConnection | null } = { conn: null };
+  const handle = startWyomingServer({
+    port: 0,
+    bindHost: "127.0.0.1",
+    identity,
+    voiceSessionFactory: ({ conn }) => {
+      captured.conn = conn;
+      return {
+        onInboundAudio() {
+          /* no-op */
+        },
+        onInboundEvent() {
+          /* no-op */
+        },
+        close() {
+          /* no-op */
+        },
+      };
+    },
+    log: () => {},
+  });
+  await handle.ready;
+  const port = handle.boundPort();
+  try {
+    // Open the connection + collect outbound events.
+    const sock = net.connect(port, "127.0.0.1");
+    await new Promise<void>((resolve) => sock.once("connect", () => resolve()));
+    const parser = new WyomingFrameParser();
+    const replies: WyomingEvent[] = [];
+    sock.on("data", (c: Buffer) => {
+      for (const e of parser.push(c)) replies.push(e);
+    });
+    // Trigger session open by sending audio-start.
+    sock.write(
+      encodeWyomingEvent({
+        type: WyomingEventType.AudioStart,
+        data: { rate: 16000, width: 2, channels: 1 },
+      }),
+    );
+    // Wait briefly for the factory to fire.
+    await new Promise((r) => setTimeout(r, 50));
+    assert.ok(captured.conn, "connection hook captured");
+
+    // Brain emits one TTS chunk + one end frame.
+    const ttsChunk = Buffer.alloc(640, 0x42);
+    captured.conn!.send(
+      MessageType.VoiceAssistantAudio,
+      buildVoiceAssistantAudio({ data: ttsChunk, end: false }),
+    );
+    captured.conn!.send(
+      MessageType.VoiceAssistantAudio,
+      buildVoiceAssistantAudio({ data: Buffer.alloc(0), end: true }),
+    );
+    await new Promise((r) => setTimeout(r, 100));
+
+    sock.destroy();
+
+    const audioStarts = replies.filter(
+      (e) => e.type === WyomingEventType.AudioStart,
+    );
+    const audioChunks = replies.filter(
+      (e) => e.type === WyomingEventType.AudioChunk,
+    );
+    const audioStops = replies.filter(
+      (e) => e.type === WyomingEventType.AudioStop,
+    );
+    assert.equal(audioStarts.length, 1, "exactly one outbound audio-start");
+    assert.equal(audioChunks.length, 1, "exactly one outbound audio-chunk");
+    assert.equal(audioStops.length, 1, "exactly one outbound audio-stop");
+    assert.deepEqual(
+      Array.from(audioChunks[0].payload!),
+      Array.from(ttsChunk),
+      "tts chunk arrives byte-exact",
+    );
+  } finally {
+    await handle.close();
+  }
+});
+
+test("wyoming: brain STT_END event maps to a Wyoming transcript event", async () => {
+  const identity = computeIdentity({ tenantSeed: "wyoming-test-G" });
+  const captured: { conn: VoiceSessionConnection | null } = { conn: null };
+  const handle = startWyomingServer({
+    port: 0,
+    bindHost: "127.0.0.1",
+    identity,
+    voiceSessionFactory: ({ conn }) => {
+      captured.conn = conn;
+      return {
+        onInboundAudio() {
+          /* no-op */
+        },
+        onInboundEvent() {
+          /* no-op */
+        },
+        close() {
+          /* no-op */
+        },
+      };
+    },
+    log: () => {},
+  });
+  await handle.ready;
+  const port = handle.boundPort();
+  try {
+    const sock = net.connect(port, "127.0.0.1");
+    await new Promise<void>((resolve) => sock.once("connect", () => resolve()));
+    const parser = new WyomingFrameParser();
+    const replies: WyomingEvent[] = [];
+    sock.on("data", (c: Buffer) => {
+      for (const e of parser.push(c)) replies.push(e);
+    });
+    sock.write(
+      encodeWyomingEvent({
+        type: WyomingEventType.AudioStart,
+        data: { rate: 16000, width: 2, channels: 1 },
+      }),
+    );
+    await new Promise((r) => setTimeout(r, 50));
+    assert.ok(captured.conn);
+    captured.conn!.send(
+      MessageType.VoiceAssistantEventResponse,
+      buildVoiceAssistantEventResponse({
+        eventType: VoiceAssistantEvent.STT_END,
+        data: [{ name: "text", value: "what is on my desk today" }],
+      }),
+    );
+    await new Promise((r) => setTimeout(r, 100));
+    sock.destroy();
+
+    const transcripts = replies.filter(
+      (e) => e.type === WyomingEventType.Transcript,
+    );
+    assert.equal(transcripts.length, 1, "exactly one transcript event");
+    const data = transcripts[0].data as { text: string };
+    assert.equal(data.text, "what is on my desk today");
+  } finally {
+    await handle.close();
+  }
+});
+
+test("wyoming: lastHandshakeAt updates after the first frame on a connection", async () => {
+  const identity = computeIdentity({ tenantSeed: "wyoming-test-H" });
+  const handle = startWyomingServer({
+    port: 0,
+    bindHost: "127.0.0.1",
+    identity,
+    voiceSessionFactory: () =>
+      makeRecordingSession({ inbound: [], closed: [] }),
+    log: () => {},
+  });
+  await handle.ready;
+  const port = handle.boundPort();
+  try {
+    const before = handle.lastHandshakeAt();
+    await exchange(
+      port,
+      [{ type: WyomingEventType.Describe }],
+      { collectMs: 150 },
+    );
+    const after = handle.lastHandshakeAt();
+    assert.ok(after !== null, "lastHandshakeAt is set after a frame arrives");
+    if (before !== null) {
+      assert.ok(after! >= before, "handshake time advances monotonically");
+    }
+  } finally {
+    await handle.close();
+  }
+});

--- a/packages/voice-bridge/src/wyoming-server.ts
+++ b/packages/voice-bridge/src/wyoming-server.ts
@@ -1,0 +1,723 @@
+// wyoming-server.ts — Wyoming Protocol fallback for HA Voice (#112 PR5).
+//
+// Wyoming is the JSONL-over-TCP protocol that Home Assistant uses to talk to
+// satellite / STT / TTS / wake-word services (the rhasspy/wyoming repo).
+// HA's `wyoming` integration calls out to a Wyoming server when the operator
+// picks one as the conversation / pipeline endpoint. This file implements
+// the satellite-side surface so HA can route a full pipeline through us
+// without going via the ESPHome Native API.
+//
+// THE WYOMING-vs-ESPHOME-NATIVE TRADE-OFF
+// --------------------------------------
+//
+// Both transports terminate at the same brain (`EsphomeVoiceSession`), but
+// they reach it through different HA-side stacks:
+//
+//   - ESPHome Native API (PR1/PR2):  satellite ──(api)──> voice-bridge :6053
+//     HA discovers the bridge as if it were a single ESPHome firmware
+//     device, the satellite is configured to forward voice_assistant audio
+//     here directly. HA never sees the audio.
+//
+//   - Wyoming (this file):           satellite ──> HA Assist ──> wyoming
+//     :10300 ──> voice-bridge        HA's wake/STT/intent/TTS stack sits
+//     in the middle; the audio is decoded + re-encoded once. Costs ~30ms
+//     latency + a serialisation round-trip per turn.
+//
+// We default to ESPHome Native (the audio path is shorter, the wake-word
+// stays on-device for free, and the HA satellite "Just Works" via mDNS).
+// Wyoming is the fallback for two cases:
+//
+//   1. HA-OS / HA-Cloud installs that can't reach voice-bridge's :6053 over
+//      the LAN — they CAN reach :10300 because Wyoming is a normal HTTP-ish
+//      service HA's REST + wyoming integrations both speak.
+//   2. Non-ESPHome satellites (Raspberry Pi running Wyoming-Satellite, a
+//      M5StickC running rhasspy-wyoming, etc.). The Wyoming protocol is the
+//      universal "I have a microphone, please be my brain" interface in
+//      HA's voice ecosystem.
+//
+// Off by default — flip WYOMING_ENABLED=1 in /opt/alfred/.env on tenants
+// that prefer this route.
+//
+// WIRE FORMAT
+// -----------
+//
+// Each event = one JSONL line (header) + optional binary payload:
+//
+//     {"type":"audio-chunk","data":{"rate":16000,"width":2,"channels":1},
+//      "payload_length":640}\n
+//     <640 raw bytes of pcm16>
+//
+// Header keys we honour:
+//   type            string  — required, names the event (see WyomingEventType)
+//   data            object  — event-specific payload (rate, width, etc.)
+//   payload_length  uint    — 0 / absent for header-only events
+//   version         string  — Wyoming protocol version we advertise (1.0.0)
+//
+// Reference: https://github.com/rhasspy/wyoming — README has the full event
+// grammar. Where the spec is ambiguous (e.g. payload framing edge cases) we
+// document the deviation in the test file `wyoming-server.test.ts`.
+//
+// NOT in scope for PR5:
+//   - TLS termination — Wyoming runs as plain TCP behind the tailnet boundary.
+//   - Authentication — same boundary applies; HA's Wyoming integration has
+//     no built-in auth layer.
+//   - Streaming `synthesize` text-to-audio — we forward OpenAI Realtime audio
+//     as a stream of `audio-chunk` events instead; the brain doesn't do
+//     standalone TTS turns.
+
+import net from "node:net";
+import {
+  EsphomeServerIdentity,
+  VoiceSessionFactory,
+  VoiceSessionHandle,
+  VoiceSessionConnection,
+} from "./esphome-server.js";
+import {
+  MessageType,
+  VoiceAssistantEvent,
+} from "./esphome-protocol.js";
+
+// ── Event grammar ──────────────────────────────────────────────────────────
+
+/** Wyoming event names we read or emit. Sourced from
+ * github.com/rhasspy/wyoming/blob/master/wyoming/event.py + the event docs
+ * in github.com/rhasspy/wyoming-satellite. */
+export const WyomingEventType = {
+  // ── Discovery ─────────────────────────────────────────────────────────
+  /** HA → us. "Tell me what you are." Triggers an `info` reply. */
+  Describe: "describe",
+  /** Us → HA. Response to `describe`. Carries `info` for each service this
+   * server offers (asr, tts, satellite, wake, intent). */
+  Info: "info",
+
+  // ── Audio in (mic from HA, possibly forwarded from a satellite) ───────
+  AudioStart: "audio-start",
+  AudioChunk: "audio-chunk",
+  AudioStop: "audio-stop",
+
+  // ── Transcript (we emit a Wyoming `transcript` once the brain finishes) ─
+  Transcript: "transcript",
+
+  // ── Synthesis (HA → us when used as a TTS service; we use it for
+  // "OpenAI-Realtime is about to speak the following"). PR5 keeps this
+  // off the request path because the brain emits audio directly. ────────
+  Synthesize: "synthesize",
+
+  // ── Pipeline lifecycle (we emit these for HA's voice UI). ─────────────
+  RunPipeline: "run-pipeline",
+  RunEnd: "run-end",
+
+  // ── Errors ────────────────────────────────────────────────────────────
+  Error: "error",
+} as const;
+
+export type WyomingEventName = (typeof WyomingEventType)[keyof typeof WyomingEventType];
+
+export interface WyomingEvent {
+  type: string;
+  data?: Record<string, unknown>;
+  payload?: Buffer;
+  /** Wyoming protocol version we received / emit. Optional in the header
+   * (HA's `wyoming` integration sometimes omits it). */
+  version?: string;
+}
+
+// ── Encoder / decoder ──────────────────────────────────────────────────────
+
+/** Serialise one Wyoming event into the on-wire format:
+ *  `<json header>\n[<binary payload>]`. */
+export function encodeWyomingEvent(event: WyomingEvent): Buffer {
+  const headerObj: Record<string, unknown> = { type: event.type };
+  if (event.data !== undefined) headerObj.data = event.data;
+  if (event.version !== undefined) headerObj.version = event.version;
+  const payload = event.payload ?? Buffer.alloc(0);
+  if (payload.length > 0) headerObj.payload_length = payload.length;
+  const headerLine = Buffer.from(JSON.stringify(headerObj) + "\n", "utf-8");
+  return payload.length > 0 ? Buffer.concat([headerLine, payload]) : headerLine;
+}
+
+/** Stateful framing parser. Wyoming events split across TCP chunks the same
+ * way ESPHome frames do; this class smooths over both. Yields one event per
+ * call to `push()` until the buffered bytes can't form a full event yet. */
+export class WyomingFrameParser {
+  private buffer: Buffer = Buffer.alloc(0);
+
+  push(chunk: Buffer): WyomingEvent[] {
+    this.buffer = this.buffer.length === 0 ? chunk : Buffer.concat([this.buffer, chunk]);
+    const events: WyomingEvent[] = [];
+
+    while (this.buffer.length > 0) {
+      // Find the header newline.
+      const nl = this.buffer.indexOf(0x0a /* \n */);
+      if (nl < 0) break; // partial header
+      const headerBytes = this.buffer.subarray(0, nl);
+      let header: Record<string, unknown>;
+      try {
+        header = JSON.parse(headerBytes.toString("utf-8")) as Record<
+          string,
+          unknown
+        >;
+      } catch (err) {
+        throw new Error(
+          `wyoming: header is not valid JSON (${headerBytes
+            .toString("utf-8")
+            .slice(0, 80)})`,
+        );
+      }
+      if (typeof header.type !== "string" || header.type.length === 0) {
+        throw new Error("wyoming: event header missing required `type`");
+      }
+      const payloadLen =
+        typeof header.payload_length === "number" && header.payload_length > 0
+          ? header.payload_length
+          : 0;
+      const totalNeeded = nl + 1 + payloadLen;
+      if (this.buffer.length < totalNeeded) break; // partial payload
+      const payload =
+        payloadLen > 0
+          ? this.buffer.subarray(nl + 1, nl + 1 + payloadLen)
+          : undefined;
+      events.push({
+        type: header.type,
+        data: header.data as Record<string, unknown> | undefined,
+        version:
+          typeof header.version === "string" ? header.version : undefined,
+        payload,
+      });
+      this.buffer = this.buffer.subarray(totalNeeded);
+    }
+
+    return events;
+  }
+
+  /** Test hook — bytes buffered but not yet a full event. */
+  pendingBytes(): number {
+    return this.buffer.length;
+  }
+}
+
+// ── Info response ──────────────────────────────────────────────────────────
+
+/** Build the JSON we send back on `describe`. Wyoming's `info` event carries
+ * one or more service-type arrays — we only advertise `satellite` (because
+ * the brain answers the full pipeline) so HA wires us as the satellite + the
+ * conversation/intent agent simultaneously. */
+export function buildWyomingInfo(opts: {
+  identity: EsphomeServerIdentity;
+}): Record<string, unknown> {
+  return {
+    satellite: {
+      name: opts.identity.friendlyName,
+      attribution: {
+        name: opts.identity.manufacturer,
+        url: "https://alfred.black",
+      },
+      installed: true,
+      description:
+        "Alfred — GPT-Realtime butler. One brain across phone, Slack, and voice.",
+      version: opts.identity.projectVersion,
+      area: null,
+      snd_format: { rate: 16000, width: 2, channels: 1 },
+      mic_format: { rate: 16000, width: 2, channels: 1 },
+    },
+  };
+}
+
+// ── Per-connection session ─────────────────────────────────────────────────
+
+/** Wyoming-side connection — one TCP socket from HA's wyoming integration.
+ * Bridges audio in/out through the shared voiceSessionFactory so the same
+ * `EsphomeVoiceSession` brain answers both ESPHome-Native and Wyoming
+ * pipelines. */
+export class WyomingConnection {
+  private parser = new WyomingFrameParser();
+  /** The active voice session for the current turn, if any. We open one on
+   * the first `audio-start` and dispose on `audio-stop` or socket close. */
+  private session: VoiceSessionHandle | null = null;
+  /** Tracks the format HA announced in `audio-start` so we can sanity-check
+   * subsequent chunks. The brain assumes 16 kHz pcm16 mono regardless; if
+   * HA announces something else we transcode at the brain edge (PR2's
+   * resampler in esphome-session.ts handles the rate conversion). */
+  private inboundFormat: { rate: number; width: number; channels: number } | null =
+    null;
+  /** Outbound `audio-start` deferred until we have a first audio chunk to
+   * ship — sending it earlier confuses HA when the brain decides to reply
+   * with text-only. */
+  private outboundAudioStarted = false;
+  /** Last seen `info` request — we cache the response so repeat probes are
+   * cheap. */
+  private cachedInfo: Record<string, unknown> | null = null;
+
+  constructor(
+    private readonly socket: net.Socket,
+    private readonly opts: WyomingServerOptions,
+  ) {
+    const log = opts.log ?? defaultLog;
+    const remote = socket.remoteAddress ?? "?";
+    log("wyoming connection accepted", { remote });
+    socket.on("data", (chunk) => this.onData(chunk));
+    socket.on("error", (err) =>
+      log("wyoming socket error", { remote, err: err.message }),
+    );
+    socket.on("close", () => {
+      log("wyoming connection closed", { remote });
+      if (this.session) {
+        try {
+          this.session.close("wyoming-connection-closed");
+        } catch {
+          /* ignore */
+        }
+        this.session = null;
+      }
+    });
+  }
+
+  private onData(chunk: Buffer): void {
+    let events: WyomingEvent[];
+    try {
+      events = this.parser.push(chunk);
+    } catch (err) {
+      const log = this.opts.log ?? defaultLog;
+      log("wyoming parser error — closing connection", {
+        err: err instanceof Error ? err.message : String(err),
+      });
+      this.socket.destroy();
+      return;
+    }
+    for (const e of events) this.handleEvent(e);
+  }
+
+  private handleEvent(event: WyomingEvent): void {
+    const log = this.opts.log ?? defaultLog;
+    switch (event.type) {
+      case WyomingEventType.Describe: {
+        if (!this.cachedInfo) {
+          this.cachedInfo = buildWyomingInfo({ identity: this.opts.identity });
+        }
+        this.sendEvent({
+          type: WyomingEventType.Info,
+          data: this.cachedInfo,
+          version: "1.5.4",
+        });
+        return;
+      }
+      case WyomingEventType.AudioStart: {
+        const data = (event.data ?? {}) as {
+          rate?: number;
+          width?: number;
+          channels?: number;
+        };
+        this.inboundFormat = {
+          rate: typeof data.rate === "number" ? data.rate : 16000,
+          width: typeof data.width === "number" ? data.width : 2,
+          channels: typeof data.channels === "number" ? data.channels : 1,
+        };
+        log("wyoming audio-start", this.inboundFormat as unknown as Record<
+          string,
+          unknown
+        >);
+        // Open a brain session. EsphomeVoiceSession assumes 16 kHz pcm16
+        // mono on its `onInboundAudio` boundary — same wire shape Wyoming
+        // gives us. If HA announces 8 kHz or stereo we still feed the
+        // bytes through; the brain's `resamplePcm16` handles the upsample.
+        this.openSession();
+        return;
+      }
+      case WyomingEventType.AudioChunk: {
+        if (!this.session) {
+          // Stray chunk after audio-stop / before audio-start. Drop +
+          // emit an error event so HA can surface the misordering instead
+          // of silently dropping the turn.
+          this.sendEvent({
+            type: WyomingEventType.Error,
+            data: {
+              text: "audio-chunk arrived without a preceding audio-start",
+              code: "no-active-session",
+            },
+          });
+          return;
+        }
+        const data = event.payload ?? Buffer.alloc(0);
+        if (data.length === 0) return; // header-only chunk = no-op
+        this.session.onInboundAudio(data, false);
+        return;
+      }
+      case WyomingEventType.AudioStop: {
+        if (!this.session) return;
+        // Signal end-of-mic to the brain.
+        this.session.onInboundAudio(Buffer.alloc(0), true);
+        return;
+      }
+      case WyomingEventType.Synthesize: {
+        // HA can ask us to synthesize a text string standalone (as if we
+        // were a TTS service). The brain doesn't offer that surface — we
+        // only ship audio that comes out of a full pipeline turn — so we
+        // surface an explicit error rather than silently 200. HA's TTS
+        // selector will fall back to its other configured TTS.
+        this.sendEvent({
+          type: WyomingEventType.Error,
+          data: {
+            text:
+              "Alfred Voice Bridge is a satellite, not a TTS service — pick a different TTS in the Assist pipeline.",
+            code: "tts-not-supported",
+          },
+        });
+        return;
+      }
+      case WyomingEventType.RunEnd:
+      case "run-end": {
+        // HA closing the pipeline mid-turn. Tear down our session.
+        if (this.session) {
+          try {
+            this.session.close("ha-run-end");
+          } catch {
+            /* ignore */
+          }
+          this.session = null;
+        }
+        return;
+      }
+      default: {
+        log("wyoming unhandled event (ignored)", { type: event.type });
+        return;
+      }
+    }
+  }
+
+  private openSession(): void {
+    if (this.session) {
+      // Belt-and-braces — HA shouldn't open two pipelines on one connection,
+      // but if it does we drop the old one. Same behaviour as
+      // EsphomeConnection on overlapping VoiceAssistantRequest.
+      try {
+        this.session.close("wyoming-overlapping-start");
+      } catch {
+        /* ignore */
+      }
+      this.session = null;
+    }
+
+    const log = this.opts.log ?? defaultLog;
+    // The Wyoming-side "connection hook" the brain expects: it speaks the
+    // ESPHome Native API message vocabulary, so we translate inside `send`.
+    // The brain only emits four message types end-to-end:
+    //   - VoiceAssistantAudio          → us → HA `audio-chunk`
+    //   - VoiceAssistantEventResponse  → us → HA `transcript` / `run-end`
+    //   - VoiceAssistantResponse       → ignored (ack of audio-start)
+    // Anything else gets logged + dropped.
+    const connHook: VoiceSessionConnection = {
+      send: (messageType, payload) =>
+        this.translateAndSend(messageType, payload),
+      log,
+      identity: this.opts.identity,
+    };
+    try {
+      this.session = this.opts.voiceSessionFactory({
+        conn: connHook,
+        conversationId: `wyoming-${Date.now()}`,
+        wakeWordPhrase: "",
+        flags: 0,
+      });
+    } catch (err) {
+      log("wyoming session factory threw", {
+        err: err instanceof Error ? err.message : String(err),
+      });
+      this.sendEvent({
+        type: WyomingEventType.Error,
+        data: {
+          text: "session-init-failed",
+          code: "openai-connect-failed",
+        },
+      });
+    }
+  }
+
+  /** Convert one ESPHome-format outbound frame into the Wyoming-format
+   * equivalent and ship it. */
+  private translateAndSend(messageType: number, payload: Buffer): void {
+    switch (messageType) {
+      case MessageType.VoiceAssistantAudio: {
+        // The brain frames audio as `pcm16 @ 16 kHz` with `data` (field 1) +
+        // `end` (field 2). For Wyoming we re-wrap as `audio-chunk`.
+        // We re-decode field 1 ourselves rather than depending on the
+        // protobuf decoder here — the wire shape is `<tag(1,2)> <varint len>
+        // <pcm bytes> <tag(2,0)> <bool>`. Simpler: the brain calls
+        // `buildVoiceAssistantAudio({data, end})`, so we just strip the
+        // protobuf tags by walking the payload.
+        const { data, end } = decodeVoiceAssistantAudio(payload);
+        if (!this.outboundAudioStarted && data.length > 0) {
+          // First chunk of a TTS-style reply → emit `audio-start` so HA's
+          // playback pipeline opens its sink.
+          this.sendEvent({
+            type: WyomingEventType.AudioStart,
+            data: { rate: 16000, width: 2, channels: 1, timestamp: Date.now() },
+          });
+          this.outboundAudioStarted = true;
+        }
+        if (data.length > 0) {
+          this.sendEvent({
+            type: WyomingEventType.AudioChunk,
+            data: { rate: 16000, width: 2, channels: 1 },
+            payload: data,
+          });
+        }
+        if (end && this.outboundAudioStarted) {
+          this.sendEvent({
+            type: WyomingEventType.AudioStop,
+            data: { timestamp: Date.now() },
+          });
+          this.outboundAudioStarted = false;
+        }
+        return;
+      }
+      case MessageType.VoiceAssistantEventResponse: {
+        const { eventType, dataKv } = decodeVoiceAssistantEvent(payload);
+        if (eventType === VoiceAssistantEvent.STT_END) {
+          // Carry the user transcript through to HA so its UI shows what
+          // the principal said.
+          const text = dataKv.text ?? "";
+          this.sendEvent({
+            type: WyomingEventType.Transcript,
+            data: { text },
+          });
+          return;
+        }
+        if (eventType === VoiceAssistantEvent.RUN_END) {
+          if (this.outboundAudioStarted) {
+            this.sendEvent({
+              type: WyomingEventType.AudioStop,
+              data: { timestamp: Date.now() },
+            });
+            this.outboundAudioStarted = false;
+          }
+          this.sendEvent({
+            type: WyomingEventType.RunEnd,
+          });
+          this.session = null;
+          return;
+        }
+        if (eventType === VoiceAssistantEvent.ERROR) {
+          this.sendEvent({
+            type: WyomingEventType.Error,
+            data: {
+              text: dataKv.message ?? "openai-error",
+              code: dataKv.code ?? "openai-error",
+            },
+          });
+          return;
+        }
+        // RUN_START / TTS_START / TTS_END — Wyoming has no analog. Drop.
+        return;
+      }
+      case MessageType.VoiceAssistantResponse: {
+        // ACK of voice-start — Wyoming has no equivalent (HA pre-knows the
+        // pipeline opened when `audio-chunk` events start arriving). Drop.
+        return;
+      }
+      default: {
+        // Anything else from the brain is unexpected on this transport.
+        const log = this.opts.log ?? defaultLog;
+        log("wyoming brain emitted unexpected esphome message", {
+          messageType,
+        });
+        return;
+      }
+    }
+  }
+
+  private sendEvent(event: WyomingEvent): void {
+    if (this.socket.destroyed) return;
+    try {
+      this.socket.write(encodeWyomingEvent(event));
+    } catch (err) {
+      const log = this.opts.log ?? defaultLog;
+      log("wyoming write error", {
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}
+
+// ── Server bootstrap ───────────────────────────────────────────────────────
+
+export interface WyomingServerOptions {
+  port: number;
+  bindHost: string;
+  identity: EsphomeServerIdentity;
+  voiceSessionFactory: VoiceSessionFactory;
+  log?: (msg: string, extra?: Record<string, unknown>) => void;
+}
+
+export interface WyomingServerHandle {
+  server: net.Server;
+  ready: Promise<void>;
+  boundPort(): number;
+  close(): Promise<void>;
+  /** Unix-ms of the most recent `describe` we answered, or null. The
+   * /channels card uses this as a freshness signal. */
+  lastHandshakeAt(): number | null;
+}
+
+let _lastHandshakeAt: number | null = null;
+
+export function startWyomingServer(opts: WyomingServerOptions): WyomingServerHandle {
+  const log = opts.log ?? defaultLog;
+  const server = net.createServer((socket) => {
+    socket.setNoDelay(true);
+    new WyomingConnection(socket, opts);
+    // Wrap the connection so we can tap `describe` for the handshake tag.
+    // Cheaper than wiring a callback through WyomingConnection because the
+    // server module is single-process.
+    socket.once("data", () => {
+      _lastHandshakeAt = Date.now();
+    });
+  });
+  server.on("error", (err) => log("wyoming server error", { err: err.message }));
+
+  const ready = new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(opts.port, opts.bindHost, () => {
+      server.removeListener("error", reject);
+      log(`Wyoming Protocol listening on ${opts.bindHost}:${opts.port}`);
+      resolve();
+    });
+  });
+
+  return {
+    server,
+    ready,
+    boundPort: () => {
+      const addr = server.address();
+      if (addr && typeof addr === "object") return addr.port;
+      throw new Error("server not yet bound");
+    },
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      }),
+    lastHandshakeAt: () => _lastHandshakeAt,
+  };
+}
+
+// ── Helpers: decode the two ESPHome messages the brain emits at us ────────
+// We use these inside `WyomingConnection.translateAndSend` rather than
+// pulling in `decodeFields` from `esphome-protocol.ts` because we only
+// care about three field paths and the inline path is clearer.
+
+function decodeVoiceAssistantAudio(payload: Buffer): {
+  data: Buffer;
+  end: boolean;
+} {
+  let data = Buffer.alloc(0);
+  let end = false;
+  let off = 0;
+  while (off < payload.length) {
+    const tag = payload[off++];
+    const fieldNumber = tag >>> 3;
+    const wireType = tag & 0x07;
+    if (wireType === 2 /* length-delimited */) {
+      // varint length
+      let len = 0;
+      let shift = 0;
+      while (off < payload.length) {
+        const b = payload[off++];
+        len |= (b & 0x7f) << shift;
+        if ((b & 0x80) === 0) break;
+        shift += 7;
+      }
+      const bytes = payload.subarray(off, off + len);
+      off += len;
+      if (fieldNumber === 1) data = Buffer.from(bytes); // copy out
+    } else if (wireType === 0 /* varint */) {
+      let v = 0;
+      let shift = 0;
+      while (off < payload.length) {
+        const b = payload[off++];
+        v |= (b & 0x7f) << shift;
+        if ((b & 0x80) === 0) break;
+        shift += 7;
+      }
+      if (fieldNumber === 2) end = v !== 0;
+    } else {
+      // Unsupported wire type — bail.
+      break;
+    }
+  }
+  return { data, end };
+}
+
+function decodeVoiceAssistantEvent(payload: Buffer): {
+  eventType: number;
+  dataKv: Record<string, string>;
+} {
+  let eventType = 0;
+  const dataKv: Record<string, string> = {};
+  let off = 0;
+  while (off < payload.length) {
+    const tag = payload[off++];
+    const fieldNumber = tag >>> 3;
+    const wireType = tag & 0x07;
+    if (wireType === 0) {
+      let v = 0;
+      let shift = 0;
+      while (off < payload.length) {
+        const b = payload[off++];
+        v |= (b & 0x7f) << shift;
+        if ((b & 0x80) === 0) break;
+        shift += 7;
+      }
+      if (fieldNumber === 1) eventType = v;
+    } else if (wireType === 2) {
+      let len = 0;
+      let shift = 0;
+      while (off < payload.length) {
+        const b = payload[off++];
+        len |= (b & 0x7f) << shift;
+        if ((b & 0x80) === 0) break;
+        shift += 7;
+      }
+      const subPayload = payload.subarray(off, off + len);
+      off += len;
+      if (fieldNumber === 2 /* data — repeated submessage */) {
+        const { name, value } = decodeKvSubmessage(subPayload);
+        if (name) dataKv[name] = value;
+      }
+    } else {
+      break;
+    }
+  }
+  return { eventType, dataKv };
+}
+
+function decodeKvSubmessage(payload: Buffer): {
+  name: string;
+  value: string;
+} {
+  let name = "";
+  let value = "";
+  let off = 0;
+  while (off < payload.length) {
+    const tag = payload[off++];
+    const fieldNumber = tag >>> 3;
+    const wireType = tag & 0x07;
+    if (wireType !== 2) break;
+    let len = 0;
+    let shift = 0;
+    while (off < payload.length) {
+      const b = payload[off++];
+      len |= (b & 0x7f) << shift;
+      if ((b & 0x80) === 0) break;
+      shift += 7;
+    }
+    const str = payload.subarray(off, off + len).toString("utf-8");
+    off += len;
+    if (fieldNumber === 1) name = str;
+    if (fieldNumber === 2) value = str;
+  }
+  return { name, value };
+}
+
+function defaultLog(msg: string, extra?: Record<string, unknown>): void {
+  if (extra) console.log(`[wyoming] ${msg}`, extra);
+  else console.log(`[wyoming] ${msg}`);
+}

--- a/packages/web/main.wasp
+++ b/packages/web/main.wasp
@@ -1032,6 +1032,23 @@ query getEsphomeDevices {
   entities: []
 }
 
+// #112 PR5 — operator-side probe of a satellite IP. Opens an outbound
+// ESPHome Native API connection from the tenant VM, runs Hello →
+// DeviceInfo → ListEntities, looks for a voice_assistant entity,
+// reports back with structured recommendations the card renders inline.
+action testEsphomeDevice {
+  fn: import { testEsphomeDevice } from "@src/dashboard/operations",
+  entities: []
+}
+
+// #112 PR5 — Wyoming-fallback readiness. Returns enabled / port /
+// last_handshake_at — the card renders a tile distinguishing
+// "Wyoming on" from "Wyoming off (the default)".
+query getWyomingStatus {
+  fn: import { getWyomingStatus } from "@src/dashboard/operations",
+  entities: []
+}
+
 // Lane I (Home Assistant, #110 PR3 — 2026-05-29) — operator deep-integrates
 // HA on /channels. Four ops backed by ctrl-api /api/v1/channels/ha/*
 // (PR1 #133 backfill landed the routes). State derivation lives in

--- a/packages/web/src/dashboard/VoiceWakeWordsCard.tsx
+++ b/packages/web/src/dashboard/VoiceWakeWordsCard.tsx
@@ -22,7 +22,11 @@
 // the principal-facing payoff.
 
 import { useMemo, useState } from "react";
-import { useQuery, getEsphomeDevices } from "wasp/client/operations";
+import {
+  useQuery,
+  getEsphomeDevices,
+  testEsphomeDevice,
+} from "wasp/client/operations";
 import {
   WAKE_WORD_CATALOGUE,
   WAKE_WORD_UPSTREAM_URL,
@@ -31,6 +35,25 @@ import {
   formatEsphomeDeviceRow,
   type EsphomeDevice,
 } from "./voiceWakeWordsCardCore";
+
+/** Result shape returned by ctrl-api's POST /api/v1/channels/voice/
+ *  esphome/devices/test (PR5). Kept in sync with EsphomeProbeResult in
+ *  packages/ctrl/src/api/routes/voice_esphome.ts. */
+interface EsphomeProbeResultView {
+  ok: boolean;
+  info: {
+    reachable: boolean;
+    server_info: string;
+    esphome_version: string;
+    mac_address: string;
+    friendly_name: string;
+    voice_assistant_present: boolean;
+    codec: string;
+    recommendations: string[];
+    error: string | null;
+  };
+  hostname: string | null;
+}
 
 interface DevicesResponse {
   devices: EsphomeDevice[];
@@ -51,6 +74,36 @@ export function VoiceWakeWordsCard() {
 
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [manifestOpen, setManifestOpen] = useState(false);
+
+  // PR5 — operator-side probe state. One panel + one in-flight probe at
+  // a time, keyed by device row id ("hostname-ip"). We don't preserve
+  // results across reloads — the dashboard's not the place for a
+  // diagnosis history.
+  const [probeKey, setProbeKey] = useState<string | null>(null);
+  const [probeRunning, setProbeRunning] = useState(false);
+  const [probeResult, setProbeResult] =
+    useState<EsphomeProbeResultView | null>(null);
+  const [probeError, setProbeError] = useState<string | null>(null);
+
+  async function runProbe(device: EsphomeDevice): Promise<void> {
+    const key = `${device.hostname}-${device.ip}`;
+    setProbeKey(key);
+    setProbeRunning(true);
+    setProbeResult(null);
+    setProbeError(null);
+    try {
+      const result = (await testEsphomeDevice({
+        ip: device.ip,
+        hostname: device.hostname,
+      })) as EsphomeProbeResultView;
+      setProbeResult(result);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setProbeError(msg);
+    } finally {
+      setProbeRunning(false);
+    }
+  }
 
   const manifest = useMemo(
     () => selectedWakeWordsToManifest([...selected]),
@@ -144,16 +197,16 @@ export function VoiceWakeWordsCard() {
                 <th className="font-normal pb-2">Model</th>
                 <th className="font-normal pb-2">Wake word</th>
                 <th className="font-normal pb-2">Status</th>
+                <th className="font-normal pb-2" aria-label="Test"></th>
               </tr>
             </thead>
             <tbody>
               {devices.map((d) => {
                 const r = formatEsphomeDeviceRow(d);
+                const key = `${d.hostname}-${d.ip}`;
+                const isProbing = probeRunning && probeKey === key;
                 return (
-                  <tr
-                    key={`${d.hostname}-${d.ip}`}
-                    className="border-t border-rule"
-                  >
+                  <tr key={key} className="border-t border-rule">
                     <td className="py-2" style={{ color: "var(--ink)" }}>
                       {r.shortHost}
                     </td>
@@ -196,11 +249,116 @@ export function VoiceWakeWordsCard() {
                         </div>
                       )}
                     </td>
+                    <td className="py-2 text-right">
+                      <button
+                        onClick={() => runProbe(d)}
+                        disabled={probeRunning}
+                        className="btn-ghost"
+                        style={{ fontSize: "10px" }}
+                      >
+                        {isProbing ? "Probing…" : "Test"}
+                      </button>
+                    </td>
                   </tr>
                 );
               })}
             </tbody>
           </table>
+        )}
+
+        {/* PR5 — Probe-result side panel. Renders below the table so
+            the dashboard's vertical flow stays predictable. */}
+        {probeKey && (probeResult || probeError || probeRunning) && (
+          <div
+            className="mt-3 border border-rule p-3 space-y-2"
+            style={{ borderColor: "var(--brass)" }}
+          >
+            <div className="flex items-baseline justify-between">
+              <span
+                className="font-mono text-[10px] uppercase tracking-[0.22em]"
+                style={{ color: "var(--brass)" }}
+              >
+                Probe — {probeKey}
+              </span>
+              <button
+                onClick={() => {
+                  setProbeKey(null);
+                  setProbeResult(null);
+                  setProbeError(null);
+                }}
+                className="btn-ghost"
+                style={{ fontSize: "10px" }}
+              >
+                Close
+              </button>
+            </div>
+            {probeRunning && (
+              <p
+                className="font-body italic text-[12px]"
+                style={{ color: "var(--marginalia)" }}
+              >
+                Opening ESPHome Native API on :6053…
+              </p>
+            )}
+            {probeError && (
+              <p
+                className="font-body italic text-[12px]"
+                style={{ color: "var(--brass)" }}
+              >
+                Probe failed — {probeError}
+              </p>
+            )}
+            {probeResult && (
+              <div className="space-y-1">
+                <p
+                  className="font-body text-[12px]"
+                  style={{
+                    color: probeResult.ok ? "var(--ink)" : "var(--brass)",
+                  }}
+                >
+                  {probeResult.ok
+                    ? `OK — ESPHome ${probeResult.info.esphome_version} on ${probeResult.info.friendly_name || probeResult.hostname || "the satellite"}`
+                    : probeResult.info.error
+                      ? `Failed — ${probeResult.info.error}`
+                      : "Reachable but missing voice_assistant entity"}
+                </p>
+                <ul
+                  className="font-mono text-[10px] space-y-1"
+                  style={{ color: "var(--marginalia)" }}
+                >
+                  <li>reachable: {String(probeResult.info.reachable)}</li>
+                  {probeResult.info.mac_address && (
+                    <li>mac: {probeResult.info.mac_address}</li>
+                  )}
+                  {probeResult.info.codec && (
+                    <li>codec: {probeResult.info.codec}</li>
+                  )}
+                  <li>
+                    voice_assistant:{" "}
+                    {String(probeResult.info.voice_assistant_present)}
+                  </li>
+                </ul>
+                {probeResult.info.recommendations.length > 0 && (
+                  <div className="pt-1">
+                    <div
+                      className="font-mono text-[10px] uppercase tracking-[0.22em] pb-1"
+                      style={{ color: "var(--brass)" }}
+                    >
+                      Recommendations
+                    </div>
+                    <ul
+                      className="font-body italic text-[11px] space-y-1 list-disc list-inside"
+                      style={{ color: "var(--ink)" }}
+                    >
+                      {probeResult.info.recommendations.map((r, i) => (
+                        <li key={i}>{r}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
         )}
       </div>
 

--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -2880,12 +2880,12 @@ export const revokeChannelToken = async (
 };
 
 /** Read the list of ESPHome satellites the voice-bridge has seen on
- *  the local network. The listener landed in #112 PR1 but the
- *  ctrl-api status endpoint is queued for #112 PR4 — when the route
- *  isn't there yet, return `{ devices: [], unavailable: true }` so
- *  the card surfaces "ESPHome listener disabled" copy instead of an
- *  error toast. The card's job is to publish the catalogue + show
- *  what's there; absence is a normal state. */
+ *  the local network. The listener landed in #112 PR1; PR5 (this PR)
+ *  shipped the live ctrl-api route at /api/v1/channels/voice/esphome/
+ *  devices. The ctrl-api route now returns its own
+ *  `{enabled, listener_address, devices, unavailable?, error?}` shape
+ *  even when voice-bridge is unreachable — so the historical 404
+ *  fall-through is belt-and-braces only. */
 export const getEsphomeDevices = async (_args: unknown, context: any) => {
   const instance = await getUserInstance(context);
   try {
@@ -2898,6 +2898,54 @@ export const getEsphomeDevices = async (_args: unknown, context: any) => {
     }
     throw e;
   }
+};
+
+/** Run an outbound ESPHome Native API probe against a satellite IP that
+ *  the operator pastes in the /channels card. ctrl-api opens a TCP
+ *  connection from the tenant VM, walks the Hello → DeviceInfo →
+ *  ListEntities handshake, looks for a `voice_assistant:` entity, and
+ *  returns a structured diagnosis the card renders inline.
+ *
+ *  Body: { ip: string, hostname?: string, timeoutMs?: number }
+ *  Returns: { ok: boolean, info: { reachable, esphome_version,
+ *            mac_address, friendly_name, voice_assistant_present,
+ *            codec, recommendations: string[], error: string | null },
+ *            hostname: string | null }
+ *
+ *  Wired by #112 PR5. The operation is an action (it opens an outbound
+ *  TCP connection that costs O(timeoutMs) on the tenant) — Wasp
+ *  ergonomics prefer that for non-idempotent surfaces even when the
+ *  observable side-effect is "ran a probe". */
+export const testEsphomeDevice = async (
+  args: { ip: string; hostname?: string; timeoutMs?: number },
+  context: any,
+) => {
+  if (!args?.ip?.trim()) {
+    throw new HttpError(400, "ip is required");
+  }
+  const body: Record<string, unknown> = { ip: args.ip.trim() };
+  if (args.hostname && args.hostname.trim()) body.hostname = args.hostname.trim();
+  if (typeof args.timeoutMs === "number" && args.timeoutMs > 0) {
+    body.timeoutMs = args.timeoutMs;
+  }
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    path: "/api/v1/channels/voice/esphome/devices/test",
+    method: "POST",
+    body,
+  });
+};
+
+/** Read the Wyoming-fallback readiness status. Returns
+ *  `{enabled, port, bind, last_handshake_at, unavailable?, error?}`.
+ *  Used by the channels dashboard to render a tile distinguishing
+ *  "Wyoming on" from "Wyoming off (the default)" so the operator can
+ *  confirm WYOMING_ENABLED=1 actually took effect on the tenant VM. */
+export const getWyomingStatus = async (_args: unknown, context: any) => {
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    path: "/api/v1/channels/voice/wyoming/status",
+  });
 };
 
 // ============================================================


### PR DESCRIPTION
Closes the end-to-end loop promised in #112 — an ESPHome Voice PE / S3-Box satellite on the principal's network can now talk to voice-bridge → OpenAI Realtime → back, and the operator can see which HA installs have paired and probe a satellite's YAML without leaving the dashboard.

## What ships

### Lane I — voice-bridge

- New `wyoming-server.ts` — JSONL-over-TCP Wyoming Protocol listener on `:10300`. Same brain factory as the ESPHome Native API path; HA reaches it through HA's `wyoming` integration. Off by default (`WYOMING_ENABLED=0`).
- `esphome-server.ts` gains an `EsphomeDeviceRegistry` that tracks paired HA installs (last-seen IP, clientInfo, voice-subscribed, frame + turn counts). Exposed via `handle.getKnownDevices()`.
- `server.ts` adds two unauthenticated HTTP endpoints on `:9000`: `GET /esphome/devices` + `GET /wyoming/status` — both read-only, both bound to the docker-bridge so only ctrl-api reaches them.

### Lane II — ctrl-api

- New `routes/voice_esphome.ts` registering:
  - `GET /api/v1/channels/voice/esphome/devices` — proxies voice-bridge's `/esphome/devices`
  - `POST /api/v1/channels/voice/esphome/devices/test` — opens an outbound ESPHome Native API connection from the tenant VM, walks Hello → DeviceInfo → ListEntities, returns a structured diagnosis (`reachable` / `esphome_version` / `voice_assistant_present` / `codec` / `recommendations`)
  - `GET /api/v1/channels/voice/wyoming/status`
- All three are operator-only (`requireOperatorBearer`). NOT added to `VOICE_BRIDGE_ALLOWLIST`.

### Lane III — compose + Caddy

- `docker-compose.yaml`: voice-bridge env adds `WYOMING_ENABLED` + port + bind; `127.0.0.1:10300:10300` published (no-op when disabled).
- `caddy/Caddyfile`: existing `voice.{$DOMAIN}` block already proxies voice-bridge:9000 so the new GET routes ride along; comment updated to document the new endpoints.

### Lane IV — docs + verify

- `packages/voice-bridge/docs/ha-pipeline-setup.md` gains a Verification section with the exact `curl` invocations Sir runs from his laptop, plus an "Alternative — the Wyoming Protocol route" section that lays out the trade-off and the WYOMING_ENABLED=1 setup.
- New `packages/voice-bridge/scripts/smoke-esphome-device.sh` — bare ESPHome Native API probe runnable from any host with `node`. Useful when SSH'd into the VM without `\$AAS_API_KEY` handy.

### Lane V — Wasp wiring

- `operations.ts` gains `testEsphomeDevice` (action) + `getWyomingStatus` (query). Existing `getEsphomeDevices` keeps its shape — the ctrl-api side now returns live data.
- `main.wasp` declares both new ops.
- `VoiceWakeWordsCard.tsx` adds a `[Test]` button per device row and a side-panel that renders the probe's structured recommendations.

## Testing

**Voice-bridge: 80 tests pass, 0 fail (70 baseline + 10 new Wyoming).** Coverage:
- encoder/parser round-trips (header-only + with binary payload)
- split-TCP-chunk handling, non-JSON-header rejection
- info-response shape advertises 16 kHz pcm16 mono satellite
- audio-start → audio-chunk* → audio-stop drives a session end-to-end
- audio-chunk without audio-start emits an explicit error event (intentional deviation from the upstream Wyoming spec, which drops silently — we surface misconfiguration so it shows in the operator log)
- synthesize is rejected with `tts-not-supported`
- brain VoiceAssistantAudio translates to Wyoming audio-start/chunk/stop
- brain STT_END maps to a Wyoming transcript event
- lastHandshakeAt updates after first frame

**Ctrl: 781 pass + 1 skipped, 0 fail (775 baseline + 7 new).** Coverage:
- probe happy path (voice_assistant_present + clean recommendations)
- probe with no voice_assistant entity surfaces the recommendation
- probe against an unreachable IP returns `reachable:false` + advice
- probe against ESPHome 2024.5 flags the upgrade-needed recommendation
- POST /devices/test rejects an empty body
- POST /devices/test rejects a body with scheme prefix
- GET /esphome/devices falls through to `unavailable:true` when voice-bridge is unreachable

## Wyoming-vs-ESPHome-native trade-off

We default to ESPHome Native because the audio path is shorter (one fewer serialisation hop, ~30ms latency saved) and the wake word stays on-device for free. Wyoming is the opt-in fallback for HA-OS / HA-Cloud installs that can't reach `:6053` over the LAN but CAN reach a Wyoming server on the tailnet — and for the long tail of non-ESPHome satellites (Raspberry Pi running `wyoming-satellite`, M5StickC with `rhasspy-wyoming`, etc.). Same brain factory either way; the operator picks the transport that matches their HA setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)