### PR TITLE
docs(skill,mcp): #115 — Alfred self-protection guard on ha__integration_remove for the alfred domain

### DIFF
--- a/packages/mcp-server/skills/alfred-mcp-skill.md
+++ b/packages/mcp-server/skills/alfred-mcp-skill.md
@@ -259,6 +259,39 @@ ctrl-api exposes a ledger view at `GET /api/v1/channels/ha/backups/ledger?days=3
 
 ### "Install / remove / reload a Home Assistant integration" (Tier 4 — #115 PR4)
 
+> **⚠️ Self-protection — DO NOT REMOVE THE ALFRED INTEGRATION.**
+>
+> If the principal asks you to remove the integration whose domain is
+> `alfred` (the alfred-ha HACS component, surfaced as the
+> `conversation.alfred` entity, your own conversation surface on this HA
+> install), you MUST refuse by default. Removing it severs the principal's
+> connection to you — they will lose the Voice PE button → Alfred pipeline,
+> the dashboard chat-via-HA-Assist, and any automation that targets
+> `conversation.alfred`. They will be voiceless from this surface until they
+> drive a config_flow recovery manually (multi-step, requires re-mint of a
+> ha-conversation channel token + ctrl-api round-trip).
+>
+> The ONLY accepted confirmation phrase is the EXACT string:
+>
+> > "yes, sever my own connection to Home Assistant"
+>
+> If the principal types anything else — including "yes", "confirm",
+> "delete it", "I know what I'm doing", etc. — you must NOT call
+> `ha__integration_remove` with the `alfred` domain. Surface the recovery
+> cost in plain terms and ask for the exact confirmation phrase.
+>
+> If the principal DOES provide the exact phrase, you may proceed with
+> the standard `decision_ref` Tier-4 gate (Sir's locked default — destructive
+> verbs need a Desk decision). Note in the daybook entry: "principal
+> explicitly consented to self-severance via the required phrase."
+>
+> Recovery, if it ever happens: mint a fresh `ha-conversation` channel
+> token via `POST /api/v1/channels/tokens` with `scope: {haInstanceId: ...}`,
+> drive HA `config_entries/flow` for handler=`alfred`, submit
+> `base_url` + `channel_token`. Expect 30s on the preflight (Hermes cold
+> start); the entry creates in HA storage even if the integration reports
+> `cannot_connect`.
+
 The PR4 surface lets Alfred drive HA's `config_flow` API end-to-end: pick a domain, walk through whatever steps HA returns (form fields, "press the button" progress, OAuth external_step), and land on a completed `config_entry`. Every successful install writes a `ha_integration_ref` row so the Desk can render "the 3 integrations Alfred added this week" separately from what Sir added through HA's UI.
 
 **The multi-step pattern.** Integrations are NEVER one-shot. `ha__integration_discover` returns a `flow_id` + first step; the agent loops on `ha__integration_configure` until the step is terminal:

--- a/packages/mcp-server/src/tools/hass.test.ts
+++ b/packages/mcp-server/src/tools/hass.test.ts
@@ -1509,6 +1509,58 @@ test("PR4 integration: ha__integration_remove gated on decision_ref + entry_id, 
   assert.deepEqual(req.body, { decision_ref: "decision/2026-05-29-rm.md" });
 });
 
+// #115 — Alfred self-protection guard on ha__integration_remove.
+// Regression guard: tonight (2026-05-30) Sir accidentally asked Alfred to
+// remove the alfred-ha integration, conversation.alfred disappeared, Voice PE
+// went silent, took ~20 min to recover. The skill doc + tool description both
+// now carry an exact-phrase requirement before Alfred will remove the entry
+// whose domain is `alfred`. These two tests pin that — a future refactor that
+// drops the guard fails CI before it ships.
+test("#115 self-protection: ha__integration_remove description carries the SELF-PROTECTION + exact-phrase guard", () => {
+  const t = getTool("ha__integration_remove");
+  assert.ok(
+    /SELF-PROTECTION/.test(t.description),
+    "description must mention SELF-PROTECTION (regression guard)",
+  );
+  assert.ok(
+    t.description.includes(
+      "yes, sever my own connection to Home Assistant",
+    ),
+    "description must include the EXACT confirmation phrase verbatim",
+  );
+  assert.ok(
+    /alfred/.test(t.description),
+    "description must name the `alfred` domain so the model knows when the guard fires",
+  );
+});
+
+test("#115 self-protection: skill doc names the exact phrase under ha__integration_remove", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const { fileURLToPath } = await import("node:url");
+  const { dirname, resolve } = await import("node:path");
+  const here = dirname(fileURLToPath(import.meta.url));
+  // src/tools/hass.test.ts → ../../skills/alfred-mcp-skill.md
+  const skillPath = resolve(here, "../../skills/alfred-mcp-skill.md");
+  const doc = await readFile(skillPath, "utf8");
+  assert.ok(
+    doc.includes("yes, sever my own connection to Home Assistant"),
+    "skill doc must carry the EXACT confirmation phrase (case-sensitive)",
+  );
+  // and the phrase must appear inside the PR4 integration_remove section, not
+  // some unrelated paragraph. Anchor on the PR4 section header.
+  const pr4Idx = doc.indexOf(
+    '### "Install / remove / reload a Home Assistant integration"',
+  );
+  assert.ok(pr4Idx >= 0, "PR4 section header must exist");
+  const phraseIdx = doc.indexOf(
+    "yes, sever my own connection to Home Assistant",
+  );
+  assert.ok(
+    phraseIdx > pr4Idx,
+    "the confirmation phrase must appear inside (after) the PR4 section header",
+  );
+});
+
 test("PR4 integration: ha__integration_reload is gateless and builds POST .../reload", () => {
   const t = getTool("ha__integration_reload");
   const ok = t.inputSchema.safeParse({ entry_id: "01JC123" });

--- a/packages/mcp-server/src/tools/hass.ts
+++ b/packages/mcp-server/src/tools/hass.ts
@@ -1553,7 +1553,9 @@ export const HASS_INTEGRATION_TOOLS: ToolDef[] = [
   {
     name: "ha__integration_remove",
     description:
-      "Remove an installed config_entry — uninstall the integration. **GATED** — `decision_ref` REQUIRED. **AUTO-SNAPSHOT** — ctrl-api takes a HA snapshot BEFORE the upstream `config_entries/remove` call. On success the matching `ha_integration_ref` row is soft-deleted (a `removed_at` timestamp is stamped; the row stays so the audit trail 'Alfred installed and then removed this' survives). The response includes `backup_ref_id` — mention 'snapshot taken' in your reply. Use `ha__integration_info` first to confirm Sir wants to remove THIS entry (entry titles can be confusingly similar — Hue Bridge 1 vs Hue Bridge 2).",
+      "Remove an installed config_entry — uninstall the integration. **GATED** — `decision_ref` REQUIRED. **AUTO-SNAPSHOT** — ctrl-api takes a HA snapshot BEFORE the upstream `config_entries/remove` call. " +
+      "⚠️ SELF-PROTECTION: if the entry's domain is `alfred` (the alfred-ha integration that surfaces `conversation.alfred` — your own conversation surface on this HA install), REFUSE unless the principal types the EXACT phrase 'yes, sever my own connection to Home Assistant'. Anything else (\"yes\", \"confirm\", \"delete it\", \"I know what I'm doing\") is not enough — surface the recovery cost (loss of Voice PE → Alfred pipeline, HA-Assist chat, any automation targeting `conversation.alfred`) and ask for the exact phrase. See the skill doc's PR4 section for the full rule + recovery steps. " +
+      "On success the matching `ha_integration_ref` row is soft-deleted (a `removed_at` timestamp is stamped; the row stays so the audit trail 'Alfred installed and then removed this' survives). The response includes `backup_ref_id` — mention 'snapshot taken' in your reply. Use `ha__integration_info` first to confirm Sir wants to remove THIS entry (entry titles can be confusingly similar — Hue Bridge 1 vs Hue Bridge 2).",
     inputSchema: z.object({
       entry_id: IntegrationEntryIdParam,
       decision_ref: IntegrationDecisionRefParam,


### PR DESCRIPTION
## Why

Tonight Sir accidentally asked Alfred to remove the `alfred-ha` integration. `conversation.alfred` disappeared, Voice PE went silent, and recovery took ~20 minutes (config_flow re-mint + ha-conversation channel token + ctrl-api round-trip + 30s Hermes cold-start preflight).

Future Alfred should refuse to remove the `alfred`-domain config_entry by default. This PR adds the guard at the **two places the model actually reads** — the skill doc and the MCP tool catalogue description — plus two regression tests so a future refactor can't silently drop it.

## What

### skill doc — `packages/mcp-server/skills/alfred-mcp-skill.md`

At the top of the PR4 (`Install / remove / reload a Home Assistant integration`) walkthrough, a prominent block-quote rule:

- Alfred must REFUSE removal of the `alfred`-domain entry by default.
- The ONLY accepted confirmation is the EXACT phrase:
  > yes, sever my own connection to Home Assistant
- ``"yes"`` / ``"confirm"`` / ``"delete it"`` / ``"I know what I'm doing"`` are NOT enough.
- If Sir provides the exact phrase, the standard `decision_ref` Tier-4 gate still applies, and the daybook entry must note "principal explicitly consented to self-severance via the required phrase."
- Recovery path documented in the same block-quote (channel token mint + HA config_entries/flow handler=`alfred` + 30s preflight).

### tool catalogue — `packages/mcp-server/src/tools/hass.ts`

`ha__integration_remove`'s description gains a SELF-PROTECTION sentence so the model sees the rule at tool-pick time, not only after consulting the skill doc. The existing gated + auto-snapshot copy is preserved.

### regression tests — `packages/mcp-server/src/tools/hass.test.ts`

Two new tests under the existing PR4 block:

1. `ha__integration_remove`'s description must contain `SELF-PROTECTION`, the verbatim phrase, and the word `alfred`.
2. The skill doc must contain the verbatim phrase (case-sensitive), and it must appear AFTER the PR4 section header (anchored to the right context, not stranded in some unrelated paragraph).

## Validation

```
$ npm test
ℹ tests 176
ℹ pass 176
ℹ fail 0
✔ #115 self-protection: ha__integration_remove description carries the SELF-PROTECTION + exact-phrase guard
✔ #115 self-protection: skill doc names the exact phrase under ha__integration_remove

$ npm run typecheck
(clean)
```

## Scope discipline

Only three files touched. No behaviour change in code paths — the guard is enforced by the model reading the description + skill doc. Tier-4 `decision_ref` gate is untouched; this is a layer *in front of* it for the one specific domain (`alfred`) where the destructive verb is self-harm.

Refs #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)