### PR TITLE
fix(ctrl): HA WS client LLAT shape — unblock HaBootstrapWorkflow (closes #155)

### DIFF
--- a/packages/ctrl/src/api/lib/ha_ws_client.ts
+++ b/packages/ctrl/src/api/lib/ha_ws_client.ts
@@ -131,6 +131,18 @@ function haWsUrlFromHttp(haUrl: string): string {
  * Mirrors `channels_ha.ts:readHaLlat` but is duplicated here to keep the
  * lib free of cross-file imports (channels_ha.ts imports this file via
  * channels_ha_ws.ts, the inverse would be a cycle).
+ *
+ * SHAPE CONTRACT — vault-cli (`bw serve`) returns single-wrapped
+ * `{success, data: {id, login, ...}}` for GET /object/item/:id, NOT
+ * double-wrapped. The previous double-wrap shape was a copy-paste from
+ * the LIST endpoint (which IS `{data:{data:[…]}}`); live-verified wrong
+ * 2026-05-29 on home — `ws/registries` 502'd with `LLAT read failed:
+ * vault-cli GET <id> returned HTTP 400` (vault locked) but even after
+ * unlock the double-wrap path returned undefined and the WS client
+ * failed `not authed within 10000ms`. Mirrors the fix in
+ * `channels_ha.ts:readHaLlat` (which had the same bug, fixed earlier).
+ * Closes #155 — HaBootstrapWorkflow's WS-bridge call to
+ * `/api/v1/channels/ha/ws/registries` can now actually authenticate.
  */
 async function readHaLlat(vaultItemId: string): Promise<string> {
   const vaultUrl = process.env.VAULT_CLI_URL ?? "http://vault-cli:8087";
@@ -141,9 +153,9 @@ async function readHaLlat(vaultItemId: string): Promise<string> {
     throw new Error(`vault-cli GET ${vaultItemId} returned HTTP ${r.status}`);
   }
   const j = (await r.json()) as {
-    data?: { data?: { login?: { password?: string } } };
+    data?: { login?: { password?: string } };
   };
-  const pw = j?.data?.data?.login?.password;
+  const pw = j?.data?.login?.password;
   if (typeof pw !== "string" || pw.length === 0) {
     throw new Error("vault-cli returned an HA item without a login.password");
   }

--- a/packages/ctrl/tests/channels_ha_registries.test.ts
+++ b/packages/ctrl/tests/channels_ha_registries.test.ts
@@ -222,14 +222,10 @@ globalThis.fetch = (async (input: any, init?: any) => {
     const id = objMatch[1];
     const item = vaultStore.find((i) => i.id === id);
     if (!item) return makeJsonResponse({ success: false, message: "not found" }, 404);
-    return makeJsonResponse({
-      success: true,
-      data: {
-        ...item,
-        // Embed double-wrapped login.password for ha_ws_client's readHaLlat.
-        data: { login: { password: item.login.password } },
-      },
-    });
+    // vault-cli (`bw serve`) returns single-wrapped `{success,data:<item>}`
+    // for GET /object/item/:id. Post-#155 fix, ha_ws_client.readHaLlat
+    // reads `j.data.login.password` (matching channels_ha.ts:readHaLlat).
+    return makeJsonResponse({ success: true, data: item });
   }
   if (url.endsWith("/object/item") && method === "POST") {
     const b = JSON.parse(bodyRaw ?? "{}");

--- a/packages/ctrl/tests/channels_ha_users.test.ts
+++ b/packages/ctrl/tests/channels_ha_users.test.ts
@@ -350,16 +350,11 @@ globalThis.fetch = (async (input: any, init?: any) => {
     const id = objMatch[1];
     const item = vaultStore.find((i) => i.id === id);
     if (!item) return makeJsonResponse({ success: false, message: "not found" }, 404);
-    // SHAPE NOTE — channels_ha.ts:readHaLlat reads `j.data.login.password`
-    // (single-wrapped post-23917964) but api/lib/ha_ws_client.ts:readHaLlat
-    // reads `j.data.data.login.password` (double-wrapped). Mirror both
-    // shapes so EITHER reader resolves the LLAT cleanly. We carry the
-    // full item at `data` AND a nested `data.data = item` self-reference;
-    // every other consumer ignores the extra key.
-    return makeJsonResponse({
-      success: true,
-      data: { ...item, data: item },
-    });
+    // SHAPE — vault-cli (`bw serve`) returns single-wrapped
+    // `{success, data: <item>}` for GET /object/item/:id. BOTH
+    // `channels_ha.ts:readHaLlat` and (post-#155 fix)
+    // `api/lib/ha_ws_client.ts:readHaLlat` read `j.data.login.password`.
+    return makeJsonResponse({ success: true, data: item });
   }
   if (url.endsWith("/object/item") && method === "POST") {
     const b = JSON.parse(bodyRaw ?? "{}");

--- a/packages/ctrl/tests/channels_ha_ws_routes.test.ts
+++ b/packages/ctrl/tests/channels_ha_ws_routes.test.ts
@@ -166,10 +166,14 @@ const originalFetch = globalThis.fetch;
 globalThis.fetch = (async (input: any) => {
   const url = typeof input === "string" ? input : (input?.url ?? String(input));
   if (url.includes("/object/item/")) {
+    // vault-cli (`bw serve`) returns single-wrapped `{success,data:<item>}` for
+    // GET /object/item/:id — NOT double-wrapped. The HaWsClient.readHaLlat
+    // reads `j.data.login.password`. See channels_ha_vault_parse.test.ts for
+    // the full bw-serve shape contract. (Fix for #155.)
     return new Response(
       JSON.stringify({
         success: true,
-        data: { data: { login: { password: "llat_test", username: null, uris: [] } } },
+        data: { login: { password: "llat_test", username: null, uris: [] } },
       }),
       { status: 200, headers: { "content-type": "application/json" } },
     );
@@ -272,5 +276,56 @@ describe("/api/v1/channels/ha/ws/* — #115/#158 PR1", () => {
     const parsed = JSON.parse(kitchenArea!.payload_json as string) as Record<string, unknown>;
     assert.equal(parsed.area_id, "kitchen");
     assert.equal(parsed.name, "Kitchen");
+  });
+
+  // Regression guard for #155 — if a future agent re-introduces the
+  // double-wrap shape in `ha_ws_client.ts:readHaLlat`, the route MUST
+  // refuse to lift an LLAT and surface HA_WS_REGISTRY_FAILED. Pairs with
+  // the positive test above: positive proves single-wrap works; this
+  // proves double-wrap fails. Live-observed failure mode (home, 2026-05-30):
+  // `{"error":{"code":"HA_WS_REGISTRY_FAILED","message":"...HaWsClient not
+  // authed within 10000ms (last_error=LLAT read failed:
+  // vault-cli returned an HA item without a login.password)"}}`.
+  it("GET /ha/ws/registries — 502s when vault-cli double-wraps single-object responses (regression guard for #155)", async () => {
+    // Swap fetch to return the WRONG (double-wrap) shape that the bug
+    // assumed. ha_ws_client.readHaLlat must look at `data.login.password`,
+    // not `data.data.login.password`, so this must fail to extract.
+    globalThis.fetch = (async (input: any) => {
+      const url = typeof input === "string" ? input : (input?.url ?? String(input));
+      if (url.includes("/object/item/")) {
+        return new Response(
+          JSON.stringify({
+            success: true,
+            // Wrong shape — embeds login.password under data.data instead
+            // of data. Pre-fix readHaLlat read this and "worked" — but
+            // the real bw serve never returns this for single-object GET.
+            data: { data: { login: { password: "llat_test", username: null, uris: [] } } },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return originalFetch(input);
+    }) as typeof fetch;
+    // Reset so the client re-tries auth with the broken-shape vault-cli.
+    _resetHaWsClientForTests();
+
+    const r = await call("GET", "/api/v1/channels/ha/ws/registries");
+    assert.equal(r.status, 502, JSON.stringify(r.payload));
+    assert.equal(r.payload.error?.code, "HA_WS_REGISTRY_FAILED");
+
+    // Restore the correct-shape mock for any subsequent test ordering.
+    globalThis.fetch = (async (input: any) => {
+      const url = typeof input === "string" ? input : (input?.url ?? String(input));
+      if (url.includes("/object/item/")) {
+        return new Response(
+          JSON.stringify({
+            success: true,
+            data: { login: { password: "llat_test", username: null, uris: [] } },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return originalFetch(input);
+    }) as typeof fetch;
   });
 });


### PR DESCRIPTION
Closes #155.

## What the bug was

The issue text describes `HaBootstrapWorkflow` Phase A's REST calls to
`/api/config/area_registry/list` etc. returning 404 because those
endpoints only exist over HA's WebSocket API. That part of the bug was
already fixed in #115/#158 PR1: the Python activity at
`packages/learn/src/activities/ha_bootstrap.py` delegates the
area/device/entity registry pull to ctrl-api's
`GET /api/v1/channels/ha/ws/registries`, which proxies through the
long-lived `HaWsClient`.

But on live home.alfred.black (2026-05-30, verified just now), the WS
bridge was still 502-ing on every call. The activity correctly hit the
WS-bridge route; the route silently failed to authenticate; the
workflow finished with `areas=0, devices=0` exactly as #155 describes.

## Root cause

`packages/ctrl/src/api/lib/ha_ws_client.ts:readHaLlat` parsed the
vault-cli (`bw serve`) `GET /object/item/:id` response as
DOUBLE-wrapped (`j.data.data.login.password`). `bw serve` only
double-wraps LIST endpoints; single-object `GET/POST/PUT` are
SINGLE-wrapped (`{success, data: {id, login, ...}}`).

The same bug shipped in `channels_ha.ts:readHaLlat` and was fixed
earlier (the live comment on line 1199 of `channels_ha.ts` says
\`Live-verified 2026-05-29 on home\`) — but the duplicate in
`ha_ws_client.ts` was missed. Result: every Tier 4 surface that
needed the long-lived WS connection silently broke.

Live-confirmed failure mode on home today:

\`\`\`
GET /api/v1/channels/ha/ws/registries
  → 502 HA_WS_REGISTRY_FAILED
  → HaWsClient not authed within 10000ms
  → last_error = LLAT read failed:
       vault-cli returned an HA item without a login.password
\`\`\`

## Fix

Bring `ha_ws_client.ts:readHaLlat` into shape parity with
`channels_ha.ts:readHaLlat` — read `j.data.login.password`.

## Routes mapped (REST → WS)

The activity already maps:

| Old (broken REST) | New (WS bridge) |
|---|---|
| `GET HA /api/config/area_registry/list` | `GET ctrl-api /api/v1/channels/ha/ws/registries` (split on `kind=area`) |
| `GET HA /api/config/device_registry/list` | `GET ctrl-api /api/v1/channels/ha/ws/registries` (split on `kind=device`) |
| `GET HA /api/config/entity_registry/list` | `GET ctrl-api /api/v1/channels/ha/ws/registries` (split on `kind=entity`) |
| `GET HA /api/states` | unchanged — REST works for this |
| `GET HA /api/services` | unchanged — REST works for this |

The ctrl-api WS bridge route in turn issues:
- `wsCall(\"config/area_registry/list\")`
- `wsCall(\"config/device_registry/list\")`
- `wsCall(\"config/entity_registry/list\")`
- `wsCall(\"config/scene/list\")` (best-effort)
- `wsCall(\"config/script/list\")` (best-effort)

## Test changes

- `channels_ha_ws_routes.test.ts` — fix the vault-cli mock to use the
  single-wrap shape; add a regression-guard test that asserts the
  `ws/registries` route 502s with `HA_WS_REGISTRY_FAILED` when
  vault-cli returns the double-wrap shape (proves the route reads the
  right key).
- `channels_ha_users.test.ts` + `channels_ha_registries.test.ts` — drop
  the dual-shape mock compatibility (both `readHaLlat` implementations
  now read single-wrap).

The existing `channels_ha_vault_parse.test.ts` continues to pin the
contract for `channels_ha.ts:readHaLlat`; the new regression guard in
`channels_ha_ws_routes.test.ts` pins the WS-client side.

## Files touched

- `packages/ctrl/src/api/lib/ha_ws_client.ts`
- `packages/ctrl/tests/channels_ha_ws_routes.test.ts`
- `packages/ctrl/tests/channels_ha_users.test.ts`
- `packages/ctrl/tests/channels_ha_registries.test.ts`

## Verification

- `packages/ctrl` — `node ... --test tests/channels_ha_ws_routes.test.ts`
  → 3/3 pass (status + registries happy path + new regression guard).
- `packages/learn` — `pytest tests/test_ha_bootstrap.py` → 19/19 pass.

Pre-existing failure: `tests/channels_ha_hacs.test.ts` times out on
main (independent of this change — `git stash` + re-run on main
confirms the same failure without these edits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)