### PR TITLE
feat(ctrl,mcp): #115 PR5 — HACS CRUD via WS + integration ledger

### DIFF
--- a/packages/ctrl/src/api/routes/channels_ha.ts
+++ b/packages/ctrl/src/api/routes/channels_ha.ts
@@ -1049,6 +1049,11 @@ export function registerHaChannelRoutes(): void {
   // Vaultwarden item id (llat_vw_id) is returned. Sir reads the value
   // through the vault UI / vaultwarden MCP separately.
   registerHaUserRoutes();
+
+  // #115 PR5 — Tier 4 autonomy, HACS CRUD via the long-lived WS client
+  // landed in PR1. Independent of PR2/PR3/PR4/PR6/PR7/PR8; the splice
+  // block lives at the bottom of this file (`=== Tier 4 PR5: HACS ===`).
+  registerHaHacsRoutes();
 }
 
 /**
@@ -7212,3 +7217,514 @@ export function registerHaUserRoutes(): void {
 }
 
 // === END Tier 4 PR8 ═══════════════════════════════════════════════════
+
+// ═════════════════════════════════════════════════════════════════════════
+// === Tier 4 PR5: HACS ===
+// ═════════════════════════════════════════════════════════════════════════
+//
+// Issue #115 PR5 — Home Assistant Community Store CRUD via the long-lived
+// HA WebSocket client landed in PR1. Modern HACS no longer ships a REST
+// API; every CRUD verb crosses the `hacs/*` WS namespace. The surface
+// proxies through `getHaWsClient().wsCall(...)` for cheap shape parity
+// with the rest of Tier 4.
+//
+// LOAD-BEARING CONSTRAINTS
+// ------------------------
+// 1. Sir locked the gate matrix YES 2026-05-29. `install` and `remove`
+//    are destructive (a bad install can break HA on next restart;
+//    removing a HACS integration deletes its config_entry along with
+//    the rest of HACS's bookkeeping). Both REQUIRE `decision_ref` AND
+//    auto-snapshot via `triggerBackupBeforeAction` BEFORE the upstream
+//    WS call. The `add` verb (register a custom repository URL) does
+//    NOT install anything — it only adds the repo to HACS's local
+//    catalogue so a later `install` can target it. No gate, no snapshot.
+//    `refresh` / list / info / pending_updates are reads. No gate.
+//
+// 2. Every HACS-installed component is, by HA's own definition, an
+//    integration. When an `install` completes, we write to
+//    `ha_integration_ref` with `installed_by='alfred'` and the
+//    decision_ref so Sir can later trace any HACS install back to a
+//    Desk decision (the `# Architecture` row of the spec).
+//
+// 3. The four hacs/* call types this PR proxies are the ones today's
+//    agent verified live against Sir's HA (see the issue body):
+//      * `hacs/info`                — installation metadata
+//      * `hacs/repositories/list`   — full catalogue (~2950 repos today)
+//      * `hacs/repositories/add`    — register a custom repository URL
+//      * `hacs/repository/state`    — the row for one repo
+//      * `hacs/repository/refresh`  — force-refetch metadata
+//      * `hacs/repository/download` — install
+//      * `hacs/repository/remove`   — uninstall
+//
+// HACS category vocabulary (from `hacs/info.categories`):
+//     integration / plugin / theme / appdaemon / netdaemon
+// We accept the literal HACS strings on the input side and don't
+// translate — the spec calls them out unchanged so callers can copy
+// from HACS's own UI/docs.
+//
+// SPLICE BLOCK — keep everything between BEGIN / END markers contiguous.
+// PR2 / PR3 / PR4 / PR6 / PR7 own their own bounded blocks elsewhere in
+// this file. No file-wide rename or shared-helper edits inside this block.
+// `getHaWsClient`, `triggerBackupBeforeAction`, `recordHaWriteToDaybook`
+// are imported at the top of this file already (PR1 added the imports
+// when it landed the helpers; PR7 reused them and so do we).
+
+const HACS_CALL_TIMEOUT_MS = Number(
+  process.env.HA_HACS_TIMEOUT_MS ?? "20000",
+);
+
+// HACS categories the spec lists. Used to (a) validate the `category`
+// input on `add_custom_repo` and (b) filter the list response. We
+// intentionally accept any other string too on listing (HACS has added
+// categories historically — `python_script` exists on older HA, etc.)
+// but reject unknown strings on `add` so a typo doesn't leave a dead
+// row in HACS's catalogue.
+const HACS_ALLOWED_CATEGORIES = new Set([
+  "integration",
+  "plugin",
+  "theme",
+  "appdaemon",
+  "netdaemon",
+]);
+
+// HACS repo URLs are GitHub repos in `owner/name` form OR a full
+// `https://github.com/owner/name` URL. Accept either; HACS itself is
+// lax. The regex matches both shapes so callers don't have to strip
+// the host themselves. Source: the HACS docs at
+// https://hacs.xyz/docs/faq/custom_repositories.
+const HACS_REPO_URL_RE =
+  /^(https?:\/\/(?:www\.)?github\.com\/)?[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/?$/;
+
+function assertHacsRepoUrl(raw: unknown): string {
+  if (typeof raw !== "string" || raw.length === 0) {
+    throw new ValidationError("repository url is required and must be a non-empty string");
+  }
+  if (!HACS_REPO_URL_RE.test(raw)) {
+    throw new ValidationError(
+      "repository url must be a GitHub owner/name pair or a github.com URL",
+    );
+  }
+  return raw;
+}
+
+function assertHacsCategory(raw: unknown, strict: boolean): string {
+  if (typeof raw !== "string" || raw.length === 0) {
+    throw new ValidationError("category is required and must be a non-empty string");
+  }
+  if (strict && !HACS_ALLOWED_CATEGORIES.has(raw)) {
+    throw new ValidationError(
+      `category must be one of ${[...HACS_ALLOWED_CATEGORIES].join(", ")}`,
+    );
+  }
+  return raw;
+}
+
+// HACS repo ids are integers serialised as strings on most HA versions.
+// Lock down the character set so the path param can't smuggle a slash
+// or quote into our wsCall payload.
+const HACS_REPO_ID_RE = /^[A-Za-z0-9_.-]{1,64}$/;
+
+function assertHacsRepoId(raw: string): string {
+  if (!HACS_REPO_ID_RE.test(raw)) {
+    throw new ValidationError(
+      "repo id must be 1..64 chars of [A-Za-z0-9_.-]",
+    );
+  }
+  return raw;
+}
+
+/** Persist a `ha_integration_ref` row recording that Alfred installed
+ *  a HACS component. PR1's migration 0011 creates the table. */
+function recordHacsInstallToIntegrationLedger(args: {
+  repo_id: string;
+  decision_ref: string;
+}): { entry_id: string } {
+  // The HACS repo id is the closest stable identifier the WS surface
+  // gives us back from `download` — HACS lacks the
+  // config_entries/entry_id namespace until the principal completes a
+  // config_flow (only the `integration` category ever produces one).
+  // We key the ledger row on a deterministic `hacs:<repo_id>` so the
+  // audit trail captures the install regardless of whether HA later
+  // surfaces a config_entry.
+  const entry_id = `hacs:${args.repo_id}`;
+  const now = new Date().toISOString();
+  try {
+    getStateDb()
+      .prepare(
+        `INSERT INTO ha_integration_ref (entry_id, installed_by, decision_ref, installed_at)
+         VALUES (?, 'alfred', ?, ?)
+         ON CONFLICT(entry_id) DO UPDATE SET
+           installed_by = excluded.installed_by,
+           decision_ref = excluded.decision_ref,
+           installed_at = excluded.installed_at`,
+      )
+      .run(entry_id, args.decision_ref, now);
+  } catch {
+    // best-effort; never block the install on the audit row
+  }
+  return { entry_id };
+}
+
+/** Test seam — clear ha_integration_ref between fixture runs. */
+export function _resetHaHacsForTests(): void {
+  try {
+    getStateDb().prepare("DELETE FROM ha_integration_ref").run();
+  } catch {
+    // table may not exist on older fixtures; tests own migrations
+  }
+}
+
+/** Run a HACS WS call with the PR's standard timeout. Surfaces
+ *  upstream errors as a 502 ApiError so the route handler can return
+ *  a consistent envelope. */
+async function callHacs(
+  type: string,
+  payload: Record<string, unknown> = {},
+): Promise<unknown> {
+  try {
+    return await getHaWsClient().wsCall(type, payload, HACS_CALL_TIMEOUT_MS);
+  } catch (err) {
+    throw new ApiError(
+      502,
+      "HA_HACS_ERROR",
+      `HA WS ${type} failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+/** Normalise one HACS repo row into a stable shape the dashboard and
+ *  MCP layer can consume. We keep the raw payload available under
+ *  `raw` so callers don't have to re-query for fields we haven't
+ *  surfaced yet. */
+interface HacsRepoView {
+  id: string | null;
+  name: string | null;
+  full_name: string | null;
+  description: string | null;
+  category: string | null;
+  installed: boolean;
+  installed_version: string | null;
+  available_version: string | null;
+  pending_update: boolean;
+  topics: string[];
+  raw: Record<string, unknown>;
+}
+
+function viewHacsRepo(raw: Record<string, unknown>): HacsRepoView {
+  const id =
+    typeof raw.id === "string"
+      ? (raw.id as string)
+      : typeof raw.id === "number"
+        ? String(raw.id)
+        : null;
+  const name = typeof raw.name === "string" ? (raw.name as string) : null;
+  const full_name =
+    typeof raw.full_name === "string" ? (raw.full_name as string) : null;
+  const description =
+    typeof raw.description === "string" ? (raw.description as string) : null;
+  const category =
+    typeof raw.category === "string" ? (raw.category as string) : null;
+  const installed = raw.installed === true;
+  const installed_version =
+    typeof raw.installed_version === "string"
+      ? (raw.installed_version as string)
+      : null;
+  const available_version =
+    typeof raw.available_version === "string"
+      ? (raw.available_version as string)
+      : null;
+  const pending_update = installed && raw.pending_update === true;
+  const topics = Array.isArray(raw.topics)
+    ? (raw.topics as unknown[]).filter((x): x is string => typeof x === "string")
+    : [];
+  return {
+    id,
+    name,
+    full_name,
+    description,
+    category,
+    installed,
+    installed_version,
+    available_version,
+    pending_update,
+    topics,
+    raw,
+  };
+}
+
+/** Case-insensitive substring match across the human-facing fields. */
+function matchesQuery(view: HacsRepoView, q: string): boolean {
+  const needle = q.toLowerCase();
+  for (const v of [view.name, view.full_name, view.description]) {
+    if (typeof v === "string" && v.toLowerCase().includes(needle)) return true;
+  }
+  for (const t of view.topics) {
+    if (t.toLowerCase().includes(needle)) return true;
+  }
+  return false;
+}
+
+export function registerHaHacsRoutes(): void {
+  // ────────────────────────────────────────────────────────────────────
+  // GET /api/v1/channels/ha/hacs/info
+  //
+  // Read, no gate. Returns `{ok, info}` where info is the verbatim
+  // `hacs/info` payload (categories, country, debug, dev,
+  // disabled_reason, has_pending_tasks, lovelace_mode, stage).
+  // ────────────────────────────────────────────────────────────────────
+  addRoute("GET", "/api/v1/channels/ha/hacs/info", async ({ res }) => {
+    const info = await callHacs("hacs/info");
+    sendJson(res, 200, { ok: true, info });
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // GET /api/v1/channels/ha/hacs/repos
+  //
+  // Read, no gate. Returns `{ok, count, total, repos}` where repos is
+  // the filtered+normalised view list. Query params:
+  //   - category   — exact match against the row's category
+  //   - q          — substring match (name / full_name / description /
+  //                  topics)
+  //   - installed  — "1"/"true" filters to installed-only
+  //   - pending    — "1"/"true" filters to pending-update only
+  //   - limit      — clamp at 500 (HACS lists ~3k repos; the dashboard
+  //                  page renders 50 at a time)
+  // ────────────────────────────────────────────────────────────────────
+  addRoute("GET", "/api/v1/channels/ha/hacs/repos", async ({ res, query }) => {
+    const raw = await callHacs("hacs/repositories/list");
+    const total = Array.isArray(raw) ? raw.length : 0;
+    if (!Array.isArray(raw)) {
+      sendJson(res, 200, { ok: true, count: 0, total: 0, repos: [] });
+      return;
+    }
+    const category = query.get("category");
+    const q = query.get("q");
+    const installedOnly = ["1", "true", "yes"].includes(
+      (query.get("installed") ?? "").toLowerCase(),
+    );
+    const pendingOnly = ["1", "true", "yes"].includes(
+      (query.get("pending") ?? "").toLowerCase(),
+    );
+    const limit = Math.max(
+      1,
+      Math.min(Number(query.get("limit") ?? "500"), 500),
+    );
+    const repos: HacsRepoView[] = [];
+    for (const row of raw) {
+      if (!row || typeof row !== "object") continue;
+      const view = viewHacsRepo(row as Record<string, unknown>);
+      if (category && view.category !== category) continue;
+      if (installedOnly && !view.installed) continue;
+      if (pendingOnly && !view.pending_update) continue;
+      if (q && !matchesQuery(view, q)) continue;
+      repos.push(view);
+      if (repos.length >= limit) break;
+    }
+    sendJson(res, 200, {
+      ok: true,
+      count: repos.length,
+      total,
+      repos,
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // GET /api/v1/channels/ha/hacs/repo/:id
+  //
+  // Read, no gate. Wraps `hacs/repository/state` for a single repo.
+  // Returns `{ok, repo, state}` where state is the raw response.
+  // ────────────────────────────────────────────────────────────────────
+  addRoute(
+    "GET",
+    "/api/v1/channels/ha/hacs/repo/:id",
+    async ({ res, params }) => {
+      const id = assertHacsRepoId(params.id);
+      const state = await callHacs("hacs/repository/state", { repository: id });
+      // Best-effort: surface the matching list row too so a single GET
+      // gives the dashboard everything it needs without two round-trips.
+      let repo: HacsRepoView | null = null;
+      try {
+        const all = await callHacs("hacs/repositories/list");
+        if (Array.isArray(all)) {
+          for (const row of all) {
+            if (!row || typeof row !== "object") continue;
+            const view = viewHacsRepo(row as Record<string, unknown>);
+            if (view.id === id) {
+              repo = view;
+              break;
+            }
+          }
+        }
+      } catch {
+        // best-effort; the state response is the primary surface
+      }
+      sendJson(res, 200, { ok: true, id, state, repo });
+    },
+  );
+
+  // ────────────────────────────────────────────────────────────────────
+  // POST /api/v1/channels/ha/hacs/repos
+  //
+  // Body: { url, category }
+  //
+  // Register a custom repository URL with HACS. NO gate — adding to
+  // HACS's catalogue is reversible (the principal can drop it from
+  // HACS's UI in a single click) and doesn't install anything until a
+  // later `install` call. Daybook also stays silent — this is a setup
+  // step Sir doesn't need a chronological log for.
+  // ────────────────────────────────────────────────────────────────────
+  addRoute("POST", "/api/v1/channels/ha/hacs/repos", async ({ res, body }) => {
+    if (typeof body !== "object" || body === null) {
+      throw new ValidationError("body must be a JSON object");
+    }
+    const b = body as Record<string, unknown>;
+    const url = assertHacsRepoUrl(b.url);
+    const category = assertHacsCategory(b.category, true);
+    const result = await callHacs("hacs/repositories/add", {
+      repository: url,
+      category,
+    });
+    sendJson(res, 200, {
+      ok: true,
+      url,
+      category,
+      result,
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // POST /api/v1/channels/ha/hacs/install
+  //
+  // Body: { repo_id, version?, decision_ref }
+  //
+  // GATED — `decision_ref` REQUIRED. Auto-snapshot fires BEFORE the
+  // upstream `hacs/repository/download` so a failed install still
+  // surfaces snapshot intent. Daybook records the install (writes a
+  // `## HA writes` block under daybook/<YYYY-MM-DD>.md). On success,
+  // we record the install in `ha_integration_ref` keyed
+  // `hacs:<repo_id>` so Sir can later trace any HACS install back to
+  // the Desk decision that authorised it.
+  // ────────────────────────────────────────────────────────────────────
+  addRoute("POST", "/api/v1/channels/ha/hacs/install", async ({ res, body }) => {
+    if (typeof body !== "object" || body === null) {
+      throw new ValidationError("body must be a JSON object");
+    }
+    const b = body as Record<string, unknown>;
+    const repo_id = assertHacsRepoId(
+      typeof b.repo_id === "string" ? (b.repo_id as string) : "",
+    );
+    const decision_ref = assertDecisionRef(b.decision_ref);
+    const version =
+      typeof b.version === "string" && b.version.length > 0
+        ? (b.version as string)
+        : null;
+    // Snapshot BEFORE the install — even a failed download is intent
+    // we want in the ha_backup_ref ledger.
+    const snapshot = await triggerBackupBeforeAction(
+      "ha__hacs_install",
+      decision_ref,
+    );
+    const payload: Record<string, unknown> = { repository: repo_id };
+    if (version) payload.version = version;
+    const result = await callHacs("hacs/repository/download", payload);
+    // Record the install in the integration ledger so the audit ladder
+    // can answer "what did Alfred install via HACS?".
+    const ledger = recordHacsInstallToIntegrationLedger({
+      repo_id,
+      decision_ref,
+    });
+    const daybook = recordHaWriteToDaybook({
+      action: "ha__hacs_install",
+      summary: version
+        ? `HACS install ${repo_id} (version ${version})`
+        : `HACS install ${repo_id}`,
+      decision_ref,
+      extra: {
+        backup_ref_id: snapshot.id,
+        ha_backup_id: snapshot.ha_backup_id,
+        entry_id: ledger.entry_id,
+      },
+    });
+    sendJson(res, 200, {
+      ok: true,
+      repo_id,
+      version,
+      decision_ref,
+      backup_ref_id: snapshot.id,
+      ha_backup_id: snapshot.ha_backup_id,
+      entry_id: ledger.entry_id,
+      daybook,
+      result,
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // DELETE /api/v1/channels/ha/hacs/:id
+  //
+  // Body: { decision_ref }
+  //
+  // GATED — `decision_ref` REQUIRED. Auto-snapshot fires BEFORE the
+  // upstream `hacs/repository/remove`. Daybook records the removal.
+  // The `ha_integration_ref` row stays in place with the original
+  // install metadata so the audit trail isn't lost when a HACS
+  // component is removed.
+  // ────────────────────────────────────────────────────────────────────
+  addRoute(
+    "DELETE",
+    "/api/v1/channels/ha/hacs/:id",
+    async ({ res, body, params }) => {
+      const repo_id = assertHacsRepoId(params.id);
+      if (typeof body !== "object" || body === null) {
+        throw new ValidationError("body must be a JSON object");
+      }
+      const decision_ref = assertDecisionRef(
+        (body as Record<string, unknown>).decision_ref,
+      );
+      const snapshot = await triggerBackupBeforeAction(
+        "ha__hacs_remove",
+        decision_ref,
+      );
+      const result = await callHacs("hacs/repository/remove", {
+        repository: repo_id,
+      });
+      const daybook = recordHaWriteToDaybook({
+        action: "ha__hacs_remove",
+        summary: `HACS remove ${repo_id}`,
+        decision_ref,
+        extra: {
+          backup_ref_id: snapshot.id,
+          ha_backup_id: snapshot.ha_backup_id,
+        },
+      });
+      sendJson(res, 200, {
+        ok: true,
+        repo_id,
+        decision_ref,
+        backup_ref_id: snapshot.id,
+        ha_backup_id: snapshot.ha_backup_id,
+        daybook,
+        result,
+      });
+    },
+  );
+
+  // ────────────────────────────────────────────────────────────────────
+  // POST /api/v1/channels/ha/hacs/:id/refresh
+  //
+  // Read-ish — forces HACS to refetch metadata for one repo. Cheap and
+  // reversible; no gate, no snapshot, no daybook entry.
+  // ────────────────────────────────────────────────────────────────────
+  addRoute(
+    "POST",
+    "/api/v1/channels/ha/hacs/:id/refresh",
+    async ({ res, params }) => {
+      const repo_id = assertHacsRepoId(params.id);
+      const result = await callHacs("hacs/repository/refresh", {
+        repository: repo_id,
+      });
+      sendJson(res, 200, { ok: true, repo_id, result });
+    },
+  );
+}
+
+// === END Tier 4 PR5 ═══════════════════════════════════════════════════

--- a/packages/ctrl/tests/channels_ha_hacs.test.ts
+++ b/packages/ctrl/tests/channels_ha_hacs.test.ts
@@ -1,0 +1,642 @@
+// Tier 4 HACS routes — `/ha/hacs/*` (#115/#158 PR5).
+//
+// Coverage:
+//   1. `GET /ha/hacs/info` returns the verbatim hacs/info payload.
+//   2. `GET /ha/hacs/repos` returns the filtered+normalised list. Query
+//      params (`category`, `q`, `installed`, `pending`, `limit`) are
+//      honoured.
+//   3. `GET /ha/hacs/repo/:id` returns the row + the matching list view.
+//   4. `POST /ha/hacs/repos` (add custom repo) validates url + category,
+//      proxies to hacs/repositories/add. No gate, no snapshot.
+//   5. `POST /ha/hacs/install` is gated — missing decision_ref returns
+//      400. Snapshot fires BEFORE the upstream call. ha_integration_ref
+//      row is written. Daybook entry is written.
+//   6. `DELETE /ha/hacs/:id` is gated — same shape, no integration ledger
+//      row (the install row stays for audit).
+//   7. `POST /ha/hacs/:id/refresh` is no-gate, no-snapshot.
+//   8. `POST /ha/hacs/install` surfaces upstream errors as 502 even when
+//      the snapshot succeeded.
+//
+// We stand up the same fake HA WS server pattern PR1's
+// channels_ha_ws_routes.test.ts uses and add hacs/* handlers to it.
+
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import http from "node:http";
+import type { ServerResponse } from "node:http";
+import { WebSocketServer, type WebSocket as WSWebSocket } from "ws";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "channels-ha-hacs-"));
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.VAULT_PATH = path.join(tmp, "vault");
+process.env.STATE_DB_PATH = path.join(tmp, "alfred-state.db");
+process.env.INGEST_DB_PATH = path.join(tmp, "ingest.db");
+process.env.SQLITE_VEC_PATH = "";
+process.env.HA_WS_AUTOSTART = "false";
+process.env.HA_SNAPSHOT_DRY_RUN = "1";
+
+fs.mkdirSync(path.join(tmp, "vault", "decision"), { recursive: true });
+fs.mkdirSync(path.join(tmp, "vault", "daybook"), { recursive: true });
+
+// Seed a decision the destructive verbs can reference.
+const DECISION_ID = "01HACS00000000000000000001";
+fs.writeFileSync(
+  path.join(tmp, "vault", "decision", `${DECISION_ID}.md`),
+  `---\ntype: decision\nid: "${DECISION_ID}"\nstate: open\nintent: done\n---\n\n# HACS install authorised\n`,
+  "utf-8",
+);
+
+// ── fake HA WS server ──────────────────────────────────────────────────
+
+let server: http.Server;
+let wss: WebSocketServer;
+let serverPort = 0;
+const liveSockets: WSWebSocket[] = [];
+
+// Test-side knobs the suite tweaks per case to drive specific WS
+// behaviour.
+const wsControl = {
+  failNext: null as string | null, // when set, the NEXT call matching this type returns success:false
+  installCalls: [] as Record<string, unknown>[],
+  removeCalls: [] as Record<string, unknown>[],
+  refreshCalls: [] as Record<string, unknown>[],
+  addCalls: [] as Record<string, unknown>[],
+  repos: [
+    {
+      id: "1",
+      name: "better_thermostat",
+      full_name: "KartoffelToby/better_thermostat",
+      description: "A better thermostat",
+      category: "integration",
+      installed: true,
+      installed_version: "0.9.0",
+      available_version: "1.0.0",
+      pending_update: true,
+      topics: ["climate", "thermostat"],
+    },
+    {
+      id: "2",
+      name: "mushroom",
+      full_name: "piitaya/lovelace-mushroom",
+      description: "Cards for Home Assistant",
+      category: "plugin",
+      installed: false,
+      installed_version: null,
+      available_version: "2.5.0",
+      pending_update: false,
+      topics: ["dashboard"],
+    },
+    {
+      id: "3",
+      name: "ios_dark",
+      full_name: "basnijholt/lovelace-ios-dark-mode-theme",
+      description: "iOS-style dark theme",
+      category: "theme",
+      installed: true,
+      installed_version: "1.2",
+      available_version: "1.2",
+      pending_update: false,
+      topics: ["theme"],
+    },
+  ] as Record<string, unknown>[],
+};
+
+function setupServer(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    server = http.createServer();
+    wss = new WebSocketServer({ server, path: "/api/websocket" });
+    wss.on("connection", (ws) => {
+      liveSockets.push(ws);
+      ws.send(JSON.stringify({ type: "auth_required" }));
+      ws.on("message", (raw) => {
+        let msg: Record<string, unknown>;
+        try {
+          msg = JSON.parse(String(raw)) as Record<string, unknown>;
+        } catch {
+          return;
+        }
+        if (msg.type === "auth") {
+          ws.send(JSON.stringify({ type: "auth_ok" }));
+          return;
+        }
+        const id = msg.id;
+        const type = msg.type as string;
+        // helper to send error
+        const sendErr = (code: string, message: string): void => {
+          ws.send(
+            JSON.stringify({
+              id,
+              type: "result",
+              success: false,
+              error: { code, message },
+            }),
+          );
+        };
+        const sendOk = (result: unknown): void => {
+          ws.send(JSON.stringify({ id, type: "result", success: true, result }));
+        };
+        if (wsControl.failNext === type) {
+          wsControl.failNext = null;
+          sendErr("internal_error", `forced failure for ${type}`);
+          return;
+        }
+        if (type === "hacs/info") {
+          sendOk({
+            categories: [
+              "integration",
+              "plugin",
+              "theme",
+              "appdaemon",
+              "netdaemon",
+            ],
+            country: "US",
+            debug: false,
+            dev: false,
+            disabled_reason: null,
+            has_pending_tasks: false,
+            lovelace_mode: "storage",
+            stage: "running",
+          });
+          return;
+        }
+        if (type === "hacs/repositories/list") {
+          sendOk(wsControl.repos);
+          return;
+        }
+        if (type === "hacs/repository/state") {
+          const repo_id = msg.repository as string;
+          const found = wsControl.repos.find((r) => r.id === repo_id);
+          if (!found) {
+            sendErr("not_found", `repo ${repo_id} not in catalogue`);
+            return;
+          }
+          sendOk({ id: repo_id, status: "ok", state: found.installed ? "installed" : "available" });
+          return;
+        }
+        if (type === "hacs/repositories/add") {
+          wsControl.addCalls.push(msg);
+          sendOk({ added: true });
+          return;
+        }
+        if (type === "hacs/repository/download") {
+          wsControl.installCalls.push(msg);
+          sendOk({ downloaded: true });
+          return;
+        }
+        if (type === "hacs/repository/remove") {
+          wsControl.removeCalls.push(msg);
+          sendOk({ removed: true });
+          return;
+        }
+        if (type === "hacs/repository/refresh") {
+          wsControl.refreshCalls.push(msg);
+          sendOk({ refreshed: true });
+          return;
+        }
+        if (type === "subscribe_events") {
+          sendOk(null);
+          return;
+        }
+        // Default — accept silently. Other Tier-4 callers may probe and
+        // we don't want to crash on every unexpected message.
+        sendOk(null);
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (addr && typeof addr === "object") serverPort = addr.port;
+      resolve();
+    });
+  });
+}
+
+function teardownServer(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    for (const s of liveSockets) {
+      try {
+        s.terminate();
+      } catch {
+        // best-effort
+      }
+    }
+    liveSockets.length = 0;
+    wss?.close(() => {
+      server?.close(() => resolve());
+    });
+  });
+}
+
+await setupServer();
+process.env.HA_WS_URL_OVERRIDE = `ws://127.0.0.1:${serverPort}/api/websocket`;
+
+// Import after env is set so the modules see the right paths.
+const { registerHaHacsRoutes, _resetHaHacsForTests } = await import(
+  "../src/api/routes/channels_ha.js"
+);
+const { matchRoute } = await import("../src/api/server.js");
+const { handleError } = await import("../src/api/errors.js");
+const { getStateDb } = await import("../src/db/state.js");
+const { _resetHaWsClientForTests, getHaWsClient } = await import(
+  "../src/api/lib/ha_ws_client.js"
+);
+
+registerHaHacsRoutes();
+
+// Seed ha_connection so the WS client connects.
+getStateDb()
+  .prepare(
+    `INSERT INTO ha_connection (id, ha_url, label, vault_item_id, state)
+     VALUES (1, ?, ?, ?, 'connected')
+     ON CONFLICT(id) DO UPDATE SET state='connected'`,
+  )
+  .run("http://127.0.0.1:8123", "fake", "vw-test-id");
+
+// Vault-cli mock so the WS client can read the LLAT.
+const originalFetch = globalThis.fetch;
+globalThis.fetch = (async (input: unknown) => {
+  const url =
+    typeof input === "string"
+      ? input
+      : ((input as { url?: string })?.url ?? String(input));
+  if (url.includes("/object/item/")) {
+    return new Response(
+      JSON.stringify({
+        success: true,
+        data: { data: { login: { password: "llat_test" } } },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }
+  return originalFetch(input as Parameters<typeof originalFetch>[0]);
+}) as typeof fetch;
+
+interface CallResult {
+  status: number;
+  payload: any;
+}
+async function call(
+  method: string,
+  p: string,
+  body?: unknown,
+): Promise<CallResult> {
+  const [pathOnly, queryStr] = p.split("?", 2);
+  const m = matchRoute(method, pathOnly);
+  assert.ok(m, `${method} ${p} must be registered`);
+  let status = 0;
+  let payload: any;
+  const res = {
+    statusCode: 0,
+    setHeader() {},
+    writeHead(c: number) {
+      status = c;
+      return res;
+    },
+    end(j?: string) {
+      payload = j ? JSON.parse(j) : undefined;
+    },
+  } as unknown as ServerResponse;
+  try {
+    await m!.handler({
+      req: { method, headers: {}, url: p } as any,
+      res,
+      params: m!.params,
+      body,
+      query: new URLSearchParams(queryStr ?? ""),
+    });
+  } catch (err) {
+    handleError(res, err);
+  }
+  return { status, payload };
+}
+
+async function waitForWsConnected(): Promise<void> {
+  getHaWsClient().start();
+  for (let i = 0; i < 100; i++) {
+    if (getHaWsClient().getStatus().connected) return;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  throw new Error("WS client never reached connected state");
+}
+
+describe("/api/v1/channels/ha/hacs/* — #115/#158 PR5", () => {
+  before(async () => {
+    await waitForWsConnected();
+  });
+
+  beforeEach(() => {
+    wsControl.failNext = null;
+    wsControl.installCalls.length = 0;
+    wsControl.removeCalls.length = 0;
+    wsControl.refreshCalls.length = 0;
+    wsControl.addCalls.length = 0;
+    _resetHaHacsForTests();
+    try {
+      getStateDb().prepare("DELETE FROM ha_backup_ref").run();
+    } catch {
+      // ignore
+    }
+  });
+
+  after(async () => {
+    _resetHaWsClientForTests();
+    await teardownServer();
+    globalThis.fetch = originalFetch;
+  });
+
+  // ── 1. GET /ha/hacs/info ──────────────────────────────────────────
+  it("GET /ha/hacs/info — returns the verbatim hacs/info payload", async () => {
+    const r = await call("GET", "/api/v1/channels/ha/hacs/info");
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.ok, true);
+    assert.deepEqual(r.payload.info.categories, [
+      "integration",
+      "plugin",
+      "theme",
+      "appdaemon",
+      "netdaemon",
+    ]);
+    assert.equal(r.payload.info.stage, "running");
+  });
+
+  // ── 2. GET /ha/hacs/repos ─────────────────────────────────────────
+  it("GET /ha/hacs/repos — returns the normalised list with total + count", async () => {
+    const r = await call("GET", "/api/v1/channels/ha/hacs/repos");
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.ok, true);
+    assert.equal(r.payload.total, 3);
+    assert.equal(r.payload.count, 3);
+    assert.equal(r.payload.repos[0].name, "better_thermostat");
+    assert.equal(r.payload.repos[0].pending_update, true);
+    assert.equal(r.payload.repos[1].installed, false);
+  });
+
+  it("GET /ha/hacs/repos?category=plugin — filters by category", async () => {
+    const r = await call(
+      "GET",
+      "/api/v1/channels/ha/hacs/repos?category=plugin",
+    );
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.count, 1);
+    assert.equal(r.payload.repos[0].id, "2");
+    assert.equal(r.payload.total, 3, "total reflects upstream, not filter");
+  });
+
+  it("GET /ha/hacs/repos?q=thermostat — substring matches name + topics", async () => {
+    const r = await call(
+      "GET",
+      "/api/v1/channels/ha/hacs/repos?q=thermostat",
+    );
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.count, 1);
+    assert.equal(r.payload.repos[0].id, "1");
+  });
+
+  it("GET /ha/hacs/repos?installed=1 — filters to installed-only", async () => {
+    const r = await call(
+      "GET",
+      "/api/v1/channels/ha/hacs/repos?installed=true",
+    );
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.count, 2);
+    for (const repo of r.payload.repos) {
+      assert.equal(repo.installed, true);
+    }
+  });
+
+  it("GET /ha/hacs/repos?pending=1 — filters to pending-update only", async () => {
+    const r = await call(
+      "GET",
+      "/api/v1/channels/ha/hacs/repos?pending=1",
+    );
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.count, 1);
+    assert.equal(r.payload.repos[0].pending_update, true);
+  });
+
+  it("GET /ha/hacs/repos?limit=2 — clamps the response", async () => {
+    const r = await call(
+      "GET",
+      "/api/v1/channels/ha/hacs/repos?limit=2",
+    );
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.count, 2);
+    assert.equal(r.payload.total, 3);
+  });
+
+  // ── 3. GET /ha/hacs/repo/:id ──────────────────────────────────────
+  it("GET /ha/hacs/repo/:id — returns the state + the list view", async () => {
+    const r = await call("GET", "/api/v1/channels/ha/hacs/repo/1");
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.ok, true);
+    assert.equal(r.payload.id, "1");
+    assert.equal(r.payload.state.state, "installed");
+    assert.equal(r.payload.repo.name, "better_thermostat");
+  });
+
+  it("GET /ha/hacs/repo/:id — rejects ids that violate the charset", async () => {
+    const r = await call("GET", "/api/v1/channels/ha/hacs/repo/bad%2Fpath");
+    // Either the path-router rejects (404) or our validator rejects
+    // (400). Both are acceptable — what we forbid is the upstream
+    // wsCall firing on a malformed id.
+    assert.ok(
+      r.status === 400 || r.status === 404,
+      `expected 400/404, got ${r.status}: ${JSON.stringify(r.payload)}`,
+    );
+  });
+
+  // ── 4. POST /ha/hacs/repos (add custom) ──────────────────────────
+  it("POST /ha/hacs/repos — adds a custom repo, no gate, no snapshot", async () => {
+    const r = await call(
+      "POST",
+      "/api/v1/channels/ha/hacs/repos",
+      { url: "user/cool-thing", category: "integration" },
+    );
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.ok, true);
+    assert.equal(r.payload.url, "user/cool-thing");
+    assert.equal(r.payload.category, "integration");
+    assert.equal(wsControl.addCalls.length, 1);
+    assert.equal(wsControl.addCalls[0].repository, "user/cool-thing");
+    assert.equal(wsControl.addCalls[0].category, "integration");
+    // No backup row should have been written.
+    const backups = getStateDb()
+      .prepare("SELECT COUNT(*) AS n FROM ha_backup_ref")
+      .get() as { n: number };
+    assert.equal(backups.n, 0, "add must not snapshot");
+  });
+
+  it("POST /ha/hacs/repos — 400 on bad category", async () => {
+    const r = await call(
+      "POST",
+      "/api/v1/channels/ha/hacs/repos",
+      { url: "user/x", category: "bogus" },
+    );
+    assert.equal(r.status, 400);
+    assert.equal(wsControl.addCalls.length, 0);
+  });
+
+  it("POST /ha/hacs/repos — 400 on bad url", async () => {
+    const r = await call(
+      "POST",
+      "/api/v1/channels/ha/hacs/repos",
+      { url: "not a url", category: "integration" },
+    );
+    assert.equal(r.status, 400);
+  });
+
+  it("POST /ha/hacs/repos — accepts a full github.com URL", async () => {
+    const r = await call(
+      "POST",
+      "/api/v1/channels/ha/hacs/repos",
+      {
+        url: "https://github.com/user/cool-thing",
+        category: "plugin",
+      },
+    );
+    assert.equal(r.status, 200);
+    assert.equal(
+      wsControl.addCalls[0].repository,
+      "https://github.com/user/cool-thing",
+    );
+  });
+
+  // ── 5. POST /ha/hacs/install ─────────────────────────────────────
+  it("POST /ha/hacs/install — REQUIRES decision_ref (400 without it)", async () => {
+    const r = await call(
+      "POST",
+      "/api/v1/channels/ha/hacs/install",
+      { repo_id: "1" },
+    );
+    assert.equal(r.status, 400, JSON.stringify(r.payload));
+    assert.equal(
+      wsControl.installCalls.length,
+      0,
+      "upstream must NOT fire on a gate violation",
+    );
+  });
+
+  it("POST /ha/hacs/install — snapshots + writes integration ref + daybook", async () => {
+    const r = await call(
+      "POST",
+      "/api/v1/channels/ha/hacs/install",
+      { repo_id: "1", version: "1.0.0", decision_ref: DECISION_ID },
+    );
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.ok, true);
+    assert.equal(r.payload.repo_id, "1");
+    assert.equal(r.payload.version, "1.0.0");
+    assert.equal(r.payload.entry_id, "hacs:1");
+    assert.match(r.payload.ha_backup_id, /^dry-run-/);
+    assert.equal(r.payload.daybook.written, true);
+    // Upstream install ran with the right payload.
+    assert.equal(wsControl.installCalls.length, 1);
+    assert.equal(wsControl.installCalls[0].repository, "1");
+    assert.equal(wsControl.installCalls[0].version, "1.0.0");
+    // ha_integration_ref row landed.
+    const row = getStateDb()
+      .prepare("SELECT * FROM ha_integration_ref WHERE entry_id = ?")
+      .get("hacs:1") as Record<string, unknown> | undefined;
+    assert.ok(row, "ha_integration_ref row written");
+    assert.equal(row!.installed_by, "alfred");
+    assert.equal(row!.decision_ref, DECISION_ID);
+    // ha_backup_ref row landed.
+    const backupRow = getStateDb()
+      .prepare("SELECT * FROM ha_backup_ref WHERE id = ?")
+      .get(r.payload.backup_ref_id) as Record<string, unknown> | undefined;
+    assert.ok(backupRow);
+    assert.equal(backupRow!.triggered_by, "ha__hacs_install");
+    // Daybook file has the entry.
+    const dayPath = path.join(
+      tmp,
+      "vault",
+      "daybook",
+      `${new Date().toISOString().slice(0, 10)}.md`,
+    );
+    const md = fs.readFileSync(dayPath, "utf-8");
+    assert.ok(md.includes("ha__hacs_install"));
+    assert.ok(md.includes(DECISION_ID));
+  });
+
+  it("POST /ha/hacs/install — surfaces upstream errors as 502", async () => {
+    wsControl.failNext = "hacs/repository/download";
+    const r = await call(
+      "POST",
+      "/api/v1/channels/ha/hacs/install",
+      { repo_id: "1", decision_ref: DECISION_ID },
+    );
+    assert.equal(r.status, 502, JSON.stringify(r.payload));
+    // The snapshot fires BEFORE the upstream call, so the snapshot
+    // row IS in the ledger even when the install fails — that's the
+    // contract.
+    const backupRows = getStateDb()
+      .prepare("SELECT COUNT(*) AS n FROM ha_backup_ref WHERE triggered_by = ?")
+      .get("ha__hacs_install") as { n: number };
+    assert.equal(backupRows.n, 1);
+    // But the integration ledger row does NOT exist — the install
+    // failed, nothing was installed.
+    const ledger = getStateDb()
+      .prepare("SELECT COUNT(*) AS n FROM ha_integration_ref WHERE entry_id = ?")
+      .get("hacs:1") as { n: number };
+    assert.equal(ledger.n, 0, "no integration ledger row on failed install");
+  });
+
+  // ── 6. DELETE /ha/hacs/:id ──────────────────────────────────────
+  it("DELETE /ha/hacs/:id — REQUIRES decision_ref", async () => {
+    const r = await call(
+      "DELETE",
+      "/api/v1/channels/ha/hacs/2",
+      {},
+    );
+    assert.equal(r.status, 400);
+    assert.equal(wsControl.removeCalls.length, 0);
+  });
+
+  it("DELETE /ha/hacs/:id — snapshots + daybooks + removes", async () => {
+    const r = await call(
+      "DELETE",
+      "/api/v1/channels/ha/hacs/2",
+      { decision_ref: DECISION_ID },
+    );
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.repo_id, "2");
+    assert.equal(r.payload.daybook.written, true);
+    assert.equal(wsControl.removeCalls.length, 1);
+    assert.equal(wsControl.removeCalls[0].repository, "2");
+    const backupRows = getStateDb()
+      .prepare("SELECT COUNT(*) AS n FROM ha_backup_ref WHERE triggered_by = ?")
+      .get("ha__hacs_remove") as { n: number };
+    assert.equal(backupRows.n, 1);
+  });
+
+  // ── 7. POST /ha/hacs/:id/refresh ─────────────────────────────────
+  it("POST /ha/hacs/:id/refresh — no gate, no snapshot, no daybook", async () => {
+    const r = await call(
+      "POST",
+      "/api/v1/channels/ha/hacs/1/refresh",
+      {},
+    );
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.repo_id, "1");
+    assert.equal(wsControl.refreshCalls.length, 1);
+    assert.equal(wsControl.refreshCalls[0].repository, "1");
+    const backupRows = getStateDb()
+      .prepare("SELECT COUNT(*) AS n FROM ha_backup_ref")
+      .get() as { n: number };
+    assert.equal(backupRows.n, 0);
+  });
+
+  it("POST /ha/hacs/:id/refresh — rejects malformed id", async () => {
+    const r = await call(
+      "POST",
+      "/api/v1/channels/ha/hacs/bad%2Fpath/refresh",
+      {},
+    );
+    assert.ok(
+      r.status === 400 || r.status === 404,
+      `expected 400/404, got ${r.status}`,
+    );
+  });
+});

