### PR TITLE
fix(hermes): #175 trim main-profile MCP tool catalogue (321→170 tools)

### DIFF
--- a/packages/hermes/hermes-config.yaml.njk
+++ b/packages/hermes/hermes-config.yaml.njk
@@ -120,6 +120,24 @@ agent:
   restart_drain_timeout: 60
 
 # =============================================================================
+# Kanban dispatcher — disabled fleet-wide
+# =============================================================================
+# Hermes ships with a built-in kanban board surface — a SQLite-backed task
+# queue at <HERMES_HOME>/profiles/<p>/kanban.db that the gateway can poll
+# every 60s to spawn workers for ready tasks. Alfred Black does NOT use it:
+# work coordination flows through Paperclip (which has its own runtime
+# workspace concept) and Plane (issues). With dispatch_in_gateway=True
+# (Hermes default), the gateway tries to open kanban.db every tick — and
+# when the file/dir is readonly to the gateway user, the result is a 60-
+# second-spaced ERROR Traceback in the logs that swamps every other signal
+# (see issue #175 log noise on home.alfred.black, 2026-05-30).
+#
+# Disabling here on every profile makes the dispatcher a no-op without
+# touching filesystem perms or runtime image config — the right knob.
+kanban:
+  dispatch_in_gateway: false
+
+# =============================================================================
 # Cron jobs
 # =============================================================================
 {%- if is_main %}
@@ -444,6 +462,67 @@ mcp_servers:
       AAS_API_KEY: "${AAS_API_KEY}"
     timeout: 120
     connect_timeout: 60
+{%- if is_main %}
+    # MAIN-PROFILE TOOL TRIM — see issue #175 (2026-05-30, Sir's
+    # voice-bridge calendar-query timeout).
+    #
+    # The full sure catalogue is 95 tools. At 321 tools total, every Hermes
+    # `/v1/responses` turn carries ~67 k input tokens (the JSON-Schema for
+    # every tool inlines into the system prompt). That makes the model's
+    # time-to-first-token ~3-5 s per turn, and a multi-turn tool-cascade
+    # (the calendar query alone is 8 turns × 16 tool calls) blows past the
+    # voice-bridge's 90 s budget.
+    #
+    # `tools.include` is a Hermes-native whitelist (see
+    # /usr/local/lib/python3.12/site-packages/tools/mcp_tool.py:2967-2974
+    # in hermes-agent v2026.5.16). Tools NOT listed are still REACHABLE on
+    # the workers profile (which keeps the full catalogue) and via
+    # `delegate_task` — they're just not inlined into main's tool schema.
+    #
+    # The retained surface is the user-facing chat's actual hot path:
+    # account/transaction/holding reads, the bulk-edit endpoints Sir
+    # categorises with, and the budget + sync top-level verbs. Niche CRUD
+    # (single-transaction create/update/split/unsplit, manual valuations,
+    # category/merchant/tag/rule mutation, holding cost-basis, transfer
+    # confirmation, recurring management, shares/invitations, imports,
+    # api-usage admin, full-tenant reset) routes through workers via
+    # `delegate_task` when the principal asks for it. Anything Sir CAN'T
+    # do via main's catalogue, he can still do via "ask Alfred to do X" —
+    # main delegates and reports.
+    tools:
+      include:
+        # net-worth + accounts (reads + the rare account create)
+        - get_balance_sheet
+        - list_accounts
+        - create_manual_account
+        - update_account
+        # transactions: reads + the bulk verbs Sir uses for categorisation
+        - list_transactions
+        - get_transaction
+        - bulk_update_transactions
+        - bulk_delete_transactions
+        # categories / merchants / tags / rules — list-only on main; create
+        # via delegate_task. update_budget_category stays because it's the
+        # one principal-driven write surface (budget allocations).
+        - list_categories
+        - list_merchants
+        - list_tags
+        - list_rules
+        - update_budget_category
+        - find_or_bootstrap_budget
+        # holdings + trades — reads only; cost-basis / security remap on workers
+        - list_holdings
+        - get_holding
+        - list_trades
+        - get_trade
+        # imports + exports — top-level lifecycle
+        - list_imports
+        - create_export
+        # tenant-wide ops the principal actually invokes
+        - trigger_sync
+        - cluster_transactions
+        - identify_recurring_patterns
+{%- endif %}
 
   plane:
     command: "node"
@@ -500,6 +579,50 @@ mcp_servers:
       AAS_API_KEY: "${AAS_API_KEY}"
     timeout: 120
     connect_timeout: 60
