### PR TITLE
fix(deploy): caddyfile @public_webhooks + pids_limit + inode-mismatch note

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -71,12 +71,21 @@ import /tailscale-snippets/*.caddy
 	# matcher was never updated and every Composio webhook was 405-ing
 	# at the SPA's nginx.
 	#
-	# /api/v1/channels/ha/turn is the Home Assistant conversation-agent
-	# inbound surface (#111 PR1). The handler validates a per-installation
-	# bearer against the shared channel_tokens table (channel='ha-conversation')
-	# — same pattern as Paperclip's heartbeat (HMAC instead of bearer),
-	# routed through the same Caddy gate so HA can reach ctrl-api directly
+	# /api/v1/channels/ha/* is the Home Assistant channel surface (#111).
+	# /turn is the conversation-agent inbound (PR1) — bearer-authed via
+	# the shared channel_tokens table (channel='ha-conversation'), same
+	# pattern as Paperclip's heartbeat (HMAC instead of bearer), routed
+	# through the same Caddy gate so HA can reach ctrl-api directly
 	# rather than bouncing through the SPA's nginx (which would 405).
+	#
+	# The wildcard (rather than `/turn` literal) is intentional: every
+	# other /api/v1/channels/ha/* route (status / registry / proposal /
+	# service / etc.) is operator-auth-gated by server.ts's
+	# `authenticate()` call, so routing them through ctrl-api is safe —
+	# unauthorised callers get a clean 401 from ctrl-api instead of a
+	# misleading 405 from the SPA's nginx. Discovered 2026-05-29 wiring
+	# HA conversation on home: the live Caddyfile only had the literal
+	# `/turn` entry and HA's preflight POST was 405-ing at the SPA.
 	#
 	# /api/v1/webhooks/vexa stays in the matcher even though the upstream
 	# Vexa stack was retired in #113 PR1 — ctrl-api keeps a 410 Gone stub
@@ -84,7 +93,7 @@ import /tailscale-snippets/*.caddy
 	# 405-ing at the SPA's nginx. Drop this entry when the stub goes (the
 	# PR that lands Recall.ai — #113 PR2).
 	@public_webhooks {
-		path /api/v1/streams/omi/* /api/v1/plane/webhook /api/v1/webhooks/plane/steward /api/v1/webhooks/vexa /api/v1/webhooks/recall /api/v1/webhooks/in/* /api/v1/channels/email/inbound /api/v1/channels/paperclip/* /api/v1/channels/ha/turn /api/v1/composio/webhook
+		path /api/v1/streams/omi/* /api/v1/plane/webhook /api/v1/webhooks/plane/steward /api/v1/webhooks/vexa /api/v1/webhooks/recall /api/v1/webhooks/in/* /api/v1/channels/email/inbound /api/v1/channels/paperclip/* /api/v1/channels/ha/* /api/v1/composio/webhook
 	}
 	handle @public_webhooks {
 		reverse_proxy ctrl-api:3100

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -69,6 +69,30 @@ Default key path is `~/.ssh/alfred-black-verify`. The target validates the
 compose file locally before touching any tenant; if `docker compose config`
 fails, nothing ships.
 
+## Gotcha: Caddyfile edits + the bind-mount inode
+
+Editing `/opt/alfred/caddy/Caddyfile` on a running host with `sed -i` (or
+any editor that rewrites the file rather than truncating-and-writing in
+place) changes the host inode. The Caddy container is bind-mounting the
+old inode, so it keeps serving stale content even after `caddy reload`.
+
+Fix is one of:
+
+```sh
+docker restart alfred-black-caddy-1
+# or
+docker compose -p alfred-black up -d caddy
+```
+
+Both remount the path and pick up the new inode. The `deploy-compose.yml`
+workflow uses `scp -p` (which truncates rather than re-inodes), followed
+by `caddy reload`, so the CI path is unaffected — this only bites
+operators doing one-off edits on a tenant.
+
+Live evidence (home, 2026-05-29 HA wiring): host inode 257610, container
+inode 257899 after a `sed -i` patch; `caddy reload` returned success but
+the matcher still 405'd until the container was restarted.
+
 ## Why this directory exists
 
 PR #121 (2026-05-29) added the `tailscale` profile to `docker-compose.yaml`.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -62,7 +62,16 @@ services:
       retries: 3
       start_period: 10s
     mem_limit: 256m
-    pids_limit: 256
+    # Bumped 256 -> 1024 on 2026-05-29. Caddy's runtime is small but every
+    # operator `caddy validate` / `caddy reload` (e.g. ctrl-api's tailscale
+    # cert route, an interactive shell-out during incident response, or the
+    # deploy-compose.yml graceful-reload step) forks a fresh Go runtime —
+    # which spawns ~30-50 OS threads per invocation. On home.alfred.black
+    # the cap was hit live during HA wiring: `caddy reload` returned
+    # `runtime: failed to create new OS thread; errno=11` (EAGAIN) and
+    # every shell-out inside the container failed. 1024 is well clear of
+    # the steady-state ~80-100 threads + room for concurrent reloads.
+    pids_limit: 1024
 
   # ── web-db — Postgres for the Wasp web app (auth, ApiKey, OAuth) ────
   web-db:


### PR DESCRIPTION
## Summary

Three durable fixes from tonight's HA-conversation wiring on home.alfred.black. All three sit on PR #156's auto-rollout path (`deploy-compose.yml` syncs `docker-compose.yaml` + `caddy/Caddyfile` to every tenant on push to main, then graceful-reloads Caddy).

## 1. caddy/Caddyfile — broaden `@public_webhooks` to `/api/v1/channels/ha/*`

PR #122 added the literal `/api/v1/channels/ha/turn` to the matcher. Tonight while wiring the alfred-ha HACS component on home, the agent hit a 405 from the SPA's nginx on `POST /api/v1/channels/ha/turn` because the live tenant Caddyfile was the pre-#122 version (it had drifted from upstream — PR #156 only landed today).

PR #122 already covers the `/turn` literal. This PR broadens to `/api/v1/channels/ha/*` so any other HA channel route (`/status`, `/registry`, `/connect`, `/service`, `/proposal`, `/snapshot`, …) lands at ctrl-api rather than 405-ing at the SPA. Those routes are operator-auth-gated by `server.ts`'s `authenticate()` call, so unauthorised callers get a clean 401 from ctrl-api instead of a misleading 405. `/turn` keeps its specific `isPublic` bypass in `server.ts`.

Same pattern as the Composio webhook fix (PR #96, 2026-05-28).

## 2. docker-compose.yaml — caddy `pids_limit` 256 -> 1024

The Caddy container hit its 256 pids cap tonight during HA wiring. Every operator `caddy validate` / `caddy reload` (e.g. ctrl-api's tailscale cert route, an interactive shell-out during incident response, or the `deploy-compose.yml` graceful-reload step) forks a fresh Go runtime which spawns ~30-50 OS threads. Steady state is ~80-100 threads; the cap left no headroom for any concurrent shell-out.

`caddy reload` returned `runtime: failed to create new OS thread; errno=11` (EAGAIN) and every `docker exec caddy …` failed for the duration. Hot-fix was `docker update --pids-limit 1024 alfred-black-caddy-1` (runtime-only, lost on recreate). Bumped to 1024 in compose with an in-file comment referencing tonight's saturation so a future maintainer doesn't pull it back.

## 3. deploy/README.md — Caddyfile bind-mount inode-mismatch note

Operator one-off edits with `sed -i` (or any editor that rewrites rather than truncates) change the host inode and leave the container serving the old one. `caddy reload` returns success but the matcher keeps responding to the old config. The fix is `docker restart alfred-black-caddy-1` or `docker compose up -d caddy` to remount.

The `deploy-compose.yml` workflow uses `scp -p` (which truncates rather than re-inodes), so the CI path is unaffected — this only bites operators doing live edits during incident response. One-line note added under a new "Gotcha" section in `deploy/README.md`.

## Validation

- Caddyfile validates clean against `caddy:2-alpine caddy validate` (warns only that the file is not `caddy fmt`-formatted, which is pre-existing).
- `docker compose config --quiet` parses clean (env-var warnings only, expected without `.env`).

## Fleet rollout

On merge, `.github/workflows/deploy-compose.yml` (from PR #156) will rsync the new files to all 5 tenants (home, rj, joe, zsolt, miguel) and graceful-reload Caddy + `docker compose up -d`. caddy will restart because its `pids_limit` changed; the Caddyfile change will be picked up by the explicit reload step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)