### PR TITLE
feat(ctrl,mcp): #115 PR7 — HA core lifecycle + backup CRUD + ha_backup_ref ledger

### DIFF
--- a/packages/ctrl/src/api/routes/channels_ha.ts
+++ b/packages/ctrl/src/api/routes/channels_ha.ts
@@ -36,6 +36,12 @@ import { dockerExec } from "../helpers.js";
 import { ulid } from "../../db/ulid.js";
 import fs from "node:fs";
 import { WebSocket } from "ws";
+import { getHaWsClient } from "../lib/ha_ws_client.js";
+import {
+  triggerBackupBeforeAction,
+  listBackupRefs,
+} from "../lib/ha_snapshot.js";
+import { recordHaWriteToDaybook } from "../lib/ha_daybook.js";
 
 const HERMES_MAIN_URL =
   process.env.HERMES_GATEWAY_URL ?? "http://hermes:18789";
@@ -1017,6 +1023,14 @@ export function registerHaChannelRoutes(): void {
   // "=== Tier 4 PR6: Supervisor addons ===" block at the bottom of this
   // file.
   registerHaAddonRoutes();
+
+  // #115 PR7 — Tier 4 autonomy, HA core lifecycle + backup CRUD.
+  // check_config / restart / update / reload_yaml / version + backup
+  // info/details/generate/delete/restore/strategy. Uses PR1's WS client
+  // for the WS-only verbs (backup/*) and REST for the homeassistant
+  // service domain. See the "=== Tier 4 PR7: Core + Backups ===" block
+  // at the bottom of this file.
+  registerHaPr7CoreBackupRoutes();
 }
 
 /**
@@ -4767,3 +4781,676 @@ export function registerHaAddonRoutes(): void {
 }
 
 // === END Tier 4 PR6 ═══════════════════════════════════════════════════
+
+// ═════════════════════════════════════════════════════════════════════════
+// === Tier 4 PR7: Core + Backups ===
+// ═════════════════════════════════════════════════════════════════════════
+//
+// Issue #115 PR7 — HA core lifecycle (restart / update / check_config /
+// reload_yaml / version) + backup CRUD (info / details / generate /
+// delete / restore / strategy) + ledger ergonomics on `ha_backup_ref`.
+//
+// Wire layer
+// ----------
+// HA's core lifecycle verbs split across REST + WS:
+//
+//   * `homeassistant.check_config`   — REST POST /api/services/homeassistant/check_config
+//   * `homeassistant.restart`        — REST POST /api/services/homeassistant/restart
+//   * `homeassistant.reload_all`     — REST POST /api/services/homeassistant/reload_all
+//   * `core/update` (OTA)            — WS supervisor/api endpoint=/core/update method=post
+//   * `GET /api/config`              — REST (returns ha_version, installation_type, …)
+//   * `backup/info`                  — WS
+//   * `backup/details`               — WS
+//   * `backup/generate`              — WS (also used by PR1's snapshot helper)
+//   * `backup/delete`                — WS
+//   * `backup/restore`               — WS
+//   * `backup/strategy/info`         — WS
+//   * `backup/strategy/update`       — WS
+//
+// REST verbs use the same `callHaRest` helper PR3 introduced; WS verbs
+// go through the long-lived `getHaWsClient().wsCall(...)` PR1 shipped.
+//
+// Gates + auto-snapshot (locked YES 2026-05-29)
+// ---------------------------------------------
+// | Route                        | decision_ref | auto-snapshot |
+// |------------------------------|--------------|----------------|
+// | core/check_config            | no           | no             |
+// | core/reload_yaml             | no           | no             |
+// | core/version (GET)           | no           | no             |
+// | core/restart                 | REQUIRED     | YES            |
+// | core/update                  | REQUIRED     | YES            |
+// | backups GET list/details     | no           | no             |
+// | backups POST (create)        | no           | no             |
+// | backups DELETE               | REQUIRED     | no             |
+// | backups POST restore         | REQUIRED     | NO (restoring IS the recovery action)
+// | backups/strategy GET         | no           | no             |
+// | backups/strategy PUT         | REQUIRED     | no             |
+//
+// Auto-snapshot semantics
+// -----------------------
+// `triggerBackupBeforeAction(action, decision_ref)` from PR1 fires a real
+// HA backup (via WS `backup/generate`), persists a row in `ha_backup_ref`
+// with `triggered_by=<action>`, and returns `{id, ha_backup_id, name}`.
+// The route's response payload carries `backup_ref_id` + `ha_backup_id`
+// so the MCP tool surfaces "snapshot taken — id <id>" to Sir.
+//
+// If `triggerBackupBeforeAction` throws (no disk space, HA down, …) the
+// route propagates the error as 502 — destructive verbs MUST NOT run on
+// an unbackupped HA.
+//
+// ha_backup_ref ledger ergonomics
+// -------------------------------
+// Every PR7 entry-point that creates a backup (auto-snapshot OR explicit
+// user create OR HA's own strategy-auto) lands a row. The
+// `triggered_by` column distinguishes:
+//
+//   * `ha__core_restart` / `ha__core_update`         — auto-snapshot before another verb
+//   * `ha__create_backup` / `user`                   — explicit user request
+//   * `strategy:auto`                                — HA's scheduled backup strategy
+//                                                      (reserved — observable via the
+//                                                      backup_create event stream which
+//                                                      Tier 4 PR1's drainEvent will see
+//                                                      on later PRs)
+//
+// Sir can query "what backed up my system the last 30 days" by reading
+// `GET /api/v1/channels/ha/backups/ledger?days=30`.
+//
+// Restore semantics
+// -----------------
+// `backup/restore` is special — it IS the recovery action, so we don't
+// auto-snapshot before restoring (that'd be backing up to the same
+// volume HA's about to overwrite). We do require a `decision_ref` for
+// audit. The route also stops short of polling — HA returns success when
+// the restore is QUEUED, and HA itself restarts to apply it; we surface
+// the WS response verbatim and let the caller follow up via `/version`
+// + `/status` after HA comes back.
+//
+// MCP tools
+// ---------
+// `ha__core_check_config`, `ha__core_restart`, `ha__core_update`,
+// `ha__core_reload_yaml`, `ha__core_version`, `ha__list_backups`,
+// `ha__backup_info`, `ha__create_backup`, `ha__delete_backup`,
+// `ha__restore_backup`. (10 tools — strategy GET/PUT not currently surfaced
+// to the model; Sir adjusts HA's auto-backup schedule via the Desk if needed.)
+
+const HA_CORE_REST_TIMEOUT_MS = Number(
+  process.env.HA_CORE_REST_TIMEOUT_MS ?? "30000",
+);
+
+const HA_BACKUP_WS_TIMEOUT_MS = Number(
+  process.env.HA_BACKUP_WS_TIMEOUT_MS ?? "120000", // backups can take 60-120s
+);
+
+const HA_CORE_UPDATE_WS_TIMEOUT_MS = Number(
+  process.env.HA_CORE_UPDATE_WS_TIMEOUT_MS ?? "300000", // OTA can take 5min
+);
+
+/**
+ * Format the HA WS error message into the ApiError detail string.
+ * WS calls throw Error("HA WS error <code>: <message>") on failure;
+ * we re-wrap to keep the response envelope shape consistent with the
+ * REST surface.
+ */
+function wrapHaWsError(action: string, err: unknown): ApiError {
+  const msg = err instanceof Error ? err.message : String(err);
+  return new ApiError(502, "HA_WS_ERROR", `${action}: ${msg}`);
+}
+
+/**
+ * Backup id format guard. HA's backup ids are short slugs (e.g.
+ * `abc123def` from `backup/generate`) — printable ASCII no slash, length
+ * 1..128. Same shape we use for addon slugs (PR6) so the URL-traversal
+ * guard stays uniform.
+ */
+const HA_BACKUP_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_.\-]{0,127}$/;
+
+function assertBackupId(raw: string): string {
+  if (!HA_BACKUP_ID_RE.test(raw)) {
+    throw new ValidationError(
+      "backup id must be 1..128 chars of [A-Za-z0-9_.-], starting with [A-Za-z0-9]",
+    );
+  }
+  return raw;
+}
+
+export function registerHaPr7CoreBackupRoutes(): void {
+  // ── core lifecycle ────────────────────────────────────────────────────
+
+  // GET /api/v1/channels/ha/version — read HA's /api/config.
+  // Returns `{ha_version, installation_type, location_name, …}` from HA
+  // verbatim. Cheap, no gate, no snapshot.
+  addRoute("GET", "/api/v1/channels/ha/version", async ({ res }) => {
+    const { haUrl, llat } = await loadHaCredentials();
+    const r = await callHaRest({
+      haUrl,
+      llat,
+      method: "GET",
+      path: "/api/config",
+    });
+    if (!r.ok) {
+      throw new ApiError(
+        r.status >= 400 && r.status < 600 ? r.status : 502,
+        "HA_UPSTREAM_ERROR",
+        r.detail,
+      );
+    }
+    // Pluck the canonical fields the MCP tool needs at the top level so
+    // the model doesn't have to dig — but pass the full data through too.
+    const d = (r.data ?? {}) as Record<string, unknown>;
+    sendJson(res, 200, {
+      ok: true,
+      ha_version: typeof d.version === "string" ? d.version : null,
+      installation_type:
+        typeof d.installation_type === "string" ? d.installation_type : null,
+      location_name:
+        typeof d.location_name === "string" ? d.location_name : null,
+      data: r.data,
+    });
+  });
+
+  // POST /api/v1/channels/ha/core/check_config — REST POST
+  // /api/services/homeassistant/check_config. Read-only check (verifies
+  // configuration.yaml parses + restartable). No gate; idempotent.
+  addRoute(
+    "POST",
+    "/api/v1/channels/ha/core/check_config",
+    async ({ res }) => {
+      const { haUrl, llat } = await loadHaCredentials();
+      const r = await callHaRest({
+        haUrl,
+        llat,
+        method: "POST",
+        path: "/api/services/homeassistant/check_config",
+        body: {},
+      });
+      if (!r.ok) {
+        throw new ApiError(
+          r.status >= 400 && r.status < 600 ? r.status : 502,
+          "HA_UPSTREAM_ERROR",
+          r.detail,
+        );
+      }
+      sendJson(res, 200, { ok: true, data: r.data });
+    },
+  );
+
+  // POST /api/v1/channels/ha/core/reload_yaml — REST POST
+  // /api/services/homeassistant/reload_all. Reload every YAML-defined
+  // domain (automations, scripts, scenes, helpers, …) without
+  // restarting HA. No gate (idempotent + reversible: edit YAML +
+  // reload again).
+  addRoute(
+    "POST",
+    "/api/v1/channels/ha/core/reload_yaml",
+    async ({ res }) => {
+      const { haUrl, llat } = await loadHaCredentials();
+      const r = await callHaRest({
+        haUrl,
+        llat,
+        method: "POST",
+        path: "/api/services/homeassistant/reload_all",
+        body: {},
+      });
+      if (!r.ok) {
+        throw new ApiError(
+          r.status >= 400 && r.status < 600 ? r.status : 502,
+          "HA_UPSTREAM_ERROR",
+          r.detail,
+        );
+      }
+      sendJson(res, 200, { ok: true, data: r.data });
+    },
+  );
+
+  // POST /api/v1/channels/ha/core/restart — REST POST
+  // /api/services/homeassistant/restart. GATED + AUTO-SNAPSHOT.
+  // Body: { decision_ref }.
+  //
+  // Snapshot fires BEFORE the restart so a failed restart still has the
+  // backup to roll back to. HA returns immediately when the restart is
+  // queued; the WS connection (and thus the client) will reconnect once
+  // HA comes back up.
+  addRoute(
+    "POST",
+    "/api/v1/channels/ha/core/restart",
+    async ({ res, body }) => {
+      if (typeof body !== "object" || body === null) {
+        throw new ValidationError("body must be a JSON object");
+      }
+      const decision_ref = assertDecisionRef(
+        (body as Record<string, unknown>).decision_ref,
+      );
+      const { haUrl, llat } = await loadHaCredentials();
+      const snapshot = await triggerBackupBeforeAction(
+        "ha__core_restart",
+        decision_ref,
+      );
+      const r = await callHaRest({
+        haUrl,
+        llat,
+        method: "POST",
+        path: "/api/services/homeassistant/restart",
+        body: {},
+      });
+      if (!r.ok) {
+        throw new ApiError(
+          r.status >= 400 && r.status < 600 ? r.status : 502,
+          "HA_UPSTREAM_ERROR",
+          r.detail,
+          { backup_ref_id: snapshot.id, ha_backup_id: snapshot.ha_backup_id },
+        );
+      }
+      recordHaWriteToDaybook({
+        action: "ha__core_restart",
+        summary: `HA core restart queued (snapshot ${snapshot.name})`,
+        decision_ref,
+        extra: { ha_backup_id: snapshot.ha_backup_id },
+      });
+      sendJson(res, 200, {
+        ok: true,
+        decision_ref,
+        backup_ref_id: snapshot.id,
+        ha_backup_id: snapshot.ha_backup_id,
+        backup_name: snapshot.name,
+        data: r.data,
+      });
+    },
+  );
+
+  // POST /api/v1/channels/ha/core/update — WS supervisor/api endpoint=/core/update.
+  // GATED + AUTO-SNAPSHOT. Body: { decision_ref, version? }.
+  //
+  // HA Core update is run via Supervisor's API even on Container HA
+  // (Container HA gets a 5xx from supervisor/api with method=post that we
+  // pass through). On HAOS this triggers an OTA update — long-running
+  // (3-10min); we use a 5-minute WS timeout so the call doesn't hang the
+  // whole request loop.
+  addRoute(
+    "POST",
+    "/api/v1/channels/ha/core/update",
+    async ({ res, body }) => {
+      if (typeof body !== "object" || body === null) {
+        throw new ValidationError("body must be a JSON object");
+      }
+      const b = body as Record<string, unknown>;
+      const decision_ref = assertDecisionRef(b.decision_ref);
+      // Optional version pin — HA accepts {version: "2025.7.0"}.
+      let version: string | undefined;
+      if (b.version !== undefined && b.version !== null) {
+        if (typeof b.version !== "string" || b.version.length === 0) {
+          throw new ValidationError("version, if set, must be a non-empty string");
+        }
+        if (!/^[A-Za-z0-9._\-+]{1,32}$/.test(b.version)) {
+          throw new ValidationError(
+            "version must be 1..32 chars of [A-Za-z0-9._-+]",
+          );
+        }
+        version = b.version;
+      }
+      // Defensive: ensure HA is connected before paying snapshot cost.
+      await loadHaCredentials();
+      const snapshot = await triggerBackupBeforeAction(
+        "ha__core_update",
+        decision_ref,
+      );
+      const wsPayload: Record<string, unknown> = {
+        endpoint: "/core/update",
+        method: "post",
+      };
+      if (version !== undefined) {
+        wsPayload.data = { version };
+      }
+      let result: unknown;
+      try {
+        result = await getHaWsClient().wsCall(
+          "supervisor/api",
+          wsPayload,
+          HA_CORE_UPDATE_WS_TIMEOUT_MS,
+        );
+      } catch (err) {
+        throw wrapHaWsError("ha__core_update", err);
+      }
+      recordHaWriteToDaybook({
+        action: "ha__core_update",
+        summary:
+          version !== undefined
+            ? `HA core update queued → ${version} (snapshot ${snapshot.name})`
+            : `HA core update queued (snapshot ${snapshot.name})`,
+        decision_ref,
+        extra: { ha_backup_id: snapshot.ha_backup_id },
+      });
+      sendJson(res, 200, {
+        ok: true,
+        decision_ref,
+        backup_ref_id: snapshot.id,
+        ha_backup_id: snapshot.ha_backup_id,
+        backup_name: snapshot.name,
+        target_version: version ?? null,
+        data: result,
+      });
+    },
+  );
+
+  // ── backups CRUD ──────────────────────────────────────────────────────
+
+  // GET /api/v1/channels/ha/backups — WS backup/info.
+  // List every backup HA knows about. Read-only, no gate.
+  addRoute("GET", "/api/v1/channels/ha/backups", async ({ res }) => {
+    await loadHaCredentials(); // 409 if HA not connected
+    let result: unknown;
+    try {
+      result = await getHaWsClient().wsCall(
+        "backup/info",
+        {},
+        HA_BACKUP_WS_TIMEOUT_MS,
+      );
+    } catch (err) {
+      throw wrapHaWsError("backup/info", err);
+    }
+    sendJson(res, 200, { ok: true, data: result });
+  });
+
+  // GET /api/v1/channels/ha/backups/strategy — WS backup/strategy/info.
+  // Read the auto-backup schedule (HA 2025.1+).
+  //
+  // Registered BEFORE /backups/:id so the `strategy` segment doesn't get
+  // shadowed by the `:id` capture.
+  addRoute(
+    "GET",
+    "/api/v1/channels/ha/backups/strategy",
+    async ({ res }) => {
+      await loadHaCredentials();
+      let result: unknown;
+      try {
+        result = await getHaWsClient().wsCall(
+          "backup/strategy/info",
+          {},
+          HA_BACKUP_WS_TIMEOUT_MS,
+        );
+      } catch (err) {
+        throw wrapHaWsError("backup/strategy/info", err);
+      }
+      sendJson(res, 200, { ok: true, data: result });
+    },
+  );
+
+  // PUT /api/v1/channels/ha/backups/strategy — WS backup/strategy/update.
+  // GATED. Body: { decision_ref, strategy: { …HA strategy fields… } }.
+  addRoute(
+    "PUT",
+    "/api/v1/channels/ha/backups/strategy",
+    async ({ res, body }) => {
+      if (typeof body !== "object" || body === null) {
+        throw new ValidationError("body must be a JSON object");
+      }
+      const b = body as Record<string, unknown>;
+      const decision_ref = assertDecisionRef(b.decision_ref);
+      if (
+        b.strategy === undefined ||
+        b.strategy === null ||
+        typeof b.strategy !== "object" ||
+        Array.isArray(b.strategy)
+      ) {
+        throw new ValidationError("strategy is required and must be a JSON object");
+      }
+      await loadHaCredentials();
+      let result: unknown;
+      try {
+        result = await getHaWsClient().wsCall(
+          "backup/strategy/update",
+          b.strategy as Record<string, unknown>,
+          HA_BACKUP_WS_TIMEOUT_MS,
+        );
+      } catch (err) {
+        throw wrapHaWsError("backup/strategy/update", err);
+      }
+      recordHaWriteToDaybook({
+        action: "ha__backup_strategy_update",
+        summary: "HA backup strategy updated",
+        decision_ref,
+      });
+      sendJson(res, 200, { ok: true, decision_ref, data: result });
+    },
+  );
+
+  // GET /api/v1/channels/ha/backups/ledger — read our own ha_backup_ref
+  // ledger. Sir can answer "what backed up my system the last 30 days"
+  // without touching HA at all. Optional ?days=N (default 30, max 365).
+  //
+  // Registered BEFORE /backups/:id so the `ledger` segment isn't
+  // shadowed.
+  addRoute(
+    "GET",
+    "/api/v1/channels/ha/backups/ledger",
+    async ({ res, query }) => {
+      const daysRaw = query.get("days");
+      let days = 30;
+      if (daysRaw !== null) {
+        const n = Number(daysRaw);
+        if (!Number.isFinite(n) || n <= 0) {
+          throw new ValidationError("days must be a positive number");
+        }
+        days = Math.min(365, Math.floor(n));
+      }
+      const limitRaw = query.get("limit");
+      let limit = 200;
+      if (limitRaw !== null) {
+        const n = Number(limitRaw);
+        if (!Number.isFinite(n) || n <= 0) {
+          throw new ValidationError("limit must be a positive number");
+        }
+        limit = Math.min(500, Math.floor(n));
+      }
+      const since = new Date(Date.now() - days * 24 * 3600 * 1000).toISOString();
+      const refs = listBackupRefs({ since, limit });
+      sendJson(res, 200, {
+        ok: true,
+        days,
+        since,
+        count: refs.length,
+        refs,
+      });
+    },
+  );
+
+  // GET /api/v1/channels/ha/backups/:id — WS backup/details.
+  addRoute(
+    "GET",
+    "/api/v1/channels/ha/backups/:id",
+    async ({ res, params }) => {
+      const backup_id = assertBackupId(params.id);
+      await loadHaCredentials();
+      let result: unknown;
+      try {
+        result = await getHaWsClient().wsCall(
+          "backup/details",
+          { backup_id },
+          HA_BACKUP_WS_TIMEOUT_MS,
+        );
+      } catch (err) {
+        throw wrapHaWsError("backup/details", err);
+      }
+      sendJson(res, 200, { ok: true, backup_id, data: result });
+    },
+  );
+
+  // POST /api/v1/channels/ha/backups — WS backup/generate.
+  // No gate (cheap; explicit user-initiated backups are always fine).
+  //
+  // Body: optional fields HA's backup/generate accepts:
+  //   { name?, password?, include_addons?, include_database?,
+  //     include_homeassistant?, include_folders? }.
+  //
+  // We persist a `ha_backup_ref` row with `triggered_by='user'` (the
+  // default when decision_ref is absent) so the ledger keeps a complete
+  // picture of every Alfred-triggered backup.
+  addRoute(
+    "POST",
+    "/api/v1/channels/ha/backups",
+    async ({ res, body }) => {
+      const raw = (body ?? {}) as Record<string, unknown>;
+      if (body !== undefined && body !== null && typeof body !== "object") {
+        throw new ValidationError("body must be a JSON object");
+      }
+      const wsPayload: Record<string, unknown> = {};
+      if (raw.name !== undefined) {
+        if (typeof raw.name !== "string" || raw.name.length === 0) {
+          throw new ValidationError("name, if set, must be a non-empty string");
+        }
+        wsPayload.name = raw.name;
+      }
+      if (raw.password !== undefined) {
+        if (typeof raw.password !== "string" || raw.password.length === 0) {
+          throw new ValidationError(
+            "password, if set, must be a non-empty string",
+          );
+        }
+        wsPayload.password = raw.password;
+      }
+      for (const k of [
+        "include_addons",
+        "include_database",
+        "include_homeassistant",
+        "include_folders",
+      ] as const) {
+        if (raw[k] !== undefined) {
+          wsPayload[k] = raw[k];
+        }
+      }
+      await loadHaCredentials();
+      let result: unknown;
+      try {
+        result = await getHaWsClient().wsCall(
+          "backup/generate",
+          wsPayload,
+          HA_BACKUP_WS_TIMEOUT_MS,
+        );
+      } catch (err) {
+        throw wrapHaWsError("backup/generate", err);
+      }
+      // Persist into ha_backup_ref so the ledger has every user-initiated
+      // backup alongside the auto-snapshots. PR1's helper takes (action,
+      // decision_ref); for user-initiated we use the `user` sentinel and
+      // call the same persistence path inline.
+      const r = (result ?? {}) as Record<string, unknown>;
+      const ha_backup_id =
+        (typeof r.slug === "string" && r.slug) ||
+        (typeof r.backup_id === "string" && r.backup_id) ||
+        (typeof r.id === "string" && r.id) ||
+        "";
+      let backup_ref_id: string | null = null;
+      if (ha_backup_id) {
+        backup_ref_id = ulid();
+        const ts = new Date().toISOString();
+        try {
+          getStateDb()
+            .prepare(
+              `INSERT INTO ha_backup_ref (id, ha_backup_id, triggered_by, decision_ref, ts)
+               VALUES (?, ?, ?, ?, ?)`,
+            )
+            .run(backup_ref_id, ha_backup_id, "user", null, ts);
+        } catch {
+          // best-effort — never block the route on the ledger write
+          backup_ref_id = null;
+        }
+      }
+      // No daybook entry — explicit user backups are cheap and Sir asked
+      // for the backup, the daybook would be noise.
+      sendJson(res, 200, {
+        ok: true,
+        backup_ref_id,
+        ha_backup_id: ha_backup_id || null,
+        data: result,
+      });
+    },
+  );
+
+  // DELETE /api/v1/channels/ha/backups/:id — WS backup/delete.
+  // GATED. Body: { decision_ref }.
+  addRoute(
+    "DELETE",
+    "/api/v1/channels/ha/backups/:id",
+    async ({ res, body, params }) => {
+      const backup_id = assertBackupId(params.id);
+      if (typeof body !== "object" || body === null) {
+        throw new ValidationError("body must be a JSON object");
+      }
+      const decision_ref = assertDecisionRef(
+        (body as Record<string, unknown>).decision_ref,
+      );
+      await loadHaCredentials();
+      let result: unknown;
+      try {
+        result = await getHaWsClient().wsCall(
+          "backup/delete",
+          { backup_id },
+          HA_BACKUP_WS_TIMEOUT_MS,
+        );
+      } catch (err) {
+        throw wrapHaWsError("backup/delete", err);
+      }
+      recordHaWriteToDaybook({
+        action: "ha__delete_backup",
+        summary: `Backup ${backup_id} deleted`,
+        decision_ref,
+        extra: { ha_backup_id: backup_id },
+      });
+      sendJson(res, 200, {
+        ok: true,
+        backup_id,
+        decision_ref,
+        data: result,
+      });
+    },
+  );
+
+  // POST /api/v1/channels/ha/backups/:id/restore — WS backup/restore.
+  // GATED, NO snapshot (restoring IS the recovery action).
+  // Body: { decision_ref, password? }.
+  addRoute(
+    "POST",
+    "/api/v1/channels/ha/backups/:id/restore",
+    async ({ res, body, params }) => {
+      const backup_id = assertBackupId(params.id);
+      if (typeof body !== "object" || body === null) {
+        throw new ValidationError("body must be a JSON object");
+      }
+      const b = body as Record<string, unknown>;
+      const decision_ref = assertDecisionRef(b.decision_ref);
+      const wsPayload: Record<string, unknown> = { backup_id };
+      if (b.password !== undefined) {
+        if (typeof b.password !== "string" || b.password.length === 0) {
+          throw new ValidationError(
+            "password, if set, must be a non-empty string",
+          );
+        }
+        wsPayload.password = b.password;
+      }
+      await loadHaCredentials();
+      let result: unknown;
+      try {
+        result = await getHaWsClient().wsCall(
+          "backup/restore",
+          wsPayload,
+          HA_BACKUP_WS_TIMEOUT_MS,
+        );
+      } catch (err) {
+        throw wrapHaWsError("backup/restore", err);
+      }
+      recordHaWriteToDaybook({
+        action: "ha__restore_backup",
+        summary: `Backup ${backup_id} restored (HA will restart)`,
+        decision_ref,
+        extra: { ha_backup_id: backup_id },
+      });
+      sendJson(res, 200, {
+        ok: true,
+        backup_id,
+        decision_ref,
+        data: result,
+      });
+    },
+  );
+}
+
+// === END Tier 4 PR7 ═══════════════════════════════════════════════════

