### PR TITLE
fix(ctrl,web): /tools page surfaces real per-server tool counts

### DIFF
--- a/packages/ctrl/src/api/routes/hermes.ts
+++ b/packages/ctrl/src/api/routes/hermes.ts
@@ -326,25 +326,88 @@ export function registerHermesRoutes(): void {
       description: string;
       prime_only: boolean;
     }> = [];
+    // Per-server inclusion metadata — used by the /tools UI's disposition
+    // panel so it can render "23 tools (whitelisted)" vs "all tools (count
+    // not surfaced)" vs "none — delegated" without lying.
+    const mcpServerInclusion: Array<{
+      server: string;
+      // 'whitelist' — config.yaml has tools.include with explicit names; we
+      //   know the exact catalogue and surface it in mcp_tools below.
+      // 'all'       — no tools.include set; Hermes passes through whatever
+      //   the spawned MCP server advertises. We can't enumerate without
+      //   asking the running process, so we report the count as unknown.
+      // 'none'      — tools.include is an empty array (the DELEGATED shape
+      //   from PR #178). The server still runs for the workers profile but
+      //   main's LLM sees nothing.
+      mode: "whitelist" | "all" | "none";
+      tool_count: number | null;
+    }> = [];
+
     for (const server of mcpServers) {
+      const serverCfg = mcpSection?.[server] ?? {};
+      const includeRaw = serverCfg?.tools?.include;
+      const isExplicitList = Array.isArray(includeRaw);
       const known = MCP_SERVER_TOOLS[server];
-      if (!known) continue;
-      for (const t of known) {
-        if (t.prime_only && !primeEnabled) continue;
-        mcpTools.push({
-          name: t.name,
-          server,
-          description: t.description,
-          prime_only: t.prime_only,
-        });
+
+      let mode: "whitelist" | "all" | "none";
+      let toolCount: number | null;
+
+      if (isExplicitList && includeRaw.length === 0) {
+        mode = "none";
+        toolCount = 0;
+      } else if (isExplicitList) {
+        mode = "whitelist";
+        toolCount = includeRaw.length;
+        // Surface every whitelisted name. Descriptions only exist for the
+        // few servers in MCP_SERVER_TOOLS; the rest fall back to a
+        // placeholder rather than blocking the row from appearing.
+        for (const name of includeRaw as unknown[]) {
+          if (typeof name !== "string") continue;
+          const desc =
+            known?.find((t) => t.name === name)?.description ??
+            "(tool advertised by the MCP server; description not catalogued in ctrl-api)";
+          mcpTools.push({
+            name,
+            server,
+            description: desc,
+            prime_only:
+              known?.find((t) => t.name === name)?.prime_only ?? false,
+          });
+        }
+      } else if (known) {
+        // No `tools.include` set, and we have a curated description list:
+        // expose those (this preserves the alfred-ctrl behaviour where the
+        // 4 known tools have rich descriptions).
+        mode = "all";
+        toolCount = null;
+        for (const t of known) {
+          if (t.prime_only && !primeEnabled) continue;
+          mcpTools.push({
+            name: t.name,
+            server,
+            description: t.description,
+            prime_only: t.prime_only,
+          });
+        }
+      } else {
+        // No include list AND no curated descriptions — Hermes is passing
+        // through whatever the server advertises, but ctrl-api can't
+        // enumerate without asking the running process. Surface the row
+        // honestly so the UI can render "all tools" instead of "0 tools".
+        mode = "all";
+        toolCount = null;
       }
+
+      mcpServerInclusion.push({ server, mode, tool_count: toolCount });
     }
     mcpTools.sort((a, b) => a.name.localeCompare(b.name));
+    mcpServerInclusion.sort((a, b) => a.server.localeCompare(b.server));
 
     sendJson(res, 200, {
       builtin_tools: builtinTools,
       mcp_tools: mcpTools,
       mcp_servers: mcpServers,
+      mcp_server_inclusion: mcpServerInclusion,
       prime_enabled: primeEnabled,
     });
   });

--- a/packages/web/src/tools/ToolsPage2.tsx
+++ b/packages/web/src/tools/ToolsPage2.tsx
@@ -65,11 +65,26 @@ interface McpTool {
   prime_only: boolean;
 }
 
