### PR TITLE
fix(codex-builder): preserve 0711 profile dir mode (closes #119)

### DIFF
--- a/packages/hermes/Dockerfile
+++ b/packages/hermes/Dockerfile
@@ -178,6 +178,36 @@ RUN python3 /tmp/patch_openai_sdk.py \
  && rm /tmp/patch_openai_sdk.py
 
 # =============================================================================
+# Patch: profile-dir-aware parent chmod in hermes_cli/auth.py.
+#
+# Upstream Hermes' _save_auth_store (and the qwen + nous shared-store
+# variants) hard-codes `os.chmod(<path>.parent, 0o700)` on every save —
+# token refresh, provider login, write-back of cached creds. In
+# alfred-black HERMES_HOME points at a *profile* dir
+# (e.g. /hermes-state/profiles/codex-builder) whose mode is owned by the
+# init container. PR #118 set the codex-builder profile dir to 0o711 so
+# the paperclip-hermes adapter (uid 1000) can traverse to .env for the
+# gateway's API_SERVER_KEY; an auth-store save then resets it back to
+# 0o700 and the next paperclip → :18793 dispatch 401s with
+# hermes_auth_failed / invalid_api_key (GH #119). The companion fix —
+# HERMES_HOME_MODE=0711 in the codex-builder profile .env — handles the
+# `_secure_dir(home)` path that fires at every CLI startup; this patch
+# handles the auth-save path that fires at every token write.
+#
+# See patch_upstream_hermes_auth.py for the full rationale. The patch is
+# idempotent + tripwire'd; a future HERMES_REF bump that moves any of
+# the three needles fails the build loudly.
+#
+# Sir 2026-05-30 — durable fix for GH #119.
+COPY packages/hermes/patch_upstream_hermes_auth.py /tmp/patch_upstream_hermes_auth.py
+RUN python3 /tmp/patch_upstream_hermes_auth.py \
+ && grep -q "alfred-black: profile-dir-aware chmod" \
+        /usr/local/lib/python3.12/site-packages/hermes_cli/auth.py \
+ && grep -q "_alfred_is_profile_dir" \
+        /usr/local/lib/python3.12/site-packages/hermes_cli/auth.py \
+ && rm /tmp/patch_upstream_hermes_auth.py
+
+# =============================================================================
 # Bake the hermes-lcm plugin (lossless cross-session context engine).
 # =============================================================================
 # The `stephenschoettler/hermes-lcm` plugin enables Hermes' LCM context engine

--- a/packages/hermes/hermes-profile.env.njk
+++ b/packages/hermes/hermes-profile.env.njk
@@ -86,6 +86,19 @@ CODEX_HOME=/hermes-state/profiles/codex-builder/.codex
 # Workspace mount — see docs/codex-builder-runtime.md §5. Owned uid 10001
 # mode 0700 by the init container.
 CODEX_WORKSPACE_ROOT=/work
+# HERMES_HOME mode preservation — pinned to 0711 so the paperclip-hermes
+# adapter (uid 1000 via the upstream `gosu node` entrypoint) can traverse
+# this profile dir to read .env for the gateway's API_SERVER_KEY. Without
+# this, upstream Hermes' `_secure_dir(home)` (hermes_cli/config.py) runs
+# at every CLI startup and resets the dir to 0700 (the upstream default),
+# silently undoing PR #118's chmod and 401-ing every paperclip → :18793
+# dispatch with hermes_auth_failed / invalid_api_key (GH #119).
+#
+# Mode 0o711 = owner rwx + others --x. uid 1000 can `open()` a specific
+# filename (.env) but cannot `ls` the dir. auth.json, .codex/, workspace/,
+# etc. stay 0600/0700 by their own modes — the dir-traverse bit alone
+# does not expose them.
+HERMES_HOME_MODE=0711
 # SSH key for git push, written by the PR 4 init step. Until then this
 # variable is set but the file doesn't exist — `git push` will fail clean
 # with "no such file" instead of leaking an ambient agent identity.

--- a/packages/hermes/patch_upstream_hermes_auth.py
+++ b/packages/hermes/patch_upstream_hermes_auth.py
@@ -1,0 +1,229 @@
+"""In-place patch of the pip-installed Hermes auth store, applied at
+image-build time inside packages/hermes/Dockerfile.
+
+Why this exists
+---------------
+Upstream NousResearch/hermes-agent's `hermes_cli/auth.py` hardens the
+auth-store parent directory to 0o700 on every save:
+
+    # Tighten parent dir to 0o700 so siblings can't traverse to creds.
+    try:
+        os.chmod(auth_file.parent, 0o700)
+    except OSError:
+        pass
+
+For Hermes' single-user assumption (the parent is `~/.hermes/`) this is
+fine. For alfred-black's per-profile layout where `HERMES_HOME` is the
+*profile* directory itself, this chmod **rewrites the profile dir mode
+on every OAuth token refresh** — silently undoing the init container's
+careful 0o711 hardening on `/hermes-state/profiles/codex-builder`
+(PR #118) and locking the paperclip-hermes adapter (uid 1000 via the
+upstream `gosu node` entrypoint) out of `.env`.
+
+The visible failure is identical to the pre-#118 state: every Paperclip
+dispatch to the codex-builder profile gets
+`hermes_auth_failed` / `invalid_api_key` because
+`readHermesProfileApiKey("codex-builder")` returns null (EACCES on the
+0o700 parent dir) and the adapter sends no `Authorization` header.
+
+The companion fix lives in `hermes-profile.env.njk`:
+`HERMES_HOME_MODE=0711` makes `_secure_dir(home)` honor 0o711 at every
+CLI startup. This patch handles the `_save_auth_store` (and qwen + nous
+shared-store) chmod path that fires on every token write — together
+they cover both the startup and the runtime resets.
+
+What this patch changes
+-----------------------
+Three call sites in `hermes_cli/auth.py` (~ line 1009 in
+`_save_auth_store`, ~ line 1593 in `_save_qwen_cli_tokens`, ~ line 3556
+in the nous-shared-store writer) all do the same
+`os.chmod(<x>.parent, 0o700)`. We replace each with a guarded variant:
+
+    if not _alfred_is_profile_dir(<x>.parent):
+        os.chmod(<x>.parent, 0o700)
+
+…where `_alfred_is_profile_dir` is a tiny helper appended to the module
+that returns True iff the path lives under `/hermes-state/profiles/`
+(matching every alfred-black profile dir, not just codex-builder). For
+those paths, init owns the mode; the file itself is still chmod'd 0o600
+by the same function below the change, so the auth tokens stay sealed.
+On a real `~/.hermes/auth.json` install the helper returns False and
+the patch is a no-op — the upstream tightening still happens.
+
+The needles are picked to be byte-stable across upstream changes that
+don't touch this specific chmod call; the build fails loudly via the
+tripwire if a future HERMES_REF bump moves them.
+
+Idempotent + tripwire'd
+-----------------------
+Each patch checks for the alfred sentinel comment
+`# alfred-black: profile-dir-aware chmod` before patching and exits 0 if
+already done. If a needle has moved, the script exits 2 — the
+Dockerfile then fails the build rather than silently baking an
+unpatched image.
+
+Sir 2026-05-30 — durable fix for GH #119 (codex-feature-builder
+heartbeat dispatch returns hermes_auth_failed).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+
+AUTH_PY = "/usr/local/lib/python3.12/site-packages/hermes_cli/auth.py"
+
+SENTINEL = "# alfred-black: profile-dir-aware chmod"
+
+
+# A small helper appended once at the END of the file. We do NOT touch
+# the import block to keep the diff to upstream as narrow as possible —
+# Python resolves _alfred_is_profile_dir lazily at call time, so its
+# placement after the call sites is fine.
+HELPER = '''
+
+
+# === alfred-black patch (GH #119): profile-dir-aware parent chmod ============
+# Hermes' upstream auth.py chmods the auth-store parent dir to 0o700 on every
+# save (see needles patched in this file). In alfred-black HERMES_HOME points
+# at a per-profile directory (e.g. /hermes-state/profiles/codex-builder)
+# whose mode is owned by the init container — re-chmodding it here clobbers
+# PR #118's 0o711 traverse-bit and locks the paperclip-hermes adapter
+# (uid 1000) out of .env. The auth.json file itself stays 0o600, so credential
+# hygiene is preserved by the file mode, not the dir mode.
+#
+# This helper is a no-op on a stock single-user install where the parent is
+# ~/.hermes/ — the alfred-black sentinel path /hermes-state/profiles/ is only
+# present in our containers.
+def _alfred_is_profile_dir(parent_path) -> bool:  # pragma: no cover
+    try:
+        s = str(parent_path)
+    except Exception:
+        return False
+    # Match /hermes-state/profiles/<name>/ — all 4 alfred-black profiles.
+    return "/hermes-state/profiles/" in s
+'''
+
+
+# Each patch tuple: (needle, replacement, label).
+PATCHES = [
+    # 1. _save_auth_store — the OAuth provider token store. Hit on every
+    #    `_save_auth_store(auth_store)` call (provider login, token
+    #    refresh, write-back of cached creds). This is the call site that
+    #    most often resets the codex-builder profile dir at runtime.
+    (
+        (
+            "    auth_file.parent.mkdir(parents=True, exist_ok=True)\n"
+            "    # Tighten parent dir to 0o700 so siblings can't traverse to creds.\n"
+            "    # No-op on Windows (POSIX mode bits not enforced); ignore failures.\n"
+            "    try:\n"
+            "        os.chmod(auth_file.parent, 0o700)\n"
+            "    except OSError:\n"
+            "        pass\n"
+        ),
+        (
+            "    auth_file.parent.mkdir(parents=True, exist_ok=True)\n"
+            "    # Tighten parent dir to 0o700 so siblings can't traverse to creds.\n"
+            "    # No-op on Windows (POSIX mode bits not enforced); ignore failures.\n"
+            "    # " + SENTINEL + " (GH #119) — skip when parent is an alfred-black\n"
+            "    # profile dir; init owns the mode (0o711 for codex-builder).\n"
+            "    try:\n"
+            "        if not _alfred_is_profile_dir(auth_file.parent):\n"
+            "            os.chmod(auth_file.parent, 0o700)\n"
+            "    except OSError:\n"
+            "        pass\n"
+        ),
+        "auth.py:_save_auth_store",
+    ),
+    # 2. _save_qwen_cli_tokens — Qwen CLI's token store. Also calls
+    #    chmod(parent, 0o700) on every save. Same fix.
+    (
+        (
+            "def _save_qwen_cli_tokens(tokens: Dict[str, Any]) -> Path:\n"
+            "    auth_path = _qwen_cli_auth_path()\n"
+            "    auth_path.parent.mkdir(parents=True, exist_ok=True)\n"
+            "    try:\n"
+            "        os.chmod(auth_path.parent, 0o700)\n"
+            "    except OSError:\n"
+            "        pass\n"
+        ),
+        (
+            "def _save_qwen_cli_tokens(tokens: Dict[str, Any]) -> Path:\n"
+            "    auth_path = _qwen_cli_auth_path()\n"
+            "    auth_path.parent.mkdir(parents=True, exist_ok=True)\n"
+            "    # " + SENTINEL + " (GH #119) — see helper at file end.\n"
+            "    try:\n"
+            "        if not _alfred_is_profile_dir(auth_path.parent):\n"
+            "            os.chmod(auth_path.parent, 0o700)\n"
+            "    except OSError:\n"
+            "        pass\n"
+        ),
+        "auth.py:_save_qwen_cli_tokens",
+    ),
+    # 3. nous shared store writer — same pattern, nested under
+    #    `with _nous_shared_store_lock():`. Less frequently hit on
+    #    codex-builder (no Nous account by default) but patched for
+    #    completeness so a future cross-profile auth share doesn't
+    #    silently reintroduce the regression.
+    (
+        (
+            "            path = _nous_shared_store_path()\n"
+            "            path.parent.mkdir(parents=True, exist_ok=True)\n"
+            "            try:\n"
+            "                os.chmod(path.parent, 0o700)\n"
+            "            except OSError:\n"
+            "                pass\n"
+        ),
+        (
+            "            path = _nous_shared_store_path()\n"
+            "            path.parent.mkdir(parents=True, exist_ok=True)\n"
+            "            # " + SENTINEL + " (GH #119) — see helper at file end.\n"
+            "            try:\n"
+            "                if not _alfred_is_profile_dir(path.parent):\n"
+            "                    os.chmod(path.parent, 0o700)\n"
+            "            except OSError:\n"
+            "                pass\n"
+        ),
+        "auth.py:_nous_shared_store",
+    ),
+]
+
+
+def patch_file(path: str, patches, helper: str) -> None:
+    p = pathlib.Path(path)
+    src = p.read_text()
+
+    if SENTINEL in src:
+        print(f"{path}: already patched (sentinel present), skipping")
+        return
+
+    new_src = src
+    for needle, replacement, label in patches:
+        if needle not in new_src:
+            print(
+                f"{label}: NEEDLE_NOT_FOUND in {path} — upstream Hermes "
+                f"may have moved this hunk; re-author the patch.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        new_src = new_src.replace(needle, replacement, 1)
+        print(f"{label}: patched")
+
+    # Append the helper at the end of the file (after any trailing
+    # newline). Idempotent because we check SENTINEL above; the helper
+    # body contains the sentinel string.
+    if not new_src.endswith("\n"):
+        new_src += "\n"
+    new_src += helper
+
+    p.write_text(new_src)
+    print(f"{path}: helper appended ({len(helper)} bytes)")
+
+
+def main() -> None:
+    patch_file(AUTH_PY, PATCHES, HELPER)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/hermes/tests/test_patch_upstream_hermes_auth.py
+++ b/packages/hermes/tests/test_patch_upstream_hermes_auth.py
@@ -1,0 +1,218 @@
+"""Tests for patch_upstream_hermes_auth.py — the in-place patch that
+teaches Hermes' auth.py to skip the parent-dir chmod 0o700 when the
+parent is an alfred-black profile dir.
+
+GH #119: the codex-feature-builder paperclip dispatch was failing with
+hermes_auth_failed / invalid_api_key because Hermes' own
+_save_auth_store was reaching down on every save and re-chmodding
+/hermes-state/profiles/codex-builder back to 0o700, undoing PR #118's
+0o711 traverse bit and locking the paperclip-hermes adapter (uid 1000)
+out of `.env`.
+
+These tests verify the patch script:
+
+  1. Successfully patches a synthetic upstream-shaped auth.py.
+  2. Is idempotent (re-run is a no-op).
+  3. Fails loudly when an upstream needle has moved (tripwire).
+  4. The patched code's runtime guard skips the chmod for
+     /hermes-state/profiles/* paths AND preserves it for any other
+     parent (e.g. ~/.hermes/).
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PATCH_SCRIPT = REPO_ROOT / "packages" / "hermes" / "patch_upstream_hermes_auth.py"
+
+
+# A trimmed but byte-exact replica of the three upstream chmod sites the
+# patch script targets. The signatures below match upstream Hermes
+# (hermes-agent v2026.5.16) exactly — keep these aligned with the real
+# upstream signatures whenever they drift. When the upstream Hermes
+# moves them, both this fixture AND the patch script need to update,
+# and the build-time tripwire will catch the drift in CI.
+UPSTREAM_AUTH_PY_FIXTURE = '''"""Synthetic hermes_cli/auth.py stub mirroring three chmod call sites."""
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Dict
+
+
+def _auth_file_path() -> Path:
+    return Path("/tmp/auth.json")
+
+
+def _qwen_cli_auth_path() -> Path:
+    return Path("/tmp/qwen-auth.json")
+
+
+def _nous_shared_store_path() -> Path:
+    return Path("/tmp/nous-shared.json")
+
+
+@contextmanager
+def _nous_shared_store_lock():
+    yield
+
+
+def _save_auth_store(auth_store: Dict[str, Any]) -> Path:
+    auth_file = _auth_file_path()
+    auth_file.parent.mkdir(parents=True, exist_ok=True)
+    # Tighten parent dir to 0o700 so siblings can't traverse to creds.
+    # No-op on Windows (POSIX mode bits not enforced); ignore failures.
+    try:
+        os.chmod(auth_file.parent, 0o700)
+    except OSError:
+        pass
+    return auth_file
+
+
+def _save_qwen_cli_tokens(tokens: Dict[str, Any]) -> Path:
+    auth_path = _qwen_cli_auth_path()
+    auth_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(auth_path.parent, 0o700)
+    except OSError:
+        pass
+    return auth_path
+
+
+def _save_nous_shared(state):
+    try:
+        with _nous_shared_store_lock():
+            path = _nous_shared_store_path()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                os.chmod(path.parent, 0o700)
+            except OSError:
+                pass
+    except Exception:
+        pass
+'''
+
+
+@pytest.fixture
+def fake_auth_py(tmp_path):
+    """Materialise a fake hermes_cli/auth.py under tmp_path/site-packages."""
+    site = tmp_path / "site-packages" / "hermes_cli"
+    site.mkdir(parents=True)
+    auth = site / "auth.py"
+    auth.write_text(UPSTREAM_AUTH_PY_FIXTURE)
+    return auth
+
+
+def _load_patch_module(monkeypatch, fake_auth_path):
+    spec = importlib.util.spec_from_file_location(
+        "patch_upstream_hermes_auth", PATCH_SCRIPT
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    monkeypatch.setattr(mod, "AUTH_PY", str(fake_auth_path))
+    return mod
+
+
+def test_patch_applies_to_synthetic_upstream(fake_auth_py, monkeypatch):
+    """All three call sites are patched and the helper is appended."""
+    mod = _load_patch_module(monkeypatch, fake_auth_py)
+    mod.main()
+    patched = fake_auth_py.read_text()
+
+    # Sentinel present at each of the three call sites (+ the helper
+    # comment block reuses the phrase, so we expect >= 3).
+    assert patched.count(mod.SENTINEL) >= 3, (
+        f"sentinel count: {patched.count(mod.SENTINEL)}"
+    )
+    # Helper function appended.
+    assert "_alfred_is_profile_dir" in patched
+    assert "/hermes-state/profiles/" in patched
+    # The original `os.chmod(..., 0o700)` lines are now guarded — each
+    # call site references the helper. Exactly three call-site guards.
+    assert patched.count("if not _alfred_is_profile_dir") == 3
+
+
+def test_patch_is_idempotent(fake_auth_py, monkeypatch):
+    """Re-running the patch must be a byte-stable no-op."""
+    mod = _load_patch_module(monkeypatch, fake_auth_py)
+    mod.main()
+    first = fake_auth_py.read_text()
+    mod.main()
+    second = fake_auth_py.read_text()
+    assert first == second
+
+
+def test_patch_tripwire_on_missing_needle(tmp_path, monkeypatch):
+    """If a future HERMES_REF bump moves the upstream chmod hunk so the
+    needle no longer matches, the script must exit non-zero (not
+    silently bake an unpatched image).
+    """
+    site = tmp_path / "site-packages" / "hermes_cli"
+    site.mkdir(parents=True)
+    auth = site / "auth.py"
+    auth.write_text("# upstream moved; no chmod calls here at all\nimport os\n")
+
+    mod = _load_patch_module(monkeypatch, auth)
+    with pytest.raises(SystemExit) as exc:
+        mod.main()
+    assert exc.value.code == 2
+
+
+def test_patched_helper_returns_true_for_profile_dirs(fake_auth_py, monkeypatch):
+    """The helper appended by the patch must recognise any
+    `/hermes-state/profiles/<name>/` parent (codex-builder, main,
+    workers, heavy) as an alfred-black profile dir, AND must return
+    False for stock single-user installs.
+    """
+    mod = _load_patch_module(monkeypatch, fake_auth_py)
+    mod.main()
+
+    # Exec the patched file into a fresh namespace and pull the helper.
+    ns: dict = {}
+    exec(fake_auth_py.read_text(), ns)
+    helper = ns["_alfred_is_profile_dir"]
+
+    for name in ("codex-builder", "main", "workers", "heavy"):
+        assert helper(Path(f"/hermes-state/profiles/{name}")) is True, name
+    # Stock single-user install path: must NOT match — the patch is a
+    # no-op on a real user's machine. This is the graceful-degradation
+    # contract: on a non-alfred-black box, the upstream tightening still
+    # happens, so we don't ship a security regression to anybody else.
+    assert helper(Path("/root/.hermes")) is False
+    assert helper(Path("/home/sir/.hermes")) is False
+    # Nested paths still match (substring contract is intentional —
+    # `/hermes-state/profiles/codex-builder/.codex` would also count,
+    # which is fine: those subdirs aren't chmod'd by auth.py in upstream;
+    # only the auth-file parent is).
+    assert helper(Path("/hermes-state/profiles/main/sub/dir")) is True
+
+
+def test_patch_script_runs_as_subprocess(fake_auth_py, tmp_path):
+    """End-to-end: run the patch script as `python3 path/to/patch.py`
+    via a thin shim that overrides AUTH_PY. This catches argv handling
+    + import-time errors that the in-process tests miss.
+    """
+    # Write a runner that imports the patch module, redirects AUTH_PY,
+    # then calls main().
+    runner = tmp_path / "run_patch.py"
+    runner.write_text(
+        "import importlib.util\n"
+        f"spec = importlib.util.spec_from_file_location('p', {str(PATCH_SCRIPT)!r})\n"
+        "mod = importlib.util.module_from_spec(spec); spec.loader.exec_module(mod)\n"
+        f"mod.AUTH_PY = {str(fake_auth_py)!r}\n"
+        "mod.main()\n"
+    )
+    result = subprocess.run(
+        [sys.executable, str(runner)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    patched = fake_auth_py.read_text()
+    assert "_alfred_is_profile_dir" in patched


### PR DESCRIPTION
Closes #119.

## What was broken

Every Paperclip dispatch to the `codex-feature-builder` agent has been
returning `hermes_auth_failed` / `invalid_api_key` since the sealed
runtime went live. The 401 originates at the codex-builder Hermes
gateway on `:18793` because the paperclip-hermes adapter (uid 1000 via
the upstream `gosu node` entrypoint) cannot read
`/hermes-state/profiles/codex-builder/.env` to pull `API_SERVER_KEY`:
with the dir at `0o700`, `readHermesProfileApiKey()` hits `EACCES`,
returns `null`, and the adapter sends the request with no
`Authorization` header.

## Root cause — two upstream chmod sites resetting the dir

PR #118 already chmod'd that dir to `0o711` in the init container. The
mode does not stick because **two upstream Hermes code paths reset it**
after every hermes restart and every token write:

1. **`hermes_cli/config.py::_secure_dir(home)`** — fires at every CLI
   startup (`hermes -p codex-builder gateway run`). `HERMES_HOME` is
   resolved per-profile to `/hermes-state/profiles/codex-builder`; the
   function chmods that dir to `0o700` (its upstream default) unless
   the `HERMES_HOME_MODE` env var overrides it.

2. **`hermes_cli/auth.py::_save_auth_store`** (and the qwen + nous
   shared-store variants) — fires on every OAuth token refresh /
   login / write-back. Hard-codes `os.chmod(auth_file.parent, 0o700)`
   with **no env-var escape hatch**.

## Fix — env-var for one site, monkey-patch for the other

* `hermes-profile.env.njk` adds `HERMES_HOME_MODE=0711` to the
  codex-builder profile's `.env`. `_secure_dir` reads the env var and
  honors `0o711` from then on — preserves the traverse bit across every
  CLI startup. Scoped to the codex-builder block; `main`/`workers`/
  `heavy` keep upstream's `0o700` behaviour.

* `patch_upstream_hermes_auth.py` is a new build-time monkey-patch
  (same shape as `patch_upstream_hermes.py` / `patch_openai_sdk.py`)
  that guards the three hard-coded chmod sites in `auth.py` with a
  `_alfred_is_profile_dir(parent)` check. On `/hermes-state/profiles/`
  parents the chmod is skipped; on any other parent (a stock
  `~/.hermes/auth.json` install) the chmod still happens, so we don't
  ship a security regression to anybody else. The `auth.json` file
  itself stays `0o600`, so credential hygiene is preserved by the
  file mode — losing the dir-mode tightening for this one path is the
  intended trade.

## Safety rails

The patch is idempotent and tripwire'd: if a future `HERMES_REF` bump
moves any of the three needles, the Dockerfile build fails loudly via
two `grep -q` checks on the deployed sentinel string + helper name.

Tests under `packages/hermes/tests/test_patch_upstream_hermes_auth.py`
cover:
- The happy path on a synthetic upstream-shaped fixture.
- Idempotency (re-running is a byte-stable no-op).
- Tripwire on a missing needle (exit code 2).
- The runtime helper's profile-dir contract — positives for all 4
  alfred-black profiles, negatives for `/root/.hermes` / `/home/sir/.hermes`.
- An end-to-end `python3 path/to/patch.py` subprocess run.

## Live verification

With the dir hot-set to `0o711` + the env-var loaded and the
monkey-patched `auth.py`, two consecutive heartbeat runs flipped from
`failed/hermes_auth_failed` to `succeeded` with no error code:

```
{
  "id": "c4022546-0147-48fe-9468-031cfb2942e0",
  "status": "succeeded",
  "error_code": null
}
{
  "id": "d900b27e-51e3-4806-bf5d-fd7b9076f822",
  "status": "succeeded",
  "error_code": null
}
```

The Hermes-codex-builder agent successfully read its assigned issue +
updated it through the Paperclip MCP — the dispatch path is live.

(Sir's note on the family of bugs: same shape as
[hermes-paperclip-eacces](https://github.com/ssdavidai/alfred/pull/92)
and PR #118 — adapter silently returns on `EACCES`, dispatch 401s, the
fix is on the file-mode side because the adapter's contract is
already correct.)

## Smoke test post-deploy

```bash
ssh -i ~/.ssh/alfred-black-verify -o IdentityAgent=none -o BatchMode=yes \
  -o StrictHostKeyChecking=no root@home.alfred.black '
    cd /opt/alfred && \
    docker compose -p alfred-black pull hermes && \
    docker compose -p alfred-black up -d --force-recreate init hermes && \
    docker exec --user node alfred-black-paperclip-1 \
      cat /hermes-state/profiles/codex-builder/.env | head -1 && \
    docker run --rm -v alfred-black_hermes_data:/hs alpine \
      stat -c "%a" /hs/profiles/codex-builder
  '
```

Expected: `# Hermes Agent .env — profile: codex-builder` from the cat
(uid 1000 can read .env), `711` from stat (dir mode preserved across
init re-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)