### PR TITLE
feat(ctrl,mcp,hermes): Phase B — runtime-flippable tool dispositions + delegate_to_focused_agent

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -172,6 +172,15 @@ services:
       # data is invisible to the rest of the stack. See the hermes service
       # volumes for the matching mount on the consumer side.
       - hermes_codex_work:/work
+      # Phase B — runtime-flippable tool dispositions. The init container's
+      # render_mcp_servers.py reads state.db.tool_disposition READ-ONLY to
+      # decide which MCP servers on main get `tools.include: []`. ctrl-api
+      # remains the SOLE writer; this mount is :ro so the init container
+      # can never accidentally write to the single-writer DB. On a fresh
+      # tenant the file doesn't yet exist — the mutator falls back to
+      # all-direct (matching the migration seed) so init never blocks on
+      # this signal.
+      - state_data:/ctrl-data:ro
     env_file:
       - .env
     environment:
@@ -180,6 +189,12 @@ services:
       # and the hermes runtime sees the same volume at the same path.
       - HERMES_DATA_DIR=/hermes-state
       - HERMES_RUNTIME_HOME=/hermes-state
+      # Phase B — path to ctrl-api's state.db for the disposition reader.
+      # The mount above lands the volume at /ctrl-data; the DB lives at
+      # /ctrl-data/alfred-state.db (matching ctrl-api's STATE_DB_PATH
+      # default of /state/alfred-state.db). Best-effort: render_mcp_servers
+      # gracefully degrades if the file or table is missing.
+      - STATE_DB_PATH=/ctrl-data/alfred-state.db
       # init step 9 seeds the sender allowlist + stages the Sure/owner email
       # files from OWNER_EMAIL. env_file already injects it, but pin it
       # explicitly so the canonical name is unambiguous at this boundary (C9).

--- a/packages/ctrl/src/api/routes/agents.ts
+++ b/packages/ctrl/src/api/routes/agents.ts
@@ -1,10 +1,12 @@
 import { spawn } from "node:child_process";
+import crypto from "node:crypto";
 import fs from "node:fs";
 import yaml from "js-yaml";
 import { addRoute } from "../server.js";
 import { sendJson, ValidationError } from "../errors.js";
 import { execAsync, dockerExec, dockerComposeCmd, HERMES_CMD, HERMES_CONTAINER } from "../helpers.js";
 import { resolveDeliveryTarget } from "../hermes-sessions.js";
+import { getStateDb } from "../../db/state.js";
 
 // alfred daemon config (the surveyor lives here, not in the Hermes config).
 const ALFRED_DATA_DIR = process.env.ALFRED_DATA_DIR ?? "/alfred-data";
@@ -166,6 +168,124 @@ async function getAgentModelStatus(agentDef: typeof AGENTS[number]): Promise<Rec
     providers,
     missingProviders,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Tool disposition (Phase B — runtime-flippable DIRECT vs DELEGATED per MCP
+// server). Source of truth: state.db.tool_disposition (migration 0014).
+//
+// Two reads + one mutator drive the surface:
+//   * GET  /api/v1/agents/tool-disposition         — dashboard + LLM "what's
+//                                                    current?" probe
+//   * POST /api/v1/agents/tool-disposition         — Sir/Alfred flip via the
+//                                                    dashboard toggle OR the
+//                                                    set_tool_disposition MCP
+//                                                    tool. Triggers a
+//                                                    debounced 10s Hermes
+//                                                    restart so a flurry of
+//                                                    flips coalesces into a
+//                                                    single profile reload.
+//   * POST /api/v1/agents/focused-subagent         — the `delegate_to_focused
+//                                                    _agent` MCP tool's
+//                                                    backing. Spawns a
+//                                                    workers-profile session
+//                                                    keyed by domain + hash,
+//                                                    loads the right skill,
+//                                                    returns plain-text.
+//
+// The 9 known servers mirror migration 0014's seed. Anything outside this
+// allowlist is rejected — "files" still needs to be added by migration before
+// it can be flipped, etc. ---------------------------------------------------
+const KNOWN_MCP_SERVERS = [
+  "alfred-ctrl",
+  "alfred",
+  "sure",
+  "plane",
+  "vaultwarden",
+  "execute",
+  "paperclip",
+  "hass",
+  "files",
+] as const;
+type KnownServer = (typeof KNOWN_MCP_SERVERS)[number];
+const KNOWN_SERVER_SET: ReadonlySet<string> = new Set(KNOWN_MCP_SERVERS);
+
+const VALID_DISPOSITIONS = ["direct", "delegated"] as const;
+type Disposition = (typeof VALID_DISPOSITIONS)[number];
+const VALID_DISPOSITION_SET: ReadonlySet<string> = new Set(VALID_DISPOSITIONS);
+
+const VALID_UPDATED_BY = ["sir", "alfred", "init"] as const;
+const VALID_UPDATED_BY_SET: ReadonlySet<string> = new Set(VALID_UPDATED_BY);
+
+// Debounce window for the Hermes restart triggered after a disposition flip.
+// A burst of flips inside this window coalesces into one `docker compose
+// restart hermes` invocation (pay the ~10s cost once, not N times).
+const HERMES_RESTART_DEBOUNCE_MS = 10_000;
+let _hermesRestartTimer: NodeJS.Timeout | null = null;
+
+/** Debounce coalesces flurries into one restart. Pulled out for test mocking. */
+function scheduleDebouncedHermesRestart(): void {
+  if (_hermesRestartTimer) clearTimeout(_hermesRestartTimer);
+  _hermesRestartTimer = setTimeout(() => {
+    _hermesRestartTimer = null;
+    dockerComposeCmd(["restart", HERMES_CONTAINER]).catch(() => {
+      // Best effort — operator can `docker compose restart hermes` manually
+      // if needed; the disposition row is already persisted.
+    });
+  }, HERMES_RESTART_DEBOUNCE_MS);
+  // unref so the timer doesn't keep the process alive on test teardown.
+  _hermesRestartTimer.unref?.();
+}
+
+/** Test hook: cancel any pending debounced restart. */
+export function _resetHermesRestartDebounceForTests(): void {
+  if (_hermesRestartTimer) {
+    clearTimeout(_hermesRestartTimer);
+    _hermesRestartTimer = null;
+  }
+}
+
+/** Test hook: is there a pending restart queued? */
+export function _hermesRestartPendingForTests(): boolean {
+  return _hermesRestartTimer !== null;
+}
+
+// Workers-profile gateway URL (focused-subagent target). The :18790 default
+// matches the compose-template binding (see render_hermes.py + helpers.ts's
+// HERMES_WORKERS_GATEWAY_URL fallback).
+const HERMES_WORKERS_GATEWAY_URL =
+  process.env.HERMES_WORKERS_GATEWAY_URL ?? "http://hermes:18790";
+
+/** Read API_SERVER_KEY for the workers profile out of its rendered .env.
+ *
+ *  Same key-resolution pattern as channels_paperclip.ts /
+ *  channels_ha.ts / hermes.ts — the /opt/alfred/.env's
+ *  HERMES_API_SERVER_KEY is a *seed* for first-boot; render_hermes.py
+ *  may regenerate per-profile keys, so the live key lives in
+ *  /hermes-state/profiles/workers/.env's API_SERVER_KEY. */
+function readWorkersApiKey(): string | null {
+  const envPath = `${HERMES_CONFIG_DIR}/workers/.env`;
+  let raw: string;
+  try {
+    raw = fs.readFileSync(envPath, "utf-8");
+  } catch {
+    return null;
+  }
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq < 0) continue;
+    if (trimmed.slice(0, eq).trim() === "API_SERVER_KEY") {
+      return trimmed.slice(eq + 1).trim();
+    }
+  }
+  return null;
+}
+
+/** Sanitise an arbitrary string into a session-key-safe slug. */
+function _domainSlug(domain: string): string {
+  return domain.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 32) || "any";
 }
 
 /** Get surveyor config from config.yaml. */
@@ -446,5 +566,231 @@ export function registerAgentRoutes(): void {
       const message = err instanceof Error ? err.message : String(err);
       sendJson(res, 500, { status: "error", error: message });
     }