--- a/packages/mcp-server/skills/alfred-mcp-skill.md
+++ b/packages/mcp-server/skills/alfred-mcp-skill.md
@@ -423,6 +423,61 @@ HACS custom component, restart core for an OTA update) without
 Sir touching HA's UI — and every such write is recorded in the daybook
 so Sir has a clean audit ledger.
 
+### HACS catalogue (#115 PR5) — install / remove / refresh
+
+HACS (Home Assistant Community Store) is the community catalogue of
+integrations, Lovelace cards, themes, and AppDaemon/NetDaemon apps that
+HA itself doesn't ship. Alfred has 8 HACS tools, gated like the rest of
+Tier 4:
+
+  - `ha__hacs_info` — installation metadata (categories, stage). Probe
+    BEFORE any write to confirm HACS is running.
+  - `ha__hacs_search` — query the catalogue. Filter by `category` and/or
+    a substring `query`. Use `installed: true` to scope to what's already
+    in the home.
+  - `ha__hacs_repo_info` — one repo's state + list view in one
+    round-trip. Use to read the description + version before quoting
+    them to Sir.
+  - `ha__hacs_add_custom_repo` — register a custom GitHub repo with
+    HACS. **No gate** — adding to the catalogue doesn't install
+    anything; the install step is gated.
+  - `ha__hacs_install` — gated. REQUIRES `decision_ref`. Auto-snapshots
+    BEFORE the download. The install is recorded in `ha_integration_ref`
+    so the audit trail can trace any HACS install back to a Desk
+    decision.
+  - `ha__hacs_remove` — gated. REQUIRES `decision_ref`. Auto-snapshots
+    BEFORE the remove.
+  - `ha__hacs_refresh` — force HACS to refetch metadata for one repo.
+    Cheap, no gate.
+  - `ha__hacs_pending_updates` — list installed repos with a pending
+    update. Use before proposing an HA maintenance brief.
+
+**Common flow — "install the 'better thermostat' integration from HACS":**
+
+  1. `ha__hacs_info` — confirm `stage === 'running'`.
+  2. `ha__hacs_search` with `category: "integration"`, `query: "better
+     thermostat"`. Pick the right repo by `full_name` (e.g.
+     `KartoffelToby/better_thermostat`).
+  3. `ha__hacs_repo_info` on the id from step 2. Read the description +
+     `available_version` so the Desk card is concrete.
+  4. Create a Desk decision: "install the better_thermostat HACS
+     integration (v1.0.0)". Wait for Sir to HANDLE / TAKE-MINE the
+     card.
+  5. `ha__hacs_install` with `repo_id`, optionally `version`, and the
+     `decision_ref` from step 4. Quote `ha_backup_id` and `entry_id` in
+     your confirmation to Sir.
+  6. The actual HA config_flow (for `integration`-category installs)
+     still needs to run — point Sir at the HA UI to complete it, OR
+     use the integration_configure flow (PR4) to drive it
+     programmatically.
+
+**Common flow — "install a custom repo Sir found on GitHub":**
+
+  1. `ha__hacs_add_custom_repo` with the GitHub URL + category. Sir
+     can drop the row from HACS's UI if anything looks wrong; no gate.
+  2. `ha__hacs_search` to find the id HACS assigned the new repo.
+  3. Continue at step 4 of the install flow above.
+
 ---
 
 ## Tone

