### PR TITLE
feat(web): tool-disposition toggle on /tools page

### DIFF
--- a/packages/web/main.wasp
+++ b/packages/web/main.wasp
@@ -1587,6 +1587,21 @@ query getAllowedTools {
   entities: [ComposioConnection]
 }
 
+// Phase B tool dispositions: read the 9-row direct/delegated map for the
+// MCP servers Hermes-main loads, and flip a server between the two
+// modes. The action queues a debounced Hermes restart so the new
+// `tools.include: []` whitelist takes effect; the UI shows a "Hermes is
+// restarting" line and refetches once the window closes.
+query getToolDispositions {
+  fn: import { getToolDispositions } from "@src/tools/operations",
+  entities: []
+}
+
+action setToolDisposition {
+  fn: import { setToolDisposition } from "@src/tools/operations",
+  entities: []
+}
+
 // ============================================================
 // Intuition (Learning Engine)
 // ============================================================

--- a/packages/web/src/tools/ToolsPage2.tsx
+++ b/packages/web/src/tools/ToolsPage2.tsx
@@ -7,8 +7,28 @@
 // OpenClaw allowlist, where privileged commands now ask before running.
 import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
-import { useQuery, getAllowedTools } from "wasp/client/operations";
+import {
+  useQuery,
+  useAction,
+  getAllowedTools,
+  getToolDispositions,
+  setToolDisposition,
+} from "wasp/client/operations";
 import { Frame } from "../client/components/ab/Frame";
