### PR TITLE
feat(ctrl,mcp): #115 PR3 — HA automations/scenes/scripts CRUD

### DIFF
--- a/docs/specs/issue-115-ha-tier4-autonomy.md
+++ b/docs/specs/issue-115-ha-tier4-autonomy.md
@@ -1,0 +1,241 @@
+# Issue #115 — Full HA autonomy (Tier 4): Alfred as HA's superuser
+
+**Status:** spec draft 2026-05-29  
+**Author:** Sir + Claude  
+**Companion to:** #110 (HA integration), #111 (Alfred as conversation agent), #112 (HA voice bridge)
+
+## The decision
+
+Sir explicitly chose **Tier 4** when asked which autonomy level Alfred should
+have over HA. That tier is *every CRUD verb on every HA surface:*
+
+| Surface | Tier 1 (read) | Tier 2 (+CRUD entities) | Tier 3 (+addons/integrations) | **Tier 4 (+core+users)** |
+|---|---|---|---|---|
+| Entity state | ✅ | ✅ | ✅ | ✅ |
+| Service calls | — | ✅ | ✅ | ✅ |
+| Automations / scripts / scenes | — | ✅ | ✅ | ✅ |
+| Areas / devices / labels | — | ✅ | ✅ | ✅ |
+| Integrations (config_flow) | — | — | ✅ | ✅ |
+| HACS custom components | — | — | ✅ | ✅ |
+| Supervisor addons | — | — | ✅ | ✅ |
+| HA core (restart / version / backups) | — | — | — | ✅ |
+| Users / auth / API tokens | — | — | — | ✅ |
+
+Today Alfred is at **Tier 1 + partial Tier 2** (11 read tools shipped in #128;
+5 write stubs in PR3 that wave-D #143 wired to the write surface). Tier 4 is
+~50 new tools spread across the next 4 waves.
+
+## Why tier 4 specifically
+
+Sir said "I want Alfred to be the one setting and maintaining everything for
+me not me." A tier-3 Alfred can react to the principal's home but can't
+adopt a new device class without Sir clicking through HA's UI; a tier-4
+Alfred can. That changes the relationship from "Alfred operates what Sir
+configured" to "Alfred maintains the home." Concretely:
+
+- "I just got a new Hue bridge" → tier-3 Alfred says "Sir, please add the
+  Hue integration in HA Settings." Tier-4 Alfred says "Done — 12 bulbs
+  named, all grouped under Living Room, scenes Day/Night/Reading
+  imported."
+- "HA is out of date" → tier-3 Alfred surfaces a Desk card. Tier-4 Alfred
+  reads the release notes, takes a snapshot, applies the OTA update,
+  rolls back if any entity goes unavailable for >5min after restart.
+- "My kid needs HA access without seeing the security cams" → tier-3
+  Alfred is silent. Tier-4 Alfred provisions a HA user, mints an LLAT,
+  configures a person-scoped allowlist, gives Sir the link.
+
+## What's not yet decided (Sir to confirm)
+
+The blast radius of tier 4 is higher. Three knobs to set:
+
+1. **Approval gates.** Today the 5 PR4 write tools (`ha__call_service` etc.)
+   are gated by `decision_ref` — every write either references a Desk
+   decision Sir approved, or is rejected. Extend to all tier-4 verbs?
+   Probably yes for `ha__core_restart` / `ha__user_create` / `ha__addon_install`;
+   probably no for cheap entity-level CRUD (`ha__create_scene`,
+   `ha__update_automation`). Suggested split below in §4.
+2. **Snapshots.** Tier 4 writes can break HA in ways Tier 2 can't (a bad
+   addon install vs. a wrong service call). Auto-snapshot before
+   `addon_install`, `integration_add`, `core_restart`, `core_update`?
+   Default yes.
+3. **What gets a daybook entry vs. silent.** Cheap reversible writes
+   silent; everything else recorded in a daybook so Sir has an audit
+   trail.
+
+Defaults proposed; Sir says yes or amends.
+
+## Architecture
+
+### REST vs WebSocket
+
+HA's REST API is a strict subset of its WebSocket API. The Tier 4 surface
+crosses that boundary:
+
+- **REST-only:** `/api/states/*`, `/api/services/*`, `/api/history/*`,
+  `/api/logbook/*`, `/api/calendars/*`, `/api/config/automation/*`,
+  `/api/config/scene/*`, `/api/config/script/*` — already used.
+- **WS-only:** `area_registry`, `device_registry`, `entity_registry`
+  (full CRUD), `assist_pipeline/*`, `auth/*` (user mgmt), `hacs/*`,
+  `supervisor/*` (addons), `backup/*`, `config_entries/flow/*`
+  (integrations), `subscribe_events`.
+
+Tonight's HaBootstrap revealed that #110 PR5 hit this — areas/devices/scenes
+came back 0 because PR5 used REST and those registries are WS-only. Issue
+#149 tracks it.
+
+**Tier 4 needs a long-lived HA WebSocket client in ctrl-api.** One
+durable connection, auto-reconnect with exponential backoff, message
+multiplexer with per-request `id` counter, drains the event stream
+into `state.db.ha_event` for the LearningWorkflow to read.
+
+### ctrl-api routes (new)
+
+```
+# Integrations
+POST   /api/v1/channels/ha/integrations/discover       — config_flow flow_init
+POST   /api/v1/channels/ha/integrations/configure      — config_flow flow_progress
+GET    /api/v1/channels/ha/integrations               — list all config_entries
+DELETE /api/v1/channels/ha/integrations/:entry_id     — config_entries/remove
+POST   /api/v1/channels/ha/integrations/:entry_id/reload — config_entries/reload
+
+# HACS
+GET    /api/v1/channels/ha/hacs/repos                  — hacs/repositories/list
+POST   /api/v1/channels/ha/hacs/install                — hacs/repository/download
+DELETE /api/v1/channels/ha/hacs/:repo                  — hacs/repository/remove
+POST   /api/v1/channels/ha/hacs/refresh                — hacs/repository/refresh
+
+# Supervisor addons (HAOS-only — surface returns 501 on Container HA)
+GET    /api/v1/channels/ha/addons                      — supervisor/addons
+POST   /api/v1/channels/ha/addons/:slug/install        — supervisor/addons/<slug>/install
+POST   /api/v1/channels/ha/addons/:slug/start          — supervisor/addons/<slug>/start
+POST   /api/v1/channels/ha/addons/:slug/stop
+POST   /api/v1/channels/ha/addons/:slug/uninstall
+PUT    /api/v1/channels/ha/addons/:slug/options        — supervisor/addons/<slug>/options
+
+# Core
+POST   /api/v1/channels/ha/core/restart                — homeassistant/restart
+POST   /api/v1/channels/ha/core/check_config           — homeassistant/check_config
+POST   /api/v1/channels/ha/core/update                 — supervisor/core/update
+GET    /api/v1/channels/ha/backups                     — backup/info
+POST   /api/v1/channels/ha/backups                     — backup/generate
+DELETE /api/v1/channels/ha/backups/:id                 — backup/remove
+POST   /api/v1/channels/ha/backups/:id/restore         — backup/restore
+GET    /api/v1/channels/ha/version                     — REST GET /api/config
+
+# Users (HA Auth)
+GET    /api/v1/channels/ha/users                       — config/auth/list
+POST   /api/v1/channels/ha/users                       — config/auth/create
+DELETE /api/v1/channels/ha/users/:id                   — config/auth/delete
+POST   /api/v1/channels/ha/users/:id/long_lived_token  — auth/long_lived_access_token
+
+# Areas / Devices / Entities / Labels (full CRUD via WS registries)
+GET/POST/PUT/DELETE /api/v1/channels/ha/areas/...
+GET/POST/PUT/DELETE /api/v1/channels/ha/devices/...
+GET/POST/PUT/DELETE /api/v1/channels/ha/entities/...
+GET/POST/PUT/DELETE /api/v1/channels/ha/labels/...
+
+# Scenes / Scripts / Automations (full CRUD — REST exists, just wire it)
+GET/POST/PUT/DELETE /api/v1/channels/ha/scenes/...
+GET/POST/PUT/DELETE /api/v1/channels/ha/scripts/...
+GET/POST/PUT/DELETE /api/v1/channels/ha/automations/...
+```
+
+### Hass MCP tools (new — ~35 tools)
+
+| Tool | Approval gate | Snapshot before? |
+|---|---|---|
+| `ha__integration_discover` | none | no |
+| `ha__integration_configure` | `decision_ref` | yes if reload-required |
+| `ha__integration_remove` | `decision_ref` | yes |
+| `ha__integration_reload` | `decision_ref` | no |
+| `ha__hacs_search` | none | no |
+| `ha__hacs_install` | `decision_ref` | yes |
+| `ha__hacs_remove` | `decision_ref` | yes |
+| `ha__hacs_refresh` | none | no |
+| `ha__addon_list` | none | no |
+| `ha__addon_install` | `decision_ref` | yes |
+| `ha__addon_uninstall` | `decision_ref` | yes |
+| `ha__addon_configure` | `decision_ref` | no |
+| `ha__addon_start` / `ha__addon_stop` | none (reversible) | no |
+| `ha__core_restart` | `decision_ref` | yes |
+| `ha__core_update` | `decision_ref` | yes |
+| `ha__core_check_config` | none | no |
+| `ha__backup_create` | none | no |
+| `ha__backup_restore` | `decision_ref` + Sir-confirm | n/a |
+| `ha__backup_delete` | `decision_ref` | no |
+| `ha__user_create` | `decision_ref` | no |
+| `ha__user_delete` | `decision_ref` | no |
+| `ha__user_mint_llat` | `decision_ref` | no |
+| `ha__area_create` / `update` / `delete` | none | no |
+| `ha__device_label` / `move` | none | no |
+| `ha__entity_rename` / `hide` / `disable` | none | no |
+| `ha__label_create` / `apply` / `remove` | none | no |
+| `ha__scene_create` / `update` / `delete` | none | no |
+| `ha__script_create` / `update` / `delete` | none | no |
+| `ha__automation_create` / `update` / `delete` | none for create+update / `decision_ref` for delete | no |
+
+**Rule:** gate any verb whose effect a non-technical principal couldn't
+trivially reverse in <2 minutes through HA's own UI. Everything else
+runs free.
+
+### state.db additions
+
+```sql
+CREATE TABLE ha_backup_ref (        -- index of HA snapshots Alfred made
+  id TEXT PRIMARY KEY,
+  ha_backup_id TEXT NOT NULL,
+  triggered_by TEXT NOT NULL,         -- 'ha__core_update', 'ha__addon_install', ...
+  decision_ref TEXT,                  -- which decision the trigger came from
+  ts TEXT NOT NULL
+);
+
+CREATE TABLE ha_integration_ref (   -- what Alfred added vs what Sir added
+  entry_id TEXT PRIMARY KEY,
+  installed_by TEXT NOT NULL,         -- 'alfred' | 'sir'
+  decision_ref TEXT,
+  installed_at TEXT
+);
+
+CREATE TABLE ha_user_ref (          -- principals Alfred provisioned
+  ha_user_id TEXT PRIMARY KEY,
+  name TEXT,
+  decision_ref TEXT,
+  llat_vw_id TEXT,                    -- Vaultwarden item id holding their LLAT
+  created_at TEXT
+);
+```
+
+Migration `0009_ha_tier4.sql` adds these.
+
+## Phasing
+
+- **PR1 — WS client.** Long-lived `ctrl-api ↔ HA` WS connection,
+  auto-reconnect, request multiplexer, event-stream → `state.db.ha_event`.
+  Closes #149 (the area/device gap).
+- **PR2 — Registries CRUD.** `/areas/*`, `/devices/*`, `/entities/*`,
+  `/labels/*` + matching MCP tools. No approval gate (cheap, reversible).
+- **PR3 — Automations / scenes / scripts CRUD.** Wire the REST endpoints,
+  add tools.
+- **PR4 — Integrations.** config_flow REST. The trickiest one — flow
+  steps can require multiple POSTs and user input. Skill doc tells
+  Alfred how to drive multi-step flows.
+- **PR5 — HACS.** WS API, install/remove/refresh, repo search.
+- **PR6 — Supervisor addons.** HAOS-only; surface returns 501 on
+  Container HA. PR3 of #110 already detects HA install type.
+- **PR7 — Core + backups.** restart / update / check_config / backup CRUD.
+  Snapshot-on-trigger logic.
+- **PR8 — Users + LLAT.** Provision HA users, mint LLATs into a
+  per-user Vaultwarden item.
+
+Each PR shippable independently; PR1 is the load-bearing prerequisite
+for PR2/PR5/PR8.
+
+## Done criteria
+
+- All 35 new MCP tools registered in main profile
+- Approval-gate semantics enforced (test: a `ha__addon_install` without
+  `decision_ref` returns 400)
+- Backup-on-trigger tested with a real install/uninstall round-trip on home
+- Skill doc (`alfred-mcp-skill.md`) updated with the tier-4 playbook
+- `home.alfred.black` Alfred can answer "install the Hue integration with
+  ip 192.168.1.42" end-to-end without Sir touching HA's UI.

--- a/docs/specs/issue-115-ha-tier4-autonomy.md
+++ b/docs/specs/issue-115-ha-tier4-autonomy.md
@@ -44,7 +44,7 @@ configured" to "Alfred maintains the home." Concretely:
   Alfred is silent. Tier-4 Alfred provisions a HA user, mints an LLAT,
   configures a person-scoped allowlist, gives Sir the link.
 
-## What's not yet decided (Sir to confirm)
+## Defaults — LOCKED 2026-05-29 by Sir
 
 The blast radius of tier 4 is higher. Three knobs to set:
 
@@ -62,7 +62,7 @@ The blast radius of tier 4 is higher. Three knobs to set:
    silent; everything else recorded in a daybook so Sir has an audit
    trail.
 
-Defaults proposed; Sir says yes or amends.
+**All three locked YES, 2026-05-29.** Implementation proceeds against these defaults; future changes require an explicit decision.
 
 ## Architecture
 