--- a/packages/ctrl/tests/channels_ha_pr7.test.ts
+++ b/packages/ctrl/tests/channels_ha_pr7.test.ts
@@ -1,0 +1,793 @@
+// Issue #115 PR7 — HA core lifecycle + backup CRUD integration tests.
+//
+// PR7 adds 11 routes fronting:
+//   - REST `/api/services/homeassistant/{check_config,restart,reload_all}`
+//   - REST `/api/config` (version)
+//   - WS `supervisor/api {endpoint: '/core/update'}`
+//   - WS `backup/{info,details,generate,delete,restore}`
+//   - WS `backup/strategy/{info,update}`
+//
+// Plus a ledger surface `/backups/ledger` reading our own
+// `ha_backup_ref` rows.
+//
+// Coverage (12 tests):
+//   1.  GET /version returns ha_version + installation_type from /api/config.
+//   2.  POST /core/check_config — no gate, POSTs to /api/services/homeassistant/check_config.
+//   3.  POST /core/reload_yaml — no gate, POSTs to .../reload_all.
+//   4.  POST /core/restart — auto-snapshots + records daybook + responds with backup_ref_id.
+//   5.  POST /core/restart without decision_ref → 400.
+//   6.  POST /core/update — gated, snapshot, WS supervisor/api carries /core/update endpoint
+//       (and version pin when supplied).
+//   7.  GET /backups — WS backup/info, returns data.
+//   8.  POST /backups (create) — no gate, records ha_backup_ref with triggered_by='user'.
+//   9.  DELETE /backups/:id — gated, daybook entry written.
+//   10. POST /backups/:id/restore — gated, NO new snapshot row (restoring IS the recovery action).
+//   11. GET /backups/strategy + PUT /backups/strategy (gated).
+//   12. GET /backups/ledger — reads ha_backup_ref, indexed by triggered_by.
+//
+// Test plumbing
+// -------------
+// Mirrors the addons test (fetch-mock for REST) + the ha_ws_client test
+// (in-process WebSocketServer for the WS verbs). The two surfaces don't
+// interfere — REST goes through `fetch`, WS through the long-lived
+// `HaWsClient` singleton.
+
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import http from "node:http";
+import { WebSocketServer, type WebSocket as WSWebSocket } from "ws";
+import type { ServerResponse } from "node:http";
+
+// ── env (must be set before module imports) ────────────────────────────
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "channels-ha-pr7-"));
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.VAULT_PATH = path.join(tmp, "vault");
+process.env.STATE_DB_PATH = path.join(tmp, "alfred-state.db");
+process.env.INGEST_DB_PATH = path.join(tmp, "ingest.db");
+process.env.SQLITE_VEC_PATH = "";
+process.env.VAULT_CLI_URL = "http://vault-cli-stub:8087";
+process.env.HA_VAULTWARDEN_FOLDER = "Home Assistant";
+process.env.HA_LLAT_ITEM = "LLAT";
+process.env.HA_PROBE_TIMEOUT_MS = "5000";
+process.env.HA_WRITE_TIMEOUT_MS = "5000";
+process.env.HA_CORE_REST_TIMEOUT_MS = "5000";
+process.env.HA_BACKUP_WS_TIMEOUT_MS = "5000";
+process.env.HA_CORE_UPDATE_WS_TIMEOUT_MS = "5000";
+process.env.HA_WS_AUTOSTART = "false";
+
+const VALID_LLAT = "llat_TEST_" + "0".repeat(40);
+const HA_URL = "http://homeassistant.local:8123";
+const HA_VERSION = "2025.6.1";
+
+// ── fake HA WS server ──────────────────────────────────────────────────
+
+let server: http.Server;
+let wss: WebSocketServer;
+let serverPort = 0;
+const liveSockets: WSWebSocket[] = [];
+
+interface WsRouteResp {
+  success?: boolean;
+  result?: unknown;
+  error?: { code: string; message: string };
+}
+
+/**
+ * Map of WS message-type → response. Tests mutate this between cases.
+ * Default 'success: true, result: {}' for unset types.
+ */
+let wsRoutes: Map<string, WsRouteResp> = new Map();
+const wsLog: Array<Record<string, unknown>> = [];
+
+function setupServer(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    server = http.createServer();
+    wss = new WebSocketServer({ server, path: "/api/websocket" });
+    wss.on("connection", (ws) => {
+      liveSockets.push(ws);
+      ws.send(JSON.stringify({ type: "auth_required", ha_version: HA_VERSION }));
+      ws.on("message", (raw) => {
+        let msg: Record<string, unknown>;
+        try {
+          msg = JSON.parse(String(raw)) as Record<string, unknown>;
+        } catch {
+          return;
+        }
+        wsLog.push(msg);
+        if (msg.type === "auth") {
+          ws.send(JSON.stringify({ type: "auth_ok" }));
+          return;
+        }
+        const id = msg.id;
+        // subscribe_events — Tier 4 event streams the client subscribes to.
+        if (msg.type === "subscribe_events") {
+          ws.send(JSON.stringify({ id, type: "result", success: true, result: null }));
+          return;
+        }
+        const type = String(msg.type);
+        const resp = wsRoutes.get(type) ?? {
+          success: true,
+          result: {},
+        };
+        ws.send(
+          JSON.stringify({
+            id,
+            type: "result",
+            success: resp.success ?? true,
+            ...(resp.result !== undefined ? { result: resp.result } : {}),
+            ...(resp.error !== undefined ? { error: resp.error } : {}),
+          }),
+        );
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (addr && typeof addr === "object") serverPort = addr.port;
+      resolve();
+    });
+  });
+}
+
+function teardownServer(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    for (const s of liveSockets) {
+      try {
+        s.terminate();
+      } catch {
+        // best-effort
+      }
+    }
+    liveSockets.length = 0;
+    wss?.close(() => {
+      server?.close(() => resolve());
+    });
+  });
+}
+
+// ── fetch mock (REST surface — homeassistant.* + /api/config + vault-cli) ──
+
+interface VaultItem {
+  id: string;
+  name: string;
+  type: 1;
+  folderId: string | null;
+  login: { username: string | null; password: string; uris: unknown[] };
+}
+interface VaultFolder {
+  id: string;
+  name: string;
+}
+let vaultStore: VaultItem[] = [];
+let vaultFolders: VaultFolder[] = [];
+
+interface RestResp {
+  status?: number;
+  body?: unknown;
+}
+let restRoutes: Map<string, RestResp> = new Map();
+const restCalls: { url: string; method: string; body: string | undefined }[] = [];
+
+function makeJsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const originalFetch = globalThis.fetch;
+
+globalThis.fetch = (async (input: any, init?: any) => {
+  const url = typeof input === "string" ? input : (input?.url ?? String(input));
+  const method = (init?.method ?? "GET").toUpperCase();
+  const bodyRaw = init?.body !== undefined ? String(init.body) : undefined;
+  restCalls.push({ url, method, body: bodyRaw });
+
+  // HA /api/ auth gate.
+  if (url === `${HA_URL}/api/` && method === "GET") {
+    return makeJsonResponse({ message: "API running." }, 200);
+  }
+  // HA /api/config — used by /connect AND by PR7's /version route.
+  if (url === `${HA_URL}/api/config` && method === "GET") {
+    return makeJsonResponse(
+      {
+        version: HA_VERSION,
+        installation_type: "Home Assistant OS",
+        location_name: "Home",
+      },
+      200,
+    );
+  }
+  // homeassistant.* services.
+  const haServiceMatch = url.match(
+    /^http:\/\/homeassistant\.local:8123(\/api\/services\/homeassistant\/[a-z_]+)$/,
+  );
+  if (haServiceMatch && method === "POST") {
+    const key = `POST ${haServiceMatch[1]}`;
+    const r = restRoutes.get(key);
+    if (r === undefined) {
+      return makeJsonResponse([], 200);
+    }
+    return makeJsonResponse(r.body ?? [], r.status ?? 200);
+  }
+
+  // vault-cli folders + items.
+  if (url.endsWith("/list/object/folders") && method === "GET") {
+    return makeJsonResponse({ success: true, data: { data: vaultFolders } });
+  }
+  if (url.endsWith("/object/folder") && method === "POST") {
+    const b = JSON.parse(bodyRaw ?? "{}");
+    const f: VaultFolder = {
+      id: "fld-" + String(Date.now()) + "-" + Math.random().toString(36).slice(2, 6),
+      name: b.name,
+    };
+    vaultFolders.push(f);
+    return makeJsonResponse({ success: true, data: f });
+  }
+  if (url.includes("/list/object/items")) {
+    const qIdx = url.indexOf("?");
+    const params = new URLSearchParams(qIdx >= 0 ? url.slice(qIdx + 1) : "");
+    const search = params.get("search") ?? "";
+    const filtered = search
+      ? vaultStore.filter((i) => i.name.toLowerCase().includes(search.toLowerCase()))
+      : vaultStore.slice();
+    return makeJsonResponse({ success: true, data: { data: filtered } });
+  }
+  const objMatch = url.match(/\/object\/item\/([^/?]+)/);
+  if (objMatch && method === "GET") {
+    const id = objMatch[1];
+    const item = vaultStore.find((i) => i.id === id);
+    if (!item) return makeJsonResponse({ success: false, message: "not found" }, 404);
+    // Two callers read this endpoint with different envelope expectations:
+    //  - channels_ha.ts:readHaLlat (post-23917969 fix) reads single-wrapped
+    //    `data.login.password`
+    //  - ha_ws_client.ts:readHaLlat (PR1 of #115) reads double-wrapped
+    //    `data.data.login.password`
+    // We satisfy both by returning a payload with both shapes — the
+    // outer `data` is the item itself (single-wrapped) AND it embeds
+    // `data: {login: {password}}` (double-wrapped) for the WS client.
+    return makeJsonResponse({
+      success: true,
+      data: {
+        ...item,
+        data: { login: { password: item.login.password } },
+      },
+    });
+  }
+  if (url.endsWith("/object/item") && method === "POST") {
+    const b = JSON.parse(bodyRaw ?? "{}");
+    const id = "id-" + String(Date.now()) + "-" + Math.random().toString(36).slice(2, 8);
+    const item: VaultItem = {
+      id,
+      name: b.name,
+      type: 1,
+      folderId: b.folderId ?? null,
+      login: {
+        username: b.login?.username ?? null,
+        password: b.login?.password ?? "",
+        uris: b.login?.uris ?? [],
+      },
+    };
+    vaultStore.push(item);
+    return makeJsonResponse({ success: true, data: item });
+  }
+  if (objMatch && method === "PUT") {
+    const id = objMatch[1];
+    const idx = vaultStore.findIndex((i) => i.id === id);
+    if (idx < 0) return makeJsonResponse({ success: false, message: "not found" }, 404);
+    const b = JSON.parse(bodyRaw ?? "{}");
+    vaultStore[idx] = {
+      ...vaultStore[idx],
+      name: b.name ?? vaultStore[idx].name,
+      folderId: b.folderId ?? vaultStore[idx].folderId,
+      login: { ...vaultStore[idx].login, ...(b.login ?? {}) },
+    };
+    return makeJsonResponse({ success: true, data: vaultStore[idx] });
+  }
+  if (objMatch && method === "DELETE") {
+    const id = objMatch[1];
+    const idx = vaultStore.findIndex((i) => i.id === id);
+    if (idx < 0) return makeJsonResponse({ success: false, message: "not found" }, 404);
+    vaultStore.splice(idx, 1);
+    return makeJsonResponse({ success: true });
+  }
+  throw new Error(`unexpected fetch in test_channels_ha_pr7: ${method} ${url}`);
+}) as typeof fetch;
+
+// ── server up + module imports ─────────────────────────────────────────
+
+await setupServer();
+process.env.HA_WS_URL_OVERRIDE = `ws://127.0.0.1:${serverPort}/api/websocket`;
+
+const {
+  registerChannelsHaRoutes,
+  _resetHaSubscriptionsForTests,
+  _resetHaAddonsForTests,
+  _resetHaInstallationTypeCache,
+} = await import("../src/api/routes/channels_ha.js");
+const { matchRoute } = await import("../src/api/server.js");
+const { handleError } = await import("../src/api/errors.js");
+const { getStateDb } = await import("../src/db/state.js");
+const { _resetHaWsClientForTests, getHaWsClient } = await import(
+  "../src/api/lib/ha_ws_client.js"
+);
+
+registerChannelsHaRoutes();
+
+// ── helpers ────────────────────────────────────────────────────────────
+
+interface CallResult {
+  status: number;
+  payload: any;
+}
+
+async function call(
+  method: string,
+  p: string,
+  body?: unknown,
+): Promise<CallResult> {
+  const qIdx = p.indexOf("?");
+  const pathname = qIdx >= 0 ? p.slice(0, qIdx) : p;
+  const query = new URLSearchParams(qIdx >= 0 ? p.slice(qIdx + 1) : "");
+  const m = matchRoute(method, pathname);
+  assert.ok(m, `${method} ${p} must be registered`);
+  let status = 0;
+  let payload: any;
+  const res = {
+    statusCode: 0,
+    setHeader() {},
+    writeHead(c: number) {
+      status = c;
+      return res;
+    },
+    end(j?: string) {
+      payload = j ? JSON.parse(j) : undefined;
+    },
+  } as unknown as ServerResponse;
+  try {
+    await m!.handler({
+      req: { method, headers: {}, url: p } as any,
+      res,
+      params: m!.params,
+      body,
+      query,
+    });
+  } catch (err) {
+    handleError(res, err);
+  }
+  return { status, payload };
+}
+
+async function connectHa(): Promise<void> {
+  const r = await call("POST", "/api/v1/channels/ha/connect", {
+    ha_url: HA_URL,
+    llat: VALID_LLAT,
+    label: "Test",
+  });
+  assert.equal(r.status, 200, JSON.stringify(r.payload));
+}
+
+/** Ensure the HA WS client is freshly authed against the fake HA server.
+ *  Called at the top of every test that exercises a WS verb. */
+async function ensureWsAuthed(): Promise<void> {
+  const client = getHaWsClient();
+  client.start();
+  // Drive a probe call so we know the client is past auth_ok.
+  await new Promise<void>((resolve, reject) => {
+    const deadline = Date.now() + 3000;
+    const tick = () => {
+      const s = client.getStatus();
+      if (s.connected) return resolve();
+      if (Date.now() > deadline) {
+        return reject(
+          new Error(
+            `WS never reached connected state (last_error=${s.last_error ?? "none"})`,
+          ),
+        );
+      }
+      setTimeout(tick, 25);
+    };
+    tick();
+  });
+}
+
+// ── tests ──────────────────────────────────────────────────────────────
+
+describe("/api/v1/channels/ha/* — #115 PR7 core + backups", () => {
+  before(async () => {
+    // First-time DB init.
+    getStateDb();
+  });
+
+  beforeEach(() => {
+    vaultStore = [];
+    vaultFolders = [];
+    restCalls.length = 0;
+    restRoutes = new Map();
+    wsLog.length = 0;
+    wsRoutes = new Map();
+    const db = getStateDb();
+    try {
+      db.prepare("DELETE FROM ha_connection").run();
+      db.prepare("DELETE FROM ha_run").run();
+      db.prepare("DELETE FROM ha_proposal").run();
+      db.prepare("DELETE FROM ha_snapshot").run();
+      db.prepare("DELETE FROM ha_event").run();
+      db.prepare("DELETE FROM ha_event_subscription").run();
+      db.prepare("DELETE FROM ha_backup_ref").run();
+    } catch {
+      // first run before tables exist
+    }
+    _resetHaSubscriptionsForTests();
+    _resetHaAddonsForTests();
+    _resetHaInstallationTypeCache();
+    _resetHaWsClientForTests();
+  });
+
+  after(async () => {
+    _resetHaWsClientForTests();
+    await teardownServer();
+    globalThis.fetch = originalFetch;
+  });
+
+  // ── 1 ── version
+  it("GET /version returns ha_version + installation_type from /api/config", async () => {
+    await connectHa();
+    const r = await call("GET", "/api/v1/channels/ha/version");
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.ha_version, HA_VERSION);
+    assert.equal(r.payload.installation_type, "Home Assistant OS");
+    assert.equal(r.payload.location_name, "Home");
+    assert.ok(r.payload.data);
+  });
+
+  // ── 2 ── check_config (no gate)
+  it("POST /core/check_config posts to /api/services/homeassistant/check_config", async () => {
+    await connectHa();
+    restRoutes.set("POST /api/services/homeassistant/check_config", {
+      body: [],
+    });
+    const r = await call("POST", "/api/v1/channels/ha/core/check_config");
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.ok, true);
+    // Confirm we hit the right upstream path.
+    const hit = restCalls.find((c) =>
+      c.url.endsWith("/api/services/homeassistant/check_config") &&
+      c.method === "POST",
+    );
+    assert.ok(hit, "check_config must POST to homeassistant.check_config service");
+  });
+
+  // ── 3 ── reload_yaml (no gate)
+  it("POST /core/reload_yaml posts to /api/services/homeassistant/reload_all", async () => {
+    await connectHa();
+    restRoutes.set("POST /api/services/homeassistant/reload_all", { body: [] });
+    const r = await call("POST", "/api/v1/channels/ha/core/reload_yaml");
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.ok, true);
+    const hit = restCalls.find((c) =>
+      c.url.endsWith("/api/services/homeassistant/reload_all") &&
+      c.method === "POST",
+    );
+    assert.ok(hit, "reload_yaml must POST to homeassistant.reload_all service");
+  });
+
+  // ── 4 ── restart (gated + auto-snapshot)
+  it("POST /core/restart auto-snapshots BEFORE the restart + records ha_backup_ref + daybook", async () => {
+    await connectHa();
+    await ensureWsAuthed();
+    // backup/generate returns a slug — drives triggerBackupBeforeAction.
+    wsRoutes.set("backup/generate", { success: true, result: { slug: "bk_abc123" } });
+    restRoutes.set("POST /api/services/homeassistant/restart", { body: [] });
+
+    const decision_ref = "decision/2026-05-29-restart.md";
+    const r = await call(
+      "POST",
+      "/api/v1/channels/ha/core/restart",
+      { decision_ref },
+    );
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.decision_ref, decision_ref);
+    assert.equal(r.payload.ha_backup_id, "bk_abc123");
+    assert.ok(typeof r.payload.backup_ref_id === "string");
+    assert.match(r.payload.backup_name, /^alfred-pre-ha__core_restart-\d{8}T\d{6}$/);
+
+    // ha_backup_ref row landed.
+    const refs = getStateDb()
+      .prepare("SELECT * FROM ha_backup_ref")
+      .all() as any[];
+    assert.equal(refs.length, 1);
+    assert.equal(refs[0].triggered_by, "ha__core_restart");
+    assert.equal(refs[0].decision_ref, decision_ref);
+    assert.equal(refs[0].ha_backup_id, "bk_abc123");
+
+    // Daybook entry landed under HA writes.
+    const day = new Date().toISOString().slice(0, 10);
+    const dayPath = path.join(process.env.VAULT_PATH!, "daybook", `${day}.md`);
+    const body = fs.readFileSync(dayPath, "utf-8");
+    assert.match(body, /action: ha__core_restart/);
+    assert.match(body, /## HA writes/);
+  });
+
+  // ── 5 ── restart without decision_ref → 400
+  it("POST /core/restart without decision_ref → 400 VALIDATION_ERROR", async () => {
+    await connectHa();
+    const r = await call("POST", "/api/v1/channels/ha/core/restart", {});
+    assert.equal(r.status, 400, JSON.stringify(r.payload));
+    assert.equal(r.payload.error?.code, "VALIDATION_ERROR");
+  });
+
+  // ── 6 ── update (gated + snapshot, WS supervisor/api carries the endpoint)
+  it("POST /core/update — WS supervisor/api endpoint=/core/update + version pin", async () => {
+    await connectHa();
+    await ensureWsAuthed();
+    wsRoutes.set("backup/generate", { success: true, result: { slug: "bk_upd123" } });
+    wsRoutes.set("supervisor/api", { success: true, result: { ok: true } });
+
+    const r = await call("POST", "/api/v1/channels/ha/core/update", {
+      version: "2025.7.0",
+      decision_ref: "decision/2026-05-29-update.md",
+    });
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.target_version, "2025.7.0");
+    assert.equal(r.payload.ha_backup_id, "bk_upd123");
+
+    // supervisor/api was called with the right payload.
+    const supervisorCall = wsLog.find((m) => m.type === "supervisor/api");
+    assert.ok(supervisorCall, "supervisor/api WS call must have been issued");
+    assert.equal(supervisorCall!.endpoint, "/core/update");
+    assert.equal(supervisorCall!.method, "post");
+    assert.deepEqual(supervisorCall!.data, { version: "2025.7.0" });
+  });
+
+  // ── 7 ── list backups (WS backup/info)
+  it("GET /backups returns WS backup/info data", async () => {
+    await connectHa();
+    await ensureWsAuthed();
+    const fakeBackups = {
+      backups: [
+        { slug: "bk_one", name: "Auto 2026-05-29", date: "2026-05-29T03:00:00Z" },
+        { slug: "bk_two", name: "Manual", date: "2026-05-28T19:00:00Z" },
+      ],
+    };
+    wsRoutes.set("backup/info", { success: true, result: fakeBackups });
+
+    const r = await call("GET", "/api/v1/channels/ha/backups");
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.deepEqual(r.payload.data, fakeBackups);
+    // Confirm the WS call fired.
+    const wsCall = wsLog.find((m) => m.type === "backup/info");
+    assert.ok(wsCall, "backup/info WS call must have been issued");
+  });
+
+  // ── 8 ── create backup (no gate, ha_backup_ref row triggered_by='user')
+  it("POST /backups creates a backup + records ha_backup_ref with triggered_by='user'", async () => {
+    await connectHa();
+    await ensureWsAuthed();
+    wsRoutes.set("backup/generate", { success: true, result: { slug: "bk_user_made" } });
+
+    const r = await call("POST", "/api/v1/channels/ha/backups", {
+      name: "alfred-pre-zwave",
+      include_database: false,
+    });
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.ha_backup_id, "bk_user_made");
+    assert.ok(typeof r.payload.backup_ref_id === "string");
+
+    // ledger has one user-triggered row.
+    const refs = getStateDb()
+      .prepare("SELECT * FROM ha_backup_ref")
+      .all() as any[];
+    assert.equal(refs.length, 1);
+    assert.equal(refs[0].triggered_by, "user");
+    assert.equal(refs[0].decision_ref, null);
+    assert.equal(refs[0].ha_backup_id, "bk_user_made");
+
+    // Confirm payload was forwarded (name + include_database).
+    const wsCall = wsLog.find((m) => m.type === "backup/generate");
+    assert.ok(wsCall);
+    assert.equal(wsCall!.name, "alfred-pre-zwave");
+    assert.equal(wsCall!.include_database, false);
+  });
+
+  // ── 9 ── delete backup (gated, daybook entry)
+  it("DELETE /backups/:id requires decision_ref + writes daybook entry", async () => {
+    await connectHa();
+    await ensureWsAuthed();
+    wsRoutes.set("backup/delete", { success: true, result: { ok: true } });
+
+    // missing decision_ref → 400.
+    const bad = await call(
+      "DELETE",
+      "/api/v1/channels/ha/backups/bk_abc",
+      {},
+    );
+    assert.equal(bad.status, 400);
+    assert.equal(bad.payload.error?.code, "VALIDATION_ERROR");
+
+    // happy path.
+    const decision_ref = "decision/2026-05-29-prune.md";
+    const ok = await call(
+      "DELETE",
+      "/api/v1/channels/ha/backups/bk_abc",
+      { decision_ref },
+    );
+    assert.equal(ok.status, 200, JSON.stringify(ok.payload));
+    assert.equal(ok.payload.backup_id, "bk_abc");
+    assert.equal(ok.payload.decision_ref, decision_ref);
+
+    // Daybook entry.
+    const day = new Date().toISOString().slice(0, 10);
+    const dayPath = path.join(process.env.VAULT_PATH!, "daybook", `${day}.md`);
+    const body = fs.readFileSync(dayPath, "utf-8");
+    assert.match(body, /action: ha__delete_backup/);
+    assert.match(body, new RegExp(`decision_ref: ${decision_ref.replace(/[/.]/g, "\\$&")}`));
+
+    // WS call had the right backup_id.
+    const wsCall = wsLog.find((m) => m.type === "backup/delete");
+    assert.ok(wsCall);
+    assert.equal(wsCall!.backup_id, "bk_abc");
+  });
+
+  // ── 10 ── restore backup (gated, NO new snapshot)
+  it("POST /backups/:id/restore — gated, NO ha_backup_ref row added (restoring IS recovery)", async () => {
+    await connectHa();
+    await ensureWsAuthed();
+    wsRoutes.set("backup/restore", { success: true, result: { ok: true } });
+
+    // missing decision_ref → 400.
+    const bad = await call(
+      "POST",
+      "/api/v1/channels/ha/backups/bk_abc/restore",
+      {},
+    );
+    assert.equal(bad.status, 400);
+
+    // happy path.
+    const decision_ref = "decision/2026-05-29-restore.md";
+    const r = await call(
+      "POST",
+      "/api/v1/channels/ha/backups/bk_abc/restore",
+      { decision_ref, password: "secret" },
+    );
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+
+    // No ha_backup_ref row added by the restore.
+    const refs = getStateDb()
+      .prepare("SELECT * FROM ha_backup_ref")
+      .all() as any[];
+    assert.equal(refs.length, 0);
+
+    // WS payload carried backup_id + password.
+    const wsCall = wsLog.find((m) => m.type === "backup/restore");
+    assert.ok(wsCall);
+    assert.equal(wsCall!.backup_id, "bk_abc");
+    assert.equal(wsCall!.password, "secret");
+  });
+
+  // ── 11 ── strategy GET + PUT (gated)
+  it("GET /backups/strategy + PUT /backups/strategy (gated)", async () => {
+    await connectHa();
+    await ensureWsAuthed();
+    wsRoutes.set("backup/strategy/info", {
+      success: true,
+      result: { days: 7, time: "03:00:00" },
+    });
+    wsRoutes.set("backup/strategy/update", { success: true, result: { ok: true } });
+
+    // GET — no gate.
+    const get = await call("GET", "/api/v1/channels/ha/backups/strategy");
+    assert.equal(get.status, 200);
+    assert.equal(get.payload.data.days, 7);
+
+    // PUT without decision_ref → 400.
+    const bad = await call(
+      "PUT",
+      "/api/v1/channels/ha/backups/strategy",
+      { strategy: { days: 14 } },
+    );
+    assert.equal(bad.status, 400);
+    assert.equal(bad.payload.error?.code, "VALIDATION_ERROR");
+
+    // PUT without strategy → 400.
+    const bad2 = await call(
+      "PUT",
+      "/api/v1/channels/ha/backups/strategy",
+      { decision_ref: "decision/2026-05-29-strat.md" },
+    );
+    assert.equal(bad2.status, 400);
+
+    // happy path.
+    const ok = await call(
+      "PUT",
+      "/api/v1/channels/ha/backups/strategy",
+      {
+        decision_ref: "decision/2026-05-29-strat.md",
+        strategy: { days: 14, time: "04:00:00" },
+      },
+    );
+    assert.equal(ok.status, 200, JSON.stringify(ok.payload));
+    // WS call carried the strategy body.
+    const wsCall = wsLog.find((m) => m.type === "backup/strategy/update");
+    assert.ok(wsCall);
+    assert.equal(wsCall!.days, 14);
+    assert.equal(wsCall!.time, "04:00:00");
+  });
+
+  // ── 12 ── ledger surface reads ha_backup_ref, indexed by triggered_by
+  it("GET /backups/ledger reads ha_backup_ref, properly indexed by triggered_by", async () => {
+    await connectHa();
+    await ensureWsAuthed();
+    wsRoutes.set("backup/generate", { success: true, result: { slug: "bk_X" } });
+
+    // Seed: one auto-snapshot via /core/restart, one user-initiated via
+    // /backups create, one direct ha_backup_ref row (simulating
+    // strategy:auto from HA's own scheduler that the PR1 drain would
+    // populate on later PRs).
+    restRoutes.set("POST /api/services/homeassistant/restart", { body: [] });
+    await call(
+      "POST",
+      "/api/v1/channels/ha/core/restart",
+      { decision_ref: "decision/2026-05-29-restart.md" },
+    );
+    // Reset backup/generate slug for the user-initiated create so we get a
+    // different ha_backup_id.
+    wsRoutes.set("backup/generate", { success: true, result: { slug: "bk_user_Y" } });
+    await call("POST", "/api/v1/channels/ha/backups", { name: "Manual" });
+    // Direct insert: strategy:auto row.
+    getStateDb()
+      .prepare(
+        `INSERT INTO ha_backup_ref (id, ha_backup_id, triggered_by, decision_ref, ts)
+         VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run(
+        "01J_STRATEGY_TEST_ROW_____",
+        "bk_strategy_Z",
+        "strategy:auto",
+        null,
+        new Date().toISOString(),
+      );
+
+    const r = await call("GET", "/api/v1/channels/ha/backups/ledger");
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.ok, true);
+    assert.equal(r.payload.count, 3);
+    const byKind: Record<string, number> = {};
+    for (const ref of r.payload.refs) {
+      byKind[ref.triggered_by] = (byKind[ref.triggered_by] ?? 0) + 1;
+    }
+    assert.equal(byKind["ha__core_restart"], 1, "auto-snapshot row present");
+    assert.equal(byKind["user"], 1, "user-initiated backup row present");
+    assert.equal(byKind["strategy:auto"], 1, "strategy:auto row present");
+
+    // ?days=N narrows the window. Insert an old row, confirm it gets
+    // filtered.
+    getStateDb()
+      .prepare(
+        `INSERT INTO ha_backup_ref (id, ha_backup_id, triggered_by, decision_ref, ts)
+         VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run(
+        "01J_OLD_TEST_ROW_________",
+        "bk_old_X",
+        "user",
+        null,
+        // 60 days ago.
+        new Date(Date.now() - 60 * 24 * 3600 * 1000).toISOString(),
+      );
+
+    const narrow = await call(
+      "GET",
+      "/api/v1/channels/ha/backups/ledger?days=7",
+    );
+    assert.equal(narrow.payload.count, 3, "60d-old row filtered out");
+    const wide = await call(
+      "GET",
+      "/api/v1/channels/ha/backups/ledger?days=120",
+    );
+    assert.equal(wide.payload.count, 4, "60d-old row included with 120d window");
+  });
+});

