### PR TITLE
fix(learn): reject envelope/source workflow-name drift (closes #150)

### DIFF
--- a/packages/learn/src/activities/chore_generation.py
+++ b/packages/learn/src/activities/chore_generation.py
@@ -20,6 +20,7 @@ Design contract:
 """
 from __future__ import annotations
 
+import ast
 import asyncio
 import hashlib
 import json
@@ -932,6 +933,92 @@ def _resolve_tenant_timezone() -> str:
     return os.environ.get("TENANT_TIMEZONE", "UTC") or "UTC"
 
 
+def _extract_registered_workflow_name(python_source: str) -> tuple[str | None, str | None]:
+    """Extract the Temporal workflow name registered by the source.
+
+    Returns (class_name, registered_name) where:
+      - class_name is the bare class name of the @workflow.defn-decorated class
+      - registered_name is the Temporal name Temporal will use to register the
+        workflow — the `name=...` kwarg of @workflow.defn if present, else the
+        class name itself.
+
+    Returns (None, None) on:
+      - source that fails to parse
+      - source with no @workflow.defn class
+      - source with multiple @workflow.defn classes (we let the downstream
+        structural validator handle that; we don't pick one arbitrarily)
+
+    GH #150: the schedule's workflow_type comes from the envelope's
+    `workflow_class_name`, but the Temporal-registered name comes from the
+    source. If they disagree (e.g. envelope says "GitHubFailureTriageWorkflow"
+    but the source has `@workflow.defn(name="GithubFailureTriageWorkflow")`),
+    the schedule fires forever against an unregistered workflow type. This
+    helper exposes the registered name so the envelope validator can compare
+    them and reject the mismatch.
+    """
+    try:
+        tree = ast.parse(python_source)
+    except SyntaxError:
+        return None, None
+
+    defn_classes: list[ast.ClassDef] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and _has_workflow_defn_decorator_local(node):
+            defn_classes.append(node)
+
+    if len(defn_classes) != 1:
+        # Zero → the structural validator catches it.
+        # More than one → also a structural-validator concern; we don't
+        # guess which class the envelope was supposed to name.
+        return None, None
+
+    cls = defn_classes[0]
+    class_name = cls.name
+    registered_name = _workflow_defn_name_kwarg(cls) or class_name
+    return class_name, registered_name
+
+
+def _has_workflow_defn_decorator_local(node: ast.ClassDef) -> bool:
+    """Return True iff the class is decorated with @workflow.defn (with or without args).
+
+    Mirrors the helper in src.workflows.chores._dynamic_loader but kept local
+    to avoid a cross-module import cycle through the validator.
+    """
+    for dec in node.decorator_list:
+        if isinstance(dec, ast.Attribute) and dec.attr == "defn":
+            if isinstance(dec.value, ast.Name) and dec.value.id == "workflow":
+                return True
+        elif isinstance(dec, ast.Call):
+            inner = dec.func
+            if (
+                isinstance(inner, ast.Attribute)
+                and inner.attr == "defn"
+                and isinstance(inner.value, ast.Name)
+                and inner.value.id == "workflow"
+            ):
+                return True
+    return False
+
+
+def _workflow_defn_name_kwarg(node: ast.ClassDef) -> str | None:
+    """Return the `name=...` string literal passed to @workflow.defn, if any."""
+    for dec in node.decorator_list:
+        if not isinstance(dec, ast.Call):
+            continue
+        inner = dec.func
+        if not (
+            isinstance(inner, ast.Attribute)
+            and inner.attr == "defn"
+            and isinstance(inner.value, ast.Name)
+            and inner.value.id == "workflow"
+        ):
+            continue
+        for kw in dec.keywords:
+            if kw.arg == "name" and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+                return kw.value.value
+    return None
+
+
 def _validate_envelope(parsed: dict[str, Any]) -> tuple[bool, str]:
     """Validate that the parsed Opus response has the required envelope keys.
 
@@ -964,6 +1051,43 @@ def _validate_envelope(parsed: dict[str, Any]) -> tuple[bool, str]:
         return False, "missing or empty 'python_source'"
     if len(python_source) > 100_000:
         return False, f"python_source too large: {len(python_source)} bytes (max 100000)"
+
+    # GH #150 — workflow-name consistency between envelope and source.
+    #
+    # The schedule the caller creates uses envelope.workflow_class_name as its
+    # workflow_type. The string Temporal actually registers comes from the
+    # @workflow.defn(name=...) kwarg in the source (or, if omitted, the bare
+    # class name). When those two disagree (e.g. envelope says
+    # "GitHubFailureTriageWorkflow" but the source declares
+    # `@workflow.defn(name="GithubFailureTriageWorkflow")`) the schedule fires
+    # forever against a workflow type Temporal never registered — the
+    # original symptom of GH #150.
+    #
+    # Reject the mismatch here so the retry loop gets specific feedback and
+    # Opus aligns the two on the next attempt. Skip silently when the
+    # source is unparseable or has !=1 @workflow.defn classes; the
+    # structural validator (validate_template_source, called next) gives
+    # cleaner errors for those cases.
+    class_name, registered_name = _extract_registered_workflow_name(python_source)
+    if registered_name is not None and registered_name != workflow_class_name:
+        if class_name and class_name != registered_name:
+            # `@workflow.defn(name="...")` override is in play.
+            return False, (
+                f"workflow_class_name {workflow_class_name!r} does not match the "
+                f"Temporal name registered by the source: class "
+                f"{class_name!r} is decorated with "
+                f"@workflow.defn(name={registered_name!r}). Set "
+                f"workflow_class_name to {registered_name!r} (the name Temporal "
+                f"will use to look up the workflow), or remove the name= kwarg "
+                f"and rename the class to match the envelope."
+            )
+        return False, (
+            f"workflow_class_name {workflow_class_name!r} does not match the "
+            f"@workflow.defn class in the source ({registered_name!r}). The "
+            f"schedule registers under the envelope name but Temporal registers "
+            f"the class under the source name — they must be identical or the "
+            f"schedule fires against an unregistered workflow type."
+        )
 
     # C.1: user_facing_description is required for the new Chores UI.
     # We accept missing field for backwards compat but emit a warning,

--- a/packages/learn/tests/test_chore_generation.py
+++ b/packages/learn/tests/test_chore_generation.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from src.activities.chore_generation import (
     _extract_description_timezone,
+    _extract_registered_workflow_name,
     _slice_profile_for_opportunity,
     _try_parse_envelope,
     _validate_cron_expression,
@@ -165,6 +166,140 @@ class TestValidateEnvelope:
         ok, err = _validate_envelope(env)
         assert not ok
         assert "5-field" in err
+
+
+# ---------------------------------------------------------------------------
+# GH #150 — workflow_class_name <-> @workflow.defn name consistency
+#
+# When the envelope's workflow_class_name doesn't match the Temporal name
+# the source actually registers, the schedule fires forever against an
+# unregistered workflow type. The original bug surfaced as
+# `GitHubFailureTriageWorkflow` (envelope, capital H) vs
+# `@workflow.defn(name="GithubFailureTriageWorkflow")` (source, lowercase h).
+# ---------------------------------------------------------------------------
+
+def _source_with_defn(class_name: str, defn_name: str | None = None) -> str:
+    """Return minimal valid-looking source declaring one @workflow.defn class."""
+    decorator = (
+        f"@workflow.defn(name={defn_name!r})" if defn_name is not None
+        else "@workflow.defn"
+    )
+    return (
+        "from __future__ import annotations\n"
+        "from temporalio import workflow\n"
+        "\n"
+        f"{decorator}\n"
+        f"class {class_name}:\n"
+        "    @workflow.run\n"
+        "    async def run(self) -> None:\n"
+        "        return None\n"
+    )
+
+
+class TestExtractRegisteredWorkflowName:
+    """_extract_registered_workflow_name returns the Temporal-side name."""
+
+    def test_bare_class_no_name_kwarg(self):
+        src = _source_with_defn("MyWorkflow")
+        class_name, registered = _extract_registered_workflow_name(src)
+        assert class_name == "MyWorkflow"
+        assert registered == "MyWorkflow"
+
+    def test_explicit_name_kwarg_wins(self):
+        src = _source_with_defn("InternalClass", defn_name="ExternalNameWorkflow")
+        class_name, registered = _extract_registered_workflow_name(src)
+        assert class_name == "InternalClass"
+        assert registered == "ExternalNameWorkflow"
+
+    def test_unparseable_returns_none_pair(self):
+        class_name, registered = _extract_registered_workflow_name("def : :: not python")
+        assert class_name is None
+        assert registered is None
+
+    def test_no_defn_class_returns_none_pair(self):
+        src = (
+            "from __future__ import annotations\n"
+            "x = 1\n"
+        )
+        class_name, registered = _extract_registered_workflow_name(src)
+        assert class_name is None
+        assert registered is None
+
+    def test_multiple_defn_classes_returns_none_pair(self):
+        # We don't pick one arbitrarily — let the structural validator
+        # complain about the "exactly one @workflow.defn class" rule.
+        src = (
+            _source_with_defn("OneWorkflow")
+            + "\n"
+            + _source_with_defn("TwoWorkflow")
+        )
+        class_name, registered = _extract_registered_workflow_name(src)
+        assert class_name is None
+        assert registered is None
+
+
+class TestEnvelopeWorkflowNameConsistency:
+    """_validate_envelope rejects envelope/source workflow-name mismatches."""
+
+    def test_matching_bare_class_passes(self):
+        env = _good_envelope()
+        env["workflow_class_name"] = "FooWorkflow"
+        env["python_source"] = _source_with_defn("FooWorkflow")
+        ok, err = _validate_envelope(env)
+        assert ok, err
+
+    def test_matching_name_kwarg_passes(self):
+        env = _good_envelope()
+        env["workflow_class_name"] = "ExposedWorkflow"
+        env["python_source"] = _source_with_defn(
+            "InternalImpl", defn_name="ExposedWorkflow"
+        )
+        ok, err = _validate_envelope(env)
+        assert ok, err
+
+    def test_github_capital_h_envelope_lowercase_source_rejected(self):
+        """The exact GH #150 symptom — capital-H envelope, lowercase-h class."""
+        env = _good_envelope()
+        env["workflow_class_name"] = "GitHubFailureTriageWorkflow"
+        env["python_source"] = _source_with_defn("GithubFailureTriageWorkflow")
+        ok, err = _validate_envelope(env)
+        assert not ok
+        assert "GitHubFailureTriageWorkflow" in err
+        assert "GithubFailureTriageWorkflow" in err
+
+    def test_github_lowercase_h_envelope_capital_source_rejected(self):
+        """Same drift, the other direction."""
+        env = _good_envelope()
+        env["workflow_class_name"] = "GithubFailureTriageWorkflow"
+        env["python_source"] = _source_with_defn("GitHubFailureTriageWorkflow")
+        ok, err = _validate_envelope(env)
+        assert not ok
+        assert "GitHubFailureTriageWorkflow" in err
+        assert "GithubFailureTriageWorkflow" in err
+
+    def test_name_kwarg_mismatch_explains_override(self):
+        """When @workflow.defn(name=...) overrides the class name, the
+        rejection should call out the override so the retry loop knows
+        which knob to turn."""
+        env = _good_envelope()
+        env["workflow_class_name"] = "InternalImplWorkflow"
+        env["python_source"] = _source_with_defn(
+            "InternalImplWorkflow", defn_name="ExposedNameWorkflow"
+        )
+        ok, err = _validate_envelope(env)
+        assert not ok
+        assert "name=" in err
+        assert "ExposedNameWorkflow" in err
+
+    def test_unparseable_source_does_not_trip_consistency_check(self):
+        """Garbage source falls through to the structural validator — the
+        consistency check stays silent rather than masking the real issue."""
+        env = _good_envelope()
+        env["workflow_class_name"] = "AnythingWorkflow"
+        env["python_source"] = "def : :: not python at all"
+        ok, err = _validate_envelope(env)
+        # The envelope-shape rules pass; structural validation happens after.
+        assert ok, err
 
 
 # ---------------------------------------------------------------------------
@@ -1012,7 +1147,11 @@ class TestGeneratorReRollOnStaticValidation:
         """First _call_llm returns bad ordering → second returns good →
         generator returns the good one with attempts==2."""
         responses = [
-            _envelope(_bad_ordering_python_source()),
+            # GH #150 — keep envelope's workflow_class_name aligned with the
+            # class declared by the source so the new consistency check
+            # doesn't short-circuit before the import-ordering violation
+            # gets a chance to drive the re-roll.
+            _envelope(_bad_ordering_python_source(), cls="BadOrderingChoreWorkflow"),
             _envelope(_good_python_source(), module="good_chore", cls="GoodOrderingChoreWorkflow"),
         ]
         captured_prompts: list[str] = []
@@ -1058,7 +1197,12 @@ class TestGeneratorReRollOnStaticValidation:
         """If every attempt has bad ordering, the generator exhausts its
         budget and raises — caller in assign_chores then skips the
         opportunity instead of writing broken code to disk."""
-        bad_envelope = _envelope(_bad_ordering_python_source())
+        # GH #150 — align the envelope class name with the source's so the
+        # exhaustion is driven by the import-ordering violation (the bug
+        # this test is here to cover) rather than the new name-mismatch check.
+        bad_envelope = _envelope(
+            _bad_ordering_python_source(), cls="BadOrderingChoreWorkflow"
+        )
 
         async def fake_call_llm(prompt, max_tokens=8192, heartbeat_message=""):
             return bad_envelope
@@ -1209,9 +1353,11 @@ class TestChoreGenerationCronAutocorrect:
         The generator must auto-correct the DOW and return on attempt 1 with
         the corrected schedule — NOT re-roll the LLM into a timeout."""
         import json
+        # GH #150 — workflow_class_name has to match the class declared in
+        # python_source. `_good_python_source()` declares `GoodOrderingChoreWorkflow`.
         result, exc, n = _run_generation(json.dumps({
             "module_name": "weekday_digest",
-            "workflow_class_name": "WeekdayDigestWorkflow",
+            "workflow_class_name": "GoodOrderingChoreWorkflow",
             "user_facing_description": (
                 "Every weekday at 04:00 UTC, this chore assembles a single "
                 "morning digest summarising your day-ahead calendar and any "
@@ -1234,7 +1380,8 @@ class TestChoreGenerationCronAutocorrect:
         import json
         result, exc, n = _run_generation(json.dumps({
             "module_name": "wrong_time_chore",
-            "workflow_class_name": "WrongTimeChoreWorkflow",
+            # GH #150 — match the class declared by _good_python_source().
+            "workflow_class_name": "GoodOrderingChoreWorkflow",
             "user_facing_description": (
                 "Every day at 09:00 UTC, this chore drafts your day plan and "
                 "highlights anything that needs your attention this morning."


### PR DESCRIPTION
Closes #150.

## Symptom

\`alfred-learn\` worker logged:

\`\`\`
temporalio.exceptions.ApplicationError: NotFoundError:
  Workflow class GitHubFailureTriageWorkflow is not registered on this worker,
  available workflows: ..., GithubFailureTriageWorkflow, ...
\`\`\`

The chore was silently dead since it shipped — the schedule referenced
\`GitHubFailureTriageWorkflow\` (capital H) but Temporal had registered
the workflow as \`GithubFailureTriageWorkflow\` (lowercase h).

## Root cause

The chore-template generation pipeline (\`packages/learn/src/activities/chore_generation.py\`)
takes a JSON envelope from Opus that includes a \`workflow_class_name\`
field. The downstream schedule-creation code (\`assign_chores._resolve_workflow_type\`)
sends that string to ctrl-api as the schedule's \`workflow_type\`. But
Temporal actually registers the workflow under whatever name the
generated source declares — either the bare class name, or the
\`@workflow.defn(name=...)\` kwarg if present.

Nothing enforced that those two strings agreed. The 150 case:

- envelope: \`workflow_class_name: \"GitHubFailureTriageWorkflow\"\` (capital H)
- source: \`@workflow.defn(name=\"GithubFailureTriageWorkflow\")\` (lowercase h)

Schedule was created pointing at the capital-H name; worker registered
the lowercase-h name; every fire raised NotFoundError forever.

## Fix

Extend \`_validate_envelope\` with an AST-based consistency check:

1. Parse \`python_source\`.
2. Locate the single \`@workflow.defn\`-decorated class.
3. Compute the **Temporal-registered name**: the \`name=...\` kwarg if
   present, else the bare class name.
4. Compare it to envelope.\`workflow_class_name\`. Reject mismatches
   with feedback that names both sides so the bounded retry loop can
   align them on the next attempt.

Skip silently when the source is unparseable or has !=1 defn-decorated
classes — the existing \`validate_template_source\` already gives
cleaner errors for those shapes; the new check stays narrowly scoped
to the name-drift invariant.

## Tests

- \`TestExtractRegisteredWorkflowName\` — 5 cases: bare class, name-kwarg
  override, unparseable, no defn, multiple defns.
- \`TestEnvelopeWorkflowNameConsistency\` — 6 cases: matching bare class,
  matching name kwarg, exact GH #150 capital-H/lowercase-h pair (both
  directions), name-kwarg override error message, unparseable source
  falls through to the structural validator.

Three pre-existing tests had fixtures whose envelope \`workflow_class_name\`
didn't match the class declared by their \`python_source\` (silent latent
defect the new check exposes — they were testing the import-ordering
and cron-autocorrect paths but the envelope/source name drift would
have shorted the schedule on a real tenant). Aligned them so each test
still drives the bug it was written to cover.

Full learn suite: **2298 passed, 101 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)