+    # MAIN-PROFILE TOOL TRIM — see issue #175. hass has 85 tools (covering
+    # the full HA admin surface: backups, HACS, users, LLATs, addons,
+    # integrations, area/device/label registries, …). The user-facing
+    # chat needs the OPERATOR surface — registry reads + state + history
+    # + the proposal/apply/rollback write path. Admin verbs (addons,
+    # users, LLATs, HACS, backups, registry mutations, integrations
+    # management) route through the dashboard's Home page UI or via
+    # `delegate_task` on workers when an automation needs them.
+    tools:
+      include:
+        # connection + registry reads (the everyday ops surface)
+        - ha__connection_status
+        - ha__list_entities
+        - ha__get_state
+        - ha__get_history
+        - ha__get_logbook
+        - ha__list_areas
+        - ha__list_devices
+        - ha__list_automations
+        - ha__list_scripts
+        - ha__get_calendars
+        - ha__resolve_entity
+        # the safe write path: proposal → apply → rollback. ha__call_service
+        # stays because the principal asks the agent to turn things on/off
+        # all day and the loop-guard contract is enforced server-side.
+        - ha__call_service
+        - ha__propose_automation
+        - ha__apply_proposal
+        - ha__rollback_snapshot
+        - ha__subscribe_events
+        # automation/scene/script read+write (PR3 first-class CRUD)
+        - ha__list_automations_full
+        - ha__create_automation
+        - ha__update_automation
+        - ha__delete_automation
+        - ha__create_scene
+        - ha__update_scene
+        - ha__delete_scene
+        - ha__create_script
+        - ha__update_script
+        - ha__delete_script
+        # core check/version — light read surface every triage flow uses
+        - ha__core_version
+        - ha__core_check_config
 {%- endif %}
 
   # --- paperclip: Paperclip's first-party MCP server (paperclip.ing) -------
@@ -539,6 +662,40 @@ mcp_servers:
       PAPERCLIP_AGENT_ID: "${PAPERCLIP_AGENT_ID}"
     timeout: 120
     connect_timeout: 60
+{%- if is_main %}
+    # MAIN-PROFILE TOOL TRIM — see issue #175. The upstream
+    # @paperclipai/mcp-server exposes 40 tools across issues / approvals
+    # / documents / projects / goals / runtime workspaces. The user-facing
+    # chat needs read access + the issue/comment/approval surface Sir
+    # actually drives; the workspace runtime control surface, document
+    # revisions, and link/unlink primitives are workers-only (the
+    # paperclip heartbeat agent on workers handles them autonomously).
+    tools:
+      include:
+        # identity / inbox
+        - paperclipMe
+        - paperclipInboxLite
+        # issue lifecycle (Sir's most-asked surface)
+        - paperclipListIssues
+        - paperclipGetIssue
+        - paperclipGetHeartbeatContext
+        - paperclipCreateIssue
+        - paperclipUpdateIssue
+        # comments — the chat surface for ongoing issues
+        - paperclipListComments
+        - paperclipAddComment
+        # approvals — the principal's decision surface
+        - paperclipListApprovals
+        - paperclipCreateApproval
+        - paperclipGetApproval
+        - paperclipApprovalDecision
+        # projects / agents / goals — directory reads
+        - paperclipListProjects
+        - paperclipGetProject
+        - paperclipListAgents
+        - paperclipGetAgent
+        - paperclipListGoals
+{%- endif %}
 
 {%- if is_main or profile == "workers" %}
 

--- a/packages/hermes/init/Dockerfile
+++ b/packages/hermes/init/Dockerfile
@@ -83,6 +83,13 @@ COPY packages/hermes/init/render_sms_gateway.py ./render_sms_gateway.py
 # required MCP server entries (e.g. `hass` PR #128, `files` PR #130) into
 # the operator-owned per-profile config.yaml. Sibling of render_sms_gateway.
 COPY packages/hermes/init/render_mcp_servers.py ./render_mcp_servers.py
+# migrate_main_profile_tool_trim.py — idempotent ADD-only mutator that
+# backfills `mcp_servers.{sure,hass,paperclip}.tools.include` on the
+# operator-owned main-profile config.yaml. Issue #175 (2026-05-30): voice
+# /HA-Assist calendar queries timed out because the main profile was
+# inlining 321 MCP tool schemas (~67k input tokens per turn). Workers/
+# heavy/codex-builder are unaffected (no-op). Sibling of render_mcp_servers.
+COPY packages/hermes/init/migrate_main_profile_tool_trim.py ./migrate_main_profile_tool_trim.py
 # Paperclip auto-bootstrap. Invoked as the entrypoint of the sibling
 # `paperclip-init` compose service (see docker-compose.yaml). Not run by
 # this image's default entrypoint.sh — keeps the main init container