--- a/packages/ctrl/src/api/routes/channels_ha.ts
+++ b/packages/ctrl/src/api/routes/channels_ha.ts
@@ -999,6 +999,11 @@ export function registerHaChannelRoutes(): void {
   // server.ts wiring AND callable from a single registerHaChannelRoutes()
   // entry point.
   registerHaWriteRoutes();
+
+  // #115 PR3 — automations / scenes / scripts CRUD. REST-only; ships
+  // independent of #115 PR1 (the WS client). See the SPLICE block at the
+  // bottom of this file marked `BEGIN #115 PR3`.
+  registerHaPr3Routes();
 }
 
 /**
@@ -2843,3 +2848,1118 @@ export function _resetHaGapsForTests(): void {
     // table may not exist; tests own migrations
   }
 }
+
+// ═════════════════════════════════════════════════════════════════════════
+// === BEGIN #115 PR3 — automations / scenes / scripts CRUD ===
+// ═════════════════════════════════════════════════════════════════════════
+//
+// REST-only. Closes the spec §4 "Scenes / Scripts / Automations" row by
+// wiring HA's long-standing `/api/config/{automation,scene,script}/config`
+// endpoints AND the `/api/states/<domain>.*` list helper. Independent of
+// #115 PR1's WS client — every route here goes through fetch().
+//
+// PR1 (parallel) will introduce two helpers we defensively reach for:
+//   * `requireDecisionRef`  — middleware that fishes `decision_ref` out of
+//     the body and 400s if it's missing/malformed.
+//   * `recordHaWriteToDaybook` — drops a daybook vault record per Sir's
+//     locked YES default (snapshots / daybook / gates).
+//
+// Both are wrapped in `tryRequireDecisionRef` / `tryRecordDaybook` below
+// so they no-op cleanly if PR1 hasn't merged yet. The runtime semantics
+// stay correct either way: every PR3 write persists a `ha_run` row (the
+// existing audit ledger), and DELETE-automation enforces decision_ref via
+// the same `assertDecisionRef` parser as PR4's call_service.
+//
+// SPLICE BLOCK — keep everything between the BEGIN / END markers
+// contiguous so a parallel PR (PR1) that touches this file rebases
+// mechanically. No file-wide rename or shared-helper edits inside this
+// block.
+
+// Slug shape for automation/scene/script ids that come back from HA. HA
+// itself accepts more characters, but the practical surface for ids we
+// see in the wild is `[a-zA-Z0-9_-]`. Keep this generous enough that we
+// don't reject valid ids, strict enough that path traversal can't
+// sneak through.
+const HA_OBJECT_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$/;
+
+function assertHaObjectId(raw: string, kind: string): string {
+  if (!HA_OBJECT_ID_RE.test(raw)) {
+    throw new ValidationError(
+      `${kind} id must be 1..128 chars of [A-Za-z0-9_.-], starting with [A-Za-z0-9]`,
+    );
+  }
+  return raw;
+}
+
+interface HaRestCallResult {
+  ok: boolean;
+  status: number;
+  data: unknown;
+  detail: string;
+}
+
+/** Generic HA REST proxy — used for /api/config/* CRUD + /api/states/* reads.
+ *
+ *  HA's /api/config GETs return JSON; POST/DELETE on the same path returns
+ *  `{result: "ok"}` JSON; /api/states/* returns JSON. We parse text as
+ *  JSON best-effort and fall back to the raw string. */
+async function callHaRest(args: {
+  haUrl: string;
+  llat: string;
+  method: "GET" | "POST" | "DELETE";
+  path: string;
+  body?: unknown;
+}): Promise<HaRestCallResult> {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${args.llat}`,
+  };
+  let reqBody: string | undefined;
+  if (args.body !== undefined && args.method !== "GET") {
+    headers["Content-Type"] = "application/json";
+    reqBody = JSON.stringify(args.body);
+  }
+  let resp: Response;
+  try {
+    resp = await fetch(`${args.haUrl}${args.path}`, {
+      method: args.method,
+      headers,
+      body: reqBody,
+      signal: AbortSignal.timeout(HA_WRITE_TIMEOUT_MS),
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      status: 502,
+      data: null,
+      detail: `HA unreachable: ${msg}`,
+    };
+  }
+  let parsed: unknown = null;
+  const text = await resp.text().catch(() => "");
+  if (text) {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = text;
+    }
+  }
+  if (!resp.ok) {
+    let detail = `HA REST ${args.method} ${args.path} returned HTTP ${resp.status}`;
+    if (typeof parsed === "string" && parsed.length > 0) {
+      detail = `${detail}: ${parsed.slice(0, 500)}`;
+    } else if (parsed && typeof parsed === "object") {
+      const m =
+        (parsed as Record<string, unknown>).message ??
+        (parsed as Record<string, unknown>).error;
+      if (typeof m === "string") detail = `${detail}: ${m.slice(0, 500)}`;
+    }
+    return { ok: false, status: resp.status, data: parsed, detail };
+  }
+  return { ok: true, status: resp.status, data: parsed, detail: "" };
+}
+
+/** Gate helper — every PR3 route needs LLAT + ha_url + a "is HA connected?"
+ *  check. Returns the loaded credentials on success; throws ApiError if
+ *  the connection isn't ready.
+ *
+ *  Mirrors the body of #110 PR4's call_service handler (readHaLlat + the
+ *  ha_connection row read) so the failure modes line up with the rest of
+ *  the write surface. */
+async function loadHaCredentials(): Promise<{
+  haUrl: string;
+  llat: string;
+}> {
+  const llat = await readHaLlat(); // throws HA_NOT_CONNECTED / VAULT_* if unset
+  const row = getHaConnectionRow();
+  if (!row || row.state !== "connected") {
+    // readHaLlat() already covers this, but assert here too — defence in
+    // depth in case the ha_connection row was mutated between fetches.
+    throw new ApiError(
+      409,
+      "HA_NOT_CONNECTED",
+      "Home Assistant is not connected. POST /api/v1/channels/ha/connect first.",
+    );
+  }
+  return { haUrl: row.ha_url, llat };
+}
+
+/** PR1-aware decision_ref enforcement. If PR1's `requireDecisionRef`
+ *  middleware lands first, swap this to call it; for now it defers to the
+ *  same `assertDecisionRef` parser the PR4 write surface uses.
+ *
+ *  TODO(post-PR1): replace direct `assertDecisionRef` with the middleware
+ *  once it's available on the route context. */
+function tryRequireDecisionRef(body: unknown): string {
+  const raw =
+    body && typeof body === "object"
+      ? (body as Record<string, unknown>).decision_ref
+      : undefined;
+  return assertDecisionRef(raw);
+}
+
+/** PR1-aware daybook recorder. PR1 will introduce a `recordHaWriteToDaybook`
+ *  helper that drops a daybook vault record per the locked YES default.
+ *  Today this is a no-op — the audit shape is fully covered by `ha_run`,
+ *  which every PR3 write persists. PR1 will swap this for the vault writer
+ *  without changing PR3 call sites.
+ *
+ *  TODO(post-PR1): replace with the daybook vault writer. */
+async function tryRecordDaybook(_args: {
+  kind: string;
+  ha_id: string | null;
+  decision_ref: string | null;
+  outcome: "ok" | "error";
+  detail: string | null;
+}): Promise<void> {
+  // intentional no-op pre-PR1; ha_run row carries the audit shape today.
+}
+
+// ── string / sequence parsers ──────────────────────────────────────────
+
+function parseStringField(
+  raw: unknown,
+  field: string,
+  required: boolean,
+): string | undefined {
+  if (raw === undefined || raw === null) {
+    if (required) {
+      throw new ValidationError(`${field} is required`);
+    }
+    return undefined;
+  }
+  if (typeof raw !== "string" || raw.length === 0) {
+    throw new ValidationError(`${field} must be a non-empty string`);
+  }
+  return raw;
+}
+
+function parseTriggerOrAction(
+  raw: unknown,
+  field: string,
+  required: boolean,
+): unknown {
+  if (raw === undefined || raw === null) {
+    if (required) {
+      throw new ValidationError(`${field} is required`);
+    }
+    return undefined;
+  }
+  if (Array.isArray(raw)) return raw;
+  if (typeof raw === "object") return raw;
+  throw new ValidationError(`${field} must be an object or array`);
+}
+
+// ── automation parsing ─────────────────────────────────────────────────
+
+interface AutomationCreateBody {
+  alias: string;
+  trigger: unknown;
+  condition?: unknown;
+  action: unknown;
+  description?: string;
+  mode?: string;
+  initial_state?: string;
+}
+
+function parseAutomationCreateBody(raw: unknown): AutomationCreateBody {
+  if (typeof raw !== "object" || raw === null) {
+    throw new ValidationError("body must be a JSON object");
+  }
+  const b = raw as Record<string, unknown>;
+  return {
+    alias: parseStringField(b.alias, "alias", true)!,
+    trigger: parseTriggerOrAction(b.trigger, "trigger", true),
+    condition: parseTriggerOrAction(b.condition, "condition", false),
+    action: parseTriggerOrAction(b.action, "action", true),
+    description: parseStringField(b.description, "description", false),
+    mode: parseStringField(b.mode, "mode", false),
+    initial_state: parseStringField(b.initial_state, "initial_state", false),
+  };
+}
+
+interface AutomationUpdateBody {
+  alias?: string;
+  trigger?: unknown;
+  condition?: unknown;
+  action?: unknown;
+  description?: string;
+  mode?: string;
+}
+
+function parseAutomationUpdateBody(raw: unknown): AutomationUpdateBody {
+  if (typeof raw !== "object" || raw === null) {
+    throw new ValidationError("body must be a JSON object");
+  }
+  const b = raw as Record<string, unknown>;
+  return {
+    alias: parseStringField(b.alias, "alias", false),
+    trigger: parseTriggerOrAction(b.trigger, "trigger", false),
+    condition: parseTriggerOrAction(b.condition, "condition", false),
+    action: parseTriggerOrAction(b.action, "action", false),
+    description: parseStringField(b.description, "description", false),
+    mode: parseStringField(b.mode, "mode", false),
+  };
+}
+
+function automationCreatePayload(b: AutomationCreateBody): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    alias: b.alias,
+    trigger: b.trigger,
+    action: b.action,
+  };
+  if (b.condition !== undefined) out.condition = b.condition;
+  if (b.description !== undefined) out.description = b.description;
+  if (b.mode !== undefined) out.mode = b.mode;
+  if (b.initial_state !== undefined) out.initial_state = b.initial_state;
+  return out;
+}
+
+function automationUpdatePayload(b: AutomationUpdateBody): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  if (b.alias !== undefined) out.alias = b.alias;
+  if (b.trigger !== undefined) out.trigger = b.trigger;
+  if (b.condition !== undefined) out.condition = b.condition;
+  if (b.action !== undefined) out.action = b.action;
+  if (b.description !== undefined) out.description = b.description;
+  if (b.mode !== undefined) out.mode = b.mode;
+  return out;
+}
+
+// ── scene parsing ──────────────────────────────────────────────────────
+
+interface SceneCreateBody {
+  name: string;
+  entities: Record<string, Record<string, unknown>>;
+  icon?: string;
+}
+
+function parseSceneEntitiesMap(
+  raw: unknown,
+  field: string,
+  required: boolean,
+): Record<string, Record<string, unknown>> | undefined {
+  if (raw === undefined || raw === null) {
+    if (required) throw new ValidationError(`${field} is required`);
+    return undefined;
+  }
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    throw new ValidationError(`${field} must be a JSON object`);
+  }
+  const out: Record<string, Record<string, unknown>> = {};
+  for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof v !== "object" || v === null || Array.isArray(v)) {
+      throw new ValidationError(
+        `${field}.${k} must be a JSON object of {state, ...attributes}`,
+      );
+    }
+    out[k] = v as Record<string, unknown>;
+  }
+  return out;
+}
+
+function parseSceneCreateBody(raw: unknown): SceneCreateBody {
+  if (typeof raw !== "object" || raw === null) {
+    throw new ValidationError("body must be a JSON object");
+  }
+  const b = raw as Record<string, unknown>;
+  return {
+    name: parseStringField(b.name, "name", true)!,
+    entities: parseSceneEntitiesMap(b.entities, "entities", true)!,
+    icon: parseStringField(b.icon, "icon", false),
+  };
+}
+
+interface SceneUpdateBody {
+  name?: string;
+  entities?: Record<string, Record<string, unknown>>;
+  icon?: string;
+}
+
+function parseSceneUpdateBody(raw: unknown): SceneUpdateBody {
+  if (typeof raw !== "object" || raw === null) {
+    throw new ValidationError("body must be a JSON object");
+  }
+  const b = raw as Record<string, unknown>;
+  return {
+    name: parseStringField(b.name, "name", false),
+    entities: parseSceneEntitiesMap(b.entities, "entities", false),
+    icon: parseStringField(b.icon, "icon", false),
+  };
+}
+
+function sceneCreatePayload(b: SceneCreateBody): Record<string, unknown> {
+  const out: Record<string, unknown> = { name: b.name, entities: b.entities };
+  if (b.icon !== undefined) out.icon = b.icon;
+  return out;
+}
+
+function sceneUpdatePayload(b: SceneUpdateBody): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  if (b.name !== undefined) out.name = b.name;
+  if (b.entities !== undefined) out.entities = b.entities;
+  if (b.icon !== undefined) out.icon = b.icon;
+  return out;
+}
+
+// ── script parsing ─────────────────────────────────────────────────────
+
+interface ScriptCreateBody {
+  alias: string;
+  sequence: unknown[];
+  description?: string;
+  mode?: string;
+  icon?: string;
+}
+
+function parseScriptSequence(
+  raw: unknown,
+  field: string,
+  required: boolean,
+): unknown[] | undefined {
+  if (raw === undefined || raw === null) {
+    if (required) throw new ValidationError(`${field} is required`);
+    return undefined;
+  }
+  if (!Array.isArray(raw)) {
+    throw new ValidationError(`${field} must be a JSON array`);
+  }
+  return raw;
+}
+
+function parseScriptCreateBody(raw: unknown): ScriptCreateBody {
+  if (typeof raw !== "object" || raw === null) {
+    throw new ValidationError("body must be a JSON object");
+  }
+  const b = raw as Record<string, unknown>;
+  return {
+    alias: parseStringField(b.alias, "alias", true)!,
+    sequence: parseScriptSequence(b.sequence, "sequence", true)!,
+    description: parseStringField(b.description, "description", false),
+    mode: parseStringField(b.mode, "mode", false),
+    icon: parseStringField(b.icon, "icon", false),
+  };
+}
+
+interface ScriptUpdateBody {
+  alias?: string;
+  sequence?: unknown[];
+  description?: string;
+  mode?: string;
+  icon?: string;
+}
+
+function parseScriptUpdateBody(raw: unknown): ScriptUpdateBody {
+  if (typeof raw !== "object" || raw === null) {
+    throw new ValidationError("body must be a JSON object");
+  }
+  const b = raw as Record<string, unknown>;
+  return {
+    alias: parseStringField(b.alias, "alias", false),
+    sequence: parseScriptSequence(b.sequence, "sequence", false),
+    description: parseStringField(b.description, "description", false),
+    mode: parseStringField(b.mode, "mode", false),
+    icon: parseStringField(b.icon, "icon", false),
+  };
+}
+
+function scriptCreatePayload(b: ScriptCreateBody): Record<string, unknown> {
+  const out: Record<string, unknown> = { alias: b.alias, sequence: b.sequence };
+  if (b.description !== undefined) out.description = b.description;
+  if (b.mode !== undefined) out.mode = b.mode;
+  if (b.icon !== undefined) out.icon = b.icon;
+  return out;
+}
+
+function scriptUpdatePayload(b: ScriptUpdateBody): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  if (b.alias !== undefined) out.alias = b.alias;
+  if (b.sequence !== undefined) out.sequence = b.sequence;
+  if (b.description !== undefined) out.description = b.description;
+  if (b.mode !== undefined) out.mode = b.mode;
+  if (b.icon !== undefined) out.icon = b.icon;
+  return out;
+}
+
+// ── states list helpers ────────────────────────────────────────────────
+
+/** Filter HA's `/api/states` payload down to one domain. HA's /api/states
+ *  returns a flat list; the principal-friendly /scenes and /scripts list
+ *  endpoints want only the matching `<domain>.*` entities. */
+function filterStatesByDomain(states: unknown, domain: string): unknown[] {
+  if (!Array.isArray(states)) return [];
+  const prefix = `${domain}.`;
+  return states.filter((s) => {
+    if (!s || typeof s !== "object") return false;
+    const eid = (s as Record<string, unknown>).entity_id;
+    return typeof eid === "string" && eid.startsWith(prefix);
+  });
+}
+
+// ── slug derived from an HA alias/name ─────────────────────────────────
+//
+// HA itself slugifies aliases server-side, but the REST POST endpoints
+// for /api/config/<kind>/config/<id> require us to PICK an id. We mint
+// one with the same algorithm HA uses (lowercase, non-word→underscore)
+// so the entity_id Sir sees matches what HA's UI would have generated.
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9_]+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_|_$/g, "")
+    .slice(0, 128);
+}
+
+// ── route registration ─────────────────────────────────────────────────
+
+export function registerHaPr3Routes(): void {
+  // ──────────────────────────────────────────────────────────────────────
+  // AUTOMATIONS
+  // ──────────────────────────────────────────────────────────────────────
+
+  // GET /api/v1/channels/ha/automations — list all automation configs.
+  addRoute("GET", "/api/v1/channels/ha/automations", async ({ res }) => {
+    const { haUrl, llat } = await loadHaCredentials();
+    const r = await callHaRest({
+      haUrl,
+      llat,
+      method: "GET",
+      path: "/api/config/automation/config",
+    });
+    if (!r.ok) {
+      throw new ApiError(
+        r.status >= 400 && r.status < 600 ? r.status : 502,
+        "HA_UPSTREAM_ERROR",
+        r.detail,
+      );
+    }
+    sendJson(res, 200, { ok: true, data: r.data });
+  });
+
+  // GET /api/v1/channels/ha/automations/:id — fetch one automation.
+  addRoute(
+    "GET",
+    "/api/v1/channels/ha/automations/:id",
+    async ({ res, params }) => {
+      const id = assertHaObjectId(params.id, "automation");
+      const { haUrl, llat } = await loadHaCredentials();
+      const r = await callHaRest({
+        haUrl,
+        llat,
+        method: "GET",
+        path: `/api/config/automation/config/${encodeURIComponent(id)}`,
+      });
+      if (!r.ok) {
+        if (r.status === 404) {
+          throw new NotFoundError(`automation ${id} not found in HA`);
+        }
+        throw new ApiError(
+          r.status >= 400 && r.status < 600 ? r.status : 502,
+          "HA_UPSTREAM_ERROR",
+          r.detail,
+        );
+      }
+      sendJson(res, 200, { ok: true, automation_id: id, data: r.data });
+    },
+  );
+
+  // POST /api/v1/channels/ha/automations — create a new automation.
+  // No gate (create is reversible). The new automation_id is minted from
+  // the alias slug; if the slug collides with an existing automation, HA
+  // will overwrite the existing config — caller's responsibility (or
+  // ha__list_automations_full first).
+  addRoute("POST", "/api/v1/channels/ha/automations", async ({ res, body }) => {
+    const parsed = parseAutomationCreateBody(body);
+    const { haUrl, llat } = await loadHaCredentials();
+    const automationId = slugify(parsed.alias) || `automation_${Date.now()}`;
+    const payload = automationCreatePayload(parsed);
+    const r = await callHaRest({
+      haUrl,
+      llat,
+      method: "POST",
+      path: `/api/config/automation/config/${encodeURIComponent(automationId)}`,
+      body: payload,
+    });
+    if (!r.ok) {
+      insertHaRun({
+        kind: "automation_create",
+        domain: "automation",
+        service: null,
+        entity_id: `automation.${automationId}`,
+        decision_ref: "",
+        payload,
+        outcome: "error",
+        ha_response: r.data,
+        error: r.detail,
+      });
+      throw new ApiError(
+        r.status >= 400 && r.status < 600 ? r.status : 502,
+        "HA_UPSTREAM_ERROR",
+        r.detail,
+      );
+    }
+    const run = insertHaRun({
+      kind: "automation_create",
+      domain: "automation",
+      service: null,
+      entity_id: `automation.${automationId}`,
+      decision_ref: "",
+      payload,
+      outcome: "ok",
+      ha_response: r.data,
+      error: null,
+    });
+    await tryRecordDaybook({
+      kind: "automation_create",
+      ha_id: automationId,
+      decision_ref: null,
+      outcome: "ok",
+      detail: null,
+    });
+    sendJson(res, 200, {
+      ok: true,
+      automation_id: automationId,
+      run_id: run.id,
+      ha_response: r.data,
+    });
+  });
+
+  // PUT /api/v1/channels/ha/automations/:id — idempotent upsert. HA's
+  // REST POST and PUT both write to the same /config/<id> endpoint, so
+  // this is a thin alias that lets callers signal intent.
+  addRoute(
+    "PUT",
+    "/api/v1/channels/ha/automations/:id",
+    async ({ res, params, body }) => {
+      const id = assertHaObjectId(params.id, "automation");
+      const parsed = parseAutomationUpdateBody(body);
+      const { haUrl, llat } = await loadHaCredentials();
+      const payload = automationUpdatePayload(parsed);
+      const r = await callHaRest({
+        haUrl,
+        llat,
+        method: "POST",
+        path: `/api/config/automation/config/${encodeURIComponent(id)}`,
+        body: payload,
+      });
+      if (!r.ok) {
+        insertHaRun({
+          kind: "automation_update",
+          domain: "automation",
+          service: null,
+          entity_id: `automation.${id}`,
+          decision_ref: "",
+          payload,
+          outcome: "error",
+          ha_response: r.data,
+          error: r.detail,
+        });
+        throw new ApiError(
+          r.status >= 400 && r.status < 600 ? r.status : 502,
+          "HA_UPSTREAM_ERROR",
+          r.detail,
+        );
+      }
+      const run = insertHaRun({
+        kind: "automation_update",
+        domain: "automation",
+        service: null,
+        entity_id: `automation.${id}`,
+        decision_ref: "",
+        payload,
+        outcome: "ok",
+        ha_response: r.data,
+        error: null,
+      });
+      await tryRecordDaybook({
+        kind: "automation_update",
+        ha_id: id,
+        decision_ref: null,
+        outcome: "ok",
+        detail: null,
+      });
+      sendJson(res, 200, {
+        ok: true,
+        automation_id: id,
+        run_id: run.id,
+        ha_response: r.data,
+      });
+    },
+  );
+
+  // DELETE /api/v1/channels/ha/automations/:id — GATED.
+  //
+  // Per spec §4 gate matrix (locked YES on 2026-05-29): irreversible
+  // deletes require a `decision_ref`. We assert it via
+  // `tryRequireDecisionRef` (which falls back to `assertDecisionRef`
+  // until PR1's middleware lands). The audit ledger (`ha_run`) carries
+  // the decision_ref alongside the kind/entity_id so the post-mortem of
+  // a stray delete is a single SELECT.
+  addRoute(
+    "DELETE",
+    "/api/v1/channels/ha/automations/:id",
+    async ({ res, params, body }) => {
+      const id = assertHaObjectId(params.id, "automation");
+      const decision_ref = tryRequireDecisionRef(body);
+      const { haUrl, llat } = await loadHaCredentials();
+      const r = await callHaRest({
+        haUrl,
+        llat,
+        method: "DELETE",
+        path: `/api/config/automation/config/${encodeURIComponent(id)}`,
+      });
+      if (!r.ok) {
+        insertHaRun({
+          kind: "automation_delete",
+          domain: "automation",
+          service: null,
+          entity_id: `automation.${id}`,
+          decision_ref,
+          payload: null,
+          outcome: "error",
+          ha_response: r.data,
+          error: r.detail,
+        });
+        if (r.status === 404) {
+          throw new NotFoundError(`automation ${id} not found in HA`);
+        }
+        throw new ApiError(
+          r.status >= 400 && r.status < 600 ? r.status : 502,
+          "HA_UPSTREAM_ERROR",
+          r.detail,
+        );
+      }
+      const run = insertHaRun({
+        kind: "automation_delete",
+        domain: "automation",
+        service: null,
+        entity_id: `automation.${id}`,
+        decision_ref,
+        payload: null,
+        outcome: "ok",
+        ha_response: r.data,
+        error: null,
+      });
+      await tryRecordDaybook({
+        kind: "automation_delete",
+        ha_id: id,
+        decision_ref,
+        outcome: "ok",
+        detail: null,
+      });
+      sendJson(res, 200, {
+        ok: true,
+        automation_id: id,
+        decision_ref,
+        run_id: run.id,
+        ha_response: r.data,
+      });
+    },
+  );
+
+  // ──────────────────────────────────────────────────────────────────────
+  // SCENES
+  // ──────────────────────────────────────────────────────────────────────
+
+  // GET /api/v1/channels/ha/scenes — list every scene.* state.
+  addRoute("GET", "/api/v1/channels/ha/scenes", async ({ res }) => {
+    const { haUrl, llat } = await loadHaCredentials();
+    const r = await callHaRest({
+      haUrl,
+      llat,
+      method: "GET",
+      path: "/api/states",
+    });
+    if (!r.ok) {
+      throw new ApiError(
+        r.status >= 400 && r.status < 600 ? r.status : 502,
+        "HA_UPSTREAM_ERROR",
+        r.detail,
+      );
+    }
+    sendJson(res, 200, { ok: true, data: filterStatesByDomain(r.data, "scene") });
+  });
+
+  // GET /api/v1/channels/ha/scenes/:id — fetch one scene config.
+  addRoute("GET", "/api/v1/channels/ha/scenes/:id", async ({ res, params }) => {
+    const id = assertHaObjectId(params.id, "scene");
+    const { haUrl, llat } = await loadHaCredentials();
+    const r = await callHaRest({
+      haUrl,
+      llat,
+      method: "GET",
+      path: `/api/config/scene/config/${encodeURIComponent(id)}`,
+    });
+    if (!r.ok) {
+      if (r.status === 404) {
+        throw new NotFoundError(`scene ${id} not found in HA`);
+      }
+      throw new ApiError(
+        r.status >= 400 && r.status < 600 ? r.status : 502,
+        "HA_UPSTREAM_ERROR",
+        r.detail,
+      );
+    }
+    sendJson(res, 200, { ok: true, scene_id: id, data: r.data });
+  });
+
+  addRoute("POST", "/api/v1/channels/ha/scenes", async ({ res, body }) => {
+    const parsed = parseSceneCreateBody(body);
+    const { haUrl, llat } = await loadHaCredentials();
+    const sceneId = slugify(parsed.name) || `scene_${Date.now()}`;
+    const payload = sceneCreatePayload(parsed);
+    const r = await callHaRest({
+      haUrl,
+      llat,
+      method: "POST",
+      path: `/api/config/scene/config/${encodeURIComponent(sceneId)}`,
+      body: payload,
+    });
+    if (!r.ok) {
+      insertHaRun({
+        kind: "scene_create",
+        domain: "scene",
+        service: null,
+        entity_id: `scene.${sceneId}`,
+        decision_ref: "",
+        payload,
+        outcome: "error",
+        ha_response: r.data,
+        error: r.detail,
+      });
+      throw new ApiError(
+        r.status >= 400 && r.status < 600 ? r.status : 502,
+        "HA_UPSTREAM_ERROR",
+        r.detail,
+      );
+    }
+    const run = insertHaRun({
+      kind: "scene_create",
+      domain: "scene",
+      service: null,
+      entity_id: `scene.${sceneId}`,
+      decision_ref: "",
+      payload,
+      outcome: "ok",
+      ha_response: r.data,
+      error: null,
+    });
+    sendJson(res, 200, {
+      ok: true,
+      scene_id: sceneId,
+      run_id: run.id,
+      ha_response: r.data,
+    });
+  });
+
+  addRoute(
+    "PUT",
+    "/api/v1/channels/ha/scenes/:id",
+    async ({ res, params, body }) => {
+      const id = assertHaObjectId(params.id, "scene");
+      const parsed = parseSceneUpdateBody(body);
+      const { haUrl, llat } = await loadHaCredentials();
+      const payload = sceneUpdatePayload(parsed);
+      const r = await callHaRest({
+        haUrl,
+        llat,
+        method: "POST",
+        path: `/api/config/scene/config/${encodeURIComponent(id)}`,
+        body: payload,
+      });
+      if (!r.ok) {
+        insertHaRun({
+          kind: "scene_update",
+          domain: "scene",
+          service: null,
+          entity_id: `scene.${id}`,
+          decision_ref: "",
+          payload,
+          outcome: "error",
+          ha_response: r.data,
+          error: r.detail,
+        });
+        throw new ApiError(
+          r.status >= 400 && r.status < 600 ? r.status : 502,
+          "HA_UPSTREAM_ERROR",
+          r.detail,
+        );
+      }
+      const run = insertHaRun({
+        kind: "scene_update",
+        domain: "scene",
+        service: null,
+        entity_id: `scene.${id}`,
+        decision_ref: "",
+        payload,
+        outcome: "ok",
+        ha_response: r.data,
+        error: null,
+      });
+      sendJson(res, 200, {
+        ok: true,
+        scene_id: id,
+        run_id: run.id,
+        ha_response: r.data,
+      });
+    },
+  );
+
+  addRoute(
+    "DELETE",
+    "/api/v1/channels/ha/scenes/:id",
+    async ({ res, params }) => {
+      const id = assertHaObjectId(params.id, "scene");
+      const { haUrl, llat } = await loadHaCredentials();
+      const r = await callHaRest({
+        haUrl,
+        llat,
+        method: "DELETE",
+        path: `/api/config/scene/config/${encodeURIComponent(id)}`,
+      });
+      if (!r.ok) {
+        insertHaRun({
+          kind: "scene_delete",
+          domain: "scene",
+          service: null,
+          entity_id: `scene.${id}`,
+          decision_ref: "",
+          payload: null,
+          outcome: "error",
+          ha_response: r.data,
+          error: r.detail,
+        });
+        if (r.status === 404) {
+          throw new NotFoundError(`scene ${id} not found in HA`);
+        }
+        throw new ApiError(
+          r.status >= 400 && r.status < 600 ? r.status : 502,
+          "HA_UPSTREAM_ERROR",
+          r.detail,
+        );
+      }
+      const run = insertHaRun({
+        kind: "scene_delete",
+        domain: "scene",
+        service: null,
+        entity_id: `scene.${id}`,
+        decision_ref: "",
+        payload: null,
+        outcome: "ok",
+        ha_response: r.data,
+        error: null,
+      });
+      sendJson(res, 200, {
+        ok: true,
+        scene_id: id,
+        run_id: run.id,
+        ha_response: r.data,
+      });
+    },
+  );
+
+  // ──────────────────────────────────────────────────────────────────────
+  // SCRIPTS
+  // ──────────────────────────────────────────────────────────────────────
+
+  addRoute("GET", "/api/v1/channels/ha/scripts", async ({ res }) => {
+    const { haUrl, llat } = await loadHaCredentials();
+    const r = await callHaRest({
+      haUrl,
+      llat,
+      method: "GET",
+      path: "/api/states",
+    });
+    if (!r.ok) {
+      throw new ApiError(
+        r.status >= 400 && r.status < 600 ? r.status : 502,
+        "HA_UPSTREAM_ERROR",
+        r.detail,
+      );
+    }
+    sendJson(res, 200, {
+      ok: true,
+      data: filterStatesByDomain(r.data, "script"),
+    });
+  });
+
+  addRoute("GET", "/api/v1/channels/ha/scripts/:id", async ({ res, params }) => {
+    const id = assertHaObjectId(params.id, "script");
+    const { haUrl, llat } = await loadHaCredentials();
+    const r = await callHaRest({
+      haUrl,
+      llat,
+      method: "GET",
+      path: `/api/config/script/config/${encodeURIComponent(id)}`,
+    });
+    if (!r.ok) {
+      if (r.status === 404) {
+        throw new NotFoundError(`script ${id} not found in HA`);
+      }
+      throw new ApiError(
+        r.status >= 400 && r.status < 600 ? r.status : 502,
+        "HA_UPSTREAM_ERROR",
+        r.detail,
+      );
+    }
+    sendJson(res, 200, { ok: true, script_id: id, data: r.data });
+  });
+
+  addRoute("POST", "/api/v1/channels/ha/scripts", async ({ res, body }) => {
+    const parsed = parseScriptCreateBody(body);
+    const { haUrl, llat } = await loadHaCredentials();
+    const scriptId = slugify(parsed.alias) || `script_${Date.now()}`;
+    const payload = scriptCreatePayload(parsed);
+    const r = await callHaRest({
+      haUrl,
+      llat,
+      method: "POST",
+      path: `/api/config/script/config/${encodeURIComponent(scriptId)}`,
+      body: payload,
+    });
+    if (!r.ok) {
+      insertHaRun({
+        kind: "script_create",
+        domain: "script",
+        service: null,
+        entity_id: `script.${scriptId}`,
+        decision_ref: "",
+        payload,
+        outcome: "error",
+        ha_response: r.data,
+        error: r.detail,
+      });
+      throw new ApiError(
+        r.status >= 400 && r.status < 600 ? r.status : 502,
+        "HA_UPSTREAM_ERROR",
+        r.detail,
+      );
+    }
+    const run = insertHaRun({
+      kind: "script_create",
+      domain: "script",
+      service: null,
+      entity_id: `script.${scriptId}`,
+      decision_ref: "",
+      payload,
+      outcome: "ok",
+      ha_response: r.data,
+      error: null,
+    });
+    sendJson(res, 200, {
+      ok: true,
+      script_id: scriptId,
+      run_id: run.id,
+      ha_response: r.data,
+    });
+  });
+
+  addRoute(
+    "PUT",
+    "/api/v1/channels/ha/scripts/:id",
+    async ({ res, params, body }) => {
+      const id = assertHaObjectId(params.id, "script");
+      const parsed = parseScriptUpdateBody(body);
+      const { haUrl, llat } = await loadHaCredentials();
+      const payload = scriptUpdatePayload(parsed);
+      const r = await callHaRest({
+        haUrl,
+        llat,
+        method: "POST",
+        path: `/api/config/script/config/${encodeURIComponent(id)}`,
+        body: payload,
+      });
+      if (!r.ok) {
+        insertHaRun({
+          kind: "script_update",
+          domain: "script",
+          service: null,
+          entity_id: `script.${id}`,
+          decision_ref: "",
+          payload,
+          outcome: "error",
+          ha_response: r.data,
+          error: r.detail,
+        });
+        throw new ApiError(
+          r.status >= 400 && r.status < 600 ? r.status : 502,
+          "HA_UPSTREAM_ERROR",
+          r.detail,
+        );
+      }
+      const run = insertHaRun({
+        kind: "script_update",
+        domain: "script",
+        service: null,
+        entity_id: `script.${id}`,
+        decision_ref: "",
+        payload,
+        outcome: "ok",
+        ha_response: r.data,
+        error: null,
+      });
+      sendJson(res, 200, {
+        ok: true,
+        script_id: id,
+        run_id: run.id,
+        ha_response: r.data,
+      });
+    },
+  );
+
+  addRoute(
+    "DELETE",
+    "/api/v1/channels/ha/scripts/:id",
+    async ({ res, params }) => {
+      const id = assertHaObjectId(params.id, "script");
+      const { haUrl, llat } = await loadHaCredentials();
+      const r = await callHaRest({
+        haUrl,
+        llat,
+        method: "DELETE",
+        path: `/api/config/script/config/${encodeURIComponent(id)}`,
+      });
+      if (!r.ok) {
+        insertHaRun({
+          kind: "script_delete",
+          domain: "script",
+          service: null,
+          entity_id: `script.${id}`,
+          decision_ref: "",
+          payload: null,
+          outcome: "error",
+          ha_response: r.data,
+          error: r.detail,
+        });
+        if (r.status === 404) {
+          throw new NotFoundError(`script ${id} not found in HA`);
+        }
+        throw new ApiError(
+          r.status >= 400 && r.status < 600 ? r.status : 502,
+          "HA_UPSTREAM_ERROR",
+          r.detail,
+        );
+      }
+      const run = insertHaRun({
+        kind: "script_delete",
+        domain: "script",
+        service: null,
+        entity_id: `script.${id}`,
+        decision_ref: "",
+        payload: null,
+        outcome: "ok",
+        ha_response: r.data,
+        error: null,
+      });
+      sendJson(res, 200, {
+        ok: true,
+        script_id: id,
+        run_id: run.id,
+        ha_response: r.data,
+      });
+    },
+  );
+}
+
+// === END #115 PR3 ═══════════════════════════════════════════════════════

--- a/packages/ctrl/tests/channels_ha_pr3.test.ts
+++ b/packages/ctrl/tests/channels_ha_pr3.test.ts
@@ -1,0 +1,594 @@
+// /api/v1/channels/ha/{automations,scenes,scripts}/* — #115 PR3 CRUD.
+//
+// REST-only (no WS dependency). Spec doc:
+//   docs/specs/issue-115-ha-tier4-autonomy.md §4 (gate matrix locked YES).
+//
+// Coverage (10 round-trip tests):
+//   1.  automations: list → 200 + array
+//   2.  automations: create → 200 + automation_id slug + ha_run row
+//   3.  automations: update via PUT → 200 + ha_run row
+//   4.  automations: DELETE WITHOUT decision_ref → 400 VALIDATION_ERROR + no HA call
+//   5.  automations: DELETE WITH valid decision_ref → 200 + decision_ref in ha_run
+//   6.  scenes: create → 200 + scene_id slug + ha_run row
+//   7.  scenes: DELETE → 200 (no gate)
+//   8.  scripts: create → 200 + script_id slug + ha_run row
+//   9.  scripts: update via PUT → 200 + ha_run row
+//   10. all writes blocked when HA_NOT_CONNECTED → 409
+//
+// The HA REST surface is mocked via globalThis.fetch — same pattern as
+// channels_ha_pr4.test.ts. The vault-cli stub serves the LLAT.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ServerResponse } from "node:http";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "channels-ha-pr3-"));
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.VAULT_PATH = path.join(tmp, "vault");
+process.env.STATE_DB_PATH = path.join(tmp, "alfred-state.db");
+process.env.INGEST_DB_PATH = path.join(tmp, "ingest.db");
+process.env.SQLITE_VEC_PATH = "";
+process.env.VAULT_CLI_URL = "http://vault-cli-stub:8087";
+process.env.HA_VAULTWARDEN_FOLDER = "Home Assistant";
+process.env.HA_LLAT_ITEM = "LLAT";
+process.env.HA_PROBE_TIMEOUT_MS = "5000";
+process.env.HA_WRITE_TIMEOUT_MS = "5000";
+process.env.HA_LOOP_GUARD_COOLDOWN_MS = "60000";
+process.env.HA_WS_URL_OVERRIDE = "skip"; // bypass real WS connect in tests
+
+const VALID_LLAT = "llat_TEST_" + "0".repeat(40);
+const HA_URL = "http://homeassistant.local:8123";
+const HA_VERSION = "2025.6.1";
+
+// ── fetch mock ─────────────────────────────────────────────────────────
+
+interface VaultItem {
+  id: string;
+  name: string;
+  type: 1;
+  folderId: string | null;
+  login: { username: string | null; password: string; uris: unknown[] };
+}
+interface VaultFolder {
+  id: string;
+  name: string;
+}
+let vaultStore: VaultItem[] = [];
+let vaultFolders: VaultFolder[] = [];
+
+// HA mock state. Each test resets in beforeEach.
+let haConfigGetMap: Map<string, string | null> = new Map();
+let haConfigShouldFail = false;
+let haStates: unknown[] = [];
+const haCalls: { url: string; method: string; body: string | undefined }[] = [];
+
+function makeJsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+function makeTextResponse(body: string, status = 200): Response {
+  return new Response(body, {
+    status,
+    headers: { "content-type": "text/plain" },
+  });
+}
+
+globalThis.fetch = (async (input: any, init?: any) => {
+  const url = typeof input === "string" ? input : (input?.url ?? String(input));
+  const method = (init?.method ?? "GET").toUpperCase();
+  const bodyRaw = init?.body !== undefined ? String(init.body) : undefined;
+  haCalls.push({ url, method, body: bodyRaw });
+
+  // HA /api/ auth gate.
+  if (url === `${HA_URL}/api/` && method === "GET") {
+    return makeJsonResponse({ message: "API running." }, 200);
+  }
+  // HA /api/config — used by /connect.
+  if (url === `${HA_URL}/api/config` && method === "GET") {
+    return makeJsonResponse({ version: HA_VERSION }, 200);
+  }
+
+  // HA /api/states — for scenes/scripts list.
+  if (url === `${HA_URL}/api/states` && method === "GET") {
+    return makeJsonResponse(haStates, 200);
+  }
+
+  // HA /api/config/{automation,scene,script}/config (list) and /:id (get/post/delete).
+  const cfgListMatch = url.match(
+    /^http:\/\/homeassistant\.local:8123\/api\/config\/(automation|scene|script)\/config$/,
+  );
+  if (cfgListMatch && method === "GET") {
+    if (haConfigShouldFail) {
+      return makeJsonResponse({ error: "boom" }, 500);
+    }
+    const kind = cfgListMatch[1];
+    const entries: unknown[] = [];
+    for (const [key, val] of haConfigGetMap.entries()) {
+      if (key.startsWith(`${kind}:`) && val !== null) {
+        try {
+          entries.push({ id: key.slice(kind.length + 1), ...JSON.parse(val) });
+        } catch {
+          // skip
+        }
+      }
+    }
+    return makeJsonResponse(entries, 200);
+  }
+  const cfgIdMatch = url.match(
+    /^http:\/\/homeassistant\.local:8123\/api\/config\/(automation|scene|script)\/config\/([^/?]+)$/,
+  );
+  if (cfgIdMatch) {
+    const kind = cfgIdMatch[1];
+    const id = decodeURIComponent(cfgIdMatch[2]);
+    const key = `${kind}:${id}`;
+    if (method === "GET") {
+      const v = haConfigGetMap.get(key);
+      if (v === null || v === undefined) {
+        return makeJsonResponse({ error: "not found" }, 404);
+      }
+      return makeTextResponse(v, 200);
+    }
+    if (method === "POST") {
+      // Persist whatever was sent so subsequent GETs reflect it.
+      haConfigGetMap.set(key, bodyRaw ?? "");
+      return makeJsonResponse({ result: "ok" }, 200);
+    }
+    if (method === "DELETE") {
+      if (!haConfigGetMap.has(key)) {
+        return makeJsonResponse({ error: "not found" }, 404);
+      }
+      haConfigGetMap.delete(key);
+      return makeJsonResponse({ result: "ok" }, 200);
+    }
+  }
+
+  // vault-cli folders.
+  if (url.endsWith("/list/object/folders") && method === "GET") {
+    return makeJsonResponse({ success: true, data: { data: vaultFolders } });
+  }
+  if (url.endsWith("/object/folder") && method === "POST") {
+    const b = JSON.parse(bodyRaw ?? "{}");
+    const f: VaultFolder = {
+      id: "fld-" + String(Date.now()) + "-" + Math.random().toString(36).slice(2, 6),
+      name: b.name,
+    };
+    vaultFolders.push(f);
+    // bw serve single-object endpoints are SINGLE-wrapped per #157.
+    return makeJsonResponse({ success: true, data: f });
+  }
+  // vault-cli items.
+  if (url.includes("/list/object/items")) {
+    const qIdx = url.indexOf("?");
+    const params = new URLSearchParams(qIdx >= 0 ? url.slice(qIdx + 1) : "");
+    const search = params.get("search") ?? "";
+    const filtered = search
+      ? vaultStore.filter((i) => i.name.toLowerCase().includes(search.toLowerCase()))
+      : vaultStore.slice();
+    return makeJsonResponse({ success: true, data: { data: filtered } });
+  }
+  const objMatch = url.match(/\/object\/item\/([^/?]+)/);
+  if (objMatch && method === "GET") {
+    const id = objMatch[1];
+    const item = vaultStore.find((i) => i.id === id);
+    if (!item) return makeJsonResponse({ success: false, message: "not found" }, 404);
+    // single-object GET — bw serve responds with single-wrap envelope
+    // (PR #157 fix lives in vault-cli helper read path; we match the
+    // current production shape).
+    return makeJsonResponse({ success: true, data: item });
+  }
+  if (url.endsWith("/object/item") && method === "POST") {
+    const b = JSON.parse(bodyRaw ?? "{}");
+    const id = "id-" + String(Date.now()) + "-" + Math.random().toString(36).slice(2, 8);
+    const item: VaultItem = {
+      id,
+      name: b.name,
+      type: 1,
+      folderId: b.folderId ?? null,
+      login: {
+        username: b.login?.username ?? null,
+        password: b.login?.password ?? "",
+        uris: b.login?.uris ?? [],
+      },
+    };
+    vaultStore.push(item);
+    // bw serve single-object endpoints are SINGLE-wrapped per #157.
+    return makeJsonResponse({ success: true, data: item });
+  }
+  if (objMatch && method === "PUT") {
+    const id = objMatch[1];
+    const idx = vaultStore.findIndex((i) => i.id === id);
+    if (idx < 0) return makeJsonResponse({ success: false, message: "not found" }, 404);
+    const b = JSON.parse(bodyRaw ?? "{}");
+    vaultStore[idx] = {
+      ...vaultStore[idx],
+      name: b.name ?? vaultStore[idx].name,
+      folderId: b.folderId ?? vaultStore[idx].folderId,
+      login: { ...vaultStore[idx].login, ...(b.login ?? {}) },
+    };
+    return makeJsonResponse({ success: true, data: vaultStore[idx] });
+  }
+  if (objMatch && method === "DELETE") {
+    const id = objMatch[1];
+    const idx = vaultStore.findIndex((i) => i.id === id);
+    if (idx < 0) return makeJsonResponse({ success: false, message: "not found" }, 404);
+    vaultStore.splice(idx, 1);
+    return makeJsonResponse({ success: true });
+  }
+  throw new Error(`unexpected fetch in test_channels_ha_pr3: ${method} ${url}`);
+}) as typeof fetch;
+
+// ── module imports (after env + fetch are wired) ──────────────────────
+
+const { registerChannelsHaRoutes } = await import(
+  "../src/api/routes/channels_ha.js"
+);
+const { matchRoute } = await import("../src/api/server.js");
+const { handleError } = await import("../src/api/errors.js");
+const { getStateDb } = await import("../src/db/state.js");
+
+registerChannelsHaRoutes();
+
+interface CallResult {
+  status: number;
+  payload: any;
+}
+async function call(
+  method: string,
+  p: string,
+  body?: unknown,
+): Promise<CallResult> {
+  const m = matchRoute(method, p);
+  assert.ok(m, `${method} ${p} must be registered`);
+  let status = 0;
+  let payload: any;
+  const res = {
+    statusCode: 0,
+    setHeader() {},
+    writeHead(c: number) {
+      status = c;
+      return res;
+    },
+    end(j?: string) {
+      payload = j ? JSON.parse(j) : undefined;
+    },
+  } as unknown as ServerResponse;
+  try {
+    await m!.handler({
+      req: { method, headers: {}, url: p } as any,
+      res,
+      params: m!.params,
+      body,
+      query: new URLSearchParams(),
+    });
+  } catch (err) {
+    handleError(res, err);
+  }
+  return { status, payload };
+}
+
+async function connectHa(): Promise<void> {
+  const r = await call("POST", "/api/v1/channels/ha/connect", {
+    ha_url: HA_URL,
+    llat: VALID_LLAT,
+    label: "Test",
+  });
+  assert.equal(r.status, 200, JSON.stringify(r.payload));
+}
+
+// ── tests ──────────────────────────────────────────────────────────────
+
+describe("/api/v1/channels/ha/{automations,scenes,scripts} — #115 PR3", () => {
+  beforeEach(() => {
+    vaultStore = [];
+    vaultFolders = [];
+    haCalls.length = 0;
+    haConfigGetMap = new Map();
+    haConfigShouldFail = false;
+    haStates = [];
+    const db = getStateDb();
+    try {
+      db.prepare("DELETE FROM ha_connection").run();
+      db.prepare("DELETE FROM ha_run").run();
+    } catch {
+      // first run before any table exists
+    }
+  });
+
+  // ── 1 ── automations list
+  it("GET /automations → 200 + array (passes through HA list)", async () => {
+    await connectHa();
+    haConfigGetMap.set(
+      "automation:morning_routine",
+      JSON.stringify({
+        alias: "Morning routine",
+        trigger: { platform: "time", at: "06:30" },
+        action: { service: "light.turn_on", target: { area_id: "kitchen" } },
+      }),
+    );
+
+    const r = await call("GET", "/api/v1/channels/ha/automations");
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.ok, true);
+    assert.ok(Array.isArray(r.payload.data));
+    assert.equal(r.payload.data.length, 1);
+    assert.equal(r.payload.data[0].alias, "Morning routine");
+  });
+
+  // ── 2 ── automation create — happy path
+  it("POST /automations → 200 + slug-derived automation_id + ha_run", async () => {
+    await connectHa();
+
+    const r = await call("POST", "/api/v1/channels/ha/automations", {
+      alias: "Lights off at sunrise",
+      trigger: { platform: "sun", event: "sunrise" },
+      action: { service: "light.turn_off", target: { area_id: "living_room" } },
+    });
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.ok, true);
+    assert.equal(r.payload.automation_id, "lights_off_at_sunrise");
+    assert.ok(typeof r.payload.run_id === "string" && r.payload.run_id.length > 0);
+
+    // ha_run row exists with the expected shape.
+    const run = getStateDb()
+      .prepare("SELECT * FROM ha_run WHERE id = ?")
+      .get(r.payload.run_id) as any;
+    assert.ok(run, "ha_run row must exist");
+    assert.equal(run.kind, "automation_create");
+    assert.equal(run.entity_id, "automation.lights_off_at_sunrise");
+    assert.equal(run.outcome, "ok");
+    // decision_ref is empty string (no gate on create); the schema's column
+    // is NOT NULL but accepts empty strings.
+    assert.equal(run.decision_ref, "");
+
+    // HA was actually called.
+    assert.ok(
+      haCalls.some(
+        (c) =>
+          c.method === "POST" &&
+          c.url ===
+            `${HA_URL}/api/config/automation/config/lights_off_at_sunrise`,
+      ),
+    );
+  });
+
+  // ── 3 ── automation update via PUT
+  it("PUT /automations/:id → 200 + ha_run row carries kind=automation_update", async () => {
+    await connectHa();
+    // Pre-existing config so HA's POST upsert is sensible.
+    haConfigGetMap.set(
+      "automation:morning_routine",
+      JSON.stringify({ alias: "Morning routine", trigger: [], action: [] }),
+    );
+
+    const r = await call(
+      "PUT",
+      "/api/v1/channels/ha/automations/morning_routine",
+      {
+        alias: "Morning routine v2",
+        action: { service: "light.turn_on", target: { area_id: "kitchen" } },
+      },
+    );
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.automation_id, "morning_routine");
+
+    const run = getStateDb()
+      .prepare("SELECT * FROM ha_run WHERE id = ?")
+      .get(r.payload.run_id) as any;
+    assert.equal(run.kind, "automation_update");
+    assert.equal(run.entity_id, "automation.morning_routine");
+    assert.equal(run.outcome, "ok");
+  });
+
+  // ── 4 ── automation DELETE without decision_ref → 400
+  it("DELETE /automations/:id WITHOUT decision_ref → 400 VALIDATION_ERROR, no HA call", async () => {
+    await connectHa();
+    haConfigGetMap.set(
+      "automation:drop_me",
+      JSON.stringify({ alias: "Drop me", trigger: [], action: [] }),
+    );
+    haCalls.length = 0;
+
+    const r = await call(
+      "DELETE",
+      "/api/v1/channels/ha/automations/drop_me",
+      {},
+    );
+    assert.equal(r.status, 400, JSON.stringify(r.payload));
+    assert.equal(r.payload.error.code, "VALIDATION_ERROR");
+
+    // No HA DELETE was fired.
+    assert.equal(
+      haCalls.filter(
+        (c) =>
+          c.method === "DELETE" && c.url.includes("/api/config/automation/"),
+      ).length,
+      0,
+    );
+
+    // The automation is still in the mock store (delete did not happen).
+    assert.ok(haConfigGetMap.has("automation:drop_me"));
+  });
+
+  // ── 5 ── automation DELETE with valid decision_ref → 200
+  it("DELETE /automations/:id with valid decision_ref → 200 + ha_run carries decision_ref", async () => {
+    await connectHa();
+    haConfigGetMap.set(
+      "automation:drop_me",
+      JSON.stringify({ alias: "Drop me", trigger: [], action: [] }),
+    );
+
+    const r = await call(
+      "DELETE",
+      "/api/v1/channels/ha/automations/drop_me",
+      { decision_ref: "decision/2026-05-29-drop-me.md" },
+    );
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.ok, true);
+    assert.equal(r.payload.automation_id, "drop_me");
+    assert.equal(r.payload.decision_ref, "decision/2026-05-29-drop-me.md");
+
+    const run = getStateDb()
+      .prepare("SELECT * FROM ha_run WHERE id = ?")
+      .get(r.payload.run_id) as any;
+    assert.equal(run.kind, "automation_delete");
+    assert.equal(run.entity_id, "automation.drop_me");
+    assert.equal(run.outcome, "ok");
+    assert.equal(run.decision_ref, "decision/2026-05-29-drop-me.md");
+
+    // HA delete actually fired.
+    assert.ok(
+      haCalls.some(
+        (c) =>
+          c.method === "DELETE" &&
+          c.url === `${HA_URL}/api/config/automation/config/drop_me`,
+      ),
+    );
+
+    // Mock store no longer has the automation.
+    assert.equal(haConfigGetMap.has("automation:drop_me"), false);
+  });
+
+  // ── 6 ── scene create — no gate, cheap
+  it("POST /scenes → 200 + slug scene_id + ha_run kind=scene_create", async () => {
+    await connectHa();
+
+    const r = await call("POST", "/api/v1/channels/ha/scenes", {
+      name: "Bedtime",
+      entities: {
+        "light.bedroom_main": { state: "on", brightness_pct: 15 },
+        "light.living_room_lamp": { state: "off" },
+      },
+      icon: "mdi:weather-night",
+    });
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.ok, true);
+    assert.equal(r.payload.scene_id, "bedtime");
+
+    const run = getStateDb()
+      .prepare("SELECT * FROM ha_run WHERE id = ?")
+      .get(r.payload.run_id) as any;
+    assert.equal(run.kind, "scene_create");
+    assert.equal(run.entity_id, "scene.bedtime");
+    assert.equal(run.outcome, "ok");
+    // No gate, no decision_ref required → recorded as empty string.
+    assert.equal(run.decision_ref, "");
+  });
+
+  // ── 7 ── scene DELETE — no gate, cheap
+  it("DELETE /scenes/:id (no gate, no decision_ref) → 200 + ha_run kind=scene_delete", async () => {
+    await connectHa();
+    haConfigGetMap.set(
+      "scene:bedtime",
+      JSON.stringify({ name: "Bedtime", entities: {} }),
+    );
+
+    const r = await call(
+      "DELETE",
+      "/api/v1/channels/ha/scenes/bedtime",
+    );
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.scene_id, "bedtime");
+
+    const run = getStateDb()
+      .prepare("SELECT * FROM ha_run WHERE id = ?")
+      .get(r.payload.run_id) as any;
+    assert.equal(run.kind, "scene_delete");
+    assert.equal(run.entity_id, "scene.bedtime");
+    assert.equal(run.outcome, "ok");
+
+    // Mock store no longer has the scene.
+    assert.equal(haConfigGetMap.has("scene:bedtime"), false);
+  });
+
+  // ── 8 ── script create — no gate, cheap
+  it("POST /scripts → 200 + slug script_id + ha_run kind=script_create", async () => {
+    await connectHa();
+
+    const r = await call("POST", "/api/v1/channels/ha/scripts", {
+      alias: "Goodnight",
+      sequence: [
+        { service: "scene.turn_on", target: { entity_id: "scene.bedtime" } },
+        { delay: "00:05:00" },
+        { service: "lock.lock", target: { entity_id: "lock.front_door" } },
+      ],
+    });
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.script_id, "goodnight");
+
+    const run = getStateDb()
+      .prepare("SELECT * FROM ha_run WHERE id = ?")
+      .get(r.payload.run_id) as any;
+    assert.equal(run.kind, "script_create");
+    assert.equal(run.entity_id, "script.goodnight");
+    assert.equal(run.outcome, "ok");
+
+    // HA was actually called with the alias body.
+    const haPost = haCalls.find(
+      (c) =>
+        c.method === "POST" &&
+        c.url === `${HA_URL}/api/config/script/config/goodnight`,
+    );
+    assert.ok(haPost, "HA POST must have fired");
+    const sent = JSON.parse(haPost!.body!);
+    assert.equal(sent.alias, "Goodnight");
+    assert.equal(Array.isArray(sent.sequence), true);
+    assert.equal(sent.sequence.length, 3);
+  });
+
+  // ── 9 ── script update via PUT
+  it("PUT /scripts/:id → 200 + ha_run kind=script_update", async () => {
+    await connectHa();
+    haConfigGetMap.set(
+      "script:goodnight",
+      JSON.stringify({ alias: "Goodnight", sequence: [] }),
+    );
+
+    const r = await call(
+      "PUT",
+      "/api/v1/channels/ha/scripts/goodnight",
+      { sequence: [{ delay: "00:01:00" }] },
+    );
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.script_id, "goodnight");
+
+    const run = getStateDb()
+      .prepare("SELECT * FROM ha_run WHERE id = ?")
+      .get(r.payload.run_id) as any;
+    assert.equal(run.kind, "script_update");
+    assert.equal(run.entity_id, "script.goodnight");
+    assert.equal(run.outcome, "ok");
+  });
+
+  // ── 10 ── all writes 409 when HA_NOT_CONNECTED
+  it("all writes blocked when HA_NOT_CONNECTED → 409", async () => {
+    // Deliberately NOT connecting first — the ha_connection row is empty.
+    const cases: Array<[string, string, unknown]> = [
+      ["POST", "/api/v1/channels/ha/automations", { alias: "x", trigger: {}, action: {} }],
+      ["PUT", "/api/v1/channels/ha/automations/x", { alias: "x" }],
+      [
+        "DELETE",
+        "/api/v1/channels/ha/automations/x",
+        { decision_ref: "decision/2026-05-29-x.md" },
+      ],
+      ["POST", "/api/v1/channels/ha/scenes", { name: "x", entities: {} }],
+      ["PUT", "/api/v1/channels/ha/scenes/x", { name: "x" }],
+      ["DELETE", "/api/v1/channels/ha/scenes/x", undefined],
+      ["POST", "/api/v1/channels/ha/scripts", { alias: "x", sequence: [] }],
+      ["PUT", "/api/v1/channels/ha/scripts/x", { alias: "x" }],
+      ["DELETE", "/api/v1/channels/ha/scripts/x", undefined],
+    ];
+    for (const [method, p, body] of cases) {
+      const r = await call(method, p, body);
+      assert.equal(
+        r.status,
+        409,
+        `${method} ${p} should 409 when HA not connected; got ${JSON.stringify(r.payload)}`,
+      );
+    }
+  });
+});

--- a/packages/mcp-server/skills/alfred-mcp-skill.md
+++ b/packages/mcp-server/skills/alfred-mcp-skill.md
@@ -55,6 +55,15 @@ The catalogue is intentionally narrow. Container restarts, credential rotation, 
 
 - `notify_principal` — send Sir a message on his preferred channel (Telegram, Slack, …)
 
+### Home Assistant — Tier 4 (#115 PR3, automations / scenes / scripts CRUD)
+
+- `ha__list_automations_full` — pull the full automation configs (trigger / condition / action), not the slim registry index
+- `ha__create_automation` — new automation; no gate (Sir can disable in HA UI)
+- `ha__update_automation` — replace existing automation; no gate
+- `ha__delete_automation` — GATED: `decision_ref` required (irreversible without backup)
+- `ha__create_scene` / `ha__update_scene` / `ha__delete_scene` — scenes are cheap; no gates
+- `ha__create_script` / `ha__update_script` / `ha__delete_script` — scripts are cheap; no gates
+
 ### DM pairing (1)
 
 - `approve_device` — approve a pending Hermes DM-pairing code by `platform` + `code` (the only pairing op exposed here)
@@ -113,6 +122,25 @@ The common task queue on the learn package is `alfred-learn`. If Sir doesn't kno
 ### "Approve my Telegram / Slack pairing"
 
 `approve_device({platform: "telegram", code: "<8-char code from Sir's pairing screen>"})`. Hermes hands an unknown messaging account a one-hour pairing code; this approves it so the conversation can reach Alfred. This is the ONLY pairing operation exposed — revoke / clear-pending are not, by design.
+
+### "Author a bedtime scene" / "Set up a sunrise automation"
+
+The tier-4 surface (#115 PR3) lets Alfred CRUD HA automations / scenes / scripts directly — no Sir-side clicking through HA's UI. Two example flows:
+
+**Bedtime scene from a Desk observation:**
+1. `ha__list_areas` — confirm the bedroom area_id.
+2. `ha__list_entities({area: "bedroom"})` — read the bedroom lights / climate entities.
+3. `ha__create_scene({name: "Bedtime", entities: {"light.bedroom_main": {state: "on", brightness_pct: 15}, "light.living_room_lamp": {state: "off"}, "climate.bedroom": {temperature: 19}}, icon: "mdi:weather-night"})`.
+4. Confirm to Sir: "Scene created — `scene.bedtime`. Triggering it dims the bedroom to 15%, turns off the lamp, sets the thermostat to 19°."
+
+**Sunrise automation from an observation Sir approved:**
+1. `ha__list_automations_full` — make sure there isn't already a sunrise automation (don't double-up).
+2. `ha__create_automation({alias: "Lights off at sunrise", trigger: {platform: "sun", event: "sunrise"}, action: {service: "light.turn_off", target: {area_id: "living_room"}}, description: "Created by Alfred — observation 2026-05-29 a.m."})`.
+3. The automation is created in the OFF state by default — confirm with Sir before flipping `initial_state: "on"`.
+
+**Removing a stale automation (GATED):**
+1. `ha__list_automations_full` — read its YAML first, store a backup in a `decision/` vault record if Sir might want it back.
+2. `ha__delete_automation({automation_id: "old_routine", decision_ref: "decision/2026-05-29-drop-old-routine.md"})`. `decision_ref` is REQUIRED — Alfred refuses without it.
 
 ---
 

--- a/packages/mcp-server/src/tools/hass.test.ts
+++ b/packages/mcp-server/src/tools/hass.test.ts
@@ -26,17 +26,18 @@ function getTool(name: string) {
 
 // ─── catalogue shape ────────────────────────────────────────────────────
 
-test("hass catalogue: exactly 16 tools (11 read + 5 PR3 placeholders)", () => {
+test("hass catalogue: exactly 26 tools (11 read + 5 PR4 writes + 10 PR3 CRUD)", () => {
   assert.equal(HASS_READ_TOOLS.length, 11);
-  assert.equal(HASS_DEFERRED_TOOLS.length, 5);
-  assert.equal(ALL_HASS_TOOLS.length, 16);
+  // After #115 PR3 splice: PR4's 5 + PR3's 10 = 15 writes.
+  assert.equal(HASS_DEFERRED_TOOLS.length, 15);
+  assert.equal(ALL_HASS_TOOLS.length, 26);
 });
 
-test("registry: hass is a supported app and registers all 16 tools", () => {
+test("registry: hass is a supported app and registers all 26 tools", () => {
   assert.ok(isAppId("hass"));
   assert.ok((SUPPORTED_APPS as Set<string>).has("hass"));
   const tools = getToolsForApp("hass");
-  assert.equal(tools.length, 16);
+  assert.equal(tools.length, 26);
 });
 
 test("hass: every tool name is unique", () => {
@@ -530,4 +531,281 @@ test("ha__list_entities buildRequest shape mocks cleanly against a fake fetch", 
   // helpers.ts/toolResult takes.
   const text = JSON.stringify(mockResponse, null, 2);
   assert.ok(text.includes("light.kitchen_main"));
+});
+
+// ─── #115 PR3 — automations / scenes / scripts CRUD ─────────────────────
+//
+// 15 tests covering tool registration + schema validation +
+// buildRequest shape for the 10 new CRUD tools. Hits the contract that
+// `packages/ctrl/src/api/routes/channels_ha.ts` implements at
+// `/api/v1/channels/ha/{automations,scenes,scripts}`.
+
+const PR3_TOOL_NAMES = [
+  "ha__list_automations_full",
+  "ha__create_automation",
+  "ha__update_automation",
+  "ha__delete_automation",
+  "ha__create_scene",
+  "ha__update_scene",
+  "ha__delete_scene",
+  "ha__create_script",
+  "ha__update_script",
+  "ha__delete_script",
+];
+
+test("#115 PR3: all 10 CRUD tool names exist + begin with ha__", () => {
+  for (const name of PR3_TOOL_NAMES) {
+    const t = ALL_HASS_TOOLS.find((x) => x.name === name);
+    assert.ok(t, `${name} missing from ALL_HASS_TOOLS`);
+    assert.ok(name.startsWith("ha__"));
+  }
+});
+
+test("#115 PR3: ha__list_automations_full → GET /automations", () => {
+  const t = getTool("ha__list_automations_full");
+  assert.equal(t.inputSchema.safeParse({}).success, true);
+  const req = t.buildRequest({});
+  assert.equal(req.method, "GET");
+  assert.equal(req.path, "/api/v1/channels/ha/automations");
+});
+
+test("#115 PR3: ha__create_automation accepts {alias, trigger, action} minimal", () => {
+  const t = getTool("ha__create_automation");
+  assert.equal(t.inputSchema.safeParse({}).success, false);
+  assert.equal(
+    t.inputSchema.safeParse({
+      alias: "Lights off sunrise",
+      trigger: { platform: "sun", event: "sunrise" },
+      action: { service: "light.turn_off", target: { area_id: "living_room" } },
+    }).success,
+    true,
+  );
+});
+
+test("#115 PR3: ha__create_automation builds POST /automations with full body", () => {
+  const t = getTool("ha__create_automation");
+  const req = t.buildRequest({
+    alias: "Lights off sunrise",
+    trigger: { platform: "sun", event: "sunrise" },
+    condition: { condition: "state", entity_id: "sun.sun", state: "above_horizon" },
+    action: { service: "light.turn_off", target: { area_id: "living_room" } },
+    description: "Created by Alfred 2026-05-29",
+    mode: "single",
+    initial_state: "off",
+  });
+  assert.equal(req.method, "POST");
+  assert.equal(req.path, "/api/v1/channels/ha/automations");
+  assert.deepEqual(req.body, {
+    alias: "Lights off sunrise",
+    trigger: { platform: "sun", event: "sunrise" },
+    condition: { condition: "state", entity_id: "sun.sun", state: "above_horizon" },
+    action: { service: "light.turn_off", target: { area_id: "living_room" } },
+    description: "Created by Alfred 2026-05-29",
+    mode: "single",
+    initial_state: "off",
+  });
+});
+
+test("#115 PR3: ha__update_automation requires automation_id, builds PUT", () => {
+  const t = getTool("ha__update_automation");
+  assert.equal(t.inputSchema.safeParse({}).success, false);
+  assert.equal(t.inputSchema.safeParse({ alias: "x" }).success, false);
+  assert.equal(
+    t.inputSchema.safeParse({
+      automation_id: "lights_off_sunrise",
+      alias: "Lights off at sunrise",
+    }).success,
+    true,
+  );
+  const req = t.buildRequest({
+    automation_id: "lights_off_sunrise",
+    alias: "Lights off at sunrise",
+    action: { service: "light.turn_off", target: { area_id: "living_room" } },
+  });
+  assert.equal(req.method, "PUT");
+  assert.equal(req.path, "/api/v1/channels/ha/automations/lights_off_sunrise");
+  assert.deepEqual(req.body, {
+    alias: "Lights off at sunrise",
+    action: { service: "light.turn_off", target: { area_id: "living_room" } },
+  });
+});
+
+test("#115 PR3: ha__delete_automation requires decision_ref (gated)", () => {
+  const t = getTool("ha__delete_automation");
+  // automation_id alone — fails (decision_ref REQUIRED for irreversible delete).
+  assert.equal(
+    t.inputSchema.safeParse({ automation_id: "lights_off_sunrise" }).success,
+    false,
+  );
+  // Valid.
+  assert.equal(
+    t.inputSchema.safeParse({
+      automation_id: "lights_off_sunrise",
+      decision_ref: "decision/2026-05-29-drop-sunrise.md",
+    }).success,
+    true,
+  );
+});
+
+test("#115 PR3: ha__delete_automation rejects whitespace / too-short decision_ref", () => {
+  const t = getTool("ha__delete_automation");
+  assert.equal(
+    t.inputSchema.safeParse({
+      automation_id: "x",
+      decision_ref: "abc def",
+    }).success,
+    false,
+  );
+  assert.equal(
+    t.inputSchema.safeParse({
+      automation_id: "x",
+      decision_ref: "abc",
+    }).success,
+    false,
+    "min 6 chars",
+  );
+});
+
+test("#115 PR3: ha__delete_automation DELETE shape carries decision_ref in body", () => {
+  const t = getTool("ha__delete_automation");
+  const req = t.buildRequest({
+    automation_id: "lights_off_sunrise",
+    decision_ref: "decision/2026-05-29-drop-sunrise.md",
+  });
+  assert.equal(req.method, "DELETE");
+  assert.equal(req.path, "/api/v1/channels/ha/automations/lights_off_sunrise");
+  assert.deepEqual(req.body, {
+    decision_ref: "decision/2026-05-29-drop-sunrise.md",
+  });
+});
+
+test("#115 PR3: ha__create_scene accepts {name, entities}, builds POST", () => {
+  const t = getTool("ha__create_scene");
+  assert.equal(t.inputSchema.safeParse({}).success, false);
+  assert.equal(t.inputSchema.safeParse({ name: "Bedtime" }).success, false);
+  assert.equal(
+    t.inputSchema.safeParse({
+      name: "Bedtime",
+      entities: {
+        "light.bedroom_main": { state: "on", brightness_pct: 15 },
+        "light.living_room_lamp": { state: "off" },
+      },
+    }).success,
+    true,
+  );
+  const req = t.buildRequest({
+    name: "Bedtime",
+    entities: {
+      "light.bedroom_main": { state: "on", brightness_pct: 15 },
+    },
+    icon: "mdi:weather-night",
+  });
+  assert.equal(req.method, "POST");
+  assert.equal(req.path, "/api/v1/channels/ha/scenes");
+  assert.deepEqual(req.body, {
+    name: "Bedtime",
+    entities: { "light.bedroom_main": { state: "on", brightness_pct: 15 } },
+    icon: "mdi:weather-night",
+  });
+});
+
+test("#115 PR3: ha__update_scene requires scene_id, builds PUT", () => {
+  const t = getTool("ha__update_scene");
+  assert.equal(t.inputSchema.safeParse({}).success, false);
+  assert.equal(t.inputSchema.safeParse({ name: "x" }).success, false);
+  assert.equal(t.inputSchema.safeParse({ scene_id: "bedtime" }).success, true);
+  const req = t.buildRequest({
+    scene_id: "bedtime",
+    entities: { "light.bedroom_main": { state: "off" } },
+  });
+  assert.equal(req.method, "PUT");
+  assert.equal(req.path, "/api/v1/channels/ha/scenes/bedtime");
+  assert.deepEqual(req.body, {
+    entities: { "light.bedroom_main": { state: "off" } },
+  });
+});
+
+test("#115 PR3: ha__delete_scene requires scene_id, DELETE without body", () => {
+  const t = getTool("ha__delete_scene");
+  assert.equal(t.inputSchema.safeParse({}).success, false);
+  assert.equal(t.inputSchema.safeParse({ scene_id: "bedtime" }).success, true);
+  const req = t.buildRequest({ scene_id: "bedtime" });
+  assert.equal(req.method, "DELETE");
+  assert.equal(req.path, "/api/v1/channels/ha/scenes/bedtime");
+  assert.equal(req.body, undefined);
+});
+
+test("#115 PR3: ha__create_script accepts {alias, sequence}, builds POST", () => {
+  const t = getTool("ha__create_script");
+  assert.equal(t.inputSchema.safeParse({}).success, false);
+  assert.equal(t.inputSchema.safeParse({ alias: "Goodnight" }).success, false);
+  assert.equal(
+    t.inputSchema.safeParse({
+      alias: "Goodnight",
+      sequence: [
+        { service: "scene.turn_on", target: { entity_id: "scene.bedtime" } },
+        { delay: "00:05:00" },
+      ],
+    }).success,
+    true,
+  );
+  const req = t.buildRequest({
+    alias: "Goodnight",
+    sequence: [
+      { service: "scene.turn_on", target: { entity_id: "scene.bedtime" } },
+    ],
+    mode: "single",
+  });
+  assert.equal(req.method, "POST");
+  assert.equal(req.path, "/api/v1/channels/ha/scripts");
+  assert.deepEqual(req.body, {
+    alias: "Goodnight",
+    sequence: [
+      { service: "scene.turn_on", target: { entity_id: "scene.bedtime" } },
+    ],
+    mode: "single",
+  });
+});
+
+test("#115 PR3: ha__update_script requires script_id, builds PUT", () => {
+  const t = getTool("ha__update_script");
+  assert.equal(t.inputSchema.safeParse({}).success, false);
+  assert.equal(t.inputSchema.safeParse({ alias: "x" }).success, false);
+  assert.equal(t.inputSchema.safeParse({ script_id: "goodnight" }).success, true);
+  const req = t.buildRequest({
+    script_id: "goodnight",
+    sequence: [{ delay: "00:01:00" }],
+  });
+  assert.equal(req.method, "PUT");
+  assert.equal(req.path, "/api/v1/channels/ha/scripts/goodnight");
+  assert.deepEqual(req.body, { sequence: [{ delay: "00:01:00" }] });
+});
+
+test("#115 PR3: ha__delete_script DELETE without body", () => {
+  const t = getTool("ha__delete_script");
+  assert.equal(t.inputSchema.safeParse({}).success, false);
+  assert.equal(t.inputSchema.safeParse({ script_id: "goodnight" }).success, true);
+  const req = t.buildRequest({ script_id: "goodnight" });
+  assert.equal(req.method, "DELETE");
+  assert.equal(req.path, "/api/v1/channels/ha/scripts/goodnight");
+  assert.equal(req.body, undefined);
+});
+
+test("#115 PR3: catalogue order — reads first, then all writes (PR4 + PR3 CRUD)", () => {
+  // First 11 must be the 11 reads.
+  for (let i = 0; i < 11; i++) {
+    assert.ok(
+      READ_TOOL_NAMES.includes(ALL_HASS_TOOLS[i].name),
+      `slot ${i} (${ALL_HASS_TOOLS[i].name}) should be a read tool`,
+    );
+  }
+  // Slots 11..25 are writes. PR4's 5 + PR3's 10.
+  const writeNames = ALL_HASS_TOOLS.slice(11).map((t) => t.name);
+  for (const n of WRITE_TOOL_NAMES) {
+    assert.ok(writeNames.includes(n), `${n} missing from write tail`);
+  }
+  for (const n of PR3_TOOL_NAMES) {
+    assert.ok(writeNames.includes(n), `${n} missing from write tail`);
+  }
+  assert.equal(writeNames.length, 15);
 });

--- a/packages/mcp-server/src/tools/hass.ts
+++ b/packages/mcp-server/src/tools/hass.ts
@@ -460,14 +460,370 @@ export const HASS_WRITE_TOOLS: ToolDef[] = [
   },
 ];
 
+// ─── BEGIN #115 PR3 — automations / scenes / scripts CRUD ───────────────
+//
+// 10 new write tools, fronting the REST CRUD that ctrl-api exposes at
+// /api/v1/channels/ha/{automations,scenes,scripts}. The HA REST API for
+// these three surfaces is mature (long-standing /api/config/* endpoints),
+// so unlike the registry CRUD (#115 PR2) these don't need the WS client.
+//
+// Per spec §4 gate matrix — locked YES on 2026-05-29:
+//   * automation_create / automation_update : NO gate (reversible — Sir
+//     can disable in HA UI)
+//   * automation_delete                     : decision_ref REQUIRED
+//   * scene_*                               : NO gate (cheap)
+//   * script_*                              : NO gate (cheap)
+//
+// Snapshots + daybook entries — the ctrl-api side records every write in
+// `ha_run` (today's audit ledger). The richer "daybook vault record" half
+// of the locked YES default arrives in #115 PR1 (WS + daybook helper); we
+// gate-fail-open here and stamp ha_run for now (see ctrl-api comments).
+//
+// Loop guard — automations/scenes/scripts CRUD doesn't loop back through
+// state_changed events (the writes mutate config, they don't trigger
+// entity state). The existing per-entity guard in #110 PR4 still applies
+// transitively (`scene.activate` via call_service / etc.). PR3 CRUD
+// itself bypasses the entity-state guard because the entity it touches is
+// the automation/scene/script config object, not a stateful entity.
+
+const HaAutomationTriggerSchema = z
+  .union([z.record(z.string(), z.unknown()), z.array(z.unknown())])
+  .describe(
+    "HA trigger block(s). Either a single trigger object `{platform: 'time', at: '06:30'}` or an array of triggers. See https://www.home-assistant.io/docs/automation/trigger/ for the supported platforms.",
+  );
+
+const HaAutomationActionSchema = z
+  .union([z.record(z.string(), z.unknown()), z.array(z.unknown())])
+  .describe(
+    "HA action block(s). Either a single action `{service: 'light.turn_on', target: {...}}` or an array of actions. See https://www.home-assistant.io/docs/automation/action/.",
+  );
+
+const HaAutomationConditionSchema = z
+  .union([z.record(z.string(), z.unknown()), z.array(z.unknown())])
+  .describe(
+    "Optional HA condition block(s). Either a single condition or an array — automation only fires when all conditions evaluate true. See https://www.home-assistant.io/docs/automation/condition/.",
+  );
+
+const HA_WRITE_PR3_TOOLS: ToolDef[] = [
+  // ── automations ────────────────────────────────────────────────────────
+
+  {
+    name: "ha__list_automations_full",
+    description:
+      "List every HA automation with its FULL config — alias / trigger / condition / action / mode — NOT the slim registry index `ha__list_automations` returns. Resolves via `GET /api/v1/channels/ha/automations` → REST `GET /api/config/automation/config`. **When to call:** before `ha__update_automation` (to read current trigger/action before patching), before proposing a NEW automation that might overlap an existing one (so you can edit instead of double-up), or when Sir asks 'show me the morning routine — what does it actually do?'. Cheap, idempotent. Returns `[{id, alias, description, mode, trigger, condition, action}, ...]`.",
+    inputSchema: z.object({}),
+    buildRequest: () => ({
+      method: "GET",
+      path: "/api/v1/channels/ha/automations",
+    }),
+  },
+
+  {
+    name: "ha__create_automation",
+    description:
+      "Create a brand-new HA automation. Resolves to `POST /api/v1/channels/ha/automations` → HA REST `POST /api/config/automation/config/<new_id>`. **No approval gate** — create is reversible (Sir disables it in HA UI in 5 seconds). The new automation is created in the OFF state by default unless you explicitly include `initial_state: 'on'` in the body. **Always `ha__list_automations_full` FIRST** so you don't author a third 'morning routine' on top of two existing ones. Example payload: `{alias: 'Lights off when sunny', trigger: {platform: 'sun', event: 'sunrise'}, action: {service: 'light.turn_off', target: {area_id: 'living_room'}}}`. Returns `{ok, automation_id, ha_response}`.",
+    inputSchema: z.object({
+      alias: z
+        .string()
+        .min(1)
+        .describe(
+          "Human-readable name for the automation (shown in HA UI + spoken by Alfred). Must be unique-ish — HA itself doesn't enforce uniqueness, but two automations with the same alias confuse principals.",
+        ),
+      trigger: HaAutomationTriggerSchema,
+      condition: HaAutomationConditionSchema.optional(),
+      action: HaAutomationActionSchema,
+      description: z
+        .string()
+        .optional()
+        .describe(
+          "Optional longer description shown in HA's automation editor. Use this to record WHY Alfred created this automation (which signal / decision / observation).",
+        ),
+      mode: z
+        .enum(["single", "restart", "queued", "parallel"])
+        .optional()
+        .describe(
+          "How HA handles re-trigger while already running. `single` (default) drops re-triggers, `restart` cancels + reruns, `queued` queues them up, `parallel` runs concurrently.",
+        ),
+      initial_state: z
+        .enum(["on", "off"])
+        .optional()
+        .describe(
+          "Optional initial state. Default `off` — the principal turns it on in HA's UI after reviewing. Set `on` only when Alfred is confident the automation is safe to fire immediately.",
+        ),
+    }),
+    buildRequest: ({
+      alias,
+      trigger,
+      condition,
+      action,
+      description,
+      mode,
+      initial_state,
+    }) => ({
+      method: "POST",
+      path: "/api/v1/channels/ha/automations",
+      body: {
+        alias,
+        trigger,
+        ...(condition !== undefined ? { condition } : {}),
+        action,
+        ...(description !== undefined ? { description } : {}),
+        ...(mode !== undefined ? { mode } : {}),
+        ...(initial_state !== undefined ? { initial_state } : {}),
+      },
+    }),
+  },
+
+  {
+    name: "ha__update_automation",
+    description:
+      "Update an existing HA automation by id. Resolves to `PUT /api/v1/channels/ha/automations/:id` (the underlying HA endpoint is idempotent — POST and PUT both upsert at the same URL). **No approval gate** (reversible). **Always `ha__list_automations_full` FIRST** to read the current config — HA's REST does a full-replace, not a patch. Only the fields you pass land; any unset field is wiped. Build the new body from the old one + your edits, don't ship a partial. Example: `{automation_id: 'lights_off_sunrise', alias: 'Lights off at sunrise', trigger: {platform: 'sun', event: 'sunrise'}, action: {service: 'light.turn_off', target: {area_id: 'living_room'}}}`. Returns `{ok, automation_id, ha_response}`.",
+    inputSchema: z.object({
+      automation_id: z
+        .string()
+        .min(1)
+        .describe(
+          "The id portion of the entity_id (e.g. `lights_off_sunrise` for entity `automation.lights_off_sunrise`). Read this from `ha__list_automations_full` — NEVER invent.",
+        ),
+      alias: z.string().optional(),
+      trigger: HaAutomationTriggerSchema.optional(),
+      condition: HaAutomationConditionSchema.optional(),
+      action: HaAutomationActionSchema.optional(),
+      description: z.string().optional(),
+      mode: z.enum(["single", "restart", "queued", "parallel"]).optional(),
+    }),
+    buildRequest: ({
+      automation_id,
+      alias,
+      trigger,
+      condition,
+      action,
+      description,
+      mode,
+    }) => ({
+      method: "PUT",
+      path: `/api/v1/channels/ha/automations/${encodeURIComponent(automation_id)}`,
+      body: {
+        ...(alias !== undefined ? { alias } : {}),
+        ...(trigger !== undefined ? { trigger } : {}),
+        ...(condition !== undefined ? { condition } : {}),
+        ...(action !== undefined ? { action } : {}),
+        ...(description !== undefined ? { description } : {}),
+        ...(mode !== undefined ? { mode } : {}),
+      },
+    }),
+  },
+
+  {
+    name: "ha__delete_automation",
+    description:
+      "Delete an HA automation. Resolves to `DELETE /api/v1/channels/ha/automations/:id` → HA REST `DELETE /api/config/automation/config/<id>`. **GATED:** `decision_ref` REQUIRED — deletion is irreversible without a backup (no undo button in HA UI). The agent's contract is 'I decided to remove this automation based on signal/observation X, run it'. ctrl-api persists a `ha_run` ledger row with the decision_ref + a daybook entry (per #115 default 3) BEFORE the upstream DELETE so the audit trail survives. If Sir might want this back later, `ha__list_automations_full` first and store the YAML in a `decision/` vault record before calling this.",
+    inputSchema: z.object({
+      automation_id: z
+        .string()
+        .min(1)
+        .describe(
+          "Automation id to delete. Read from `ha__list_automations_full`. NEVER invent.",
+        ),
+      decision_ref: z
+        .string()
+        .min(6)
+        .max(256)
+        .regex(
+          /^[\x21-\x7E]+$/,
+          "decision_ref must be printable ASCII with no whitespace",
+        )
+        .describe(
+          "Vault path or ulid of the `decision/` record that authorised the delete. REQUIRED — Alfred refuses without it.",
+        ),
+    }),
+    buildRequest: ({ automation_id, decision_ref }) => ({
+      method: "DELETE",
+      path: `/api/v1/channels/ha/automations/${encodeURIComponent(automation_id)}`,
+      body: { decision_ref },
+    }),
+  },
+
+  // ── scenes ─────────────────────────────────────────────────────────────
+
+  {
+    name: "ha__create_scene",
+    description:
+      "Create an HA scene — a snapshot of entity states the principal can re-enter with one tap or voice command. Resolves to `POST /api/v1/channels/ha/scenes`. **No approval gate** (cheap, reversible). Example for a bedtime scene: `{name: 'Bedtime', entities: {'light.bedroom_main': {state: 'on', brightness_pct: 15}, 'light.living_room_lamp': {state: 'off'}, 'climate.bedroom': {temperature: 19}}}`. The keys of `entities` are entity_ids; the values are `{state: 'on'|'off', ...attributes}` blocks HA replays on `scene.turn_on`. Returns `{ok, scene_id, ha_response}`.",
+    inputSchema: z.object({
+      name: z
+        .string()
+        .min(1)
+        .describe(
+          "Human-readable scene name. Becomes the entity friendly name; the scene_id is derived as a slug of this.",
+        ),
+      entities: z
+        .record(z.string(), z.record(z.string(), z.unknown()))
+        .describe(
+          "Map of entity_id → state object. Each state object must include `state` (e.g. 'on', 'off', '22.5') plus any attributes (brightness, color, temperature, …) the entity supports. Build from `ha__get_state` reads if you want to capture a 'current' snapshot.",
+        ),
+      icon: z
+        .string()
+        .optional()
+        .describe(
+          "Optional MDI icon name (e.g. `mdi:weather-night` for bedtime). Shown in HA dashboards.",
+        ),
+    }),
+    buildRequest: ({ name, entities, icon }) => ({
+      method: "POST",
+      path: "/api/v1/channels/ha/scenes",
+      body: {
+        name,
+        entities,
+        ...(icon !== undefined ? { icon } : {}),
+      },
+    }),
+  },
+
+  {
+    name: "ha__update_scene",
+    description:
+      "Update an existing HA scene. Resolves to `PUT /api/v1/channels/ha/scenes/:id`. **No approval gate** (cheap). HA's REST does a full-replace — fetch the current scene via `GET /api/v1/channels/ha/scenes/:id` (or `ha__get_state` on the scene entity), merge your edits, ship the whole config. Returns `{ok, scene_id, ha_response}`.",
+    inputSchema: z.object({
+      scene_id: z
+        .string()
+        .min(1)
+        .describe(
+          "The id portion of the entity_id (e.g. `bedtime` for `scene.bedtime`). NEVER invent.",
+        ),
+      name: z.string().optional(),
+      entities: z
+        .record(z.string(), z.record(z.string(), z.unknown()))
+        .optional()
+        .describe(
+          "Replacement entity state map. See ha__create_scene for shape.",
+        ),
+      icon: z.string().optional(),
+    }),
+    buildRequest: ({ scene_id, name, entities, icon }) => ({
+      method: "PUT",
+      path: `/api/v1/channels/ha/scenes/${encodeURIComponent(scene_id)}`,
+      body: {
+        ...(name !== undefined ? { name } : {}),
+        ...(entities !== undefined ? { entities } : {}),
+        ...(icon !== undefined ? { icon } : {}),
+      },
+    }),
+  },
+
+  {
+    name: "ha__delete_scene",
+    description:
+      "Delete an HA scene. Resolves to `DELETE /api/v1/channels/ha/scenes/:id`. **No approval gate** — scenes are cheap to recreate from a saved snapshot. Returns `{ok, scene_id, ha_response}`.",
+    inputSchema: z.object({
+      scene_id: z
+        .string()
+        .min(1)
+        .describe("Scene id to delete. NEVER invent."),
+    }),
+    buildRequest: ({ scene_id }) => ({
+      method: "DELETE",
+      path: `/api/v1/channels/ha/scenes/${encodeURIComponent(scene_id)}`,
+    }),
+  },
+
+  // ── scripts ────────────────────────────────────────────────────────────
+
+  {
+    name: "ha__create_script",
+    description:
+      "Create an HA script — a reusable, parameterised action sequence. Narrower than an automation (no trigger), broader than a scene (executes a sequence rather than a state snapshot). Resolves to `POST /api/v1/channels/ha/scripts`. **No approval gate** (cheap, reversible). Example: `{alias: 'Goodnight', sequence: [{service: 'scene.turn_on', target: {entity_id: 'scene.bedtime'}}, {delay: '00:05:00'}, {service: 'lock.lock', target: {entity_id: 'lock.front_door'}}]}`. Returns `{ok, script_id, ha_response}`.",
+    inputSchema: z.object({
+      alias: z
+        .string()
+        .min(1)
+        .describe(
+          "Human-readable script name. Becomes the entity friendly name; script_id is derived as a slug.",
+        ),
+      sequence: z
+        .array(z.unknown())
+        .describe(
+          "Array of HA action steps the script runs sequentially. See https://www.home-assistant.io/docs/scripts/.",
+        ),
+      description: z.string().optional(),
+      mode: z.enum(["single", "restart", "queued", "parallel"]).optional(),
+      icon: z.string().optional(),
+    }),
+    buildRequest: ({ alias, sequence, description, mode, icon }) => ({
+      method: "POST",
+      path: "/api/v1/channels/ha/scripts",
+      body: {
+        alias,
+        sequence,
+        ...(description !== undefined ? { description } : {}),
+        ...(mode !== undefined ? { mode } : {}),
+        ...(icon !== undefined ? { icon } : {}),
+      },
+    }),
+  },
+
+  {
+    name: "ha__update_script",
+    description:
+      "Update an existing HA script. Resolves to `PUT /api/v1/channels/ha/scripts/:id`. **No approval gate** (cheap). HA's REST does a full-replace — read current config first, merge your edits, ship the whole config. Returns `{ok, script_id, ha_response}`.",
+    inputSchema: z.object({
+      script_id: z
+        .string()
+        .min(1)
+        .describe(
+          "The id portion of the entity_id (e.g. `goodnight` for `script.goodnight`). NEVER invent.",
+        ),
+      alias: z.string().optional(),
+      sequence: z.array(z.unknown()).optional(),
+      description: z.string().optional(),
+      mode: z.enum(["single", "restart", "queued", "parallel"]).optional(),
+      icon: z.string().optional(),
+    }),
+    buildRequest: ({ script_id, alias, sequence, description, mode, icon }) => ({
+      method: "PUT",
+      path: `/api/v1/channels/ha/scripts/${encodeURIComponent(script_id)}`,
+      body: {
+        ...(alias !== undefined ? { alias } : {}),
+        ...(sequence !== undefined ? { sequence } : {}),
+        ...(description !== undefined ? { description } : {}),
+        ...(mode !== undefined ? { mode } : {}),
+        ...(icon !== undefined ? { icon } : {}),
+      },
+    }),
+  },
+
+  {
+    name: "ha__delete_script",
+    description:
+      "Delete an HA script. Resolves to `DELETE /api/v1/channels/ha/scripts/:id`. **No approval gate** — scripts are cheap to recreate. Returns `{ok, script_id, ha_response}`.",
+    inputSchema: z.object({
+      script_id: z
+        .string()
+        .min(1)
+        .describe("Script id to delete. NEVER invent."),
+    }),
+    buildRequest: ({ script_id }) => ({
+      method: "DELETE",
+      path: `/api/v1/channels/ha/scripts/${encodeURIComponent(script_id)}`,
+    }),
+  },
+];
+
+// Splice the PR3 tools onto HASS_WRITE_TOOLS so downstream importers
+// (registry.ts, alias HASS_DEFERRED_TOOLS) pick them up without a churn.
+HASS_WRITE_TOOLS.push(...HA_WRITE_PR3_TOOLS);
+
+// ─── END #115 PR3 ──────────────────────────────────────────────────────
+
 // Back-compat alias — PR2 exported these stubs under `HASS_DEFERRED_TOOLS`,
 // and downstream callers (registry.ts, tests) referenced that name. Keep
 // the binding live so the PR2→PR4 transition doesn't churn import sites.
 export const HASS_DEFERRED_TOOLS: ToolDef[] = HASS_WRITE_TOOLS;
 
-// Final catalogue: 16 tools total = 11 read + 5 PR3 placeholders. Order
-// kept deliberately (reads first, deferred last) so the model that lists
-// the catalogue sees the safe read surface before the placeholders.
+// Final catalogue: 26 tools total = 11 read + 5 PR4 writes + 10 PR3 CRUD
+// (#115 — automations / scenes / scripts). Order kept deliberately
+// (reads first, writes last) so the model that lists the catalogue sees
+// the safe read surface before the write surface.
 export const ALL_HASS_TOOLS: ToolDef[] = [
   ...HASS_READ_TOOLS,
   ...HASS_DEFERRED_TOOLS,


### PR DESCRIPTION
Closes part of #158. Spec: `docs/specs/issue-115-ha-tier4-autonomy.md` §4 (gate matrix locked YES on 2026-05-29).

REST-only. Independent of #115 PR1 (the WS client) — both PRs ship in parallel; this one lives in a clearly-bounded `BEGIN/END #115 PR3` splice block so a PR1-first merge rebases mechanically.

## What ships

### A. ctrl-api routes — `packages/ctrl/src/api/routes/channels_ha.ts`

```
GET    /api/v1/channels/ha/automations          — REST GET /api/config/automation/config
GET    /api/v1/channels/ha/automations/:id      — REST GET /api/config/automation/config/:id
POST   /api/v1/channels/ha/automations          — REST POST /api/config/automation/config/<slug>
PUT    /api/v1/channels/ha/automations/:id      — idempotent upsert
DELETE /api/v1/channels/ha/automations/:id      — GATED: decision_ref REQUIRED

GET    /api/v1/channels/ha/scenes               — /api/states filtered to scene.*
GET    /api/v1/channels/ha/scenes/:id           — REST GET /api/config/scene/config/:id
POST/PUT/DELETE /api/v1/channels/ha/scenes[/:id] — no gate (cheap)

GET    /api/v1/channels/ha/scripts              — /api/states filtered to script.*
GET    /api/v1/channels/ha/scripts/:id          — REST GET /api/config/script/config/:id
POST/PUT/DELETE /api/v1/channels/ha/scripts[/:id] — no gate (cheap)
```

Every write persists a `ha_run` row (kind + entity_id + decision_ref) so the audit ledger covers the whole surface. `tryRequireDecisionRef` defers to `assertDecisionRef` (same parser PR4 uses) until PR1's middleware lands; `tryRecordDaybook` is a no-op stub for the same reason. Both are TODO-flagged.

### B. MCP tools — `packages/mcp-server/src/tools/hass.ts`

10 new write tools spliced onto `HASS_WRITE_TOOLS`:

- `ha__list_automations_full` — full configs (not the registry index)
- `ha__create_automation`, `ha__update_automation` — no gate
- `ha__delete_automation` — decision_ref REQUIRED (zod-enforced before ctrl-api)
- `ha__create_scene`, `ha__update_scene`, `ha__delete_scene` — no gate
- `ha__create_script`, `ha__update_script`, `ha__delete_script` — no gate

Catalogue grows 16 → 26 (11 read + 5 PR4 writes + 10 PR3 CRUD).

### C. Skill doc — `packages/mcp-server/skills/alfred-mcp-skill.md`

New "Home Assistant — Tier 4" tool listing + three example flows (bedtime scene, sunrise automation, removing a stale automation with backup-then-delete).

### D. Tests

- **15 mcp-server unit tests** in `packages/mcp-server/src/tools/hass.test.ts` — tool registration, schema validation, gate enforcement on delete-automation, catalogue order.
- **10 ctrl-api integration tests** in `packages/ctrl/tests/channels_ha_pr3.test.ts` — round-trip CRUD against mocked HA REST, ha_run persistence for every verb, decision_ref enforcement for delete-automation, HA_NOT_CONNECTED 409 guard across all 9 write verbs.

## Gate matrix (locked YES per spec §4)

| Tool | Gate |
|---|---|
| `ha__automation_create` / `ha__automation_update` | none (reversible) |
| `ha__automation_delete` | `decision_ref` REQUIRED |
| `ha__scene_*` | none (cheap) |
| `ha__script_*` | none (cheap) |

## Test runs

```
packages/mcp-server: 90 tests, 90 pass (15 new for PR3)
packages/ctrl: 820 tests, 819 pass, 1 skipped (pre-existing; 10 new for PR3)
```

## Notes

- The splice block is contiguous (`BEGIN/END #115 PR3` markers). If PR1 lands first, swap `tryRequireDecisionRef`/`tryRecordDaybook` for the real middleware/vault-writer in two line edits — TODO-flagged in-block.
- Loop guard: PR3 CRUD mutates config objects, not stateful entities, so the per-entity guard from #110 PR4 doesn't apply directly. Service-call writes still go through `ha__call_service` and carry the existing guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)