### PR TITLE
feat(ctrl,mcp): #115 PR2 — HA registries CRUD (areas/devices/entities/labels via WS)

### DIFF
--- a/packages/ctrl/src/api/routes/channels_ha.ts
+++ b/packages/ctrl/src/api/routes/channels_ha.ts
@@ -1054,6 +1054,13 @@ export function registerHaChannelRoutes(): void {
   // landed in PR1. Independent of PR2/PR3/PR4/PR6/PR7/PR8; the splice
   // block lives at the bottom of this file (`=== Tier 4 PR5: HACS ===`).
   registerHaHacsRoutes();
+
+  // #115 PR2 — Tier 4 autonomy, registries CRUD. Areas / devices /
+  // entities / labels — all WS-only on HA's side, all cheap +
+  // reversible, no decision_ref gate per Sir's locked YES defaults
+  // (2026-05-29). See the "=== Tier 4 PR2: Registries CRUD ===" block
+  // at the bottom of this file.
+  registerHaPr2RegistriesRoutes();
 }
 
 /**
@@ -7728,3 +7735,605 @@ export function registerHaHacsRoutes(): void {
 }
 
 // === END Tier 4 PR5 ═══════════════════════════════════════════════════
+
+// ═════════════════════════════════════════════════════════════════════════
+// === Tier 4 PR2: Registries CRUD ===
+// ═════════════════════════════════════════════════════════════════════════
+//
+// Issue #115 PR2 — 14 new routes fronting HA's four registry surfaces:
+//
+//   area_registry    — list / create / update / delete  (WS only)
+//   device_registry  — list / get / update              (WS only — no
+//                      create/delete; devices come from integrations)
+//   entity_registry  — list / get / update / remove     (WS only)
+//   label_registry   — list / create / update / delete  (WS only)
+//
+// Why this lives in its own bounded block
+// ----------------------------------------
+// PR3, PR4, PR6, PR7, and PR8 already landed in this file with their
+// own bounded blocks. By keeping every registry route in ONE contiguous
+// block at the file tail, a future rebase against this file is one
+// mechanical "is this block intact?" check. No edits to shared helpers,
+// no insertion points scattered through the file.
+//
+// Per Sir's defaults (locked 2026-05-29):
+//
+//   * NO `decision_ref` gate — every verb in here is cheap + reversible:
+//     create an area → delete it; rename an entity → rename it back.
+//     The verb whose effect a non-technical principal couldn't reverse in
+//     <2 minutes through HA's own UI gets a gate; renaming the kitchen
+//     light doesn't.
+//   * NO snapshot — same rationale; registry mutations don't take HA
+//     down.
+//   * NO daybook entry — the daybook surface is for changes Sir would
+//     notice (core_restart, addon_install, integration_add). Renaming
+//     an entity is noise.
+//
+// The WS calls themselves
+// -----------------------
+// HA's WS protocol for these (verified against `homeassistant/core` HEAD
+// 2026-05):
+//
+//   {type: "config/area_registry/list"}
+//   {type: "config/area_registry/create", name, …}
+//   {type: "config/area_registry/update", area_id, name?, icon?, labels?, …}
+//   {type: "config/area_registry/delete", area_id}
+//
+//   {type: "config/device_registry/list"}
+//   {type: "config/device_registry/get", device_id} — not all HA versions; we
+//     read from list() and filter as a fallback so an older HA still works.
+//   {type: "config/device_registry/update", device_id, name_by_user?, area_id?,
+//     labels?, disabled_by?}
+//
+//   {type: "config/entity_registry/list"}
+//   {type: "config/entity_registry/get", entity_id}
+//   {type: "config/entity_registry/update", entity_id, name?, icon?, area_id?,
+//     hidden_by?, disabled_by?, labels?, new_entity_id?, aliases?, …}
+//   {type: "config/entity_registry/remove", entity_id}
+//
+//   {type: "config/label_registry/list"}
+//   {type: "config/label_registry/create", name, …}
+//   {type: "config/label_registry/update", label_id, name?, color?, icon?, description?}
+//   {type: "config/label_registry/delete", label_id}
+//
+// Wrap each `client.wsCall(...)` in try/catch → wrapHaWsError so the
+// failure envelope matches the PR7 block (502 HA_WS_ERROR with the
+// upstream error message preserved).
+
+/**
+ * Default WS timeout for registry calls. Registry CRUD is fast (~50ms
+ * on a local HA); ten seconds is generous enough that a transiently
+ * slow HA still passes.
+ */
+const HA_REGISTRY_WS_TIMEOUT_MS = Number(
+  process.env.HA_REGISTRY_WS_TIMEOUT_MS ?? "10000",
+);
+
+/**
+ * Area / device / label id format. HA mints these as a slug from the
+ * create-time name — lowercase ASCII + underscores. The shape we want
+ * to enforce here is the URL-traversal guard: no `/`, no leading dot,
+ * length 1..128.
+ */
+const HA_REGISTRY_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_.:\-]{0,127}$/;
+
+function assertRegistryId(raw: string, kind: string): string {
+  if (!HA_REGISTRY_ID_RE.test(raw)) {
+    throw new ValidationError(
+      `${kind} id must be 1..128 chars of [A-Za-z0-9_.:-], starting with [A-Za-z0-9]`,
+    );
+  }
+  return raw;
+}
+
+/**
+ * Entity id format. Strict dotted form — `<domain>.<object_id>` with
+ * lowercase ASCII + underscores. Mirrors the MCP tool's EntityIdParam.
+ */
+const HA_PR2_ENTITY_ID_RE = /^[a-z0-9_]+\.[a-z0-9_]+$/;
+
+function assertPr2EntityId(raw: string): string {
+  if (!HA_PR2_ENTITY_ID_RE.test(raw)) {
+    throw new ValidationError(
+      "entity_id must be HA's dotted form `<domain>.<object_id>`",
+    );
+  }
+  return raw;
+}
+
+/** Read an optional string field; rejects empty strings + non-strings. */
+function pr2OptionalString(
+  raw: unknown,
+  field: string,
+  maxLen = 256,
+): string | undefined {
+  if (raw === undefined) return undefined;
+  if (raw === null) return undefined;
+  if (typeof raw !== "string" || raw.length === 0) {
+    throw new ValidationError(`${field} must be a non-empty string`);
+  }
+  if (raw.length > maxLen) {
+    throw new ValidationError(`${field} must be <= ${maxLen} chars`);
+  }
+  return raw;
+}
+
+/**
+ * Allow null/undefined OR string. HA uses `null` to clear a field
+ * (e.g. {area_id: null} unassigns the area from a device). We honour
+ * that — the route passes through `null` if the caller sent it.
+ */
+function pr2NullableString(
+  raw: unknown,
+  field: string,
+  maxLen = 256,
+): { present: boolean; value: string | null } {
+  if (raw === undefined) return { present: false, value: null };
+  if (raw === null) return { present: true, value: null };
+  if (typeof raw !== "string") {
+    throw new ValidationError(`${field} must be a string or null`);
+  }
+  if (raw.length === 0) {
+    throw new ValidationError(`${field} must be non-empty or null`);
+  }
+  if (raw.length > maxLen) {
+    throw new ValidationError(`${field} must be <= ${maxLen} chars`);
+  }
+  return { present: true, value: raw };
+}
+
+/** Optional string[] of label ids. */
+function pr2OptionalStringArray(
+  raw: unknown,
+  field: string,
+): string[] | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  if (!Array.isArray(raw)) {
+    throw new ValidationError(`${field} must be an array of strings`);
+  }
+  for (const v of raw) {
+    if (typeof v !== "string" || v.length === 0) {
+      throw new ValidationError(`${field} entries must be non-empty strings`);
+    }
+  }
+  return raw as string[];
+}
+
+/** Parse a body object — throws on non-object input. */
+function pr2AssertBodyObject(body: unknown): Record<string, unknown> {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    throw new ValidationError("body must be a JSON object");
+  }
+  return body as Record<string, unknown>;
+}
+
+export function registerHaPr2RegistriesRoutes(): void {
+  // ── areas ─────────────────────────────────────────────────────────────
+
+  // GET /api/v1/channels/ha/areas — WS `config/area_registry/list`.
+  // Returns `{ok, areas: [...]}` straight from HA. Cheap, no gate.
+  addRoute("GET", "/api/v1/channels/ha/areas", async ({ res }) => {
+    await loadHaCredentials();
+    let result: unknown;
+    try {
+      result = await getHaWsClient().wsCall(
+        "config/area_registry/list",
+        {},
+        HA_REGISTRY_WS_TIMEOUT_MS,
+      );
+    } catch (err) {
+      throw wrapHaWsError("config/area_registry/list", err);
+    }
+    const areas = Array.isArray(result) ? result : [];
+    sendJson(res, 200, { ok: true, areas });
+  });
+
+  // POST /api/v1/channels/ha/areas — WS `config/area_registry/create`.
+  // Body: { name (required), icon?, picture?, aliases?, labels?, floor_id? }.
+  // No gate (cheap, reversible — DELETE undoes it).
+  addRoute("POST", "/api/v1/channels/ha/areas", async ({ res, body }) => {
+    const b = pr2AssertBodyObject(body);
+    const name = pr2OptionalString(b.name, "name", 128);
+    if (name === undefined) {
+      throw new ValidationError("name is required");
+    }
+    const wsPayload: Record<string, unknown> = { name };
+    const icon = pr2OptionalString(b.icon, "icon", 64);
+    if (icon !== undefined) wsPayload.icon = icon;
+    const picture = pr2OptionalString(b.picture, "picture", 256);
+    if (picture !== undefined) wsPayload.picture = picture;
+    const floorId = pr2OptionalString(b.floor_id, "floor_id", 128);
+    if (floorId !== undefined) wsPayload.floor_id = floorId;
+    const aliases = pr2OptionalStringArray(b.aliases, "aliases");
+    if (aliases !== undefined) wsPayload.aliases = aliases;
+    const labels = pr2OptionalStringArray(b.labels, "labels");
+    if (labels !== undefined) wsPayload.labels = labels;
+    await loadHaCredentials();
+    let result: unknown;
+    try {
+      result = await getHaWsClient().wsCall(
+        "config/area_registry/create",
+        wsPayload,
+        HA_REGISTRY_WS_TIMEOUT_MS,
+      );
+    } catch (err) {
+      throw wrapHaWsError("config/area_registry/create", err);
+    }
+    const r = (result ?? {}) as Record<string, unknown>;
+    const area_id = typeof r.area_id === "string" ? r.area_id : null;
+    sendJson(res, 200, { ok: true, area_id, area: result });
+  });
+
+  // PUT /api/v1/channels/ha/areas/:id — WS `config/area_registry/update`.
+  // Body fields all optional — only fields the caller sets get forwarded.
+  addRoute(
+    "PUT",
+    "/api/v1/channels/ha/areas/:id",
+    async ({ res, body, params }) => {
+      const area_id = assertRegistryId(params.id, "area");
+      const b = pr2AssertBodyObject(body);
+      const wsPayload: Record<string, unknown> = { area_id };
+      const name = pr2OptionalString(b.name, "name", 128);
+      if (name !== undefined) wsPayload.name = name;
+      // icon/picture/floor_id accept null (unset) — use pr2NullableString.
+      const icon = pr2NullableString(b.icon, "icon", 64);
+      if (icon.present) wsPayload.icon = icon.value;
+      const picture = pr2NullableString(b.picture, "picture", 256);
+      if (picture.present) wsPayload.picture = picture.value;
+      const floorId = pr2NullableString(b.floor_id, "floor_id", 128);
+      if (floorId.present) wsPayload.floor_id = floorId.value;
+      const aliases = pr2OptionalStringArray(b.aliases, "aliases");
+      if (aliases !== undefined) wsPayload.aliases = aliases;
+      const labels = pr2OptionalStringArray(b.labels, "labels");
+      if (labels !== undefined) wsPayload.labels = labels;
+      await loadHaCredentials();
+      let result: unknown;
+      try {
+        result = await getHaWsClient().wsCall(
+          "config/area_registry/update",
+          wsPayload,
+          HA_REGISTRY_WS_TIMEOUT_MS,
+        );
+      } catch (err) {
+        throw wrapHaWsError("config/area_registry/update", err);
+      }
+      sendJson(res, 200, { ok: true, area_id, area: result });
+    },
+  );
+
+  // DELETE /api/v1/channels/ha/areas/:id — WS `config/area_registry/delete`.
+  // No gate — areas are cheap to recreate; HA itself moves any
+  // entities/devices in the area to "no area" on delete (non-destructive
+  // to the underlying things).
+  addRoute(
+    "DELETE",
+    "/api/v1/channels/ha/areas/:id",
+    async ({ res, params }) => {
+      const area_id = assertRegistryId(params.id, "area");
+      await loadHaCredentials();
+      let result: unknown;
+      try {
+        result = await getHaWsClient().wsCall(
+          "config/area_registry/delete",
+          { area_id },
+          HA_REGISTRY_WS_TIMEOUT_MS,
+        );
+      } catch (err) {
+        throw wrapHaWsError("config/area_registry/delete", err);
+      }
+      sendJson(res, 200, { ok: true, area_id, data: result });
+    },
+  );
+
+  // ── devices ──────────────────────────────────────────────────────────
+
+  // GET /api/v1/channels/ha/devices — WS `config/device_registry/list`.
+  addRoute("GET", "/api/v1/channels/ha/devices", async ({ res }) => {
+    await loadHaCredentials();
+    let result: unknown;
+    try {
+      result = await getHaWsClient().wsCall(
+        "config/device_registry/list",
+        {},
+        HA_REGISTRY_WS_TIMEOUT_MS,
+      );
+    } catch (err) {
+      throw wrapHaWsError("config/device_registry/list", err);
+    }
+    const devices = Array.isArray(result) ? result : [];
+    sendJson(res, 200, { ok: true, devices });
+  });
+
+  // GET /api/v1/channels/ha/devices/:id — pull one device by reading the
+  // list and filtering. HA doesn't expose a per-device `get` WS verb on
+  // every version, and the list is cheap (~50ms on a local HA), so this
+  // is the durable shape.
+  addRoute(
+    "GET",
+    "/api/v1/channels/ha/devices/:id",
+    async ({ res, params }) => {
+      const device_id = assertRegistryId(params.id, "device");
+      await loadHaCredentials();
+      let result: unknown;
+      try {
+        result = await getHaWsClient().wsCall(
+          "config/device_registry/list",
+          {},
+          HA_REGISTRY_WS_TIMEOUT_MS,
+        );
+      } catch (err) {
+        throw wrapHaWsError("config/device_registry/list", err);
+      }
+      const devices = Array.isArray(result) ? result : [];
+      const device = devices.find((d) => {
+        const dd = d as Record<string, unknown>;
+        return dd.id === device_id;
+      });
+      if (!device) {
+        throw new NotFoundError(`device ${device_id} not found`);
+      }
+      sendJson(res, 200, { ok: true, device_id, device });
+    },
+  );
+
+  // PUT /api/v1/channels/ha/devices/:id — WS
+  // `config/device_registry/update`. Fields the caller may set:
+  // name_by_user / area_id / disabled_by / labels. HA accepts `null` to
+  // clear name_by_user / area_id / disabled_by.
+  addRoute(
+    "PUT",
+    "/api/v1/channels/ha/devices/:id",
+    async ({ res, body, params }) => {
+      const device_id = assertRegistryId(params.id, "device");
+      const b = pr2AssertBodyObject(body);
+      const wsPayload: Record<string, unknown> = { device_id };
+      const nameByUser = pr2NullableString(b.name_by_user, "name_by_user", 128);
+      if (nameByUser.present) wsPayload.name_by_user = nameByUser.value;
+      const areaId = pr2NullableString(b.area_id, "area_id", 128);
+      if (areaId.present) wsPayload.area_id = areaId.value;
+      const disabledBy = pr2NullableString(b.disabled_by, "disabled_by", 64);
+      if (disabledBy.present) wsPayload.disabled_by = disabledBy.value;
+      const labels = pr2OptionalStringArray(b.labels, "labels");
+      if (labels !== undefined) wsPayload.labels = labels;
+      await loadHaCredentials();
+      let result: unknown;
+      try {
+        result = await getHaWsClient().wsCall(
+          "config/device_registry/update",
+          wsPayload,
+          HA_REGISTRY_WS_TIMEOUT_MS,
+        );
+      } catch (err) {
+        throw wrapHaWsError("config/device_registry/update", err);
+      }
+      sendJson(res, 200, { ok: true, device_id, device: result });
+    },
+  );
+
+  // ── entities ─────────────────────────────────────────────────────────
+
+  // GET /api/v1/channels/ha/entities — WS `config/entity_registry/list`.
+  addRoute("GET", "/api/v1/channels/ha/entities", async ({ res }) => {
+    await loadHaCredentials();
+    let result: unknown;
+    try {
+      result = await getHaWsClient().wsCall(
+        "config/entity_registry/list",
+        {},
+        HA_REGISTRY_WS_TIMEOUT_MS,
+      );
+    } catch (err) {
+      throw wrapHaWsError("config/entity_registry/list", err);
+    }
+    const entities = Array.isArray(result) ? result : [];
+    sendJson(res, 200, { ok: true, entities });
+  });
+
+  // GET /api/v1/channels/ha/entities/:id — WS `config/entity_registry/get`.
+  addRoute(
+    "GET",
+    "/api/v1/channels/ha/entities/:id",
+    async ({ res, params }) => {
+      const entity_id = assertPr2EntityId(params.id);
+      await loadHaCredentials();
+      let result: unknown;
+      try {
+        result = await getHaWsClient().wsCall(
+          "config/entity_registry/get",
+          { entity_id },
+          HA_REGISTRY_WS_TIMEOUT_MS,
+        );
+      } catch (err) {
+        throw wrapHaWsError("config/entity_registry/get", err);
+      }
+      if (result === null || result === undefined) {
+        throw new NotFoundError(`entity ${entity_id} not found`);
+      }
+      sendJson(res, 200, { ok: true, entity_id, entity: result });
+    },
+  );
+
+  // PUT /api/v1/channels/ha/entities/:id — WS
+  // `config/entity_registry/update`. Fields the caller may set:
+  // name / icon / area_id / hidden_by / disabled_by / labels / new_entity_id /
+  // aliases. HA accepts `null` to clear most of these.
+  addRoute(
+    "PUT",
+    "/api/v1/channels/ha/entities/:id",
+    async ({ res, body, params }) => {
+      const entity_id = assertPr2EntityId(params.id);
+      const b = pr2AssertBodyObject(body);
+      const wsPayload: Record<string, unknown> = { entity_id };
+      const name = pr2NullableString(b.name, "name", 128);
+      if (name.present) wsPayload.name = name.value;
+      const icon = pr2NullableString(b.icon, "icon", 64);
+      if (icon.present) wsPayload.icon = icon.value;
+      const areaId = pr2NullableString(b.area_id, "area_id", 128);
+      if (areaId.present) wsPayload.area_id = areaId.value;
+      const hiddenBy = pr2NullableString(b.hidden_by, "hidden_by", 64);
+      if (hiddenBy.present) wsPayload.hidden_by = hiddenBy.value;
+      const disabledBy = pr2NullableString(b.disabled_by, "disabled_by", 64);
+      if (disabledBy.present) wsPayload.disabled_by = disabledBy.value;
+      const labels = pr2OptionalStringArray(b.labels, "labels");
+      if (labels !== undefined) wsPayload.labels = labels;
+      // new_entity_id supports renaming the dotted form itself; same
+      // entity-id regex applies.
+      if (b.new_entity_id !== undefined && b.new_entity_id !== null) {
+        if (typeof b.new_entity_id !== "string") {
+          throw new ValidationError("new_entity_id must be a string");
+        }
+        assertPr2EntityId(b.new_entity_id);
+        wsPayload.new_entity_id = b.new_entity_id;
+      }
+      const aliases = pr2OptionalStringArray(b.aliases, "aliases");
+      if (aliases !== undefined) wsPayload.aliases = aliases;
+      await loadHaCredentials();
+      let result: unknown;
+      try {
+        result = await getHaWsClient().wsCall(
+          "config/entity_registry/update",
+          wsPayload,
+          HA_REGISTRY_WS_TIMEOUT_MS,
+        );
+      } catch (err) {
+        throw wrapHaWsError("config/entity_registry/update", err);
+      }
+      sendJson(res, 200, { ok: true, entity_id, entity: result });
+    },
+  );
+
+  // DELETE /api/v1/channels/ha/entities/:id — WS
+  // `config/entity_registry/remove`. Only removable entities (those
+  // marked `entity_category=config` or whose integration allows
+  // removal) can be deleted; HA returns an error otherwise, which we
+  // propagate through wrapHaWsError as 502.
+  //
+  // No gate — HA's own UI exposes this with no confirmation; the agent
+  // contract is just "I'm cleaning up an orphaned entity".
+  addRoute(
+    "DELETE",
+    "/api/v1/channels/ha/entities/:id",
+    async ({ res, params }) => {
+      const entity_id = assertPr2EntityId(params.id);
+      await loadHaCredentials();
+      let result: unknown;
+      try {
+        result = await getHaWsClient().wsCall(
+          "config/entity_registry/remove",
+          { entity_id },
+          HA_REGISTRY_WS_TIMEOUT_MS,
+        );
+      } catch (err) {
+        throw wrapHaWsError("config/entity_registry/remove", err);
+      }
+      sendJson(res, 200, { ok: true, entity_id, data: result });
+    },
+  );
+
+  // ── labels ───────────────────────────────────────────────────────────
+
+  // GET /api/v1/channels/ha/labels — WS `config/label_registry/list`.
+  addRoute("GET", "/api/v1/channels/ha/labels", async ({ res }) => {
+    await loadHaCredentials();
+    let result: unknown;
+    try {
+      result = await getHaWsClient().wsCall(
+        "config/label_registry/list",
+        {},
+        HA_REGISTRY_WS_TIMEOUT_MS,
+      );
+    } catch (err) {
+      throw wrapHaWsError("config/label_registry/list", err);
+    }
+    const labels = Array.isArray(result) ? result : [];
+    sendJson(res, 200, { ok: true, labels });
+  });
+
+  // POST /api/v1/channels/ha/labels — WS `config/label_registry/create`.
+  // Body: { name (required), color?, icon?, description? }.
+  addRoute("POST", "/api/v1/channels/ha/labels", async ({ res, body }) => {
+    const b = pr2AssertBodyObject(body);
+    const name = pr2OptionalString(b.name, "name", 128);
+    if (name === undefined) {
+      throw new ValidationError("name is required");
+    }
+    const wsPayload: Record<string, unknown> = { name };
+    const color = pr2OptionalString(b.color, "color", 32);
+    if (color !== undefined) wsPayload.color = color;
+    const icon = pr2OptionalString(b.icon, "icon", 64);
+    if (icon !== undefined) wsPayload.icon = icon;
+    const description = pr2OptionalString(b.description, "description", 256);
+    if (description !== undefined) wsPayload.description = description;
+    await loadHaCredentials();
+    let result: unknown;
+    try {
+      result = await getHaWsClient().wsCall(
+        "config/label_registry/create",
+        wsPayload,
+        HA_REGISTRY_WS_TIMEOUT_MS,
+      );
+    } catch (err) {
+      throw wrapHaWsError("config/label_registry/create", err);
+    }
+    const r = (result ?? {}) as Record<string, unknown>;
+    const label_id = typeof r.label_id === "string" ? r.label_id : null;
+    sendJson(res, 200, { ok: true, label_id, label: result });
+  });
+
+  // PUT /api/v1/channels/ha/labels/:id — WS `config/label_registry/update`.
+  addRoute(
+    "PUT",
+    "/api/v1/channels/ha/labels/:id",
+    async ({ res, body, params }) => {
+      const label_id = assertRegistryId(params.id, "label");
+      const b = pr2AssertBodyObject(body);
+      const wsPayload: Record<string, unknown> = { label_id };
+      const name = pr2OptionalString(b.name, "name", 128);
+      if (name !== undefined) wsPayload.name = name;
+      const color = pr2NullableString(b.color, "color", 32);
+      if (color.present) wsPayload.color = color.value;
+      const icon = pr2NullableString(b.icon, "icon", 64);
+      if (icon.present) wsPayload.icon = icon.value;
+      const description = pr2NullableString(b.description, "description", 256);
+      if (description.present) wsPayload.description = description.value;
+      await loadHaCredentials();
+      let result: unknown;
+      try {
+        result = await getHaWsClient().wsCall(
+          "config/label_registry/update",
+          wsPayload,
+          HA_REGISTRY_WS_TIMEOUT_MS,
+        );
+      } catch (err) {
+        throw wrapHaWsError("config/label_registry/update", err);
+      }
+      sendJson(res, 200, { ok: true, label_id, label: result });
+    },
+  );
+
+  // DELETE /api/v1/channels/ha/labels/:id — WS `config/label_registry/delete`.
+  // HA removes the label binding from any area/device/entity that
+  // referenced it (the things themselves stay).
+  addRoute(
+    "DELETE",
+    "/api/v1/channels/ha/labels/:id",
+    async ({ res, params }) => {
+      const label_id = assertRegistryId(params.id, "label");
+      await loadHaCredentials();
+      let result: unknown;
+      try {
+        result = await getHaWsClient().wsCall(
+          "config/label_registry/delete",
+          { label_id },
+          HA_REGISTRY_WS_TIMEOUT_MS,
+        );
+      } catch (err) {
+        throw wrapHaWsError("config/label_registry/delete", err);
+      }
+      sendJson(res, 200, { ok: true, label_id, data: result });
+    },
+  );
+}
+
+// === END Tier 4 PR2 ═══════════════════════════════════════════════════
+