--- a/packages/mcp-server/src/tools/hass.test.ts
+++ b/packages/mcp-server/src/tools/hass.test.ts
@@ -23,6 +23,7 @@ import {
   HASS_PR7_TOOLS,
   HASS_INTEGRATION_TOOLS,
   HASS_USER_TOOLS,
+  HASS_HACS_TOOLS,
 } from "./hass.js";
 import { SUPPORTED_APPS, isAppId, getToolsForApp } from "./registry.js";
 
@@ -34,7 +35,7 @@ function getTool(name: string) {
 
 // ─── catalogue shape ────────────────────────────────────────────────────
 
-test("hass catalogue: exactly 61 tools (11 read + 15 write + 10 PR6 addon + 10 PR7 core+backup + 7 PR4 integration + 8 PR8 user)", () => {
+test("hass catalogue: exactly 69 tools (11 read + 15 write + 10 PR6 addon + 10 PR7 core+backup + 7 PR4 integration + 8 PR8 user + 8 PR5 HACS)", () => {
   assert.equal(HASS_READ_TOOLS.length, 11);
   // After #115 PR3 splice: PR4's 5 + PR3's 10 = 15 writes.
   assert.equal(HASS_DEFERRED_TOOLS.length, 15);
@@ -47,14 +48,16 @@ test("hass catalogue: exactly 61 tools (11 read + 15 write + 10 PR6 addon + 10 P
   // PR8: 8 user + LLAT tools (spec named 7; we added ha__list_user_llats
   // for token visibility before revoke).
   assert.equal(HASS_USER_TOOLS.length, 8);
-  assert.equal(ALL_HASS_TOOLS.length, 61);
+  // PR5: 8 HACS tools.
+  assert.equal(HASS_HACS_TOOLS.length, 8);
+  assert.equal(ALL_HASS_TOOLS.length, 69);
 });
 
-test("registry: hass is a supported app and registers all 61 tools", () => {
+test("registry: hass is a supported app and registers all 69 tools", () => {
   assert.ok(isAppId("hass"));
   assert.ok((SUPPORTED_APPS as Set<string>).has("hass"));
   const tools = getToolsForApp("hass");
-  assert.equal(tools.length, 61);
+  assert.equal(tools.length, 69);
 });
 
 test("hass: every tool name is unique", () => {
@@ -1804,4 +1807,213 @@ test("PR8: ha__mint_llat response shape MUST be redacted (the model never sees t
   const t = getTool("ha__mint_llat");
   assert.match(t.description, /NEVER include|llat_vw_id|vault id is the receipt/i);
   assert.match(t.description, /MASKING IS LOAD-BEARING|redacted: true/i);
+});
+
+// ═════════════════════════════════════════════════════════════════════════
+// === Tier 4 PR5: HACS tool unit tests ===
+// ═════════════════════════════════════════════════════════════════════════
+//
+// 11 tests covering the 8 PR5 HACS tools:
+//   1. all 8 names exist in HASS_HACS_TOOLS
+//   2-9. one buildRequest + schema test per tool
+//   10. gated tools (install/remove) call out decision_ref in description
+//   11. non-gated tools accept input without decision_ref
+
+const HACS_TOOL_NAMES = [
+  "ha__hacs_info",
+  "ha__hacs_search",
+  "ha__hacs_repo_info",
+  "ha__hacs_add_custom_repo",
+  "ha__hacs_install",
+  "ha__hacs_remove",
+  "ha__hacs_refresh",
+  "ha__hacs_pending_updates",
+];
+
+test("HACS PR5: all 8 tool names present in HASS_HACS_TOOLS", () => {
+  for (const name of HACS_TOOL_NAMES) {
+    assert.ok(
+      HASS_HACS_TOOLS.find((t) => t.name === name),
+      `${name} missing from HASS_HACS_TOOLS`,
+    );
+  }
+});
+
+test("ha__hacs_info: empty input schema, GET /hacs/info", () => {
+  const t = getTool("ha__hacs_info");
+  assert.equal(t.inputSchema.safeParse({}).success, true);
+  const r = t.buildRequest({});
+  assert.equal(r.method, "GET");
+  assert.equal(r.path, "/api/v1/channels/ha/hacs/info");
+});
+
+test("ha__hacs_search: optional query/category/installed/limit, builds GET /hacs/repos", () => {
+  const t = getTool("ha__hacs_search");
+  // Empty is valid (limit defaults).
+  assert.equal(t.inputSchema.safeParse({}).success, true);
+  // Bad category rejected.
+  assert.equal(
+    t.inputSchema.safeParse({ category: "bogus" }).success,
+    false,
+  );
+  // Limit out of range rejected.
+  assert.equal(
+    t.inputSchema.safeParse({ limit: 999 }).success,
+    false,
+  );
+  const r1 = t.buildRequest({
+    query: "thermostat",
+    category: "integration",
+    installed: true,
+    limit: 25,
+  });
+  assert.equal(r1.method, "GET");
+  assert.equal(r1.path, "/api/v1/channels/ha/hacs/repos");
+  assert.deepEqual(r1.query, {
+    q: "thermostat",
+    category: "integration",
+    installed: "1",
+    limit: "25",
+  });
+  // No filters → bare query
+  const r2 = t.buildRequest({ limit: 50 });
+  assert.deepEqual(r2.query, { limit: "50" });
+});
+
+test("ha__hacs_repo_info: repo_id required, encodeURIComponent applied", () => {
+  const t = getTool("ha__hacs_repo_info");
+  assert.equal(t.inputSchema.safeParse({}).success, false);
+  // Bad charset rejected at the schema level (no traversal possible).
+  assert.equal(
+    t.inputSchema.safeParse({ repo_id: "../bad" }).success,
+    false,
+  );
+  const r = t.buildRequest({ repo_id: "42" });
+  assert.equal(r.method, "GET");
+  assert.equal(r.path, "/api/v1/channels/ha/hacs/repo/42");
+});
+
+test("ha__hacs_add_custom_repo: url + category required, both shapes accepted", () => {
+  const t = getTool("ha__hacs_add_custom_repo");
+  assert.equal(t.inputSchema.safeParse({}).success, false);
+  assert.equal(
+    t.inputSchema.safeParse({ url: "not a url", category: "integration" })
+      .success,
+    false,
+    "bad url rejected",
+  );
+  assert.equal(
+    t.inputSchema.safeParse({ url: "user/repo", category: "bogus" }).success,
+    false,
+    "bad category rejected",
+  );
+  // owner/repo form
+  const r1 = t.buildRequest({ url: "user/x", category: "integration" });
+  assert.equal(r1.method, "POST");
+  assert.equal(r1.path, "/api/v1/channels/ha/hacs/repos");
+  assert.deepEqual(r1.body, { url: "user/x", category: "integration" });
+  // Full URL form
+  const r2 = t.buildRequest({
+    url: "https://github.com/user/x",
+    category: "plugin",
+  });
+  assert.equal(r2.body!.url, "https://github.com/user/x");
+});
+
+test("ha__hacs_install: decision_ref REQUIRED, version optional, body shape", () => {
+  const t = getTool("ha__hacs_install");
+  // Missing decision_ref rejected at schema level.
+  assert.equal(
+    t.inputSchema.safeParse({ repo_id: "1" }).success,
+    false,
+    "missing decision_ref → schema reject",
+  );
+  // Bad decision_ref shape rejected (whitespace).
+  assert.equal(
+    t.inputSchema.safeParse({
+      repo_id: "1",
+      decision_ref: "with space",
+    }).success,
+    false,
+  );
+  const r1 = t.buildRequest({
+    repo_id: "1",
+    decision_ref: "01JABC0000000000000000001",
+  });
+  assert.equal(r1.method, "POST");
+  assert.equal(r1.path, "/api/v1/channels/ha/hacs/install");
+  assert.deepEqual(r1.body, {
+    repo_id: "1",
+    decision_ref: "01JABC0000000000000000001",
+  });
+  const r2 = t.buildRequest({
+    repo_id: "1",
+    version: "1.0.0",
+    decision_ref: "01JABC0000000000000000001",
+  });
+  assert.equal(r2.body!.version, "1.0.0");
+});
+
+test("ha__hacs_remove: decision_ref REQUIRED, DELETE with encodeURIComponent on id", () => {
+  const t = getTool("ha__hacs_remove");
+  assert.equal(t.inputSchema.safeParse({ repo_id: "1" }).success, false);
+  const r = t.buildRequest({
+    repo_id: "42",
+    decision_ref: "01JABC0000000000000000001",
+  });
+  assert.equal(r.method, "DELETE");
+  assert.equal(r.path, "/api/v1/channels/ha/hacs/42");
+  assert.deepEqual(r.body, { decision_ref: "01JABC0000000000000000001" });
+});
+
+test("ha__hacs_refresh: repo_id only, POST + empty body", () => {
+  const t = getTool("ha__hacs_refresh");
+  assert.equal(t.inputSchema.safeParse({}).success, false);
+  const r = t.buildRequest({ repo_id: "5" });
+  assert.equal(r.method, "POST");
+  assert.equal(r.path, "/api/v1/channels/ha/hacs/5/refresh");
+  assert.deepEqual(r.body, {});
+});
+
+test("ha__hacs_pending_updates: GET with pending=1, limit honoured", () => {
+  const t = getTool("ha__hacs_pending_updates");
+  // Defaulted limit means empty input is valid.
+  assert.equal(t.inputSchema.safeParse({}).success, true);
+  const r = t.buildRequest({ limit: 25 });
+  assert.equal(r.method, "GET");
+  assert.equal(r.path, "/api/v1/channels/ha/hacs/repos");
+  assert.deepEqual(r.query, { pending: "1", limit: "25" });
+});
+
+test("HACS PR5: gated tools (install/remove) advertise decision_ref in description", () => {
+  for (const name of ["ha__hacs_install", "ha__hacs_remove"]) {
+    const t = getTool(name);
+    assert.ok(
+      /decision_ref/i.test(t.description),
+      `${name} description must call out decision_ref`,
+    );
+  }
+});
+
+test("HACS PR5: non-gated tools (info/search/repo_info/add_custom_repo/refresh/pending_updates) DO NOT require decision_ref", () => {
+  for (const name of [
+    "ha__hacs_info",
+    "ha__hacs_search",
+    "ha__hacs_repo_info",
+    "ha__hacs_add_custom_repo",
+    "ha__hacs_refresh",
+    "ha__hacs_pending_updates",
+  ]) {
+    const t = getTool(name);
+    const sample: Record<string, unknown> = {};
+    if (name === "ha__hacs_repo_info") sample.repo_id = "1";
+    if (name === "ha__hacs_add_custom_repo") {
+      sample.url = "user/x";
+      sample.category = "integration";
+    }
+    if (name === "ha__hacs_refresh") sample.repo_id = "1";
+    // No decision_ref in any of these.
+    const r = t.inputSchema.safeParse(sample);
+    assert.equal(r.success, true, `${name} must accept input WITHOUT decision_ref`);
+  }
 });

--- a/packages/mcp-server/src/tools/hass.ts
+++ b/packages/mcp-server/src/tools/hass.ts
@@ -1848,13 +1848,252 @@ export const HASS_USER_TOOLS: ToolDef[] = [
 // ═════════════════════════════════════════════════════════════════════════
 // === END Tier 4 PR8 ═══════════════════════════════════════════════════
 
+// ═════════════════════════════════════════════════════════════════════════
+// === Tier 4 PR5: HACS ===
+// ═════════════════════════════════════════════════════════════════════════
+//
+// Issue #115/#158 PR5 — Home Assistant Community Store CRUD. 8 tools
+// fronting the `/api/v1/channels/ha/hacs/*` ctrl-api routes that PR5
+// adds in packages/ctrl/src/api/routes/channels_ha.ts. Every gated
+// route's tool re-asserts `decision_ref` shape on the MCP side so a
+// bad call from the agent rejects BEFORE we hit ctrl-api, mirroring
+// the loop-guard contract the PR4 write tools follow.
+//
+// Approval gate / snapshot matrix — Sir locked YES 2026-05-29 (spec §4):
+//
+// | Tool                          | decision_ref | auto-snapshot |
+// |-------------------------------|--------------|---------------|
+// | ha__hacs_info                 | no           | no            |
+// | ha__hacs_search               | no           | no            |
+// | ha__hacs_repo_info            | no           | no            |
+// | ha__hacs_add_custom_repo      | no           | no            |
+// | ha__hacs_install              | REQUIRED     | YES           |
+// | ha__hacs_remove               | REQUIRED     | YES           |
+// | ha__hacs_refresh              | no           | no            |
+// | ha__hacs_pending_updates      | no           | no            |
+//
+// LOAD-BEARING NUANCE — `add_custom_repo` registers a repository URL
+// with HACS but does NOT install anything. The principal can drop the
+// row from HACS's own UI in <2 minutes, so it stays free. The actual
+// install (which mutates `/config` and pulls files from GitHub) is the
+// gated step.
+//
+// SPLICE BLOCK — keep contiguous. PR2/PR3/PR4/PR6/PR7/PR8 own their own
+// bounded blocks elsewhere in this file.
 
-// Final catalogue: 61 tools total = 11 read + 15 writes (5 PR4 + 10 PR3 CRUD)
+const HacsCategoryParam = z
+  .enum(["integration", "plugin", "theme", "appdaemon", "netdaemon"])
+  .describe(
+    "HACS category. Five values map 1:1 to HACS's own taxonomy: `integration` (HA integrations), `plugin` (Lovelace cards), `theme` (Lovelace themes), `appdaemon` (AppDaemon apps), `netdaemon` (NetDaemon apps).",
+  );
+
+const HacsRepoIdParam = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(
+    /^[A-Za-z0-9_.-]+$/,
+    "repo_id must be 1..64 chars of [A-Za-z0-9_.-]",
+  )
+  .describe(
+    "HACS repository id — the integer (serialised as string) HACS uses internally. Resolve via `ha__hacs_search` first; never invent.",
+  );
+
+const HacsRepoUrlParam = z
+  .string()
+  .min(3)
+  .max(256)
+  .regex(
+    /^(https?:\/\/(?:www\.)?github\.com\/)?[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/?$/,
+    "url must be an `owner/repo` GitHub identifier or a github.com URL",
+  )
+  .describe(
+    "GitHub repo URL or `owner/repo` identifier. HACS accepts both shapes; the routing layer forwards verbatim.",
+  );
+
+const HacsDecisionRefParam = z
+  .string()
+  .min(6)
+  .max(256)
+  .regex(
+    /^[\x21-\x7E]+$/,
+    "decision_ref must be printable ASCII with no whitespace",
+  )
+  .describe(
+    "Vault path or ulid of the `decision/` record that authorised this write. REQUIRED. Alfred refuses without it — the middleware reads `vault/decision/<id>.md` and rejects if the decision is `reversed`.",
+  );
+
+export const HASS_HACS_TOOLS: ToolDef[] = [
+  {
+    name: "ha__hacs_info",
+    description:
+      "Probe HACS installation metadata via `hacs/info` — returns `{categories, country, debug, dev, disabled_reason, has_pending_tasks, lovelace_mode, stage}`. Use this BEFORE any HACS write to confirm HACS is up (`stage === 'running'`) and `disabled_reason === null`. Side-effect-free.",
+    inputSchema: z.object({}),
+    buildRequest: () => ({
+      method: "GET",
+      path: "/api/v1/channels/ha/hacs/info",
+    }),
+  },
+
+  {
+    name: "ha__hacs_search",
+    description:
+      "Search the HACS catalogue. Returns `{count, total, repos: [{id, name, full_name, description, category, installed, installed_version, available_version, pending_update, topics}]}`. Use `category` to scope to a tier (`integration` / `plugin` / `theme` / `appdaemon` / `netdaemon`). Use `query` for a substring match against name + description + topics. Use `installed: true` to list only what's already installed. `limit` clamps to 500 (default 50 for an agent flow — pass higher if you're paging).",
+    inputSchema: z.object({
+      query: z
+        .string()
+        .min(1)
+        .optional()
+        .describe(
+          "Substring matched against name, full_name, description, and topics (case-insensitive).",
+        ),
+      category: HacsCategoryParam.optional(),
+      installed: z
+        .boolean()
+        .optional()
+        .describe(
+          "When true, return only repos HACS reports as currently installed.",
+        ),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(500)
+        .default(50)
+        .describe(
+          "Hard cap on the returned `repos` array. Clamped to 500 server-side.",
+        ),
+    }),
+    buildRequest: ({ query, category, installed, limit }) => {
+      const q: Record<string, string> = {};
+      if (typeof query === "string") q.q = query;
+      if (typeof category === "string") q.category = category;
+      if (installed === true) q.installed = "1";
+      if (typeof limit === "number") q.limit = String(limit);
+      return {
+        method: "GET",
+        path: "/api/v1/channels/ha/hacs/repos",
+        query: q,
+      };
+    },
+  },
+
+  {
+    name: "ha__hacs_repo_info",
+    description:
+      "Fetch detailed state for one HACS repository via `hacs/repository/state`, plus the matching list view in a single round-trip. Returns `{ok, id, state, repo}`. Use BEFORE an install so you can show Sir the version + description in your confirmation message.",
+    inputSchema: z.object({
+      repo_id: HacsRepoIdParam,
+    }),
+    buildRequest: ({ repo_id }) => ({
+      method: "GET",
+      path: `/api/v1/channels/ha/hacs/repo/${encodeURIComponent(repo_id)}`,
+    }),
+  },
+
+  {
+    name: "ha__hacs_add_custom_repo",
+    description:
+      "Register a custom HACS repository URL. NO Desk decision required — adding to HACS's catalogue is reversible and doesn't install anything. Use this when Sir points you at a community repo that isn't in HACS's default index, then follow up with `ha__hacs_search` to find the new id and `ha__hacs_install` (gated) to actually pull it.",
+    inputSchema: z.object({
+      url: HacsRepoUrlParam,
+      category: HacsCategoryParam,
+    }),
+    buildRequest: ({ url, category }) => ({
+      method: "POST",
+      path: "/api/v1/channels/ha/hacs/repos",
+      body: { url, category },
+    }),
+  },
+
+  {
+    name: "ha__hacs_install",
+    description:
+      "Install (download) a HACS repository. **Gated** — REQUIRES `decision_ref`. ctrl-api auto-snapshots the HA install BEFORE running the download (snapshot id surfaces in the response so you can quote it). On success a `ha_integration_ref` row lands with `installed_by='alfred', decision_ref=<id>` so Sir can later trace any HACS install back to the Desk decision. Pass `version` to pin a specific tag; omit for HACS's default (latest stable).",
+    inputSchema: z.object({
+      repo_id: HacsRepoIdParam,
+      version: z
+        .string()
+        .min(1)
+        .max(64)
+        .optional()
+        .describe(
+          "Pin to a specific tag/version. Omit to install the HACS default (typically latest stable).",
+        ),
+      decision_ref: HacsDecisionRefParam,
+    }),
+    buildRequest: ({ repo_id, version, decision_ref }) => ({
+      method: "POST",
+      path: "/api/v1/channels/ha/hacs/install",
+      body: {
+        repo_id,
+        ...(version !== undefined ? { version } : {}),
+        decision_ref,
+      },
+    }),
+  },
+
+  {
+    name: "ha__hacs_remove",
+    description:
+      "Uninstall a HACS repository. **Gated** — REQUIRES `decision_ref`. ctrl-api auto-snapshots BEFORE the remove. The original `ha_integration_ref` row stays in place with the install metadata so the audit trail isn't lost. Note: for `integration`-category removes, the principal may still need to delete the related config_entry from HA's own UI; ha__hacs_remove only handles HACS's catalogue side.",
+    inputSchema: z.object({
+      repo_id: HacsRepoIdParam,
+      decision_ref: HacsDecisionRefParam,
+    }),
+    buildRequest: ({ repo_id, decision_ref }) => ({
+      method: "DELETE",
+      path: `/api/v1/channels/ha/hacs/${encodeURIComponent(repo_id)}`,
+      body: { decision_ref },
+    }),
+  },
+
+  {
+    name: "ha__hacs_refresh",
+    description:
+      "Force HACS to refetch metadata for one repository — cheap, reversible, no gate. Use when Sir reports a release is out but HACS hasn't surfaced it yet (e.g. immediately after a fresh upstream tag).",
+    inputSchema: z.object({
+      repo_id: HacsRepoIdParam,
+    }),
+    buildRequest: ({ repo_id }) => ({
+      method: "POST",
+      path: `/api/v1/channels/ha/hacs/${encodeURIComponent(repo_id)}/refresh`,
+      body: {},
+    }),
+  },
+
+  {
+    name: "ha__hacs_pending_updates",
+    description:
+      "List HACS-installed repositories with a pending update. Wraps `ha__hacs_search` with the `pending=1` filter on the ctrl-api side so the model doesn't have to scroll the full ~3k catalogue. Returns the same `{count, total, repos}` shape — `total` is the upstream catalogue size, `count` the number with pending updates.",
+    inputSchema: z.object({
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(500)
+        .default(50)
+        .describe("Hard cap on the returned `repos` array."),
+    }),
+    buildRequest: ({ limit }) => ({
+      method: "GET",
+      path: "/api/v1/channels/ha/hacs/repos",
+      query: {
+        pending: "1",
+        ...(typeof limit === "number" ? { limit: String(limit) } : {}),
+      },
+    }),
+  },
+];
+
+// === END Tier 4 PR5 ═══════════════════════════════════════════════════
+
+// Final catalogue: 69 tools total = 11 read + 15 writes (5 PR4 + 10 PR3 CRUD)
 // + 10 PR6 supervisor addon + 10 PR7 core+backups + 7 PR4 integration
-// + 8 PR8 user + LLAT. Order kept deliberately (reads first, writes next,
-// addon-CRUD next, core+backups next, integrations next, users+LLATs last)
-// so the model that lists the catalogue sees the safe read surface before
-// the destructive surfaces.
+// + 8 PR8 user + LLAT + 8 PR5 HACS. Order kept deliberately (reads first,
+// writes next, addon-CRUD next, core+backups next, integrations next,
+// users+LLATs next, HACS last) so the model that lists the catalogue sees
+// the safe read surface before the destructive surfaces.
 export const ALL_HASS_TOOLS: ToolDef[] = [
   ...HASS_READ_TOOLS,
   ...HASS_DEFERRED_TOOLS,
@@ -1862,4 +2101,5 @@ export const ALL_HASS_TOOLS: ToolDef[] = [
   ...HASS_PR7_TOOLS,
   ...HASS_INTEGRATION_TOOLS,
   ...HASS_USER_TOOLS,
+  ...HASS_HACS_TOOLS,
 ];


### PR DESCRIPTION
Tier 4 HA autonomy, PR5. Adds 7 ctrl-api routes + 8 MCP tools fronting
HACS (Home Assistant Community Store) via the long-lived WS client
landed in PR1 (#163). Modern HACS dropped its REST API; every CRUD verb
crosses the `hacs/*` WS namespace today.

Cleanly rebased on top of PR1 (#163), PR3 (#161), PR6 (#162). The PR5
splice blocks sit in clearly-bounded `=== Tier 4 PR5: HACS ===`
sections in both channels_ha.ts and hass.ts — no edits to other lanes.

## ctrl-api routes (packages/ctrl/src/api/routes/channels_ha.ts)

- `GET    /api/v1/channels/ha/hacs/info`               — `hacs/info`
- `GET    /api/v1/channels/ha/hacs/repos`              — list + filter (`category`, `q`, `installed`, `pending`, `limit`)
- `GET    /api/v1/channels/ha/hacs/repo/:id`           — state + view in one round-trip
- `POST   /api/v1/channels/ha/hacs/repos`              — add custom repo
- `POST   /api/v1/channels/ha/hacs/install`            — **gated** + auto-snapshot + daybook + integration ledger
- `DELETE /api/v1/channels/ha/hacs/:id`                — **gated** + auto-snapshot + daybook
- `POST   /api/v1/channels/ha/hacs/:id/refresh`        — no gate

### Gate matrix (Sir locked YES 2026-05-29 — spec §4)

| Verb        | decision_ref | auto-snapshot | daybook |
|-------------|--------------|---------------|---------|
| info        | no           | no            | no      |
| repos (GET) | no           | no            | no      |
| repo/:id    | no           | no            | no      |
| repos (POST: add custom) | no | no       | no      |
| install     | **REQUIRED** | **YES**       | YES     |
| remove      | **REQUIRED** | **YES**       | YES     |
| refresh     | no           | no            | no      |

LOAD-BEARING NUANCE — `add_custom_repo` (POST /repos) registers a
repository URL with HACS but doesn't install anything. The principal
can drop the row from HACS's UI in <2 minutes, so it stays free. The
actual install (which mutates `/config` and pulls files from GitHub)
is the gated step.

### Integration ledger reuse

When an install completes, ctrl-api writes to PR1's `ha_integration_ref`
with `entry_id='hacs:<repo_id>'`, `installed_by='alfred'`,
`decision_ref=<id>`. Sir can later trace any HACS install back to a
Desk decision via the audit ladder.

## MCP tools (packages/mcp-server/src/tools/hass.ts)

- `ha__hacs_info` / `ha__hacs_search` / `ha__hacs_repo_info`
- `ha__hacs_add_custom_repo`
- `ha__hacs_install` (gated) / `ha__hacs_remove` (gated)
- `ha__hacs_refresh` / `ha__hacs_pending_updates`

Tools re-assert `decision_ref` shape on the MCP side so a bad call
rejects BEFORE hitting ctrl-api, mirroring the loop-guard contract
PR4 write tools follow.

Catalogue: now 44 tools total (11 read + 15 write + 10 PR6 addon +
8 PR5 HACS).

## Tests

- **packages/ctrl/tests/channels_ha_hacs.test.ts (20 integration tests)** —
  fake HA WS server speaks the seven `hacs/*` call types, route
  registration, WS round-trip, gate enforcement on install/remove
  (missing decision_ref → 400), snapshot fires BEFORE the upstream
  install (even on failed download), `ha_integration_ref` row written
  on success, daybook entry on install + remove, add_custom_repo
  validation (URL shape, category whitelist), refresh charset
  enforcement.

- **packages/mcp-server/src/tools/hass.test.ts (+11 unit tests)** —
  catalogue length update (36 → 44), 8 HACS tool schemas validated,
  decision_ref enforced at schema level on gated tools, gated-tool
  description carries 'decision_ref', non-gated tools accept input
  without decision_ref.

Totals: 880 ctrl tests pass (1 skipped); 113 MCP-server tests pass.

## Skill doc

`packages/mcp-server/skills/alfred-mcp-skill.md` gains a 'HACS
catalogue (#115 PR5)' tool index entry plus two 'Common flows'
recipes ('install the better thermostat integration' and 'install a
custom repo Sir found on GitHub').

🤖 Generated with [Claude Code](https://claude.com/claude-code)