--- a/packages/mcp-server/skills/alfred-mcp-skill.md
+++ b/packages/mcp-server/skills/alfred-mcp-skill.md
@@ -76,6 +76,19 @@ The catalogue is intentionally narrow. Container restarts, credential rotation, 
 
 **HAOS caveat.** Every addon tool returns a 501 envelope on non-HAOS installs: `{error: "supervisor_not_available", installation_type, message}`. Read `installation_type` and explain to Sir; don't retry. Sir's home (home.alfred.black) is HAOS so this surface is live there.
 
+### Home Assistant — Tier 4 (#115 PR7, HA core lifecycle + backups)
+
+- `ha__core_version` — read `ha_version` + `installation_type`; no gate
+- `ha__core_check_config` — verify configuration.yaml parses (run before restart); no gate
+- `ha__core_reload_yaml` — reload every YAML domain without restarting; no gate
+- `ha__core_restart` — GATED: `decision_ref` REQUIRED; auto-snapshot recorded in `ha_backup_ref`; HA OFFLINE 30-120s
+- `ha__core_update` — GATED: `decision_ref` REQUIRED; auto-snapshot recorded; optional `version` pin; HA OFFLINE 3-10 min
+- `ha__list_backups` — every backup HA knows about; no gate
+- `ha__backup_info` — full details for one backup; no gate
+- `ha__create_backup` — generate a fresh backup; no gate (this IS a backup; `ha_backup_ref` row gets `triggered_by='user'`)
+- `ha__delete_backup` — GATED: `decision_ref` REQUIRED; daybook entry recorded; irreversible
+- `ha__restore_backup` — GATED: `decision_ref` REQUIRED; NO snapshot (restoring IS the recovery); HA OFFLINE several minutes
+
 ### DM pairing (1)
 
 - `approve_device` — approve a pending Hermes DM-pairing code by `platform` + `code` (the only pairing op exposed here)
