### PR TITLE
feat(ctrl,web): Recall API-key persistence — validate → vault + .env + restart (#113 PR3a)

### DIFF
--- a/packages/ctrl/src/api/routes/channels_recall.ts
+++ b/packages/ctrl/src/api/routes/channels_recall.ts
@@ -15,6 +15,7 @@
 // Surface:
 //
 //   POST /api/v1/channels/recall/validate-key            — paste+round-trip test
+//   POST /api/v1/channels/recall/api-key                  — persist a validated key (PR3a)
 //   GET  /api/v1/channels/recall/config                  — current dials
 //   PATCH /api/v1/channels/recall/config                 — update dials
 //   GET  /api/v1/channels/recall/usage                   — month-to-date rollup
@@ -31,16 +32,34 @@
 // recall_bot rows when it creates a bot; this file owns the row updates
 // driven by inbound webhooks.
 //
-// API-key persistence: validation only round-trips the key against
-// Recall — it does NOT persist. The /channels card POST handler (PR3a)
-// is responsible for writing RECALL_API_KEY into the host .env once
-// validation succeeds, mirroring the paperclip POST /api-key pattern.
-// PR3a + PR3b own the operator-facing key paste; PR2 stops at validate.
+// API-key persistence: PR3a (this commit) adds
+// POST /api/v1/channels/recall/api-key as the operator-only setter that
+// round-trips the key against Recall, then writes it to BOTH stores:
+//
+//   1. Vaultwarden (canonical) — via the existing vault-cli sidecar, as
+//      a Login item named "Recall API Key" with `region` in notes. This
+//      is the durable source of truth; vault-init re-reads it into the
+//      host .env on tenant boot.
+//   2. /opt/alfred/.env (immediate) — atomic write via tempfile + rename
+//      using credentials.ts's patchEnv() helper. Skips the wait for the
+//      next vault-init cycle so the new key is hot the moment ctrl-api
+//      restarts.
+//
+// Then the route triggers `docker compose restart ctrl-api alfred-learn`
+// in the background so the new key takes effect immediately. Mirrors
+// the Telegram channel persistence pattern (telegram.ts:548), with the
+// /opt/alfred/.env write borrowed from the OpenAI key flow
+// (credentials.ts:patchEnv) — except the .env write here is atomic (tmp
+// + rename) per Sir's PR brief.
 
 import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
 import { addRoute } from "../server.js";
 import { sendJson, ValidationError, ApiError } from "../errors.js";
 import { getStateDb } from "../../db/state.js";
+import { dockerComposeCmd, COMPOSE_DIR } from "../helpers.js";
+import { requireOperatorBearer } from "../auth.js";
 import type { DatabaseSync } from "node:sqlite";
 
 // ── Recall API endpoint helpers ───────────────────────────────────────────
@@ -157,6 +176,10 @@ function rowToApiConfig(row: RecallConfigRow): Record<string, unknown> {
     // Fall back to the default — never reject a row on a corrupted JSON
     // field; the operator can re-PATCH to fix it.
   }
+  // Expose key_first6 + api_key_set so the /channels card can render
+  // the rotation row ("first 6 chars …") without ever round-tripping
+  // the full value. PR3a adds this; the field was previously absent.
+  const apiKey = process.env.RECALL_API_KEY?.trim() ?? "";
   return {
     region: row.region,
     bot_name: row.bot_name,
@@ -169,6 +192,8 @@ function rowToApiConfig(row: RecallConfigRow): Record<string, unknown> {
     wake_word: row.wake_word,
     cost_alert_thresholds: thresholds,
     updated_at: row.updated_at,
+    api_key_set: apiKey.length > 0,
+    api_key_first6: apiKey.length > 0 ? apiKey.slice(0, 6) : null,
   };
 }
 
@@ -378,6 +403,276 @@ async function validateRecallKey(
     ok: true,
     account: { region, bots_known: count },
   };
+}
+
+// ── api-key persistence helpers (PR3a) ────────────────────────────────────
+//
+// The persist path has four steps:
+//   1. round-trip-validate via validateRecallKey() above (NEVER trust a
+//      paste);
+//   2. upsert a "Recall API Key" Login item in Vaultwarden through the
+//      vault-cli sidecar (canonical store);
+//   3. atomically merge RECALL_API_KEY + RECALL_REGION into the compose
+//      .env at ${COMPOSE_DIR}/.env via tempfile + rename (so a crash
+//      mid-write leaves the old .env untouched);
+//   4. restart ctrl-api and alfred-learn via `docker compose restart` so
+//      the new env takes effect immediately. Background; do not block
+//      the response.
+//
+// Idempotence: if the *same* key value is already in the .env on disk
+// AND already on file in Vaultwarden, the route returns
+// `{ok, idempotent: true}` without writing or restarting anything.
+//
+// Concurrency: a process-local lock serialises the persistence path so
+// two concurrent calls cannot double-restart. A second concurrent
+// caller waits for the first to finish, then re-checks idempotence.
+
+const VAULT_CLI_URL = process.env.VAULT_CLI_URL || "http://vault-cli:8087";
+const RECALL_VAULT_ITEM_NAME = "Recall API Key";
+const RECALL_ENV_PATH = `${COMPOSE_DIR}/.env`;
+const RECALL_RESTART_SERVICES = ["ctrl-api", "alfred-learn"] as const;
+const RECALL_RESTART_ETA_SECONDS = 30;
+
+// In-process serialiser. Awaited by every persistence call so two
+// requests landing simultaneously cannot both validate-then-restart
+// (the second would no-op via idempotence once it sees the first
+// caller's write).
+let _persistLock: Promise<void> = Promise.resolve();
+
+async function withPersistLock<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = _persistLock;
+  let release!: () => void;
+  _persistLock = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  try {
+    await prev;
+    return await fn();
+  } finally {
+    release();
+  }
+}
+
+// ── vault-cli sidecar helpers (mirrors telegram.ts:97-184) ───────────────
+
+interface BwEnvelope {
+  success?: boolean;
+  data?: unknown;
+  message?: string;
+}
+
+async function _bwFetch(
+  p: string,
+  init: RequestInit = {},
+): Promise<{ status: number; body: unknown }> {
+  const r = await fetch(`${VAULT_CLI_URL}${p}`, {
+    ...init,
+    headers: { "content-type": "application/json", ...(init.headers ?? {}) },
+    signal: AbortSignal.timeout(15_000),
+  });
+  const text = await r.text();
+  try {
+    return { status: r.status, body: JSON.parse(text) };
+  } catch {
+    return { status: r.status, body: text };
+  }
+}
+
+function _bwUnwrap(
+  body: unknown,
+): { ok: true; data: unknown } | { ok: false; message: string } {
+  if (typeof body !== "object" || body === null) {
+    return { ok: false, message: "vault-cli returned non-JSON body" };
+  }
+  const env = body as BwEnvelope;
+  if (env.success === false) {
+    return { ok: false, message: env.message ?? "vault-cli error" };
+  }
+  if (env.success === true && "data" in env) return { ok: true, data: env.data };
+  return { ok: true, data: body };
+}
+
+async function findRecallVaultItem(): Promise<
+  { id: string; password: string | null; notes: string | null } | null
+> {
+  const r = await _bwFetch(
+    `/list/object/items?search=${encodeURIComponent(RECALL_VAULT_ITEM_NAME)}`,
+  );
+  if (r.status >= 500) throw new Error(`vault-cli unreachable (HTTP ${r.status})`);
+  const u = _bwUnwrap(r.body);
+  if (!u.ok) throw new Error(u.message);
+  const data = u.data as Record<string, unknown> | unknown[];
+  const list = Array.isArray(data)
+    ? data
+    : Array.isArray((data as Record<string, unknown>).data)
+      ? ((data as Record<string, unknown>).data as unknown[])
+      : [];
+  for (const raw of list) {
+    if (typeof raw !== "object" || raw === null) continue;
+    const it = raw as Record<string, unknown>;
+    if (typeof it.name !== "string") continue;
+    if (it.name.toLowerCase() !== RECALL_VAULT_ITEM_NAME.toLowerCase()) continue;
+    const login =
+      typeof it.login === "object" && it.login !== null
+        ? (it.login as Record<string, unknown>)
+        : null;
+    const password = login && typeof login.password === "string" ? login.password : null;
+    const notes = typeof it.notes === "string" ? it.notes : null;
+    return { id: typeof it.id === "string" ? it.id : "", password, notes };
+  }
+  return null;
+}
+
+/** Upsert the Recall API Key item. Notes carries the region so vault-init
+ *  can re-derive RECALL_REGION on next boot without an extra item. */
+async function upsertRecallVaultItem(key: string, region: string): Promise<void> {
+  const existing = await findRecallVaultItem();
+  const notes =
+    `Recall.ai API key for the meeting-bot channel (#113). ` +
+    `Region: ${region}. Source of truth — vault-init reads this back ` +
+    `into RECALL_API_KEY and RECALL_REGION on tenant boot.`;
+  if (existing && existing.id) {
+    const cur = await _bwFetch(`/object/item/${existing.id}`);
+    const curU = _bwUnwrap(cur.body);
+    if (!curU.ok) throw new Error(curU.message);
+    const existingItem = (curU.data as Record<string, unknown>).data ?? curU.data;
+    const e = existingItem as Record<string, unknown>;
+    const existingLogin =
+      typeof e.login === "object" && e.login !== null
+        ? ({ ...(e.login as Record<string, unknown>) } as Record<string, unknown>)
+        : { username: null, password: null, uris: [] };
+    existingLogin.password = key;
+    const merged = {
+      ...e,
+      name: RECALL_VAULT_ITEM_NAME,
+      notes,
+      login: existingLogin,
+    };
+    const r = await _bwFetch(`/object/item/${existing.id}`, {
+      method: "PUT",
+      body: JSON.stringify(merged),
+    });
+    const u = _bwUnwrap(r.body);
+    if (!u.ok) throw new Error(u.message);
+    return;
+  }
+  const payload = {
+    type: 1,
+    name: RECALL_VAULT_ITEM_NAME,
+    notes,
+    folderId: null,
+    favorite: false,
+    reprompt: 0,
+    login: {
+      username: null,
+      password: key,
+      uris: [{ uri: "https://recall.ai/", match: null }],
+    },
+  };
+  const r = await _bwFetch("/object/item", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+  const u = _bwUnwrap(r.body);
+  if (!u.ok) throw new Error(u.message);
+}
+
+/** Read the current .env into a {key: value} map. Missing file → {}. */
+function readEnvFile(envPath: string): Record<string, string> {
+  let content = "";
+  try {
+    content = fs.readFileSync(envPath, "utf-8");
+  } catch {
+    return {};
+  }
+  const env: Record<string, string> = {};
+  for (const line of content.split("\n")) {
+    const t = line.trim();
+    if (!t || t.startsWith("#")) continue;
+    const eq = t.indexOf("=");
+    if (eq < 0) continue;
+    env[t.slice(0, eq).trim()] = t.slice(eq + 1).trim();
+  }
+  return env;
+}
+
+/** Surgically update RECALL_API_KEY + RECALL_REGION in the compose .env,
+ *  preserving all comments / blank lines / ordering / unrelated keys.
+ *  Writes atomically: tmp file in the same directory + rename. On
+ *  success the .env.next file no longer exists; on a crashed write the
+ *  old .env is untouched and the orphan tmp is cleaned up by the next
+ *  successful write (we look for and unlink any prior tmp before
+ *  starting). */
+function atomicPatchEnv(
+  envPath: string,
+  updates: Record<string, string>,
+): void {
+  let lines: string[];
+  try {
+    lines = fs.readFileSync(envPath, "utf-8").split("\n");
+  } catch {
+    lines = [];
+  }
+  const remaining = new Map(Object.entries(updates));
+  const result = lines.map((line) => {
+    const t = line.trim();
+    if (!t || t.startsWith("#")) return line;
+    const eq = t.indexOf("=");
+    if (eq < 0) return line;
+    const k = t.slice(0, eq).trim();
+    if (!remaining.has(k)) return line;
+    const v = remaining.get(k)!;
+    remaining.delete(k);
+    return `${k}=${v}`;
+  });
+  for (const [k, v] of remaining) {
+    result.push(`${k}=${v}`);
+  }
+  const content = result.join("\n");
+  const final = content.endsWith("\n") ? content : content + "\n";
+
+  // Atomic write — tmp file in the SAME directory (rename across
+  // filesystems isn't atomic). Mode 0o600 so a stray reader can't shoulder
+  // the secret between the rename and the next docker compose restart.
+  const dir = path.dirname(envPath);
+  const tmp = path.join(dir, ".env.next");
+  // Clean up any orphan from a previous crashed write.
+  try {
+    fs.unlinkSync(tmp);
+  } catch {
+    /* swallow ENOENT */
+  }
+  fs.writeFileSync(tmp, final, { mode: 0o600 });
+  fs.renameSync(tmp, envPath);
+}
+
+/** Fire-and-forget restart of ctrl-api + alfred-learn. We do NOT await:
+ *  restarting ctrl-api will tear down the very HTTP connection we're
+ *  serving the response on, so blocking the response on the restart
+ *  guarantees the caller never sees a 200. Background it.
+ *
+ *  Best-effort logging. The /status route can read the live key from
+ *  process.env to confirm the restart landed. */
+function restartForRecallKey(): void {
+  // Sequential so we don't contend with health checks. alfred-learn
+  // first (no callers depend on it staying up), then ctrl-api (this
+  // terminates our own connection — by which point the response is
+  // already written).
+  (async () => {
+    for (const svc of RECALL_RESTART_SERVICES) {
+      try {
+        await dockerComposeCmd(["restart", svc]);
+      } catch (err) {
+        console.error(`[recall/api-key] restart of ${svc} failed:`, err);
+      }
+    }
+  })();
+}
+
+/** Mask an API key down to its first 6 chars + "…". Used in log lines
+ *  and the response envelope. We never echo the full value. */
+function keyFirst6(key: string): string {
+  return key.slice(0, 6);
 }
 
 // ── usage rollup ──────────────────────────────────────────────────────────
@@ -680,6 +975,13 @@ export const _recallInternals = {
   statusFromEvent,
   parseConfigPatch,
   classifyMeetingUrl,
+  // PR3a — persistence helpers, exported for the corresponding test.
+  atomicPatchEnv,
+  readEnvFile,
+  findRecallVaultItem,
+  upsertRecallVaultItem,
+  withPersistLock,
+  keyFirst6,
 };
 
 // ── Routes ────────────────────────────────────────────────────────────────
@@ -723,6 +1025,182 @@ export function registerChannelsRecallRoutes(): void {
       // to render. Tossing a non-2xx here would force the card to also
       // handle a generic error page on what's a normal "wrong key" path.
       sendJson(res, 200, outcome);
+    },
+  );
+
+  // POST /api/v1/channels/recall/api-key
+  //
+  // Operator-only setter (#113 PR3a). The /channels Recall card calls
+  // this AFTER /validate-key returns {ok:true}, with the same key. We:
+  //   1. round-trip-validate AGAIN against Recall (never trust a
+  //      "validate already happened" claim from a caller);
+  //   2. upsert "Recall API Key" in Vaultwarden via vault-cli;
+  //   3. atomically merge RECALL_API_KEY + RECALL_REGION into
+  //      ${COMPOSE_DIR}/.env via tempfile + rename;
+  //   4. background-restart ctrl-api + alfred-learn so the new env is
+  //      picked up immediately. (alfred-learn calls recall.ai through
+  //      ctrl-api, but RECALL_API_KEY can also leak into its own env in
+  //      future workflows, hence the explicit restart.)
+  //
+  // The response envelope NEVER carries the key. `key_first6` is the
+  // operator-visible fingerprint; everything else is a description of
+  // what was written. 502s during validation or vault write short-circuit
+  // BEFORE any .env mutation so a half-applied write is impossible.
+  //
+  // Idempotence: if the same key + region are already in the .env AND
+  // the vault item already holds the same password, we return
+  // `{ok:true, idempotent:true}` without restart. A re-paste of the
+  // same key from the card is therefore free.
+  //
+  // Concurrency: a process-local lock guarantees two parallel calls
+  // serialise. The second caller observes the first's write and
+  // idempotence-noops; no double restart.
+  addRoute(
+    "POST",
+    "/api/v1/channels/recall/api-key",
+    async ({ req, res, body }) => {
+      // Operator-only — voice-bridge / channel-token bearers get 403.
+      requireOperatorBearer(req);
+
+      const b = (body ?? {}) as { api_key?: unknown; region?: unknown };
+      if (typeof b.api_key !== "string" || b.api_key.trim().length === 0) {
+        throw new ValidationError("api_key (non-empty string) is required");
+      }
+      const key = b.api_key.trim();
+
+      // Region defaults to the configured value (the singleton row's
+      // region) when missing. Validated against the same allowlist as
+      // validate-key + PATCH /config.
+      let region: string;
+      if (b.region !== undefined) {
+        if (typeof b.region !== "string" || !VALID_REGIONS.includes(b.region)) {
+          throw new ValidationError(
+            `region must be one of: ${VALID_REGIONS.join(", ")}`,
+          );
+        }
+        region = b.region;
+      } else {
+        try {
+          const cfg = getOrSeedConfig(getStateDb());
+          region = cfg.region;
+        } catch {
+          region = "us-east-1";
+        }
+      }
+
+      const first6 = keyFirst6(key);
+
+      // Serialise the whole persist+restart sequence so a second
+      // concurrent caller can't double-restart.
+      const result = await withPersistLock(async () => {
+        // ── 1. Round-trip-validate against Recall ─────────────────────
+        const outcome = await validateRecallKey(key, region);
+        if (!outcome.ok) {
+          // Differentiate Recall's auth failure from a network blip. A
+          // 401 from Recall lands as `outcome.reason = "Recall rejected
+          // the API key"` — surface verbatim so the card renders Recall's
+          // own language. We map auth failures to 401 and everything
+          // else (timeouts / 502s / DNS / etc.) to 502. NEVER persist.
+          const reason = outcome.reason ?? "Recall rejected the API key";
+          const isAuth = /reject|invalid/i.test(reason);
+          throw new ApiError(
+            isAuth ? 401 : 502,
+            isAuth ? "RECALL_AUTH_FAILED" : "RECALL_UNREACHABLE",
+            reason,
+          );
+        }
+
+        // ── 2. Check idempotence — same key + region already on file? ─
+        const envOnDisk = readEnvFile(RECALL_ENV_PATH);
+        const sameEnvKey = envOnDisk.RECALL_API_KEY === key;
+        const sameEnvRegion = envOnDisk.RECALL_REGION === region;
+        let sameVault = false;
+        try {
+          const existing = await findRecallVaultItem();
+          sameVault = Boolean(
+            existing && existing.password === key,
+          );
+        } catch (err) {
+          // Vault read failure on the idempotence-check path is non-fatal
+          // — we just fall through to the write path, which has its own
+          // error handling.
+          console.warn(
+            `[recall/api-key] vault idempotence-check failed (key ${first6}…): ` +
+              (err instanceof Error ? err.message : String(err)),
+          );
+        }
+        if (sameEnvKey && sameEnvRegion && sameVault) {
+          return {
+            envelope: {
+              ok: true,
+              idempotent: true,
+              region,
+              key_first6: first6,
+              persisted_to: [] as string[],
+              restarted: [] as string[],
+              eta_seconds: 0,
+            },
+            shouldRestart: false,
+          };
+        }
+
+        // ── 3. Vaultwarden upsert (canonical) ────────────────────────
+        try {
+          await upsertRecallVaultItem(key, region);
+        } catch (err) {
+          // Hard fail — vault is the canonical store. We have NOT
+          // written to .env yet, so the system is still consistent.
+          throw new ApiError(
+            502,
+            "VAULT_WRITE_FAILED",
+            err instanceof Error ? err.message : String(err),
+          );
+        }
+
+        // ── 4. Atomic .env write (immediate) ─────────────────────────
+        try {
+          atomicPatchEnv(RECALL_ENV_PATH, {
+            RECALL_API_KEY: key,
+            RECALL_REGION: region,
+          });
+        } catch (err) {
+          throw new ApiError(
+            500,
+            "ENV_WRITE_FAILED",
+            err instanceof Error ? err.message : String(err),
+          );
+        }
+
+        // Update our own process.env so subsequent reads inside this
+        // ctrl-api invocation (until the restart lands) see the new key.
+        process.env.RECALL_API_KEY = key;
+        process.env.RECALL_REGION = region;
+
+        // Log with the prefix only — never the full value.
+        console.log(
+          `[recall/api-key] persisted key ${first6}… region=${region} ` +
+            `(vaultwarden + .env). Restarting ${RECALL_RESTART_SERVICES.join(", ")}.`,
+        );
+
+        return {
+          envelope: {
+            ok: true,
+            region,
+            key_first6: first6,
+            persisted_to: ["vaultwarden", ".env"],
+            restarted: [...RECALL_RESTART_SERVICES],
+            eta_seconds: RECALL_RESTART_ETA_SECONDS,
+          },
+          shouldRestart: true,
+        };
+      });
+
+      // Send the response BEFORE kicking the restart — restarting
+      // ctrl-api tears down this socket.
+      sendJson(res, 200, result.envelope);
+      if (result.shouldRestart) {
+        restartForRecallKey();
+      }
     },
   );
 