--- a/packages/hermes/init/entrypoint.sh
+++ b/packages/hermes/init/entrypoint.sh
@@ -524,6 +524,16 @@ for profile in "${PROFILES_RENDERED[@]}"; do
         CTRL_API_URL="${CTRL_API_URL:-http://ctrl-api:3100}" \
             python3 /setup/render_mcp_servers.py "$profile" \
             || echo "[init] WARN: render_mcp_servers.py failed for $profile (non-fatal)"
+
+        # --- 6a-bis. Main-profile tool-catalogue trim (issue #175) ----------
+        # Backfill `mcp_servers.{sure,hass,paperclip}.tools.include` on
+        # operator-owned configs so existing tenants benefit from the
+        # template's whitelist without an operator hand-edit. Idempotent,
+        # main-only (no-op on workers/heavy/codex-builder). Also asserts
+        # `kanban.dispatch_in_gateway: false` if the operator hasn't set it.
+        PROFILE_DIR="$INIT_PROFILE_DIR" \
+            python3 /setup/migrate_main_profile_tool_trim.py "$profile" \
+            || echo "[init] WARN: migrate_main_profile_tool_trim.py failed for $profile (non-fatal)"
     fi
 done
 

--- a/packages/hermes/init/migrate_main_profile_tool_trim.py
+++ b/packages/hermes/init/migrate_main_profile_tool_trim.py
@@ -1,0 +1,251 @@
+"""migrate_main_profile_tool_trim.py — trim main-profile MCP catalogue.
+
+Issue #175 (2026-05-30) found Hermes-main's `/v1/responses` carrying
+~67 k input tokens per turn — the JSON-Schema for every tool inlines into
+the system prompt, and the main profile was exposing 321 MCP tools (95
+sure, 85 hass, 40 paperclip + the smaller servers). Every Hermes turn paid
+3-5 s of LLM TTFT just to digest the catalogue, and multi-turn tool
+cascades (the calendar query alone took 8 turns × 16 tool calls) blew
+past the voice-bridge's 90 s budget.
+
+The fix lives in `hermes-config.yaml.njk` as
+`mcp_servers.{sure,hass,paperclip}.tools.include` whitelists. But
+`config.yaml` is OPERATOR-OWNED (`render_hermes.py` only SEEDS it when
+absent), so the template change doesn't take effect on EXISTING tenants
+until someone surgically patches the on-disk file. This script is that
+patch, modelled on `render_mcp_servers.py`:
+
+  * idempotent — safe to re-run on every init boot
+  * ADD-only — never deletes or rewrites the operator's other edits
+  * preserves an existing `tools.include` block (the operator's choice
+    trumps ours; we only seed when absent)
+  * preserves an existing `kanban.dispatch_in_gateway` setting (an
+    operator may explicitly opt back in)
+
+Uses `ruamel.yaml` (same as render_mcp_servers.py) so comments + key
+ordering survive the round-trip.
+
+CLI:
+  migrate_main_profile_tool_trim.py <profile>
+  env: PROFILE_DIR
+
+Returns one of {applied, present, empty-mcp, not-main} as a one-line
+status to stderr.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Include lists — these are the MAIN-profile-only whitelists. Workers /
+# heavy / codex-builder keep their template-default catalogues (workers
+# already runs a different, narrower use case; heavy doesn't carry hass
+# or files; codex-builder is sealed with mcp_servers: {}).
+#
+# Keep IN SYNC with hermes-config.yaml.njk — the template seeds the same
+# list on fresh tenants. Adding a tool to one without the other is a
+# stale divergence; the test suite enforces parity.
+# ---------------------------------------------------------------------------
+
+SURE_MAIN_INCLUDE = [
+    "get_balance_sheet",
+    "list_accounts",
+    "create_manual_account",
+    "update_account",
+    "list_transactions",
+    "get_transaction",
+    "bulk_update_transactions",
+    "bulk_delete_transactions",
+    "list_categories",
+    "list_merchants",
+    "list_tags",
+    "list_rules",
+    "update_budget_category",
+    "find_or_bootstrap_budget",
+    "list_holdings",
+    "get_holding",
+    "list_trades",
+    "get_trade",
+    "list_imports",
+    "create_export",
+    "trigger_sync",
+    "cluster_transactions",
+    "identify_recurring_patterns",
+]
+
+HASS_MAIN_INCLUDE = [
+    "ha__connection_status",
+    "ha__list_entities",
+    "ha__get_state",
+    "ha__get_history",
+    "ha__get_logbook",
+    "ha__list_areas",
+    "ha__list_devices",
+    "ha__list_automations",
+    "ha__list_scripts",
+    "ha__get_calendars",
+    "ha__resolve_entity",
+    "ha__call_service",
+    "ha__propose_automation",
+    "ha__apply_proposal",
+    "ha__rollback_snapshot",
+    "ha__subscribe_events",
+    "ha__list_automations_full",
+    "ha__create_automation",
+    "ha__update_automation",
+    "ha__delete_automation",
+    "ha__create_scene",
+    "ha__update_scene",
+    "ha__delete_scene",
+    "ha__create_script",
+    "ha__update_script",
+    "ha__delete_script",
+    "ha__core_version",
+    "ha__core_check_config",
+]
+
+PAPERCLIP_MAIN_INCLUDE = [
+    "paperclipMe",
+    "paperclipInboxLite",
+    "paperclipListIssues",
+    "paperclipGetIssue",
+    "paperclipGetHeartbeatContext",
+    "paperclipCreateIssue",
+    "paperclipUpdateIssue",
+    "paperclipListComments",
+    "paperclipAddComment",
+    "paperclipListApprovals",
+    "paperclipCreateApproval",
+    "paperclipGetApproval",
+    "paperclipApprovalDecision",
+    "paperclipListProjects",
+    "paperclipGetProject",
+    "paperclipListAgents",
+    "paperclipGetAgent",
+    "paperclipListGoals",
+]
+
+INCLUDES_BY_SERVER = {
+    "sure": SURE_MAIN_INCLUDE,
+    "hass": HASS_MAIN_INCLUDE,
+    "paperclip": PAPERCLIP_MAIN_INCLUDE,
+}
+
+
+def _ensure_include(server_cfg, include_list) -> bool:
+    """Mutate `server_cfg` (a ruamel CommentedMap) to add tools.include.
+
+    Returns True if a change was made. Idempotent: an existing include list
+    is preserved verbatim.
+    """
+    tools_cfg = server_cfg.get("tools")
+    if tools_cfg is not None and tools_cfg.get("include"):
+        return False
+    if tools_cfg is None:
+        # Use ruamel's CommentedMap so we preserve YAML style downstream.
+        from ruamel.yaml.comments import CommentedMap, CommentedSeq
+
+        tools_cfg = CommentedMap()
+        server_cfg["tools"] = tools_cfg
+    from ruamel.yaml.comments import CommentedSeq
+
+    seq = CommentedSeq(include_list)
+    tools_cfg["include"] = seq
+    return True
+
+
+def _ensure_kanban_disabled(data) -> bool:
+    """Add `kanban.dispatch_in_gateway: false` IFF the operator hasn't chosen.
+
+    Preserves an explicit operator setting (True or False).
+    """
+    kanban = data.get("kanban")
+    if kanban is not None and "dispatch_in_gateway" in kanban:
+        return False
+    if kanban is None:
+        from ruamel.yaml.comments import CommentedMap
+
+        kanban = CommentedMap()
+        data["kanban"] = kanban
+    kanban["dispatch_in_gateway"] = False
+    return True
+
+
+def migrate_config(config_path: Path, profile: str) -> str:
+    """Apply the trim to `config_path`.
+
+    Returns a status string: {not-main, missing, applied, present, empty-mcp}.
+    """
+    if profile != "main":
+        return "not-main"
+    if not config_path.exists():
+        return "missing"
+
+    from ruamel.yaml import YAML
+
+    yaml = YAML()
+    yaml.preserve_quotes = True
+
+    text = config_path.read_text(encoding="utf-8")
+    data = yaml.load(text)
+    if not isinstance(data, dict):
+        return "empty-mcp"
+
+    mcp_servers = data.get("mcp_servers")
+    if not isinstance(mcp_servers, dict) or not mcp_servers:
+        return "empty-mcp"
+
+    changed_servers = []
+    for server_name, include_list in INCLUDES_BY_SERVER.items():
+        server_cfg = mcp_servers.get(server_name)
+        if not isinstance(server_cfg, dict):
+            continue
+        if _ensure_include(server_cfg, include_list):
+            changed_servers.append(f"{server_name}({len(include_list)})")
+
+    kanban_changed = _ensure_kanban_disabled(data)
+
+    if not changed_servers and not kanban_changed:
+        return "present"
+
+    with config_path.open("w", encoding="utf-8") as f:
+        yaml.dump(data, f)
+
+    bits = []
+    if changed_servers:
+        bits.append("include: " + ", ".join(changed_servers))
+    if kanban_changed:
+        bits.append("kanban.dispatch_in_gateway=false")
+    return "applied " + "; ".join(bits)
+
+
+def main() -> int:
+    profile = (sys.argv[1] if len(sys.argv) > 1 else "").strip().lower()
+    if not profile:
+        print(
+            "usage: migrate_main_profile_tool_trim.py <profile>\n"
+            "  env: PROFILE_DIR",
+            file=sys.stderr,
+        )
+        return 2
+
+    profile_dir = Path(
+        os.environ.get("PROFILE_DIR", f"/hermes-state/profiles/{profile}")
+    )
+    config = profile_dir / "config.yaml"
+
+    try:
+        outcome = migrate_config(config, profile)
+    except Exception as exc:
+        # Best-effort step; never abort init.
+        print(f"[main-tool-trim] WARN {config}: {exc}", file=sys.stderr)
+        return 0
+    print(f"[main-tool-trim] {config} ({profile}): {outcome}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/hermes/init/test_main_profile_tool_trim.py
+++ b/packages/hermes/init/test_main_profile_tool_trim.py
@@ -1,0 +1,329 @@
+"""Tests for migrate_main_profile_tool_trim.py + the template's parity.
+
+Covered:
+  * No-op on workers / heavy / codex-builder profiles.
+  * Idempotent: a second pass mutates nothing after the first.
+  * Preserves an operator's pre-existing tools.include.
+  * Preserves an operator's explicit kanban.dispatch_in_gateway (True or False).
+  * Preserves the operator's other edits (model:, agent:, gateway:, …) byte-stable.
+  * Inserts a fresh include block when none exists.
+  * Template + migration script stay in sync (same include lists).
+
+Run from repo root:
+  pytest packages/hermes/init/test_main_profile_tool_trim.py -v
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+from migrate_main_profile_tool_trim import (  # type: ignore[import-not-found]
+    HASS_MAIN_INCLUDE,
+    INCLUDES_BY_SERVER,
+    PAPERCLIP_MAIN_INCLUDE,
+    SURE_MAIN_INCLUDE,
+    migrate_config,
+)
+
+
+# A representative pre-trim config.yaml. Mirrors what
+# `hermes-config.yaml.njk` rendered for the `main` profile BEFORE issue
+# #175 — the same 9 mcp_servers but no `tools.include` keys, and no
+# `kanban` top-level block.
+_LEGACY_MAIN_CONFIG = """\
+# Hermes Agent configuration — profile: main
+model:
+  default: "x-ai/grok-4.3"
+  provider: "openrouter"
+  base_url: "https://openrouter.ai/api/v1"
+  max_tokens: 8192
+
+agent:
+  max_turns: 80
+  reasoning_effort: "medium"
+
+memory:
+  memory_enabled: true
+
+mcp_servers:
+  alfred-ctrl:
+    command: "node"
+    args: ["/opt/data/profiles/main/mcp/ctrl-server.mjs"]
+    env:
+      CTRL_API_URL: "http://ctrl-api:3100"
+    timeout: 120
+  alfred:
+    command: "node"
+    args: ["/opt/data/profiles/main/mcp-stdio/dist/bin/stdio-app.js", "alfred"]
+    timeout: 120
+  sure:
+    command: "node"
+    args: ["/opt/data/profiles/main/mcp-stdio/dist/bin/stdio-app.js", "sure"]
+    timeout: 120
+  plane:
+    command: "node"
+    args: ["/opt/data/profiles/main/mcp-stdio/dist/bin/stdio-app.js", "plane"]
+    timeout: 120
+  vaultwarden:
+    command: "node"
+    args: ["/opt/data/profiles/main/mcp-stdio/dist/bin/stdio-app.js", "vaultwarden"]
+    timeout: 120
+  execute:
+    command: "node"
+    args: ["/opt/data/profiles/main/mcp-stdio/dist/bin/stdio-app.js", "execute"]
+    timeout: 120
+  hass:
+    command: "node"
+    args: ["/opt/data/profiles/main/mcp-stdio/dist/bin/stdio-app.js", "hass"]
+    timeout: 120
+  paperclip:
+    command: "node"
+    args: ["/opt/paperclip-mcp/node_modules/@paperclipai/mcp-server/dist/stdio.js"]
+    timeout: 120
+  files:
+    command: "node"
+    args: ["/opt/data/profiles/main/mcp-stdio/dist/bin/stdio-app.js", "files"]
+    timeout: 120
+
+display:
+  compact: false
+"""
+
+
+@pytest.fixture
+def cfg_dir(tmp_path: Path) -> Path:
+    p = tmp_path / "config.yaml"
+    p.write_text(_LEGACY_MAIN_CONFIG, encoding="utf-8")
+    return p
+
+
+def _load(cfg: Path) -> dict:
+    return yaml.safe_load(cfg.read_text(encoding="utf-8"))
+
+
+def test_main_profile_inserts_three_include_blocks(cfg_dir: Path):
+    outcome = migrate_config(cfg_dir, profile="main")
+    assert outcome.startswith("applied"), outcome
+
+    cfg = _load(cfg_dir)
+    assert cfg["mcp_servers"]["sure"]["tools"]["include"] == SURE_MAIN_INCLUDE
+    assert cfg["mcp_servers"]["hass"]["tools"]["include"] == HASS_MAIN_INCLUDE
+    assert cfg["mcp_servers"]["paperclip"]["tools"]["include"] == PAPERCLIP_MAIN_INCLUDE
+
+
+def test_kanban_disabled_when_absent(cfg_dir: Path):
+    migrate_config(cfg_dir, profile="main")
+    cfg = _load(cfg_dir)
+    assert cfg["kanban"]["dispatch_in_gateway"] is False
+
+
+def test_idempotent_second_pass_is_present(cfg_dir: Path):
+    first = migrate_config(cfg_dir, profile="main")
+    assert first.startswith("applied")
+    second = migrate_config(cfg_dir, profile="main")
+    assert second == "present", second
+
+
+def test_no_op_on_workers(tmp_path: Path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(_LEGACY_MAIN_CONFIG, encoding="utf-8")
+    before = cfg.read_text(encoding="utf-8")
+    outcome = migrate_config(cfg, profile="workers")
+    assert outcome == "not-main"
+    # Bytes-identical — non-main is never touched.
+    assert cfg.read_text(encoding="utf-8") == before
+
+
+def test_no_op_on_heavy(tmp_path: Path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(_LEGACY_MAIN_CONFIG, encoding="utf-8")
+    before = cfg.read_text(encoding="utf-8")
+    outcome = migrate_config(cfg, profile="heavy")
+    assert outcome == "not-main"
+    assert cfg.read_text(encoding="utf-8") == before
+
+
+def test_no_op_on_codex_builder(tmp_path: Path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("mcp_servers: {}\nmodel:\n  provider: openai-codex\n", encoding="utf-8")
+    outcome = migrate_config(cfg, profile="codex-builder")
+    assert outcome == "not-main"
+
+
+def test_preserves_operator_include_block(tmp_path: Path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        _LEGACY_MAIN_CONFIG.replace(
+            "  sure:\n    command: \"node\"\n    args: [\"/opt/data/profiles/main/mcp-stdio/dist/bin/stdio-app.js\", \"sure\"]\n    timeout: 120",
+            "  sure:\n"
+            "    command: \"node\"\n"
+            "    args: [\"/opt/data/profiles/main/mcp-stdio/dist/bin/stdio-app.js\", \"sure\"]\n"
+            "    timeout: 120\n"
+            "    tools:\n"
+            "      include:\n"
+            "        - get_balance_sheet\n"
+            "        - list_accounts\n",
+        ),
+        encoding="utf-8",
+    )
+    migrate_config(cfg, profile="main")
+    cfg_data = _load(cfg)
+    # Operator's narrow include preserved — not overwritten by the wider trim list.
+    assert cfg_data["mcp_servers"]["sure"]["tools"]["include"] == [
+        "get_balance_sheet",
+        "list_accounts",
+    ]
+    # Other servers (hass / paperclip) still receive the trim defaults.
+    assert cfg_data["mcp_servers"]["hass"]["tools"]["include"] == HASS_MAIN_INCLUDE
+
+
+def test_preserves_explicit_kanban_true(tmp_path: Path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        _LEGACY_MAIN_CONFIG + "\nkanban:\n  dispatch_in_gateway: true\n",
+        encoding="utf-8",
+    )
+    migrate_config(cfg, profile="main")
+    assert _load(cfg)["kanban"]["dispatch_in_gateway"] is True
+
+
+def test_preserves_explicit_kanban_false(tmp_path: Path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        _LEGACY_MAIN_CONFIG + "\nkanban:\n  dispatch_in_gateway: false\n",
+        encoding="utf-8",
+    )
+    outcome = migrate_config(cfg, profile="main")
+    # No kanban change — but the 3 includes still get inserted.
+    assert "kanban" not in outcome
+    assert _load(cfg)["kanban"]["dispatch_in_gateway"] is False
+
+
+def test_preserves_other_top_level_keys(cfg_dir: Path):
+    """The model:, agent:, memory:, display: blocks survive."""
+    migrate_config(cfg_dir, profile="main")
+    cfg = _load(cfg_dir)
+    assert cfg["model"]["default"] == "x-ai/grok-4.3"
+    assert cfg["model"]["provider"] == "openrouter"
+    assert cfg["agent"]["max_turns"] == 80
+    assert cfg["memory"]["memory_enabled"] is True
+    assert cfg["display"]["compact"] is False
+
+
+def test_does_not_touch_unrelated_servers(cfg_dir: Path):
+    """alfred-ctrl/alfred/plane/vaultwarden/execute/files don't grow include."""
+    migrate_config(cfg_dir, profile="main")
+    cfg = _load(cfg_dir)
+    for server in ("alfred-ctrl", "alfred", "plane", "vaultwarden", "execute", "files"):
+        assert "tools" not in cfg["mcp_servers"][server], (
+            f"{server} should not have a tools.include block — left at full catalogue"
+        )
+
+
+def test_missing_config_returns_status(tmp_path: Path):
+    outcome = migrate_config(tmp_path / "absent.yaml", profile="main")
+    assert outcome == "missing"
+
+
+def test_empty_mcp_servers_returns_status(tmp_path: Path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("model:\n  default: foo\nmcp_servers: {}\n", encoding="utf-8")
+    outcome = migrate_config(cfg, profile="main")
+    assert outcome == "empty-mcp"
+
+
+# ---------------------------------------------------------------------------
+# Template + migration script parity (the "two sources of truth" trap)
+# ---------------------------------------------------------------------------
+
+
+def _read_template_include_lists() -> dict[str, list[str]]:
+    """Extract `tools.include` lists from the .njk template.
+
+    A minimal regex-based parser — the file is a Nunjucks template (not
+    parseable as plain YAML) but the include blocks live in flat YAML
+    sections we can locate by anchoring on the server name and walking
+    forward to the next server's `  <name>:` block boundary.
+
+    Jinja `{%- if/else/endif %}` markers do NOT terminate a server block
+    (they wrap optional content WITHIN one) — only the next column-2 YAML
+    key does.
+    """
+    tpl = (
+        Path(__file__).resolve().parent.parent / "hermes-config.yaml.njk"
+    ).read_text(encoding="utf-8")
+    out: dict[str, list[str]] = {}
+    for server in ("sure", "hass", "paperclip"):
+        m = re.search(rf"(?m)^  {server}:\n", tpl)
+        assert m, f"server {server!r} not found in template"
+        rest = tpl[m.end() :]
+        # Stop at the next column-2 YAML key (the next mcp_servers entry).
+        # Jinja {%- if %} boundaries don't terminate a server block —
+        # they wrap optional content WITHIN it.
+        stop = re.search(r"(?m)^  [a-z][a-z0-9-]*:\s*\n", rest)
+        block = rest[: stop.start() if stop else len(rest)]
+        if "include:" not in block:
+            continue
+        include_block = block[block.index("include:") :]
+        items = re.findall(
+            r"(?m)^        - ([A-Za-z_][A-Za-z0-9_]*)\s*$", include_block
+        )
+        if items:
+            out[server] = items
+    return out
+
+
+def test_template_includes_match_migration_lists():
+    """Template + migration script lists must stay in sync.
+
+    Adding a tool in one without the other is a stale divergence —
+    the fresh-tenant render and the existing-tenant migration would drift.
+    """
+    template_lists = _read_template_include_lists()
+    assert set(template_lists) == set(INCLUDES_BY_SERVER), (
+        f"Template / migration servers diverge: template={set(template_lists)}, "
+        f"migration={set(INCLUDES_BY_SERVER)}"
+    )
+    for server, tools_in_template in template_lists.items():
+        assert tools_in_template == INCLUDES_BY_SERVER[server], (
+            f"{server} include list drifted: "
+            f"template={tools_in_template} vs migration={INCLUDES_BY_SERVER[server]}"
+        )
+
+
+def test_template_carries_kanban_disabled():
+    """The fresh-tenant template must also emit kanban.dispatch_in_gateway=false."""
+    tpl = (
+        Path(__file__).resolve().parent.parent / "hermes-config.yaml.njk"
+    ).read_text(encoding="utf-8")
+    assert "dispatch_in_gateway: false" in tpl, (
+        "Template missing kanban.dispatch_in_gateway:false — fresh tenants will hit "
+        "the readonly-kanban-db log storm from issue #175"
+    )
+
+
+def test_main_profile_trim_under_100_tools_target():
+    """Sanity bound — the whole point of this trim is to stay under ~100 tools.
+
+    21 alfred + 14 vaultwarden + 11 plane + 9 files + 8 execute + 7 hermes +
+    2 alfred-ctrl + 23 sure + 28 hass + 18 paperclip ≈ 141 tools (full
+    catalogue is 321). If a future commit grows the trimmed list back past
+    this bound, that's a signal that we're sliding back into the bloat that
+    issue #175 caught.
+    """
+    total_main_only = (
+        len(SURE_MAIN_INCLUDE)
+        + len(HASS_MAIN_INCLUDE)
+        + len(PAPERCLIP_MAIN_INCLUDE)
+    )
+    # 23 + 28 + 18 = 69 in the three trimmed servers; adding 60 untrimmed
+    # tools (alfred + vaultwarden + plane + files + execute + hermes +
+    # alfred-ctrl) gives ~130 total. Set the bound at 80 for the trim
+    # contribution itself to leave headroom for the 28 hass + 18 paperclip
+    # additions a follow-up may want.
+    assert total_main_only <= 80, (
+        f"Trimmed allowlists grew to {total_main_only} tools — issue #175's bloat is creeping back"
+    )


### PR DESCRIPTION
Closes #175 layer §1.

## What this PR does

Trims the main-profile MCP tool catalogue from 321 inlined tools to 170 by adding `tools.include` whitelists to the three bloated MCP servers (sure: 95→23, hass: 85→28, paperclip: 40→18). Workers / heavy / codex-builder profiles are unchanged.

Hermes-native filter (`/usr/local/lib/python3.12/site-packages/tools/mcp_tool.py:2967-2974` in hermes-agent v2026.5.16) — no upstream patch.

## Live evidence

### Before (home.alfred.black, pre-PR):
```
session.tools_count: 321
namespaces: sure=97, hass=85, paperclip=40, alfred=30, _builtin=23,
            vaultwarden=16, plane=13, files=9, execute=8
"OK" reply: 3.4 s, 67 205 input tokens
```

### After (home.alfred.black, post-PR, live verified):
```
session.tools_count: 170
namespaces: sure=25, hass=28, paperclip=18, alfred=30, _builtin=23,
            vaultwarden=16, plane=13, files=9, execute=8
"OK" reply: 4.6 s, 42 986 input tokens   (-24 k tokens, -36 %)
```

## What this PR does NOT fix

The calendar query timeout the user reported is NOT solved by this PR alone. Full calendar cascade post-trim: still ~130 s. See issue #175 §2 + §3 for the other two layers:

* §2 — `/api/v1/integrations/execute` does `docker exec alfred-learn` on every call (~4-5 s each); a long-running sidecar or Composio HTTP from Node drops this to <500 ms.
* §3 — the LLM correctly fans out across the principal's 7 calendars; baking the primary calendar into the toolkit's auto-config DEFAULT_ARGS would collapse to one call.

This PR is the highest-leverage single change — every Hermes turn is now 36 % cheaper in input tokens — but the full <20 s calendar query target needs §2 + §3.

## Changes

| File | Change |
|---|---|
| `packages/hermes/hermes-config.yaml.njk` | `mcp_servers.{sure,hass,paperclip}.tools.include` on `is_main`; `kanban.dispatch_in_gateway: false` fleet-wide (drive-by — see drive-by below) |
| `packages/hermes/init/migrate_main_profile_tool_trim.py` | Idempotent ADD-only mutator for operator-owned config.yaml on existing tenants |
| `packages/hermes/init/test_main_profile_tool_trim.py` | 16 tests — no-op-on-non-main, idempotency, operator-preserve, template/migration list-parity |
| `packages/hermes/init/Dockerfile` | `COPY migrate_main_profile_tool_trim.py` |
| `packages/hermes/init/entrypoint.sh` | Hook migration into render loop |

## Drive-by fix

`kanban.dispatch_in_gateway: false` (template + migration). The kanban dispatcher was firing an `ERROR Traceback` every 5 seconds on home (`sqlite3.OperationalError: attempt to write a readonly database`) — the file is owner-perm-bound on hermes' user but the dispatcher polls regardless. Alfred Black doesn't use Hermes' kanban surface (work coordination is Paperclip + Plane), so disabling is safe. Silences the log storm that was masking real signals.

## Tests

```
$ pytest packages/hermes/init/test_main_profile_tool_trim.py -v
…
16 passed in 0.09s
```

The `test_template_includes_match_migration_lists` test parses the .njk template's `tools.include` blocks and asserts they match the migration script's lists — a future drift would fail CI.

## Operator path

* Fresh tenant: template seeds the include lists on first init.
* Existing tenant: next `docker compose up` cycle runs `entrypoint.sh → migrate_main_profile_tool_trim.py` against each profile's operator-owned config.yaml. Idempotent; safe to re-run.
* Operator opt-out: hand-edit the operator-owned config.yaml to set a deliberate `tools.include` (the migration preserves it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