--- a/packages/ctrl/tests/channels_ha_registries.test.ts
+++ b/packages/ctrl/tests/channels_ha_registries.test.ts
@@ -1,0 +1,715 @@
+// Issue #115/#158 PR2 — HA registries CRUD integration tests.
+//
+// PR2 adds 14 routes fronting HA's four WS-only registries:
+//
+//   areas    : GET / POST / PUT / DELETE
+//   devices  : GET / GET-by-id / PUT
+//   entities : GET / GET-by-id / PUT / DELETE
+//   labels   : GET / POST / PUT / DELETE
+//
+// All proxy through the long-lived `HaWsClient` from PR1. None are gated
+// by `decision_ref`, none auto-snapshot — per Sir's locked YES defaults
+// (2026-05-29) cheap reversible verbs run free.
+//
+// Coverage (12 tests, round-trip against a mocked HA WS server):
+//
+//   1.  GET /areas → WS config/area_registry/list, returns areas[]
+//   2.  POST /areas → WS config/area_registry/create, body carries fields
+//   3.  PUT /areas/:id → WS config/area_registry/update, fields ride
+//   4.  DELETE /areas/:id → WS config/area_registry/delete with area_id
+//   5.  GET /devices → list; GET /devices/:id → 404 on miss
+//   6.  PUT /devices/:id → WS config/device_registry/update,
+//       nullable fields (name_by_user / area_id / disabled_by) honoured
+//   7.  GET /entities → list; GET /entities/:id → WS
+//       config/entity_registry/get; bad dotted form → 400
+//   8.  PUT /entities/:id → WS config/entity_registry/update with the
+//       fields the spec carved out
+//   9.  DELETE /entities/:id → WS config/entity_registry/remove
+//   10. labels: GET list + POST create + PUT update + DELETE delete
+//   11. HA WS error propagates as 502 HA_WS_ERROR (not a hung request)
+//   12. all writes blocked when HA_NOT_CONNECTED → 409
+//
+// Test plumbing
+// -------------
+// Mirrors the channels_ha_ws_routes / channels_ha_pr7 tests:
+//   - in-process fake HA WS server speaks `auth_required`/`auth_ok` +
+//     `result` envelopes
+//   - the fetch shim serves the LLAT from the vault-cli stub +
+//     answers HA REST /api/ + /api/config so /connect can succeed
+//   - HA_WS_URL_OVERRIDE points the client at our fake.
+
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import http from "node:http";
+import { WebSocketServer, type WebSocket as WSWebSocket } from "ws";
+import type { ServerResponse } from "node:http";
+
+// ── env (must be set before module imports) ────────────────────────────
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "channels-ha-pr2-"));
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.VAULT_PATH = path.join(tmp, "vault");
+process.env.STATE_DB_PATH = path.join(tmp, "alfred-state.db");
+process.env.INGEST_DB_PATH = path.join(tmp, "ingest.db");
+process.env.SQLITE_VEC_PATH = "";
+process.env.VAULT_CLI_URL = "http://vault-cli-stub:8087";
+process.env.HA_VAULTWARDEN_FOLDER = "Home Assistant";
+process.env.HA_LLAT_ITEM = "LLAT";
+process.env.HA_PROBE_TIMEOUT_MS = "5000";
+process.env.HA_WRITE_TIMEOUT_MS = "5000";
+process.env.HA_REGISTRY_WS_TIMEOUT_MS = "5000";
+process.env.HA_WS_AUTOSTART = "false";
+
+const VALID_LLAT = "llat_TEST_" + "0".repeat(40);
+const HA_URL = "http://homeassistant.local:8123";
+const HA_VERSION = "2025.6.1";
+
+// ── fake HA WS server ──────────────────────────────────────────────────
+
+let server: http.Server;
+let wss: WebSocketServer;
+let serverPort = 0;
+const liveSockets: WSWebSocket[] = [];
+
+interface WsRouteResp {
+  success?: boolean;
+  result?: unknown;
+  error?: { code: string; message: string };
+}
+
+/**
+ * Map of WS message-type → response. Tests mutate this between cases.
+ * Defaults to `{success: true, result: {}}` for unset types.
+ */
+let wsRoutes: Map<string, WsRouteResp> = new Map();
+const wsLog: Array<Record<string, unknown>> = [];
+
+function setupServer(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    server = http.createServer();
+    wss = new WebSocketServer({ server, path: "/api/websocket" });
+    wss.on("connection", (ws) => {
+      liveSockets.push(ws);
+      ws.send(JSON.stringify({ type: "auth_required", ha_version: HA_VERSION }));
+      ws.on("message", (raw) => {
+        let msg: Record<string, unknown>;
+        try {
+          msg = JSON.parse(String(raw)) as Record<string, unknown>;
+        } catch {
+          return;
+        }
+        wsLog.push(msg);
+        if (msg.type === "auth") {
+          ws.send(JSON.stringify({ type: "auth_ok" }));
+          return;
+        }
+        const id = msg.id;
+        // subscribe_events — Tier 4 event streams.
+        if (msg.type === "subscribe_events") {
+          ws.send(JSON.stringify({ id, type: "result", success: true, result: null }));
+          return;
+        }
+        const type = String(msg.type);
+        const resp = wsRoutes.get(type) ?? { success: true, result: {} };
+        ws.send(
+          JSON.stringify({
+            id,
+            type: "result",
+            success: resp.success ?? true,
+            ...(resp.result !== undefined ? { result: resp.result } : {}),
+            ...(resp.error !== undefined ? { error: resp.error } : {}),
+          }),
+        );
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (addr && typeof addr === "object") serverPort = addr.port;
+      resolve();
+    });
+  });
+}
+
+function teardownServer(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    for (const s of liveSockets) {
+      try {
+        s.terminate();
+      } catch {
+        // best-effort
+      }
+    }
+    liveSockets.length = 0;
+    wss?.close(() => {
+      server?.close(() => resolve());
+    });
+  });
+}
+
+// ── fetch mock (REST surface — vault-cli + /api/ + /api/config) ─────────
+
+interface VaultItem {
+  id: string;
+  name: string;
+  type: 1;
+  folderId: string | null;
+  login: { username: string | null; password: string; uris: unknown[] };
+}
+interface VaultFolder {
+  id: string;
+  name: string;
+}
+let vaultStore: VaultItem[] = [];
+let vaultFolders: VaultFolder[] = [];
+
+function makeJsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const originalFetch = globalThis.fetch;
+
+globalThis.fetch = (async (input: any, init?: any) => {
+  const url = typeof input === "string" ? input : (input?.url ?? String(input));
+  const method = (init?.method ?? "GET").toUpperCase();
+  const bodyRaw = init?.body !== undefined ? String(init.body) : undefined;
+
+  // HA /api/ auth gate (used by /connect).
+  if (url === `${HA_URL}/api/` && method === "GET") {
+    return makeJsonResponse({ message: "API running." }, 200);
+  }
+  // HA /api/config (used by /connect).
+  if (url === `${HA_URL}/api/config` && method === "GET") {
+    return makeJsonResponse(
+      {
+        version: HA_VERSION,
+        installation_type: "Home Assistant OS",
+        location_name: "Home",
+      },
+      200,
+    );
+  }
+
+  // vault-cli folders + items.
+  if (url.endsWith("/list/object/folders") && method === "GET") {
+    return makeJsonResponse({ success: true, data: { data: vaultFolders } });
+  }
+  if (url.endsWith("/object/folder") && method === "POST") {
+    const b = JSON.parse(bodyRaw ?? "{}");
+    const f: VaultFolder = {
+      id: "fld-" + String(Date.now()) + "-" + Math.random().toString(36).slice(2, 6),
+      name: b.name,
+    };
+    vaultFolders.push(f);
+    return makeJsonResponse({ success: true, data: f });
+  }
+  if (url.includes("/list/object/items")) {
+    const qIdx = url.indexOf("?");
+    const params = new URLSearchParams(qIdx >= 0 ? url.slice(qIdx + 1) : "");
+    const search = params.get("search") ?? "";
+    const filtered = search
+      ? vaultStore.filter((i) => i.name.toLowerCase().includes(search.toLowerCase()))
+      : vaultStore.slice();
+    return makeJsonResponse({ success: true, data: { data: filtered } });
+  }
+  const objMatch = url.match(/\/object\/item\/([^/?]+)/);
+  if (objMatch && method === "GET") {
+    const id = objMatch[1];
+    const item = vaultStore.find((i) => i.id === id);
+    if (!item) return makeJsonResponse({ success: false, message: "not found" }, 404);
+    return makeJsonResponse({
+      success: true,
+      data: {
+        ...item,
+        // Embed double-wrapped login.password for ha_ws_client's readHaLlat.
+        data: { login: { password: item.login.password } },
+      },
+    });
+  }
+  if (url.endsWith("/object/item") && method === "POST") {
+    const b = JSON.parse(bodyRaw ?? "{}");
+    const id = "id-" + String(Date.now()) + "-" + Math.random().toString(36).slice(2, 8);
+    const item: VaultItem = {
+      id,
+      name: b.name,
+      type: 1,
+      folderId: b.folderId ?? null,
+      login: {
+        username: b.login?.username ?? null,
+        password: b.login?.password ?? "",
+        uris: b.login?.uris ?? [],
+      },
+    };
+    vaultStore.push(item);
+    return makeJsonResponse({ success: true, data: item });
+  }
+  if (objMatch && method === "PUT") {
+    const id = objMatch[1];
+    const idx = vaultStore.findIndex((i) => i.id === id);
+    if (idx < 0) return makeJsonResponse({ success: false, message: "not found" }, 404);
+    const b = JSON.parse(bodyRaw ?? "{}");
+    vaultStore[idx] = {
+      ...vaultStore[idx],
+      name: b.name ?? vaultStore[idx].name,
+      folderId: b.folderId ?? vaultStore[idx].folderId,
+      login: { ...vaultStore[idx].login, ...(b.login ?? {}) },
+    };
+    return makeJsonResponse({ success: true, data: vaultStore[idx] });
+  }
+  if (objMatch && method === "DELETE") {
+    const id = objMatch[1];
+    const idx = vaultStore.findIndex((i) => i.id === id);
+    if (idx < 0) return makeJsonResponse({ success: false, message: "not found" }, 404);
+    vaultStore.splice(idx, 1);
+    return makeJsonResponse({ success: true });
+  }
+  throw new Error(`unexpected fetch in channels_ha_registries: ${method} ${url}`);
+}) as typeof fetch;
+
+// ── server up + module imports ─────────────────────────────────────────
+
+await setupServer();
+process.env.HA_WS_URL_OVERRIDE = `ws://127.0.0.1:${serverPort}/api/websocket`;
+
+const {
+  registerChannelsHaRoutes,
+  _resetHaSubscriptionsForTests,
+  _resetHaAddonsForTests,
+  _resetHaInstallationTypeCache,
+} = await import("../src/api/routes/channels_ha.js");
+const { matchRoute } = await import("../src/api/server.js");
+const { handleError } = await import("../src/api/errors.js");
+const { getStateDb } = await import("../src/db/state.js");
+const { _resetHaWsClientForTests, getHaWsClient } = await import(
+  "../src/api/lib/ha_ws_client.js"
+);
+
+registerChannelsHaRoutes();
+
+// ── helpers ────────────────────────────────────────────────────────────
+
+interface CallResult {
+  status: number;
+  payload: any;
+}
+
+async function call(
+  method: string,
+  p: string,
+  body?: unknown,
+): Promise<CallResult> {
+  const qIdx = p.indexOf("?");
+  const pathname = qIdx >= 0 ? p.slice(0, qIdx) : p;
+  const query = new URLSearchParams(qIdx >= 0 ? p.slice(qIdx + 1) : "");
+  const m = matchRoute(method, pathname);
+  assert.ok(m, `${method} ${p} must be registered`);
+  let status = 0;
+  let payload: any;
+  const res = {
+    statusCode: 0,
+    setHeader() {},
+    writeHead(c: number) {
+      status = c;
+      return res;
+    },
+    end(j?: string) {
+      payload = j ? JSON.parse(j) : undefined;
+    },
+  } as unknown as ServerResponse;
+  try {
+    await m!.handler({
+      req: { method, headers: {}, url: p } as any,
+      res,
+      params: m!.params,
+      body,
+      query,
+    });
+  } catch (err) {
+    handleError(res, err);
+  }
+  return { status, payload };
+}
+
+async function connectHa(): Promise<void> {
+  const r = await call("POST", "/api/v1/channels/ha/connect", {
+    ha_url: HA_URL,
+    llat: VALID_LLAT,
+    label: "Test",
+  });
+  assert.equal(r.status, 200, JSON.stringify(r.payload));
+}
+
+/** Ensure the HA WS client is freshly authed against the fake HA server. */
+async function ensureWsAuthed(): Promise<void> {
+  const client = getHaWsClient();
+  client.start();
+  await new Promise<void>((resolve, reject) => {
+    const deadline = Date.now() + 3000;
+    const tick = () => {
+      const s = client.getStatus();
+      if (s.connected) return resolve();
+      if (Date.now() > deadline) {
+        return reject(
+          new Error(
+            `WS never reached connected state (last_error=${s.last_error ?? "none"})`,
+          ),
+        );
+      }
+      setTimeout(tick, 25);
+    };
+    tick();
+  });
+}
+
+/** Find the last WS message of a given type in the per-test log. */
+function findLastWs(type: string): Record<string, unknown> | undefined {
+  for (let i = wsLog.length - 1; i >= 0; i--) {
+    if (wsLog[i].type === type) return wsLog[i];
+  }
+  return undefined;
+}
+
+// ── tests ──────────────────────────────────────────────────────────────
+
+describe("/api/v1/channels/ha/{areas,devices,entities,labels} — #115 PR2 registries CRUD", () => {
+  before(async () => {
+    getStateDb();
+  });
+
+  beforeEach(() => {
+    vaultStore = [];
+    vaultFolders = [];
+    wsLog.length = 0;
+    wsRoutes = new Map();
+    const db = getStateDb();
+    try {
+      db.prepare("DELETE FROM ha_connection").run();
+      db.prepare("DELETE FROM ha_run").run();
+      db.prepare("DELETE FROM ha_proposal").run();
+      db.prepare("DELETE FROM ha_snapshot").run();
+      db.prepare("DELETE FROM ha_event").run();
+      db.prepare("DELETE FROM ha_event_subscription").run();
+      db.prepare("DELETE FROM ha_backup_ref").run();
+    } catch {
+      // first run before tables exist
+    }
+    _resetHaSubscriptionsForTests();
+    _resetHaAddonsForTests();
+    _resetHaInstallationTypeCache();
+    _resetHaWsClientForTests();
+  });
+
+  after(async () => {
+    _resetHaWsClientForTests();
+    await teardownServer();
+    globalThis.fetch = originalFetch;
+  });
+
+  // ── 1 ── areas: list
+  it("GET /areas — proxies config/area_registry/list and returns areas[]", async () => {
+    await connectHa();
+    await ensureWsAuthed();
+    wsRoutes.set("config/area_registry/list", {
+      success: true,
+      result: [
+        { area_id: "kitchen", name: "Kitchen" },
+        { area_id: "living", name: "Living Room" },
+      ],
+    });
+    const r = await call("GET", "/api/v1/channels/ha/areas");
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.ok, true);
+    assert.equal(r.payload.areas.length, 2);
+    assert.equal(r.payload.areas[0].area_id, "kitchen");
+  });
+
+  // ── 2 ── areas: create
+  it("POST /areas — sends config/area_registry/create with the body fields and returns area_id", async () => {
+    await connectHa();
+    await ensureWsAuthed();
+    wsRoutes.set("config/area_registry/create", {
+      success: true,
+      result: { area_id: "garage", name: "Garage", icon: "mdi:garage" },
+    });
+    const r = await call("POST", "/api/v1/channels/ha/areas", {
+      name: "Garage",
+      icon: "mdi:garage",
+      labels: ["new"],
+    });
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.area_id, "garage");
+    const sent = findLastWs("config/area_registry/create");
+    assert.ok(sent, "config/area_registry/create must be sent");
+    assert.equal(sent!.name, "Garage");
+    assert.equal(sent!.icon, "mdi:garage");
+    assert.deepEqual(sent!.labels, ["new"]);
+  });
+
+  // ── 3 ── areas: update + delete
+  it("PUT /areas/:id and DELETE /areas/:id — config/area_registry/{update,delete} with area_id", async () => {
+    await connectHa();
+    await ensureWsAuthed();
+    wsRoutes.set("config/area_registry/update", {
+      success: true,
+      result: { area_id: "kitchen", name: "Lounge" },
+    });
+    const rUpd = await call("PUT", "/api/v1/channels/ha/areas/kitchen", {
+      name: "Lounge",
+      icon: null, // exercise the null-clear path
+    });
+    assert.equal(rUpd.status, 200, JSON.stringify(rUpd.payload));
+    const sentUpd = findLastWs("config/area_registry/update");
+    assert.equal(sentUpd!.area_id, "kitchen");
+    assert.equal(sentUpd!.name, "Lounge");
+    assert.equal(sentUpd!.icon, null);
+
+    wsRoutes.set("config/area_registry/delete", {
+      success: true,
+      result: null,
+    });
+    const rDel = await call("DELETE", "/api/v1/channels/ha/areas/kitchen");
+    assert.equal(rDel.status, 200, JSON.stringify(rDel.payload));
+    assert.equal(rDel.payload.area_id, "kitchen");
+    const sentDel = findLastWs("config/area_registry/delete");
+    assert.equal(sentDel!.area_id, "kitchen");
+  });
+
+  // ── 4 ── devices: list + get-by-id (with 404)
+  it("GET /devices and GET /devices/:id — list + filter; 404 on miss", async () => {
+    await connectHa();
+    await ensureWsAuthed();
+    wsRoutes.set("config/device_registry/list", {
+      success: true,
+      result: [
+        { id: "dev_hue_1", name: "Hue Bulb", area_id: "kitchen" },
+        { id: "dev_lock_1", name: "Front Door", area_id: "entry" },
+      ],
+    });
+    const rList = await call("GET", "/api/v1/channels/ha/devices");
+    assert.equal(rList.status, 200, JSON.stringify(rList.payload));
+    assert.equal(rList.payload.devices.length, 2);
+
+    const rOne = await call("GET", "/api/v1/channels/ha/devices/dev_hue_1");
+    assert.equal(rOne.status, 200, JSON.stringify(rOne.payload));
+    assert.equal(rOne.payload.device.id, "dev_hue_1");
+
+    const rMiss = await call("GET", "/api/v1/channels/ha/devices/nonexistent");
+    assert.equal(rMiss.status, 404, JSON.stringify(rMiss.payload));
+  });
+
+  // ── 5 ── devices: update (nullable fields)
+  it("PUT /devices/:id — sends config/device_registry/update with nullable fields honoured", async () => {
+    await connectHa();
+    await ensureWsAuthed();
+    wsRoutes.set("config/device_registry/update", {
+      success: true,
+      result: { id: "dev_hue_1", name_by_user: "Bedside Lamp" },
+    });
+    const r = await call("PUT", "/api/v1/channels/ha/devices/dev_hue_1", {
+      name_by_user: "Bedside Lamp",
+      area_id: null, // clear the area binding
+      labels: ["bedtime"],
+    });
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    const sent = findLastWs("config/device_registry/update");
+    assert.equal(sent!.device_id, "dev_hue_1");
+    assert.equal(sent!.name_by_user, "Bedside Lamp");
+    assert.equal(sent!.area_id, null);
+    assert.deepEqual(sent!.labels, ["bedtime"]);
+  });
+
+  // ── 6 ── entities: list + get-by-id (with 400 on bad dotted form)
+  it("GET /entities + GET /entities/:id — list + per-entity get; bad id format → 400", async () => {
+    await connectHa();
+    await ensureWsAuthed();
+    wsRoutes.set("config/entity_registry/list", {
+      success: true,
+      result: [
+        { entity_id: "light.kitchen_main", name: "Kitchen Light" },
+        { entity_id: "binary_sensor.front_door", name: "Front Door" },
+      ],
+    });
+    const rList = await call("GET", "/api/v1/channels/ha/entities");
+    assert.equal(rList.status, 200, JSON.stringify(rList.payload));
+    assert.equal(rList.payload.entities.length, 2);
+
+    wsRoutes.set("config/entity_registry/get", {
+      success: true,
+      result: {
+        entity_id: "light.kitchen_main",
+        name: "Kitchen Light",
+        area_id: "kitchen",
+      },
+    });
+    const rOne = await call(
+      "GET",
+      "/api/v1/channels/ha/entities/light.kitchen_main",
+    );
+    assert.equal(rOne.status, 200, JSON.stringify(rOne.payload));
+    assert.equal(rOne.payload.entity.entity_id, "light.kitchen_main");
+
+    const rBad = await call(
+      "GET",
+      "/api/v1/channels/ha/entities/NoDottedForm",
+    );
+    assert.equal(rBad.status, 400, JSON.stringify(rBad.payload));
+  });
+
+  // ── 7 ── entities: update (multi-field path)
+  it("PUT /entities/:id — sends config/entity_registry/update with name/icon/area_id/hidden_by/disabled_by/labels", async () => {
+    await connectHa();
+    await ensureWsAuthed();
+    wsRoutes.set("config/entity_registry/update", {
+      success: true,
+      result: { entity_id: "light.kitchen_main", name: "Sconce" },
+    });
+    const r = await call(
+      "PUT",
+      "/api/v1/channels/ha/entities/light.kitchen_main",
+      {
+        name: "Sconce",
+        icon: "mdi:lightbulb",
+        area_id: "kitchen",
+        hidden_by: null,
+        disabled_by: null,
+        labels: ["evening"],
+      },
+    );
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    const sent = findLastWs("config/entity_registry/update");
+    assert.equal(sent!.entity_id, "light.kitchen_main");
+    assert.equal(sent!.name, "Sconce");
+    assert.equal(sent!.icon, "mdi:lightbulb");
+    assert.equal(sent!.area_id, "kitchen");
+    assert.equal(sent!.hidden_by, null);
+    assert.equal(sent!.disabled_by, null);
+    assert.deepEqual(sent!.labels, ["evening"]);
+  });
+
+  // ── 8 ── entities: delete
+  it("DELETE /entities/:id — sends config/entity_registry/remove", async () => {
+    await connectHa();
+    await ensureWsAuthed();
+    wsRoutes.set("config/entity_registry/remove", {
+      success: true,
+      result: null,
+    });
+    const r = await call(
+      "DELETE",
+      "/api/v1/channels/ha/entities/light.unused_one",
+    );
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.entity_id, "light.unused_one");
+    const sent = findLastWs("config/entity_registry/remove");
+    assert.equal(sent!.entity_id, "light.unused_one");
+  });
+
+  // ── 9 ── labels: list + create + update + delete
+  it("labels: GET /labels + POST + PUT + DELETE round-trip the four WS verbs", async () => {
+    await connectHa();
+    await ensureWsAuthed();
+    wsRoutes.set("config/label_registry/list", {
+      success: true,
+      result: [{ label_id: "critical", name: "Critical", color: "red" }],
+    });
+    const rList = await call("GET", "/api/v1/channels/ha/labels");
+    assert.equal(rList.status, 200, JSON.stringify(rList.payload));
+    assert.equal(rList.payload.labels.length, 1);
+
+    wsRoutes.set("config/label_registry/create", {
+      success: true,
+      result: { label_id: "bedtime", name: "Bedtime", color: "indigo" },
+    });
+    const rPost = await call("POST", "/api/v1/channels/ha/labels", {
+      name: "Bedtime",
+      color: "indigo",
+      icon: "mdi:weather-night",
+    });
+    assert.equal(rPost.status, 200, JSON.stringify(rPost.payload));
+    assert.equal(rPost.payload.label_id, "bedtime");
+    const sentCreate = findLastWs("config/label_registry/create");
+    assert.equal(sentCreate!.name, "Bedtime");
+    assert.equal(sentCreate!.color, "indigo");
+
+    wsRoutes.set("config/label_registry/update", {
+      success: true,
+      result: { label_id: "bedtime", name: "Evening Routine" },
+    });
+    const rPut = await call("PUT", "/api/v1/channels/ha/labels/bedtime", {
+      name: "Evening Routine",
+      color: null, // clear
+    });
+    assert.equal(rPut.status, 200, JSON.stringify(rPut.payload));
+    const sentUpdate = findLastWs("config/label_registry/update");
+    assert.equal(sentUpdate!.label_id, "bedtime");
+    assert.equal(sentUpdate!.name, "Evening Routine");
+    assert.equal(sentUpdate!.color, null);
+
+    wsRoutes.set("config/label_registry/delete", {
+      success: true,
+      result: null,
+    });
+    const rDel = await call("DELETE", "/api/v1/channels/ha/labels/bedtime");
+    assert.equal(rDel.status, 200, JSON.stringify(rDel.payload));
+    const sentDelete = findLastWs("config/label_registry/delete");
+    assert.equal(sentDelete!.label_id, "bedtime");
+  });
+
+  // ── 10 ── HA WS error propagates as 502 HA_WS_ERROR
+  it("HA WS error → 502 HA_WS_ERROR with the upstream code/message in the detail", async () => {
+    await connectHa();
+    await ensureWsAuthed();
+    wsRoutes.set("config/area_registry/create", {
+      success: false,
+      error: { code: "invalid_format", message: "name too long" },
+    });
+    const r = await call("POST", "/api/v1/channels/ha/areas", {
+      name: "x".repeat(8),
+    });
+    assert.equal(r.status, 502, JSON.stringify(r.payload));
+    assert.equal(r.payload.error.code, "HA_WS_ERROR");
+    assert.match(String(r.payload.error.message ?? ""), /invalid_format/);
+    assert.match(String(r.payload.error.message ?? ""), /name too long/);
+  });
+
+  // ── 11 ── HA not connected → 409
+  it("registry writes blocked when HA_NOT_CONNECTED → 409", async () => {
+    // No connect call — ha_connection row absent.
+    const r = await call("POST", "/api/v1/channels/ha/areas", { name: "X" });
+    assert.equal(r.status, 409, JSON.stringify(r.payload));
+    assert.equal(r.payload.error.code, "HA_NOT_CONNECTED");
+  });
+
+  // ── 12 ── pinned: no decision_ref required (locked YES default 2026-05-29)
+  it("PR2 verbs are NOT decision_ref-gated — empty body 'name' is the only required field for create", async () => {
+    await connectHa();
+    await ensureWsAuthed();
+    wsRoutes.set("config/area_registry/create", {
+      success: true,
+      result: { area_id: "x", name: "X" },
+    });
+    // No decision_ref in the body — must NOT 400 with VALIDATION_ERROR
+    // re: decision_ref. (The cheap-reversible-default is the entire
+    // point of PR2; if a future agent quietly bolts a gate on, this
+    // test catches it.)
+    const r = await call("POST", "/api/v1/channels/ha/areas", { name: "X" });
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+
+    // Same for delete — no body required at all.
+    wsRoutes.set("config/area_registry/delete", {
+      success: true,
+      result: null,
+    });
+    const rDel = await call("DELETE", "/api/v1/channels/ha/areas/x");
+    assert.equal(rDel.status, 200, JSON.stringify(rDel.payload));
+
+    // PUT with bad body type → 400 (validation), not a gate-related error.
+    const rBad = await call("PUT", "/api/v1/channels/ha/areas/x", null);
+    assert.equal(rBad.status, 400, JSON.stringify(rBad.payload));
+  });
+});

