### PR TITLE
fix(ctrl): Phase C — read GOOGLECALENDAR_LIST_CALENDARS response under data.calendars

### DIFF
--- a/packages/ctrl/src/api/routes/integrations.ts
+++ b/packages/ctrl/src/api/routes/integrations.ts
@@ -1515,12 +1515,17 @@ async function cacheComposioPrimaryDefaults(
         return null;
       }
       const body = (await res.json()) as any;
-      // Composio responses vary: items may live under data.items, result.items, items.
+      // Composio's GOOGLECALENDAR_LIST_CALENDARS returns
+      // {data: {calendars: [...]}} (verified live on home.alfred.black —
+      // each calendar entry carries `primary: true` on Sir's main calendar).
+      // Older docs reference data.items; we fall back through those legacy
+      // shapes for resilience if the SDK ever pivots back.
       const items: any[] =
+        body?.data?.calendars ||
         body?.data?.items ||
         body?.result?.items ||
         body?.items ||
-        body?.data ||
+        (Array.isArray(body?.data) ? body.data : []) ||
         [];
       const primary = items.find((c: any) => c?.primary === true) ||
         items.find((c: any) => c?.id === "primary") ||


### PR DESCRIPTION
## Summary

Hot-fix for PR #179. The Composio v3 sidecar returns
`GOOGLECALENDAR_LIST_CALENDARS` under `data.calendars`, not `data.items` —
verified live on home.alfred.black where the previous shape walk found no
items and the cache stayed empty.

Each calendar entry carries `primary: true` on Sir's main calendar
(e.g. `david@szabostuban.com → primary: True`). The walk now reads
`data.calendars` first, then falls back through the legacy shapes for
resilience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)