### PR TITLE
docs(#109): PR5 — privacy/ToS + CLAUDE.md + Tailscale operator runbook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -150,14 +150,14 @@ TENANT_BASE_URL=https://${DOMAIN}
 # host. Override only for a multi-host SaaS deployment.
 SAAS_HOST=https://${DOMAIN}
 
-# Tailscale (off by default — turn on via /connections card). Issue #109.
+# Tailscale (off by default — turn on via /channels card). Issue #109.
 # When TAILSCALE_ENABLED=true (set by the operator), the principal can flip
-# the Tailscale card on /connections to start the sidecar
+# the Tailscale card on /channels to start the sidecar
 # (`docker compose --profile tailscale up -d tailscale`) and approve the
 # device on login.tailscale.com once. The sidecar joins the principal's own
 # tailnet; the public *.alfred.black hostname keeps working unchanged.
-# PR 1 ships only the compose foundation — the routes (PR 2), card (PR 3),
-# and Caddy/Serve outbound (PR 4) come next. See docs/specs/issue-109-*.md.
+# Full opt-in runbook in deploy/README.md "Enabling Tailscale on an
+# existing tenant"; design overview in CLAUDE.md §15.11.
 TAILSCALE_ENABLED=false
 # Optional — path A (pre-shared auth-key) bootstrap. Leave blank to use
 # path C (device-style auth URL), which is the recommended flow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,13 @@ section here.
 
 `alfred-black` is the single-VM, `docker compose up` reframing of the old
 `alfred-platform` SaaS fleet: **one repo, one VM, one stack**. No Hetzner
-auto-provisioning, no Tailscale, no Cloudflare provisioning, no billing.
+auto-provisioning, no operator-owned Tailscale tailnet, no Cloudflare
+provisioning, no billing.
+
+(Note: there IS an optional Tailscale sidecar, off by default — see §15
+"Optional Tailscale opt-in (#109)". It's the *principal's* tailnet, not
+the operator's. The old SaaS-era admin tailnet does not exist in this
+repo.)
 
 The AI runtime is **Hermes Agent** (`NousResearch/hermes-agent`), which
 replaces OpenClaw's two-container split with one Docker image running
@@ -796,6 +802,59 @@ the `IdentityAgent=none` opt.
 `state_data` / `ingest_data` / `alfred_data` / `hermes_data` are
 recoverable but contain history — back them up if you care about the
 audit trail / observations / instinct training data.
+`tailscale_data` (when the optional Tailscale sidecar is on — §15.11)
+holds the `tailscaled.state` node identity; lose it and the principal
+has to re-approve the device on `login.tailscale.com`.
+
+### 15.11 Optional Tailscale opt-in (#109)
+
+There IS a Tailscale sidecar in `docker-compose.yaml`, but it is
+**gated by `profiles: [tailscale]` and off by default**. `docker compose
+up -d` (the default) never starts it. The model is: the principal joins
+**their own** tailnet from the dashboard (`/channels` → Tailscale card).
+The operator owns nothing here — no Sir-side tailnet, no shared keys.
+
+Flip on for an existing tenant:
+
+```bash
+# 1. Edit /opt/alfred/.env
+TAILSCALE_ENABLED=true
+
+# 2. Bring the sidecar up
+docker compose --profile tailscale up -d tailscale
+
+# 3. Principal goes to /channels, clicks Connect on the Tailscale card,
+#    either pastes a tskey-auth-… key OR uses the device-auth URL the
+#    card surfaces (login.tailscale.com/a/<code>).
+
+# 4. Once the card shows "Connected", ctrl-api can mint the tailnet
+#    LE cert + bind it into Caddy:
+#    POST /api/v1/channels/tailscale/cert  {"domain":"<tailnet-hostname>"}
+#    Reach the dashboard at https://<tailnet-hostname> from any device
+#    on the principal's tailnet.
+```
+
+Key files:
+- `docker-compose.yaml` — `tailscale` service under `profiles: [tailscale]`.
+- `packages/ctrl/src/api/routes/channels_tailscale.ts` — status/connect/
+  disconnect/peers/cert/serve/funnel.
+- `packages/web/src/dashboard/tailscaleCardCore.ts` — pure card state
+  derivation + 18 tests under `node:test`.
+- `packages/web/src/dashboard/ChannelsPage.tsx` (`<TailscaleCard />`) —
+  the principal-facing surface.
+- `caddy/Caddyfile` — `import /tailscale-snippets/*.caddy` hot-loads the
+  per-domain stanza the cert route drops in.
+
+The public `<tenant>.alfred.black` hostname keeps working unchanged.
+Tailscale is **additive**, never a replacement. Webhook ingress (Composio,
+Paperclip, OMI, …) stays on the public Caddy hostname.
+
+Caveat: outbound MagicDNS (e.g. `curl http://homeassistant.tail-xxxx.ts.net`
+from inside the Hermes container) requires either (a) `network_mode:
+service:tailscale` on the consumer service, or (b) explicit `dns:`
+pointing at the sidecar. Neither is wired by default — flag a follow-up
+issue if the principal needs Alfred to reach their tailnet from inside
+containers.
 
 ---
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -118,3 +118,59 @@ does.
 - `FLEET_SSH_KEY` — repo-level GitHub Actions secret; the private half of
   `~/.ssh/alfred-black-verify`. Authorised on every tenant's `root@`
   account.
+
+## Enabling Tailscale on an existing tenant (#109)
+
+The Tailscale sidecar is off by default — `docker compose up -d` will
+not start it on any tenant. To enable on a tenant whose principal wants
+to join their own tailnet:
+
+```bash
+# 1. SSH to the tenant.
+ssh -o IdentityAgent=none -i ~/.ssh/alfred-black-verify \
+    root@<tenant>.alfred.black
+
+# 2. Flip the env flag.
+cd /opt/alfred
+sed -i 's/^TAILSCALE_ENABLED=false$/TAILSCALE_ENABLED=true/' .env
+
+# 3. Start the sidecar (still authenticated to nothing).
+docker compose --profile tailscale up -d tailscale
+
+# 4. Hand control to the principal — they open the dashboard at
+#    https://<tenant>.alfred.black/channels, find the Tailscale card,
+#    and either:
+#      • paste a tskey-auth-… key generated in their Tailscale admin
+#        console (the "Advanced" path), or
+#      • click "Use device auth URL" — the card surfaces a
+#        login.tailscale.com/a/<code> URL they open in a new tab and
+#        approve against their own Tailscale account.
+
+# 5. Once the card shows "Connected" with a 100.x IP, the operator can
+#    provision the tailnet hostname's LE cert + bind it into Caddy:
+TAILNET_HOST=$(docker exec alfred-black-tailscale-1 \
+    tailscale status --json | \
+    python3 -c 'import json,sys;print(json.load(sys.stdin)["Self"]["DNSName"].rstrip("."))')
+AAS_API_KEY=$(grep -E '^AAS_API_KEY=' /opt/alfred/.env | cut -d= -f2)
+docker exec alfred-black-ctrl-api-1 sh -c \
+    "curl -s -X POST -H 'Authorization: Bearer $AAS_API_KEY' \
+     -H 'Content-Type: application/json' \
+     -d '{\"domain\":\"$TAILNET_HOST\"}' \
+     http://127.0.0.1:3100/api/v1/channels/tailscale/cert"
+```
+
+Verify by opening `https://<tailnet-host>` from any device on the
+principal's tailnet — should load the dashboard with a valid LE cert.
+
+Caveats:
+- The public `<tenant>.alfred.black` hostname keeps working unchanged.
+  Tailscale is additive.
+- If `caddy_reload_ok` returns `false` from the cert call, check the
+  Caddy container's `pids_limit` (`docker inspect alfred-black-caddy-1
+  --format '{{.HostConfig.PidsLimit}}'`) — the reload spawns ~50
+  goroutines and the historical 1024 cap can starve newer Go runtimes.
+  PR #159 raised the limit; a `docker compose up -d caddy` re-applies
+  the new value on existing tenants.
+- Outbound MagicDNS from inside Alfred containers (e.g. the Hermes
+  agent calling `homeassistant.tail-xxxx.ts.net`) is NOT wired by
+  default — open a follow-up issue if the principal needs that surface.

--- a/packages/ctrl/SECURITY.md
+++ b/packages/ctrl/SECURITY.md
@@ -3,6 +3,30 @@
 **Date:** 2026-02-25
 **Scope:** Full security review of alfred-ctrl provisioning system, OpenClaw deployment, and supporting infrastructure.
 
+> **HISTORICAL CONTEXT — pre-`alfred-black` merge (May 2026).** This
+> document describes the security model of the **legacy multi-tenant
+> `alfred-platform` SaaS fleet**, which had:
+>
+> - a Sir-operated "admin tailnet" joining every tenant VM under
+>   `tag:admin` + `tag:tenant`,
+> - host-level `apt-get install tailscale` baked into cloud-init,
+> - shared OpenClaw infrastructure across tenants.
+>
+> **None of that applies to `alfred-black` (the current single-VM,
+> single-tenant `docker compose up` model).** The Tailscale story in
+> alfred-black is the principal-owned opt-in introduced by GH issue
+> #109 (see `CLAUDE.md` §15.11 + `deploy/README.md` "Enabling Tailscale
+> on an existing tenant"). The sidecar lives in `docker-compose.yaml`
+> under `profiles: [tailscale]`, off by default, and joins **the
+> principal's** tailnet — never an operator-owned one. Findings #5
+> (auth-key persistence) and #10 (supply-chain curl|sh) below are no
+> longer applicable in that form, though their underlying lessons
+> (treat auth keys as short-lived; never bake unverified install
+> scripts into bootstrap) carried forward into the new design.
+>
+> Read this file for the threat-modelling vocabulary and Layer 1/2/3
+> taxonomy — not as a description of what's deployed today.
+
 ---
 
 ## External Threat Landscape

--- a/packages/ctrl/src/api/routes/crossTenant.ts
+++ b/packages/ctrl/src/api/routes/crossTenant.ts
@@ -4,6 +4,20 @@
  * Admin-only feature: allows Sir's Alfred to ask questions to other tenants'
  * Alfreds via the Tailscale mesh. Each tenant gets a receiving endpoint; the
  * sending tool is only active when CROSS_TENANT_PEERS is set in the env.
+ *
+ * NOTE (#109): the `tailscaleIp` / `tailscaleHost` fields below refer to an
+ * **opt-in cross-tenant mesh** that the operator configures by hand via
+ * CROSS_TENANT_PEERS. This is orthogonal to the principal-owned Tailscale
+ * opt-in introduced in #109 (the `/channels/tailscale/*` routes + the
+ * `tailscale` compose profile). Two distinct surfaces:
+ *
+ *   • cross-tenant peer mesh — operator configures peer IPs explicitly via
+ *     env. Lives in env, not in the principal's tailnet.
+ *
+ *   • principal Tailscale — the principal joins THEIR OWN tailnet from
+ *     `/channels`. See `channels_tailscale.ts`.
+ *
+ * Do not entangle the two — a tenant can use either, both, or neither.
  */
 import fs from "node:fs";
 import { addRoute } from "../server.js";

--- a/packages/web/src/legal/PrivacyPolicyPage.tsx
+++ b/packages/web/src/legal/PrivacyPolicyPage.tsx
@@ -98,8 +98,8 @@ export default function PrivacyPolicyPage() {
                 <p className="font-body text-[15px] mt-1" style={{ color: "var(--marginalia)" }}>Your AI instance runs on dedicated virtual machines hosted by Hetzner Cloud GmbH. Hetzner processes data under EU data protection law (GDPR). Data center locations: EU (Germany, Finland) by default.</p>
               </div>
               <div>
-                <p className="font-display italic text-lg">Networking (Tailscale)</p>
-                <p className="font-body text-[15px] mt-1" style={{ color: "var(--marginalia)" }}>Your instance connects to a private Tailscale VPN network for secure, encrypted remote access. Tailscale does not have access to the content of your traffic.</p>
+                <p className="font-display italic text-lg">Networking (Tailscale — optional, principal-owned)</p>
+                <p className="font-body text-[15px] mt-1" style={{ color: "var(--marginalia)" }}>Optionally, you may connect your Alfred instance to <em>your own</em> Tailscale tailnet via the in-product Connect button on the Channels page. When you do, Tailscale Inc. provides the coordination service for the resulting WireGuard mesh; Alfred neither hosts your tailnet nor sees its membership. The connection is opt-in, you authenticate against your own Tailscale account, and you can disconnect at any time. Tailscale does not have access to the content of your traffic.</p>
               </div>
               <div>
                 <p className="font-display italic text-lg">Payments (Polar)</p>
@@ -160,7 +160,7 @@ export default function PrivacyPolicyPage() {
             <ul className="list-disc list-inside mt-3 space-y-2" style={{ color: "var(--marginalia)" }}>
               <li>TLS encryption for all data in transit</li>
               <li>AES-256 encryption for stored credentials</li>
-              <li>Private Tailscale VPN network isolating your instance</li>
+              <li>Optional Tailscale tailnet you control — you join your instance to your own tailnet from the Channels page if and when you choose</li>
               <li>Per-instance SSH keypairs with no shared credentials</li>
               <li>Regular security updates to instance software</li>
             </ul>

--- a/packages/web/src/legal/TermsOfServicePage.tsx
+++ b/packages/web/src/legal/TermsOfServicePage.tsx
@@ -44,7 +44,7 @@ export default function TermsOfServicePage() {
               <li>A persistent background AI worker that monitors streams, processes tasks, and takes autonomous actions on your behalf</li>
               <li>Integration capabilities with third-party services via credentials you provide (email, calendar, messaging, etc.)</li>
               <li>An inbox for review of AI-generated content and autonomous actions</li>
-              <li>Device management and secure remote access via Tailscale VPN</li>
+              <li>Optional secure remote access by joining your instance to your own Tailscale tailnet (opt-in, principal-authenticated)</li>
               <li>API access via bearer token authentication for programmatic control</li>
               <li>An administrative web dashboard at alfred.black</li>
             </ul>
@@ -71,7 +71,7 @@ export default function TermsOfServicePage() {
 
           <section>
             <h2 className="font-display text-2xl tracking-tight mb-3">6. Infrastructure and Instance Provisioning</h2>
-            <p>Upon activation, we provision a dedicated virtual machine on Hetzner Cloud infrastructure in your selected region, running your personal Alfred instance. The instance is connected to a private Tailscale network and assigned a subdomain (e.g., yourname.alfred.black).</p>
+            <p>Upon activation, we provision a dedicated virtual machine on Hetzner Cloud infrastructure in your selected region, running your personal Alfred instance, and assign it a subdomain (e.g., yourname.alfred.black) reachable over the public internet via standard HTTPS. Optionally, you may also connect your instance to your own Tailscale tailnet from the Channels page in the dashboard — when you do, you authenticate against your own Tailscale account, and the instance becomes reachable on your tailnet in addition to the public subdomain.</p>
             <p className="mt-3">We reserve the right to migrate instances to equivalent or superior hardware. Downtime during maintenance will be minimized and communicated in advance where feasible.</p>
             <p className="mt-3">You are responsible for the third-party credentials you store in your instance. We encrypt credentials at rest but cannot guarantee security against all attack vectors. Use strong, unique passwords and revoke credentials you no longer need.</p>
           </section>


### PR DESCRIPTION
Closes the docs/privacy half of #109 (PRs #121 / #127 / #134 / #141 already shipped the sidecar, ctrl-api routes, `/channels` card, and cert/serve/funnel).

## What ships

- `packages/web/src/legal/PrivacyPolicyPage.tsx` — replaces the stale SaaS-era *"private Tailscale VPN provided by Sir"* Networking paragraph with the principal-owned opt-in model. Reworked §7 Data Security bullet to match.
- `packages/web/src/legal/TermsOfServicePage.tsx` — same: §2 *"Device management and secure remote access via Tailscale VPN"* becomes the optional opt-in line; §6 instance provisioning paragraph reframes the Tailscale connection as a dashboard-driven, principal-authenticated opt-in additive to the public `alfred.black` subdomain.
- `CLAUDE.md` — §1 note disambiguating *"no Tailscale"* (no operator tailnet) from the new principal opt-in; new §15.11 *Optional Tailscale opt-in (#109)* with the operator flip + principal flow + cert+caddy path + outbound-MagicDNS caveat. §15.10 backups mentions `tailscale_data`.
- `deploy/README.md` — new *Enabling Tailscale on an existing tenant* section with the 5-step operator runbook, the Caddy `pids_limit` caveat live-observed on home, and the outbound-MagicDNS deferred follow-up.
- `packages/ctrl/SECURITY.md` — banner clarifying the document describes the pre-merge `alfred-platform` multi-tenant model; the `alfred-black` Tailscale story is the principal-owned opt-in.
- `packages/ctrl/src/api/routes/crossTenant.ts` — header comment distinguishing the opt-in cross-tenant operator mesh from the principal-owned tailnet introduced in #109. No functional change.
- `.env.example` — dropped the stale *"PR 1 ships only the compose foundation"* phrasing now that PRs 2–4 are live; pointed at the new runbook.

## Live verify against home.alfred.black (2026-05-30)

- Sidecar up 30+ hours, `BackendState=Running`, hostname `home-alfred-black-1.tail5ec603.ts.net`, IP `100.111.15.65`.
- ctrl-api `/api/v1/channels/tailscale/status` returns `{state:'connected', ...}` — PRs 1–4 are live.
- `POST /api/v1/channels/tailscale/cert` succeeds; cert + snippet land in the Caddy bind mount. `caddy_reload_ok=false` on home today — pre-existing `pids_limit` ulimit issue unrelated to #109 (flagged in the runbook caveat; PR #159 raised it but the running container pre-dates that flip).

## Scope

Docs-only. No code-behaviour change. Paired with the SaaS wiring in `feat/109-pr5-tailscale-web` (populates `instance.tailscaleHostname` from the live status probe). One logical change per PR per CLAUDE.md §11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)