@@ -188,6 +201,48 @@ Read the `installation_type` and explain to Sir — don't retry. Sir's home (hom
 2. Create a `decision/` record naming the version delta.
 3. `ha__addon_update({slug, decision_ref})` — snapshot taken before the upstream call.
 4. `ha__addon_logs({slug, tail: 100})` after Supervisor reports done — confirm no startup errors.
+
+### "Restart / update HA core" / "Back up before something risky" (Tier 4, #115 PR7)
+
+The PR7 surface gives Alfred HA's core lifecycle + backup CRUD: `ha__core_version`, `ha__core_check_config`, `ha__core_reload_yaml`, `ha__core_restart`, `ha__core_update`, `ha__list_backups`, `ha__backup_info`, `ha__create_backup`, `ha__delete_backup`, `ha__restore_backup`.
+
+**Gates + snapshots (locked YES on 2026-05-29).** `core/restart` + `core/update` + `delete_backup` + `restore_backup` all require a `decision_ref`. `core/restart` + `core/update` also auto-snapshot — ctrl-api triggers a real `backup/generate` BEFORE the destructive call and records the result in `ha_backup_ref`. The success envelope returns `backup_ref_id`, `ha_backup_id`, and `backup_name`. Mention "snapshot taken" to Sir. `restore_backup` is the only destructive verb that does NOT auto-snapshot — restoring IS the recovery action; backing up the broken state is backwards.
+
+**Recipe — restart HA core safely:**
+
+1. `ha__core_check_config({})` — never restart on a broken config; this catches yaml parse errors before HA goes down.
+2. If the config check returns warnings/errors, surface them to Sir and stop. Don't restart.
+3. Create a `decision/` record naming why ("restart to pick up new ESPHome device").
+4. `ha__core_restart({decision_ref: "decision/..."})` — snapshot taken; HA reboots; reply carries `backup_name`.
+5. Wait ~60s, then `ha__core_version({})` to confirm HA came back.
+
+**Recipe — update HA core to the latest stable:**
+
+1. `ha__core_version({})` — read the current version, surface it to Sir.
+2. Sir confirms the update. Create a `decision/` record naming the version delta if known.
+3. `ha__core_update({decision_ref: "decision/..."})` — omit `version` for the latest stable, or pass `version: "2025.7.0"` to pin. Snapshot taken before HA goes down.
+4. HA is OFFLINE for 3-10 min. Wait, then `ha__core_version({})` to confirm.
+5. If the update failed (Sir reports HA didn't come back): `ha__list_backups({})` → find the `alfred-pre-ha__core_update-*` snapshot → `ha__restore_backup({backup_id, decision_ref})`.
+
+**Recipe — explicit backup before a risky non-Alfred change:**
+
+Sir says "I'm about to flash my Z-Wave dongle, back HA up first" — Alfred can do this without a gated verb because creating a backup is always safe.
+
+1. `ha__create_backup({name: "alfred-pre-zwave-fw-2026-05-29"})` — name it contextually so Sir can find it later.
+2. ctrl-api records a `ha_backup_ref` row with `triggered_by='user'`; the response carries the new `ha_backup_id`.
+3. If something goes wrong later: `ha__restore_backup({backup_id, decision_ref})`.
+
+**Recipe — restore from a backup (irreversible, HA-stops-for-several-minutes):**
+
+1. `ha__list_backups({})` — find the right slug. Pick the most recent backup BEFORE the change Sir wants to undo.
+2. `ha__backup_info({backup_id})` — confirm the backup includes the components Sir needs (addons / database / homeassistant / folders).
+3. Create a `decision/` record explaining why the restore is happening.
+4. `ha__restore_backup({backup_id, decision_ref})` — HA stops, unpacks the backup, restarts. State + automations + addons revert to the backup's snapshot point.
+5. Wait several minutes, then `ha__core_version({})` to confirm HA is back. If the backup was encrypted, pass `password`.
+
+**Audit query — "what backed up my system the last 30 days":**
+
+ctrl-api exposes a ledger view at `GET /api/v1/channels/ha/backups/ledger?days=30` that reads `ha_backup_ref` directly — every Alfred-triggered snapshot, every Alfred-initiated user backup, plus future strategy-auto rows. The `triggered_by` column distinguishes `ha__core_restart` / `ha__core_update` (auto-snapshot before another verb), `user` (explicit user-initiated create), and `strategy:auto` (HA's scheduled backup strategy). Models don't need to call this directly — the dashboard / Desk surfaces it — but knowing it exists is useful when Sir asks "what's been backed up?".
 
 ---
 

--- a/packages/mcp-server/src/tools/hass.test.ts
+++ b/packages/mcp-server/src/tools/hass.test.ts
@@ -20,6 +20,7 @@ import {
   HASS_READ_TOOLS,
   HASS_DEFERRED_TOOLS,
   HASS_ADDON_TOOLS,
+  HASS_PR7_TOOLS,
 } from "./hass.js";
 import { SUPPORTED_APPS, isAppId, getToolsForApp } from "./registry.js";
 
@@ -31,20 +32,22 @@ function getTool(name: string) {
 
 // ─── catalogue shape ────────────────────────────────────────────────────
 
-test("hass catalogue: exactly 36 tools (11 read + 15 write + 10 PR6 addon)", () => {
+test("hass catalogue: exactly 46 tools (11 read + 15 write + 10 PR6 addon + 10 PR7 core+backup)", () => {
   assert.equal(HASS_READ_TOOLS.length, 11);
   // After #115 PR3 splice: PR4's 5 + PR3's 10 = 15 writes.
   assert.equal(HASS_DEFERRED_TOOLS.length, 15);
   // PR6: 10 supervisor addon tools.
   assert.equal(HASS_ADDON_TOOLS.length, 10);
-  assert.equal(ALL_HASS_TOOLS.length, 36);
+  // PR7: 10 core lifecycle + backup CRUD tools.
+  assert.equal(HASS_PR7_TOOLS.length, 10);
+  assert.equal(ALL_HASS_TOOLS.length, 46);
 });
 
-test("registry: hass is a supported app and registers all 36 tools", () => {
+test("registry: hass is a supported app and registers all 46 tools", () => {
   assert.ok(isAppId("hass"));
   assert.ok((SUPPORTED_APPS as Set<string>).has("hass"));
   const tools = getToolsForApp("hass");
-  assert.equal(tools.length, 36);
+  assert.equal(tools.length, 46);
 });
 
 test("hass: every tool name is unique", () => {
@@ -1110,4 +1113,267 @@ test("PR6 addon tool slug guard: rejects empty + slash on the 9 slug-bearing too
       `${name} must reject slug with '/'`,
     );
   }
+});
+
+// ─── #115 PR7 — Core lifecycle + backup CRUD tools ──────────────────────
+
+const PR7_TOOL_NAMES = [
+  "ha__core_version",
+  "ha__core_check_config",
+  "ha__core_reload_yaml",
+  "ha__core_restart",
+  "ha__core_update",
+  "ha__list_backups",
+  "ha__backup_info",
+  "ha__create_backup",
+  "ha__delete_backup",
+  "ha__restore_backup",
+];
+
+test("PR7: every core+backup tool name is registered and unique", () => {
+  for (const name of PR7_TOOL_NAMES) {
+    const t = HASS_PR7_TOOLS.find((x) => x.name === name);
+    assert.ok(t, `${name} missing from HASS_PR7_TOOLS`);
+  }
+  const names = HASS_PR7_TOOLS.map((t) => t.name);
+  assert.equal(new Set(names).size, names.length);
+});
+
+test("PR7 ha__core_version: empty input, GET /version", () => {
+  const t = getTool("ha__core_version");
+  assert.equal(t.inputSchema.safeParse({}).success, true);
+  const r = t.buildRequest({});
+  assert.equal(r.method, "GET");
+  assert.equal(r.path, "/api/v1/channels/ha/version");
+});
+
+test("PR7 ha__core_check_config: empty input, POST /core/check_config with empty body", () => {
+  const t = getTool("ha__core_check_config");
+  assert.equal(t.inputSchema.safeParse({}).success, true);
+  const r = t.buildRequest({});
+  assert.equal(r.method, "POST");
+  assert.equal(r.path, "/api/v1/channels/ha/core/check_config");
+  assert.deepEqual(r.body, {});
+});
+
+test("PR7 ha__core_reload_yaml: empty input, POST /core/reload_yaml with empty body", () => {
+  const t = getTool("ha__core_reload_yaml");
+  assert.equal(t.inputSchema.safeParse({}).success, true);
+  const r = t.buildRequest({});
+  assert.equal(r.method, "POST");
+  assert.equal(r.path, "/api/v1/channels/ha/core/reload_yaml");
+  assert.deepEqual(r.body, {});
+});
+
+test("PR7 ha__core_restart: requires decision_ref; builds POST /core/restart", () => {
+  const t = getTool("ha__core_restart");
+  // empty — fails.
+  assert.equal(t.inputSchema.safeParse({}).success, false);
+  // short decision_ref rejected.
+  assert.equal(
+    t.inputSchema.safeParse({ decision_ref: "abc" }).success,
+    false,
+    "min 6 chars",
+  );
+  // whitespace rejected.
+  assert.equal(
+    t.inputSchema.safeParse({ decision_ref: "abc def" }).success,
+    false,
+  );
+  // valid.
+  const args = { decision_ref: "decision/2026-05-29-restart.md" };
+  assert.equal(t.inputSchema.safeParse(args).success, true);
+  const r = t.buildRequest(args);
+  assert.equal(r.method, "POST");
+  assert.equal(r.path, "/api/v1/channels/ha/core/restart");
+  assert.deepEqual(r.body, { decision_ref: args.decision_ref });
+});
+
+test("PR7 ha__core_update: requires decision_ref, optional version pin", () => {
+  const t = getTool("ha__core_update");
+  // missing decision_ref — fails.
+  assert.equal(t.inputSchema.safeParse({}).success, false);
+  assert.equal(
+    t.inputSchema.safeParse({ version: "2025.7.0" }).success,
+    false,
+    "decision_ref required",
+  );
+  // happy path without version.
+  const noVer = { decision_ref: "decision/2026-05-29-update.md" };
+  assert.equal(t.inputSchema.safeParse(noVer).success, true);
+  const r1 = t.buildRequest(noVer);
+  assert.equal(r1.method, "POST");
+  assert.equal(r1.path, "/api/v1/channels/ha/core/update");
+  assert.deepEqual(r1.body, { decision_ref: noVer.decision_ref });
+  // happy path with version.
+  const withVer = {
+    version: "2025.7.0",
+    decision_ref: "decision/2026-05-29-update.md",
+  };
+  assert.equal(t.inputSchema.safeParse(withVer).success, true);
+  const r2 = t.buildRequest(withVer);
+  assert.deepEqual(r2.body, {
+    decision_ref: withVer.decision_ref,
+    version: withVer.version,
+  });
+  // bad version chars rejected.
+  assert.equal(
+    t.inputSchema.safeParse({
+      version: "bad version",
+      decision_ref: "decision/x-2026-05-29.md",
+    }).success,
+    false,
+  );
+});
+
+test("PR7 ha__list_backups: empty input, GET /backups", () => {
+  const t = getTool("ha__list_backups");
+  assert.equal(t.inputSchema.safeParse({}).success, true);
+  const r = t.buildRequest({});
+  assert.equal(r.method, "GET");
+  assert.equal(r.path, "/api/v1/channels/ha/backups");
+});
+
+test("PR7 ha__backup_info: backup_id required + format-gated, GET /backups/:id", () => {
+  const t = getTool("ha__backup_info");
+  assert.equal(t.inputSchema.safeParse({}).success, false);
+  assert.equal(
+    t.inputSchema.safeParse({ backup_id: "abc123" }).success,
+    true,
+  );
+  // slash rejected (URL-traversal guard).
+  assert.equal(
+    t.inputSchema.safeParse({ backup_id: "abc/123" }).success,
+    false,
+  );
+  // leading-special rejected.
+  assert.equal(
+    t.inputSchema.safeParse({ backup_id: "_abc" }).success,
+    false,
+  );
+  const r = t.buildRequest({ backup_id: "abc123def" });
+  assert.equal(r.method, "GET");
+  assert.equal(r.path, "/api/v1/channels/ha/backups/abc123def");
+});
+
+test("PR7 ha__create_backup: all-optional, NO gate; builds POST /backups with optional fields", () => {
+  const t = getTool("ha__create_backup");
+  // empty is valid — cheap, no gate.
+  assert.equal(t.inputSchema.safeParse({}).success, true);
+  const empty = t.buildRequest({});
+  assert.equal(empty.method, "POST");
+  assert.equal(empty.path, "/api/v1/channels/ha/backups");
+  assert.deepEqual(empty.body, {});
+  // populated.
+  const args = {
+    name: "alfred-pre-zwave-fw",
+    password: "secret",
+    include_addons: ["core_mosquitto"],
+    include_database: false,
+    include_homeassistant: true,
+    include_folders: ["share"],
+  };
+  assert.equal(t.inputSchema.safeParse(args).success, true);
+  const r = t.buildRequest(args);
+  assert.deepEqual(r.body, args);
+});
+
+test("PR7 ha__delete_backup: requires decision_ref + backup_id, DELETE", () => {
+  const t = getTool("ha__delete_backup");
+  // both required.
+  assert.equal(t.inputSchema.safeParse({}).success, false);
+  assert.equal(
+    t.inputSchema.safeParse({ backup_id: "abc" }).success,
+    false,
+    "decision_ref required",
+  );
+  assert.equal(
+    t.inputSchema.safeParse({ decision_ref: "decision/x-2026-05-29.md" }).success,
+    false,
+    "backup_id required",
+  );
+  // happy path.
+  const args = {
+    backup_id: "abc123",
+    decision_ref: "decision/2026-05-29-prune.md",
+  };
+  assert.equal(t.inputSchema.safeParse(args).success, true);
+  const r = t.buildRequest(args);
+  assert.equal(r.method, "DELETE");
+  assert.equal(r.path, "/api/v1/channels/ha/backups/abc123");
+  assert.deepEqual(r.body, { decision_ref: args.decision_ref });
+});
+
+test("PR7 ha__restore_backup: requires decision_ref + backup_id, optional password", () => {
+  const t = getTool("ha__restore_backup");
+  // missing decision_ref → fails.
+  assert.equal(
+    t.inputSchema.safeParse({ backup_id: "abc" }).success,
+    false,
+  );
+  // happy path no password.
+  const noPw = {
+    backup_id: "abc123",
+    decision_ref: "decision/2026-05-29-restore.md",
+  };
+  assert.equal(t.inputSchema.safeParse(noPw).success, true);
+  const r1 = t.buildRequest(noPw);
+  assert.equal(r1.method, "POST");
+  assert.equal(r1.path, "/api/v1/channels/ha/backups/abc123/restore");
+  assert.deepEqual(r1.body, { decision_ref: noPw.decision_ref });
+  // with password.
+  const withPw = {
+    backup_id: "abc123",
+    password: "encrypted-archive-pass",
+    decision_ref: "decision/2026-05-29-restore.md",
+  };
+  assert.equal(t.inputSchema.safeParse(withPw).success, true);
+  const r2 = t.buildRequest(withPw);
+  assert.deepEqual(r2.body, {
+    decision_ref: withPw.decision_ref,
+    password: withPw.password,
+  });
+});
+
+test("PR7: every gated tool description mentions decision_ref + warns destructive", () => {
+  const GATED = [
+    "ha__core_restart",
+    "ha__core_update",
+    "ha__delete_backup",
+    "ha__restore_backup",
+  ];
+  for (const name of GATED) {
+    const t = getTool(name);
+    assert.ok(
+      t.description.toLowerCase().includes("decision_ref"),
+      `${name} description must mention decision_ref`,
+    );
+    assert.ok(
+      /destructive|stops? ha|offline|irreversible|several minutes/i.test(
+        t.description,
+      ),
+      `${name} description must warn about its blast radius`,
+    );
+  }
+});
+
+test("PR7: snapshot-on-trigger tools describe the auto-snapshot semantics", () => {
+  const SNAPSHOTTED = ["ha__core_restart", "ha__core_update"];
+  for (const name of SNAPSHOTTED) {
+    const t = getTool(name);
+    assert.ok(
+      /auto-snapshot|snapshot taken|backup_ref_id|ha_backup_id/i.test(
+        t.description,
+      ),
+      `${name} description must explain the auto-snapshot semantics`,
+    );
+  }
+});
+
+test("PR7 ha__restore_backup: description explicitly warns 'stops HA for several minutes'", () => {
+  const t = getTool("ha__restore_backup");
+  assert.ok(
+    /stops? ha|several minutes/i.test(t.description),
+    "ha__restore_backup description must spell out the HA-stop blast radius",
+  );
 });

--- a/packages/mcp-server/src/tools/hass.ts
+++ b/packages/mcp-server/src/tools/hass.ts
@@ -1039,12 +1039,288 @@ export const HASS_ADDON_TOOLS: ToolDef[] = [
 // === END Tier 4 PR6 ═══════════════════════════════════════════════════
 // ═════════════════════════════════════════════════════════════════════════
 
-// Final catalogue: 36 tools total = 11 read + 15 writes (5 PR4 + 10 PR3 CRUD)
-// + 10 PR6 supervisor addon. Order kept deliberately (reads first, writes
-// next, addon-CRUD last) so the model that lists the catalogue sees the
-// safe read surface before the destructive surfaces.
+// ═════════════════════════════════════════════════════════════════════════
+// === Tier 4 PR7: Core lifecycle + Backup CRUD ===
+// ═════════════════════════════════════════════════════════════════════════
+//
+// Issue #115 PR7 — 10 new tools fronting ctrl-api's
+// /api/v1/channels/ha/core/* + /api/v1/channels/ha/backups/* + /version
+// surfaces.
+//
+// Per the spec §4 gate matrix (locked YES 2026-05-29 by Sir):
+//
+// | Tool                  | decision_ref | auto-snapshot |
+// |-----------------------|--------------|---------------|
+// | ha__core_version      | no           | no            |
+// | ha__core_check_config | no           | no            |
+// | ha__core_reload_yaml  | no           | no            |
+// | ha__core_restart      | REQUIRED     | YES           |
+// | ha__core_update       | REQUIRED     | YES           |
+// | ha__list_backups      | no           | no            |
+// | ha__backup_info       | no           | no            |
+// | ha__create_backup     | no           | no (this IS a backup)
+// | ha__delete_backup     | REQUIRED     | no            |
+// | ha__restore_backup    | REQUIRED     | NO (restoring IS the recovery)
+//
+// Why these particular gates:
+//   * core_restart / core_update: HA goes down for 2-10 min. Sir's
+//     household notices. decision_ref + auto-snapshot mandatory.
+//   * delete_backup: backups themselves are how we roll back; deleting
+//     one is unrecoverable. decision_ref required.
+//   * restore_backup: HA stops for several minutes during the restore,
+//     comes back at a different state. decision_ref required. No
+//     snapshot because restoring IS the recovery action — backing up
+//     the broken state we're about to overwrite would be backwards.
+//   * create_backup: explicit Sir-asked backups are always fine; no
+//     gate. ctrl-api still persists a `ha_backup_ref` row with
+//     `triggered_by='user'` so the ledger is complete.
+
+const CoreDecisionRefParam = z
+  .string()
+  .min(6)
+  .max(256)
+  .regex(
+    /^[\x21-\x7E]+$/,
+    "decision_ref must be printable ASCII with no whitespace",
+  )
+  .describe(
+    "Vault path or ulid of the `decision/` record that authorised this destructive HA core/backup write. REQUIRED — Alfred refuses without it.",
+  );
+
+const BackupIdParam = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(
+    /^[A-Za-z0-9][A-Za-z0-9_.\-]{0,127}$/,
+    "backup_id must be 1..128 chars of [A-Za-z0-9_.-], starting with [A-Za-z0-9]",
+  )
+  .describe(
+    "HA backup id (slug). Read via `ha__list_backups` (each backup's `slug` / `backup_id` field) — never invent.",
+  );
+
+export const HASS_PR7_TOOLS: ToolDef[] = [
+  {
+    name: "ha__core_version",
+    description:
+      "Read HA's `/api/config` — returns `{ha_version, installation_type, location_name, data}` where `ha_version` is the running HA version (e.g. `2025.6.1`) and `installation_type` is one of `Home Assistant OS` / `Home Assistant Container` / `Home Assistant Core` / `Home Assistant Supervised`. **When to call:** before `ha__core_update` (to read current vs latest), when Sir asks 'what HA am I on?', or as a cheap connectivity probe. No gate. Idempotent.",
+    inputSchema: z.object({}),
+    buildRequest: () => ({
+      method: "GET",
+      path: "/api/v1/channels/ha/version",
+    }),
+  },
+
+  {
+    name: "ha__core_check_config",
+    description:
+      "Run HA's config check — verifies configuration.yaml parses cleanly and HA could restart without crashing. Resolves to `POST /api/services/homeassistant/check_config`. **When to call:** ALWAYS before `ha__core_restart` (so a malformed yaml doesn't take HA down) and after a `ha__core_reload_yaml` that hits an error. No gate. Idempotent. Returns the HA service-call result verbatim.",
+    inputSchema: z.object({}),
+    buildRequest: () => ({
+      method: "POST",
+      path: "/api/v1/channels/ha/core/check_config",
+      body: {},
+    }),
+  },
+
+  {
+    name: "ha__core_reload_yaml",
+    description:
+      "Reload every HA YAML-defined domain (automations / scripts / scenes / helpers / templates / customise) without restarting HA. Resolves to `POST /api/services/homeassistant/reload_all`. **When to call:** after editing yaml that's outside the REST CRUD surface (most automations / scenes / scripts already reload on their own POST/PUT; this is the broad refresh). No gate (idempotent — reloading again at any time is fine). NOT a restart — entities stay alive. Returns the HA service-call result verbatim.",
+    inputSchema: z.object({}),
+    buildRequest: () => ({
+      method: "POST",
+      path: "/api/v1/channels/ha/core/reload_yaml",
+      body: {},
+    }),
+  },
+
+  {
+    name: "ha__core_restart",
+    description:
+      "Restart HA's core process. **DESTRUCTIVE** — HA is OFFLINE for 30-120s while it comes back. Entities go unavailable; automations don't fire. **GATED** — requires `decision_ref`. **AUTO-SNAPSHOT** — ctrl-api triggers a real HA backup via `backup/generate` BEFORE the restart and records it in `ha_backup_ref`. The success envelope returns `backup_ref_id` + `ha_backup_id` + `backup_name`; mention 'snapshot taken' to Sir. **Always `ha__core_check_config` FIRST** — restarting on a broken config takes HA down hard.",
+    inputSchema: z.object({
+      decision_ref: CoreDecisionRefParam,
+    }),
+    buildRequest: ({ decision_ref }) => ({
+      method: "POST",
+      path: "/api/v1/channels/ha/core/restart",
+      body: { decision_ref },
+    }),
+  },
+
+  {
+    name: "ha__core_update",
+    description:
+      "Update HA Core to a newer version via Supervisor's OTA path. **HAOS / Supervised ONLY** — Container HA's update is pulled-image swap (Sir does that with docker compose). **DESTRUCTIVE** — HA is OFFLINE for 3-10 min during the update. **GATED** — requires `decision_ref`. **AUTO-SNAPSHOT** — ctrl-api triggers a real HA backup BEFORE the update and records it in `ha_backup_ref`; rollback is `ha__restore_backup({backup_id: ha_backup_id, …})`. Optional `version` pin (e.g. `2025.7.0`); omit for the latest stable. Read `ha__core_version` first to compare current vs target.",
+    inputSchema: z.object({
+      version: z
+        .string()
+        .min(1)
+        .max(32)
+        .regex(
+          /^[A-Za-z0-9._\-+]+$/,
+          "version must be 1..32 chars of [A-Za-z0-9._-+]",
+        )
+        .optional()
+        .describe(
+          "Pin the update to a specific HA Core version (e.g. `2025.7.0`). Omit to install the latest stable. Read the current version via `ha__core_version` first.",
+        ),
+      decision_ref: CoreDecisionRefParam,
+    }),
+    buildRequest: ({ version, decision_ref }) => ({
+      method: "POST",
+      path: "/api/v1/channels/ha/core/update",
+      body: {
+        decision_ref,
+        ...(version !== undefined ? { version } : {}),
+      },
+    }),
+  },
+
+  {
+    name: "ha__list_backups",
+    description:
+      "List every backup HA knows about — both Alfred-triggered (recorded in `ha_backup_ref`) and HA's own strategy/auto/user-initiated ones. Resolves to WS `backup/info`. Returns `data` straight from HA, typically `{backups: [{slug, name, date, size, type, …}, ...]}`. **When to call:** before `ha__restore_backup` (to find the right slug), when Sir asks 'what backups do I have?', or after `ha__create_backup` to confirm it landed. No gate. Idempotent.",
+    inputSchema: z.object({}),
+    buildRequest: () => ({
+      method: "GET",
+      path: "/api/v1/channels/ha/backups",
+    }),
+  },
+
+  {
+    name: "ha__backup_info",
+    description:
+      "Full details for one HA backup — date, size, addons included, folders included, password-protected y/n, compatible HA version. Resolves to WS `backup/details`. **When to call:** before `ha__restore_backup` (to confirm the backup includes what Sir needs back), when Sir asks 'what's in that backup?'. No gate. Idempotent.",
+    inputSchema: z.object({
+      backup_id: BackupIdParam,
+    }),
+    buildRequest: ({ backup_id }) => ({
+      method: "GET",
+      path: `/api/v1/channels/ha/backups/${encodeURIComponent(backup_id)}`,
+    }),
+  },
+
+  {
+    name: "ha__create_backup",
+    description:
+      "Generate a fresh HA backup. Resolves to WS `backup/generate`. **No gate** — explicit user-requested backups are always fine, and ctrl-api records the result in `ha_backup_ref` with `triggered_by='user'` so the ledger is complete. **When to call:** Sir asks 'back up HA', or Alfred proactively snapshots before a risky change Alfred can't trigger via a gated verb (e.g. before a long manual session). All fields optional — pass `{}` for the default backup. `password` encrypts the archive; `include_addons` etc. let Sir choose a partial backup.",
+    inputSchema: z.object({
+      name: z
+        .string()
+        .min(1)
+        .max(128)
+        .optional()
+        .describe(
+          "Human-readable backup name. HA assigns one if omitted; pass an Alfred-flavour name (e.g. `alfred-pre-zwave-firmware-2026-05-29`) when the trigger is contextual.",
+        ),
+      password: z
+        .string()
+        .min(1)
+        .optional()
+        .describe(
+          "Optional password — encrypts the backup archive. Without it the backup is plaintext on Sir's disk.",
+        ),
+      include_addons: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Optional addon slug list. Omit for HA's default (all addons).",
+        ),
+      include_database: z
+        .boolean()
+        .optional()
+        .describe(
+          "Include the HA recorder database. Default true; setting false drops the largest piece for a faster backup.",
+        ),
+      include_homeassistant: z
+        .boolean()
+        .optional()
+        .describe(
+          "Include the HA core (config + state). Default true — flipping false produces an addons-only backup.",
+        ),
+      include_folders: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Optional list of supervisor-known folders to include (e.g. `share`, `media`, `ssl`). Omit for HA's default set.",
+        ),
+    }),
+    buildRequest: ({
+      name,
+      password,
+      include_addons,
+      include_database,
+      include_homeassistant,
+      include_folders,
+    }) => ({
+      method: "POST",
+      path: "/api/v1/channels/ha/backups",
+      body: {
+        ...(name !== undefined ? { name } : {}),
+        ...(password !== undefined ? { password } : {}),
+        ...(include_addons !== undefined ? { include_addons } : {}),
+        ...(include_database !== undefined ? { include_database } : {}),
+        ...(include_homeassistant !== undefined ? { include_homeassistant } : {}),
+        ...(include_folders !== undefined ? { include_folders } : {}),
+      },
+    }),
+  },
+
+  {
+    name: "ha__delete_backup",
+    description:
+      "Delete an HA backup. Resolves to WS `backup/delete`. **DESTRUCTIVE + IRREVERSIBLE** — backups themselves are how Alfred rolls back; once a backup is gone, that point-in-time is gone. **GATED** — requires `decision_ref`. **NO snapshot** (we don't auto-snapshot backups before deleting them; that'd be silly). **When to call:** Sir asks to prune old backups, or after a successful restore Sir wants the staging backup gone. ctrl-api records the delete in the daybook.",
+    inputSchema: z.object({
+      backup_id: BackupIdParam,
+      decision_ref: CoreDecisionRefParam,
+    }),
+    buildRequest: ({ backup_id, decision_ref }) => ({
+      method: "DELETE",
+      path: `/api/v1/channels/ha/backups/${encodeURIComponent(backup_id)}`,
+      body: { decision_ref },
+    }),
+  },
+
+  {
+    name: "ha__restore_backup",
+    description:
+      "Restore HA from a backup. **DESTRUCTIVE — THIS STOPS HA FOR SEVERAL MINUTES.** HA shuts down, the backup is unpacked over the current state, HA restarts at the backup's snapshot point. State + automations + addons that existed at the backup time come back; anything changed since the backup is LOST. **GATED** — requires `decision_ref`. **NO auto-snapshot** — restoring IS the recovery action; backing up the broken state we're about to overwrite would be backwards. **When to call:** Sir says 'roll back', OR an Alfred-triggered destructive verb (core_restart/core_update/addon_install) failed and Sir wants the pre-snapshot state back. Read `ha__backup_info` FIRST to confirm the backup includes what Sir needs. The MCP envelope returns when the restore is QUEUED — HA itself restarts to apply it; follow up with `ha__core_version` after a minute to confirm it came back.",
+    inputSchema: z.object({
+      backup_id: BackupIdParam,
+      password: z
+        .string()
+        .min(1)
+        .optional()
+        .describe(
+          "Password for the backup if it was created encrypted. Omit for unencrypted backups; pass the password Sir used at `ha__create_backup` time otherwise.",
+        ),
+      decision_ref: CoreDecisionRefParam,
+    }),
+    buildRequest: ({ backup_id, password, decision_ref }) => ({
+      method: "POST",
+      path: `/api/v1/channels/ha/backups/${encodeURIComponent(backup_id)}/restore`,
+      body: {
+        decision_ref,
+        ...(password !== undefined ? { password } : {}),
+      },
+    }),
+  },
+];
+
+// ═════════════════════════════════════════════════════════════════════════
+// === END Tier 4 PR7 ═══════════════════════════════════════════════════
+// ═════════════════════════════════════════════════════════════════════════
+
+// Final catalogue: 46 tools total = 11 read + 15 writes (5 PR4 + 10 PR3 CRUD)
+// + 10 PR6 supervisor addon + 10 PR7 core+backups. Order kept deliberately
+// (reads first, automations/scenes/scripts next, addon-CRUD next, core+backups
+// last) so the model that lists the catalogue sees the safe read surface
+// before the destructive surfaces.
 export const ALL_HASS_TOOLS: ToolDef[] = [
   ...HASS_READ_TOOLS,
   ...HASS_DEFERRED_TOOLS,
   ...HASS_ADDON_TOOLS,
+  ...HASS_PR7_TOOLS,
 ];


### PR DESCRIPTION
**Tier 4 PR7** of #158 / #115 — HA core lifecycle (restart / update / check_config / reload_yaml / version) + backup CRUD (info / details / generate / delete / restore / strategy) + `ha_backup_ref` ledger ergonomics.

Builds on **PR1** (#163, merged) — WS client, `triggerBackupBeforeAction`, `recordHaWriteToDaybook`, migration 0011. Parallel with PR2 / PR4 / PR5 / PR8.

## Routes (11)

```
GET    /api/v1/channels/ha/version             REST /api/config
POST   /api/v1/channels/ha/core/check_config   REST homeassistant.check_config
POST   /api/v1/channels/ha/core/reload_yaml    REST homeassistant.reload_all
POST   /api/v1/channels/ha/core/restart        REST homeassistant.restart   gated + auto-snapshot
POST   /api/v1/channels/ha/core/update         WS  supervisor/api           gated + auto-snapshot
GET    /api/v1/channels/ha/backups             WS  backup/info
GET    /api/v1/channels/ha/backups/:id         WS  backup/details
POST   /api/v1/channels/ha/backups             WS  backup/generate          no gate; triggered_by='user'
DELETE /api/v1/channels/ha/backups/:id         WS  backup/delete            gated
POST   /api/v1/channels/ha/backups/:id/restore WS  backup/restore           gated; NO snapshot
GET    /api/v1/channels/ha/backups/strategy    WS  backup/strategy/info
PUT    /api/v1/channels/ha/backups/strategy    WS  backup/strategy/update   gated
GET    /api/v1/channels/ha/backups/ledger      reads ha_backup_ref          (audit surface)
```

Inside a bounded `// === Tier 4 PR7: Core + Backups ===` block at the bottom of `channels_ha.ts`.

## Gate matrix (locked YES 2026-05-29 by Sir)

| Route | decision_ref | auto-snapshot |
|---|---|---|
| core/check_config / reload_yaml / version | no | no |
| core/restart | **REQUIRED** | **YES** |
| core/update | **REQUIRED** | **YES** |
| backups GET list/details/strategy | no | no |
| backups POST (create) | no | no (this IS a backup) |
| backups DELETE | **REQUIRED** | no |
| backups POST restore | **REQUIRED** | **NO** (restoring IS the recovery) |
| backups/strategy PUT | **REQUIRED** | no |

## ha_backup_ref ledger

Every PR7-triggered backup lands a row. `triggered_by` distinguishes:

- `ha__core_restart` / `ha__core_update` — auto-snapshot before another verb (decision_ref non-null)
- `user` — explicit `POST /backups` (decision_ref null)
- `strategy:auto` — HA's scheduled strategy (reserved for the WS event drain)

`GET /backups/ledger?days=N&limit=N` answers "what backed up my system the last 30 days" without touching HA.

## MCP tools (10)

`ha__core_version`, `ha__core_check_config`, `ha__core_reload_yaml`, `ha__core_restart`, `ha__core_update`, `ha__list_backups`, `ha__backup_info`, `ha__create_backup`, `ha__delete_backup`, `ha__restore_backup`.

Spliced into `ALL_HASS_TOOLS` after PR6 addons. Catalogue now 46 tools (11 read + 15 write + 10 PR6 addon + 10 PR7 core+backup).

`ha__restore_backup` description explicitly warns "this stops HA for several minutes" per spec.

## Tests

- ctrl-api: 12 integration tests in `channels_ha_pr7.test.ts` — in-process `WebSocketServer` for WS verbs + fetch-mock for REST/vault-cli; covers check_config + restart + reload_yaml + update with version pin + list/info/create/delete/restore backups + strategy GET/PUT + ledger with `?days=` window narrowing.
- mcp-server: 13 unit tests in `hass.test.ts` — tool registration, name uniqueness, `decision_ref` required on the 4 gated tools, backup_id URL-traversal guard, description audit ("destructive" / "stops HA for several minutes" / "snapshot taken" / "auto-snapshot").

All 116 mcp tests + 12 PR7 ctrl tests green; broader ctrl suite (871 pass / 1 skipped) stays green.

## Skill doc

Adds "Home Assistant — Tier 4 (#115 PR7)" catalogue section + "Restart / update HA core / Back up before something risky" recipe section with 4 worked examples (safe restart, OTA update + rollback, explicit user backup, irreversible restore).

## Notes for reviewers

- vault-cli envelope nuance — `channels_ha.ts:readHaLlat` (single-wrapped, post-23917969) vs `ha_ws_client.ts:readHaLlat` (double-wrapped, PR1). My test fetch mock returns both shapes inside the same payload so both code paths read the LLAT successfully. Worth a follow-up to align the two readers, but out of scope for PR7.
- `recordAddonSnapshot` placeholder in the PR6 block (lines ~4193..4236 in channels_ha.ts) still exists — left untouched in case a parallel PR is touching it. PR7's destructive verbs use PR1's real `triggerBackupBeforeAction` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)