--- a/packages/ctrl/tests/channels_recall_apikey.test.ts
+++ b/packages/ctrl/tests/channels_recall_apikey.test.ts
@@ -1,0 +1,658 @@
+// channels_recall_apikey — POST /api/v1/channels/recall/api-key (#113 PR3a).
+//
+// What's under test
+// -----------------
+// The persistence path Sir flagged PR #136 as missing:
+//
+//   1. Round-trip-validate the pasted key against Recall.
+//   2. Upsert "Recall API Key" in Vaultwarden via the vault-cli sidecar.
+//   3. Atomically merge RECALL_API_KEY + RECALL_REGION into the
+//      compose .env via a tempfile + rename in the same directory.
+//   4. Background-restart ctrl-api + alfred-learn so the new env lands.
+//
+// We stub three external surfaces:
+//   * globalThis.fetch — Recall + vault-cli HTTP traffic;
+//   * dockerComposeCmd — so the route doesn't actually restart anything
+//     (but we record the calls);
+//   * a temp directory for COMPOSE_DIR — so the atomic .env write lands
+//     on a real filesystem we can inspect.
+//
+// Coverage (10):
+//   1. Recall rejects the key (401) → 401 RECALL_AUTH_FAILED, no vault
+//      write, no .env write, no restart.
+//   2. Recall accepts the key → 200, vault item upserted, .env merged,
+//      restart triggered, response carries persisted_to + restarted.
+//   3. Idempotent: re-POST the same key/region → {ok:true,
+//      idempotent:true}, no restart, no extra vault write.
+//   4. Atomic .env write — tempfile cleaned up after success, partial
+//      state is impossible (we verify the tmp path is absent post-write).
+//   5. Vaultwarden write goes via the vault-cli HTTP sidecar — we
+//      record the request URLs and assert they target /object/item.
+//   6. Response envelope carries key_first6 only; never the full key
+//      and never the hash.
+//   7. Operator-only — voice-bridge bearer gets 403, channel-token
+//      bearer gets 403.
+//   8. Recall returns 502 mid-validate → no persist, no restart.
+//   9. Concurrent calls don't double-restart — the lock serialises.
+//  10. `region` defaults to the singleton config row when missing.
+//
+// Privacy: no real secrets in this file. The "key" values here are
+// `rec_test_*` opaque strings.
+
+import { describe, it, before, beforeEach, after, mock } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ServerResponse } from "node:http";
+
+// ── per-suite fixture dir ────────────────────────────────────────────────
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "channels-recall-apikey-"));
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.VAULT_PATH = path.join(tmp, "vault");
+process.env.STATE_DB_PATH = path.join(tmp, "alfred-state.db");
+process.env.SQLITE_VEC_PATH = "";
+process.env.DOMAIN = "test.alfred.black";
+process.env.AAS_HOST = "127.0.0.1";
+process.env.AAS_PORT = "3100";
+
+// COMPOSE_DIR is read at module-load time by helpers.ts, so it has to
+// be set BEFORE the imports below. The route writes RECALL_API_KEY
+// into `${COMPOSE_DIR}/.env`; we use a real tmp dir so the atomic
+// rename actually runs on a real filesystem.
+const composeDir = path.join(tmp, "compose");
+fs.mkdirSync(composeDir, { recursive: true });
+process.env.COMPOSE_DIR = composeDir;
+process.env.VAULT_CLI_URL = "http://vault-cli:8087";
+
+delete process.env.RECALL_API_KEY;
+delete process.env.RECALL_REGION;
+delete process.env.RECALL_WEBHOOK_SECRET;
+
+// ── fetch stub (Recall + vault-cli) ──────────────────────────────────────
+
+const originalFetch = globalThis.fetch;
+
+interface RecallStub {
+  listBotsStatus: number;
+  listBotsBody: unknown;
+}
+const recallStub: RecallStub = {
+  listBotsStatus: 200,
+  listBotsBody: { count: 0, results: [] },
+};
+let recallShouldThrow = false;
+let recallCallCount = 0;
+
+// vault-cli stub state. A fake "DB" of items keyed by id; the route
+// lists by name, fetches by id, then PUTs back or POSTs a new one.
+interface VaultItem {
+  id: string;
+  name: string;
+  notes: string | null;
+  login: {
+    username: string | null;
+    password: string | null;
+    uris: Array<{ uri: string; match: string | null }>;
+  };
+}
+const vaultStore: Map<string, VaultItem> = new Map();
+let vaultCallLog: Array<{ method: string; path: string; body?: unknown }> = [];
+let vaultShouldFail = false;
+let vaultSeq = 1;
+
+function makeJsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+globalThis.fetch = (async (input: any, init?: any) => {
+  const url = typeof input === "string" ? input : (input?.url ?? String(input));
+  const method = (init?.method ?? "GET").toUpperCase();
+
+  // Recall list-bots — validate-key
+  if (/recall\.ai/.test(url) && /\/api\/v1\/bot\/\?limit=1$/.test(url)) {
+    recallCallCount += 1;
+    if (recallShouldThrow) throw new Error("recall unreachable");
+    return makeJsonResponse(recallStub.listBotsBody, recallStub.listBotsStatus);
+  }
+
+  // vault-cli paths.
+  if (url.startsWith("http://vault-cli:8087/")) {
+    const pathOnly = url.slice("http://vault-cli:8087".length);
+    vaultCallLog.push({
+      method,
+      path: pathOnly,
+      body: init?.body ? safeJsonParse(String(init.body)) : undefined,
+    });
+    if (vaultShouldFail) {
+      return makeJsonResponse({ success: false, message: "vault-cli down" }, 502);
+    }
+    // GET /list/object/items?search=<name>
+    if (method === "GET" && pathOnly.startsWith("/list/object/items")) {
+      const u = new URL("http://x" + pathOnly);
+      const needle = (u.searchParams.get("search") ?? "").toLowerCase();
+      const list = [...vaultStore.values()].filter((it) =>
+        it.name.toLowerCase().includes(needle),
+      );
+      return makeJsonResponse({ success: true, data: { data: list } });
+    }
+    // GET /object/item/:id
+    if (method === "GET" && pathOnly.startsWith("/object/item/")) {
+      const id = pathOnly.split("/").pop()!;
+      const it = vaultStore.get(id);
+      if (!it) {
+        return makeJsonResponse(
+          { success: false, message: "not found" },
+          404,
+        );
+      }
+      return makeJsonResponse({ success: true, data: { data: it } });
+    }
+    // POST /object/item (create)
+    if (method === "POST" && pathOnly === "/object/item") {
+      const body = (safeJsonParse(String(init.body)) ?? {}) as Partial<VaultItem>;
+      const id = `vault-${vaultSeq++}`;
+      const it: VaultItem = {
+        id,
+        name: typeof body.name === "string" ? body.name : "",
+        notes: typeof body.notes === "string" ? body.notes : null,
+        login: (body.login as VaultItem["login"]) ?? {
+          username: null,
+          password: null,
+          uris: [],
+        },
+      };
+      vaultStore.set(id, it);
+      return makeJsonResponse({ success: true, data: it });
+    }
+    // PUT /object/item/:id (update)
+    if (method === "PUT" && pathOnly.startsWith("/object/item/")) {
+      const id = pathOnly.split("/").pop()!;
+      const body = (safeJsonParse(String(init.body)) ?? {}) as VaultItem;
+      const merged: VaultItem = {
+        id,
+        name: typeof body.name === "string" ? body.name : "",
+        notes: typeof body.notes === "string" ? body.notes : null,
+        login: body.login,
+      };
+      vaultStore.set(id, merged);
+      return makeJsonResponse({ success: true, data: merged });
+    }
+    return makeJsonResponse({ success: false, message: "unhandled stub" }, 500);
+  }
+
+  throw new Error(`unexpected fetch in channels_recall_apikey test: ${method} ${url}`);
+}) as typeof fetch;
+
+function safeJsonParse(s: string): unknown {
+  try {
+    return JSON.parse(s);
+  } catch {
+    return null;
+  }
+}
+
+// ── dockerComposeCmd stub (via mock.module) ──────────────────────────────
+//
+// We replace the helpers.ts module entirely so the route's
+// `dockerComposeCmd` call doesn't shell out to a real docker daemon.
+// Re-export everything else verbatim so other imports of helpers (state
+// db migrations, etc.) keep working.
+
+interface ComposeCall {
+  args: string[];
+  at: number;
+}
+const composeCalls: ComposeCall[] = [];
+let composeShouldFail = false;
+
+const _realHelpers = await import("../src/api/helpers.js");
+const dockerComposeCmdFn = mock.fn(
+  async (args: string[]): Promise<string> => {
+    composeCalls.push({ args: [...args], at: Date.now() });
+    if (composeShouldFail) throw new Error("docker compose unavailable");
+    return "ok";
+  },
+);
+
+// `namedExports` is the legacy field name; voice-routes.test.ts still uses
+// it. Node logs a deprecation warning suggesting `exports`, but the
+// stable contract today is namedExports (the deprecation will land in a
+// future release). We mirror voice-routes.test.ts.
+mock.module("../src/api/helpers.js", {
+  namedExports: {
+    ..._realHelpers,
+    dockerComposeCmd: dockerComposeCmdFn,
+  },
+});
+
+// ── module imports (after env + fetch + helpers patch) ───────────────────
+
+const { matchRoute } = await import("../src/api/server.js");
+const { handleError } = await import("../src/api/errors.js");
+const {
+  registerChannelsRecallRoutes,
+  _recallInternals,
+} = await import("../src/api/routes/channels_recall.js");
+const { getStateDb } = await import("../src/db/state.js");
+const {
+  setApiKey,
+  setVoiceBridgeKey,
+  _resetAuthForTests,
+} = await import("../src/api/auth.js");
+registerChannelsRecallRoutes();
+
+interface InvokeResult {
+  status: number;
+  payload: any;
+}
+
+async function invokeRoute(
+  method: string,
+  p: string,
+  body?: unknown,
+  headers: Record<string, string> = {},
+): Promise<InvokeResult> {
+  const m = matchRoute(method, p);
+  assert.ok(m, `${method} ${p} must be registered`);
+  let status = 0;
+  let payload: any;
+  const res = {
+    statusCode: 0,
+    setHeader() {},
+    writeHead(c: number) {
+      status = c;
+      return res;
+    },
+    end(j?: string) {
+      payload = j ? JSON.parse(j) : undefined;
+    },
+  } as unknown as ServerResponse;
+  try {
+    await m!.handler({
+      req: { method, url: p, headers } as any,
+      res,
+      params: m!.params,
+      body,
+      query: new URLSearchParams(),
+    });
+  } catch (err) {
+    handleError(res, err);
+  }
+  return { status, payload };
+}
+
+const ENV_PATH = path.join(composeDir, ".env");
+const ENV_TMP_PATH = path.join(composeDir, ".env.next");
+
+// ── auth keys for the operator-only test ──────────────────────────────────
+
+const MASTER_KEY = "test-master-" + "a".repeat(40);
+const VOICE_KEY = "test-voice-" + "b".repeat(40);
+const CHANNEL_KEY = "pcp_" + "c".repeat(48);
+
+function authHeader(bearer: string): Record<string, string> {
+  return { authorization: `Bearer ${bearer}` };
+}
+
+// ── tests ────────────────────────────────────────────────────────────────
+
+describe("POST /api/v1/channels/recall/api-key — #113 PR3a persistence", () => {
+  before(() => {
+    // Initialise the DB once.
+    getStateDb();
+  });
+
+  beforeEach(() => {
+    recallStub.listBotsStatus = 200;
+    recallStub.listBotsBody = { count: 1, results: [] };
+    recallShouldThrow = false;
+    recallCallCount = 0;
+    vaultStore.clear();
+    vaultCallLog = [];
+    vaultShouldFail = false;
+    vaultSeq = 1;
+    composeCalls.length = 0;
+    composeShouldFail = false;
+    // Fresh .env each test — write a couple of unrelated lines so we can
+    // verify they survive the surgical update.
+    fs.writeFileSync(
+      ENV_PATH,
+      "# header comment\nALREADY=present\nFOO=bar\n",
+      { mode: 0o600 },
+    );
+    try {
+      fs.unlinkSync(ENV_TMP_PATH);
+    } catch {
+      /* swallow */
+    }
+    delete process.env.RECALL_API_KEY;
+    delete process.env.RECALL_REGION;
+    _resetAuthForTests();
+    // Reset config row so region-default test starts clean.
+    const db = getStateDb();
+    db.exec("DELETE FROM recall_config");
+  });
+
+  after(() => {
+    globalThis.fetch = originalFetch;
+    try {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    } catch {
+      /* swallow */
+    }
+  });
+
+  // ── 1. bad key — Recall 401 → no persist, no restart
+  it("rejects with 401 when Recall rejects the key (no persist, no restart)", async () => {
+    recallStub.listBotsStatus = 401;
+    recallStub.listBotsBody = { detail: "Invalid token." };
+    const r = await invokeRoute(
+      "POST",
+      "/api/v1/channels/recall/api-key",
+      { api_key: "rec_bad_key", region: "us-east-1" },
+    );
+    assert.equal(r.status, 401, JSON.stringify(r.payload));
+    assert.equal(r.payload.error.code, "RECALL_AUTH_FAILED");
+    // No vault write.
+    assert.equal(vaultStore.size, 0);
+    // No restart.
+    assert.equal(composeCalls.length, 0);
+    // Env on disk unchanged.
+    const envText = fs.readFileSync(ENV_PATH, "utf-8");
+    assert.ok(!envText.includes("RECALL_API_KEY"));
+    // process.env not touched.
+    assert.equal(process.env.RECALL_API_KEY, undefined);
+  });
+
+  // ── 2. valid key — writes vault + .env + restart triggered
+  it("writes to Vaultwarden + .env and triggers a restart on success", async () => {
+    const r = await invokeRoute(
+      "POST",
+      "/api/v1/channels/recall/api-key",
+      { api_key: "rec_good_abcdef1234567890", region: "eu-central-1" },
+    );
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.ok, true);
+    assert.equal(r.payload.region, "eu-central-1");
+    assert.equal(r.payload.key_first6, "rec_go");
+    assert.deepEqual(r.payload.persisted_to, ["vaultwarden", ".env"]);
+    assert.deepEqual(r.payload.restarted, ["ctrl-api", "alfred-learn"]);
+    assert.equal(typeof r.payload.eta_seconds, "number");
+    assert.ok(r.payload.eta_seconds > 0);
+
+    // Vault item created.
+    assert.equal(vaultStore.size, 1);
+    const item = [...vaultStore.values()][0];
+    assert.equal(item.name, "Recall API Key");
+    assert.equal(item.login.password, "rec_good_abcdef1234567890");
+    assert.ok(item.notes && item.notes.includes("eu-central-1"));
+
+    // .env merged.
+    const envText = fs.readFileSync(ENV_PATH, "utf-8");
+    assert.match(envText, /^RECALL_API_KEY=rec_good_abcdef1234567890$/m);
+    assert.match(envText, /^RECALL_REGION=eu-central-1$/m);
+    // Pre-existing lines preserved.
+    assert.match(envText, /^ALREADY=present$/m);
+    assert.match(envText, /^FOO=bar$/m);
+    assert.match(envText, /^# header comment$/m);
+
+    // process.env updated in-process.
+    assert.equal(process.env.RECALL_API_KEY, "rec_good_abcdef1234567890");
+    assert.equal(process.env.RECALL_REGION, "eu-central-1");
+
+    // Give the background restart a tick to run.
+    await new Promise((r) => setTimeout(r, 10));
+
+    // ctrl-api + alfred-learn restarted, in that ORDER from the
+    // RECALL_RESTART_SERVICES const (which the route iterates).
+    // The route restarts both via `restart <svc>`.
+    const restartArgs = composeCalls
+      .filter((c) => c.args[0] === "restart")
+      .map((c) => c.args[1]);
+    assert.deepEqual(restartArgs, ["ctrl-api", "alfred-learn"]);
+  });
+
+  // ── 3. idempotent — same key + region — no restart
+  it("is idempotent when the same key + region are already on file", async () => {
+    // Seed the .env + the vault as if we already persisted once.
+    fs.writeFileSync(
+      ENV_PATH,
+      "ALREADY=present\nRECALL_API_KEY=rec_same_key_1234\nRECALL_REGION=us-east-1\n",
+      { mode: 0o600 },
+    );
+    vaultStore.set("v-1", {
+      id: "v-1",
+      name: "Recall API Key",
+      notes: "seed",
+      login: { username: null, password: "rec_same_key_1234", uris: [] },
+    });
+    const r = await invokeRoute(
+      "POST",
+      "/api/v1/channels/recall/api-key",
+      { api_key: "rec_same_key_1234", region: "us-east-1" },
+    );
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.ok, true);
+    assert.equal(r.payload.idempotent, true);
+    assert.equal(r.payload.key_first6, "rec_sa");
+    assert.deepEqual(r.payload.persisted_to, []);
+    assert.deepEqual(r.payload.restarted, []);
+    // No upsert.
+    assert.equal(vaultStore.size, 1);
+    // No restart.
+    assert.equal(composeCalls.length, 0);
+  });
+
+  // ── 4. atomic .env write — tempfile cleaned up
+  it("writes the .env atomically via tempfile + rename", async () => {
+    await invokeRoute(
+      "POST",
+      "/api/v1/channels/recall/api-key",
+      { api_key: "rec_atomic_test", region: "us-east-1" },
+    );
+    // Final .env on disk has the new keys.
+    assert.match(
+      fs.readFileSync(ENV_PATH, "utf-8"),
+      /^RECALL_API_KEY=rec_atomic_test$/m,
+    );
+    // The .env.next tempfile is GONE post-rename — atomic-write
+    // contract.
+    assert.equal(fs.existsSync(ENV_TMP_PATH), false);
+    // No stray .env.bak — the brief explicitly forbids them.
+    const dirEntries = fs.readdirSync(composeDir);
+    for (const f of dirEntries) {
+      assert.ok(
+        !f.endsWith(".bak"),
+        `no .bak file should be left behind, found ${f}`,
+      );
+    }
+  });
+
+  // ── 5. vault write goes through the vault-cli sidecar (not bw login)
+  it("writes the secret through the vault-cli HTTP sidecar", async () => {
+    await invokeRoute(
+      "POST",
+      "/api/v1/channels/recall/api-key",
+      { api_key: "rec_via_sidecar", region: "us-east-1" },
+    );
+    // We expect at minimum: a list-by-name lookup, then a POST to
+    // /object/item with the new password.
+    const search = vaultCallLog.find(
+      (c) => c.method === "GET" && c.path.startsWith("/list/object/items"),
+    );
+    assert.ok(search, "must list items by name first");
+    const create = vaultCallLog.find(
+      (c) => c.method === "POST" && c.path === "/object/item",
+    );
+    assert.ok(create, "must POST /object/item to create the new item");
+    const createBody = (create!.body ?? {}) as any;
+    assert.equal(createBody.name, "Recall API Key");
+    assert.equal(createBody.login?.password, "rec_via_sidecar");
+  });
+
+  // ── 6. response never echoes the full key or its hash
+  it("never echoes the full key or any hashed form in the response or logs", async () => {
+    const apiKey = "rec_secret_value_should_not_leak";
+    const r = await invokeRoute(
+      "POST",
+      "/api/v1/channels/recall/api-key",
+      { api_key: apiKey, region: "us-east-1" },
+    );
+    const wire = JSON.stringify(r.payload);
+    assert.ok(
+      !wire.includes(apiKey),
+      "response envelope must not contain the full key",
+    );
+    assert.ok(!/[0-9a-f]{32,}/.test(wire), "no long hex digest in the envelope");
+    // The key_first6 is the only fingerprint surfaced.
+    assert.equal(r.payload.key_first6, apiKey.slice(0, 6));
+  });
+
+  // ── 7. operator-only — voice-bridge + channel-token bearers get 403
+  it("rejects non-operator bearers with 403", async () => {
+    setApiKey(MASTER_KEY);
+    setVoiceBridgeKey(VOICE_KEY);
+
+    const vb = await invokeRoute(
+      "POST",
+      "/api/v1/channels/recall/api-key",
+      { api_key: "rec_x", region: "us-east-1" },
+      authHeader(VOICE_KEY),
+    );
+    assert.equal(vb.status, 403, JSON.stringify(vb.payload));
+    assert.equal(vb.payload.error.code, "FORBIDDEN");
+
+    const ch = await invokeRoute(
+      "POST",
+      "/api/v1/channels/recall/api-key",
+      { api_key: "rec_x", region: "us-east-1" },
+      authHeader(CHANNEL_KEY),
+    );
+    assert.equal(ch.status, 403, JSON.stringify(ch.payload));
+    assert.equal(ch.payload.error.code, "FORBIDDEN");
+
+    // No persist, no restart on either rejected call.
+    assert.equal(vaultStore.size, 0);
+    assert.equal(composeCalls.length, 0);
+
+    // Master key passes through.
+    const ok = await invokeRoute(
+      "POST",
+      "/api/v1/channels/recall/api-key",
+      { api_key: "rec_operator_ok", region: "us-east-1" },
+      authHeader(MASTER_KEY),
+    );
+    assert.equal(ok.status, 200, JSON.stringify(ok.payload));
+    assert.equal(ok.payload.ok, true);
+  });
+
+  // ── 8. 502 from Recall during validate → no persist, no restart
+  it("502s when Recall is unreachable mid-validate (no persist, no restart)", async () => {
+    recallShouldThrow = true;
+    const r = await invokeRoute(
+      "POST",
+      "/api/v1/channels/recall/api-key",
+      { api_key: "rec_unreachable", region: "us-east-1" },
+    );
+    assert.equal(r.status, 502, JSON.stringify(r.payload));
+    assert.equal(r.payload.error.code, "RECALL_UNREACHABLE");
+    assert.equal(vaultStore.size, 0);
+    assert.equal(composeCalls.length, 0);
+    const envText = fs.readFileSync(ENV_PATH, "utf-8");
+    assert.ok(!envText.includes("RECALL_API_KEY"));
+  });
+
+  // ── 9. concurrent calls don't double-restart — lock serialises
+  it("serialises concurrent calls — no double-restart", async () => {
+    // Same key in both calls. The lock should run the first call's
+    // persist+restart, then the second observes the .env + vault are
+    // already in sync and hits the idempotence branch.
+    const body = { api_key: "rec_parallel_test", region: "us-east-1" };
+    const [r1, r2] = await Promise.all([
+      invokeRoute("POST", "/api/v1/channels/recall/api-key", body),
+      invokeRoute("POST", "/api/v1/channels/recall/api-key", body),
+    ]);
+    // Both 200.
+    assert.equal(r1.status, 200, JSON.stringify(r1.payload));
+    assert.equal(r2.status, 200, JSON.stringify(r2.payload));
+    // Exactly ONE of them did the writes; the other was idempotent.
+    const persistCount =
+      Number((r1.payload as any).idempotent !== true) +
+      Number((r2.payload as any).idempotent !== true);
+    assert.equal(persistCount, 1, "exactly one call should perform the writes");
+    // Give the background restart a tick.
+    await new Promise((r) => setTimeout(r, 10));
+    // Exactly two restart args — ctrl-api + alfred-learn, ONCE.
+    const restartArgs = composeCalls
+      .filter((c) => c.args[0] === "restart")
+      .map((c) => c.args[1]);
+    assert.deepEqual(
+      restartArgs,
+      ["ctrl-api", "alfred-learn"],
+      "concurrent calls must not double-restart",
+    );
+  });
+
+  // ── 10. region defaults to the singleton config row when omitted
+  it("defaults `region` to the configured value when omitted", async () => {
+    // Seed config row at a non-default region so we can tell.
+    const db = getStateDb();
+    db.exec("DELETE FROM recall_config");
+    db.prepare(
+      `INSERT INTO recall_config (id, region, updated_at) VALUES (1, 'ap-northeast-1', ?)`,
+    ).run(Date.now());
+
+    const r = await invokeRoute(
+      "POST",
+      "/api/v1/channels/recall/api-key",
+      { api_key: "rec_region_default" }, // no region
+    );
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.region, "ap-northeast-1");
+    const envText = fs.readFileSync(ENV_PATH, "utf-8");
+    assert.match(envText, /^RECALL_REGION=ap-northeast-1$/m);
+  });
+
+  // ── 11. bonus — request-level validation (api_key missing)
+  it("400 VALIDATION_ERROR when api_key is missing", async () => {
+    const r = await invokeRoute(
+      "POST",
+      "/api/v1/channels/recall/api-key",
+      {},
+    );
+    assert.equal(r.status, 400);
+    assert.equal(r.payload.error.code, "VALIDATION_ERROR");
+  });
+});
+
+// ── direct helper tests — atomic write + first6 ──────────────────────────
+
+describe("_recallInternals.atomicPatchEnv", () => {
+  it("preserves unrelated lines and writes via tempfile + rename", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "recall-env-"));
+    const target = path.join(dir, ".env");
+    fs.writeFileSync(target, "FOO=1\n# comment\nBAR=2\n");
+    _recallInternals.atomicPatchEnv(target, {
+      RECALL_API_KEY: "rec_xyz",
+      BAR: "updated",
+    });
+    const out = fs.readFileSync(target, "utf-8");
+    assert.match(out, /^FOO=1$/m);
+    assert.match(out, /^# comment$/m);
+    assert.match(out, /^BAR=updated$/m);
+    assert.match(out, /^RECALL_API_KEY=rec_xyz$/m);
+    // No stray tempfile.
+    assert.equal(fs.existsSync(path.join(dir, ".env.next")), false);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("keyFirst6 returns exactly the first 6 chars", () => {
+    assert.equal(_recallInternals.keyFirst6("rec_abcdef_full_key"), "rec_ab");
+    assert.equal(_recallInternals.keyFirst6("short"), "short");
+  });
+});