--- a/packages/mcp-server/src/tools/hass.test.ts
+++ b/packages/mcp-server/src/tools/hass.test.ts
@@ -24,6 +24,7 @@ import {
   HASS_INTEGRATION_TOOLS,
   HASS_USER_TOOLS,
   HASS_HACS_TOOLS,
+  HASS_PR2_TOOLS,
 } from "./hass.js";
 import { SUPPORTED_APPS, isAppId, getToolsForApp } from "./registry.js";
 
@@ -35,7 +36,7 @@ function getTool(name: string) {
 
 // ─── catalogue shape ────────────────────────────────────────────────────
 
-test("hass catalogue: exactly 69 tools (11 read + 15 write + 10 PR6 addon + 10 PR7 core+backup + 7 PR4 integration + 8 PR8 user + 8 PR5 HACS)", () => {
+test("hass catalogue: exactly 85 tools (11 read + 15 write + 10 PR6 addon + 10 PR7 core+backup + 7 PR4 integration + 8 PR8 user + 8 PR5 HACS + 16 PR2 registries)", () => {
   assert.equal(HASS_READ_TOOLS.length, 11);
   // After #115 PR3 splice: PR4's 5 + PR3's 10 = 15 writes.
   assert.equal(HASS_DEFERRED_TOOLS.length, 15);
@@ -50,14 +51,16 @@ test("hass catalogue: exactly 69 tools (11 read + 15 write + 10 PR6 addon + 10 P
   assert.equal(HASS_USER_TOOLS.length, 8);
   // PR5: 8 HACS tools.
   assert.equal(HASS_HACS_TOOLS.length, 8);
-  assert.equal(ALL_HASS_TOOLS.length, 69);
+  // PR2: 16 registries CRUD tools (areas/devices/entities/labels).
+  assert.equal(HASS_PR2_TOOLS.length, 16);
+  assert.equal(ALL_HASS_TOOLS.length, 85);
 });
 
-test("registry: hass is a supported app and registers all 69 tools", () => {
+test("registry: hass is a supported app and registers all 85 tools", () => {
   assert.ok(isAppId("hass"));
   assert.ok((SUPPORTED_APPS as Set<string>).has("hass"));
   const tools = getToolsForApp("hass");
-  assert.equal(tools.length, 69);
+  assert.equal(tools.length, 85);
 });
 
 test("hass: every tool name is unique", () => {
@@ -2015,5 +2018,361 @@ test("HACS PR5: non-gated tools (info/search/repo_info/add_custom_repo/refresh/p
     // No decision_ref in any of these.
     const r = t.inputSchema.safeParse(sample);
     assert.equal(r.success, true, `${name} must accept input WITHOUT decision_ref`);
+  }
+});
+
+// ─── #115 PR2 — registries CRUD tools (areas/devices/entities/labels) ──
+
+const PR2_TOOL_NAMES = [
+  "ha__area_create",
+  "ha__area_update",
+  "ha__area_delete",
+  "ha__device_set_area",
+  "ha__device_set_name",
+  "ha__device_disable",
+  "ha__device_label",
+  "ha__entity_rename",
+  "ha__entity_set_area",
+  "ha__entity_hide",
+  "ha__entity_disable",
+  "ha__entity_label",
+  "ha__label_create",
+  "ha__label_update",
+  "ha__label_delete",
+  "ha__label_apply",
+];
+
+test("PR2: every registries tool is registered and unique", () => {
+  for (const name of PR2_TOOL_NAMES) {
+    const t = HASS_PR2_TOOLS.find((x) => x.name === name);
+    assert.ok(t, `${name} missing from HASS_PR2_TOOLS`);
+  }
+  const names = HASS_PR2_TOOLS.map((t) => t.name);
+  assert.equal(new Set(names).size, names.length);
+  // No tool name from PR2 collides with an earlier wave.
+  for (const t of HASS_PR2_TOOLS) {
+    const matches = ALL_HASS_TOOLS.filter((x) => x.name === t.name).length;
+    assert.equal(matches, 1, `${t.name} must appear exactly once in ALL_HASS_TOOLS`);
+  }
+});
+
+test("PR2 ha__area_create: name required; POST /areas; optional fields ride along", () => {
+  const t = getTool("ha__area_create");
+  assert.equal(t.inputSchema.safeParse({}).success, false, "name required");
+  const minimal = { name: "Garage" };
+  assert.equal(t.inputSchema.safeParse(minimal).success, true);
+  const r1 = t.buildRequest(minimal);
+  assert.equal(r1.method, "POST");
+  assert.equal(r1.path, "/api/v1/channels/ha/areas");
+  assert.deepEqual(r1.body, { name: "Garage" });
+  // optional fields pass through.
+  const full = {
+    name: "Master Bedroom",
+    icon: "mdi:bed",
+    picture: "/local/master.jpg",
+    floor_id: "upstairs",
+    aliases: ["main bedroom", "our room"],
+    labels: ["bedtime"],
+  };
+  assert.equal(t.inputSchema.safeParse(full).success, true);
+  const r2 = t.buildRequest(full);
+  assert.deepEqual(r2.body, full);
+});
+
+test("PR2 ha__area_update: area_id required, optional name/icon/etc.; PUT /areas/:id", () => {
+  const t = getTool("ha__area_update");
+  assert.equal(t.inputSchema.safeParse({}).success, false, "area_id required");
+  // bad id chars rejected.
+  assert.equal(
+    t.inputSchema.safeParse({ area_id: "../etc" }).success,
+    false,
+    "URL-traversal guard",
+  );
+  // valid with just area_id.
+  const minimal = { area_id: "kitchen" };
+  assert.equal(t.inputSchema.safeParse(minimal).success, true);
+  const r1 = t.buildRequest(minimal);
+  assert.equal(r1.method, "PUT");
+  assert.equal(r1.path, "/api/v1/channels/ha/areas/kitchen");
+  assert.deepEqual(r1.body, {});
+  // null icon clears the icon (HA semantics).
+  const withNull = { area_id: "kitchen", icon: null, name: "Lounge" };
+  assert.equal(t.inputSchema.safeParse(withNull).success, true);
+  const r2 = t.buildRequest(withNull);
+  assert.deepEqual(r2.body, { name: "Lounge", icon: null });
+});
+
+test("PR2 ha__area_delete: area_id required, NO body, DELETE /areas/:id", () => {
+  const t = getTool("ha__area_delete");
+  assert.equal(t.inputSchema.safeParse({}).success, false);
+  const r = t.buildRequest({ area_id: "kitchen" });
+  assert.equal(r.method, "DELETE");
+  assert.equal(r.path, "/api/v1/channels/ha/areas/kitchen");
+  assert.equal(r.body, undefined);
+});
+
+test("PR2 ha__device_set_area: device_id + area_id (nullable); PUT /devices/:id with area_id only", () => {
+  const t = getTool("ha__device_set_area");
+  // both required.
+  assert.equal(t.inputSchema.safeParse({}).success, false);
+  assert.equal(
+    t.inputSchema.safeParse({ device_id: "abc123" }).success,
+    false,
+    "area_id required (null allowed)",
+  );
+  // null area_id is valid (unassign).
+  const unassign = { device_id: "abc123def456", area_id: null };
+  assert.equal(t.inputSchema.safeParse(unassign).success, true);
+  const r1 = t.buildRequest(unassign);
+  assert.equal(r1.method, "PUT");
+  assert.equal(r1.path, "/api/v1/channels/ha/devices/abc123def456");
+  assert.deepEqual(r1.body, { area_id: null });
+  // string area_id.
+  const r2 = t.buildRequest({ device_id: "abc123def456", area_id: "garage" });
+  assert.deepEqual(r2.body, { area_id: "garage" });
+});
+
+test("PR2 ha__device_set_name: PUT /devices/:id with name_by_user; null restores integration name", () => {
+  const t = getTool("ha__device_set_name");
+  // null name is valid (clear).
+  const args = { device_id: "abc123", name: "Living Room Sconce" };
+  assert.equal(t.inputSchema.safeParse(args).success, true);
+  const r = t.buildRequest(args);
+  assert.equal(r.method, "PUT");
+  assert.equal(r.path, "/api/v1/channels/ha/devices/abc123");
+  assert.deepEqual(r.body, { name_by_user: "Living Room Sconce" });
+  // null clears.
+  const clear = { device_id: "abc123", name: null };
+  assert.equal(t.inputSchema.safeParse(clear).success, true);
+  assert.deepEqual(t.buildRequest(clear).body, { name_by_user: null });
+});
+
+test("PR2 ha__device_disable: PUT /devices/:id with disabled_by; only 'user'/null sane values", () => {
+  const t = getTool("ha__device_disable");
+  // 'user' valid.
+  assert.equal(
+    t.inputSchema.safeParse({ device_id: "abc", disabled_by: "user" }).success,
+    true,
+  );
+  // null valid (re-enable).
+  assert.equal(
+    t.inputSchema.safeParse({ device_id: "abc", disabled_by: null }).success,
+    true,
+  );
+  // bogus enum value rejected.
+  assert.equal(
+    t.inputSchema.safeParse({ device_id: "abc", disabled_by: "alfred" })
+      .success,
+    false,
+  );
+  const r = t.buildRequest({ device_id: "abc", disabled_by: "user" });
+  assert.equal(r.path, "/api/v1/channels/ha/devices/abc");
+  assert.deepEqual(r.body, { disabled_by: "user" });
+});
+
+test("PR2 ha__device_label: full-replace labels; PUT /devices/:id with labels array", () => {
+  const t = getTool("ha__device_label");
+  // labels required.
+  assert.equal(t.inputSchema.safeParse({ device_id: "abc" }).success, false);
+  // empty array is valid (clears labels).
+  assert.equal(
+    t.inputSchema.safeParse({ device_id: "abc", labels: [] }).success,
+    true,
+  );
+  const args = { device_id: "abc", labels: ["critical", "bedtime"] };
+  assert.equal(t.inputSchema.safeParse(args).success, true);
+  const r = t.buildRequest(args);
+  assert.equal(r.method, "PUT");
+  assert.deepEqual(r.body, { labels: ["critical", "bedtime"] });
+});
+
+test("PR2 ha__entity_rename: entity_id (dotted) + name (nullable); PUT /entities/:id", () => {
+  const t = getTool("ha__entity_rename");
+  // bad entity_id format rejected.
+  assert.equal(
+    t.inputSchema.safeParse({ entity_id: "NoDot", name: "x" }).success,
+    false,
+  );
+  assert.equal(
+    t.inputSchema.safeParse({ entity_id: "light.kitchen_main", name: "Kitchen Main" })
+      .success,
+    true,
+  );
+  const r = t.buildRequest({
+    entity_id: "light.kitchen_main",
+    name: "Kitchen Main",
+    icon: "mdi:lightbulb",
+  });
+  assert.equal(r.method, "PUT");
+  assert.equal(r.path, "/api/v1/channels/ha/entities/light.kitchen_main");
+  assert.deepEqual(r.body, { name: "Kitchen Main", icon: "mdi:lightbulb" });
+});
+
+test("PR2 ha__entity_set_area: PUT /entities/:id with area_id; null clears the override", () => {
+  const t = getTool("ha__entity_set_area");
+  assert.equal(
+    t.inputSchema.safeParse({ entity_id: "light.kitchen_main", area_id: "kitchen" })
+      .success,
+    true,
+  );
+  assert.equal(
+    t.inputSchema.safeParse({ entity_id: "light.kitchen_main", area_id: null })
+      .success,
+    true,
+  );
+  const r = t.buildRequest({
+    entity_id: "light.kitchen_main",
+    area_id: "kitchen",
+  });
+  assert.equal(r.method, "PUT");
+  assert.equal(r.path, "/api/v1/channels/ha/entities/light.kitchen_main");
+  assert.deepEqual(r.body, { area_id: "kitchen" });
+});
+
+test("PR2 ha__entity_hide and ha__entity_disable: PUT /entities/:id with the right field", () => {
+  const tHide = getTool("ha__entity_hide");
+  const rHide = tHide.buildRequest({
+    entity_id: "binary_sensor.diag_n",
+    hidden_by: "user",
+  });
+  assert.deepEqual(rHide.body, { hidden_by: "user" });
+  // bogus enum rejected.
+  assert.equal(
+    tHide.inputSchema.safeParse({
+      entity_id: "binary_sensor.x",
+      hidden_by: "alfred",
+    }).success,
+    false,
+  );
+
+  const tDis = getTool("ha__entity_disable");
+  const rDis = tDis.buildRequest({
+    entity_id: "sensor.cloud_thing",
+    disabled_by: null,
+  });
+  assert.deepEqual(rDis.body, { disabled_by: null });
+});
+
+test("PR2 ha__entity_label: PUT /entities/:id with labels array", () => {
+  const t = getTool("ha__entity_label");
+  const args = { entity_id: "light.kitchen_main", labels: ["security"] };
+  assert.equal(t.inputSchema.safeParse(args).success, true);
+  const r = t.buildRequest(args);
+  assert.equal(r.path, "/api/v1/channels/ha/entities/light.kitchen_main");
+  assert.deepEqual(r.body, { labels: ["security"] });
+});
+
+test("PR2 ha__label_create: name required; POST /labels with optional fields", () => {
+  const t = getTool("ha__label_create");
+  assert.equal(t.inputSchema.safeParse({}).success, false);
+  const minimal = { name: "Bedtime" };
+  assert.equal(t.inputSchema.safeParse(minimal).success, true);
+  assert.deepEqual(t.buildRequest(minimal).body, { name: "Bedtime" });
+  const full = {
+    name: "Critical",
+    color: "red",
+    icon: "mdi:alert",
+    description: "Devices that must always work.",
+  };
+  assert.equal(t.inputSchema.safeParse(full).success, true);
+  const r = t.buildRequest(full);
+  assert.equal(r.method, "POST");
+  assert.equal(r.path, "/api/v1/channels/ha/labels");
+  assert.deepEqual(r.body, full);
+});
+
+test("PR2 ha__label_update and ha__label_delete: PUT and DELETE /labels/:id", () => {
+  const tUpd = getTool("ha__label_update");
+  assert.equal(tUpd.inputSchema.safeParse({}).success, false);
+  const upd = {
+    label_id: "bedtime",
+    name: "Evening Routine",
+    color: null,
+    icon: "mdi:weather-night",
+  };
+  assert.equal(tUpd.inputSchema.safeParse(upd).success, true);
+  const rUpd = tUpd.buildRequest(upd);
+  assert.equal(rUpd.method, "PUT");
+  assert.equal(rUpd.path, "/api/v1/channels/ha/labels/bedtime");
+  assert.deepEqual(rUpd.body, {
+    name: "Evening Routine",
+    color: null,
+    icon: "mdi:weather-night",
+  });
+
+  const tDel = getTool("ha__label_delete");
+  assert.equal(tDel.inputSchema.safeParse({}).success, false);
+  const rDel = tDel.buildRequest({ label_id: "bedtime" });
+  assert.equal(rDel.method, "DELETE");
+  assert.equal(rDel.path, "/api/v1/channels/ha/labels/bedtime");
+  assert.equal(rDel.body, undefined);
+});
+
+test("PR2 ha__label_apply: target_kind routes to the right registry PUT, body carries [label_id]", () => {
+  const t = getTool("ha__label_apply");
+  // bad enum rejected.
+  assert.equal(
+    t.inputSchema.safeParse({
+      target_kind: "thingie",
+      target_id: "x",
+      label_id: "y",
+    }).success,
+    false,
+  );
+  // area.
+  const rA = t.buildRequest({
+    target_kind: "area",
+    target_id: "kitchen",
+    label_id: "critical",
+  });
+  assert.equal(rA.path, "/api/v1/channels/ha/areas/kitchen");
+  assert.deepEqual(rA.body, { labels: ["critical"] });
+  // device.
+  const rD = t.buildRequest({
+    target_kind: "device",
+    target_id: "abc123",
+    label_id: "bedtime",
+  });
+  assert.equal(rD.path, "/api/v1/channels/ha/devices/abc123");
+  assert.deepEqual(rD.body, { labels: ["bedtime"] });
+  // entity.
+  const rE = t.buildRequest({
+    target_kind: "entity",
+    target_id: "light.kitchen_main",
+    label_id: "security",
+  });
+  assert.equal(rE.path, "/api/v1/channels/ha/entities/light.kitchen_main");
+  assert.deepEqual(rE.body, { labels: ["security"] });
+});
+
+test("PR2: every tool description has 'No approval gate' AND mentions a list-tool resolution hint", () => {
+  // Sir's locked YES: cheap reversible verbs run free. Tests pin the
+  // tool docs so a future agent doesn't quietly add a gate.
+  for (const t of HASS_PR2_TOOLS) {
+    assert.ok(
+      /no approval gate/i.test(t.description),
+      `${t.name} description must say 'No approval gate' to pin the locked-YES default`,
+    );
+  }
+  // Resolution hints — every CRUD tool whose id comes from the principal
+  // (device/entity/label updates) should point at the list endpoint that
+  // resolves the id. Areas are slug-shaped + small in number so the
+  // mention isn't strictly required for area updates/deletes.
+  const ID_TOOL_HINTS: Record<string, RegExp> = {
+    ha__device_set_area: /ha__list_devices|ha__list_areas/,
+    ha__device_set_name: /ha__list_devices/,
+    ha__device_label: /ha__list_devices/,
+    ha__entity_rename: /ha__list_entities/,
+    ha__entity_set_area: /ha__list_entities|ha__list_areas/,
+    ha__entity_label: /ha__list_entities/,
+    ha__label_update: /ha__list_labels/,
+    ha__label_delete: /ha__list_labels/,
+  };
+  for (const [name, re] of Object.entries(ID_TOOL_HINTS)) {
+    const t = getTool(name);
+    assert.ok(
+      re.test(t.description),
+      `${name} description should hint at the list tool that resolves ids (${re})`,
+    );
   }
 });

--- a/packages/mcp-server/src/tools/hass.ts
+++ b/packages/mcp-server/src/tools/hass.ts
@@ -2088,12 +2088,508 @@ export const HASS_HACS_TOOLS: ToolDef[] = [
 
 // === END Tier 4 PR5 ═══════════════════════════════════════════════════
 
-// Final catalogue: 69 tools total = 11 read + 15 writes (5 PR4 + 10 PR3 CRUD)
+// ═════════════════════════════════════════════════════════════════════════
+// === Tier 4 PR2 ===
+// ═════════════════════════════════════════════════════════════════════════
+//
+// Issue #115 PR2 — 16 tools fronting ctrl-api's
+// `/api/v1/channels/ha/{areas,devices,entities,labels}` registry CRUD
+// surface. All WS-only on HA's side, all cheap + reversible — per Sir's
+// locked YES defaults (2026-05-29) NONE of these are gated by
+// `decision_ref` and NONE auto-snapshot. The verb whose effect Sir
+// couldn't reverse in <2 minutes through HA's own UI gets a gate;
+// renaming the kitchen light doesn't.
+//
+// | Tool                  | decision_ref | snapshot |
+// |-----------------------|--------------|----------|
+// | ha__area_create       | no           | no       |
+// | ha__area_update       | no           | no       |
+// | ha__area_delete       | no           | no       |
+// | ha__device_set_area   | no           | no       |
+// | ha__device_set_name   | no           | no       |
+// | ha__device_disable    | no           | no       |
+// | ha__device_label      | no           | no       |
+// | ha__entity_rename     | no           | no       |
+// | ha__entity_set_area   | no           | no       |
+// | ha__entity_hide       | no           | no       |
+// | ha__entity_disable    | no           | no       |
+// | ha__entity_label      | no           | no       |
+// | ha__label_create      | no           | no       |
+// | ha__label_update      | no           | no       |
+// | ha__label_delete      | no           | no       |
+// | ha__label_apply       | no           | no       |
+//
+// Fuzzy resolution
+// ----------------
+// Every tool description calls out the resolution hint — Alfred reads
+// `ha__list_areas` / `ha__list_devices` / `ha__list_entities` first to
+// resolve a human name like "kitchen" to the canonical `area_id`.
+// **NEVER invent ids** — registry CRUD against an invented id is a 502
+// from HA with a confusing message.
+
+const RegistryIdParam = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(
+    /^[A-Za-z0-9][A-Za-z0-9_.:\-]{0,127}$/,
+    "id must be 1..128 chars of [A-Za-z0-9_.:-], starting with [A-Za-z0-9]",
+  );
+
+const AreaIdParam = RegistryIdParam.describe(
+  "HA area id (e.g. `kitchen`, `living_room`). Resolve from `ha__list_areas`; NEVER invent — HA mints these as slugs of the create-time name.",
+);
+
+const DeviceIdParam = RegistryIdParam.describe(
+  "HA device id — the long hex string HA mints when an integration adds a device (e.g. `7b3e1f2a45c648e1b0d3f6c5a8e9d201`). Resolve from `ha__list_devices`; NEVER invent.",
+);
+
+const LabelIdParam = RegistryIdParam.describe(
+  "HA label id (e.g. `bedtime`, `critical`). Resolve from `ha__list_labels`; NEVER invent — HA mints these as slugs of the create-time name.",
+);
+
+const RegistryEntityIdParam = z
+  .string()
+  .min(1)
+  .regex(
+    /^[a-z0-9_]+\.[a-z0-9_]+$/,
+    "entity_id must be HA's dotted form, e.g. `light.kitchen_main`",
+  )
+  .describe(
+    "HA entity id in dotted form `<domain>.<object_id>`. Resolve via `ha__list_entities` first; NEVER invent.",
+  );
+
+const LabelArrayParam = z
+  .array(z.string().min(1).max(128))
+  .describe(
+    "Array of `label_id` strings. To APPEND a label keep the existing labels in the array; HA replaces the full set on every update (read current via `ha__list_devices` / `ha__list_entities` / `ha__list_areas` first if you need an append-not-replace).",
+  );
+
+export const HASS_PR2_TOOLS: ToolDef[] = [
+  // ── areas ─────────────────────────────────────────────────────────────
+
+  {
+    name: "ha__area_create",
+    description:
+      "Create a new HA area (a room / floor zone — `Kitchen`, `Bedroom`, `Garage`). Resolves to `POST /api/v1/channels/ha/areas`. **No approval gate** (cheap, reversible — `ha__area_delete` undoes it). HA mints the `area_id` as a slug of the `name`; the response carries it back. **When to call:** Sir says 'set up a Garage area', or you're bootstrapping areas from a new Hue bridge. Example: `{name: 'Master Bedroom', icon: 'mdi:bed', floor_id: 'upstairs'}`.",
+    inputSchema: z.object({
+      name: z
+        .string()
+        .min(1)
+        .max(128)
+        .describe(
+          "Human-readable area name (e.g. `Kitchen`, `Master Bedroom`). HA derives `area_id` from this as a slug.",
+        ),
+      icon: z
+        .string()
+        .min(1)
+        .max(64)
+        .optional()
+        .describe("Optional MDI icon name (e.g. `mdi:kitchen`, `mdi:bed`)."),
+      picture: z
+        .string()
+        .min(1)
+        .max(256)
+        .optional()
+        .describe("Optional URL/path to a picture HA renders on the area card."),
+      floor_id: z
+        .string()
+        .min(1)
+        .max(128)
+        .optional()
+        .describe(
+          "Optional floor this area belongs to (e.g. `upstairs`). Floors are an HA 2024.x feature.",
+        ),
+      aliases: z
+        .array(z.string().min(1).max(128))
+        .optional()
+        .describe(
+          "Optional voice-aliases the conversation agent should treat as referring to this area (e.g. `['main bedroom', 'our room']`).",
+        ),
+      labels: LabelArrayParam.optional(),
+    }),
+    buildRequest: ({ name, icon, picture, floor_id, aliases, labels }) => ({
+      method: "POST",
+      path: "/api/v1/channels/ha/areas",
+      body: {
+        name,
+        ...(icon !== undefined ? { icon } : {}),
+        ...(picture !== undefined ? { picture } : {}),
+        ...(floor_id !== undefined ? { floor_id } : {}),
+        ...(aliases !== undefined ? { aliases } : {}),
+        ...(labels !== undefined ? { labels } : {}),
+      },
+    }),
+  },
+
+  {
+    name: "ha__area_update",
+    description:
+      "Update an existing HA area — rename, swap icon/picture, move to a different floor, or change aliases/labels. Resolves to `PUT /api/v1/channels/ha/areas/:id`. **No approval gate** (cheap, reversible). Pass only the fields you're changing — omitted fields are left as-is. HA accepts `null` for `icon` / `picture` / `floor_id` to clear them. **When to call:** Sir asks 'rename the Living Room to Lounge'; you're tidying area aliases after a voice-agent confusion.",
+    inputSchema: z.object({
+      area_id: AreaIdParam,
+      name: z.string().min(1).max(128).optional(),
+      icon: z.string().min(1).max(64).nullable().optional(),
+      picture: z.string().min(1).max(256).nullable().optional(),
+      floor_id: z.string().min(1).max(128).nullable().optional(),
+      aliases: z.array(z.string().min(1).max(128)).optional(),
+      labels: LabelArrayParam.optional(),
+    }),
+    buildRequest: ({
+      area_id,
+      name,
+      icon,
+      picture,
+      floor_id,
+      aliases,
+      labels,
+    }) => ({
+      method: "PUT",
+      path: `/api/v1/channels/ha/areas/${encodeURIComponent(area_id)}`,
+      body: {
+        ...(name !== undefined ? { name } : {}),
+        ...(icon !== undefined ? { icon } : {}),
+        ...(picture !== undefined ? { picture } : {}),
+        ...(floor_id !== undefined ? { floor_id } : {}),
+        ...(aliases !== undefined ? { aliases } : {}),
+        ...(labels !== undefined ? { labels } : {}),
+      },
+    }),
+  },
+
+  {
+    name: "ha__area_delete",
+    description:
+      "Delete an HA area. Resolves to `DELETE /api/v1/channels/ha/areas/:id`. **No approval gate** — HA itself moves any entities/devices in the area to 'no area' on delete (the underlying things stay; only the binding is gone). Easy to re-create via `ha__area_create` if Sir wants it back. **When to call:** Sir asks to remove an unused area; you've consolidated two rooms into one.",
+    inputSchema: z.object({
+      area_id: AreaIdParam,
+    }),
+    buildRequest: ({ area_id }) => ({
+      method: "DELETE",
+      path: `/api/v1/channels/ha/areas/${encodeURIComponent(area_id)}`,
+    }),
+  },
+
+  // ── devices ──────────────────────────────────────────────────────────
+
+  {
+    name: "ha__device_set_area",
+    description:
+      "Move a device to an HA area (or unassign it). Resolves to `PUT /api/v1/channels/ha/devices/:id` with `{area_id}`. **No approval gate** (trivially reversible). Pass `area_id: null` to clear the device's area binding (e.g. when the principal moves a sensor between rooms). **When to call:** Sir asks 'put the new motion sensor in the Garage'; you're auto-grouping devices after a Hue bridge discovery. Resolve both ids first: `ha__list_devices` for the device, `ha__list_areas` for the area.",
+    inputSchema: z.object({
+      device_id: DeviceIdParam,
+      area_id: z
+        .string()
+        .min(1)
+        .max(128)
+        .nullable()
+        .describe(
+          "Target area id, OR `null` to unassign the device from any area. Resolve via `ha__list_areas`.",
+        ),
+    }),
+    buildRequest: ({ device_id, area_id }) => ({
+      method: "PUT",
+      path: `/api/v1/channels/ha/devices/${encodeURIComponent(device_id)}`,
+      body: { area_id },
+    }),
+  },
+
+  {
+    name: "ha__device_set_name",
+    description:
+      "Set a human-friendly name for a device (HA's `name_by_user`). Resolves to `PUT /api/v1/channels/ha/devices/:id` with `{name_by_user}`. **No approval gate** (reversible — re-call with a new name, or `null` to restore HA's original integration-supplied name). HA keeps the integration's `name` field intact — `name_by_user` overlays. **When to call:** Sir says 'call the new bulb `Living Room Sconce`'; you're tidying after an integration added 12 devices with generic names. Resolve `device_id` via `ha__list_devices` first.",
+    inputSchema: z.object({
+      device_id: DeviceIdParam,
+      name: z
+        .string()
+        .min(1)
+        .max(128)
+        .nullable()
+        .describe(
+          "New human-friendly name. Pass `null` to clear `name_by_user` and fall back to the integration's own name.",
+        ),
+    }),
+    buildRequest: ({ device_id, name }) => ({
+      method: "PUT",
+      path: `/api/v1/channels/ha/devices/${encodeURIComponent(device_id)}`,
+      body: { name_by_user: name },
+    }),
+  },
+
+  {
+    name: "ha__device_disable",
+    description:
+      "Disable (or re-enable) a device. Resolves to `PUT /api/v1/channels/ha/devices/:id` with `{disabled_by}`. **No approval gate** — disable hides every entity the device owns from automations/UI without removing it; re-enable restores them. Set `disabled_by: 'user'` to mark Alfred disabled the device on Sir's behalf, or `disabled_by: null` to re-enable. **When to call:** Sir says 'kill that smart plug, it's been flaky'; you're quieting a spammy sensor while debugging.",
+    inputSchema: z.object({
+      device_id: DeviceIdParam,
+      disabled_by: z
+        .enum(["user", "integration", "config_entry", "device"])
+        .nullable()
+        .describe(
+          "Pass `'user'` to disable (the user-level disable HA's own UI sets), or `null` to re-enable. The other values exist on HA's side but Alfred should use `'user'`/`null` only.",
+        ),
+    }),
+    buildRequest: ({ device_id, disabled_by }) => ({
+      method: "PUT",
+      path: `/api/v1/channels/ha/devices/${encodeURIComponent(device_id)}`,
+      body: { disabled_by },
+    }),
+  },
+
+  {
+    name: "ha__device_label",
+    description:
+      "Apply (or replace) the labels on a device. Resolves to `PUT /api/v1/channels/ha/devices/:id` with `{labels}`. **No approval gate** (reversible). HA does FULL REPLACE of the labels array on update — to ADD a label without dropping the existing ones, read the current labels via `ha__list_devices` first, append the new one, and ship the merged set. Use `ha__label_create` first if the label id doesn't exist yet. **When to call:** Sir asks 'tag the thermostat as `critical`'; you're labelling devices by service-call frequency.",
+    inputSchema: z.object({
+      device_id: DeviceIdParam,
+      labels: LabelArrayParam,
+    }),
+    buildRequest: ({ device_id, labels }) => ({
+      method: "PUT",
+      path: `/api/v1/channels/ha/devices/${encodeURIComponent(device_id)}`,
+      body: { labels },
+    }),
+  },
+
+  // ── entities ─────────────────────────────────────────────────────────
+
+  {
+    name: "ha__entity_rename",
+    description:
+      "Set a human-friendly name (and optionally icon) on an entity. Resolves to `PUT /api/v1/channels/ha/entities/:id` with `{name, icon?}`. **No approval gate** (trivially reversible — set `name: null` to restore HA's original `original_name`). HA's `name` overlays the integration's name without erasing it. **When to call:** Sir says 'call `sensor.0x00158d000123456_temperature` the `Bedroom Temp` sensor'; you're tidying entities after a Zigbee2MQTT join. Resolve `entity_id` via `ha__list_entities` first.",
+    inputSchema: z.object({
+      entity_id: RegistryEntityIdParam,
+      name: z
+        .string()
+        .min(1)
+        .max(128)
+        .nullable()
+        .describe(
+          "New friendly name. Pass `null` to clear and fall back to the integration's `original_name`.",
+        ),
+      icon: z
+        .string()
+        .min(1)
+        .max(64)
+        .nullable()
+        .optional()
+        .describe(
+          "Optional MDI icon (`mdi:thermometer`, `mdi:bed`). Pass `null` to clear.",
+        ),
+    }),
+    buildRequest: ({ entity_id, name, icon }) => ({
+      method: "PUT",
+      path: `/api/v1/channels/ha/entities/${encodeURIComponent(entity_id)}`,
+      body: {
+        name,
+        ...(icon !== undefined ? { icon } : {}),
+      },
+    }),
+  },
+
+  {
+    name: "ha__entity_set_area",
+    description:
+      "Move an entity into an area (or unassign it). Resolves to `PUT /api/v1/channels/ha/entities/:id` with `{area_id}`. **No approval gate** (trivially reversible). HA infers an entity's area from its parent device by default; setting it on the entity overrides that. Pass `area_id: null` to clear the entity-level override and fall back to the device's area. **When to call:** Sir says 'this lamp is in the Bedroom now'; you're fixing an entity that wasn't auto-grouped because its parent device covers multiple rooms. Resolve `entity_id` via `ha__list_entities` and `area_id` via `ha__list_areas` first.",
+    inputSchema: z.object({
+      entity_id: RegistryEntityIdParam,
+      area_id: z
+        .string()
+        .min(1)
+        .max(128)
+        .nullable()
+        .describe(
+          "Target area id, OR `null` to clear the override and inherit from the parent device. Resolve via `ha__list_areas`.",
+        ),
+    }),
+    buildRequest: ({ entity_id, area_id }) => ({
+      method: "PUT",
+      path: `/api/v1/channels/ha/entities/${encodeURIComponent(entity_id)}`,
+      body: { area_id },
+    }),
+  },
+
+  {
+    name: "ha__entity_hide",
+    description:
+      "Hide (or unhide) an entity from HA's UI. Resolves to `PUT /api/v1/channels/ha/entities/:id` with `{hidden_by}`. **No approval gate** (reversible — pass `null` to unhide). Hidden entities still exist for automations + the conversation agent; they just don't clutter the dashboards. **When to call:** Sir asks to clean up a noisy dashboard; an integration exposed 8 diagnostic sensors per device and Sir only wants the temperature one visible.",
+    inputSchema: z.object({
+      entity_id: RegistryEntityIdParam,
+      hidden_by: z
+        .enum(["user", "integration"])
+        .nullable()
+        .describe(
+          "Pass `'user'` to hide (matches HA's own UI's hide-toggle), or `null` to unhide.",
+        ),
+    }),
+    buildRequest: ({ entity_id, hidden_by }) => ({
+      method: "PUT",
+      path: `/api/v1/channels/ha/entities/${encodeURIComponent(entity_id)}`,
+      body: { hidden_by },
+    }),
+  },
+
+  {
+    name: "ha__entity_disable",
+    description:
+      "Disable (or re-enable) an entity. Resolves to `PUT /api/v1/channels/ha/entities/:id` with `{disabled_by}`. **No approval gate** — disabled entities don't poll their integration, don't fire state_changed events, and aren't usable by automations. Re-enable with `null`. **When to call:** Sir asks to stop polling an expensive cloud entity; you're disabling a chatty sensor that's filling the recorder.",
+    inputSchema: z.object({
+      entity_id: RegistryEntityIdParam,
+      disabled_by: z
+        .enum(["user", "integration", "config_entry", "device"])
+        .nullable()
+        .describe(
+          "Pass `'user'` to disable, or `null` to re-enable. Alfred should use `'user'`/`null` only.",
+        ),
+    }),
+    buildRequest: ({ entity_id, disabled_by }) => ({
+      method: "PUT",
+      path: `/api/v1/channels/ha/entities/${encodeURIComponent(entity_id)}`,
+      body: { disabled_by },
+    }),
+  },
+
+  {
+    name: "ha__entity_label",
+    description:
+      "Apply (or replace) the labels on an entity. Resolves to `PUT /api/v1/channels/ha/entities/:id` with `{labels}`. **No approval gate** (reversible). FULL REPLACE — to APPEND a label without dropping existing ones, read the current labels via `ha__list_entities` first, append, and ship the merged set. Use `ha__label_create` first if the label id doesn't exist. **When to call:** Sir says 'tag the front door sensor as `security`'; you're applying labels for an automation that targets all `security`-tagged entities.",
+    inputSchema: z.object({
+      entity_id: RegistryEntityIdParam,
+      labels: LabelArrayParam,
+    }),
+    buildRequest: ({ entity_id, labels }) => ({
+      method: "PUT",
+      path: `/api/v1/channels/ha/entities/${encodeURIComponent(entity_id)}`,
+      body: { labels },
+    }),
+  },
+
+  // ── labels ───────────────────────────────────────────────────────────
+
+  {
+    name: "ha__label_create",
+    description:
+      "Create a new HA label. Resolves to `POST /api/v1/channels/ha/labels`. **No approval gate** (cheap, reversible — `ha__label_delete` undoes it). HA mints the `label_id` from the `name` as a slug; the response carries it back. **When to call:** Sir asks to set up a new tag (e.g. `bedtime`, `critical`, `security`); you're bootstrapping labels for a tagging automation. Example: `{name: 'Bedtime', color: 'indigo', icon: 'mdi:weather-night'}`.",
+    inputSchema: z.object({
+      name: z
+        .string()
+        .min(1)
+        .max(128)
+        .describe(
+          "Human-readable label name (e.g. `Bedtime`, `Security`). HA derives `label_id` from this.",
+        ),
+      color: z
+        .string()
+        .min(1)
+        .max(32)
+        .optional()
+        .describe(
+          "Optional HA palette color name (e.g. `red`, `indigo`, `green`).",
+        ),
+      icon: z
+        .string()
+        .min(1)
+        .max(64)
+        .optional()
+        .describe("Optional MDI icon name (e.g. `mdi:weather-night`)."),
+      description: z
+        .string()
+        .min(1)
+        .max(256)
+        .optional()
+        .describe("Optional short description shown on HA's label settings page."),
+    }),
+    buildRequest: ({ name, color, icon, description }) => ({
+      method: "POST",
+      path: "/api/v1/channels/ha/labels",
+      body: {
+        name,
+        ...(color !== undefined ? { color } : {}),
+        ...(icon !== undefined ? { icon } : {}),
+        ...(description !== undefined ? { description } : {}),
+      },
+    }),
+  },
+
+  {
+    name: "ha__label_update",
+    description:
+      "Update an existing HA label — rename, change color/icon/description. Resolves to `PUT /api/v1/channels/ha/labels/:id`. **No approval gate** (reversible). Only fields you set get forwarded; `null` clears color/icon/description. **When to call:** Sir asks to rename a label; you're tidying label colors for visual consistency. Resolve `label_id` via `ha__list_labels` first.",
+    inputSchema: z.object({
+      label_id: LabelIdParam,
+      name: z.string().min(1).max(128).optional(),
+      color: z.string().min(1).max(32).nullable().optional(),
+      icon: z.string().min(1).max(64).nullable().optional(),
+      description: z.string().min(1).max(256).nullable().optional(),
+    }),
+    buildRequest: ({ label_id, name, color, icon, description }) => ({
+      method: "PUT",
+      path: `/api/v1/channels/ha/labels/${encodeURIComponent(label_id)}`,
+      body: {
+        ...(name !== undefined ? { name } : {}),
+        ...(color !== undefined ? { color } : {}),
+        ...(icon !== undefined ? { icon } : {}),
+        ...(description !== undefined ? { description } : {}),
+      },
+    }),
+  },
+
+  {
+    name: "ha__label_delete",
+    description:
+      "Delete an HA label. Resolves to `DELETE /api/v1/channels/ha/labels/:id`. **No approval gate** — HA detaches the label from every area/device/entity that referenced it on delete; the things themselves stay. Cheap to re-create with `ha__label_create`. **When to call:** Sir asks to remove an unused label; you're cleaning up auto-created labels after a labelling experiment. Resolve `label_id` via `ha__list_labels` first.",
+    inputSchema: z.object({
+      label_id: LabelIdParam,
+    }),
+    buildRequest: ({ label_id }) => ({
+      method: "DELETE",
+      path: `/api/v1/channels/ha/labels/${encodeURIComponent(label_id)}`,
+    }),
+  },
+
+  {
+    name: "ha__label_apply",
+    description:
+      "Apply a label to an area, device, OR entity by REPLACING the target's label set with `[label_id]`. Convenience wrapper — for an APPEND-not-replace operation read current labels first via `ha__list_devices` / `ha__list_entities` / `ha__list_areas`, build the merged array, and use `ha__device_label` / `ha__entity_label` / `ha__area_update` instead. Resolves to one of `PUT /areas/:id` / `PUT /devices/:id` / `PUT /entities/:id` depending on `target_kind`. **No approval gate** (reversible — call `ha__area_update` / `ha__device_label` / `ha__entity_label` with the original labels array to undo). **When to call:** the target had no labels yet and Sir asks to tag it with exactly one label.",
+    inputSchema: z.object({
+      target_kind: z
+        .enum(["area", "device", "entity"])
+        .describe(
+          "Which registry the target lives in. Used to pick the right PUT path.",
+        ),
+      target_id: z
+        .string()
+        .min(1)
+        .describe(
+          "Id of the area / device / entity to label. For `entity` use dotted form (`light.kitchen_main`); for `area`/`device` use the slug/hex.",
+        ),
+      label_id: LabelIdParam,
+    }),
+    buildRequest: ({ target_kind, target_id, label_id }) => {
+      const base =
+        target_kind === "area"
+          ? "/api/v1/channels/ha/areas"
+          : target_kind === "device"
+            ? "/api/v1/channels/ha/devices"
+            : "/api/v1/channels/ha/entities";
+      return {
+        method: "PUT",
+        path: `${base}/${encodeURIComponent(target_id)}`,
+        body: { labels: [label_id] },
+      };
+    },
+  },
+];
+
+// === END Tier 4 PR2 ═══════════════════════════════════════════════════
+
+// Final catalogue: 85 tools total = 11 read + 15 writes (5 PR4 + 10 PR3 CRUD)
 // + 10 PR6 supervisor addon + 10 PR7 core+backups + 7 PR4 integration
-// + 8 PR8 user + LLAT + 8 PR5 HACS. Order kept deliberately (reads first,
-// writes next, addon-CRUD next, core+backups next, integrations next,
-// users+LLATs next, HACS last) so the model that lists the catalogue sees
-// the safe read surface before the destructive surfaces.
+// + 8 PR8 user + LLAT + 8 PR5 HACS + 16 PR2 registries. Order kept
+// deliberately (reads first, writes next, addon-CRUD, core+backups,
+// integrations, users+LLATs, HACS, registries last) so the model that
+// lists the catalogue sees the safe read surface before the destructive
+// surfaces.
 export const ALL_HASS_TOOLS: ToolDef[] = [
   ...HASS_READ_TOOLS,
   ...HASS_DEFERRED_TOOLS,
@@ -2102,4 +2598,5 @@ export const ALL_HASS_TOOLS: ToolDef[] = [
   ...HASS_INTEGRATION_TOOLS,
   ...HASS_USER_TOOLS,
   ...HASS_HACS_TOOLS,
+  ...HASS_PR2_TOOLS,
 ];


### PR DESCRIPTION
Tier 4 autonomy, PR2. Adds 14 ctrl-api routes + 16 MCP tools fronting HA's four WS-only registry surfaces — area_registry, device_registry, entity_registry, label_registry — all driven through PR1's long-lived ha_ws_client.

## Defaults (Sir's locked YES, 2026-05-29)

- **No `decision_ref` gate** — every verb is cheap + reversible (the verb whose effect Sir couldn't reverse in <2 minutes through HA's own UI gets a gate; renaming the kitchen light doesn't).
- **No auto-snapshot** — registry mutations don't take HA down.
- **No daybook entry** — the daybook surface is for changes Sir would notice; renaming an entity is noise.

## Rebased on

PR4 (#165), PR7 (#164), PR6 (#162), PR8 (#167) — the PR2 block sits in a clearly-bounded `=== Tier 4 PR2: Registries CRUD ===` section at the file tail in both `channels_ha.ts` and `hass.ts` so future rebases are a single mechanical "is this block intact?" check.

## ctrl-api routes

```
GET    /api/v1/channels/ha/areas
POST   /api/v1/channels/ha/areas            — config/area_registry/create
PUT    /api/v1/channels/ha/areas/:id        — config/area_registry/update
DELETE /api/v1/channels/ha/areas/:id        — config/area_registry/delete

GET    /api/v1/channels/ha/devices
GET    /api/v1/channels/ha/devices/:id      — list+filter (per-version safe)
PUT    /api/v1/channels/ha/devices/:id      — config/device_registry/update

GET    /api/v1/channels/ha/entities
GET    /api/v1/channels/ha/entities/:id     — config/entity_registry/get
PUT    /api/v1/channels/ha/entities/:id     — config/entity_registry/update
DELETE /api/v1/channels/ha/entities/:id     — config/entity_registry/remove

GET    /api/v1/channels/ha/labels
POST   /api/v1/channels/ha/labels           — config/label_registry/create
PUT    /api/v1/channels/ha/labels/:id       — config/label_registry/update
DELETE /api/v1/channels/ha/labels/:id       — config/label_registry/delete
```

## MCP tools (16)

- Areas: `ha__area_create` / `ha__area_update` / `ha__area_delete`
- Devices: `ha__device_set_area` / `ha__device_set_name` / `ha__device_disable` / `ha__device_label`
- Entities: `ha__entity_rename` / `ha__entity_set_area` / `ha__entity_hide` / `ha__entity_disable` / `ha__entity_label`
- Labels: `ha__label_create` / `ha__label_update` / `ha__label_delete` / `ha__label_apply`

Each tool description spells out the no-gate semantics, the canonical `resolve via ha__list_…` hint, and HA's full-replace label semantics (read current → append → ship merged set for label appends).

## Tests

- **16 unit tests** in `packages/mcp-server/src/tools/hass.test.ts`. Catalogue size pinned at 77; URL-traversal guards on ids; dotted-form on entity_id; enum-narrowing on `disabled_by`/`hidden_by`; "No approval gate" pinned in every PR2 description so a future agent can't quietly add a gate.
- **12 integration tests** in `packages/ctrl/tests/channels_ha_registries.test.ts` round-tripping each route against an in-process WebSocket mock of HA with `auth_required`/`auth_ok` + `result` envelopes. Includes a pinned test that POST /areas with just `{name}` returns 200 (catches a future agent adding a gate) and a 502 HA_WS_ERROR propagation test.

## Catalogue

77 hass tools total (was 61) = 11 read + 15 write + 10 PR6 addon + 10 PR7 core+backups + 7 PR4 integration + 8 PR8 user + 16 PR2 registries.

Refs: #115, #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)