### PR TITLE
fix(web,ctrl): Recall card — add API key + webhook-secret inputs + correct status text

### DIFF
--- a/packages/ctrl/src/api/routes/channels_recall.ts
+++ b/packages/ctrl/src/api/routes/channels_recall.ts
@@ -179,7 +179,28 @@ function rowToApiConfig(row: RecallConfigRow): Record<string, unknown> {
   // Expose key_first6 + api_key_set so the /channels card can render
   // the rotation row ("first 6 chars …") without ever round-tripping
   // the full value. PR3a adds this; the field was previously absent.
+  //
+  // Mirror the same posture for RECALL_WEBHOOK_SECRET (the Svix signing
+  // secret the inbound webhook verifies against). The card's pill
+  // distinguishes three states off these flags:
+  //
+  //   • api_key_set=false               → "Unconfigured" (gray)
+  //   • api_key_set=true,
+  //     webhook_secret_set=false        → "API key set · webhook not
+  //                                        wired" (yellow)
+  //   • both set                        → "Connected" (green)
+  //
+  // The full secret is NEVER returned; the first6 fingerprint is the
+  // operator-visible recognition string. webhook_url is the URL the
+  // operator pastes into Recall.ai's webhook dashboard (derived from
+  // the tenant's DOMAIN env). Both fields are stable on the wire — pre-
+  // PR3a ctrl-api versions simply omit them and the web layer's
+  // optional-field-aware deserialiser still parses cleanly.
   const apiKey = process.env.RECALL_API_KEY?.trim() ?? "";
+  const webhookSecret = process.env.RECALL_WEBHOOK_SECRET?.trim() ?? "";
+  const domain = process.env.DOMAIN?.trim() ?? "";
+  const webhookUrl =
+    domain.length > 0 ? `https://${domain}/api/v1/webhooks/recall` : null;
   return {
     region: row.region,
     bot_name: row.bot_name,
@@ -194,6 +215,10 @@ function rowToApiConfig(row: RecallConfigRow): Record<string, unknown> {
     updated_at: row.updated_at,
     api_key_set: apiKey.length > 0,
     api_key_first6: apiKey.length > 0 ? apiKey.slice(0, 6) : null,
+    webhook_secret_set: webhookSecret.length > 0,
+    webhook_secret_first6:
+      webhookSecret.length > 0 ? webhookSecret.slice(0, 6) : null,
+    webhook_url: webhookUrl,
   };
 }
 
@@ -1197,6 +1222,124 @@ export function registerChannelsRecallRoutes(): void {
 
       // Send the response BEFORE kicking the restart — restarting
       // ctrl-api tears down this socket.
+      sendJson(res, 200, result.envelope);
+      if (result.shouldRestart) {
+        restartForRecallKey();
+      }
+    },
+  );
+
+  // POST /api/v1/channels/recall/webhook-secret
+  //
+  // Operator-only setter for the Svix signing secret Recall.ai's
+  // webhook dashboard mints. We don't round-trip-validate it (Recall
+  // exposes no "verify this secret" endpoint — verification is local,
+  // happening on the next inbound delivery in `verifySvixSignature`).
+  // We DO sanity-check the shape: a Svix secret is `whsec_` followed
+  // by base64; we accept either that or a raw base64 string with at
+  // least 16 chars of entropy so the operator can't accidentally
+  // paste `"x"` and lock the channel.
+  //
+  // Persistence path mirrors /api-key:
+  //   1. shape check (no network round-trip);
+  //   2. idempotence: same value already in .env → noop;
+  //   3. atomic .env merge for RECALL_WEBHOOK_SECRET (tempfile + rename);
+  //   4. background-restart ctrl-api so the new secret is picked up by
+  //      the verifySvixSignature path on the next inbound delivery.
+  //
+  // We DO NOT round-trip through Vaultwarden here — the secret is
+  // operator-pasted from Recall's dashboard and only consumed by
+  // ctrl-api's webhook verifier (alfred-learn doesn't touch it). The
+  // .env-only persistence keeps the surface tight; a future PR can add
+  // a vault item if multi-tenant operations require it.
+  //
+  // Concurrency: same withPersistLock as /api-key so a concurrent
+  // /api-key + /webhook-secret can't double-restart.
+  addRoute(
+    "POST",
+    "/api/v1/channels/recall/webhook-secret",
+    async ({ req, res, body }) => {
+      requireOperatorBearer(req);
+
+      const b = (body ?? {}) as { webhook_secret?: unknown };
+      if (
+        typeof b.webhook_secret !== "string" ||
+        b.webhook_secret.trim().length === 0
+      ) {
+        throw new ValidationError(
+          "webhook_secret (non-empty string) is required",
+        );
+      }
+      const secret = b.webhook_secret.trim();
+      // Shape check — accept `whsec_<base64>` or a raw base64 string of
+      // sufficient entropy. Reject anything obviously short / non-printable.
+      const payload = secret.startsWith("whsec_")
+        ? secret.slice("whsec_".length)
+        : secret;
+      if (payload.length < 16) {
+        throw new ValidationError(
+          "webhook_secret looks too short — paste the full value from Recall.ai",
+        );
+      }
+      if (!/^[A-Za-z0-9+/=_-]+$/.test(payload)) {
+        throw new ValidationError(
+          "webhook_secret must be base64 (Recall.ai → Webhooks → Signing secret)",
+        );
+      }
+
+      const first6 = secret.slice(0, 6);
+
+      const result = await withPersistLock(async () => {
+        // Idempotence — same secret already on disk?
+        const envOnDisk = readEnvFile(RECALL_ENV_PATH);
+        if (envOnDisk.RECALL_WEBHOOK_SECRET === secret) {
+          return {
+            envelope: {
+              ok: true,
+              idempotent: true,
+              secret_first6: first6,
+              persisted_to: [] as string[],
+              restarted: [] as string[],
+              eta_seconds: 0,
+            },
+            shouldRestart: false,
+          };
+        }
+
+        // Atomic .env write.
+        try {
+          atomicPatchEnv(RECALL_ENV_PATH, {
+            RECALL_WEBHOOK_SECRET: secret,
+          });
+        } catch (err) {
+          throw new ApiError(
+            500,
+            "ENV_WRITE_FAILED",
+            err instanceof Error ? err.message : String(err),
+          );
+        }
+
+        // Reflect into our own process.env so the inbound-webhook handler
+        // can verify deliveries before the restart lands.
+        process.env.RECALL_WEBHOOK_SECRET = secret;
+
+        console.log(
+          `[recall/webhook-secret] persisted secret ${first6}… (.env). ` +
+            `Restarting ${RECALL_RESTART_SERVICES.join(", ")}.`,
+        );
+
+        return {
+          envelope: {
+            ok: true,
+            secret_first6: first6,
+            persisted_to: [".env"],
+            restarted: [...RECALL_RESTART_SERVICES],
+            eta_seconds: RECALL_RESTART_ETA_SECONDS,
+          },
+          shouldRestart: true,
+        };
+      });
+
       sendJson(res, 200, result.envelope);
       if (result.shouldRestart) {
         restartForRecallKey();

--- a/packages/ctrl/tests/channels_recall.test.ts
+++ b/packages/ctrl/tests/channels_recall.test.ts
@@ -337,6 +337,42 @@ describe("/api/v1/channels/recall/* + webhook — #113 PR2", () => {
       assert.equal(r.payload.wake_word, "Alfred");
       assert.deepEqual(r.payload.cost_alert_thresholds, [80, 100]);
       assert.equal(typeof r.payload.updated_at, "number");
+      // PR3a — api_key_set + webhook_secret_set fingerprints drive the
+      // card's pill state. Pre-paste neither env var is set, so both
+      // flags read false and the first6 fields are null.
+      assert.equal(r.payload.api_key_set, false);
+      assert.equal(r.payload.api_key_first6, null);
+      assert.equal(r.payload.webhook_secret_set, false);
+      assert.equal(r.payload.webhook_secret_first6, null);
+      // webhook_url is derived from DOMAIN; the test fixture sets
+      // DOMAIN=test.alfred.black, so the route emits the canonical URL.
+      assert.equal(
+        r.payload.webhook_url,
+        "https://test.alfred.black/api/v1/webhooks/recall",
+      );
+    });
+
+    it("GET surfaces api_key_set + webhook_secret_set when env vars are present", async () => {
+      // Mutating process.env is the only signal rowToApiConfig reads
+      // off — the route deliberately doesn't round-trip the .env at GET
+      // time (that would be a fs read on every dashboard tick).
+      process.env.RECALL_API_KEY = "rcl_test_first6_morechars";
+      process.env.RECALL_WEBHOOK_SECRET = "whsec_first6_morechars_base64";
+      try {
+        const r = await invokeRoute("GET", "/api/v1/channels/recall/config");
+        assert.equal(r.status, 200);
+        assert.equal(r.payload.api_key_set, true);
+        assert.equal(r.payload.api_key_first6, "rcl_te");
+        assert.equal(r.payload.webhook_secret_set, true);
+        assert.equal(r.payload.webhook_secret_first6, "whsec_");
+        // The full values must NEVER be echoed.
+        const body = JSON.stringify(r.payload);
+        assert.equal(body.includes("rcl_test_first6_morechars"), false);
+        assert.equal(body.includes("whsec_first6_morechars_base64"), false);
+      } finally {
+        delete process.env.RECALL_API_KEY;
+        delete process.env.RECALL_WEBHOOK_SECRET;
+      }
     });
 
     it("PATCH updates fields and the next GET reflects them", async () => {

--- a/packages/ctrl/tests/channels_recall_apikey.test.ts
+++ b/packages/ctrl/tests/channels_recall_apikey.test.ts
@@ -656,3 +656,156 @@ describe("_recallInternals.atomicPatchEnv", () => {
     assert.equal(_recallInternals.keyFirst6("short"), "short");
   });
 });
+
+// ── POST /webhook-secret — sibling to /api-key, .env-only persistence ────
+
+describe("POST /api/v1/channels/recall/webhook-secret — Svix signing secret", () => {
+  before(() => {
+    getStateDb();
+    // The api-key describe block's `after()` rm-rf's the shared tmp dir
+    // when its tests finish. If those tests ran first (suite ordering is
+    // declaration-order in node:test), composeDir is gone before we get
+    // here — re-create it idempotently.
+    fs.mkdirSync(composeDir, { recursive: true });
+  });
+
+  beforeEach(() => {
+    composeCalls.length = 0;
+    composeShouldFail = false;
+    fs.mkdirSync(composeDir, { recursive: true });
+    fs.writeFileSync(
+      ENV_PATH,
+      "# header comment\nALREADY=present\nFOO=bar\n",
+      { mode: 0o600 },
+    );
+    try {
+      fs.unlinkSync(ENV_TMP_PATH);
+    } catch {
+      /* swallow */
+    }
+    delete process.env.RECALL_WEBHOOK_SECRET;
+    _resetAuthForTests();
+  });
+
+  it("writes the secret to .env and triggers a restart on success", async () => {
+    const secret = "whsec_abcdef1234567890_base64_payload";
+    const r = await invokeRoute(
+      "POST",
+      "/api/v1/channels/recall/webhook-secret",
+      { webhook_secret: secret },
+    );
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.ok, true);
+    assert.equal(r.payload.secret_first6, "whsec_");
+    assert.deepEqual(r.payload.persisted_to, [".env"]);
+    assert.deepEqual(r.payload.restarted, ["ctrl-api", "alfred-learn"]);
+
+    // .env merged.
+    const envText = fs.readFileSync(ENV_PATH, "utf-8");
+    assert.match(
+      envText,
+      new RegExp(`^RECALL_WEBHOOK_SECRET=${secret}$`, "m"),
+    );
+    // Unrelated lines preserved.
+    assert.match(envText, /^ALREADY=present$/m);
+    assert.match(envText, /^FOO=bar$/m);
+
+    // process.env updated in-process so verifySvixSignature picks it up
+    // before the restart lands.
+    assert.equal(process.env.RECALL_WEBHOOK_SECRET, secret);
+
+    await new Promise((r) => setTimeout(r, 10));
+    const restartArgs = composeCalls
+      .filter((c) => c.args[0] === "restart")
+      .map((c) => c.args[1]);
+    assert.deepEqual(restartArgs, ["ctrl-api", "alfred-learn"]);
+  });
+
+  it("is idempotent when the same secret is already on file", async () => {
+    const secret = "whsec_already_present_value_b64_xyz";
+    fs.writeFileSync(
+      ENV_PATH,
+      `ALREADY=present\nRECALL_WEBHOOK_SECRET=${secret}\n`,
+      { mode: 0o600 },
+    );
+    const r = await invokeRoute(
+      "POST",
+      "/api/v1/channels/recall/webhook-secret",
+      { webhook_secret: secret },
+    );
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.ok, true);
+    assert.equal(r.payload.idempotent, true);
+    assert.equal(r.payload.secret_first6, "whsec_");
+    assert.deepEqual(r.payload.persisted_to, []);
+    assert.deepEqual(r.payload.restarted, []);
+    assert.equal(composeCalls.length, 0);
+  });
+
+  it("400 VALIDATION_ERROR when webhook_secret is missing", async () => {
+    const r = await invokeRoute(
+      "POST",
+      "/api/v1/channels/recall/webhook-secret",
+      {},
+    );
+    assert.equal(r.status, 400);
+    assert.equal(r.payload.error.code, "VALIDATION_ERROR");
+  });
+
+  it("400 VALIDATION_ERROR when webhook_secret is too short", async () => {
+    const r = await invokeRoute(
+      "POST",
+      "/api/v1/channels/recall/webhook-secret",
+      { webhook_secret: "whsec_xx" },
+    );
+    assert.equal(r.status, 400);
+    assert.equal(r.payload.error.code, "VALIDATION_ERROR");
+    assert.match(r.payload.error.message, /too short/i);
+  });
+
+  it("400 VALIDATION_ERROR on non-base64 payload", async () => {
+    const r = await invokeRoute(
+      "POST",
+      "/api/v1/channels/recall/webhook-secret",
+      { webhook_secret: "whsec_not space alphabet $$$" },
+    );
+    assert.equal(r.status, 400);
+    assert.equal(r.payload.error.code, "VALIDATION_ERROR");
+  });
+
+  it("rejects non-operator bearers with 403", async () => {
+    setApiKey(MASTER_KEY);
+    setVoiceBridgeKey(VOICE_KEY);
+    const r = await invokeRoute(
+      "POST",
+      "/api/v1/channels/recall/webhook-secret",
+      { webhook_secret: "whsec_abcdef_base64_payload_xx" },
+      authHeader(VOICE_KEY),
+    );
+    assert.equal(r.status, 403, JSON.stringify(r.payload));
+    assert.equal(r.payload.error.code, "FORBIDDEN");
+    // No env write, no restart.
+    const envText = fs.readFileSync(ENV_PATH, "utf-8");
+    assert.ok(!envText.includes("RECALL_WEBHOOK_SECRET"));
+    assert.equal(composeCalls.length, 0);
+  });
+
+  it("never returns the full secret on GET /config", async () => {
+    // Round-trip: save then GET /config and confirm only first6 leaks.
+    const secret = "whsec_supersecret_value_abc123_xx";
+    await invokeRoute(
+      "POST",
+      "/api/v1/channels/recall/webhook-secret",
+      { webhook_secret: secret },
+    );
+    const g = await invokeRoute("GET", "/api/v1/channels/recall/config");
+    assert.equal(g.status, 200);
+    assert.equal(g.payload.webhook_secret_set, true);
+    assert.equal(g.payload.webhook_secret_first6, "whsec_");
+    const wire = JSON.stringify(g.payload);
+    assert.ok(
+      !wire.includes(secret),
+      "GET /config must not echo the full secret",
+    );
+  });
+});

--- a/packages/web/main.wasp
+++ b/packages/web/main.wasp
@@ -992,6 +992,15 @@ action setRecallApiKey {
   entities: []
 }
 
+// Persist the Svix signing secret Recall.ai's webhook dashboard mints.
+// Card-side companion to setRecallApiKey — required before any inbound
+// webhook delivery can be verified, otherwise ctrl-api's
+// /api/v1/webhooks/recall handler 503s with NOT_CONFIGURED.
+action setRecallWebhookSecret {
+  fn: import { setRecallWebhookSecret } from "@src/dashboard/operations",
+  entities: []
+}
+
 action testRecallWebhook {
   fn: import { testRecallWebhook } from "@src/dashboard/operations",
   entities: []

--- a/packages/web/src/dashboard/RecallCard.tsx
+++ b/packages/web/src/dashboard/RecallCard.tsx
@@ -36,6 +36,7 @@ import {
   updateRecallConfig,
   validateRecallApiKey,
   setRecallApiKey,
+  setRecallWebhookSecret,
   testRecallWebhook,
   terminateRecallBot,
 } from "wasp/client/operations";
@@ -84,12 +85,17 @@ function ChannelCard({
   address,
   note,
   status,
+  pillOverride,
   children,
 }: {
   name: string;
   address: string;
   note: string;
   status: ChannelStatus;
+  /** Override the default pill string for this status tone — used by
+   *  RecallCard to surface "Unconfigured" / "Webhook not wired" instead
+   *  of the generic "Not connected" / "Needs attention" defaults. */
+  pillOverride?: string;
   children?: React.ReactNode;
 }) {
   const pillColor =
@@ -97,7 +103,8 @@ function ChannelCard({
       ? "var(--brass)"
       : "var(--marginalia)";
   const pillText =
-    status === "active"
+    pillOverride ??
+    (status === "active"
       ? "Connected"
       : status === "soon"
         ? "Coming soon"
@@ -105,7 +112,7 @@ function ChannelCard({
           ? "Starting"
           : status === "error"
             ? "Needs attention"
-            : "Not connected";
+            : "Not connected");
   return (
     <div className="border border-rule p-6 card-hover h-full">
       <div className="flex items-baseline justify-between mb-3">
@@ -142,17 +149,28 @@ export default function RecallCard() {
   const status = (statusData as RecallStatus | undefined) ?? null;
   const card = deriveRecallCardState(status);
 
+  // Pill copy upgrade — the four-state pill text Sir asked for. The
+  // ChannelCard's defaults render "Not connected" / "Needs attention";
+  // we override per-status so the principal sees the actual condition.
+  const pillOverride =
+    card.status === "disabled"
+      ? "Unconfigured"
+      : card.status === "partial"
+        ? "Webhook not wired"
+        : undefined;
+
   return (
     <ChannelCard
       name="Meeting bot"
       address={card.address}
       note="A second pair of ears for Zoom, Meet, Teams (via Recall.ai)."
       status={card.pillTone}
+      pillOverride={pillOverride}
     >
       {card.status === "disabled" && (
         <RecallDisabledPanel onValidated={refetch} />
       )}
-      {card.status === "configured" && (
+      {(card.status === "configured" || card.status === "partial") && (
         <RecallConfiguredPanel
           status={status}
           formInitial={card.formValues}
@@ -346,10 +364,11 @@ function RecallDisabledPanel({ onValidated }: { onValidated: () => void }) {
             type="password"
             value={apiKey}
             onChange={(e) => setApiKey(e.target.value)}
-            placeholder="Paste from recall.ai → Settings → API keys"
+            placeholder="rcl_… (paste from recall.ai → Settings → API keys)"
             autoComplete="off"
             spellCheck={false}
             disabled={busy}
+            aria-label="Recall.ai API key"
             className="w-full bg-transparent border border-rule px-2 py-1 font-mono text-[12px]"
           />
         </div>
@@ -583,9 +602,17 @@ function RecallConfiguredPanel({
     (typeof window !== "undefined" ? window.location.origin : "");
   const webhookUrl = useMemo(() => formatRecallWebhookUrl(origin), [origin]);
   const secretFirst6 =
-    typeof status?.webhook_secret_first6 === "string"
-      ? status.webhook_secret_first6
-      : null;
+    typeof status?.config?.webhook_secret_first6 === "string"
+      ? status.config.webhook_secret_first6
+      : typeof status?.webhook_secret_first6 === "string"
+        ? status.webhook_secret_first6
+        : null;
+  const webhookSecretSet =
+    typeof status?.config?.webhook_secret_set === "boolean"
+      ? status.config.webhook_secret_set
+      : typeof status?.webhook_secret_set === "boolean"
+        ? status.webhook_secret_set
+        : null;
   // RECALL_API_KEY fingerprint (PR3a) — surfaced on the rotation row.
   const keyFirst6 =
     typeof status?.config?.api_key_first6 === "string"
@@ -611,6 +638,84 @@ function RecallConfiguredPanel({
     { kind: "ok" | "err"; text: string } | null
   >(null);
   const rotateBusy = rotatePhase === "validating" || rotatePhase === "saving";
+
+  // ─── webhook-secret paste state ─────────────────────────────────────
+  //
+  // Mirrors the api-key rotate flow: a password input + Save button
+  // that calls setRecallWebhookSecret. Lives in the configured panel so
+  // both the "partial" (api_key set, webhook not wired — input shown
+  // open by default) and "configured" (both wired — input behind a
+  // Rotate affordance) states share one code path.
+  const [wsOpen, setWsOpen] = useState<boolean>(webhookSecretSet === false);
+  const [wsValue, setWsValue] = useState("");
+  const [wsPhase, setWsPhase] = useState<
+    "idle" | "saving" | "done" | "err"
+  >("idle");
+  const [wsMsg, setWsMsg] = useState<
+    { kind: "ok" | "err"; text: string } | null
+  >(null);
+  const wsBusy = wsPhase === "saving";
+
+  // Re-open the input automatically if the upstream flips to "not set"
+  // (e.g. after a tenant reset). Closing it requires an explicit
+  // Cancel.
+  useEffect(() => {
+    if (webhookSecretSet === false) setWsOpen(true);
+  }, [webhookSecretSet]);
+
+  async function saveWebhookSecret(e?: React.FormEvent) {
+    if (e) e.preventDefault();
+    const trimmed = wsValue.trim();
+    if (!trimmed || wsBusy) return;
+    setWsPhase("saving");
+    setWsMsg(null);
+    try {
+      const p: any = await setRecallWebhookSecret({
+        webhook_secret: trimmed,
+      });
+      if (!p?.ok) {
+        setWsPhase("err");
+        setWsMsg({
+          kind: "err",
+          text:
+            typeof p?.reason === "string" && p.reason
+              ? p.reason
+              : "ctrl-api refused to persist the webhook secret.",
+        });
+        return;
+      }
+      setWsPhase("done");
+      const first6 =
+        typeof p?.secret_first6 === "string" ? p.secret_first6 : null;
+      setWsMsg({
+        kind: "ok",
+        text:
+          p?.idempotent === true
+            ? `Same secret on file (${first6 ?? "?"}…). Nothing to do.`
+            : `Webhook wired (${first6 ?? "saved"}…). Restarting ctrl-api.`,
+      });
+      setWsValue("");
+      const eta =
+        typeof p?.eta_seconds === "number" && p.eta_seconds > 0
+          ? Math.min(p.eta_seconds, 30) * 1000
+          : 1500;
+      window.setTimeout(() => {
+        setWsOpen(false);
+        setWsMsg(null);
+        setWsPhase("idle");
+        onSettled();
+      }, eta);
+    } catch (err: any) {
+      setWsPhase("err");
+      setWsMsg({
+        kind: "err",
+        text:
+          err?.message ??
+          err?.data?.error ??
+          "Couldn't reach ctrl-api. Try again.",
+      });
+    }
+  }
 
   async function rotate(e?: React.FormEvent) {
     if (e) e.preventDefault();
@@ -745,6 +850,7 @@ function RecallConfiguredPanel({
               autoComplete="off"
               spellCheck={false}
               disabled={rotateBusy}
+              aria-label="Recall.ai API key"
               className="w-full bg-transparent border border-rule px-2 py-1 font-mono text-[12px]"
             />
             <div className="flex gap-3 items-baseline">
@@ -785,6 +891,123 @@ function RecallConfiguredPanel({
               >
                 {rotateMsg.kind === "ok" ? "✓ " : "✗ "}
                 {rotateMsg.text}
+              </p>
+            )}
+          </form>
+        )}
+      </div>
+
+      {/* Webhook signing secret row — sibling to the API-key row. Always
+          renders so the operator never has to dig into an expander to
+          find where to paste the signing secret. When the secret IS on
+          file we collapse to first6+Rotate; when it's NOT, the input is
+          open by default (driven by webhookSecretSet === false). */}
+      <div
+        className="border border-rule p-3 space-y-2"
+        style={
+          webhookSecretSet === false
+            ? { borderColor: "var(--brass)" }
+            : undefined
+        }
+      >
+        <div className="flex flex-wrap items-baseline gap-3 justify-between">
+          <div className="flex items-baseline gap-3 flex-wrap">
+            <div
+              className="font-mono text-[10px] uppercase tracking-[0.22em]"
+              style={{ color: "var(--marginalia)" }}
+            >
+              Webhook signing secret
+            </div>
+            <code
+              className="font-mono text-[12px]"
+              style={{ color: "var(--ink)" }}
+            >
+              {secretFirst6 ? `${secretFirst6}…` : "—"}
+            </code>
+            {webhookSecretSet === false && (
+              <span
+                className="font-body italic text-[12px]"
+                style={{ color: "var(--brass)" }}
+              >
+                Required — inbound deliveries 401 until set.
+              </span>
+            )}
+          </div>
+          {!wsOpen && (
+            <button
+              type="button"
+              onClick={() => {
+                setWsOpen(true);
+                setWsMsg(null);
+                setWsPhase("idle");
+              }}
+              disabled={wsBusy}
+              className="btn-ghost"
+            >
+              {webhookSecretSet === true ? "Rotate" : "Paste secret"}
+            </button>
+          )}
+        </div>
+        <p
+          className="font-body italic text-[12px]"
+          style={{ color: "var(--marginalia)" }}
+        >
+          From recall.ai → Webhooks → Signing secret. Starts with{" "}
+          <code>whsec_</code>.
+        </p>
+        {wsOpen && (
+          <form onSubmit={saveWebhookSecret} className="space-y-2 pt-2">
+            <input
+              type="password"
+              value={wsValue}
+              onChange={(e) => setWsValue(e.target.value)}
+              placeholder="whsec_…"
+              autoComplete="off"
+              spellCheck={false}
+              disabled={wsBusy}
+              aria-label="Recall.ai webhook signing secret"
+              className="w-full bg-transparent border border-rule px-2 py-1 font-mono text-[12px]"
+            />
+            <div className="flex gap-3 items-baseline">
+              <button
+                type="submit"
+                disabled={wsBusy || wsValue.trim().length === 0}
+                className="btn-ghost"
+              >
+                {wsPhase === "saving"
+                  ? "Saving + restarting…"
+                  : webhookSecretSet === true
+                    ? "Rotate secret"
+                    : "Save secret"}
+              </button>
+              {webhookSecretSet === true && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setWsOpen(false);
+                    setWsValue("");
+                    setWsMsg(null);
+                    setWsPhase("idle");
+                  }}
+                  disabled={wsBusy}
+                  className="btn-link"
+                >
+                  Cancel
+                </button>
+              )}
+            </div>
+            {wsMsg && (
+              <p
+                className="font-body italic text-[12px]"
+                style={{
+                  color:
+                    wsMsg.kind === "ok"
+                      ? "var(--marginalia)"
+                      : "var(--brass)",
+                }}
+              >
+                {wsMsg.kind === "ok" ? "✓ " : "✗ "}
+                {wsMsg.text}
               </p>
             )}
           </form>
@@ -1118,28 +1341,58 @@ function RecallConfiguredPanel({
                 className="font-mono text-[10px] uppercase tracking-[0.22em]"
                 style={{ color: "var(--marginalia)" }}
               >
-                Webhook secret (first 6)
+                Subscribe to these events
               </div>
-              <div className="flex items-center gap-3">
+              <ul
+                className="font-mono text-[12px] list-disc ml-5 space-y-1"
+                style={{ color: "var(--ink)" }}
+              >
+                <li>
+                  <code>bot.status_change</code> — lifecycle transitions
+                  (joining → in-meeting → leaving → done).
+                </li>
+                <li>
+                  <code>bot.done</code> — bot left the meeting cleanly.
+                </li>
+                <li>
+                  <code>bot.fatal</code> — bot failed to join or crashed
+                  mid-call.
+                </li>
+                <li>
+                  <code>bot.recording_done</code> — recording artefact is
+                  ready; ctrl-api persists the transcript URL onto the
+                  bot row.
+                </li>
+              </ul>
+              <p
+                className="font-body italic text-[12px]"
+                style={{ color: "var(--marginalia)" }}
+              >
+                <code>bot.transcription.message</code> is deferred — only
+                subscribe to it once in-meeting voice (PR #154) ships.
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <div
+                className="font-mono text-[10px] uppercase tracking-[0.22em]"
+                style={{ color: "var(--marginalia)" }}
+              >
+                Signing secret on file (first 6)
+              </div>
+              <div className="flex flex-wrap items-center gap-3">
                 <code
                   className="font-mono text-[12px] border border-rule p-2"
                   style={{ color: "var(--ink)" }}
                 >
                   {secretFirst6 ? `${secretFirst6}…` : "—"}
                 </code>
-                <button
-                  type="button"
-                  disabled
-                  title="Secret rotation lands in #113 PR3a; for now the secret is fixed at tenant init."
-                  className="btn-ghost opacity-50 cursor-not-allowed"
-                >
-                  Rotate secret
-                </button>
                 <span
                   className="font-body italic text-[12px]"
                   style={{ color: "var(--marginalia)" }}
                 >
-                  coming soon
+                  Pasted in the &ldquo;Webhook signing secret&rdquo;
+                  block above.
                 </span>
               </div>
             </div>

--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -684,6 +684,7 @@ interface RecallCompositeStatus {
   error: string | null;
   webhook_url?: string;
   webhook_secret_first6?: string | null;
+  webhook_secret_set?: boolean;
 }
 
 async function safeProxy(
@@ -727,16 +728,28 @@ export const getRecallChannelStatus = async (
 
   let error: string | null = null;
   const probes = [configRes, usageRes, botsRes];
-  // enabled = at least usage came back successfully (it doesn't depend on
-  // RECALL_API_KEY; if the tenant has the route at all + state.db open
-  // it returns 200). config also doesn't gate on the key. So we treat
-  // the surface as "enabled" once both succeed AND a key is on file —
-  // which we infer from a non-503 active-bots probe (the bots GET is
-  // also key-free, but PR3a will replace this signal with an explicit
-  // "key on file" flag).
-  const usageOk = usageRes.ok;
+  // `enabled` is the "do we have a working API key on file" signal.
+  // The /config + /usage + /bots routes don't gate on RECALL_API_KEY —
+  // they return 200 on a fresh tenant with no key. Earlier versions of
+  // this code derived enabled from "all three probes succeeded" which
+  // mis-classified the no-key state as `configured` and rendered the
+  // card with NO API key paste field (PR #153 shipped the persistence
+  // endpoint; the card never got the input). Drive it off the
+  // explicit api_key_set flag instead — when the field is absent on
+  // the wire (pre-#153 ctrl-api) fall back to the old heuristic so the
+  // card stays renderable.
   const configOk = configRes.ok;
-  const enabled = usageOk && configOk;
+  const apiKeySet =
+    config && typeof config.api_key_set === "boolean"
+      ? config.api_key_set === true
+      : null;
+  const usageOk = usageRes.ok;
+  const enabled =
+    configOk &&
+    (apiKeySet === true ||
+      // Fallback: no explicit flag on the wire → treat both-routes-up as
+      // "good enough" (pre-#153 contract).
+      (apiKeySet === null && usageOk));
 
   // Surface the first hard error (non-503) we saw — 503 is the
   // "expected" pre-paste state and shouldn't render as an error.
@@ -747,12 +760,32 @@ export const getRecallChannelStatus = async (
     }
   }
 
+  // Pull through the webhook posture so the card's pill + setup expander
+  // can render off them without a second proxy hop. The fields are
+  // optional on the wire (older ctrl-api may omit) so the card layer
+  // treats `undefined` as "unknown" rather than "false".
+  const webhookSecretSet =
+    config && typeof config.webhook_secret_set === "boolean"
+      ? config.webhook_secret_set
+      : undefined;
+  const webhookSecretFirst6 =
+    config && typeof config.webhook_secret_first6 === "string"
+      ? config.webhook_secret_first6
+      : null;
+  const webhookUrl =
+    config && typeof config.webhook_url === "string"
+      ? config.webhook_url
+      : undefined;
+
   return {
     enabled,
     config,
     usage,
     active_bots,
     error,
+    webhook_url: webhookUrl,
+    webhook_secret_first6: webhookSecretFirst6,
+    webhook_secret_set: webhookSecretSet,
   };
 };
 
@@ -837,6 +870,37 @@ export const setRecallApiKey = async (
     method: "POST",
     path: "/api/v1/channels/recall/api-key",
     body,
+  });
+};
+
+/** Persist the Svix signing secret Recall.ai's webhook dashboard mints.
+ *  Operator-only; ctrl-api atomically merges RECALL_WEBHOOK_SECRET into
+ *  the compose .env and restarts ctrl-api so the next inbound delivery
+ *  verifies against the new secret. The secret NEVER enters the SaaS
+ *  layer's logs — the response carries only `secret_first6`.
+ *
+ *  Return shape on fresh writes:
+ *    { ok, secret_first6, persisted_to: ['.env'], restarted: [...],
+ *      eta_seconds }
+ *  On a re-paste of the same secret:
+ *    { ok: true, idempotent: true, secret_first6, ... }
+ *
+ *  Annotation `Promise<any>` — the Wasp Payload trap. */
+export const setRecallWebhookSecret = async (
+  args: { webhook_secret: string },
+  context: any,
+): Promise<any> => {
+  if (
+    typeof args?.webhook_secret !== "string" ||
+    args.webhook_secret.trim().length === 0
+  ) {
+    throw new HttpError(400, "webhook_secret required");
+  }
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    method: "POST",
+    path: "/api/v1/channels/recall/webhook-secret",
+    body: { webhook_secret: args.webhook_secret.trim() },
   });
 };
 

--- a/packages/web/src/dashboard/recallCardCore.test.ts
+++ b/packages/web/src/dashboard/recallCardCore.test.ts
@@ -98,7 +98,12 @@ test("derive: disabled — no API key on file (fresh tenant pre-paste)", () => {
 test("derive: configured — config + usage live; pill = Connected", () => {
   const status: RecallStatus = {
     enabled: true,
-    config: BASE_CONFIG,
+    config: {
+      ...BASE_CONFIG,
+      // Both flags must be true for the configured branch — fix/recall-card.
+      api_key_set: true,
+      webhook_secret_set: true,
+    },
     usage: { this_month_hours: 12.5, monthly_hours_cap: 60, bot_count_active: 1 },
     active_bots: [],
     error: null,
@@ -113,6 +118,53 @@ test("derive: configured — config + usage live; pill = Connected", () => {
   // Address bakes the live usage rollup.
   assert.match(card.address, /12.50h \/ 60h this month/);
   assert.match(card.address, /1 bot active/);
+});
+
+test("derive: partial — API key set but webhook_secret_set=false → 'Webhook not wired'", () => {
+  // The bug Sir flagged: api_key_set=true but webhook_secret_set=false
+  // (the most-common state immediately after PR #153 persisted the API
+  // key but before the operator pasted the signing secret). Pill must
+  // surface "Webhook not wired" so the principal knows to paste it; the
+  // dial form is still editable; test webhook is disabled because the
+  // synthetic delivery would 503 on the missing secret.
+  const status: RecallStatus = {
+    enabled: true,
+    config: {
+      ...BASE_CONFIG,
+      api_key_set: true,
+      webhook_secret_set: false,
+    },
+    usage: { this_month_hours: 0, monthly_hours_cap: 60, bot_count_active: 0 },
+    active_bots: [],
+    error: null,
+  };
+  const card = deriveRecallCardState(status, FROZEN_NOW);
+  assert.equal(card.status, "partial");
+  assert.equal(card.pillLabel, "Webhook not wired");
+  assert.equal(card.pillTone, "error");
+  assert.equal(card.canEditDials, true);
+  assert.equal(card.canTest, false);
+  assert.match(card.description, /webhook/i);
+});
+
+test("derive: configured — when webhook_secret_set is omitted (pre-#153 ctrl-api), do not regress", () => {
+  // The conservative default for an absent flag is "wired" so older
+  // deployments that lack the field don't render a yellow pill they
+  // can't clear from the UI.
+  const status: RecallStatus = {
+    enabled: true,
+    config: {
+      ...BASE_CONFIG,
+      api_key_set: true,
+      // webhook_secret_set intentionally omitted
+    },
+    usage: { this_month_hours: 0, monthly_hours_cap: 60, bot_count_active: 0 },
+    active_bots: [],
+    error: null,
+  };
+  const card = deriveRecallCardState(status, FROZEN_NOW);
+  assert.equal(card.status, "configured");
+  assert.equal(card.pillTone, "active");
 });
 
 test("derive: error — enabled but probe failed; surface verbatim error", () => {

--- a/packages/web/src/dashboard/recallCardCore.ts
+++ b/packages/web/src/dashboard/recallCardCore.ts
@@ -119,6 +119,15 @@ export interface RecallConfig {
   updated_at: number;
   api_key_set?: boolean;
   api_key_first6?: string | null;
+  /** True iff RECALL_WEBHOOK_SECRET is on file in the live ctrl-api .env.
+   *  Mirrors api_key_set; optional on the wire (older ctrl-api omits). */
+  webhook_secret_set?: boolean;
+  /** First 6 chars of the Svix signing secret, or null when unset. The
+   *  full value is NEVER round-tripped. */
+  webhook_secret_first6?: string | null;
+  /** The URL the operator pastes into Recall.ai's webhook dashboard
+   *  (ctrl-api builds it from $DOMAIN). Optional on the wire. */
+  webhook_url?: string | null;
 }
 
 /** GET /api/v1/channels/recall/usage response. */
@@ -173,11 +182,37 @@ export interface RecallStatus {
    * ctrl-api may omit).
    */
   webhook_secret_first6?: string | null;
+  /**
+   * True iff RECALL_WEBHOOK_SECRET is on file in the live ctrl-api .env.
+   * Drives the "API key set · webhook not wired" pill and the inline
+   * webhook-secret paste field on the configured panel. Optional on
+   * the wire (older ctrl-api may omit; the card treats `undefined` as
+   * "unknown" and assumes wired so older deployments don't regress).
+   */
+  webhook_secret_set?: boolean;
 }
 
 // ── derived card state ────────────────────────────────────────────────────
 
-export type RecallCardStatusKind = "disabled" | "configured" | "error";
+/**
+ * Four top-level card states the React layer renders off:
+ *
+ *   • disabled    — no API key on file. Pill = "Not connected".
+ *                   Render the API-key paste form.
+ *   • partial     — API key present, but RECALL_WEBHOOK_SECRET missing.
+ *                   Pill = "Webhook not wired". Render the full dial
+ *                   form AND a prominent webhook-secret paste field at
+ *                   the top — Recall.ai's bot deliveries will 401 at
+ *                   ctrl-api's inbound until the secret lands.
+ *   • configured  — both API key + webhook secret on file. Pill =
+ *                   "Connected". Full surface.
+ *   • error       — enabled but a probe returned a hard error.
+ */
+export type RecallCardStatusKind =
+  | "disabled"
+  | "partial"
+  | "configured"
+  | "error";
 
 export interface RecallCardState {
   /** Which top-level block renders. */
@@ -606,6 +641,35 @@ export function deriveRecallCardState(
       : `Bot in ${formValues.region}`;
 
   void now; // reserved for relative-time formatting on the address line.
+
+  // Webhook-secret posture. The flag is optional on the wire — pre-#153
+  // ctrl-api omits it; older deployments shouldn't regress to a yellow
+  // pill they have no way to clear, so an absent flag is treated as
+  // "wired" (the conservative default). Only an explicit `false`
+  // triggers the partial state.
+  const webhookSet =
+    s.config && typeof s.config.webhook_secret_set === "boolean"
+      ? s.config.webhook_secret_set
+      : null;
+  if (webhookSet === false) {
+    return {
+      status: "partial",
+      pillLabel: "Webhook not wired",
+      pillTone: "error",
+      heading: "Recall.ai webhook not wired",
+      description:
+        "API key set, but RECALL_WEBHOOK_SECRET is missing. Inbound " +
+        "deliveries from Recall.ai will be rejected until you paste " +
+        "the Svix signing secret below.",
+      address,
+      formValues,
+      visibleBots,
+      canEditDials: true,
+      canTest: false,
+      monthHours,
+      costAlertTriggered,
+    };
+  }
 
   return {
     status: "configured",


### PR DESCRIPTION
## Summary

Closes the gap PR #153 left behind: the ctrl-api persistence endpoint shipped, but the `/channels` Meeting bot card never grew the paste field, so Sir literally cannot configure Recall.ai from the UI. The card showed `CONNECTED` unconditionally (a lie when `api_key_set=false`) and had no input for either the API key or the Svix signing secret.

## Root cause

`packages/web/src/dashboard/operations.ts` derived `enabled = usageOk && configOk`. But neither `/usage` nor `/config` gates on `RECALL_API_KEY` — both return 200 on a fresh tenant. So `enabled` was always `true`, the card always hit the `configured` branch, and the API-key paste form (which lives in the `disabled` branch) never rendered.

## What the card now shows

| State | Pill | UI |
|---|---|---|
| no API key on file | `UNCONFIGURED` (gray) | API-key paste form + region selector + Recall.ai dashboard link |
| API key set, webhook secret missing | `WEBHOOK NOT WIRED` (brass) | Full dial form + prominent webhook-secret paste block (auto-open, brass-bordered) |
| both set | `CONNECTED` (brass) | Full dial form + first6 + Rotate affordances for both secrets |
| error | `NEEDS ATTENTION` | Verbatim error + Re-check |

The webhook-setup disclosure now lists the recommended event subscriptions (`bot.status_change` / `bot.done` / `bot.fatal` / `bot.recording_done`) plus the note that `bot.transcription.message` is deferred until PR #154 ships in-meeting voice.

## ctrl-api changes

- `rowToApiConfig` emits three new fields: `webhook_secret_set: boolean`, `webhook_secret_first6: string|null`, `webhook_url: string|null`. Mirrors the existing `api_key_set` / `api_key_first6` posture; full secret never echoed.
- New route `POST /api/v1/channels/recall/webhook-secret` — operator-only setter using the same atomic .env merge + background restart pattern as `/api-key`. Shape-checks `whsec_…` or raw base64 with ≥16 chars entropy; idempotent re-paste; serialised against `/api-key` via `withPersistLock`.

## web changes

- Fix `enabled` derivation in `operations.ts` — drive it off `config.api_key_set === true`, fall back to the old heuristic only when the flag is absent on the wire.
- New `setRecallWebhookSecret` Wasp action wired into `main.wasp`.
- New `partial` status in `recallCardCore.ts` for the api-key-set-but-webhook-missing state. Absent `webhook_secret_set` flag → conservative "wired" default so older deployments don't regress.
- `RecallCard.tsx` gets the webhook-secret paste block (sibling to API-key row, always visible on configured + partial), the updated event-subscription list, and the proper pill text per state.

## Tests

- `channels_recall.test.ts`: +2 cases — GET /config defaults emit the new fields; with env vars set, first6s surface but full values do NOT.
- `channels_recall_apikey.test.ts`: +7 cases for `/webhook-secret` (happy path, idempotence, 3 validation paths, operator-only auth, no-leak GET round-trip).
- `recallCardCore.test.ts`: +3 cases — `partial` derivation, `configured` requires both flags, absent flag does NOT regress to partial.

All 23 channels_recall tests pass. All 20 apikey+webhook-secret tests pass. All 41 recallCardCore tests pass. ctrl-api esbuild compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)