--- a/packages/web/main.wasp
+++ b/packages/web/main.wasp
@@ -982,6 +982,16 @@ action validateRecallApiKey {
   entities: []
 }
 
+// Lane III (#113 PR3a) — persist a validated Recall API key. The card
+// calls this immediately after validateRecallApiKey returns {ok:true},
+// with the same key. ctrl-api validates again, writes to Vaultwarden +
+// the compose .env atomically, then restarts ctrl-api + alfred-learn.
+// Never echoes the full key; response carries `key_first6` only.
+action setRecallApiKey {
+  fn: import { setRecallApiKey } from "@src/dashboard/operations",
+  entities: []
+}
+
 action testRecallWebhook {
   fn: import { testRecallWebhook } from "@src/dashboard/operations",
   entities: []

--- a/packages/web/src/dashboard/RecallCard.tsx
+++ b/packages/web/src/dashboard/RecallCard.tsx
@@ -8,20 +8,26 @@
 // Four subviews, driven by deriveRecallCardState's `status`:
 //
 //   • disabled    — no API key on file. Hero copy + API-key paste form
-//                   that round-trips via validateRecallApiKey (NO
-//                   persistence — that ships in PR3a). On a successful
-//                   round-trip we surface a "validated, persistence
-//                   pending" note and the principal can either tap
-//                   refresh or move on.
+//                   that two-steps: (1) validateRecallApiKey, (2) on
+//                   success, immediately setRecallApiKey to persist the
+//                   key into Vaultwarden + the compose .env and trigger
+//                   a ctrl-api + alfred-learn restart. The UI shows
+//                   "Validating…" then "Saving + restarting…" then
+//                   "Connected — bots will dispatch from here on."
+//                   (#113 PR3a, closing the gap PR #136 documented as
+//                   "persistence pending".)
 //   • configured  — dial form (region / bot name / auto-join / cadence
 //                   / cost cap / wake word / cost-alert thresholds),
 //                   month-to-date usage badge, recent-bots table, Test
-//                   Webhook CTA, webhook setup expander.
+//                   Webhook CTA, webhook setup expander, and a new
+//                   `key_first6 + [Rotate]` row that re-runs the
+//                   validate+persist two-step on a fresh key.
 //   • error       — verbatim error string + retry. The form is read-only.
 //
 // Secrets posture: the API key paste box is type="password", never logged,
-// never echoed in toast strings. The webhook secret is surfaced as first-6
-// only; the full secret stays in /opt/alfred/.env.
+// never echoed in toast strings. The configured surface renders
+// `api_key_first6` only — exactly six chars + "…" — and never the full
+// value. The webhook secret stays first-6 too.
 
 import { useEffect, useMemo, useState } from "react";
 import {
@@ -29,6 +35,7 @@ import {
   getRecallChannelStatus,
   updateRecallConfig,
   validateRecallApiKey,
+  setRecallApiKey,
   testRecallWebhook,
   terminateRecallBot,
 } from "wasp/client/operations";
@@ -173,64 +180,140 @@ export default function RecallCard() {
   );
 }
 
-// ─── disabled subview — API-key paste / validate ─────────────────────────
+// ─── disabled subview — API-key paste / validate + persist (#113 PR3a) ───
+
+/** The two-step state the disabled panel walks through. */
+type DisabledPanelPhase =
+  | "idle"
+  | "validating"
+  | "saving"
+  | "done"
+  | "err_validate"
+  | "err_persist";
 
 function RecallDisabledPanel({ onValidated }: { onValidated: () => void }) {
   const [apiKey, setApiKey] = useState("");
   const [region, setRegion] = useState<RecallRegion>(
     RECALL_DEFAULT_FORM.region,
   );
-  const [validating, setValidating] = useState(false);
+  const [phase, setPhase] = useState<DisabledPanelPhase>("idle");
   const [feedback, setFeedback] = useState<
     { kind: "ok" | "err"; text: string } | null
   >(null);
 
   const trimmed = apiKey.trim();
-  const canSubmit = trimmed.length > 0 && !validating;
+  const busy = phase === "validating" || phase === "saving";
+  const canSubmit = trimmed.length > 0 && !busy;
+
+  function reset() {
+    setApiKey("");
+    setPhase("idle");
+    setFeedback(null);
+  }
 
   async function submit(e?: React.FormEvent) {
     if (e) e.preventDefault();
     if (!canSubmit) return;
-    setValidating(true);
+
+    // ── step 1 — validate ────────────────────────────────────────────
+    setPhase("validating");
     setFeedback(null);
+    let validation: any;
     try {
-      const result: any = await validateRecallApiKey({
+      validation = await validateRecallApiKey({ api_key: trimmed, region });
+    } catch (err: any) {
+      setPhase("err_validate");
+      setFeedback({
+        kind: "err",
+        text:
+          err?.message ??
+          err?.data?.error ??
+          "Couldn't reach the validator. Try again, or check that ctrl-api is running.",
+      });
+      return;
+    }
+    if (!validation?.ok) {
+      // Recall rejected → show its message verbatim + offer a retry.
+      setPhase("err_validate");
+      setFeedback({
+        kind: "err",
+        text:
+          typeof validation?.reason === "string" && validation.reason
+            ? validation.reason
+            : "Recall rejected the key.",
+      });
+      return;
+    }
+
+    // ── step 2 — persist (sets vault + .env + restarts) ──────────────
+    setPhase("saving");
+    try {
+      const persisted: any = await setRecallApiKey({
         api_key: trimmed,
         region,
       });
-      if (result?.ok) {
-        // NEVER echo the key. Just confirm.
-        const knownBots =
-          typeof result?.account?.bots_known === "number"
-            ? ` (${result.account.bots_known} bots on file)`
-            : "";
+      if (!persisted?.ok) {
+        // 200 from the action but {ok:false} envelope — surface verbatim.
+        setPhase("err_persist");
         setFeedback({
-          kind: "ok",
+          kind: "err",
           text:
-            `Recall accepted the key${knownBots}. ` +
-            "Persistence ships in #113 PR3a — paste it into /opt/alfred/.env " +
-            "as RECALL_API_KEY for now, then reload this card.",
+            typeof persisted?.reason === "string" && persisted.reason
+              ? persisted.reason
+              : "ctrl-api refused to persist the key.",
         });
-        // Clear the local field — the value is in the user's clipboard
-        // already if they copied it from Recall, and there is no
-        // server-side persistence yet.
-        setApiKey("");
-        onValidated();
-      } else {
-        const reason =
-          typeof result?.reason === "string" && result.reason
-            ? result.reason
-            : "Recall rejected the key.";
-        setFeedback({ kind: "err", text: reason });
+        return;
       }
+      setPhase("done");
+      // We never echo the key — only the first6 fingerprint.
+      const first6 =
+        typeof persisted?.key_first6 === "string" ? persisted.key_first6 : null;
+      const restartedHint =
+        Array.isArray(persisted?.restarted) && persisted.restarted.length > 0
+          ? ` Restarting ${persisted.restarted.join(" + ")}.`
+          : "";
+      setFeedback({
+        kind: "ok",
+        text:
+          persisted?.idempotent === true
+            ? `Recall key already on file${first6 ? ` (${first6}…)` : ""}. Nothing to do.`
+            : `Connected — bots will dispatch from here on${first6 ? ` (${first6}…)` : ""}.${restartedHint}`,
+      });
+      // Clear the local field. The value is durable on the tenant.
+      setApiKey("");
+      // Give the restart a moment to land before the next refetch.
+      const eta =
+        typeof persisted?.eta_seconds === "number" && persisted.eta_seconds > 0
+          ? Math.min(persisted.eta_seconds, 30) * 1000
+          : 1500;
+      window.setTimeout(() => {
+        onValidated();
+      }, eta);
     } catch (err: any) {
-      const message =
-        err?.message ?? err?.data?.error ?? "Couldn't reach the validator.";
-      setFeedback({ kind: "err", text: message });
-    } finally {
-      setValidating(false);
+      // ctrl-api rejected the persist — but validate already succeeded,
+      // so revert to a state that lets the user retry just the persist
+      // step (or paste a different key).
+      setPhase("err_persist");
+      setFeedback({
+        kind: "err",
+        text:
+          err?.message ??
+          err?.data?.error ??
+          "Validated, but couldn't save. Try again — the previous key is unchanged.",
+      });
     }
   }
+
+  const submitLabel =
+    phase === "validating"
+      ? "Validating…"
+      : phase === "saving"
+        ? "Saving + restarting…"
+        : phase === "err_validate"
+          ? "Try a different key"
+          : phase === "err_persist"
+            ? "Retry"
+            : "Validate + save";
 
   return (
     <div className="mt-5 space-y-4">
@@ -266,6 +349,7 @@ function RecallDisabledPanel({ onValidated }: { onValidated: () => void }) {
             placeholder="Paste from recall.ai → Settings → API keys"
             autoComplete="off"
             spellCheck={false}
+            disabled={busy}
             className="w-full bg-transparent border border-rule px-2 py-1 font-mono text-[12px]"
           />
         </div>
@@ -280,6 +364,7 @@ function RecallDisabledPanel({ onValidated }: { onValidated: () => void }) {
           <select
             value={region}
             onChange={(e) => setRegion(e.target.value as RecallRegion)}
+            disabled={busy}
             className="bg-transparent border border-rule px-2 py-1 font-mono text-[12px]"
           >
             {RECALL_REGION_OPTIONS.map((r) => (
@@ -296,8 +381,13 @@ function RecallDisabledPanel({ onValidated }: { onValidated: () => void }) {
             disabled={!canSubmit}
             className="btn-ghost"
           >
-            {validating ? "Validating…" : "Validate key"}
+            {submitLabel}
           </button>
+          {(phase === "err_validate" || phase === "err_persist") && (
+            <button type="button" onClick={reset} className="btn-link">
+              Reset
+            </button>
+          )}
           <a
             href="https://www.recall.ai/dashboard"
             target="_blank"
@@ -496,12 +586,100 @@ function RecallConfiguredPanel({
     typeof status?.webhook_secret_first6 === "string"
       ? status.webhook_secret_first6
       : null;
+  // RECALL_API_KEY fingerprint (PR3a) — surfaced on the rotation row.
+  const keyFirst6 =
+    typeof status?.config?.api_key_first6 === "string"
+      ? status.config.api_key_first6
+      : null;
 
   function copyWebhook() {
     if (!webhookUrl) return;
     navigator.clipboard?.writeText(webhookUrl);
     setCopied(true);
     setTimeout(() => setCopied(false), 1500);
+  }
+
+  // ─── rotate state — re-paste a new key, runs the same validate+persist
+  //     two-step the disabled panel does. Lives in the configured panel
+  //     so the principal never has to disconnect to rotate.
+  const [rotateOpen, setRotateOpen] = useState(false);
+  const [rotateKey, setRotateKey] = useState("");
+  const [rotatePhase, setRotatePhase] = useState<
+    "idle" | "validating" | "saving" | "done" | "err"
+  >("idle");
+  const [rotateMsg, setRotateMsg] = useState<
+    { kind: "ok" | "err"; text: string } | null
+  >(null);
+  const rotateBusy = rotatePhase === "validating" || rotatePhase === "saving";
+
+  async function rotate(e?: React.FormEvent) {
+    if (e) e.preventDefault();
+    const trimmed = rotateKey.trim();
+    if (!trimmed || rotateBusy) return;
+    setRotatePhase("validating");
+    setRotateMsg(null);
+    try {
+      const v: any = await validateRecallApiKey({
+        api_key: trimmed,
+        region: form.region,
+      });
+      if (!v?.ok) {
+        setRotatePhase("err");
+        setRotateMsg({
+          kind: "err",
+          text:
+            typeof v?.reason === "string" && v.reason
+              ? v.reason
+              : "Recall rejected the new key.",
+        });
+        return;
+      }
+      setRotatePhase("saving");
+      const p: any = await setRecallApiKey({
+        api_key: trimmed,
+        region: form.region,
+      });
+      if (!p?.ok) {
+        setRotatePhase("err");
+        setRotateMsg({
+          kind: "err",
+          text:
+            typeof p?.reason === "string" && p.reason
+              ? p.reason
+              : "Validated, but couldn't save the new key.",
+        });
+        return;
+      }
+      setRotatePhase("done");
+      const first6 = typeof p?.key_first6 === "string" ? p.key_first6 : null;
+      setRotateMsg({
+        kind: "ok",
+        text:
+          p?.idempotent === true
+            ? `Same key — nothing to rotate (${first6 ?? "?"}…).`
+            : `Rotated to ${first6 ?? "new key"}…. Restarting.`,
+      });
+      setRotateKey("");
+      const eta =
+        typeof p?.eta_seconds === "number" && p.eta_seconds > 0
+          ? Math.min(p.eta_seconds, 30) * 1000
+          : 1500;
+      window.setTimeout(() => {
+        setRotateOpen(false);
+        setRotateMsg(null);
+        setRotatePhase("idle");
+        onSettled();
+      }, eta);
+    } catch (err: any) {
+      setRotatePhase("err");
+      setRotateMsg({
+        kind: "err",
+        text:
+          err?.message ??
+          err?.data?.error ??
+          "Couldn't reach the validator. Try again.",
+      });
+    }
   }
 
   return (
@@ -522,6 +700,94 @@ function RecallConfiguredPanel({
           >
             Cost alert · threshold reached
           </span>
+        )}
+      </div>
+
+      {/* API key row — never echoes the full value. (#113 PR3a) */}
+      <div className="border border-rule p-3 space-y-2">
+        <div className="flex flex-wrap items-baseline gap-3 justify-between">
+          <div className="flex items-baseline gap-3">
+            <div
+              className="font-mono text-[10px] uppercase tracking-[0.22em]"
+              style={{ color: "var(--marginalia)" }}
+            >
+              Recall API key
+            </div>
+            <code
+              className="font-mono text-[12px]"
+              style={{ color: "var(--ink)" }}
+            >
+              {keyFirst6 ? `${keyFirst6}…` : "—"}
+            </code>
+          </div>
+          {!rotateOpen && (
+            <button
+              type="button"
+              onClick={() => {
+                setRotateOpen(true);
+                setRotateMsg(null);
+                setRotatePhase("idle");
+              }}
+              disabled={rotateBusy}
+              className="btn-ghost"
+            >
+              Rotate
+            </button>
+          )}
+        </div>
+        {rotateOpen && (
+          <form onSubmit={rotate} className="space-y-2 pt-2">
+            <input
+              type="password"
+              value={rotateKey}
+              onChange={(e) => setRotateKey(e.target.value)}
+              placeholder="Paste a new Recall API key"
+              autoComplete="off"
+              spellCheck={false}
+              disabled={rotateBusy}
+              className="w-full bg-transparent border border-rule px-2 py-1 font-mono text-[12px]"
+            />
+            <div className="flex gap-3 items-baseline">
+              <button
+                type="submit"
+                disabled={rotateBusy || rotateKey.trim().length === 0}
+                className="btn-ghost"
+              >
+                {rotatePhase === "validating"
+                  ? "Validating…"
+                  : rotatePhase === "saving"
+                    ? "Saving + restarting…"
+                    : "Validate + save"}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setRotateOpen(false);
+                  setRotateKey("");
+                  setRotateMsg(null);
+                  setRotatePhase("idle");
+                }}
+                disabled={rotateBusy}
+                className="btn-link"
+              >
+                Cancel
+              </button>
+            </div>
+            {rotateMsg && (
+              <p
+                className="font-body italic text-[12px]"
+                style={{
+                  color:
+                    rotateMsg.kind === "ok"
+                      ? "var(--marginalia)"
+                      : "var(--brass)",
+                }}
+              >
+                {rotateMsg.kind === "ok" ? "✓ " : "✗ "}
+                {rotateMsg.text}
+              </p>
+            )}
+          </form>
         )}
       </div>
 

--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -775,14 +775,14 @@ export const updateRecallConfig = async (
 };
 
 /** Round-trip-validate a Recall API key against the Recall API. The key
- *  is NEVER logged here; the ctrl-api persists nothing on its side
- *  either (PR3a ships the persistent setter). The response is
- *  `{ ok, account? }` or `{ ok: false, reason }` — we pass it through
- *  verbatim so the card can render the reason. */
+ *  is NEVER logged here; the ctrl-api persists nothing on its side either
+ *  — that's setRecallApiKey's job. The response is `{ ok, account? }` or
+ *  `{ ok: false, reason }` — we pass it through verbatim so the card can
+ *  render the reason. */
 export const validateRecallApiKey = async (
   args: { api_key: string; region?: string },
   context: any,
-) => {
+): Promise<any> => {
   if (typeof args?.api_key !== "string" || args.api_key.trim().length === 0) {
     throw new HttpError(400, "api_key required");
   }
@@ -794,6 +794,48 @@ export const validateRecallApiKey = async (
   return proxyToTenant(instance, {
     method: "POST",
     path: "/api/v1/channels/recall/validate-key",
+    body,
+  });
+};
+
+/** Persist a validated Recall API key (#113 PR3a). Closes the gap PR #136
+ *  documented as "persistence pending": after the card receives an
+ *  {ok:true} from validateRecallApiKey, it immediately calls this action
+ *  with the same key. ctrl-api validates AGAIN against Recall (never
+ *  trust a "validate already happened" claim), then writes to BOTH
+ *  Vaultwarden (canonical, via the vault-cli sidecar) AND the compose
+ *  /.env (atomic, via tempfile + rename), then restarts ctrl-api +
+ *  alfred-learn so the new env takes effect.
+ *
+ *  The key never enters the SaaS layer's logs — we only log the action
+ *  call itself; the value rides the proxied body and the ctrl-api
+ *  response carries only `key_first6`.
+ *
+ *  Return shape on fresh writes:
+ *    { ok, region, key_first6, persisted_to: ['vaultwarden', '.env'],
+ *      restarted: ['ctrl-api', 'alfred-learn'], eta_seconds }
+ *  On a re-paste of the same key + region:
+ *    { ok: true, idempotent: true, region, key_first6, ... }
+ *
+ *  Annotation `Promise<any>` — the Wasp Payload trap. Operations whose
+ *  return type isn't a Prisma entity must be annotated as `Promise<any>`
+ *  so Wasp's TypeScript generator doesn't squeeze the shape into an
+ *  unrelated Payload type. */
+export const setRecallApiKey = async (
+  args: { api_key: string; region?: string },
+  context: any,
+): Promise<any> => {
+  if (typeof args?.api_key !== "string" || args.api_key.trim().length === 0) {
+    throw new HttpError(400, "api_key required");
+  }
+  const instance = await getUserInstance(context);
+  const body: Record<string, string> = { api_key: args.api_key.trim() };
+  if (typeof args.region === "string" && args.region.length > 0) {
+    body.region = args.region;
+  }
+  return proxyToTenant(instance, {
+    method: "POST",
+    path: "/api/v1/channels/recall/api-key",
     body,
   });
 };

--- a/packages/web/src/dashboard/recallCardCore.test.ts
+++ b/packages/web/src/dashboard/recallCardCore.test.ts
@@ -511,3 +511,162 @@ test("enum option lists carry the exact strings the route validator accepts", ()
   assert.equal(RECALL_WAKE_WORD_RANGE.max, 64);
   assert.equal(RECALL_COST_THRESHOLD_RANGE.max, 200);
 });
+
+// ── API-key persistence flow state machine (#113 PR3a) ───────────────────
+
+import {
+  API_KEY_FLOW_IDLE,
+  apiKeyFlowOnPersist,
+  apiKeyFlowOnValidate,
+  apiKeyFlowReset,
+  apiKeyFlowStartValidate,
+} from "./recallCardCore";
+
+test("API key flow — idle → validating on Submit", () => {
+  const next = apiKeyFlowStartValidate();
+  assert.equal(next.phase, "validating");
+  assert.equal(next.error, null);
+});
+
+test("API key flow — validate ok → saving (persist fires next)", () => {
+  const next = apiKeyFlowOnValidate(apiKeyFlowStartValidate(), {
+    ok: true,
+  });
+  assert.equal(next.phase, "saving");
+  assert.equal(next.error, null);
+});
+
+test("API key flow — validate {ok:false} → err_validate with reason verbatim", () => {
+  const next = apiKeyFlowOnValidate(apiKeyFlowStartValidate(), {
+    ok: false,
+    reason: "Recall rejected the API key",
+  });
+  assert.equal(next.phase, "err_validate");
+  assert.equal(next.error, "Recall rejected the API key");
+});
+
+test("API key flow — validate throws → err_validate with thrown msg", () => {
+  const next = apiKeyFlowOnValidate(
+    apiKeyFlowStartValidate(),
+    null,
+    "network blip",
+  );
+  assert.equal(next.phase, "err_validate");
+  assert.equal(next.error, "network blip");
+});
+
+test("API key flow — persist ok → done + keyFirst6 from wire", () => {
+  const after = apiKeyFlowOnPersist(
+    apiKeyFlowOnValidate(apiKeyFlowStartValidate(), { ok: true }),
+    {
+      ok: true,
+      key_first6: "rec_ab",
+      restarted: ["ctrl-api", "alfred-learn"],
+      persisted_to: ["vaultwarden", ".env"],
+      eta_seconds: 30,
+    },
+  );
+  assert.equal(after.phase, "done");
+  assert.equal(after.keyFirst6, "rec_ab");
+  assert.equal(after.idempotent, false);
+});
+
+test("API key flow — persist {ok,idempotent:true} → done + idempotent flag", () => {
+  const after = apiKeyFlowOnPersist(
+    apiKeyFlowOnValidate(apiKeyFlowStartValidate(), { ok: true }),
+    {
+      ok: true,
+      idempotent: true,
+      key_first6: "rec_ab",
+      persisted_to: [],
+      restarted: [],
+    },
+  );
+  assert.equal(after.phase, "done");
+  assert.equal(after.idempotent, true);
+});
+
+test("API key flow — persist throws → err_persist; prior keyFirst6 PRESERVED (revert contract)", () => {
+  // Seed `prev.keyFirst6` so we can verify the failure path keeps it.
+  const seeded = {
+    ...API_KEY_FLOW_IDLE,
+    phase: "saving" as const,
+    keyFirst6: "old_xx",
+  };
+  const after = apiKeyFlowOnPersist(seeded, null, "vault-cli down");
+  assert.equal(after.phase, "err_persist");
+  assert.equal(after.error, "vault-cli down");
+  // Critical: the previous keyFirst6 survives the failed persist —
+  // ctrl-api short-circuited before any .env write, so the tenant
+  // still has the OLD key.
+  assert.equal(after.keyFirst6, "old_xx");
+  assert.equal(after.idempotent, false);
+});
+
+test("API key flow — persist {ok:false} → err_persist with reason verbatim", () => {
+  const after = apiKeyFlowOnPersist(
+    {
+      ...API_KEY_FLOW_IDLE,
+      phase: "saving" as const,
+      keyFirst6: "old_xx",
+    },
+    { ok: false, reason: "Vault upsert failed" },
+  );
+  assert.equal(after.phase, "err_persist");
+  assert.equal(after.error, "Vault upsert failed");
+  assert.equal(after.keyFirst6, "old_xx");
+});
+
+test("API key flow — reset returns to idle", () => {
+  const errored = apiKeyFlowOnValidate(
+    apiKeyFlowStartValidate(),
+    { ok: false, reason: "nope" },
+  );
+  assert.equal(errored.phase, "err_validate");
+  const reset = apiKeyFlowReset();
+  assert.equal(reset.phase, "idle");
+  assert.equal(reset.error, null);
+});
+
+test("API key flow — full happy path: idle → validating → saving → done", () => {
+  // Simulates the React panel's full transition graph.
+  let state = API_KEY_FLOW_IDLE;
+  assert.equal(state.phase, "idle");
+  state = apiKeyFlowStartValidate();
+  assert.equal(state.phase, "validating");
+  state = apiKeyFlowOnValidate(state, { ok: true });
+  assert.equal(state.phase, "saving");
+  state = apiKeyFlowOnPersist(state, {
+    ok: true,
+    key_first6: "rec_xy",
+    persisted_to: ["vaultwarden", ".env"],
+    restarted: ["ctrl-api", "alfred-learn"],
+    eta_seconds: 30,
+  });
+  assert.equal(state.phase, "done");
+  assert.equal(state.keyFirst6, "rec_xy");
+  assert.equal(state.idempotent, false);
+});
+
+test("API key flow — RecallConfig type carries optional api_key_first6 surface", () => {
+  // Construct a config with the PR3a fields to make sure the type still
+  // accepts them. Compile-time more than runtime — but a sanity check.
+  const cfg: RecallConfig = {
+    region: "us-east-1",
+    bot_name: "Bot",
+    announces_on_join: true,
+    auto_join_policy: "principal_attendee",
+    calendar_source: "composio",
+    monthly_hours_cap: 60,
+    leave_after_minutes: 90,
+    respond_mode: "on_mention",
+    wake_word: "Alfred",
+    cost_alert_thresholds: [80, 100],
+    updated_at: 0,
+    api_key_set: true,
+    api_key_first6: "rec_ab",
+  };
+  const f = configToFormValues(cfg);
+  // The fields aren't part of the form values — just the wire type.
+  assert.equal(f.region, "us-east-1");
+});

--- a/packages/web/src/dashboard/recallCardCore.ts
+++ b/packages/web/src/dashboard/recallCardCore.ts
@@ -98,6 +98,12 @@ const TERMINAL_BOT_STATUSES: ReadonlySet<RecallBotStatus> = new Set([
 /**
  * GET /api/v1/channels/recall/config response (1:1 with rowToApiConfig).
  * All fields always present; updated_at is unix-ms.
+ *
+ * `api_key_set` + `api_key_first6` (PR3a) surface whether RECALL_API_KEY
+ * is on file in the live ctrl-api .env. NEVER carries the full key —
+ * `api_key_first6` is exactly six chars (or null when no key is set).
+ * Both fields are optional on the wire so a pre-PR3a ctrl-api still
+ * deserialises cleanly.
  */
 export interface RecallConfig {
   region: RecallRegion;
@@ -111,6 +117,8 @@ export interface RecallConfig {
   wake_word: string;
   cost_alert_thresholds: number[];
   updated_at: number;
+  api_key_set?: boolean;
+  api_key_first6?: string | null;
 }
 
 /** GET /api/v1/channels/recall/usage response. */
@@ -794,4 +802,164 @@ export function botStatusLabel(s: RecallBotStatus): string {
     case "fail":
       return "Failed";
   }
+}
+
+// ── API-key persistence state machine (#113 PR3a) ────────────────────────
+//
+// The /channels Recall card walks a paste through two server round-trips:
+//
+//   1. validate — POST /api/v1/channels/recall/validate-key
+//   2. persist  — POST /api/v1/channels/recall/api-key (only fires if
+//                 step 1 returned {ok:true})
+//
+// We model the panel as a tiny pure state machine here so the React
+// component stays declarative and the contract gets exercised by
+// recallCardCore.test.ts without a DOM. The phases mirror the strings
+// the React layer renders:
+//
+//   • idle           — user is typing
+//   • validating     — validate request in flight
+//   • saving         — persist request in flight (validate already
+//                       returned ok)
+//   • done           — persist returned ok (fresh write OR idempotent)
+//   • err_validate   — validate returned {ok:false} or threw; the
+//                       previous key (if any) is UNCHANGED on the
+//                       tenant
+//   • err_persist    — validate returned ok but persist threw; the
+//                       previous key (if any) is UNCHANGED on the
+//                       tenant (this is the "revert" contract)
+
+export type ApiKeyFlowPhase =
+  | "idle"
+  | "validating"
+  | "saving"
+  | "done"
+  | "err_validate"
+  | "err_persist";
+
+export interface ApiKeyFlowState {
+  phase: ApiKeyFlowPhase;
+  /** Verbatim error string from the latest failed step, if any. */
+  error: string | null;
+  /** First six chars of the latest persisted key, if any. Never the full
+   *  key. */
+  keyFirst6: string | null;
+  /** True when the latest persist call hit the idempotence branch (same
+   *  key was already on file). */
+  idempotent: boolean;
+}
+
+export const API_KEY_FLOW_IDLE: ApiKeyFlowState = {
+  phase: "idle",
+  error: null,
+  keyFirst6: null,
+  idempotent: false,
+};
+
+/** validate-key envelope as ctrl-api returns it on the
+ *  /validate-key route. */
+export interface ValidateKeyOutcomeWire {
+  ok?: boolean;
+  reason?: string;
+}
+
+/** api-key envelope as ctrl-api returns it on the /api-key route. */
+export interface PersistKeyOutcomeWire {
+  ok?: boolean;
+  idempotent?: boolean;
+  region?: string;
+  key_first6?: string;
+  persisted_to?: string[];
+  restarted?: string[];
+  eta_seconds?: number;
+  reason?: string;
+}
+
+/** Transition from `phase=idle` when the user clicks Submit — the
+ *  validate request enters flight. */
+export function apiKeyFlowStartValidate(): ApiKeyFlowState {
+  return { phase: "validating", error: null, keyFirst6: null, idempotent: false };
+}
+
+/** Apply the validate-key result. On {ok:true} we move to `saving`
+ *  immediately (the persist request fires); on anything else we land in
+ *  `err_validate` with the reason verbatim. The previous key remains
+ *  untouched on the tenant in both branches — the persist request
+ *  hasn't fired yet. */
+export function apiKeyFlowOnValidate(
+  prev: ApiKeyFlowState,
+  outcome: ValidateKeyOutcomeWire | null | undefined,
+  thrownMessage?: string,
+): ApiKeyFlowState {
+  if (typeof thrownMessage === "string") {
+    return {
+      phase: "err_validate",
+      error: thrownMessage,
+      keyFirst6: prev.keyFirst6,
+      idempotent: false,
+    };
+  }
+  if (!outcome || outcome.ok !== true) {
+    return {
+      phase: "err_validate",
+      error:
+        typeof outcome?.reason === "string" && outcome.reason
+          ? outcome.reason
+          : "Recall rejected the key.",
+      keyFirst6: prev.keyFirst6,
+      idempotent: false,
+    };
+  }
+  return {
+    phase: "saving",
+    error: null,
+    keyFirst6: prev.keyFirst6,
+    idempotent: false,
+  };
+}
+
+/** Apply the persist (api-key) result. On {ok:true} we land in `done`
+ *  with the new keyFirst6 and idempotent flag. On any failure we land
+ *  in `err_persist`. CRITICAL: the failure branch keeps `prev.keyFirst6`
+ *  unchanged — the tenant's previous key was not overwritten (ctrl-api
+ *  short-circuits BEFORE the .env write when the vault upsert fails). */
+export function apiKeyFlowOnPersist(
+  prev: ApiKeyFlowState,
+  outcome: PersistKeyOutcomeWire | null | undefined,
+  thrownMessage?: string,
+): ApiKeyFlowState {
+  if (typeof thrownMessage === "string") {
+    return {
+      phase: "err_persist",
+      error: thrownMessage,
+      keyFirst6: prev.keyFirst6,
+      idempotent: false,
+    };
+  }
+  if (!outcome || outcome.ok !== true) {
+    return {
+      phase: "err_persist",
+      error:
+        typeof outcome?.reason === "string" && outcome.reason
+          ? outcome.reason
+          : "ctrl-api refused to persist the key.",
+      keyFirst6: prev.keyFirst6,
+      idempotent: false,
+    };
+  }
+  return {
+    phase: "done",
+    error: null,
+    keyFirst6:
+      typeof outcome.key_first6 === "string"
+        ? outcome.key_first6
+        : prev.keyFirst6,
+    idempotent: outcome.idempotent === true,
+  };
+}
+
+/** Reset back to idle — used by the "Try a different key" / "Reset"
+ *  affordance. */
+export function apiKeyFlowReset(): ApiKeyFlowState {
+  return API_KEY_FLOW_IDLE;
 }


### PR DESCRIPTION
Closes the gap PR #136 documented as "persistence pending."

PR #136 shipped the Recall card UI that calls `/validate-key` — which
round-trips an operator-pasted key against Recall but does not store
it anywhere. PR #144 shipped the alfred-learn dispatcher which reads
`RECALL_API_KEY` from env. The seam in the middle — actually WRITING
the key — was missing. The card displayed "validated, persistence
pending — paste it into /opt/alfred/.env for now," which Sir flagged
as theatre.

## What this PR ships

### ctrl-api — `POST /api/v1/channels/recall/api-key`

Operator-only setter (rejects voice-bridge + channel-token bearers
with 403, same gate as the HA LLAT route). On a valid bearer:

1. **Round-trip-validate** the pasted key against Recall via the same
   `validateRecallKey()` helper PR2 already uses for `/validate-key`.
   We do NOT trust a "validate already happened" claim from the
   caller; the validate runs again before any write.
2. **Upsert to Vaultwarden** as a Login item named `Recall API Key`
   through the existing vault-cli HTTP sidecar — no new `bw login`
   session. Region rides in `notes`. This is the canonical store;
   vault-init reads it back on next boot.
3. **Atomically merge** `RECALL_API_KEY` + `RECALL_REGION` into
   `${COMPOSE_DIR}/.env` via tempfile (`.env.next`) + rename in the
   SAME directory. A crashed write leaves the old `.env` untouched;
   no `.bak` files left behind.
4. **Background-restart** `ctrl-api` and `alfred-learn` via
   `docker compose restart` so the new env takes effect immediately.

**Idempotence.** If the same key + region are already on file
(checked by reading the live `.env` AND the vault item), the route
returns `{ok: true, idempotent: true}` with no writes and no restart.

**Concurrency.** A process-local async lock serialises the
persistence sequence so two parallel calls cannot double-restart.
The second caller observes the first's write and idempotence-noops.

**Secrets posture.** Response envelope carries `key_first6` only — six
characters, never the full key, never a hash. Logs use the same
prefix. The route never echoes the value on any path.

### web — two-step validate → persist + rotate

`RecallCard.tsx` disabled panel now walks:

```
idle  →  validating  →  saving  →  done
                    ↘
                     err_validate  ──  [Try a different key]
                                  ↘
                                   err_persist  ──  [Retry]
```

On a Recall 401 the panel shows Recall's reason verbatim + a
"Try a different key" affordance. On a persist failure, the previous
key on the tenant is **unchanged** — ctrl-api short-circuits before
the .env write when the vault upsert fails.

The configured panel adds a rotation row at the top:

```
RECALL API KEY    rec_ab…    [Rotate]
```

`[Rotate]` opens an inline form that re-runs the same two-step on a
fresh key. Never echoes the full value — only the first-6 fingerprint.

### main.wasp / operations.ts

New `setRecallApiKey({api_key, region?})` action wired through
`tenantProxy` to `POST /api/v1/channels/recall/api-key`. Return
annotation is `Promise<any>` (the Wasp Payload trap).

### Tests

`packages/ctrl/tests/channels_recall_apikey.test.ts` — 13 tests:

- Recall 401 → 401 `RECALL_AUTH_FAILED`, no vault write, no .env write,
  no restart, `process.env.RECALL_API_KEY` unset
- Valid key → 200 + vault item upserted + .env merged + restart
  triggered + `persisted_to: ['vaultwarden', '.env']` + `restarted:
  ['ctrl-api', 'alfred-learn']`
- Idempotent re-paste → no restart, no extra vault write
- Atomic .env write — tempfile cleaned up after success, no `.bak`
  files left in `COMPOSE_DIR`
- Vault write goes through the vault-cli HTTP sidecar (asserts the
  request URLs target `/list/object/items` + `/object/item`, not a
  spawned `bw login`)
- `key_first6` returned, full key + hash absent from envelope
- Operator-only: voice-bridge + channel-token bearers get 403;
  master key passes
- 502 from Recall mid-validate → no persist, no restart
- Concurrent identical calls don't double-restart (lock serialises)
- `region` defaults to the singleton config row when omitted
- 400 VALIDATION_ERROR when `api_key` is missing
- `_recallInternals.atomicPatchEnv` preserves unrelated lines +
  cleans up the tmp
- `_recallInternals.keyFirst6` sanity

`recallCardCore.test.ts` — 11 new tests for the validate → persist
state machine, including the **revert-on-persist-error** contract
(`keyFirst6` from `prev` survives a thrown persist).

### Baseline impact

- ctrl-api: 791 → 805 tests, 0 failures, 1 skipped (pre-existing).
- web `recallCardCore.test.ts`: 28 → 39 tests, 0 failures.

## Persistence pattern mirrored

Telegram channel (`packages/ctrl/src/api/routes/telegram.ts:548`)
— validate → vault upsert → per-profile env → restart. Same
shape, same vault-cli sidecar helpers, same fire-and-forget
restart. The OpenAI key route (`credentials.ts:patchEnv`) was
considered but its `.env` write is non-atomic; Sir's brief
required atomic, so this route ships its own `atomicPatchEnv`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)