+
+// Phase B self-protected servers: flipping these to DELEGATED would break
+// Alfred's ability to reach his own ctrl-api (alfred-ctrl), call his own
+// briefing/decision tools (alfred), or run the Composio progressive-
+// disclosure surface that Phase A optimised (execute). The backend
+// allows the flip; the UI disables it so you don't trip yourself up.
+const SELF_PROTECTED_SERVERS = new Set(["alfred", "alfred-ctrl", "execute"]);
+
+interface ToolDispositionRow {
+  server: string;
+  disposition: "direct" | "delegated";
+  updated_at: string;
+  updated_by: string | null;
+}
 
 interface StreamEntry {
   slug: string;
@@ -50,6 +70,16 @@ export default function ToolsPage2() {
   const apps: AppEntry[] = (data?.apps ?? []) as AppEntry[];
   const builtins: BuiltinTool[] = (data?.builtin_tools ?? []) as BuiltinTool[];
   const mcps: McpTool[] = (data?.mcp_tools ?? []) as McpTool[];
+
+  const { data: dispData, refetch: refetchDispositions } =
+    useQuery(getToolDispositions);
+  const dispositions: ToolDispositionRow[] =
+    (dispData?.dispositions ?? []) as ToolDispositionRow[];
+  const setDisposition = useAction(setToolDisposition);
+  // "server slug → 'queued at epoch ms'": used to show the "Hermes is
+  // restarting…" line for ~12s after a flip, then refetch the live state.
+  const [restarts, setRestarts] = useState<Record<string, number>>({});
+  const [flipError, setFlipError] = useState<string | null>(null);
 
   const [search, setSearch] = useState("");
   const q = search.trim().toLowerCase();
@@ -106,6 +136,60 @@ export default function ToolsPage2() {
     apps.reduce((s, a) => s + a.streams.length + a.actions.length, 0) +
     builtins.length +
     mcps.length;
+
+  // Group filtered MCP tools by server, joined with the live disposition row.
+  // Servers with a disposition row but no tools in the catalogue still
+  // appear (so Sir can flip them ahead of time); servers in the catalogue
+  // but missing from the disposition table render as DIRECT (the seeded
+  // default — happens only on a pre-migration tenant).
+  const mcpServerGroups = useMemo(() => {
+    const byServer = new Map<
+      string,
+      { server: string; tools: McpTool[]; disposition: ToolDispositionRow | null }
+    >();
+    for (const d of dispositions) {
+      byServer.set(d.server, { server: d.server, tools: [], disposition: d });
+    }
+    for (const m of filteredMcps) {
+      const existing = byServer.get(m.server);
+      if (existing) {
+        existing.tools.push(m);
+      } else {
+        byServer.set(m.server, {
+          server: m.server,
+          tools: [m],
+          disposition: null,
+        });
+      }
+    }
+    // Stable order: dispositions first (alphabetical), then orphan servers.
+    return Array.from(byServer.values()).sort((a, b) =>
+      a.server.localeCompare(b.server),
+    );
+  }, [dispositions, filteredMcps]);
+
+  const handleFlip = async (
+    server: string,
+    next: "direct" | "delegated",
+  ) => {
+    setFlipError(null);
+    try {
+      await setDisposition({ server, disposition: next });
+      setRestarts((r) => ({ ...r, [server]: Date.now() }));
+      // Refetch once the debounced restart window closes (10s + 2s slack).
+      setTimeout(() => {
+        refetchDispositions();
+        setRestarts((r) => {
+          const { [server]: _drop, ...rest } = r;
+          return rest;
+        });
+      }, 12_000);
+    } catch (e: any) {
+      setFlipError(
+        `Couldn't flip ${server}: ${e?.message ?? "unknown error"}`,
+      );
+    }
+  };
 
   return (
     <Frame>
@@ -284,9 +368,13 @@ export default function ToolsPage2() {
               )}
             </section>
 
-            {/* MCP tools */}
+            {/* MCP servers + dispositions (Phase B). Each server is a card
+                with: name, tool count, current DIRECT/DELEGATED state,
+                last-flipped-by/when, and the flip toggle. Three servers
+                are SELF-PROTECTED (alfred, alfred-ctrl, execute) — flipping
+                them would break Alfred's ability to talk to himself. */}
             <section>
-              <div className="border-b border-rule pb-3 mb-6 flex items-baseline justify-between">
+              <div className="border-b border-rule pb-3 mb-3 flex items-baseline justify-between">
                 <h2
                   className="font-mono uppercase smallcaps"
                   style={{
@@ -301,10 +389,33 @@ export default function ToolsPage2() {
                   className="font-mono text-[10px] uppercase tracking-[0.28em]"
                   style={{ color: "var(--marginalia)" }}
                 >
-                  {filteredMcps.length}
+                  {mcpServerGroups.length}
                 </span>
               </div>
-              {filteredMcps.length === 0 ? (
+
+              <p
+                className="font-body text-[14px] max-w-[68ch] mb-6"
+                style={{ color: "var(--marginalia)" }}
+              >
+                <strong>Direct</strong> — Alfred sees the server's tools
+                inline every turn (fastest, costs tokens).{" "}
+                <strong>Delegated</strong> — the tools are hidden on the main
+                runtime; Alfred reaches them by spawning a focused
+                sub-agent on the workers profile (cheaper model, +3-5s
+                per use). Flipping queues a ~10-second Hermes restart.
+                Default: Direct.
+              </p>
+
+              {flipError ? (
+                <div
+                  className="border border-rule p-3 mb-4 font-mono text-[12px]"
+                  style={{ color: "var(--marginalia)" }}
+                >
+                  {flipError}
+                </div>
+              ) : null}
+
+              {mcpServerGroups.length === 0 ? (
                 <p
                   className="font-body italic text-[14px]"
                   style={{ color: "var(--marginalia)" }}
@@ -312,26 +423,16 @@ export default function ToolsPage2() {
                   None.
                 </p>
               ) : (
-                <ul>
-                  {filteredMcps.map((m) => (
-                    <li
-                      key={`${m.server}::${m.name}`}
-                      className="grid grid-cols-[220px_140px_1fr] gap-4 py-3 border-b border-rule items-baseline"
-                    >
-                      <span className="font-mono text-[12px]">{m.name}</span>
-                      <span
-                        className="font-mono text-[10px] uppercase tracking-[0.22em]"
-                        style={{ color: "var(--brass)" }}
-                      >
-                        {m.server}
-                      </span>
-                      <span
-                        className="font-body text-[14px]"
-                        style={{ color: "var(--marginalia)" }}
-                      >
-                        {m.description}
-                      </span>
-                    </li>
+                <ul className="space-y-4">
+                  {mcpServerGroups.map((g) => (
+                    <McpServerCard
+                      key={g.server}
+                      server={g.server}
+                      tools={g.tools}
+                      disposition={g.disposition}
+                      restartingSince={restarts[g.server] ?? null}
+                      onFlip={handleFlip}
+                    />
                   ))}
                 </ul>
               )}
@@ -341,6 +442,153 @@ export default function ToolsPage2() {
       </section>
     </Frame>
   );
+}
+
+function McpServerCard({
+  server,
+  tools,
+  disposition,
+  restartingSince,
+  onFlip,
+}: {
+  server: string;
+  tools: McpTool[];
+  disposition: ToolDispositionRow | null;
+  restartingSince: number | null;
+  onFlip: (server: string, next: "direct" | "delegated") => void | Promise<void>;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const current = disposition?.disposition ?? "direct";
+  const isDelegated = current === "delegated";
+  const selfProtected = SELF_PROTECTED_SERVERS.has(server);
+  const restarting =
+    restartingSince !== null && Date.now() - restartingSince < 12_000;
+  const next: "direct" | "delegated" = isDelegated ? "direct" : "delegated";
+
+  const updatedAt = disposition?.updated_at
+    ? formatUpdated(disposition.updated_at)
+    : null;
+  const updatedBy = disposition?.updated_by ?? null;
+
+  return (
+    <li className="border border-rule p-5">
+      <div className="flex items-baseline justify-between gap-4 flex-wrap">
+        <div className="flex items-baseline gap-3">
+          <span className="font-display text-[22px]">{server}</span>
+          <span
+            className="font-mono text-[10px] uppercase tracking-[0.22em]"
+            style={{ color: "var(--marginalia)" }}
+          >
+            {tools.length} {tools.length === 1 ? "tool" : "tools"}
+          </span>
+        </div>
+        <div className="flex items-center gap-3">
+          <span
+            className="font-mono text-[10px] uppercase tracking-[0.28em]"
+            style={{
+              color: isDelegated ? "var(--marginalia)" : "var(--brass)",
+            }}
+            aria-label={`Current disposition: ${current}`}
+          >
+            {current}
+          </span>
+          {selfProtected ? (
+            <span
+              className="font-mono text-[10px] uppercase tracking-[0.22em] px-2 py-1 border border-rule"
+              style={{ color: "var(--marginalia)" }}
+              title="Self-protected — delegating this server would break Alfred's ability to talk to himself."
+            >
+              locked
+            </span>
+          ) : restarting ? (
+            <span
+              className="font-mono text-[10px] uppercase tracking-[0.22em]"
+              style={{ color: "var(--marginalia)" }}
+            >
+              hermes restarting…
+            </span>
+          ) : (
+            <button
+              type="button"
+              onClick={() => onFlip(server, next)}
+              className="font-mono text-[10px] uppercase tracking-[0.22em] px-3 py-1 border border-rule"
+              style={{ color: "var(--ink)" }}
+              aria-label={`Flip ${server} to ${next}`}
+            >
+              flip to {next}
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div
+        className="font-mono text-[10px] uppercase tracking-[0.22em] mt-2"
+        style={{ color: "var(--marginalia)" }}
+      >
+        {updatedAt
+          ? `last flipped ${updatedAt}${updatedBy ? ` by ${updatedBy}` : ""}`
+          : "not yet recorded"}
+      </div>
+
+      {tools.length > 0 ? (
+        <>
+          <button
+            type="button"
+            onClick={() => setExpanded((e) => !e)}
+            className="font-mono text-[10px] uppercase tracking-[0.22em] mt-4"
+            style={{ color: "var(--brass)" }}
+          >
+            {expanded ? "hide tools ▾" : "show tools ▸"}
+          </button>
+          {expanded ? (
+            <ul className="mt-3">
+              {tools.map((t) => (
+                <li
+                  key={`${t.server}::${t.name}`}
+                  className="grid grid-cols-[220px_1fr] gap-4 py-2 border-b border-rule items-baseline"
+                >
+                  <span className="font-mono text-[12px]">{t.name}</span>
+                  <span
+                    className="font-body text-[14px]"
+                    style={{ color: "var(--marginalia)" }}
+                  >
+                    {t.description}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </>
+      ) : (
+        <p
+          className="font-body italic text-[13px] mt-3"
+          style={{ color: "var(--marginalia)" }}
+        >
+          (no tools loaded — server may be misconfigured)
+        </p>
+      )}
+    </li>
+  );
+}
+
+// "2026-05-30 13:27:09" → "today 13:27" / "Wed 13:27" / "2026-05-30"
+function formatUpdated(iso: string): string {
+  const t = Date.parse(iso.replace(" ", "T") + "Z");
+  if (Number.isNaN(t)) return iso;
+  const d = new Date(t);
+  const now = new Date();
+  const sameDay =
+    d.getUTCFullYear() === now.getUTCFullYear() &&
+    d.getUTCMonth() === now.getUTCMonth() &&
+    d.getUTCDate() === now.getUTCDate();
+  const hh = String(d.getUTCHours()).padStart(2, "0");
+  const mm = String(d.getUTCMinutes()).padStart(2, "0");
+  if (sameDay) return `today ${hh}:${mm} UTC`;
+  const days = Math.round((now.getTime() - t) / 86_400_000);
+  if (days < 7) {
+    return `${d.toUTCString().slice(0, 3)} ${hh}:${mm} UTC`;
+  }
+  return iso;
 }
 
 function ColumnList({

--- a/packages/web/src/tools/operations.ts
+++ b/packages/web/src/tools/operations.ts
@@ -25,11 +25,7 @@
  * catalog internally (CATALOG_TTL_MS), so the per-toolkit HTTP round-trip to
  * Composio is amortized across all users on this tenant.
  */
-import type {
-  GetAllowedTools,
-  GetToolDispositions,
-  SetToolDisposition,
-} from "wasp/server/operations";
+import type { GetAllowedTools } from "wasp/server/operations";
 import { HttpError } from "wasp/server";
 import { getUserInstance, proxyToTenant } from "../server/tenantProxy";
 
@@ -202,17 +198,26 @@ interface ToolDispositionsResp {
   dispositions: ToolDisposition[];
 }
 
-export const getToolDispositions: GetToolDispositions<void, ToolDispositionsResp> =
-  async (_args, context) => {
-    if (!context.user) throw new HttpError(401, "Not authenticated");
-    const instance = await getUserInstance(context);
-    const resp = (await proxyToTenant(instance, {
-      path: "/api/v1/agents/tool-disposition",
-    })) as ToolDispositionsResp;
-    return {
-      dispositions: Array.isArray(resp?.dispositions) ? resp.dispositions : [],
-    };
+// Plain async functions, no Wasp generic types. The Wasp-generated
+// `GetToolDispositions<void, T>` constraint rejects the `(args, context)`
+// shape for void-input queries; the dashboard convention (see
+// setTelegramBotToken, getTelegramChannelStatus, etc.) is to just declare
+// the shape inline. The Wasp runtime introspects main.wasp for the wire
+// shape — the TS types here are local hints, not the source of truth.
+
+export const getToolDispositions = async (
+  _args: unknown,
+  context: any,
+): Promise<ToolDispositionsResp> => {
+  if (!context.user) throw new HttpError(401, "Not authenticated");
+  const instance = await getUserInstance(context);
+  const resp = (await proxyToTenant(instance, {
+    path: "/api/v1/agents/tool-disposition",
+  })) as ToolDispositionsResp;
+  return {
+    dispositions: Array.isArray(resp?.dispositions) ? resp.dispositions : [],
   };
+};
 
 interface SetToolDispositionArgs {
   server: string;
@@ -227,10 +232,10 @@ interface SetToolDispositionResp {
   restart_in_ms: number;
 }
 
-export const setToolDisposition: SetToolDisposition<
-  SetToolDispositionArgs,
-  SetToolDispositionResp
-> = async (args, context) => {
+export const setToolDisposition = async (
+  args: SetToolDispositionArgs,
+  context: any,
+): Promise<SetToolDispositionResp> => {
   if (!context.user) throw new HttpError(401, "Not authenticated");
   const server = String(args?.server ?? "").trim();
   const disposition = args?.disposition;

--- a/packages/web/src/tools/operations.ts
+++ b/packages/web/src/tools/operations.ts
@@ -198,17 +198,23 @@ interface ToolDispositionsResp {
   dispositions: ToolDisposition[];
 }
 
-// Plain async functions, no Wasp generic types. The Wasp-generated
-// `GetToolDispositions<void, T>` constraint rejects the `(args, context)`
-// shape for void-input queries; the dashboard convention (see
-// setTelegramBotToken, getTelegramChannelStatus, etc.) is to just declare
-// the shape inline. The Wasp runtime introspects main.wasp for the wire
-// shape — the TS types here are local hints, not the source of truth.
+// Plain async functions, no Wasp generic types AND no explicit return
+// type. The Wasp-generated `GenericAuthenticatedOperationDefinition`
+// constraint requires `Promise<Payload>`, and a concrete custom type
+// is not assignable to `Payload`. The dashboard convention
+// (setTelegramBotToken, setPaperclipApiKey, ~14 others) is plain
+// async + context: any, with no return-type annotation (so TS infers
+// the loose `Promise<any>` that satisfies the constraint). The Wasp
+// runtime reads main.wasp for the wire schema — the TS types here
+// are local hints, not the source of truth.
+//
+// Memory: PRs #139 and #145 both fixed the same `Promise<T>` trap. Do
+// not reintroduce explicit return types on Wasp operations.
 
 export const getToolDispositions = async (
   _args: unknown,
   context: any,
-): Promise<ToolDispositionsResp> => {
+): Promise<any> => {
   if (!context.user) throw new HttpError(401, "Not authenticated");
   const instance = await getUserInstance(context);
   const resp = (await proxyToTenant(instance, {
@@ -235,7 +241,7 @@ interface SetToolDispositionResp {
 export const setToolDisposition = async (
   args: SetToolDispositionArgs,
   context: any,
-): Promise<SetToolDispositionResp> => {
+): Promise<any> => {
   if (!context.user) throw new HttpError(401, "Not authenticated");
   const server = String(args?.server ?? "").trim();
   const disposition = args?.disposition;

--- a/packages/web/src/tools/operations.ts
+++ b/packages/web/src/tools/operations.ts
@@ -25,7 +25,11 @@
  * catalog internally (CATALOG_TTL_MS), so the per-toolkit HTTP round-trip to
  * Composio is amortized across all users on this tenant.
  */
-import type { GetAllowedTools } from "wasp/server/operations";
+import type {
+  GetAllowedTools,
+  GetToolDispositions,
+  SetToolDisposition,
+} from "wasp/server/operations";
 import { HttpError } from "wasp/server";
 import { getUserInstance, proxyToTenant } from "../server/tenantProxy";
 
@@ -167,5 +171,86 @@ export const getAllowedTools: GetAllowedTools<void, any> = async (
     builtin_tools,
     mcp_tools,
     prime_enabled,
+  };
+};
+
+// ----------------------------------------------------------------------------
+// Tool dispositions (Phase B) — per-MCP-server DIRECT/DELEGATED toggle
+// ----------------------------------------------------------------------------
+// The `tool_disposition` table in state.db records, for each of the 9 MCP
+// servers Hermes-main loads, whether its tools are exposed inline (DIRECT)
+// or hidden behind the `delegate_to_focused_agent` gateway (DELEGATED).
+// Defaults are all-DIRECT so existing tenants behave unchanged. A flip
+// queues a debounced Hermes restart (~10s) so the new `tools.include: []`
+// whitelist takes effect.
+//
+// Three servers are SELF-PROTECTED: alfred-ctrl, alfred, execute. Delegating
+// them would break Alfred's ability to reach the ctrl-api side of his own
+// brain (alfred-ctrl), call his own briefing/decision tools (alfred), or
+// run the Composio progressive-disclosure surface that Phase A optimised
+// (execute). The backend accepts the flip but the UI surfaces them as
+// locked with an explanation.
+
+export interface ToolDisposition {
+  server: string;
+  disposition: "direct" | "delegated";
+  updated_at: string;
+  updated_by: string | null;
+}
+
+interface ToolDispositionsResp {
+  dispositions: ToolDisposition[];
+}
+
+export const getToolDispositions: GetToolDispositions<void, ToolDispositionsResp> =
+  async (_args, context) => {
+    if (!context.user) throw new HttpError(401, "Not authenticated");
+    const instance = await getUserInstance(context);
+    const resp = (await proxyToTenant(instance, {
+      path: "/api/v1/agents/tool-disposition",
+    })) as ToolDispositionsResp;
+    return {
+      dispositions: Array.isArray(resp?.dispositions) ? resp.dispositions : [],
+    };
+  };
+
+interface SetToolDispositionArgs {
+  server: string;
+  disposition: "direct" | "delegated";
+}
+
+interface SetToolDispositionResp {
+  ok: boolean;
+  server: string;
+  disposition: "direct" | "delegated";
+  restart_queued: boolean;
+  restart_in_ms: number;
+}
+
+export const setToolDisposition: SetToolDisposition<
+  SetToolDispositionArgs,
+  SetToolDispositionResp
+> = async (args, context) => {
+  if (!context.user) throw new HttpError(401, "Not authenticated");
+  const server = String(args?.server ?? "").trim();
+  const disposition = args?.disposition;
+  if (!server) throw new HttpError(400, "server required");
+  if (disposition !== "direct" && disposition !== "delegated") {
+    throw new HttpError(400, "disposition must be 'direct' or 'delegated'");
+  }
+  const instance = await getUserInstance(context);
+  // updated_by is always 'sir' from the UI — Alfred himself flips via the
+  // MCP tool which sets updated_by='alfred'. The init seed uses 'init'.
+  const resp = await proxyToTenant(instance, {
+    method: "POST",
+    path: "/api/v1/agents/tool-disposition",
+    body: { server, disposition, updated_by: "sir" },
+  });
+  return {
+    ok: Boolean(resp?.ok ?? true),
+    server: String(resp?.server ?? server),
+    disposition: (resp?.disposition ?? disposition) as "direct" | "delegated",
+    restart_queued: Boolean(resp?.restart_queued ?? false),
+    restart_in_ms: Number(resp?.restart_in_ms ?? 10_000),
   };
 };


### PR DESCRIPTION
**What** — surfaces the Phase B `tool_disposition` map on /tools so the principal can see (and flip) which MCP servers are DIRECT vs DELEGATED without dropping to the MCP tool.

**Why** — Phase B (#178) shipped the backend (table + GET/POST routes + Alfred-side MCP tools); this closes the loop so the principal can manage the same lever from the UI. Direct = Alfred sees the tools inline every turn (fastest, costs tokens). Delegated = tools hidden on main, accessed via `delegate_to_focused_agent` on the workers profile (cheaper model, +3-5s/use).

**UI** — /tools now groups the MCP catalogue **by server** (was: flat per-tool list). Each server card carries:
- current state (DIRECT or DELEGATED)
- audit (`last flipped <when> by <who>`)
- a `flip to <next>` button (queues debounced ~10s Hermes restart; UI shows `hermes restarting…` for ~12s then refetches)
- expandable per-tool detail (the previous flat view, now collapsed by default)
- three servers (alfred, alfred-ctrl, execute) render as `locked` instead of toggleable — flipping them to DELEGATED would break Alfred's ability to talk to himself. Backend still accepts the flip via the MCP tool if Sir is deliberate.

**Backend** — two new Wasp ops in `packages/web/src/tools/operations.ts`:
- `getToolDispositions` (query) → `GET /api/v1/agents/tool-disposition`
- `setToolDisposition` (action) → `POST /api/v1/agents/tool-disposition` with `updated_by='sir'`

Alfred's MCP `set_tool_disposition` tool writes `updated_by='alfred'`; init seeds with `'init'`. The audit row tells the truth about who flipped what.

**No backend changes** — the routes already exist (PR #178, live on home since 13:35 UTC today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)