+interface McpServerInclusion {
+  server: string;
+  // 'whitelist' — tools.include in config.yaml lists explicit names → we
+  //   know the exact catalogue and the count is meaningful.
+  // 'all'       — no whitelist; Hermes passes through whatever the spawned
+  //   MCP server advertises. ctrl-api can't enumerate without asking the
+  //   running process, so render the count as unknown.
+  // 'none'      — tools.include is an empty array (the DELEGATED shape from
+  //   PR #178). Server still serves the workers profile, just hidden on main.
+  mode: "whitelist" | "all" | "none";
+  tool_count: number | null;
+}
+
 export default function ToolsPage2() {
   const { data, isLoading } = useQuery(getAllowedTools);
   const apps: AppEntry[] = (data?.apps ?? []) as AppEntry[];
   const builtins: BuiltinTool[] = (data?.builtin_tools ?? []) as BuiltinTool[];
   const mcps: McpTool[] = (data?.mcp_tools ?? []) as McpTool[];
+  const mcpInclusion: McpServerInclusion[] =
+    (data?.mcp_server_inclusion ?? []) as McpServerInclusion[];
 
   const { data: dispData, refetch: refetchDispositions } =
     useQuery(getToolDispositions);
@@ -137,18 +152,38 @@ export default function ToolsPage2() {
     builtins.length +
     mcps.length;
 
-  // Group filtered MCP tools by server, joined with the live disposition row.
-  // Servers with a disposition row but no tools in the catalogue still
-  // appear (so Sir can flip them ahead of time); servers in the catalogue
-  // but missing from the disposition table render as DIRECT (the seeded
-  // default — happens only on a pre-migration tenant).
+  // Group filtered MCP tools by server, joined with the live disposition
+  // row AND the per-server inclusion shape from config.yaml. Each server
+  // card surfaces three orthogonal facts:
+  //   • disposition (DIRECT vs DELEGATED, from state.db.tool_disposition)
+  //   • inclusion shape (whitelist / all / none, from config.yaml mcp_servers)
+  //   • per-tool detail (only meaningful when inclusion = whitelist)
+  //
+  // The two states the OLD UI conflated are now distinct:
+  //   - disposition=DIRECT + inclusion=all  → "all tools available, count not
+  //     surfaced". No misleading "0 tools / misconfigured" message.
+  //   - disposition=DELEGATED                → inclusion will be 'none' after
+  //     the debounced restart fires; we render 'delegated' regardless.
   const mcpServerGroups = useMemo(() => {
+    const inclusionMap = new Map<string, McpServerInclusion>();
+    for (const i of mcpInclusion) inclusionMap.set(i.server, i);
+
     const byServer = new Map<
       string,
-      { server: string; tools: McpTool[]; disposition: ToolDispositionRow | null }
+      {
+        server: string;
+        tools: McpTool[];
+        disposition: ToolDispositionRow | null;
+        inclusion: McpServerInclusion | null;
+      }
     >();
     for (const d of dispositions) {
-      byServer.set(d.server, { server: d.server, tools: [], disposition: d });
+      byServer.set(d.server, {
+        server: d.server,
+        tools: [],
+        disposition: d,
+        inclusion: inclusionMap.get(d.server) ?? null,
+      });
     }
     for (const m of filteredMcps) {
       const existing = byServer.get(m.server);
@@ -159,6 +194,7 @@ export default function ToolsPage2() {
           server: m.server,
           tools: [m],
           disposition: null,
+          inclusion: inclusionMap.get(m.server) ?? null,
         });
       }
     }
@@ -166,7 +202,7 @@ export default function ToolsPage2() {
     return Array.from(byServer.values()).sort((a, b) =>
       a.server.localeCompare(b.server),
     );
-  }, [dispositions, filteredMcps]);
+  }, [dispositions, filteredMcps, mcpInclusion]);
 
   const handleFlip = async (
     server: string,
@@ -430,6 +466,7 @@ export default function ToolsPage2() {
                       server={g.server}
                       tools={g.tools}
                       disposition={g.disposition}
+                      inclusion={g.inclusion}
                       restartingSince={restarts[g.server] ?? null}
                       onFlip={handleFlip}
                     />
@@ -448,12 +485,14 @@ function McpServerCard({
   server,
   tools,
   disposition,
+  inclusion,
   restartingSince,
   onFlip,
 }: {
   server: string;
   tools: McpTool[];
   disposition: ToolDispositionRow | null;
+  inclusion: McpServerInclusion | null;
   restartingSince: number | null;
   onFlip: (server: string, next: "direct" | "delegated") => void | Promise<void>;
 }) {
@@ -470,6 +509,31 @@ function McpServerCard({
     : null;
   const updatedBy = disposition?.updated_by ?? null;
 
+  // Two facts the previous render conflated:
+  //   1. How many tools does the LLM SEE on every turn? (from inclusion)
+  //   2. Do we have a per-tool catalogue we can show? (depends on mode)
+  //
+  // mode='whitelist' → we know the exact count + the names; render both.
+  // mode='all'       → all of the server's tools are exposed, but ctrl-api
+  //                    doesn't know the list (would have to ask the running
+  //                    MCP process). Render "all tools" with no expander.
+  // mode='none'      → 0 tools on main; the server is being treated as
+  //                    DELEGATED. Render "0 (delegated)" — never "misconfigured".
+  // inclusion=null    → API older than 2026-05-30; fall back to the previous
+  //                    catalogue-only behaviour, but DON'T say "misconfigured".
+  const inclusionMode = inclusion?.mode ?? null;
+  const inclusionCount = inclusion?.tool_count ?? null;
+  const countLabel: string =
+    inclusionMode === "whitelist" && inclusionCount !== null
+      ? `${inclusionCount} ${inclusionCount === 1 ? "tool" : "tools"}`
+      : inclusionMode === "all"
+        ? "all tools"
+        : inclusionMode === "none"
+          ? "0 tools (delegated)"
+          : tools.length > 0
+            ? `${tools.length} ${tools.length === 1 ? "tool" : "tools"}`
+            : "—";
+
   return (
     <li className="border border-rule p-5">
       <div className="flex items-baseline justify-between gap-4 flex-wrap">
@@ -479,7 +543,7 @@ function McpServerCard({
             className="font-mono text-[10px] uppercase tracking-[0.22em]"
             style={{ color: "var(--marginalia)" }}
           >
-            {tools.length} {tools.length === 1 ? "tool" : "tools"}
+            {countLabel}
           </span>
         </div>
         <div className="flex items-center gap-3">
@@ -559,12 +623,29 @@ function McpServerCard({
             </ul>
           ) : null}
         </>
+      ) : inclusionMode === "all" ? (
+        <p
+          className="font-body italic text-[13px] mt-3"
+          style={{ color: "var(--marginalia)" }}
+        >
+          Every tool this MCP server advertises is passed through to the
+          main runtime. Exact list isn't surfaced here yet — Hermes knows
+          it; ctrl-api would have to ask the running process.
+        </p>
+      ) : inclusionMode === "none" ? (
+        <p
+          className="font-body italic text-[13px] mt-3"
+          style={{ color: "var(--marginalia)" }}
+        >
+          Tools hidden from main. The server still runs and is reachable
+          via <code>delegate_to_focused_agent</code> on the workers profile.
+        </p>
       ) : (
         <p
           className="font-body italic text-[13px] mt-3"
           style={{ color: "var(--marginalia)" }}
         >
-          (no tools loaded — server may be misconfigured)
+          (catalogue not yet surfaced — disposition control still works)
         </p>
       )}
     </li>

--- a/packages/web/src/tools/operations.ts
+++ b/packages/web/src/tools/operations.ts
@@ -87,6 +87,18 @@ export const getAllowedTools: GetAllowedTools<void, any> = async (
     Array.isArray(builtinMcpResp?.builtin_tools) ? builtinMcpResp.builtin_tools : [];
   const mcp_tools: Array<{ name: string; server: string; description: string; prime_only: boolean }> =
     Array.isArray(builtinMcpResp?.mcp_tools) ? builtinMcpResp.mcp_tools : [];
+  // Per-server inclusion mode (whitelist / all / none) + count so the
+  // dashboard can render "23 tools" vs "all tools (count not surfaced)"
+  // honestly. Added 2026-05-30 — the previous endpoint only knew about
+  // the curated MCP_SERVER_TOOLS map (alfred-ctrl only) and silently
+  // returned 0 for every other server.
+  const mcp_server_inclusion: Array<{
+    server: string;
+    mode: "whitelist" | "all" | "none";
+    tool_count: number | null;
+  }> = Array.isArray(builtinMcpResp?.mcp_server_inclusion)
+    ? builtinMcpResp.mcp_server_inclusion
+    : [];
   const prime_enabled: boolean = Boolean(builtinMcpResp?.prime_enabled);
 
   // 2. All connected apps + their auto-config state. We join with
@@ -166,6 +178,7 @@ export const getAllowedTools: GetAllowedTools<void, any> = async (
     apps: appResults,
     builtin_tools,
     mcp_tools,
+    mcp_server_inclusion,
     prime_enabled,
   };
 };


### PR DESCRIPTION
Closes the regression Sir hit on home: every MCP server card showed '0 tools' / '(server may be misconfigured)' even though Hermes is running with 170+ tools loaded.

**Root cause** (pre-existing, not introduced by PR #182): `ctrl-api`'s `/api/v1/hermes/allowed-tools` route uses a static `MCP_SERVER_TOOLS` map that only ever had `alfred-ctrl` entries. As Hermes grew `sure` / `plane` / `vaultwarden` / `paperclip` / `execute` / `hass` / `files` MCP servers, the map was never updated. The old flat ToolsPage2 happened to hide this (it just showed whatever 2 tools came back); the new grouping-by-server made it visible as 9 cards saying 'misconfigured'.

**Fix** — route now reads each server's `tools.include` directly from the live `config.yaml` and returns a new `mcp_server_inclusion` array distinguishing three modes:

| mode | meaning | count |
|---|---|---|
| `whitelist` | `tools.include` is a list of names | exact (e.g. sure: 23 from PR #176) |
| `all` | no `tools.include` set; pass-through | unknown — Hermes knows, ctrl-api would have to ask the running MCP process |
| `none` | empty array — the DELEGATED shape from PR #178 | 0 (intentional) |

UI updated: count label and explanatory text now match reality, never says 'misconfigured' for a server that is in fact working as designed.

Live config on home today:
```
alfred-ctrl       include=ALL
alfred            include=ALL
sure              include=[23 tools]
plane             include=ALL
vaultwarden       include=ALL
execute           include=ALL
paperclip         include=[18 tools]
hass              include=[28 tools]
files             include=ALL
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)