### PR TITLE
feat(web,#109): PR5 — populate instance.tailscaleHostname from live ctrl-api status

### DIFF
--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -38,6 +38,7 @@ import {
   type OnboardingGmailMode,
 } from "../server/onboardingGmailMode";
 import { checkGmailConnection } from "../integrations/operations";
+import { pickTailnetHostnameForDashboard } from "./tailscaleCardCore";
 
 // ============================================================
 // AgentPhone (Phase 8 — dashboard PhonePage)
@@ -1105,6 +1106,25 @@ export const getDashboardData: GetDashboardData<void, any> = async (
   // Single aggregated endpoint — one tunnel round-trip instead of six
   const raw = await proxyToTenant(instance, { path: "/api/v1/admin/dashboard" });
 
+  // #109 PR5: fire a tiny secondary probe for Tailscale state. We can't
+  // bundle this into /admin/dashboard without a server-side change there
+  // (the singleton tailscale_connection row lives in ctrl-api state.db,
+  // and /admin/dashboard already round-trips a bunch of containers/health
+  // queries). Keep the probe fail-soft: any error → tailscaleHostname stays
+  // null and the dashboard renders exactly as it did pre-this-patch.
+  let tailscaleHostnameFromLive: string | null = null;
+  try {
+    const ts = await proxyToTenant(instance, {
+      path: "/api/v1/channels/tailscale/status",
+    });
+    tailscaleHostnameFromLive = pickTailnetHostnameForDashboard(ts);
+  } catch {
+    // Fail-soft. Tailscale may be off; probe may 502; ctrl-api may have
+    // skipped its singleton row. tailscaleHostname stays null and widgets
+    // that read it render the no-tailnet state.
+    tailscaleHostnameFromLive = null;
+  }
+
   const healthRaw = raw?.health ?? null;
   const vaultRaw = raw?.vault ?? null;
   const inboxRaw = raw?.inbox ?? null;
@@ -1155,7 +1175,13 @@ export const getDashboardData: GetDashboardData<void, any> = async (
     instance: {
       status: instance!.status,
       tier: instance!.tier,
-      tailscaleHostname: instance!.tailscaleHostname ?? null,
+      // #109 PR5: was always null (single-VM tenantProxy.getUserInstance
+      // returns {} so the back-compat `instance!.tailscaleHostname` field
+      // is undefined). Populate from the live ctrl-api status probe so
+      // dashboard widgets that read this field light up as soon as the
+      // principal connects on /channels.
+      tailscaleHostname:
+        tailscaleHostnameFromLive ?? instance!.tailscaleHostname ?? null,
       subdomainUrl: (instance as any).subdomainUrl ?? null,
       agentmailInboxAddress: (instance as any).agentmailInboxAddress ?? null,
     },

--- a/packages/web/src/dashboard/tailscaleCardCore.test.ts
+++ b/packages/web/src/dashboard/tailscaleCardCore.test.ts
@@ -30,6 +30,7 @@ import {
   formatProbeTime,
   isProbablyValidAuthKey,
   normalisePeer,
+  pickTailnetHostnameForDashboard,
   redactAuthKey,
   type TailscaleStatus,
   type TailscalePeersResponse,
@@ -350,4 +351,89 @@ test("formatProbeTime: just now / N min / N hours / N days", () => {
   assert.equal(formatProbeTime(Number.NaN), "");
   assert.equal(formatProbeTime(0), "");
   assert.equal(formatProbeTime(-1), "");
+});
+
+// ── pickTailnetHostnameForDashboard (#109 PR5) ────────────────────────────
+
+test("pickTailnetHostnameForDashboard: connected with hostname → that hostname", () => {
+  const status: TailscaleStatus = {
+    ...BASE,
+    state: "connected",
+    tailnet_hostname: "home-alfred-black-1.tail5ec603.ts.net",
+    tailnet_ip: "100.111.15.65",
+  };
+  assert.equal(
+    pickTailnetHostnameForDashboard(status),
+    "home-alfred-black-1.tail5ec603.ts.net",
+  );
+});
+
+test("pickTailnetHostnameForDashboard: connected but hostname empty/null → null", () => {
+  assert.equal(
+    pickTailnetHostnameForDashboard({
+      ...BASE,
+      state: "connected",
+      tailnet_hostname: null,
+    }),
+    null,
+  );
+  assert.equal(
+    pickTailnetHostnameForDashboard({
+      ...BASE,
+      state: "connected",
+      tailnet_hostname: "",
+    }),
+    null,
+  );
+  assert.equal(
+    pickTailnetHostnameForDashboard({
+      ...BASE,
+      state: "connected",
+      tailnet_hostname: "   ",
+    }),
+    null,
+  );
+});
+
+test("pickTailnetHostnameForDashboard: not connected → null even with a hostname present", () => {
+  for (const state of [
+    "disabled",
+    "starting",
+    "authenticating",
+    "error",
+  ] as const) {
+    assert.equal(
+      pickTailnetHostnameForDashboard({
+        ...BASE,
+        state,
+        tailnet_hostname: "stale.tail5ec603.ts.net",
+      }),
+      null,
+      `state=${state} must return null`,
+    );
+  }
+});
+
+test("pickTailnetHostnameForDashboard: garbage input fails soft", () => {
+  assert.equal(pickTailnetHostnameForDashboard(null), null);
+  assert.equal(pickTailnetHostnameForDashboard(undefined), null);
+  assert.equal(pickTailnetHostnameForDashboard("not an object"), null);
+  assert.equal(pickTailnetHostnameForDashboard(42), null);
+  assert.equal(pickTailnetHostnameForDashboard({}), null);
+  // Hostname-only without state → null (defensive).
+  assert.equal(
+    pickTailnetHostnameForDashboard({ tailnet_hostname: "x" }),
+    null,
+  );
+});
+
+test("pickTailnetHostnameForDashboard: trims whitespace before returning", () => {
+  assert.equal(
+    pickTailnetHostnameForDashboard({
+      ...BASE,
+      state: "connected",
+      tailnet_hostname: "  home-alfred-black-1.tail5ec603.ts.net  ",
+    }),
+    "home-alfred-black-1.tail5ec603.ts.net",
+  );
 });

--- a/packages/web/src/dashboard/tailscaleCardCore.ts
+++ b/packages/web/src/dashboard/tailscaleCardCore.ts
@@ -378,6 +378,30 @@ export function formatProbeTime(
   return `${days} ${days === 1 ? "day" : "days"} ago`;
 }
 
+// ── Dashboard-payload helper ─────────────────────────────────────────────
+
+/**
+ * Pick the tailnet hostname out of a /channels/tailscale/status payload
+ * for callers that only care whether to surface the field as a connected
+ * value (the dashboard's `instance.tailscaleHostname` slot). Returns the
+ * trimmed hostname iff the connection is live AND the hostname is a
+ * non-empty string; otherwise null. Fail-soft: any shape mismatch → null.
+ *
+ * Lives in tailscaleCardCore (and not in operations.ts) so the derivation
+ * can unit-test under node:test without pulling in the Wasp server-op
+ * surface.
+ *
+ * #109 PR 5.
+ */
+export function pickTailnetHostnameForDashboard(
+  status: unknown,
+): string | null {
+  if (!status || typeof status !== "object") return null;
+  const s = status as Partial<TailscaleStatus>;
+  if (s.state !== "connected") return null;
+  return pickNonEmpty(s.tailnet_hostname);
+}
+
 // ── Internal helpers ─────────────────────────────────────────────────────
 
 function pickNonEmpty(s: string | null | undefined): string | null {


### PR DESCRIPTION
Closes #109.

PRs in this fan-out:
- #121 — compose sidecar + state.db migration (MERGED 2026-05-29)
- #127 — ctrl-api `/channels/tailscale/*` routes (MERGED 2026-05-29)
- #134 — `/channels` Tailscale card UI (MERGED 2026-05-29)
- #141 — `/cert` + `/serve` + `/funnel` real impls + Caddyfile import (MERGED 2026-05-29)
- #190 — docs/privacy/ToS + operator runbook
- **this PR** — wires `instance.tailscaleHostname` from live status

## What this PR ships

Closes the dashboard pass-through gap left by #134: `operations.ts:1158` was returning `instance!.tailscaleHostname` which single-VM `tenantProxy.getUserInstance()` never populates (returns `{}`), so the field was always `null` even after the principal connected on `/channels`. The Tailscale card lit up but the wider dashboard (`getDashboardData` consumers reading `instance.tailscaleHostname`) saw stale-empty state.

Fix is one fail-soft probe to `/api/v1/channels/tailscale/status` from inside `getDashboardData`. Any error / non-connected state / missing hostname leaves the field `null` — the dashboard renders exactly as it did pre-this-patch on tenants without Tailscale, and lights up the hostname slot as soon as the principal connects.

## Files

- `packages/web/src/dashboard/tailscaleCardCore.ts` — new pure helper `pickTailnetHostnameForDashboard(status)` returning the trimmed hostname iff `status.state === 'connected'` AND `tailnet_hostname` is non-empty. Any shape mismatch → `null`.
- `packages/web/src/dashboard/tailscaleCardCore.test.ts` — +5 tests (connected / empty / non-connected / garbage / whitespace). Suite now 23 green (was 18).
- `packages/web/src/dashboard/operations.ts` — fire the probe in `getDashboardData`; pipe the result into the existing `tailscaleHostname` slot.

## Live verify against home.alfred.black (2026-05-30)

- ctrl-api `/status` returns `{state:'connected', tailnet_hostname:'home-alfred-black-1.tail5ec603.ts.net', tailnet_ip:'100.111.15.65', ...}` from inside ctrl-api container.
- `pickTailnetHostnameForDashboard` against the same payload returns the trimmed hostname; tests assert this against a recorded fixture.

## Acceptance criteria from issue #109 §11 — final state

| # | AC | State |
|---|----|-------|
| 1 | `docker compose up -d` default profile doesn't start tailscale | DONE (#121) |
| 2 | `--profile tailscale up -d` starts sidecar without auth | DONE (#121) |
| 3 | UI shows Tailscale card in `not_connected` | DONE (#134; card lives on `/channels`, see #190 for the docs trail) |
| 4 | Clicking Connect opens an auth URL on `login.tailscale.com` | DONE (#127 + #134; Path A pasted-key + Path C device-URL) |
| 5 | Card flips to `connected` within 10s | DONE (#127 polling cadence) |
| 6 | Hostname + IP copyable | DONE (#134) |
| 7 | Phone-on-tailnet → `https://<host>.tail-xxxx.ts.net` serves dashboard w/ valid LE cert | INFRA READY (#141 cert+serve, Caddy snippet import) — verifiable on a phone joined to the principal's tailnet. The cert call on home succeeded; `caddy_reload_ok=false` is a pre-existing `pids_limit` ulimit issue covered by PR #159 and the operator runbook in #190. |
| 8 | From inside containers, `<peer>.tail-xxxx.ts.net` resolves | DEFERRED — needs either `network_mode: service:tailscale` on the consumer service or explicit `dns:` config. Both have hermes-healthcheck risk and warrant their own PR. Documented as a deferred follow-up in CLAUDE.md §15.11 + `deploy/README.md` (PR #190). |
| 9 | Disconnect removes node + wipes creds + flips card back | DONE (#127) |
| 10 | Privacy + ToS updated | DONE (PR #190) |
| 11 | Connect/disconnect events in /decisions ledger | DONE (#127 `appendAudit` with `tailscale_*`) |
| 12 | Public `<tenant>.alfred.black` keeps working | DONE (verified live) |

## Caveats / follow-ups

- `caddy_reload_ok=false` on home is a Caddy `pids_limit: 1024` ulimit issue, NOT a #109 regression. PR #159 raised the limit but the live container pre-dates that flip; `docker compose up -d caddy` on the tenant re-applies. Documented in PR #190's runbook.
- AC #8 (outbound MagicDNS from inside containers) is deferred — needs its own issue because the two options (`network_mode: service:tailscale` vs explicit `dns:`) both have hermes-healthcheck blast radius. The principal-visible flow (open dashboard at tailnet URL, click around) does not depend on it; outbound is for Alfred reaching the principal's Home Assistant / NAS / etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)