+  });
+
+  // ─── Tool disposition (Phase B) ──────────────────────────────────────────
+  //
+  // GET  /api/v1/agents/tool-disposition           — list all dispositions
+  // POST /api/v1/agents/tool-disposition           — flip one server
+  // POST /api/v1/agents/focused-subagent           — delegate task to workers
+
+  addRoute("GET", "/api/v1/agents/tool-disposition", async ({ res }) => {
+    const db = getStateDb();
+    const rows = db
+      .prepare(
+        "SELECT server, disposition, updated_at, updated_by FROM tool_disposition ORDER BY server",
+      )
+      .all() as Array<{
+        server: string;
+        disposition: string;
+        updated_at: string;
+        updated_by: string | null;
+      }>;
+    sendJson(res, 200, { dispositions: rows });
+  });
+
+  addRoute("POST", "/api/v1/agents/tool-disposition", async ({ res, body }) => {
+    const b = body as Record<string, unknown> | undefined;
+    if (!b || typeof b.server !== "string") {
+      throw new ValidationError("`server` is required (string)");
+    }
+    if (typeof b.disposition !== "string") {
+      throw new ValidationError("`disposition` is required (string)");
+    }
+
+    const server = b.server as string;
+    const disposition = b.disposition as string;
+    const updatedBy = typeof b.updated_by === "string" ? (b.updated_by as string) : "alfred";
+
+    if (!KNOWN_SERVER_SET.has(server)) {
+      throw new ValidationError(
+        `Unknown server: ${server}. Known servers: ${[...KNOWN_MCP_SERVERS].join(", ")}`,
+      );
+    }
+    if (!VALID_DISPOSITION_SET.has(disposition)) {
+      throw new ValidationError(
+        `Invalid disposition: ${disposition}. Must be one of: ${[...VALID_DISPOSITIONS].join(", ")}`,
+      );
+    }
+    if (!VALID_UPDATED_BY_SET.has(updatedBy)) {
+      throw new ValidationError(
+        `Invalid updated_by: ${updatedBy}. Must be one of: ${[...VALID_UPDATED_BY].join(", ")}`,
+      );
+    }
+
+    const db = getStateDb();
+    const now = new Date().toISOString();
+    db.prepare(
+      `INSERT INTO tool_disposition (server, disposition, updated_at, updated_by)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(server) DO UPDATE SET
+         disposition = excluded.disposition,
+         updated_at  = excluded.updated_at,
+         updated_by  = excluded.updated_by`,
+    ).run(server, disposition as Disposition, now, updatedBy);
+
+    const row = db
+      .prepare(
+        "SELECT server, disposition, updated_at, updated_by FROM tool_disposition WHERE server = ?",
+      )
+      .get(server) as
+        | { server: string; disposition: string; updated_at: string; updated_by: string | null }
+        | undefined;
+
+    // Debounced Hermes restart — the disposition change only takes effect
+    // after init re-runs render_mcp_servers.py at boot, which is driven by
+    // the compose restart. Coalesce a flurry into one.
+    scheduleDebouncedHermesRestart();
+
+    sendJson(res, 200, {
+      ok: true,
+      row,
+      restart_scheduled: true,
+      restart_debounce_ms: HERMES_RESTART_DEBOUNCE_MS,
+    });
+  });
+
+  // POST /api/v1/agents/focused-subagent
+  //
+  // Spawn a short-lived focused subagent on the workers profile. Sister of
+  // the existing `dispatch_action_to_agent` in alfred-learn — but synchronous,
+  // and reachable from the LLM via the `delegate_to_focused_agent` MCP tool.
+  //
+  // Body:
+  //   task:    string  required — what the subagent should do (plain prose)
+  //   domain:  string  required — the tool surface label (sure / plane /
+  //                               vaultwarden / paperclip / hass / files /
+  //                               execute / alfred / alfred-ctrl OR a
+  //                               composio toolkit like googlecalendar /
+  //                               gmail / notion / linear / slack).
+  //   context: string  optional — 1-2 sentences from the parent turn.
+  //
+  // Returns plain-text body — the subagent's reply, intended to be relayed
+  // verbatim by the calling LLM.
+  addRoute("POST", "/api/v1/agents/focused-subagent", async ({ res, body }) => {
+    const b = body as Record<string, unknown> | undefined;
+    if (!b || typeof b.task !== "string" || !(b.task as string).trim()) {
+      throw new ValidationError("`task` is required (non-empty string)");
+    }
+    if (typeof b.domain !== "string" || !(b.domain as string).trim()) {
+      throw new ValidationError("`domain` is required (non-empty string)");
+    }
+    const task = (b.task as string).trim();
+    const domain = (b.domain as string).trim();
+    const context = typeof b.context === "string" ? (b.context as string).trim() : "";
+
+    // Session key shape: `focus-<sanitised-domain>-<short-hash>`
+    // Hash incorporates a UUID slice so two simultaneous delegations on the
+    // same domain don't share a session key (and the workers profile's
+    // per-session memory isn't accidentally polluted).
+    const slug = _domainSlug(domain);
+    const shortHash = crypto.randomBytes(4).toString("hex");
+    const sessionKey = `focus-${slug}-${shortHash}`;
+
+    // Skill directive — instructs the subagent to load the right skill for
+    // the domain (either a per-MCP-server skill like alfred-sure-skill or a
+    // composio toolkit skill). The workers profile resolves these from
+    // /hermes-state/profiles/workers/skills/ (rendered at init time).
+    const skillHint = `LOAD skill alfred-${slug}-skill.md OR alfred-composio-${slug}-skill.md if present; if neither exists, proceed with the workers-profile defaults.`;
+
+    const persona = [
+      "You are a focused subagent spawned by Alfred Black to handle ONE specific task.",
+      "Identity + memory: same as Alfred main, but this session is one-shot.",
+      "Reply in plain text — no JSON envelopes, no markdown decoration unless the answer truly needs it.",
+      "The calling agent will relay your reply VERBATIM. Be concise, direct, and accurate.",
+      skillHint,
+    ].join("\n");
+
+    const userMessage = context
+      ? `Context from the parent turn:\n${context}\n\nTask:\n${task}`
+      : `Task:\n${task}`;
+
+    const workersKey = readWorkersApiKey();
+    if (!workersKey) {
+      sendJson(res, 500, {
+        ok: false,
+        error: "HERMES_WORKERS_KEY_MISSING",
+        detail: `Hermes workers API key not found at ${HERMES_CONFIG_DIR}/workers/.env — has hermes-init run?`,
+      });
+      return;
+    }
+
+    const url = `${HERMES_WORKERS_GATEWAY_URL}/v1/responses`;
+    const init: RequestInit & { signal: AbortSignal } = {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${workersKey}`,
+        "X-Hermes-Session-Key": sessionKey,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        input: [
+          { role: "system", content: persona },
+          { role: "user", content: userMessage },
+        ],
+      }),
+      // 60s timeout — the subagent should complete within that for most
+      // tool-heavy fanouts.
+      signal: AbortSignal.timeout(60_000),
+    };
+
+    let resp: Response;
+    try {
+      resp = await fetch(url, init);
+    } catch (err: any) {
+      sendJson(res, 504, {
+        ok: false,
+        error: "HERMES_WORKERS_UNREACHABLE",
+        detail: String(err?.message ?? err).slice(0, 300),
+        session_key: sessionKey,
+      });
+      return;
+    }
+
+    const rawText = await resp.text();
+    if (!resp.ok) {
+      sendJson(res, resp.status === 401 ? 502 : resp.status, {
+        ok: false,
+        error: "HERMES_WORKERS_ERROR",
+        status: resp.status,
+        detail: rawText.slice(0, 500),
+        session_key: sessionKey,
+      });
+      return;
+    }
+
+    // Extract plain-text reply. Hermes /v1/responses returns an OpenAI-style
+    // envelope with `output` items; for a simple text reply the message body
+    // lives at output[].content[].text. Fall back to dumping the raw envelope
+    // if the shape is unfamiliar (better to surface SOMETHING than nothing).
+    let reply = "";
+    try {
+      const env = JSON.parse(rawText);
+      // shape 1 — Hermes-style envelope with output messages
+      if (Array.isArray(env?.output)) {
+        for (const item of env.output) {
+          if (Array.isArray(item?.content)) {
+            for (const part of item.content) {
+              if (typeof part?.text === "string") reply += part.text;
+            }
+          } else if (typeof item?.text === "string") {
+            reply += item.text;
+          }
+        }
+      }
+      // shape 2 — explicit top-level reply
+      if (!reply && typeof env?.reply === "string") reply = env.reply;
+      // shape 3 — explicit top-level text
+      if (!reply && typeof env?.text === "string") reply = env.text;
+    } catch {
+      reply = rawText;
+    }
+
+    sendJson(res, 200, {
+      ok: true,
+      reply: reply.trim() || "(subagent returned empty reply)",
+      session_key: sessionKey,
+      domain,
+    });
   });
 }

--- a/packages/ctrl/src/db/migrate.ts
+++ b/packages/ctrl/src/db/migrate.ts
@@ -27,6 +27,7 @@ import m0010 from "./migrations/0010_files_cold_archive.sql";
 import m0011 from "./migrations/0011_ha_tier4.sql";
 import m0012 from "./migrations/0012_ha_integration_ref_removed_at.sql";
 import m0013 from "./migrations/0013_recall_realtime.sql";
+import m0014 from "./migrations/0014_tool_disposition.sql";
 
 interface Migration {
   version: number;
@@ -49,6 +50,7 @@ const MIGRATIONS: Migration[] = [
   { version: 11, name: "ha_tier4",            sql: m0011 },
   { version: 12, name: "ha_integration_ref_removed_at", sql: m0012 },
   { version: 13, name: "recall_realtime",     sql: m0013 },
+  { version: 14, name: "tool_disposition",    sql: m0014 },
 ];
 
 /**

--- a/packages/ctrl/src/db/migrations/0014_tool_disposition.sql
+++ b/packages/ctrl/src/db/migrations/0014_tool_disposition.sql
@@ -1,0 +1,45 @@
+-- 0014_tool_disposition — runtime-flippable MCP-server tool disposition (Phase B).
+--
+-- Sir's "both tracks" architecture: every MCP server registered on the main
+-- profile gets a per-server disposition flag — DIRECT (LLM calls native
+-- tools) or DELEGATED (tools hidden on main, accessed via the new
+-- `delegate_to_focused_agent` MCP tool that fans out to a workers-profile
+-- focused subagent).
+--
+-- This table is the source of truth read by:
+--   * `packages/hermes/init/render_mcp_servers.py` at init time to decide
+--     whether each server's `tools.include` should be the full whitelist
+--     (DIRECT) or an empty array `[]` (DELEGATED — tools hidden but the
+--     server stays spawned so workers + heavy profiles still have access).
+--   * `packages/ctrl/src/api/routes/agents.ts` for the GET/POST
+--     /api/v1/agents/tool-disposition surface that powers both the
+--     dashboard toggle and the `set_tool_disposition` / `list_tool_dispositions`
+--     MCP tools.
+--
+-- Default seed: every known server lands as `direct` — initial deploy is
+-- behaviour-identical to today. Sir's the one who flips servers to
+-- `delegated` when he wants the token savings (and accepts the +3-5s
+-- delegation hop per tool use).
+--
+-- The PRIMARY KEY on `server` is deliberate: there's exactly one
+-- disposition per server. UPDATEs of the same server are upserts via
+-- INSERT ... ON CONFLICT in the route layer; this table never grows
+-- past the 9-row catalogue.
+
+CREATE TABLE IF NOT EXISTS tool_disposition (
+  server TEXT PRIMARY KEY,
+  disposition TEXT NOT NULL DEFAULT 'direct',
+  updated_at TEXT NOT NULL,
+  updated_by TEXT
+);
+
+INSERT OR IGNORE INTO tool_disposition (server, disposition, updated_at, updated_by) VALUES
+  ('alfred-ctrl', 'direct', CURRENT_TIMESTAMP, 'init'),
+  ('alfred',      'direct', CURRENT_TIMESTAMP, 'init'),
+  ('sure',        'direct', CURRENT_TIMESTAMP, 'init'),
+  ('plane',       'direct', CURRENT_TIMESTAMP, 'init'),
+  ('vaultwarden', 'direct', CURRENT_TIMESTAMP, 'init'),
+  ('execute',     'direct', CURRENT_TIMESTAMP, 'init'),
+  ('paperclip',   'direct', CURRENT_TIMESTAMP, 'init'),
+  ('hass',        'direct', CURRENT_TIMESTAMP, 'init'),
+  ('files',       'direct', CURRENT_TIMESTAMP, 'init');

--- a/packages/ctrl/tests/agents_focused_subagent.test.ts
+++ b/packages/ctrl/tests/agents_focused_subagent.test.ts
@@ -1,0 +1,241 @@
+// POST /api/v1/agents/focused-subagent — the backing for the
+// delegate_to_focused_agent MCP tool (Phase B).
+//
+// What's under test:
+//   * Validation: task + domain required, both non-empty.
+//   * Workers .env discovery: writes a fake .env into a temp HERMES_CONFIG_DIR
+//     before importing the route module, then asserts the route reads
+//     API_SERVER_KEY from there and pipes it through to fetch.
+//   * Session-key shape: `focus-<sanitised-domain>-<8-hex-chars>`.
+//   * Skill directive lands in the system message: `LOAD skill
+//     alfred-<domain>-skill.md OR alfred-composio-<domain>-skill.md`.
+//   * Hermes :18790/v1/responses is the actual target URL.
+//   * Plain-text reply extraction from the Hermes-style envelope.
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ServerResponse } from "node:http";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "agents-focused-"));
+const hermesConfigDir = path.join(tmp, "hermes-state", "profiles");
+fs.mkdirSync(path.join(hermesConfigDir, "workers"), { recursive: true });
+fs.writeFileSync(
+  path.join(hermesConfigDir, "workers", ".env"),
+  "API_SERVER_KEY=test-workers-key-43chars-xxxxxxxxxxxxxxx\nOTHER=ignored\n",
+);
+
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.STATE_DB_PATH = path.join(tmp, "alfred-state.db");
+process.env.VAULT_PATH = path.join(tmp, "vault");
+process.env.SQLITE_VEC_PATH = "";
+process.env.HERMES_HOME = path.join(tmp, "hermes-state");
+process.env.HERMES_CONFIG_DIR = hermesConfigDir;
+process.env.HERMES_WORKERS_GATEWAY_URL = "http://hermes-test:18790";
+
+const realFetch = globalThis.fetch;
+let lastFetchCall: { url: string; init: any } | null = null;
+let nextFetchResponse: { status: number; body: string } = {
+  status: 200,
+  body: JSON.stringify({
+    output: [
+      {
+        content: [{ text: "The subagent ran the task and replied verbatim." }],
+      },
+    ],
+  }),
+};
+
+globalThis.fetch = (async (url: any, init?: any) => {
+  lastFetchCall = { url: String(url), init };
+  return new Response(nextFetchResponse.body, {
+    status: nextFetchResponse.status,
+    headers: { "content-type": "application/json" },
+  });
+}) as typeof globalThis.fetch;
+
+const { matchRoute } = await import("../src/api/server.js");
+const { handleError } = await import("../src/api/errors.js");
+const {
+  registerAgentRoutes,
+  _resetHermesRestartDebounceForTests,
+} = await import("../src/api/routes/agents.js");
+const { getStateDb } = await import("../src/db/state.js");
+
+registerAgentRoutes();
+getStateDb(); // run migrations
+
+after(() => {
+  _resetHermesRestartDebounceForTests();
+  globalThis.fetch = realFetch;
+  try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+interface InvokeOpts { body?: unknown; }
+
+async function invokeRoute(
+  method: string,
+  p: string,
+  opts: InvokeOpts = {},
+): Promise<{ status: number; payload: any }> {
+  const m = matchRoute(method, p);
+  assert.ok(m, `${method} ${p} must be registered`);
+  let status = 0;
+  let payload: any;
+  const res = {
+    setHeader() {},
+    writeHead(c: number) { status = c; return res; },
+    end(j?: string) { payload = j ? JSON.parse(j) : undefined; },
+  } as unknown as ServerResponse;
+  try {
+    await m!.handler({
+      req: { method, url: p, headers: {}, socket: { remoteAddress: "10.0.0.42" } } as any,
+      res,
+      params: m!.params,
+      body: opts.body,
+      query: new URLSearchParams(""),
+    });
+  } catch (err) {
+    handleError(res, err);
+  }
+  return { status, payload };
+}
+
+describe("POST /api/v1/agents/focused-subagent — validation", () => {
+  it("rejects missing task", async () => {
+    const r = await invokeRoute("POST", "/api/v1/agents/focused-subagent", {
+      body: { domain: "sure" },
+    });
+    assert.equal(r.status, 400);
+    assert.ok(String(r.payload.error?.message ?? "").includes("task"));
+  });
+
+  it("rejects empty task", async () => {
+    const r = await invokeRoute("POST", "/api/v1/agents/focused-subagent", {
+      body: { task: "   ", domain: "sure" },
+    });
+    assert.equal(r.status, 400);
+  });
+
+  it("rejects missing domain", async () => {
+    const r = await invokeRoute("POST", "/api/v1/agents/focused-subagent", {
+      body: { task: "List my checking balance" },
+    });
+    assert.equal(r.status, 400);
+    assert.ok(String(r.payload.error?.message ?? "").includes("domain"));
+  });
+});
+
+describe("POST /api/v1/agents/focused-subagent — happy path", () => {
+  it("posts to Hermes workers :18790 with bearer + session-key header", async () => {
+    lastFetchCall = null;
+    const r = await invokeRoute("POST", "/api/v1/agents/focused-subagent", {
+      body: { task: "What's my checking balance?", domain: "sure" },
+    });
+    assert.equal(r.status, 200);
+    assert.ok(lastFetchCall, "fetch must have been called");
+    assert.equal(
+      lastFetchCall!.url,
+      "http://hermes-test:18790/v1/responses",
+      "URL must be workers /v1/responses",
+    );
+    const headers = lastFetchCall!.init.headers as Record<string, string>;
+    assert.equal(
+      headers["Authorization"],
+      "Bearer test-workers-key-43chars-xxxxxxxxxxxxxxx",
+      "Bearer must be the workers .env API_SERVER_KEY",
+    );
+    assert.ok(
+      typeof headers["X-Hermes-Session-Key"] === "string",
+      "X-Hermes-Session-Key header must be present",
+    );
+  });
+
+  it("session key has shape `focus-<domain-slug>-<8-hex>`", async () => {
+    lastFetchCall = null;
+    await invokeRoute("POST", "/api/v1/agents/focused-subagent", {
+      body: { task: "List events tomorrow", domain: "googlecalendar" },
+    });
+    const headers = lastFetchCall!.init.headers as Record<string, string>;
+    const key = headers["X-Hermes-Session-Key"];
+    // 8 hex chars (crypto.randomBytes(4).toString('hex')) at the tail; the
+    // middle slug is the sanitised domain.
+    assert.match(key, /^focus-googlecalendar-[a-f0-9]{8}$/);
+  });
+
+  it("sanitises hostile domain characters in the session key", async () => {
+    lastFetchCall = null;
+    await invokeRoute("POST", "/api/v1/agents/focused-subagent", {
+      body: { task: "task", domain: "../etc/passwd" },
+    });
+    const headers = lastFetchCall!.init.headers as Record<string, string>;
+    const key = headers["X-Hermes-Session-Key"];
+    // Slashes + dots collapsed to underscores; no path traversal in the key.
+    assert.doesNotMatch(key, /[./]/);
+    assert.match(key, /^focus-_+etc_passwd-[a-f0-9]{8}$/);
+  });
+
+  it("body carries the LOAD skill directive for the domain", async () => {
+    lastFetchCall = null;
+    await invokeRoute("POST", "/api/v1/agents/focused-subagent", {
+      body: { task: "any task", domain: "paperclip" },
+    });
+    const body = JSON.parse(lastFetchCall!.init.body);
+    const sys = body.input.find((m: any) => m.role === "system");
+    assert.ok(
+      String(sys.content).includes(
+        "LOAD skill alfred-paperclip-skill.md OR alfred-composio-paperclip-skill.md",
+      ),
+      "skill directive must mention both per-MCP-server and composio toolkit skill paths",
+    );
+  });
+
+  it("user content includes task + context when context supplied", async () => {
+    lastFetchCall = null;
+    await invokeRoute("POST", "/api/v1/agents/focused-subagent", {
+      body: {
+        task: "Pull tomorrow's events",
+        domain: "googlecalendar",
+        context: "Sir's primary calendar id is abc-123.",
+      },
+    });
+    const body = JSON.parse(lastFetchCall!.init.body);
+    const usr = body.input.find((m: any) => m.role === "user");
+    assert.ok(usr.content.includes("Pull tomorrow's events"));
+    assert.ok(usr.content.includes("Sir's primary calendar id is abc-123."));
+  });
+
+  it("extracts plain-text reply from Hermes envelope", async () => {
+    nextFetchResponse = {
+      status: 200,
+      body: JSON.stringify({
+        output: [{ content: [{ text: "Your balance is $4,231." }] }],
+      }),
+    };
+    const r = await invokeRoute("POST", "/api/v1/agents/focused-subagent", {
+      body: { task: "balance?", domain: "sure" },
+    });
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.ok, true);
+    assert.equal(r.payload.reply, "Your balance is $4,231.");
+    assert.equal(r.payload.domain, "sure");
+    assert.match(r.payload.session_key, /^focus-sure-[a-f0-9]{8}$/);
+  });
+
+  it("surfaces 502 when the workers gateway returns non-2xx", async () => {
+    nextFetchResponse = { status: 500, body: "internal explosion" };
+    const r = await invokeRoute("POST", "/api/v1/agents/focused-subagent", {
+      body: { task: "task", domain: "sure" },
+    });
+    assert.equal(r.status, 500);
+    assert.equal(r.payload.ok, false);
+    assert.equal(r.payload.error, "HERMES_WORKERS_ERROR");
+    // Reset for the next test (mutable shared state).
+    nextFetchResponse = {
+      status: 200,
+      body: JSON.stringify({ output: [{ content: [{ text: "ok" }] }] }),
+    };
+  });
+});

--- a/packages/ctrl/tests/agents_tool_disposition.test.ts
+++ b/packages/ctrl/tests/agents_tool_disposition.test.ts
@@ -1,0 +1,273 @@
+// Tool disposition routes — GET/POST /api/v1/agents/tool-disposition (Phase B).
+//
+// What's under test:
+//   * GET round-trips the migration-0014 seed (9 rows, all 'direct').
+//   * POST validates server + disposition + updated_by enums.
+//   * POST upserts and writes a fresh updated_at.
+//   * The debounced Hermes restart is scheduled exactly once per flurry of
+//     flips inside the window.
+//
+// We exercise the routes through matchRoute (same pattern as
+// channels_tokens.test.ts) — no need to spin up the http listener for these
+// tests. The Hermes restart is verified via the test hooks
+// _resetHermesRestartDebounceForTests + _hermesRestartPendingForTests
+// exported from the agents route module (we never actually invoke
+// docker compose in unit tests; the debounce timer just sits pending).
+
+import { describe, it, before, beforeEach, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ServerResponse } from "node:http";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "agents-disposition-"));
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.STATE_DB_PATH = path.join(tmp, "alfred-state.db");
+process.env.VAULT_PATH = path.join(tmp, "vault");
+process.env.SQLITE_VEC_PATH = "";
+
+const { getStateDb } = await import("../src/db/state.js");
+const { matchRoute } = await import("../src/api/server.js");
+const { handleError } = await import("../src/api/errors.js");
+const {
+  registerAgentRoutes,
+  _resetHermesRestartDebounceForTests,
+  _hermesRestartPendingForTests,
+} = await import("../src/api/routes/agents.js");
+
+registerAgentRoutes();
+
+interface InvokeOpts {
+  body?: unknown;
+  query?: string;
+  params?: Record<string, string>;
+  headers?: Record<string, string>;
+}
+
+async function invokeRoute(
+  method: string,
+  p: string,
+  opts: InvokeOpts = {},
+): Promise<{ status: number; payload: any }> {
+  const pathOnly = p.split("?")[0];
+  const m = matchRoute(method, pathOnly);
+  assert.ok(m, `${method} ${pathOnly} must be registered`);
+  let status = 0;
+  let payload: any;
+  const res = {
+    setHeader() {},
+    writeHead(c: number) {
+      status = c;
+      return res;
+    },
+    end(j?: string) {
+      payload = j ? JSON.parse(j) : undefined;
+    },
+  } as unknown as ServerResponse;
+  try {
+    await m!.handler({
+      req: {
+        method,
+        url: p,
+        headers: opts.headers ?? {},
+        socket: { remoteAddress: "10.0.0.42" },
+      } as any,
+      res,
+      params: opts.params ?? m!.params,
+      body: opts.body,
+      query: new URLSearchParams(opts.query ?? ""),
+    });
+  } catch (err) {
+    handleError(res, err);
+  }
+  return { status, payload };
+}
+
+function resetDispositions(): void {
+  // Reset to migration-0014 seed values so each test starts from the same
+  // baseline.
+  const db = getStateDb();
+  db.exec("DELETE FROM tool_disposition");
+  const stmt = db.prepare(
+    `INSERT INTO tool_disposition (server, disposition, updated_at, updated_by)
+     VALUES (?, 'direct', ?, 'init')`,
+  );
+  const seed = [
+    "alfred-ctrl", "alfred", "sure", "plane", "vaultwarden",
+    "execute", "paperclip", "hass", "files",
+  ];
+  const now = new Date().toISOString();
+  for (const s of seed) stmt.run(s, now);
+}
+
+before(() => {
+  // getStateDb() runs migrations — including 0014 — on first call.
+  getStateDb();
+});
+
+after(() => {
+  _resetHermesRestartDebounceForTests();
+  try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+beforeEach(() => {
+  _resetHermesRestartDebounceForTests();
+  resetDispositions();
+});
+
+describe("GET /api/v1/agents/tool-disposition", () => {
+  it("returns all 9 seeded dispositions, all 'direct'", async () => {
+    const { status, payload } = await invokeRoute(
+      "GET",
+      "/api/v1/agents/tool-disposition",
+    );
+    assert.equal(status, 200);
+    assert.ok(Array.isArray(payload.dispositions));
+    assert.equal(payload.dispositions.length, 9);
+    const servers = payload.dispositions.map((d: any) => d.server).sort();
+    assert.deepEqual(servers, [
+      "alfred", "alfred-ctrl", "execute", "files", "hass",
+      "paperclip", "plane", "sure", "vaultwarden",
+    ]);
+    for (const d of payload.dispositions) {
+      assert.equal(d.disposition, "direct");
+      assert.ok(typeof d.updated_at === "string" && d.updated_at.length > 0);
+    }
+  });
+});
+
+describe("POST /api/v1/agents/tool-disposition", () => {
+  it("flips sure to delegated, persists, returns updated row", async () => {
+    const { status, payload } = await invokeRoute(
+      "POST",
+      "/api/v1/agents/tool-disposition",
+      {
+        body: { server: "sure", disposition: "delegated", updated_by: "alfred" },
+      },
+    );
+    assert.equal(status, 200);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.row.server, "sure");
+    assert.equal(payload.row.disposition, "delegated");
+    assert.equal(payload.row.updated_by, "alfred");
+
+    // Verify the GET surface sees the change.
+    const list = await invokeRoute("GET", "/api/v1/agents/tool-disposition");
+    const sure = list.payload.dispositions.find((d: any) => d.server === "sure");
+    assert.equal(sure.disposition, "delegated");
+  });
+
+  it("rejects unknown server with 400 + suggestion", async () => {
+    const { status, payload } = await invokeRoute(
+      "POST",
+      "/api/v1/agents/tool-disposition",
+      { body: { server: "ghost-server", disposition: "delegated" } },
+    );
+    assert.equal(status, 400);
+    assert.ok(String(payload.error?.message ?? "").includes("Unknown server"));
+  });
+
+  it("rejects invalid disposition value", async () => {
+    const { status, payload } = await invokeRoute(
+      "POST",
+      "/api/v1/agents/tool-disposition",
+      { body: { server: "sure", disposition: "stealthy" } },
+    );
+    assert.equal(status, 400);
+    assert.ok(String(payload.error?.message ?? "").includes("Invalid disposition"));
+  });
+
+  it("rejects invalid updated_by value", async () => {
+    const { status, payload } = await invokeRoute(
+      "POST",
+      "/api/v1/agents/tool-disposition",
+      {
+        body: {
+          server: "sure",
+          disposition: "delegated",
+          updated_by: "anonymous",
+        },
+      },
+    );
+    assert.equal(status, 400);
+    assert.ok(String(payload.error?.message ?? "").includes("Invalid updated_by"));
+  });
+
+  it("rejects missing required fields", async () => {
+    const r1 = await invokeRoute(
+      "POST",
+      "/api/v1/agents/tool-disposition",
+      { body: { disposition: "direct" } },
+    );
+    assert.equal(r1.status, 400);
+    const r2 = await invokeRoute(
+      "POST",
+      "/api/v1/agents/tool-disposition",
+      { body: { server: "sure" } },
+    );
+    assert.equal(r2.status, 400);
+  });
+
+  it("upserts: second flip of same server overwrites the row", async () => {
+    await invokeRoute(
+      "POST",
+      "/api/v1/agents/tool-disposition",
+      { body: { server: "paperclip", disposition: "delegated", updated_by: "sir" } },
+    );
+    await invokeRoute(
+      "POST",
+      "/api/v1/agents/tool-disposition",
+      { body: { server: "paperclip", disposition: "direct", updated_by: "alfred" } },
+    );
+    const list = await invokeRoute("GET", "/api/v1/agents/tool-disposition");
+    const pc = list.payload.dispositions.find((d: any) => d.server === "paperclip");
+    assert.equal(pc.disposition, "direct");
+    assert.equal(pc.updated_by, "alfred");
+    // Table size unchanged — upsert, not insert.
+    assert.equal(list.payload.dispositions.length, 9);
+  });
+});
+
+describe("Hermes restart debounce", () => {
+  it("a single flip schedules a pending restart", async () => {
+    assert.equal(_hermesRestartPendingForTests(), false);
+    await invokeRoute(
+      "POST",
+      "/api/v1/agents/tool-disposition",
+      { body: { server: "sure", disposition: "delegated" } },
+    );
+    assert.equal(_hermesRestartPendingForTests(), true);
+  });
+
+  it("three flips inside the window coalesce into one pending restart", async () => {
+    await invokeRoute(
+      "POST",
+      "/api/v1/agents/tool-disposition",
+      { body: { server: "sure", disposition: "delegated" } },
+    );
+    await invokeRoute(
+      "POST",
+      "/api/v1/agents/tool-disposition",
+      { body: { server: "plane", disposition: "delegated" } },
+    );
+    await invokeRoute(
+      "POST",
+      "/api/v1/agents/tool-disposition",
+      { body: { server: "paperclip", disposition: "delegated" } },
+    );
+    // Still exactly one pending timer — the second + third flips reset it
+    // rather than queuing additional restarts.
+    assert.equal(_hermesRestartPendingForTests(), true);
+  });
+
+  it("response advertises the debounce window", async () => {
+    const { payload } = await invokeRoute(
+      "POST",
+      "/api/v1/agents/tool-disposition",
+      { body: { server: "sure", disposition: "delegated" } },
+    );
+    assert.equal(payload.restart_scheduled, true);
+    assert.equal(payload.restart_debounce_ms, 10_000);
+  });
+});

--- a/packages/ctrl/tests/alfred-journal.test.ts
+++ b/packages/ctrl/tests/alfred-journal.test.ts
@@ -52,15 +52,15 @@ function tableNames(db: DatabaseSync): string[] {
 describe("alfred_journal migration", () => {
   it("bumps user_version to the latest migration", () => {
     // The runner applies every migration > current version, so the value
-    // naturally tracks the highest registered version. Today: 13
+    // naturally tracks the highest registered version. Today: 14
     // (0001 fix_pack + 0002 alfred_journal + 0003 tailscale_connection
     // + 0004 channel_tokens + 0005 ha_channel + 0006 files_table
     // + 0007 recall + 0008 ha_event_subscription
     // + 0009 ha_registry_vanished + 0010 files_cold_archive
     // + 0011 ha_tier4 + 0012 ha_integration_ref_removed_at
-    // + 0013 recall_realtime).
+    // + 0013 recall_realtime + 0014 tool_disposition).
     const db = makeDb();
-    assert.equal(userVersion(db), 13);
+    assert.equal(userVersion(db), 14);
     db.close();
   });
 

--- a/packages/ctrl/tests/migrate.test.ts
+++ b/packages/ctrl/tests/migrate.test.ts
@@ -36,15 +36,15 @@ describe("state.db migration runner", () => {
     const db = new DatabaseSync(":memory:");
     db.exec(schema);
     const v = runMigrations(db);
-    // Latest version moves as new migrations land. Today: 13
+    // Latest version moves as new migrations land. Today: 14
     // (0001_fix_pack + 0002_alfred_journal + 0003_tailscale_connection
     // + 0004_channel_tokens + 0005_ha_channel + 0006_files_table
     // + 0007_recall + 0008_ha_event_subscription
     // + 0009_ha_registry_vanished + 0010_files_cold_archive
     // + 0011_ha_tier4 + 0012_ha_integration_ref_removed_at
-    // + 0013_recall_realtime).
-    assert.equal(v, 13, "migrated to latest version");
-    assert.equal(userVersion(db), 13);
+    // + 0013_recall_realtime + 0014_tool_disposition).
+    assert.equal(v, 14, "migrated to latest version");
+    assert.equal(userVersion(db), 14);
     assert.ok(cols(db, "observation").includes("processed_at"), "0001: processed_at present after migrate");
     // 0002: alfred_journal + alfred_principal tables present.
     const tables = (
@@ -254,7 +254,7 @@ describe("state.db migration runner", () => {
     db.exec(schema);
     runMigrations(db);
     const v2 = runMigrations(db);
-    assert.equal(v2, 13);
+    assert.equal(v2, 14);
     assert.equal(
       cols(db, "observation").filter((c) => c === "processed_at").length,
       1,

--- a/packages/hermes/init/entrypoint.sh
+++ b/packages/hermes/init/entrypoint.sh
@@ -522,6 +522,7 @@ for profile in "${PROFILES_RENDERED[@]}"; do
         PROFILE_DIR="$INIT_PROFILE_DIR" \
         HERMES_RUNTIME_PROFILE_DIR="$RUNTIME_PROFILE_DIR" \
         CTRL_API_URL="${CTRL_API_URL:-http://ctrl-api:3100}" \
+        STATE_DB_PATH="${STATE_DB_PATH:-/ctrl-data/alfred-state.db}" \
             python3 /setup/render_mcp_servers.py "$profile" \
             || echo "[init] WARN: render_mcp_servers.py failed for $profile (non-fatal)"
     fi

--- a/packages/hermes/init/render_mcp_servers.py
+++ b/packages/hermes/init/render_mcp_servers.py
@@ -48,6 +48,7 @@ template shape no matter when the tenant was provisioned.
 
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 from typing import Iterable, Literal
 
@@ -116,6 +117,91 @@ _REQUIRED_MCP_SERVERS: dict[str, list[tuple[str, dict]]] = {
 _SEALED_PROFILES: frozenset[str] = frozenset({"codex-builder"})
 
 
+# -----------------------------------------------------------------------------
+# Phase B: runtime-flippable DIRECT vs DELEGATED disposition per MCP server.
+#
+# Source of truth is state.db.tool_disposition (migration 0014). The dispositions
+# only affect the MAIN profile's `tools.include` block:
+#
+#   * disposition='direct'      → leave tools.include alone (operator-owned
+#                                  whitelists from PR #176 are preserved).
+#   * disposition='delegated'   → set tools.include: [] for that server. The
+#                                  server stays spawned (the LLM can still
+#                                  reach it via delegate_to_focused_agent on
+#                                  the workers profile), but its tools are
+#                                  invisible to main's catalogue.
+#
+# Workers + heavy + codex-builder are unaffected — the disposition flag is a
+# main-only knob. -------------------------------------------------------------
+def _read_dispositions(state_db_path: Path) -> dict[str, str]:
+    """Read tool_disposition rows from state.db. Returns {server: disposition}.
+    Missing file / missing table → empty dict (fresh-tenant fallback: every
+    server is treated as 'direct', matching the migration seed)."""
+    if not state_db_path.exists():
+        return {}
+    # READ-ONLY connection (`mode=ro`) so the init container never accidentally
+    # writes to ctrl-api's single-writer DB. The mutator is a renderer, not an
+    # updater.
+    try:
+        uri = f"file:{state_db_path}?mode=ro"
+        conn = sqlite3.connect(uri, uri=True, timeout=2.0)
+        try:
+            cur = conn.execute(
+                "SELECT server, disposition FROM tool_disposition"
+            )
+            return {row[0]: row[1] for row in cur.fetchall()}
+        finally:
+            conn.close()
+    except sqlite3.OperationalError:
+        # Table doesn't exist yet (state.db predates migration 0014) — same
+        # fallback as "no file": every server defaults to direct.
+        return {}
+    except Exception:
+        # Any other SQLite hiccup: treat as no data; init must not abort.
+        return {}
+
+
+def _apply_dispositions_to_main(
+    mcp_servers: dict,
+    dispositions: dict[str, str],
+) -> bool:
+    """For each server in `dispositions` with disposition='delegated', set
+    `tools.include: []` on its config block (main profile only — callers gate
+    this). Returns True if any block was mutated.
+
+    Preserves operator-owned blocks: if a server is set to `null` (disabled
+    by operator) we skip it. If a server is a customised dict, we set
+    `tools.include: []` on it (the delegate flag wins over whitelist-based
+    customisation — the operator can always promote-to-direct via the
+    dashboard if they want their custom whitelist back).
+    """
+    mutated = False
+    for server, disposition in dispositions.items():
+        if server not in mcp_servers:
+            continue
+        block = mcp_servers[server]
+        if block is None:
+            # Operator-disabled — respect it.
+            continue
+        if not isinstance(block, dict):
+            continue
+
+        if disposition == "delegated":
+            tools = block.get("tools") if isinstance(block.get("tools"), dict) else {}
+            # Round-trip-friendly: only mutate if the current state isn't
+            # already `tools.include: []`. Avoids needless writes.
+            current_include = tools.get("include") if tools else None
+            if current_include == [] or (isinstance(current_include, list) and len(current_include) == 0):
+                continue
+            if not isinstance(block.get("tools"), dict):
+                block["tools"] = {}
+            block["tools"]["include"] = []
+            mutated = True
+        # disposition='direct' → no mutation. The operator-owned tools.include
+        # whitelist (or absence thereof) wins.
+    return mutated
+
+
 def _substitute(value: str, *, mcp_stdio_dir: str, ctrl_api_url: str) -> str:
     """Substitute the two whitelisted placeholders in a template string.
 
@@ -173,6 +259,7 @@ def ensure_mcp_servers(
     profile: str,
     mcp_stdio_dir: str,
     ctrl_api_url: str,
+    state_db_path: Path | None = None,
 ) -> Literal["added", "present", "no-config", "sealed", "unknown-profile", "empty-mcp"]:
     """Idempotently add required `mcp_servers` entries to ``config_path``.
 
@@ -181,12 +268,23 @@ def ensure_mcp_servers(
       "sealed"          — codex-builder; mcp_servers stays {} (no-op)
       "unknown-profile" — profile has no required-server allowlist
       "empty-mcp"       — operator set `mcp_servers: {}` deliberately; preserved
-      "present"         — all required servers already in the config
-      "added"           — at least one missing entry was inserted
+      "present"         — all required servers already in the config (incl.
+                          disposition-derived `tools.include: []` already
+                          where it should be)
+      "added"           — at least one missing entry was inserted OR a
+                          disposition flip required mutating an existing
+                          server's tools.include block
 
-    ADD-only: an existing entry under any of the required names is
-    preserved verbatim (operator-owned, may be a hand-customised block
-    or even an explicit `null` to disable). The mutator never overwrites.
+    ADD-only for the server set: an existing entry under any of the required
+    names is preserved verbatim (operator-owned, may be a hand-customised
+    block or even an explicit `null` to disable). The mutator never deletes.
+
+    Phase B: disposition-driven `tools.include` mutation runs on the MAIN
+    profile only — when state_db_path is provided and the disposition table
+    is populated. A server with disposition='delegated' gets `tools.include:
+    []` lands on its block (whether the block was just-grafted or was
+    already operator-owned). Workers/heavy/codex-builder profiles are
+    untouched by this layer.
     """
     if not config_path.exists():
         return "no-config"
@@ -195,7 +293,7 @@ def ensure_mcp_servers(
         return "sealed"
 
     required = _REQUIRED_MCP_SERVERS.get(profile)
-    if not required:
+    if required is None:
         return "unknown-profile"
 
     from ruamel.yaml import YAML
@@ -237,7 +335,16 @@ def ensure_mcp_servers(
         )
         added_any = True
 
-    if not added_any:
+    # Phase B: apply DELEGATED disposition to main profile's mcp_servers.
+    # Workers/heavy stay full-catalogue — the focused-subagent path needs
+    # them. codex-builder was sealed above so never lands here.
+    disposition_mutated = False
+    if profile == "main" and state_db_path is not None:
+        dispositions = _read_dispositions(state_db_path)
+        if dispositions:
+            disposition_mutated = _apply_dispositions_to_main(mcp_servers, dispositions)
+
+    if not added_any and not disposition_mutated:
         return "present"
 
     with config_path.open("w", encoding="utf-8") as f:
@@ -275,12 +382,24 @@ if __name__ == "__main__":
 
     ctrl_api_url = os.environ.get("CTRL_API_URL", "http://ctrl-api:3100")
 
+    # Phase B: state.db lives in ctrl-api's data volume. The init container
+    # mounts it read-only at /ctrl-data (compose-template setting). Fresh
+    # tenants don't have the file yet — _read_dispositions handles missing
+    # file + missing table gracefully, so every server defaults to direct.
+    state_db_env = os.environ.get("STATE_DB_PATH", "").strip()
+    if state_db_env:
+        state_db_path: Path | None = Path(state_db_env)
+    else:
+        candidate = Path("/ctrl-data/alfred-state.db")
+        state_db_path = candidate if candidate.exists() else None
+
     try:
         outcome = ensure_mcp_servers(
             config,
             profile=profile,
             mcp_stdio_dir=mcp_stdio_dir,
             ctrl_api_url=ctrl_api_url,
+            state_db_path=state_db_path,
         )
     except Exception as exc:
         # Best-effort step; never abort init on a render hiccup.

--- a/packages/hermes/tests/test_init_mcp_servers_disposition.py
+++ b/packages/hermes/tests/test_init_mcp_servers_disposition.py
@@ -1,0 +1,422 @@
+"""Tests for the Phase B disposition layer on render_mcp_servers.py.
+
+ensure_mcp_servers now optionally reads state.db.tool_disposition and, for the
+MAIN profile, applies `tools.include: []` to any server marked DELEGATED.
+
+Pinned behaviours:
+  * MAIN profile + state_db with `sure=delegated` → tools.include: [] lands
+    on the sure block.
+  * MAIN profile + state_db with all servers DIRECT (the migration-0014 seed)
+    → no mutation. Result code stays "present" (nothing to do).
+  * WORKERS profile is UNAFFECTED by dispositions even when sure=delegated.
+    Focused subagents need the full catalogue.
+  * Missing state.db → defaults to all-direct (fresh-tenant fallback).
+  * Missing tool_disposition table on an old state.db → same fallback.
+  * Disposition on an operator-disabled server (block is `null`) → respect
+    the null; do not graft tools.include onto a null.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+HERMES = Path(__file__).resolve().parent.parent
+RENDER_SCRIPT = HERMES / "init" / "render_mcp_servers.py"
+
+
+def _load_render_module():
+    spec = importlib.util.spec_from_file_location(
+        "render_mcp_servers", RENDER_SCRIPT
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def render_module():
+    pytest.importorskip("ruamel.yaml")
+    return _load_render_module()
+
+
+def _seed_state_db(state_db_path: Path, dispositions: dict[str, str]) -> None:
+    """Build a fresh state.db with migration 0014's table seeded with the
+    given dispositions. Mirrors the live schema so the mutator reads it
+    correctly via mode=ro URI."""
+    conn = sqlite3.connect(state_db_path)
+    try:
+        conn.execute(
+            "CREATE TABLE tool_disposition ("
+            "  server TEXT PRIMARY KEY,"
+            "  disposition TEXT NOT NULL DEFAULT 'direct',"
+            "  updated_at TEXT NOT NULL,"
+            "  updated_by TEXT"
+            ")"
+        )
+        for server, disposition in dispositions.items():
+            conn.execute(
+                "INSERT INTO tool_disposition (server, disposition, updated_at, updated_by)"
+                " VALUES (?, ?, '2026-05-30T00:00:00Z', 'test')",
+                (server, disposition),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+_PRE_PHASE_B_CONFIG = """\
+model:
+  provider: openrouter
+  name: x-ai/grok-4.3
+
+mcp_servers:
+  alfred-ctrl:
+    command: node
+    args: ["/opt/data/profiles/main/mcp/ctrl-server.mjs"]
+    env:
+      CTRL_API_URL: http://ctrl-api:3100
+      AAS_API_KEY: ${AAS_API_KEY}
+    timeout: 120
+    connect_timeout: 60
+  alfred:
+    command: node
+    args: ["/opt/data/profiles/main/mcp-stdio/dist/bin/stdio-app.js", "alfred"]
+    env:
+      CTRL_API_URL: http://ctrl-api:3100
+      AAS_API_KEY: ${AAS_API_KEY}
+    timeout: 120
+    connect_timeout: 60
+  sure:
+    command: node
+    args: ["/opt/data/profiles/main/mcp-stdio/dist/bin/stdio-app.js", "sure"]
+    env:
+      SURE_API_URL: http://sure:3000/api
+      SURE_API_TOKEN: ${SURE_API_TOKEN}
+    timeout: 120
+    connect_timeout: 60
+  paperclip:
+    command: node
+    args: ["/opt/paperclip-mcp/node_modules/@paperclipai/mcp-server/dist/stdio.js"]
+    env:
+      PAPERCLIP_API_URL: http://paperclip:3100/api
+      PAPERCLIP_API_KEY: ${PAPERCLIP_API_KEY}
+    timeout: 120
+    connect_timeout: 60
+  hass:
+    command: node
+    args: ["/opt/data/profiles/main/mcp-stdio/dist/bin/stdio-app.js", "hass"]
+    env:
+      CTRL_API_URL: http://ctrl-api:3100
+      AAS_API_KEY: ${AAS_API_KEY}
+    timeout: 120
+    connect_timeout: 60
+  files:
+    command: node
+    args: ["/opt/data/profiles/main/mcp-stdio/dist/bin/stdio-app.js", "files"]
+    env:
+      CTRL_API_URL: http://ctrl-api:3100
+      AAS_API_KEY: ${AAS_API_KEY}
+    timeout: 120
+    connect_timeout: 60
+"""
+
+
+def test_main_profile_delegated_server_gets_tools_include_empty(
+    tmp_path: Path, render_module
+):
+    """sure=delegated → main's sure block grows tools.include: []."""
+    config = tmp_path / "config.yaml"
+    config.write_text(_PRE_PHASE_B_CONFIG, encoding="utf-8")
+    state_db = tmp_path / "alfred-state.db"
+    _seed_state_db(state_db, {"sure": "delegated"})
+
+    outcome = render_module.ensure_mcp_servers(
+        config,
+        profile="main",
+        mcp_stdio_dir="/opt/data/profiles/main/mcp-stdio",
+        ctrl_api_url="http://ctrl-api:3100",
+        state_db_path=state_db,
+    )
+    assert outcome == "added"
+
+    from ruamel.yaml import YAML
+    data = YAML().load(config.read_text())
+    sure = data["mcp_servers"]["sure"]
+    assert "tools" in sure
+    assert sure["tools"]["include"] == []
+    # The other servers are untouched.
+    assert "tools" not in data["mcp_servers"]["paperclip"] or \
+           data["mcp_servers"]["paperclip"].get("tools", {}).get("include") != []
+    assert "tools" not in data["mcp_servers"]["alfred-ctrl"] or \
+           data["mcp_servers"]["alfred-ctrl"].get("tools", {}).get("include") != []
+
+
+def test_main_profile_all_direct_no_mutation(tmp_path: Path, render_module):
+    """The default seed (all 9 servers DIRECT) yields no mutation: outcome
+    'present' and the config is byte-equal to before."""
+    config = tmp_path / "config.yaml"
+    config.write_text(_PRE_PHASE_B_CONFIG, encoding="utf-8")
+    state_db = tmp_path / "alfred-state.db"
+    _seed_state_db(
+        state_db,
+        {
+            "alfred-ctrl": "direct", "alfred": "direct", "sure": "direct",
+            "plane": "direct", "vaultwarden": "direct", "execute": "direct",
+            "paperclip": "direct", "hass": "direct", "files": "direct",
+        },
+    )
+
+    before = config.read_text()
+    outcome = render_module.ensure_mcp_servers(
+        config,
+        profile="main",
+        mcp_stdio_dir="/opt/data/profiles/main/mcp-stdio",
+        ctrl_api_url="http://ctrl-api:3100",
+        state_db_path=state_db,
+    )
+    # 'present' because the required-server allowlist is also already
+    # satisfied (hass + files are in the config), and no disposition mutation
+    # was needed.
+    assert outcome == "present"
+    assert config.read_text() == before
+
+
+def test_workers_profile_ignores_dispositions(tmp_path: Path, render_module):
+    """sure=delegated must NOT affect the workers profile. Focused subagents
+    need the full catalogue."""
+    config = tmp_path / "config.yaml"
+    config.write_text(_PRE_PHASE_B_CONFIG, encoding="utf-8")
+    state_db = tmp_path / "alfred-state.db"
+    _seed_state_db(state_db, {"sure": "delegated"})
+
+    outcome = render_module.ensure_mcp_servers(
+        config,
+        profile="workers",
+        mcp_stdio_dir="/opt/data/profiles/workers/mcp-stdio",
+        ctrl_api_url="http://ctrl-api:3100",
+        state_db_path=state_db,
+    )
+    # `files` is required for workers; it's already in this config so
+    # outcome is "present" — no disposition mutation should have happened.
+    assert outcome == "present"
+
+    from ruamel.yaml import YAML
+    data = YAML().load(config.read_text())
+    sure = data["mcp_servers"]["sure"]
+    # Critical: sure on workers MUST NOT have tools.include: [] — workers
+    # is the focused-subagent target.
+    if "tools" in sure:
+        assert sure["tools"].get("include") != []
+
+
+def test_missing_state_db_falls_back_to_direct(tmp_path: Path, render_module):
+    """No state.db file → every server stays DIRECT (fresh-tenant fallback)."""
+    config = tmp_path / "config.yaml"
+    config.write_text(_PRE_PHASE_B_CONFIG, encoding="utf-8")
+
+    outcome = render_module.ensure_mcp_servers(
+        config,
+        profile="main",
+        mcp_stdio_dir="/opt/data/profiles/main/mcp-stdio",
+        ctrl_api_url="http://ctrl-api:3100",
+        state_db_path=tmp_path / "does-not-exist.db",
+    )
+    assert outcome == "present"
+    from ruamel.yaml import YAML
+    data = YAML().load(config.read_text())
+    # No tools.include: [] anywhere — all servers stayed DIRECT.
+    for name, block in data["mcp_servers"].items():
+        if isinstance(block, dict) and "tools" in block:
+            assert block["tools"].get("include") != [], (
+                f"server {name} should NOT have tools.include: [] when state.db is missing"
+            )
+
+
+def test_missing_disposition_table_falls_back_to_direct(
+    tmp_path: Path, render_module
+):
+    """state.db exists but tool_disposition table doesn't — same fallback."""
+    state_db = tmp_path / "alfred-state.db"
+    conn = sqlite3.connect(state_db)
+    try:
+        conn.execute("CREATE TABLE some_other_table (id INTEGER)")
+        conn.commit()
+    finally:
+        conn.close()
+
+    config = tmp_path / "config.yaml"
+    config.write_text(_PRE_PHASE_B_CONFIG, encoding="utf-8")
+
+    outcome = render_module.ensure_mcp_servers(
+        config,
+        profile="main",
+        mcp_stdio_dir="/opt/data/profiles/main/mcp-stdio",
+        ctrl_api_url="http://ctrl-api:3100",
+        state_db_path=state_db,
+    )
+    assert outcome == "present"
+
+
+def test_state_db_path_none_is_a_clean_skip(tmp_path: Path, render_module):
+    """Explicit state_db_path=None — caller signals 'no disposition data
+    available' (fresh tenant). Same as missing file."""
+    config = tmp_path / "config.yaml"
+    config.write_text(_PRE_PHASE_B_CONFIG, encoding="utf-8")
+
+    outcome = render_module.ensure_mcp_servers(
+        config,
+        profile="main",
+        mcp_stdio_dir="/opt/data/profiles/main/mcp-stdio",
+        ctrl_api_url="http://ctrl-api:3100",
+        state_db_path=None,
+    )
+    assert outcome == "present"
+
+
+def test_disposition_on_operator_disabled_block_is_skipped(
+    tmp_path: Path, render_module
+):
+    """If operator set `sure: null` (disabled), a sure=delegated disposition
+    must NOT mutate the null into a dict. ADD-only contract."""
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        "mcp_servers:\n"
+        "  sure: null\n"
+        "  hass:\n"
+        "    command: node\n"
+        "    args: [/opt/data/profiles/main/mcp-stdio/dist/bin/stdio-app.js, hass]\n"
+        "  files:\n"
+        "    command: node\n"
+        "    args: [/opt/data/profiles/main/mcp-stdio/dist/bin/stdio-app.js, files]\n",
+        encoding="utf-8",
+    )
+    state_db = tmp_path / "alfred-state.db"
+    _seed_state_db(state_db, {"sure": "delegated"})
+
+    outcome = render_module.ensure_mcp_servers(
+        config,
+        profile="main",
+        mcp_stdio_dir="/opt/data/profiles/main/mcp-stdio",
+        ctrl_api_url="http://ctrl-api:3100",
+        state_db_path=state_db,
+    )
+    # No graft, no disposition mutation — operator's null wins.
+    assert outcome == "present"
+    from ruamel.yaml import YAML
+    data = YAML().load(config.read_text())
+    assert data["mcp_servers"]["sure"] is None
+
+
+def test_disposition_already_applied_no_rewrite(tmp_path: Path, render_module):
+    """If tools.include is ALREADY [] on a DELEGATED server, the mutator is
+    a no-op (no rewrite, outcome 'present'). Idempotency check."""
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        _PRE_PHASE_B_CONFIG.replace(
+            "  sure:\n"
+            "    command: node\n"
+            "    args: [\"/opt/data/profiles/main/mcp-stdio/dist/bin/stdio-app.js\", \"sure\"]\n"
+            "    env:\n"
+            "      SURE_API_URL: http://sure:3000/api\n"
+            "      SURE_API_TOKEN: ${SURE_API_TOKEN}\n"
+            "    timeout: 120\n"
+            "    connect_timeout: 60\n",
+            "  sure:\n"
+            "    command: node\n"
+            "    args: [\"/opt/data/profiles/main/mcp-stdio/dist/bin/stdio-app.js\", \"sure\"]\n"
+            "    env:\n"
+            "      SURE_API_URL: http://sure:3000/api\n"
+            "      SURE_API_TOKEN: ${SURE_API_TOKEN}\n"
+            "    timeout: 120\n"
+            "    connect_timeout: 60\n"
+            "    tools:\n"
+            "      include: []\n",
+        ),
+        encoding="utf-8",
+    )
+    state_db = tmp_path / "alfred-state.db"
+    _seed_state_db(state_db, {"sure": "delegated"})
+
+    before = config.read_text()
+    outcome = render_module.ensure_mcp_servers(
+        config,
+        profile="main",
+        mcp_stdio_dir="/opt/data/profiles/main/mcp-stdio",
+        ctrl_api_url="http://ctrl-api:3100",
+        state_db_path=state_db,
+    )
+    assert outcome == "present"
+    assert config.read_text() == before
+
+
+# --- entrypoint + docker-compose plumbing pins ------------------------------
+def test_entrypoint_passes_state_db_path_to_render_mcp_servers():
+    """The init entrypoint must export STATE_DB_PATH (defaulting to
+    /ctrl-data/alfred-state.db) when invoking render_mcp_servers.py. Without
+    it the mutator hits the no-data fallback on every boot — every server
+    stays DIRECT regardless of the dashboard toggle."""
+    src = (HERMES / "init" / "entrypoint.sh").read_text()
+    assert 'STATE_DB_PATH="${STATE_DB_PATH:-/ctrl-data/alfred-state.db}"' in src, (
+        "entrypoint.sh must export STATE_DB_PATH when calling "
+        "render_mcp_servers.py — the mutator otherwise can't see the "
+        "tool_disposition table."
+    )
+
+
+def test_docker_compose_mounts_state_data_ro_into_init():
+    """The init service in docker-compose.yaml must mount state_data at
+    /ctrl-data:ro so render_mcp_servers can read tool_disposition. Read-only
+    because ctrl-api is the sole writer on this volume (per
+    STORAGE-ARCHITECTURE.md's single-writer discipline)."""
+    compose = (HERMES.parent.parent / "docker-compose.yaml").read_text()
+    # The mount appears under the init service. Pin the literal so a future
+    # refactor that drops the :ro qualifier (which would break the
+    # single-writer discipline) lights this up.
+    assert "state_data:/ctrl-data:ro" in compose, (
+        "init service must mount state_data at /ctrl-data:ro so "
+        "render_mcp_servers.py can read tool_disposition."
+    )
+    # Pin the matching STATE_DB_PATH env var on the init service too.
+    assert "STATE_DB_PATH=/ctrl-data/alfred-state.db" in compose, (
+        "init service must set STATE_DB_PATH=/ctrl-data/alfred-state.db "
+        "matching the mount above."
+    )
+
+
+def test_multiple_servers_delegated_at_once(tmp_path: Path, render_module):
+    """sure + paperclip + hass all DELEGATED — three blocks get tools.include: []
+    in one render pass."""
+    config = tmp_path / "config.yaml"
+    config.write_text(_PRE_PHASE_B_CONFIG, encoding="utf-8")
+    state_db = tmp_path / "alfred-state.db"
+    _seed_state_db(
+        state_db,
+        {"sure": "delegated", "paperclip": "delegated", "hass": "delegated"},
+    )
+
+    outcome = render_module.ensure_mcp_servers(
+        config,
+        profile="main",
+        mcp_stdio_dir="/opt/data/profiles/main/mcp-stdio",
+        ctrl_api_url="http://ctrl-api:3100",
+        state_db_path=state_db,
+    )
+    assert outcome == "added"
+
+    from ruamel.yaml import YAML
+    data = YAML().load(config.read_text())
+    for s in ("sure", "paperclip", "hass"):
+        assert data["mcp_servers"][s]["tools"]["include"] == [], (
+            f"{s} should have tools.include: [] after the disposition pass"
+        )
+    # alfred + alfred-ctrl + files stayed DIRECT.
+    for s in ("alfred", "alfred-ctrl", "files"):
+        block = data["mcp_servers"][s]
+        if "tools" in block:
+            assert block["tools"].get("include") != []

--- a/packages/mcp-server/skills/alfred-mcp-skill.md
+++ b/packages/mcp-server/skills/alfred-mcp-skill.md
@@ -6,11 +6,59 @@ license: alfred-platform internal — see the parent monorepo's LICENSE
 
 # Alfred MCP — claude.ai Custom Connector
 
-This connector exposes Sir's tenant ctrl-api content surface to claude.ai. The tools below — 18 generic Alfred tools plus 85 Home Assistant tools (the `ha__*` surface, #115 PR1-PR8) — are the ONLY way you reach his box from a claude.ai conversation. Everything goes through this MCP server's bearer token, which is bound to one tenant for one hour.
+This connector exposes Sir's tenant ctrl-api content surface to claude.ai. The tools below — 21 generic Alfred tools plus 85 Home Assistant tools (the `ha__*` surface, #115 PR1-PR8) — are the ONLY way you reach his box from a claude.ai conversation. Everything goes through this MCP server's bearer token, which is bound to one tenant for one hour.
 
 For Sir's home tenant (home.alfred.black, an HAOS install at `100.70.124.6`) there are also two non-MCP access paths Alfred can use when the MCP catalogue doesn't fit: the **alfred-ha Supervisor bridge** (9 `alfred.supervisor_*` HA services callable via the LLAT-authenticated REST API) and **SSH** (root shell on HA OS via `mcp_alfred_execute_*`). The "Picking the right HA access path" section below is the decision tree.
 
 The catalogue is intentionally narrow. Container restarts, credential rotation, device revocation, env mutation, log streaming, and similar high-blast-radius operations are NOT exposed here — they live behind in-tenant agents (Alfred main, chores) where trust is scoped. If Sir asks for one of those over claude.ai, route him back to his Alfred channel rather than improvising.
+
+---
+
+## Tool disposition + delegation playbook (Phase B)
+
+Every MCP server registered on Alfred main runs in one of two **dispositions**:
+
+- **DIRECT** — the server's tools are in your catalogue this turn. Call them natively (e.g. `sure_list_accounts`, `paperclip_list_issues`).
+- **DELEGATED** — the server's tools are HIDDEN from your catalogue. You reach them through `delegate_to_focused_agent({domain:"<server>", task:"..."})`, which spawns a one-shot subagent on the workers profile that loads the right skill, runs the work, and returns a plain-text reply.
+
+The disposition is **runtime-flippable**. Sir flips servers via his dashboard toggle or via voice ("Alfred, demote sure to delegated") — both routes hit `set_tool_disposition`, which writes `state.db.tool_disposition` and triggers a ~10s debounced Hermes restart. After the restart the new map is live on every channel.
+
+### When to consult `list_tool_dispositions`
+
+- **Top of any session where you're uncertain.** Disposition can change between turns; if the answer to "is `sure` direct or delegated right now?" matters, glance at it. The call is cheap (Hermes caches it ~60s) and the catalogue is 9 rows.
+- Before delegating, to confirm the server is actually DELEGATED (not just absent because the user has it disabled outright).
+
+### When to use `delegate_to_focused_agent`
+
+Two clean triggers:
+
+1. **The server is DELEGATED.** You have no native tools from it this turn; delegation is the only path. Relay the subagent's reply VERBATIM.
+2. **Tool-heavy fanout, even when DIRECT.** If Sir asks for "all emails from Acme this week" (15+ tool calls) or "every issue I have open across all three Plane projects", bundling the fanout into one delegated subagent is faster than 15 inline calls, AND it keeps your own context lean for the follow-up reasoning. Same reply-verbatim rule.
+
+The `domain` argument is the server name (`sure`, `plane`, `paperclip`, `hass`, `files`, `vaultwarden`, `execute`, `alfred`, `alfred-ctrl`) OR a Composio toolkit slug (`googlecalendar`, `gmail`, `notion`, `linear`, `slack`). The subagent uses it to load the right skill.
+
+### When to suggest flipping a disposition (proactive)
+
+- Sir does a long session of one-off `sure` queries and the disposition is DIRECT → token count climbs. Mid-session, offer: "Sir, I notice you're asking a lot of `sure` questions. Want me to keep it direct (faster per call, more tokens per turn) or flip it to delegated (lean turns, +3-5s per use)?" Wait for his call before invoking `set_tool_disposition`.
+- Sir hasn't touched `paperclip` all session and DIRECT is the current state → leave it. The token cost is paid once at session start regardless.
+
+### Self-protection rule for `set_tool_disposition`
+
+Three servers carry Alfred's own self-management surface. **NEVER flip any of these to DELEGATED without Sir's explicit confirmation phrase:**
+
+- `alfred-ctrl` — admin/agents/state/health (the very plane that surfaces this disposition map)
+- `alfred` — vault + decisions + briefings + the disposition surface itself
+- `execute` — Composio gateway
+
+The confirmation phrase is: **"yes, change my Alfred's tool disposition"** (case-insensitive). It must appear verbatim in Sir's most recent message. If he asks for one of these flips without the phrase, push back:
+
+> Sir, flipping `alfred-ctrl` to delegated would hide your own self-management tools — including the way I'd undo it. Confirm with "yes, change my Alfred's tool disposition" if you really want this.
+
+Same shape as the alfred-ha self-destruct guard from PR #173. The other six servers (`sure`, `plane`, `vaultwarden`, `paperclip`, `hass`, `files`) flip freely on Sir's request.
+
+### After a flip
+
+The Hermes restart is debounced ~10s. Tell Sir: "I've queued the restart — give it about ten seconds." If he flips three servers in quick succession, that's still one restart (the timer coalesces); he gets the same ten seconds.
 
 ---
 
@@ -52,6 +100,12 @@ The catalogue is intentionally narrow. Container restarts, credential rotation, 
 - `list_in_flight_agents` — ephemeral exec-* subagents currently working
 - `act_on_decision` — press one of the five Desk buttons (delegate / defer / done / do / noise) for a card. `delegate` and `defer` REQUIRE a `note` (instructions / when); `done` / `do` take optional context; `noise` takes nothing
 - `reverse_decision` — undo a decision (best-effort: `delegate` is marked not-reversible upstream)
+
+### Tool disposition + delegation (3) — Phase B
+
+- `list_tool_dispositions` — current DIRECT-or-DELEGATED map for the 9 MCP servers
+- `set_tool_disposition` — flip one server (self-protection rule on alfred-ctrl/alfred/execute)
+- `delegate_to_focused_agent` — spawn a workers-profile focused subagent for a tool-heavy task
 
 ### Channels (1)
 

--- a/packages/mcp-server/src/tools/alfred.test.ts
+++ b/packages/mcp-server/src/tools/alfred.test.ts
@@ -199,3 +199,123 @@ test("reverse_decision · id required", () => {
   const r = reverse.inputSchema.safeParse({});
   assert.equal(r.success, false);
 });
+
+// ─── tool disposition + delegate_to_focused_agent (Phase B) ─────────────────
+
+const listDispositions = getTool("list_tool_dispositions");
+const setDisposition = getTool("set_tool_disposition");
+const delegateFocused = getTool("delegate_to_focused_agent");
+
+test("list_tool_dispositions · no args, GET /api/v1/agents/tool-disposition", () => {
+  const r = listDispositions.inputSchema.safeParse({});
+  assert.equal(r.success, true);
+  const req = listDispositions.buildRequest({});
+  assert.equal(req.method, "GET");
+  assert.equal(req.path, "/api/v1/agents/tool-disposition");
+});
+
+test("set_tool_disposition · validates server enum (9 known servers)", () => {
+  for (const server of [
+    "alfred-ctrl", "alfred", "sure", "plane", "vaultwarden",
+    "execute", "paperclip", "hass", "files",
+  ]) {
+    const r = setDisposition.inputSchema.safeParse({
+      server, disposition: "delegated",
+    });
+    assert.equal(r.success, true, `server ${server} should pass`);
+  }
+  const bad = setDisposition.inputSchema.safeParse({
+    server: "ghost", disposition: "delegated",
+  });
+  assert.equal(bad.success, false);
+});
+
+test("set_tool_disposition · disposition enum", () => {
+  const ok1 = setDisposition.inputSchema.safeParse({
+    server: "sure", disposition: "direct",
+  });
+  const ok2 = setDisposition.inputSchema.safeParse({
+    server: "sure", disposition: "delegated",
+  });
+  const bad = setDisposition.inputSchema.safeParse({
+    server: "sure", disposition: "stealthy",
+  });
+  assert.equal(ok1.success, true);
+  assert.equal(ok2.success, true);
+  assert.equal(bad.success, false);
+});
+
+test("set_tool_disposition · defaults updated_by to 'alfred'", () => {
+  const req = setDisposition.buildRequest({
+    server: "paperclip", disposition: "delegated",
+  });
+  assert.equal(req.method, "POST");
+  assert.equal(req.path, "/api/v1/agents/tool-disposition");
+  const body = req.body as any;
+  assert.equal(body.server, "paperclip");
+  assert.equal(body.disposition, "delegated");
+  assert.equal(body.updated_by, "alfred");
+});
+
+test("set_tool_disposition · honours explicit updated_by", () => {
+  const req = setDisposition.buildRequest({
+    server: "sure", disposition: "delegated", updated_by: "sir",
+  });
+  const body = req.body as any;
+  assert.equal(body.updated_by, "sir");
+});
+
+test("set_tool_disposition · description carries self-protection rule", () => {
+  // The skill + the tool description both have to call out the
+  // confirmation-phrase requirement for alfred-ctrl / alfred / execute.
+  // Pin the phrase here so a future refactor of the description doesn't
+  // silently drop the guard.
+  assert.ok(
+    setDisposition.description.includes("alfred-ctrl"),
+    "self-protection clause must mention alfred-ctrl",
+  );
+  assert.ok(
+    setDisposition.description.includes("execute"),
+    "self-protection clause must mention execute",
+  );
+  assert.ok(
+    setDisposition.description.includes(
+      'yes, change my Alfred\'s tool disposition',
+    ),
+    "self-protection clause must carry the confirmation phrase verbatim",
+  );
+});
+
+test("delegate_to_focused_agent · task + domain required", () => {
+  const bad1 = delegateFocused.inputSchema.safeParse({ domain: "sure" });
+  const bad2 = delegateFocused.inputSchema.safeParse({ task: "do the thing" });
+  assert.equal(bad1.success, false);
+  assert.equal(bad2.success, false);
+
+  const ok = delegateFocused.inputSchema.safeParse({
+    task: "Pull this week's emails from Acme",
+    domain: "gmail",
+  });
+  assert.equal(ok.success, true);
+});
+
+test("delegate_to_focused_agent · optional context flows through", () => {
+  const req = delegateFocused.buildRequest({
+    task: "Pull tomorrow's events",
+    domain: "googlecalendar",
+    context: "Sir's primary calendar id is abc-123.",
+  });
+  assert.equal(req.method, "POST");
+  assert.equal(req.path, "/api/v1/agents/focused-subagent");
+  const body = req.body as any;
+  assert.equal(body.task, "Pull tomorrow's events");
+  assert.equal(body.domain, "googlecalendar");
+  assert.equal(body.context, "Sir's primary calendar id is abc-123.");
+});
+
+test("delegate_to_focused_agent · description tells LLM to relay verbatim", () => {
+  assert.ok(
+    delegateFocused.description.toLowerCase().includes("verbatim"),
+    "description must tell the LLM to relay the subagent reply verbatim",
+  );
+});

--- a/packages/mcp-server/src/tools/alfred.ts
+++ b/packages/mcp-server/src/tools/alfred.ts
@@ -612,6 +612,98 @@ const briefDecisionTools: ToolDef[] = [
   },
 ];
 
+// ─── tool disposition + focused subagent delegation (Phase B) ───────────────
+//
+// Sir's "both tracks" architecture (see plan i-want-you-to-snazzy-pixel.md §B):
+// every MCP server registered on the main profile carries a runtime-flippable
+// DIRECT-or-DELEGATED disposition. DIRECT = LLM calls native tools. DELEGATED
+// = tools hidden on main; LLM uses `delegate_to_focused_agent` instead. Sir
+// flips via dashboard or voice ("Alfred, demote sure to delegated") through
+// `set_tool_disposition`; Alfred glances the current map via
+// `list_tool_dispositions` at session start.
+//
+// The catalogue of 9 servers mirrors migration 0014's seed.
+
+const DISPOSITION_SERVERS = [
+  "alfred-ctrl",
+  "alfred",
+  "sure",
+  "plane",
+  "vaultwarden",
+  "execute",
+  "paperclip",
+  "hass",
+  "files",
+] as const;
+
+const dispositionTools: ToolDef[] = [
+  {
+    name: "list_tool_dispositions",
+    description:
+      "List the current direct-or-delegated disposition for each of Sir's 9 MCP servers (alfred-ctrl, alfred, sure, plane, vaultwarden, execute, paperclip, hass, files). DIRECT = the server's tools are in your catalogue this turn (call them natively, e.g. `sure_list_accounts`). DELEGATED = its tools are HIDDEN from your catalogue; you reach them only through `delegate_to_focused_agent({domain:'sure',...})` which spawns a one-shot workers-profile subagent that loads the right skill and returns plain text. Use at the top of a session if you're not sure of the current map — disposition can change between turns (Sir flips via dashboard or voice). Cheap and idempotent. Returns `{dispositions: [{server, disposition, updated_at, updated_by}, ...]}`. Backing: GET /api/v1/agents/tool-disposition.",
+    inputSchema: z.object({}),
+    buildRequest: () => ({ method: "GET", path: "/api/v1/agents/tool-disposition" }),
+  },
+  {
+    name: "set_tool_disposition",
+    description:
+      "Flip one MCP server between DIRECT (native tools available on main, ~2-4k tokens per turn each) and DELEGATED (tools hidden from main; accessed via `delegate_to_focused_agent`; saves tokens but adds ~3-5s per tool use). Use when Sir says 'demote X to delegated', 'promote X to direct', 'hide the sure tools', 'bring paperclip back to main', or when you notice tokens-per-turn climbing and want to suggest the flip yourself. Triggers a ~10s debounced Hermes restart (a burst of flips coalesces into one restart). After the restart the new disposition is live; tell Sir 'I've queued the restart — give it about 10 seconds'.\n" +
+      "\n" +
+      "SELF-PROTECTION RULE — these three servers control Alfred's own self-management surface and a careless DELEGATE could brick the very tools you'd need to undo it: `alfred-ctrl` (admin/agents/state/health), `alfred` (vault + decisions + briefings + this very disposition surface), `execute` (Composio gateway). NEVER flip any of these three without Sir's explicit confirmation phrase: \"yes, change my Alfred's tool disposition\" (case-insensitive, must appear verbatim in his most recent message). If Sir asks to demote one of these and hasn't said the confirmation phrase, push back: 'Sir, flipping `alfred-ctrl` to delegated would hide your own self-management tools. Confirm with \"yes, change my Alfred's tool disposition\" if you really want this.' Same pattern as the alfred-ha self-destruct guard.\n" +
+      "\n" +
+      "Backing: POST /api/v1/agents/tool-disposition. NOT idempotent in side effects (every call re-arms the debounce timer); idempotent in steady-state (calling set('sure','delegated') twice leaves sure at delegated).",
+    inputSchema: z.object({
+      server: z.enum(DISPOSITION_SERVERS).describe(
+        "MCP server to flip. The 9 servers exactly mirror what ships on main: alfred-ctrl, alfred, sure, plane, vaultwarden, execute, paperclip, hass, files.",
+      ),
+      disposition: z.enum(["direct", "delegated"]).describe(
+        "Target disposition. `direct` = native tools available on main. `delegated` = tools hidden on main; reachable via delegate_to_focused_agent.",
+      ),
+      updated_by: z.enum(["sir", "alfred"]).optional().describe(
+        "Audit attribution. `sir` when Sir explicitly asked for the flip (voice or dashboard); `alfred` when you initiated the suggestion yourself. Defaults to `alfred`.",
+      ),
+    }),
+    buildRequest: (args) => ({
+      method: "POST",
+      path: "/api/v1/agents/tool-disposition",
+      body: {
+        server: args.server,
+        disposition: args.disposition,
+        updated_by: args.updated_by ?? "alfred",
+      },
+    }),
+  },
+  {
+    name: "delegate_to_focused_agent",
+    description:
+      "Spawn a short-lived focused subagent on the workers profile (cheaper model, same Alfred identity + same vault memory) to handle ONE task that needs a heavy tool surface. Use this when:\n" +
+      "  (1) the target server is currently DELEGATED in tool_disposition — `list_tool_dispositions` shows the live map; you have no native tools from that server this turn so delegation is the ONLY path.\n" +
+      "  (2) you're doing a tool-heavy fanout (gmail batch over many messages, calendar across multiple calendars, paperclip multi-issue update, sure transaction triage across N transactions) — even if the server is DIRECT, fanning out 10-20 calls inline blows the context budget and stalls Voice PE; delegating bundles the work into one round-trip.\n" +
+      "\n" +
+      "How it works: ctrl-api builds a workers-profile session key `focus-<domain>-<hash>`, attaches a skill-load directive (`alfred-<domain>-skill.md` OR `alfred-composio-<domain>-skill.md`), posts to Hermes workers :18790/v1/responses with your task + optional context, and returns the subagent's plain-text reply. Cost: ~3-5s spawn + the subagent's actual work (typically 5-30s for tool-heavy fanouts).\n" +
+      "\n" +
+      "RELAY THE SUBAGENT'S REPLY VERBATIM. Don't summarize, don't reformat unless the channel truly demands it. The subagent's wording is calibrated for direct relay; rewriting it dilutes correctness and burns tokens.\n" +
+      "\n" +
+      "Backing: POST /api/v1/agents/focused-subagent. 60s timeout. Returns `{ok, reply, session_key, domain}`. NOT idempotent — each call spawns a fresh session.",
+    inputSchema: z.object({
+      task: z.string().min(1).describe(
+        "What the subagent should do, in plain language. BE SPECIFIC — the subagent doesn't see this conversation, only your task + the optional context. Include any record paths, vault slugs, recipient handles, time windows, etc.",
+      ),
+      domain: z.string().min(1).describe(
+        "Which tool surface the subagent needs. For MCP servers, use the server name: `sure` / `plane` / `vaultwarden` / `paperclip` / `hass` / `files` / `execute` / `alfred` / `alfred-ctrl`. For a Composio toolkit, use the toolkit slug: `googlecalendar` / `gmail` / `notion` / `linear` / `slack` / etc. The subagent uses this label to load the right skill.",
+      ),
+      context: z.string().optional().describe(
+        "Optional 1-2 sentences from this conversation that help the subagent ground its answer (e.g. 'Sir's primary calendar is the one called Personal, id <calendar-id>.'). Keep it tight — long context blows the same token budget you're trying to save by delegating.",
+      ),
+    }),
+    buildRequest: (args) => ({
+      method: "POST",
+      path: "/api/v1/agents/focused-subagent",
+      body: args,
+    }),
+  },
+];
+
 // ─── channels (notify the principal via main openclaw) ──────────────────────
 
 // Outbound channels (Telegram, Slack, …) belong to the MAIN Hermes profile
@@ -675,5 +767,6 @@ export const ALL_ALFRED_TOOLS: ToolDef[] = [
   ...openclawTools,
   ...deviceTools,
   ...briefDecisionTools,
+  ...dispositionTools,
   ...channelTools,
 ];


### PR DESCRIPTION
Sir's both-tracks architecture. Every MCP server gets a runtime-flippable DIRECT-or-DELEGATED disposition.

**Defaults: all DIRECT (zero behaviour change on deploy).** Sir or Alfred flips at runtime when token-savings are worth the +3-5s delegation latency.

## What ships
- Migration 0014: 9 rows in `tool_disposition`, all seeded `direct`
- `render_mcp_servers.py`: reads disposition, writes `tools.include: []` on main for DELEGATED servers
- ctrl-api: GET/POST `/api/v1/agents/tool-disposition` + POST `/api/v1/agents/focused-subagent` (workers-profile session)
- 3 new MCP tools on `alfred` server:
  - `list_tool_dispositions` — read current map
  - `set_tool_disposition` — flip a server (self-protection clause on `alfred-ctrl`/`alfred`/`execute`)
  - `delegate_to_focused_agent` — workers spawn with focused skill load, verbatim reply relay
- Debounced Hermes restart on flip (10s coalesce window)
- Skill doc gains 'Tool disposition + delegation playbook' section

## Live verify after merge
1. `docker compose pull ctrl-api init mcp-server && docker compose up -d ctrl-api init`
2. `GET /api/v1/agents/tool-disposition` → 9 rows, all 'direct'
3. `POST /api/v1/agents/tool-disposition` body `{server:'paperclip',disposition:'delegated',updated_by:'alfred'}`
4. Wait 12s for debounced Hermes restart
5. `docker exec alfred-black-hermes-1 grep -A 5 'paperclip:' /hermes-state/profiles/main/config.yaml` shows `tools.include: []`

🤖 Generated with [Claude Code](https://claude.com/claude-code)