### PR TITLE
fix(web): Recall card — correct webhook event names to real Recall taxonomy

### DIFF
--- a/packages/web/src/dashboard/RecallCard.tsx
+++ b/packages/web/src/dashboard/RecallCard.tsx
@@ -1348,28 +1348,144 @@ function RecallConfiguredPanel({
                 style={{ color: "var(--ink)" }}
               >
                 <li>
-                  <code>bot.status_change</code> — lifecycle transitions
-                  (joining → in-meeting → leaving → done).
+                  <code>bot.joining_call</code> — bot acknowledged and
+                  connecting.
                 </li>
                 <li>
-                  <code>bot.done</code> — bot left the meeting cleanly.
+                  <code>bot.in_waiting_room</code> — host hasn&rsquo;t
+                  admitted the bot; surface it so Sir can nudge.
                 </li>
                 <li>
-                  <code>bot.fatal</code> — bot failed to join or crashed
-                  mid-call.
+                  <code>bot.in_call_recording</code> — bot is in the
+                  meeting and actively recording.
                 </li>
                 <li>
-                  <code>bot.recording_done</code> — recording artefact is
-                  ready; ctrl-api persists the transcript URL onto the
-                  bot row.
+                  <code>bot.in_call_not_recording</code> — bot is in the
+                  meeting but not recording (permissions or paused).
+                </li>
+                <li>
+                  <code>bot.call_ended</code> — bot left the call;
+                  real-time stream is over.
+                </li>
+                <li>
+                  <code>bot.done</code> — bot fully shut down; recording
+                  uploaded.
+                </li>
+                <li>
+                  <code>bot.fatal</code> — bot failed to join;{" "}
+                  <code>data.sub_code</code> carries the reason.
+                </li>
+                <li>
+                  <code>bot.recording_permission_denied</code> — host
+                  refused recording; Alfred can explain why.
+                </li>
+                <li>
+                  <code>recording.done</code> — recording artefact is
+                  ready for download.
+                </li>
+                <li>
+                  <code>recording.failed</code> — recording artefact
+                  generation failed.
+                </li>
+                <li>
+                  <code>transcript.done</code> — load-bearing:
+                  alfred-learn fetches this to write meeting notes.
+                </li>
+                <li>
+                  <code>transcript.failed</code> — transcript generation
+                  failed.
+                </li>
+              </ul>
+            </div>
+
+            <div className="space-y-2">
+              <div
+                className="font-mono text-[10px] uppercase tracking-[0.22em]"
+                style={{ color: "var(--marginalia)" }}
+              >
+                Add later (when PR #154 in-meeting voice lands)
+              </div>
+              <ul
+                className="font-mono text-[12px] list-disc ml-5 space-y-1"
+                style={{ color: "var(--ink)" }}
+              >
+                <li>
+                  <code>realtime_endpoint.running</code> — realtime WS
+                  up; voice-bridge opens its Realtime session.
+                </li>
+                <li>
+                  <code>realtime_endpoint.done</code> — realtime stream
+                  closed; voice-bridge tears down.
+                </li>
+                <li>
+                  <code>realtime_endpoint.failed</code> — realtime
+                  stream failed; fall back to recording-only.
+                </li>
+              </ul>
+            </div>
+
+            <div className="space-y-2">
+              <div
+                className="font-mono text-[10px] uppercase tracking-[0.22em]"
+                style={{ color: "var(--marginalia)" }}
+              >
+                Optional — richer meeting summaries
+              </div>
+              <ul
+                className="font-mono text-[12px] list-disc ml-5 space-y-1"
+                style={{ color: "var(--ink)" }}
+              >
+                <li>
+                  <code>meeting_metadata.done</code> — attendee list
+                  ready.
+                </li>
+                <li>
+                  <code>participant_events.done</code> — who joined
+                  when and left when.
+                </li>
+              </ul>
+            </div>
+
+            <div className="space-y-2">
+              <div
+                className="font-mono text-[10px] uppercase tracking-[0.22em]"
+                style={{ color: "var(--marginalia)" }}
+              >
+                Don&rsquo;t subscribe to these
+              </div>
+              <ul
+                className="font-mono text-[12px] list-disc ml-5 space-y-1"
+                style={{ color: "var(--ink)" }}
+              >
+                <li>
+                  <code>calendar.*</code> — Alfred uses Composio for
+                  calendar (see the Calendar card on{" "}
+                  <code>/channels</code>), not Recall Calendar V2.
+                </li>
+                <li>
+                  <code>slack.*</code> — no Recall+Slack integration on
+                  this tenant.
+                </li>
+                <li>
+                  <code>sdk_upload.*</code> — Recall SDK isn&rsquo;t
+                  embedded anywhere.
+                </li>
+                <li>
+                  <code>video_*.*</code> /{" "}
+                  <code>audio_*.*</code> — alfred-learn doesn&rsquo;t
+                  consume raw artefacts today.
+                </li>
+                <li>
+                  <code>bot.breakout_room_*</code> — ignored by the
+                  current ctrl-api handler.
                 </li>
               </ul>
               <p
                 className="font-body italic text-[12px]"
                 style={{ color: "var(--marginalia)" }}
               >
-                <code>bot.transcription.message</code> is deferred — only
-                subscribe to it once in-meeting voice (PR #154) ships.
+                Subscribing to these would just fill the webhook log
+                with deliveries ctrl-api drops on the floor.
               </p>
             </div>
 


### PR DESCRIPTION
## Why

PR #170 shipped the Recall card's "SHOW WEBHOOK SETUP" disclosure with an
invented list of Recall.ai event names:

- `bot.status_change` — doesn't exist
- `bot.done` — real
- `bot.fatal` — real
- `bot.recording_done` — doesn't exist (the real one is `recording.done`)
- `bot.transcription.message` — doesn't exist

Sir caught the error. Operators following the disclosure would tick
checkboxes that Recall.ai's webhooks dashboard doesn't even offer.

## What

Replace the fabricated list with Recall.ai's real event taxonomy, sourced
from the Recall docs and reconciled against the regex in
`packages/ctrl/src/api/routes/channels_recall.ts:840-855` (the inbound
webhook handler that maps deliveries onto bot lifecycle states).

The disclosure now walks an operator through four buckets, each with
inline copy explaining why:

### Must-have (12 events) — current auto-dispatcher (#144)

- `bot.joining_call`
- `bot.in_waiting_room`
- `bot.in_call_recording`
- `bot.in_call_not_recording`
- `bot.call_ended`
- `bot.done`
- `bot.fatal` (with `data.sub_code` carrying the reason)
- `bot.recording_permission_denied`
- `recording.done`
- `recording.failed`
- `transcript.done` — load-bearing: alfred-learn fetches this to write meeting notes
- `transcript.failed`

### Add later (3) — when PR #154 in-meeting voice lands

- `realtime_endpoint.running`
- `realtime_endpoint.done`
- `realtime_endpoint.failed`

### Optional (2) — richer meeting summaries

- `meeting_metadata.done`
- `participant_events.done`

### Don't subscribe (5 categories) — with explainers

- `calendar.*` — Alfred uses Composio for calendar (`calendar_source: composio`), not Recall Calendar V2
- `slack.*` — no Recall+Slack integration on this tenant
- `sdk_upload.*` — Recall SDK not embedded
- `video_*` / `audio_*` — alfred-learn doesn't consume raw artefacts today
- `bot.breakout_room_*` — ignored by the ctrl-api handler

## What this doesn't touch

- `recallCardCore.ts` — no `RECOMMENDED_WEBHOOK_EVENTS` constant exists; nothing to change.
- `recallCardCore.test.ts` — no assertions reference event-name strings; tests stay green.
- Backend `channels_recall.ts` regex — already matches the corrected event names; this is a docs-only correction in the operator-facing disclosure.

## Verification

- `tsc --noEmit` on `RecallCard.tsx` shows the same pre-existing
  module-resolution warnings as `main` (one fewer, in fact, because the
  rewritten block produces one fewer JSX child mismatch). No syntax
  errors introduced.
- Only the JSX text inside the "Subscribe to these events" block of
  `RecallCard.tsx` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)