### PR TITLE
fix(learn): Phase C — point sidecar defaults lookup at the right ctrl-api hostname

### DIFF
--- a/packages/learn/src/composio_server.py
+++ b/packages/learn/src/composio_server.py
@@ -141,7 +141,17 @@ class ExecuteRequest(BaseModel):
 # packages/ctrl/src/api/routes/integrations.ts where the execute route
 # uses the same rule.
 
-CTRL_API_URL = os.environ.get("CTRL_API_URL", "http://alfred-ctrl-api:3100")
+# ALFRED_CTRL_URL is the canonical env var alfred-learn already uses elsewhere
+# (vault_client.py, etc.); fall back to CTRL_API_URL for forward-compat. The
+# default `http://ctrl-api:3100` matches the alfred-black docker-compose
+# service name (verified live on home.alfred.black 2026-05-30). An earlier
+# default of `alfred-ctrl-api` produced silent "Temporary failure in name
+# resolution" warnings and the defaults injection never fired.
+CTRL_API_URL = (
+    os.environ.get("ALFRED_CTRL_URL")
+    or os.environ.get("CTRL_API_URL")
+    or "http://ctrl-api:3100"
+)
 CTRL_API_KEY = os.environ.get("AAS_API_KEY", "")
 CTRL_DEFAULTS_TTL_SECONDS = int(os.environ.get("COMPOSIO_DEFAULTS_TTL_SECONDS", "300"))
 


### PR DESCRIPTION
Hot-fix #2 for Phase C. Live verify on home.alfred.black surfaced a silent
`Temporary failure in name resolution` warning every time the sidecar tried
to read `composio_user_defaults` from ctrl-api: the default URL was
hard-coded to `http://alfred-ctrl-api:3100` but the alfred-black
docker-compose service is plain `ctrl-api`. The defaults injection
never fired and the LLM still fanned out across all 7 of Sir's calendars
even though the cache row was populated.

Switch the lookup to `ALFRED_CTRL_URL` (the canonical env alfred-learn
already uses for `vault_client.py` and the rest), fall back to
`CTRL_API_URL` for forward-compat, and default to the right service name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)