### PR TITLE
fix(deploy): sync docker-compose.yaml to fleet on every main push (#121 follow-up)

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -175,3 +175,27 @@ jobs:
         # zero-CLI Paperclip seed for every new tenant, so we lint it
         # alongside the host bootstrap script.
         run: shellcheck packages/hermes/init/bootstrap-paperclip.sh
+
+  workflow-lint:
+    # actionlint catches the foot-guns we previously discovered the hard way:
+    # missing `secrets.` prefix, ill-formed matrix entries, `if:` expressions
+    # that always evaluate true, and shell-script syntax in `run:` blocks.
+    # We've shipped deploy workflows before that were syntactically valid YAML
+    # but broken at expand-time; actionlint is the lightest defence.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install actionlint
+        run: |
+          set -euo pipefail
+          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          ./actionlint -version
+      - name: Lint all workflows
+        # Lint every workflow; deploy-compose.yml is the immediate reason we
+        # added the check, but the project is small enough that the full sweep
+        # is free and catches regressions in the build-*.yml family too.
+        # We disable actionlint's shellcheck integration here — the
+        # bootstrap-lint job already runs shellcheck on the scripts we care
+        # about, and the inline `run:` blocks are short and intentional
+        # (e.g. `SC2029` for ssh remote-side expansion of $SHA is desired).
+        run: ./actionlint -color -shellcheck=

--- a/.github/workflows/deploy-compose.yml
+++ b/.github/workflows/deploy-compose.yml
@@ -1,0 +1,197 @@
+# Sync host-side static config to every alfred-black tenant on push to main.
+#
+# Why this exists
+# ---------------
+# The build-*.yml workflows push Docker images to DockerHub, and tenants pull
+# them on `docker compose up -d`. But there has never been a workflow that
+# updates the host-side files compose actually loads:
+#
+#   * /opt/alfred/docker-compose.yaml — services, profiles, mounts
+#   * /opt/alfred/caddy/Caddyfile     — public ingress
+#   * /opt/alfred/caddy/plane-proxy.Caddyfile
+#   * /opt/alfred/.env.example        — operator reference (does NOT touch .env)
+#
+# Consequence: any PR that adds a new service (e.g. #121, which added the
+# `tailscale` profile) ships its image but never reaches a tenant — the
+# service literally isn't in the compose file on disk. Live evidence from
+# 2026-05-29 on home.alfred.black: `/opt/alfred/docker-compose.yaml` was
+# dated May 28 and `docker compose --profile tailscale config --services`
+# returned nothing because the service block was missing.
+#
+# This workflow closes that loop: on every push to main that touches one of
+# the tracked files, SCP the fresh copy to each tenant under /opt/alfred/,
+# back up the old copy as `.bak-<sha>`, and `docker compose up -d` to apply.
+# Compose is idempotent — only services whose definition changed restart.
+#
+# Tenant list is hard-coded for now (5 known hosts). When the SaaS Plane app
+# exposes a tenant directory we can pull this from a single source of truth.
+name: deploy-compose
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docker-compose.yaml"
+      - "caddy/Caddyfile"
+      - "caddy/plane-proxy.Caddyfile"
+      - ".env.example"
+      - ".github/workflows/deploy-compose.yml"
+  workflow_dispatch:
+    inputs:
+      tenants:
+        description: "Comma-separated tenant hostnames (default: all 5)"
+        required: false
+        default: "home.alfred.black,rj.alfred.black,joe.alfred.black,zsolt.alfred.black,miguel.alfred.black"
+
+concurrency:
+  # Serialise per-branch so two pushes don't race on the same tenant.
+  group: deploy-compose-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    strategy:
+      # Don't abort the other tenants if one fails — partial rollout is
+      # better than no rollout, and the summary makes the gap obvious.
+      fail-fast: false
+      matrix:
+        tenant:
+          - home.alfred.black
+          - rj.alfred.black
+          - joe.alfred.black
+          - zsolt.alfred.black
+          - miguel.alfred.black
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure SSH
+        # The FLEET_SSH_KEY secret holds the private half of
+        # ~/.ssh/alfred-black-verify, which is authorised on every tenant's
+        # root account. Don't add it to the agent — write it to a file with
+        # 0600 and pass it via -i so the runner is hermetic.
+        env:
+          FLEET_SSH_KEY: ${{ secrets.FLEET_SSH_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${FLEET_SSH_KEY:-}" ]; then
+            echo "FAIL: FLEET_SSH_KEY secret is empty or unset." >&2
+            exit 1
+          fi
+          mkdir -p ~/.ssh
+          printf '%s\n' "$FLEET_SSH_KEY" > ~/.ssh/alfred-black-verify
+          chmod 600 ~/.ssh/alfred-black-verify
+          # Trust the tenant on first contact — every Alfred Black tenant
+          # uses a known hostname behind Caddy, so we accept-new rather than
+          # pinning a host key (host keys rotate when the VM is reprovisioned).
+          {
+            echo "Host *.alfred.black"
+            echo "  User root"
+            echo "  IdentityFile ~/.ssh/alfred-black-verify"
+            echo "  IdentitiesOnly yes"
+            echo "  StrictHostKeyChecking accept-new"
+            echo "  UserKnownHostsFile ~/.ssh/known_hosts"
+            echo "  ConnectTimeout 15"
+          } > ~/.ssh/config
+          chmod 600 ~/.ssh/config
+
+      - name: Pre-flight — reachable?
+        # If the tenant is offline, skip cleanly with a summary entry instead
+        # of failing the whole matrix leg. Reduces alert noise from known
+        # planned-downtime hosts.
+        id: preflight
+        run: |
+          set -euo pipefail
+          host='${{ matrix.tenant }}'
+          if ssh -o BatchMode=yes "${host}" 'echo ok' >/dev/null 2>&1; then
+            echo "reachable=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "reachable=false" >> "$GITHUB_OUTPUT"
+            echo ":warning: ${host} unreachable — skipped." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Sync compose + Caddy + .env.example
+        if: steps.preflight.outputs.reachable == 'true'
+        env:
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          host='${{ matrix.tenant }}'
+          short_sha="${SHA:0:12}"
+
+          # 1. Back up the existing copies so a bad deploy is one `mv` away.
+          #    Keep the prior backup if SHA collides (re-run); the timestamp
+          #    discriminates.
+          ssh "${host}" "
+            set -e
+            ts=\$(date -u +%Y%m%dT%H%M%SZ)
+            for f in docker-compose.yaml caddy/Caddyfile caddy/plane-proxy.Caddyfile .env.example; do
+              if [ -f /opt/alfred/\${f} ]; then
+                cp -a /opt/alfred/\${f} /opt/alfred/\${f}.bak-${short_sha}-\${ts}
+              fi
+            done
+          "
+
+          # 2. scp the four tracked files. Use -p to preserve mtime so the
+          #    operator can see when the file was actually changed in the
+          #    repo, not when CI ran.
+          scp -p docker-compose.yaml "${host}:/opt/alfred/docker-compose.yaml"
+          scp -p caddy/Caddyfile "${host}:/opt/alfred/caddy/Caddyfile"
+          scp -p caddy/plane-proxy.Caddyfile "${host}:/opt/alfred/caddy/plane-proxy.Caddyfile"
+          scp -p .env.example "${host}:/opt/alfred/.env.example"
+
+      - name: Apply (docker compose up -d)
+        if: steps.preflight.outputs.reachable == 'true'
+        run: |
+          set -euo pipefail
+          host='${{ matrix.tenant }}'
+          # Compose is idempotent — only services whose hash changed restart.
+          # The `name: alfred-black` at the top of docker-compose.yaml sets
+          # the project name, but we pass -p explicitly for clarity and so
+          # this matches `docker ps`'s container naming.
+          ssh "${host}" '
+            set -e
+            cd /opt/alfred
+            # Validate the file parses before doing anything destructive.
+            docker compose -p alfred-black config --quiet
+            docker compose -p alfred-black up -d
+          '
+
+      - name: Reload Caddy (gracefully)
+        if: steps.preflight.outputs.reachable == 'true'
+        # `docker compose up -d` will NOT restart Caddy when only its
+        # bind-mounted Caddyfile changed (the container hash is unchanged).
+        # `caddy reload` re-reads the file in-place without dropping
+        # connections.
+        run: |
+          set -euo pipefail
+          host='${{ matrix.tenant }}'
+          ssh "${host}" '
+            cd /opt/alfred
+            if docker compose -p alfred-black ps caddy --status running --quiet | grep -q .; then
+              docker compose -p alfred-black exec -T caddy \
+                caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile || \
+                docker compose -p alfred-black restart caddy
+            fi
+          '
+
+      - name: Per-tenant summary
+        if: steps.preflight.outputs.reachable == 'true'
+        env:
+          SHA: ${{ github.sha }}
+        run: |
+          host='${{ matrix.tenant }}'
+          short_sha="${SHA:0:12}"
+          {
+            echo "### ${host}"
+            echo ""
+            echo "- sha: \`${short_sha}\`"
+            echo "- compose: synced + applied"
+            echo "- caddy: reloaded"
+            echo ""
+            echo "Live service list:"
+            echo ""
+            echo '```'
+            ssh "${host}" 'cd /opt/alfred && docker compose -p alfred-black ps --format "table {{.Service}}\t{{.Status}}" 2>/dev/null | head -40' || echo "(ps unavailable)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,13 @@ help:
 	@echo "  push-all           build + push every image multi-arch ($(PLATFORMS))"
 	@echo "  config             validate docker-compose.yaml"
 	@echo ""
+	@echo "  sync-compose-fleet rsync docker-compose.yaml + caddy/* + .env.example"
+	@echo "                     to every tenant in FLEET (default: 5 live hosts);"
+	@echo "                     same operation as the deploy-compose.yml workflow,"
+	@echo "                     for one-shot operator backfill."
+	@echo ""
 	@echo "  Override: make TAG=v1 IMAGE_PREFIX=myrepo build-web"
+	@echo "            make FLEET=\"host1 host2\" sync-compose-fleet"
 
 # ── single-image build targets (local arch) ────────────────────────────────
 
@@ -91,3 +97,56 @@ push-all:
 .PHONY: config
 config:
 	docker compose config --quiet && echo "docker-compose.yaml: OK"
+
+# ── one-shot fleet backfill ────────────────────────────────────────────────
+#
+# `make sync-compose-fleet` mirrors what .github/workflows/deploy-compose.yml
+# does for every push to main, but from an operator's laptop. Use it to
+# backfill any tenant the workflow couldn't reach (offline, planned downtime)
+# or to push a hot-fix without rolling main.
+#
+# Inputs (override at the CLI):
+#   FLEET   space-separated tenant hostnames (default: the 5 live tenants)
+#   SSH_KEY private key path  (default: ~/.ssh/alfred-black-verify)
+#
+# Example:
+#   make sync-compose-fleet
+#   make FLEET="zsolt.alfred.black" sync-compose-fleet
+#   make SSH_KEY=~/.ssh/id_ed25519 sync-compose-fleet
+
+FLEET   ?= home.alfred.black rj.alfred.black joe.alfred.black zsolt.alfred.black miguel.alfred.black
+SSH_KEY ?= $(HOME)/.ssh/alfred-black-verify
+
+.PHONY: sync-compose-fleet
+sync-compose-fleet:
+	@if [ ! -f "$(SSH_KEY)" ]; then \
+		echo "ERROR: SSH key not found at $(SSH_KEY)"; \
+		echo "       Override with: make SSH_KEY=/path/to/key sync-compose-fleet"; \
+		exit 1; \
+	fi
+	@docker compose config --quiet >/dev/null
+	@SHA=$$(git rev-parse --short=12 HEAD 2>/dev/null || date -u +%Y%m%dT%H%M%SZ); \
+	SSH_OPTS="-i $(SSH_KEY) -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=15"; \
+	for host in $(FLEET); do \
+		echo ""; \
+		echo "── $${host} ──"; \
+		if ! ssh $$SSH_OPTS -o BatchMode=yes "root@$${host}" 'echo ok' >/dev/null 2>&1; then \
+			echo "  SKIP: unreachable"; \
+			continue; \
+		fi; \
+		ssh $$SSH_OPTS "root@$${host}" "\
+			set -e; \
+			ts=\$$(date -u +%Y%m%dT%H%M%SZ); \
+			for f in docker-compose.yaml caddy/Caddyfile caddy/plane-proxy.Caddyfile .env.example; do \
+				if [ -f /opt/alfred/\$${f} ]; then \
+					cp -a /opt/alfred/\$${f} /opt/alfred/\$${f}.bak-$${SHA}-\$${ts}; \
+				fi; \
+			done"; \
+		scp -p $$SSH_OPTS docker-compose.yaml "root@$${host}:/opt/alfred/docker-compose.yaml"; \
+		scp -p $$SSH_OPTS caddy/Caddyfile "root@$${host}:/opt/alfred/caddy/Caddyfile"; \
+		scp -p $$SSH_OPTS caddy/plane-proxy.Caddyfile "root@$${host}:/opt/alfred/caddy/plane-proxy.Caddyfile"; \
+		scp -p $$SSH_OPTS .env.example "root@$${host}:/opt/alfred/.env.example"; \
+		ssh $$SSH_OPTS "root@$${host}" 'cd /opt/alfred && docker compose -p alfred-black config --quiet && docker compose -p alfred-black up -d'; \
+		ssh $$SSH_OPTS "root@$${host}" 'cd /opt/alfred && (docker compose -p alfred-black exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile 2>/dev/null || docker compose -p alfred-black restart caddy)'; \
+		echo "  OK: $${host}"; \
+	done

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,96 @@
+# deploy/ — fleet ops
+
+Operator notes for the live alfred-black tenant fleet. Per-tenant install
+instructions for a fresh box still live in the top-level [README](../README.md);
+this directory is for cross-tenant ops.
+
+## Fleet roster
+
+The known live tenants as of 2026-05-29 (each is a single-VM, single-tenant
+deployment — no shared infrastructure):
+
+| Hostname               | Principal       |
+| ---------------------- | --------------- |
+| `home.alfred.black`    | Sir (operator)  |
+| `rj.alfred.black`      | RJ              |
+| `joe.alfred.black`     | Joe             |
+| `zsolt.alfred.black`   | Zsolt           |
+| `miguel.alfred.black`  | Miguel          |
+
+These are hard-coded in two places that must stay in sync:
+
+- `.github/workflows/deploy-compose.yml` (matrix)
+- `Makefile` (`FLEET` variable, `sync-compose-fleet` target)
+
+When a tenant is added or retired, update both. A future refactor will pull
+this from the SaaS Plane app's tenant directory; for now we keep it explicit
+because the cost of a stale list is "a tenant silently misses a deploy" —
+exactly the failure mode this directory exists to prevent.
+
+## What CI deploys vs. what it does NOT
+
+The `build-*.yml` workflows push images to DockerHub. They do **not** touch
+any tenant. Each tenant pulls images on the next `docker compose up -d`.
+
+`deploy-compose.yml` (this directory's concern) syncs the host-side static
+files that compose loads at boot:
+
+- `docker-compose.yaml` — the service definitions
+- `caddy/Caddyfile` — public ingress + Let's Encrypt
+- `caddy/plane-proxy.Caddyfile`
+- `.env.example` — operator reference (never overwrites a tenant's `.env`)
+
+It runs automatically on every push to `main` that touches one of those
+files. Backups live at `/opt/alfred/<file>.bak-<sha>-<timestamp>` on the
+tenant; restore with a single `mv` if a deploy breaks something.
+
+The deploy is idempotent — `docker compose up -d` only restarts services
+whose definition hashed differently, and Caddy gets a graceful `caddy reload`
+that does not drop connections.
+
+## One-shot operator backfill
+
+Use this when a tenant was offline during a CI deploy (the workflow's
+pre-flight ssh check skips unreachable hosts), or when you want to push a
+local edit without rolling main:
+
+```sh
+# All five tenants:
+make sync-compose-fleet
+
+# A single tenant:
+make FLEET="zsolt.alfred.black" sync-compose-fleet
+
+# Override the SSH key:
+make SSH_KEY=~/.ssh/id_ed25519 sync-compose-fleet
+```
+
+Default key path is `~/.ssh/alfred-black-verify`. The target validates the
+compose file locally before touching any tenant; if `docker compose config`
+fails, nothing ships.
+
+## Why this directory exists
+
+PR #121 (2026-05-29) added the `tailscale` profile to `docker-compose.yaml`.
+The image rebuild and ctrl-api routes landed correctly, but the compose
+file itself never reached any tenant because no CI step copied it. Live
+evidence on `home.alfred.black`:
+
+```
+$ stat -c '%y' /opt/alfred/docker-compose.yaml
+2026-05-28 20:50:13
+$ docker compose --profile tailscale config --services
+(empty — the tailscale block isn't in the file)
+```
+
+Sir had to `scp docker-compose.yaml root@home.alfred.black:/opt/alfred/`
+by hand. The other four tenants were still on May-28 compose. This
+directory + the `deploy-compose.yml` workflow close that loop so a host-side
+file change in `main` reaches every tenant the same way an image change
+does.
+
+## Secrets
+
+- `FLEET_SSH_KEY` — repo-level GitHub Actions secret; the private half of
+  `~/.ssh/alfred-black-verify`. Authorised on every tenant's `root@`
+  account.


### PR DESCRIPTION
## What this fixes

PR [#121](https://github.com/ssdavidai/alfred/pull/121) added a `tailscale` service to `docker-compose.yaml` on 2026-05-29. The image rebuilds and ctrl-api routes landed, but **the compose file itself never reached any tenant**.

### Live evidence on `home.alfred.black`

```sh
$ stat -c '%y' /opt/alfred/docker-compose.yaml
2026-05-28 20:50:13           # one day *before* #121 merged

$ docker compose --profile tailscale config --services
                              # empty — the service block isn't in the file

$ grep -c '^  tailscale:' /opt/alfred/docker-compose.yaml
0                             # confirmed missing
```

Sir had to `scp docker-compose.yaml root@home.alfred.black:/opt/alfred/docker-compose.yaml` by hand to unblock the redeploy. The other 4 tenants (rj/joe/zsolt/miguel) were still on May-28 compose and could not bring up tailscale, recall, ha, or the files-volume sidecars even though their images had updated.

## The exact missing step

`grep -rln "ssh\|scp\|rsync\|FLEET\|tenant" .github/workflows/` returns nothing. Every `build-*.yml` workflow pushes images to DockerHub; none ever rsynced host-side static config to a tenant.

**When did this regression land?** It has been latent since the repo's CI was first scaffolded:

```
$ git log --oneline --diff-filter=A -- docker-compose.yaml
39f94c30 feat: compose stack, Caddy, env/bootstrap, CI, learn wiring (#9 #10 #11 #16 #17)
$ git show --format='%ai' --no-patch 39f94c30
2026-05-18 16:15:30 +0200
```

The compose file went into the repo on 2026-05-18 with no deploy mechanism. Every host-side change since then has required a manual scp; #121 just made the gap unmissable.

## What ships

| File | Purpose |
|---|---|
| `.github/workflows/deploy-compose.yml` | New workflow. On push to main touching `docker-compose.yaml`, `caddy/Caddyfile`, `caddy/plane-proxy.Caddyfile`, or `.env.example`, runs a matrix over the 5 live tenants — ssh pre-flight, `.bak-<sha>-<ts>` of the prior copy, `scp -p` the new files, `docker compose config --quiet` validation, `docker compose -p alfred-black up -d`, `caddy reload`. `fail-fast: false` so one offline tenant doesn't block the rest. Uses the existing `FLEET_SSH_KEY` repo secret. |
| `Makefile` | New `sync-compose-fleet` target — operator one-shot backfill. Defaults to all 5 tenants and `~/.ssh/alfred-black-verify`; override with `FLEET=` and `SSH_KEY=`. Same operation as the workflow. Run `make sync-compose-fleet` immediately after this PR lands to bring rj/joe/zsolt/miguel up to current. |
| `deploy/README.md` | New: fleet roster, what CI does vs. doesn't deploy, the postmortem evidence, one-shot backfill instructions. |
| `.github/workflows/ci-check.yml` | New `workflow-lint` job runs `actionlint` over every workflow (shellcheck integration off — bootstrap-lint already covers the scripts that matter). |

## Tests

- `actionlint -shellcheck=` passes clean against the new workflow (verified locally with actionlint 1.7.12).
- `make -n sync-compose-fleet` expands as expected.
- No SSH calls are simulated — the workflow is verified by YAML well-formedness, per the testing brief.

## Risk + rollback

- The first `deploy-compose.yml` run after this PR merges will sync **today's** `docker-compose.yaml` to every reachable tenant. That's the desired behaviour — it closes the #121 gap. Backups land at `/opt/alfred/<file>.bak-<sha>-<ts>` for one-`mv` rollback.
- Compose is idempotent; only services whose hash changed restart. Caddy gets a graceful `caddy reload`.
- An offline tenant is skipped with a `:warning:` in the step summary, not failed — partial rollout is better than no rollout.

## Tenant-list deduplication (future work)

Hostnames are hard-coded in two places (`deploy-compose.yml` matrix + `Makefile` `FLEET` var). The `deploy/README.md` flags this — when the SaaS Plane app exposes a tenant directory we'll pull it from there. For now duplication is honest; the failure mode of a stale list ("a tenant silently misses a deploy") is exactly what this PR fixes, so the call-out is on the operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)