### PR TITLE
feat(ctrl,web): live MCP-server tool enumeration on /tools (#185)

### DIFF
--- a/packages/ctrl/src/api/routes/hermes.ts
+++ b/packages/ctrl/src/api/routes/hermes.ts
@@ -20,6 +20,109 @@ import { addRoute } from "../server.js";
 import { sendJson } from "../errors.js";
 import { dockerExec, dockerComposeCmd, HERMES_CMD, HERMES_CONTAINER } from "../helpers.js";
 
+// ---------------------------------------------------------------------------
+// Per-MCP-server live tool catalogue cache (issue #185).
+//
+// For `mcp_servers.<name>.tools.include` ABSENT (mode='all'), config.yaml has
+// no list of names — Hermes passes through whatever the running MCP server
+// advertises. The only authoritative source is the running process. Hermes'
+// HTTP API has no introspection route (probed live: /v1/tools, /v1/mcp,
+// /v1/mcp_servers all 404), so we shell out to `hermes mcp test <server>`,
+// which connects to the server, lists its tools with descriptions, and exits
+// in ~250-300ms per server. Result is text — parsed into the structured
+// {name, description} shape callers expect.
+//
+// Cached for 30s per server. A Hermes restart blows the catalogue but we
+// don't need to coordinate with the restart lifecycle — the next request
+// after the TTL just re-fetches. A 30s window is short enough that a
+// dispositions flip (which triggers a debounced restart) is reflected on
+// the user's next refresh.
+// ---------------------------------------------------------------------------
+interface DiscoveredMcpTool {
+  name: string;
+  description: string;
+}
+interface McpToolsCacheEntry {
+  tools: DiscoveredMcpTool[];
+  fetchedAt: number;
+  /** True if the `hermes mcp test` invocation failed; we still cache for a
+   *  short window so a misconfigured server doesn't spam docker exec on
+   *  every /tools refresh. */
+  failed: boolean;
+}
+const MCP_TOOLS_CACHE = new Map<string, McpToolsCacheEntry>();
+const MCP_TOOLS_CACHE_TTL_MS = 30_000;
+const MCP_TOOLS_FAILED_TTL_MS = 5_000;
+
+/**
+ * Parse the text output of `hermes mcp test <server>` into a list of
+ * {name, description} pairs. The CLI prints a header (Testing/Transport/
+ * Auth/Connected/Tools discovered), a blank line, then one tool per line:
+ *
+ *     <name>                                  <description-truncated-to-~60ch>
+ *
+ * Names start at column ≥4, are word-character identifiers; description
+ * is whatever follows the run of ≥2 spaces. Truncation is the CLI's, not
+ * ours — we don't try to recover the full description. (Once Hermes grows
+ * a JSON output flag we can switch.)
+ */
+function parseHermesMcpTestOutput(stdout: string): DiscoveredMcpTool[] {
+  const out: DiscoveredMcpTool[] = [];
+  for (const line of stdout.split("\n")) {
+    // Skip header rows + empty rows + status markers (✓ / ✗).
+    if (!line.trim()) continue;
+    if (/^\s*(Testing|Transport|Auth|Available)\b/.test(line)) continue;
+    if (/^\s*[✓✗]/.test(line)) continue;
+    // Tool rows: ≥4 leading spaces, identifier, then ≥2 spaces, then prose.
+    const m = line.match(/^\s{4,}([A-Za-z_][\w-]*)\s{2,}(.*\S)\s*$/);
+    if (!m) continue;
+    out.push({ name: m[1], description: m[2] });
+  }
+  return out;
+}
+
+/**
+ * Discover the live tool catalogue advertised by one MCP server.
+ *
+ * Calls `hermes mcp test <server>` inside the hermes container. Cached for
+ * MCP_TOOLS_CACHE_TTL_MS so repeat hits on the /tools route within a session
+ * don't pay the ~300ms exec cost N times. Returns [] on any failure (server
+ * unknown, container missing, parse mismatch) — the caller falls back to
+ * whatever shape it had before.
+ *
+ * @param server  MCP-server name as it appears in config.yaml.mcp_servers
+ *                (e.g. 'alfred', 'execute', 'plane', 'files').
+ */
+async function discoverMcpToolsAdvertised(
+  server: string,
+): Promise<DiscoveredMcpTool[]> {
+  const cached = MCP_TOOLS_CACHE.get(server);
+  const now = Date.now();
+  if (cached) {
+    const ttl = cached.failed ? MCP_TOOLS_FAILED_TTL_MS : MCP_TOOLS_CACHE_TTL_MS;
+    if (now - cached.fetchedAt < ttl) return cached.tools;
+  }
+  try {
+    const stdout = await dockerExec(HERMES_CONTAINER, [
+      ...HERMES_CMD,
+      "mcp",
+      "test",
+      server,
+    ]);
+    const tools = parseHermesMcpTestOutput(stdout);
+    MCP_TOOLS_CACHE.set(server, { tools, fetchedAt: now, failed: tools.length === 0 });
+    return tools;
+  } catch {
+    MCP_TOOLS_CACHE.set(server, { tools: [], fetchedAt: now, failed: true });
+    return [];
+  }
+}
+
+/** Reset the per-server cache. Test-only. */
+export function _resetMcpToolsCacheForTest(): void {
+  MCP_TOOLS_CACHE.clear();
+}
+
 // Hermes resolves all profile state under HERMES_HOME (default /opt/data in
 // the runtime container — see packages/hermes/Dockerfile). Each profile lives
 // at ${HERMES_HOME}/profiles/<profile>/config.yaml. ctrl-api reads the `main`
@@ -343,24 +446,27 @@ export function registerHermesRoutes(): void {
       tool_count: number | null;
     }> = [];
 
+    // Partition servers by mode first so the `all` branch can fan out the
+    // `hermes mcp test` calls in parallel — sequentially we'd pay
+    // N × ~300ms; in parallel the wall-clock is whichever server is slowest.
+    const allModeServers: string[] = [];
     for (const server of mcpServers) {
       const serverCfg = mcpSection?.[server] ?? {};
       const includeRaw = serverCfg?.tools?.include;
       const isExplicitList = Array.isArray(includeRaw);
       const known = MCP_SERVER_TOOLS[server];
 
-      let mode: "whitelist" | "all" | "none";
-      let toolCount: number | null;
-
       if (isExplicitList && includeRaw.length === 0) {
-        mode = "none";
-        toolCount = 0;
-      } else if (isExplicitList) {
-        mode = "whitelist";
-        toolCount = includeRaw.length;
-        // Surface every whitelisted name. Descriptions only exist for the
-        // few servers in MCP_SERVER_TOOLS; the rest fall back to a
-        // placeholder rather than blocking the row from appearing.
+        mcpServerInclusion.push({ server, mode: "none", tool_count: 0 });
+        continue;
+      }
+      if (isExplicitList) {
+        // Whitelist — the LLM sees exactly these names every turn. Surface
+        // them straight from config.yaml. The runtime's full advertised
+        // catalogue may be a superset (e.g. `sure` whitelists 23 of 95) but
+        // showing the superset would be MORE dishonest than the whitelist.
+        const count = includeRaw.length;
+        mcpServerInclusion.push({ server, mode: "whitelist", tool_count: count });
         for (const name of includeRaw as unknown[]) {
           if (typeof name !== "string") continue;
           const desc =
@@ -374,12 +480,55 @@ export function registerHermesRoutes(): void {
               known?.find((t) => t.name === name)?.prime_only ?? false,
           });
         }
+        continue;
+      }
+      // No include list at all → mode='all'. Schedule a live discovery call
+      // and fill in mode/count below once they resolve.
+      allModeServers.push(server);
+    }
+
+    // Fan out the `hermes mcp test` calls for `all`-mode servers (issue #185).
+    // Each is cached in MCP_TOOLS_CACHE; cold path is ~300ms per server,
+    // warm path is a Map lookup. The N servers run concurrently so the
+    // wall-clock for the cold path is ~max, not ~sum.
+    const allModeResults = await Promise.all(
+      allModeServers.map(async (server) => ({
+        server,
+        tools: await discoverMcpToolsAdvertised(server),
+      })),
+    );
+
+    for (const { server, tools: discovered } of allModeResults) {
+      const known = MCP_SERVER_TOOLS[server];
+      if (discovered.length > 0) {
+        mcpServerInclusion.push({
+          server,
+          mode: "all",
+          tool_count: discovered.length,
+        });
+        for (const t of discovered) {
+          // Description fallback: live description wins; the curated
+          // MCP_SERVER_TOOLS map is description-only fallback, not the
+          // source of truth for which tools exist.
+          const curated = known?.find((k) => k.name === t.name);
+          if (curated?.prime_only && !primeEnabled) continue;
+          mcpTools.push({
+            name: t.name,
+            server,
+            description: t.description || curated?.description || "",
+            prime_only: curated?.prime_only ?? false,
+          });
+        }
       } else if (known) {
-        // No `tools.include` set, and we have a curated description list:
-        // expose those (this preserves the alfred-ctrl behaviour where the
-        // 4 known tools have rich descriptions).
-        mode = "all";
-        toolCount = null;
+        // Discovery failed (parse mismatch, container missing, …) but we
+        // do have curated descriptions for this server — fall back to the
+        // pre-#185 behaviour so the page degrades cleanly instead of
+        // pretending the server is empty.
+        mcpServerInclusion.push({
+          server,
+          mode: "all",
+          tool_count: null,
+        });
         for (const t of known) {
           if (t.prime_only && !primeEnabled) continue;
           mcpTools.push({
@@ -390,15 +539,14 @@ export function registerHermesRoutes(): void {
           });
         }
       } else {
-        // No include list AND no curated descriptions — Hermes is passing
-        // through whatever the server advertises, but ctrl-api can't
-        // enumerate without asking the running process. Surface the row
-        // honestly so the UI can render "all tools" instead of "0 tools".
-        mode = "all";
-        toolCount = null;
+        // Discovery failed AND no curated fallback — surface the row
+        // honestly. The UI renders "all tools" + the fallback copy.
+        mcpServerInclusion.push({
+          server,
+          mode: "all",
+          tool_count: null,
+        });
       }
-
-      mcpServerInclusion.push({ server, mode, tool_count: toolCount });
     }
     mcpTools.sort((a, b) => a.name.localeCompare(b.name));
     mcpServerInclusion.sort((a, b) => a.server.localeCompare(b.server));

--- a/packages/ctrl/tests/hermes-allowed-tools-enumeration.test.ts
+++ b/packages/ctrl/tests/hermes-allowed-tools-enumeration.test.ts
@@ -1,0 +1,264 @@
+// issue #185 — live MCP-server tool enumeration on /tools.
+//
+// Before this change, `/api/v1/hermes/allowed-tools` knew the names + count
+// for `whitelist`-mode servers (config.yaml had the names) and the COUNT
+// (=0) for `none`-mode servers. For `all`-mode servers (no `tools.include`
+// in config.yaml), it returned `tool_count: null` and an empty `mcp_tools`
+// slice — the UI rendered "all tools" with no expander and the misleading
+// "exact list isn't surfaced here yet" copy.
+//
+// This test fixes the route to:
+//   1. Leave the whitelist path UNCHANGED (LLM sees exactly those names).
+//   2. Populate `all`-mode servers from the live runtime via
+//      `hermes mcp test <server>` — count + names + descriptions.
+//   3. Keep `none`-mode at empty (intentionally hidden from main).
+//
+// The `hermes mcp test` exec is mocked here so CI runs deterministic without
+// touching a live container.
+//
+// Coverage:
+//   - whitelist path unchanged (sure: count from config, names from config)
+//   - all path populated from the mocked `hermes mcp test` output
+//   - none path empty
+//   - parser tolerates the real CLI output shape (header + tool rows)
+//   - per-server cache: a second hit within the TTL skips dockerExec
+//   - failure path (exec throws) — falls back without poisoning the rest
+
+import { mock, describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-allowed-tools-"));
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.STATE_DB_PATH = path.join(tmp, "state.db");
+process.env.INGEST_DB_PATH = path.join(tmp, "ingest.db");
+process.env.VAULT_PATH = path.join(tmp, "vault");
+process.env.SQLITE_VEC_PATH = "";
+
+// Write a config.yaml the route can read. Three servers — one whitelist
+// (sure, 2 names), one all (plane — no tools.include), one none
+// (vaultwarden — empty tools.include). The route reads
+// /opt/data/profiles/main/config.yaml by default; redirect via env.
+const profileDir = path.join(tmp, "profiles", "main");
+fs.mkdirSync(profileDir, { recursive: true });
+const configYaml = `
+platform_toolsets:
+  cli:
+    - terminal
+    - file
+mcp_servers:
+  sure:
+    transport: stdio
+    tools:
+      include:
+        - get_balance_sheet
+        - list_accounts
+  plane:
+    transport: stdio
+  vaultwarden:
+    transport: stdio
+    tools:
+      include: []
+`;
+fs.writeFileSync(path.join(profileDir, "config.yaml"), configYaml);
+process.env.HERMES_HOME = tmp;
+
+// ── helpers mock — stub dockerExec for `hermes mcp test <server>` ────────
+
+const dockerExecCalls: { service: string; command: string[] }[] = [];
+let dockerExecHandler: (
+  service: string,
+  command: string[],
+) => string | Promise<string> = async () => "";
+
+const realHelpers = await import("../src/api/helpers.js");
+mock.module("../src/api/helpers.js", {
+  namedExports: {
+    ...realHelpers,
+    dockerExec: async (service: string, command: string[]) => {
+      dockerExecCalls.push({ service, command: [...command] });
+      return await dockerExecHandler(service, command);
+    },
+    dockerComposeCmd: async () => "",
+  },
+});
+
+const { matchRoute } = await import("../src/api/server.js");
+const { registerHermesRoutes, _resetMcpToolsCacheForTest } = await import(
+  "../src/api/routes/hermes.js"
+);
+
+registerHermesRoutes();
+
+// Fake plane catalogue — what `hermes mcp test plane` returns. Real CLI
+// shape: ~2-space-indented header, blank, then 4-space-indented rows of
+// `<name>` + ≥2 spaces + truncated description.
+const FAKE_PLANE_OUTPUT = `  Testing 'plane'...
+  Transport: stdio → node
+  Auth: none
+  ✓ Connected (265ms)
+  ✓ Tools discovered: 3
+
+    get_issue                            Fetch a single Plane issue by id.
+    list_issues                          Simple paginated list of issues in ONE project.
+    create_issue                         Create a new issue in a Plane project.
+`;
+
+function invokeRoute(): Promise<{ status: number; body: any }> {
+  const matched = matchRoute("GET", "/api/v1/hermes/allowed-tools");
+  assert.ok(matched, "/api/v1/hermes/allowed-tools must be registered");
+  return new Promise((resolve, reject) => {
+    let bodyChunks: any[] = [];
+    let status = 0;
+    const res: any = {
+      statusCode: 200,
+      setHeader() {},
+      writeHead(s: number) {
+        status = s;
+      },
+      end(chunk?: any) {
+        if (chunk !== undefined) bodyChunks.push(chunk);
+        try {
+          const raw = Buffer.concat(
+            bodyChunks.map((c) =>
+              Buffer.isBuffer(c) ? c : Buffer.from(String(c)),
+            ),
+          ).toString();
+          resolve({ status: status || 200, body: raw ? JSON.parse(raw) : {} });
+        } catch (e) {
+          reject(e);
+        }
+      },
+      write(chunk: any) {
+        bodyChunks.push(chunk);
+      },
+    };
+    Promise.resolve(
+      matched!.handler({
+        req: {} as any,
+        res,
+        params: matched!.params,
+        query: new URLSearchParams(),
+        body: undefined,
+      }),
+    ).catch(reject);
+  });
+}
+
+beforeEach(() => {
+  dockerExecCalls.length = 0;
+  _resetMcpToolsCacheForTest();
+  dockerExecHandler = async (_svc, command) => {
+    // command shape: ['hermes', 'mcp', 'test', '<server>']
+    const server = command[command.length - 1];
+    if (server === "plane") return FAKE_PLANE_OUTPUT;
+    throw new Error(`unmocked server: ${server}`);
+  };
+});
+
+describe("issue #185 — /api/v1/hermes/allowed-tools enumerates `all`-mode MCP servers", () => {
+  it("returns the whitelist names verbatim for whitelist-mode servers (config-driven, unchanged)", async () => {
+    const { status, body } = await invokeRoute();
+    assert.equal(status, 200);
+    const inclusion = body.mcp_server_inclusion as any[];
+    const sure = inclusion.find((i) => i.server === "sure");
+    assert.ok(sure, "sure must appear in mcp_server_inclusion");
+    assert.equal(sure.mode, "whitelist");
+    assert.equal(sure.tool_count, 2);
+    const sureTools = (body.mcp_tools as any[]).filter((t) => t.server === "sure");
+    assert.deepEqual(
+      sureTools.map((t) => t.name).sort(),
+      ["get_balance_sheet", "list_accounts"],
+    );
+  });
+
+  it("populates `all`-mode servers from `hermes mcp test <server>` — count + names", async () => {
+    const { status, body } = await invokeRoute();
+    assert.equal(status, 200);
+    const inclusion = body.mcp_server_inclusion as any[];
+    const plane = inclusion.find((i) => i.server === "plane");
+    assert.ok(plane);
+    assert.equal(plane.mode, "all");
+    assert.equal(
+      plane.tool_count,
+      3,
+      "discovered count from `hermes mcp test plane` (3 in fake output)",
+    );
+    const planeTools = (body.mcp_tools as any[]).filter(
+      (t) => t.server === "plane",
+    );
+    assert.deepEqual(
+      planeTools.map((t) => t.name).sort(),
+      ["create_issue", "get_issue", "list_issues"],
+    );
+    // Descriptions came from the parsed CLI output.
+    const issueRow = planeTools.find((t) => t.name === "get_issue");
+    assert.match(issueRow.description, /Fetch a single Plane issue/);
+    // And the call landed.
+    assert.ok(
+      dockerExecCalls.some(
+        (c) =>
+          c.service === "hermes" &&
+          c.command.includes("mcp") &&
+          c.command.includes("test") &&
+          c.command.includes("plane"),
+      ),
+      "dockerExec must have been called with `hermes mcp test plane`",
+    );
+  });
+
+  it("none-mode servers (tools.include === []) stay empty — intentionally hidden from main", async () => {
+    const { status, body } = await invokeRoute();
+    assert.equal(status, 200);
+    const inclusion = body.mcp_server_inclusion as any[];
+    const vw = inclusion.find((i) => i.server === "vaultwarden");
+    assert.ok(vw);
+    assert.equal(vw.mode, "none");
+    assert.equal(vw.tool_count, 0);
+    const vwTools = (body.mcp_tools as any[]).filter(
+      (t) => t.server === "vaultwarden",
+    );
+    assert.equal(vwTools.length, 0);
+    // And we did NOT run docker exec on vaultwarden (none-mode skips
+    // discovery — the count is known to be 0 from config).
+    assert.ok(
+      !dockerExecCalls.some((c) => c.command.includes("vaultwarden")),
+      "vaultwarden must not be queried via `hermes mcp test`",
+    );
+  });
+
+  it("caches the per-server result: a second invocation within the TTL skips dockerExec", async () => {
+    await invokeRoute();
+    const firstCallCount = dockerExecCalls.length;
+    await invokeRoute();
+    const secondCallCount = dockerExecCalls.length;
+    assert.equal(
+      secondCallCount,
+      firstCallCount,
+      "second /allowed-tools hit must reuse the cached `plane` catalogue",
+    );
+  });
+
+  it("if `hermes mcp test <server>` fails, the row still appears (mode='all', count=null, no tools)", async () => {
+    dockerExecHandler = async () => {
+      throw new Error("docker exec exploded");
+    };
+    const { status, body } = await invokeRoute();
+    assert.equal(status, 200);
+    const inclusion = body.mcp_server_inclusion as any[];
+    const plane = inclusion.find((i) => i.server === "plane");
+    assert.ok(plane, "plane must still appear when discovery fails");
+    assert.equal(plane.mode, "all");
+    assert.equal(
+      plane.tool_count,
+      null,
+      "tool_count is null when discovery failed and no curated fallback exists",
+    );
+    const planeTools = (body.mcp_tools as any[]).filter(
+      (t) => t.server === "plane",
+    );
+    assert.equal(planeTools.length, 0);
+  });
+});

--- a/packages/web/src/tools/ToolsPage2.tsx
+++ b/packages/web/src/tools/ToolsPage2.tsx
@@ -514,9 +514,11 @@ function McpServerCard({
   //   2. Do we have a per-tool catalogue we can show? (depends on mode)
   //
   // mode='whitelist' → we know the exact count + the names; render both.
-  // mode='all'       → all of the server's tools are exposed, but ctrl-api
-  //                    doesn't know the list (would have to ask the running
-  //                    MCP process). Render "all tools" with no expander.
+  // mode='all'       → ctrl-api enumerates the live catalogue via
+  //                    `hermes mcp test <server>` (issue #185). When the
+  //                    discovery succeeded we have the count + the names;
+  //                    when it didn't, tool_count is null and we render
+  //                    "all tools" as a fallback label.
   // mode='none'      → 0 tools on main; the server is being treated as
   //                    DELEGATED. Render "0 (delegated)" — never "misconfigured".
   // inclusion=null    → API older than 2026-05-30; fall back to the previous
@@ -524,7 +526,8 @@ function McpServerCard({
   const inclusionMode = inclusion?.mode ?? null;
   const inclusionCount = inclusion?.tool_count ?? null;
   const countLabel: string =
-    inclusionMode === "whitelist" && inclusionCount !== null
+    (inclusionMode === "whitelist" || inclusionMode === "all") &&
+    inclusionCount !== null
       ? `${inclusionCount} ${inclusionCount === 1 ? "tool" : "tools"}`
       : inclusionMode === "all"
         ? "all tools"
@@ -624,13 +627,17 @@ function McpServerCard({
           ) : null}
         </>
       ) : inclusionMode === "all" ? (
+        // Live discovery failed for this `all`-mode server. The card still
+        // says "all tools" but we can't show the names. This is the
+        // pre-#185 fallback shape — it should be rare now (Hermes-restart
+        // window, container missing, parser mismatch).
         <p
           className="font-body italic text-[13px] mt-3"
           style={{ color: "var(--marginalia)" }}
         >
           Every tool this MCP server advertises is passed through to the
-          main runtime. Exact list isn't surfaced here yet — Hermes knows
-          it; ctrl-api would have to ask the running process.
+          main runtime. The live catalogue couldn't be read just now —
+          Hermes may be restarting; refresh in a few seconds.
         </p>
       ) : inclusionMode === "none" ? (
         <p


### PR DESCRIPTION
Closes #185.

## Context

This lands on top of today's run: #178 (runtime-flippable tool
dispositions + `delegate_to_focused_agent`), #182 (tool-disposition
toggle), #184 (real tool counts for whitelist mode). #184 stopped
lying about \`all\`-mode counts but left the names blank.

## Approach: B — docker-exec + Hermes CLI

I probed Hermes' HTTP surface live on home first:

\`\`\`
/v1/tools         → 404
/v1/mcp           → 404
/v1/mcp_servers   → 404
/v1/admin/tools   → 404
/v1/connectors    → 404
openapi.json      → 404
\`\`\`

No HTTP introspection. The only authoritative path is the CLI:

\`\`\`
$ docker exec alfred-black-hermes-1 hermes mcp test plane
  Testing 'plane'...
  ✓ Connected (265ms)
  ✓ Tools discovered: 11
    get_issue         Fetch a single Plane issue by id.
    list_issues       Simple paginated list of issues in ONE project.
    …
\`\`\`

Trade-off: docker exec is slower than HTTP would be (~250-300ms cold per
server), but with a 30s per-server cache and parallel fan-out, the
wall-clock cold load is ~max(server), not ~sum(server). Once Hermes grows
\`/v1/mcp_servers\` (or \`hermes mcp test --json\`) this can switch
trivially — the parser is isolated in one function.

## What changed

### ctrl-api (\`packages/ctrl/src/api/routes/hermes.ts\`)

- New \`discoverMcpToolsAdvertised(server)\` helper. Cached per server
  (\`MCP_TOOLS_CACHE\`, 30s TTL on success, 5s on failure).
- /api/v1/hermes/allowed-tools now fans out \`hermes mcp test\` for
  every \`all\`-mode server in parallel (\`Promise.all\`) and uses the
  result to fill \`mcp_tools[]\` and \`mcp_server_inclusion[].tool_count\`.
- Whitelist mode is unchanged. The LLM sees exactly the config.yaml
  whitelist; showing the runtime's strict superset would be MORE
  dishonest (e.g. \`sure\` whitelists 23 of the 95 it advertises).
- \`MCP_SERVER_TOOLS\` curated map demoted from \"source of truth for
  which tools exist\" to description-only fallback when discovery
  fails. Per the task spec.

### web (\`packages/web/src/tools/ToolsPage2.tsx\`)

- The count label now renders a real number for \`all\`-mode servers
  (\`29 tools\` instead of \`all tools\`).
- The misleading \"Exact list isn't surfaced here yet\" copy is gone.
  When discovery genuinely fails, the card shows \"The live catalogue
  couldn't be read just now — Hermes may be restarting\".
- The \`show tools\` expander now works for \`all\`-mode just like for
  whitelist.

### Test (\`packages/ctrl/tests/hermes-allowed-tools-enumeration.test.ts\`)

5 cases, all green locally + against the full 1003-test suite:
- whitelist path unchanged
- all-mode populated from mocked \`hermes mcp test\` output
- none-mode empty, no docker exec
- per-server cache: second invocation skips dockerExec
- failure path: row stays, \`tool_count: null\`, no tools

\`dockerExec\` is mocked via \`mock.module(\"../src/api/helpers.js\", …)\` so
CI runs deterministically.

## Live-probed pre-deploy snapshot (home.alfred.black)

| Server | Mode | Pre-#185 label | Post-#185 expected count |
|---|---|---|---|
| alfred | all | \"all tools\" | 29 |
| alfred-ctrl | all | \"all tools\" | 2 (was 4 in curated map; live is 2) |
| execute | all | \"all tools\" | 6 |
| plane | all | \"all tools\" | 11 |
| vaultwarden | all | \"all tools\" | (TBD on deploy) |
| files | all | \"all tools\" | (TBD on deploy) |
| sure | whitelist | 23 | 23 (unchanged) |
| hass | whitelist | 28 | 28 (unchanged) |
| paperclip | whitelist | 18 | 18 (unchanged) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)