### PR TITLE
feat(ctrl,learn,web): #114 Lane B — file content extraction pipeline + "Alfred read it" badge

### DIFF
--- a/packages/ctrl/src/api/routes/files.ts
+++ b/packages/ctrl/src/api/routes/files.ts
@@ -61,6 +61,7 @@ import { addRoute } from "../server.js";
 import { sendJson, ValidationError, NotFoundError, ApiError } from "../errors.js";
 import { getStateDb } from "../../db/state.js";
 import { appendAudit } from "./state.js";
+import { dockerExec } from "../helpers.js";
 
 // ── Configuration ──────────────────────────────────────────────────────────
 
@@ -234,6 +235,15 @@ interface FileRow {
   deleted_at: number | null;
   cold_promoted_at: number | null;
   ref_count: number;
+  // #114 Lane B — content-extraction columns. `alfred_read_at` flips
+  // from null → unix-ms when the FileExtractionWorkflow finishes;
+  // drives the "Alfred read it" badge on /files. `summary` is the
+  // one-paragraph description (null while pending OR on error).
+  // `extraction_error` is a short reason code (`unsupported_mime`,
+  // `extractor_failed`, `summariser_failed`); null on success.
+  alfred_read_at: number | null;
+  summary: string | null;
+  extraction_error: string | null;
 }
 
 function rowFromDb(raw: Record<string, unknown>): FileRow {
@@ -255,6 +265,13 @@ function rowFromDb(raw: Record<string, unknown>): FileRow {
     cold_promoted_at:
       raw.cold_promoted_at == null ? null : Number(raw.cold_promoted_at),
     ref_count: raw.ref_count == null ? 1 : Number(raw.ref_count),
+    // #114 Lane B — extraction columns. These three are nullable on
+    // the SQL side; coerce in the same defensive shape as the rest.
+    alfred_read_at:
+      raw.alfred_read_at == null ? null : Number(raw.alfred_read_at),
+    summary: raw.summary == null ? null : String(raw.summary),
+    extraction_error:
+      raw.extraction_error == null ? null : String(raw.extraction_error),
   };
 }
 
@@ -626,7 +643,70 @@ function rowToJson(row: FileRow): Record<string, unknown> {
     last_accessed_at: row.last_accessed_at,
     deleted_at: row.deleted_at,
     cold_promoted_at: row.cold_promoted_at,
+    // #114 Lane B — extraction surface for the /files badge.
+    alfred_read_at: row.alfred_read_at,
+    summary: row.summary,
+    extraction_error: row.extraction_error,
   };
+}
+
+// ── extraction trigger (#114 Lane B) ─────────────────────────────────────
+//
+// After a successful upload, fire-and-forget a one-shot FileExtractionWorkflow
+// run on the alfred-learn task queue. The workflow reads the blob via
+// GET /api/v1/files/blob/:path, picks the right extractor by mime, calls
+// the workers gateway for a summary, and PATCHes us back via
+// `/api/v1/files/:id/extraction`. The upload response NEVER blocks on
+// this — the badge appears asynchronously on the /files page.
+//
+// `docker compose exec temporal temporal workflow start` is the same
+// out-of-process trigger pattern the HA-bootstrap route already uses
+// (channels_ha.ts → `POST /channels/ha/registry/refresh`). Failures
+// are logged and swallowed: a missed extraction is far less bad than a
+// failed upload from the principal's view.
+//
+// Set `FILES_EXTRACTION_ENABLED=false` to short-circuit (useful for
+// the ctrl-api test harness, where the temporal CLI isn't available).
+const FILES_EXTRACTION_ENABLED =
+  (process.env.FILES_EXTRACTION_ENABLED ?? "true").toLowerCase() !== "false";
+
+function triggerFileExtraction(fileId: string, contentType: string | null): void {
+  if (!FILES_EXTRACTION_ENABLED) return;
+  // Skip extraction for mime types we know we cannot summarise. Saves a
+  // round trip + a "unsupported_mime" stamp on every screenshot.
+  // The workflow itself enforces the same gate; this is an early-out.
+  const ct = (contentType ?? "").toLowerCase();
+  const KNOWN_BINARY_NOOPS = ["application/zip", "application/x-tar", "application/gzip"];
+  if (KNOWN_BINARY_NOOPS.includes(ct)) return;
+
+  // Workflow-id includes the file id so a re-fire on the same upload
+  // (e.g. operator-driven retry) is idempotent on Temporal's side.
+  const workflowId = `file-extract-${fileId}`;
+  const input = JSON.stringify({ file_id: fileId });
+  // Fire-and-forget. The shell-out to `docker compose exec temporal` is
+  // ~500ms on a warm tenant; we explicitly do NOT `await` the promise.
+  void dockerExec("temporal", [
+    "temporal",
+    "workflow",
+    "start",
+    "--type",
+    "FileExtractionWorkflow",
+    "--task-queue",
+    "alfred-learn",
+    "--workflow-id",
+    workflowId,
+    "--input",
+    input,
+  ]).catch((err) => {
+    // ALREADY_EXISTS is fine — the workflow id is dedup-keyed, a duplicate
+    // start is a no-op from the principal's view. Anything else is logged
+    // so the operator can see it in the ctrl-api journal.
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("ALREADY_EXISTS") || msg.includes("workflow execution already started")) {
+      return;
+    }
+    console.warn(`[files] FileExtractionWorkflow start failed for ${fileId}: ${msg}`);
+  });
 }
 
 // ── bootstrap ─────────────────────────────────────────────────────────────
@@ -880,6 +960,160 @@ export function registerFilesRoutes(): void {
       uploaded_at: now,
       deduped,
     });
+
+    // #114 Lane B — fire-and-forget extraction. Runs after the response
+    // is sent so a slow temporal CLI dispatch can never tax the upload
+    // path. The workflow's workflow_id is keyed on file_id, so a
+    // duplicate start surfaces as ALREADY_EXISTS and is silently
+    // ignored. Cheapest defensible posture: trigger on every upload.
+    triggerFileExtraction(id, contentType);
+  });
+
+  // PATCH /api/v1/files/:file_id/extraction
+  //
+  // #114 Lane B — the FileExtractionWorkflow's write-back surface. The
+  // alfred-learn workflow extracts the file's text, calls the workers
+  // gateway for a one-paragraph summary, and POSTs the result here so
+  // the /files page can render the "Alfred read it" badge.
+  //
+  // Body:
+  //   {
+  //     "alfred_read_at"   : <unix-ms> | null,
+  //     "summary"          : string | null,
+  //     "extraction_error" : string | null
+  //   }
+  //
+  // Semantics:
+  //   * success path → workflow sends `alfred_read_at = <now>`,
+  //     `summary = "<paragraph>"`, `extraction_error = null`.
+  //   * failure path → workflow sends `alfred_read_at = null`,
+  //     `summary = null`, `extraction_error = "<reason_code>"`.
+  //
+  // The route is keyed by `file_id` (not the `<ULID>/<name>` path) so
+  // the workflow doesn't have to know about dedupe path rewrites.
+  // Soft-deleted rows are rejected — a tombstoned upload has no
+  // principal-facing surface, so the workflow shouldn't be stamping it.
+  //
+  // Registration order matters: the wildcard PATCH `/api/v1/files/*`
+  // (principal_label edit, PR 2) is registered later in this function
+  // and would otherwise eat this route's matches. Keeping this one
+  // here, right after upload, makes the specific path win.
+  addRoute("PATCH", "/api/v1/files/:file_id/extraction", async ({ res, params, body }) => {
+    const fileId = params.file_id ?? "";
+    if (!fileId) throw new ValidationError("file_id is required");
+    const db = getStateDb();
+    const raw = db
+      .prepare(`SELECT * FROM files WHERE id = ? LIMIT 1`)
+      .get(fileId) as Record<string, unknown> | undefined;
+    if (!raw) throw new NotFoundError(`file not found: ${fileId}`);
+    const row = rowFromDb(raw);
+    if (row.deleted_at != null) {
+      throw new ApiError(
+        409,
+        "TOMBSTONED",
+        `cannot stamp extraction on a tombstoned file: ${fileId}`,
+      );
+    }
+
+    const patch =
+      body && typeof body === "object" && !Array.isArray(body)
+        ? (body as Record<string, unknown>)
+        : {};
+
+    // Partial-replacing: a missing key in the body leaves the
+    // corresponding column unchanged (lets future pipelines stamp one
+    // column at a time without re-sending the others).
+    let nextReadAt: number | null = row.alfred_read_at;
+    let nextSummary: string | null = row.summary;
+    let nextError: string | null = row.extraction_error;
+    let touched = false;
+
+    if (Object.prototype.hasOwnProperty.call(patch, "alfred_read_at")) {
+      const v = patch.alfred_read_at;
+      if (v === null || v === undefined || v === "") {
+        nextReadAt = null;
+      } else if (typeof v === "number" && Number.isFinite(v) && v >= 0) {
+        nextReadAt = Math.floor(v);
+      } else {
+        throw new ValidationError("alfred_read_at must be a non-negative number or null");
+      }
+      touched = true;
+    }
+    if (Object.prototype.hasOwnProperty.call(patch, "summary")) {
+      const v = patch.summary;
+      if (v === null || v === undefined) {
+        nextSummary = null;
+      } else if (typeof v === "string") {
+        const trimmed = v.trim();
+        // Hard cap matches the spec §8 "one-paragraph summary"; 4 KiB
+        // is comfortably above a long English paragraph and well below
+        // the SQLite per-cell ceiling.
+        if (trimmed.length > 4096) {
+          throw new ValidationError("summary exceeds 4 KiB cap");
+        }
+        nextSummary = trimmed === "" ? null : trimmed;
+      } else {
+        throw new ValidationError("summary must be a string or null");
+      }
+      touched = true;
+    }
+    if (Object.prototype.hasOwnProperty.call(patch, "extraction_error")) {
+      const v = patch.extraction_error;
+      if (v === null || v === undefined) {
+        nextError = null;
+      } else if (typeof v === "string") {
+        const trimmed = v.trim();
+        if (trimmed.length > 256) {
+          throw new ValidationError("extraction_error exceeds 256-char cap");
+        }
+        nextError = trimmed === "" ? null : trimmed;
+      } else {
+        throw new ValidationError("extraction_error must be a string or null");
+      }
+      touched = true;
+    }
+
+    if (touched) {
+      db.prepare(
+        `UPDATE files
+            SET alfred_read_at = ?, summary = ?, extraction_error = ?
+          WHERE id = ?`,
+      ).run(nextReadAt, nextSummary, nextError, row.id);
+    }
+
+    const after = db
+      .prepare(`SELECT * FROM files WHERE id = ? LIMIT 1`)
+      .get(row.id) as Record<string, unknown>;
+    sendJson(res, 200, rowToJson(rowFromDb(after)));
+  });
+
+  // POST /api/v1/files/:file_id/extract
+  //
+  // #114 Lane B — operator re-fire of the extraction workflow. If a
+  // file has `extraction_error` set, this endpoint lets the operator
+  // (or an MCP-triggered re-try) restart the FileExtractionWorkflow.
+  // The workflow's id is keyed on file_id, so an in-flight run rejects
+  // with ALREADY_EXISTS (the trigger swallows that) — the route still
+  // returns 202.
+  addRoute("POST", "/api/v1/files/:file_id/extract", async ({ res, params }) => {
+    const fileId = params.file_id ?? "";
+    if (!fileId) throw new ValidationError("file_id is required");
+    const db = getStateDb();
+    const raw = db
+      .prepare(`SELECT * FROM files WHERE id = ? LIMIT 1`)
+      .get(fileId) as Record<string, unknown> | undefined;
+    if (!raw) throw new NotFoundError(`file not found: ${fileId}`);
+    const row = rowFromDb(raw);
+    if (row.deleted_at != null) {
+      throw new ApiError(409, "TOMBSTONED", `cannot extract a tombstoned file: ${fileId}`);
+    }
+    // Clear any prior error so the UI's "subtle error state" stops
+    // showing the moment a retry starts.
+    db.prepare(
+      `UPDATE files SET extraction_error = NULL WHERE id = ?`,
+    ).run(row.id);
+    triggerFileExtraction(row.id, row.content_type);
+    sendJson(res, 202, { ok: true, file_id: row.id, eta: "30s" });
   });
 
   // GET /api/v1/files/list?prefix=&q=&limit=&offset=
@@ -1909,6 +2143,7 @@ export function registerFilesRoutes(): void {
       restored_bytes: blob.size_bytes,
     });
   });
+
 }
 
 // ── private: blob stream (split out for the tests + future PR 2 reuse) ─────

--- a/packages/ctrl/src/db/migrate.ts
+++ b/packages/ctrl/src/db/migrate.ts
@@ -29,6 +29,7 @@ import m0012 from "./migrations/0012_ha_integration_ref_removed_at.sql";
 import m0013 from "./migrations/0013_recall_realtime.sql";
 import m0014 from "./migrations/0014_tool_disposition.sql";
 import m0015 from "./migrations/0015_composio_user_defaults.sql";
+import m0016 from "./migrations/0016_files_extraction.sql";
 
 interface Migration {
   version: number;
@@ -53,6 +54,7 @@ const MIGRATIONS: Migration[] = [
   { version: 13, name: "recall_realtime",     sql: m0013 },
   { version: 14, name: "tool_disposition",    sql: m0014 },
   { version: 15, name: "composio_user_defaults", sql: m0015 },
+  { version: 16, name: "files_extraction",    sql: m0016 },
 ];
 
 /**

--- a/packages/ctrl/src/db/migrations/0016_files_extraction.sql
+++ b/packages/ctrl/src/db/migrations/0016_files_extraction.sql
@@ -1,0 +1,44 @@
+-- 0016_files_extraction — issue #114 Lane B (extraction pipeline).
+--
+-- PR 1 (#125) shipped the `files` metadata table. PR 5 (#148) added
+-- dedupe + the cold-archive tier. What is missing for the §14 cold-
+-- start UX is the "Alfred read it" half: after every upload, alfred-
+-- learn extracts the file's text by mime, summarises it with the
+-- workers gateway, and stamps the row so the dashboard's /files page
+-- can render an "Alfred read it" badge.
+--
+-- This migration adds the three columns that the FileExtractionWorkflow
+-- writes back via `PATCH /api/v1/files/:id/extraction`:
+--
+--   * `alfred_read_at`     — unix milliseconds; null until extraction
+--                            finishes. Drives the badge.
+--   * `summary`            — short principal-readable paragraph; what
+--                            Alfred would say when asked "what's in this
+--                            file?". Null on failure or while pending.
+--   * `extraction_error`   — short reason code when extraction failed
+--                            (`unsupported_mime`, `extractor_failed`,
+--                            `summariser_failed`, ...). Null on success.
+--
+-- The three columns are nullable so existing rows (pre-extraction) keep
+-- a stable shape: `alfred_read_at IS NULL` ⇒ "Alfred hasn't read it yet",
+-- `summary IS NOT NULL` ⇒ "show the badge + summary tooltip",
+-- `extraction_error IS NOT NULL` ⇒ "show the subtle error state".
+--
+-- Why on `files`, not `file_blobs`. Extraction is per-row (the principal
+-- uploaded THIS file with THIS original filename; the summary may
+-- reference the title). Two dedupe-shared `files.id` rows pointing at
+-- the same `file_blobs` row can carry distinct summaries if the
+-- principal renamed one. Keeping the columns on `files` matches the
+-- per-upload principal-facing semantics.
+
+ALTER TABLE files ADD COLUMN alfred_read_at    INTEGER;
+ALTER TABLE files ADD COLUMN summary           TEXT;
+ALTER TABLE files ADD COLUMN extraction_error  TEXT;
+
+-- The /files list query filters on `deleted_at IS NULL`; the dashboard
+-- also wants the count of "Alfred read it" rows for the empty-state
+-- copy. A partial index on `alfred_read_at` over live rows keeps that
+-- aggregate cheap without bloating writes against the tombstone path.
+CREATE INDEX IF NOT EXISTS idx_files_alfred_read_at
+  ON files(alfred_read_at)
+  WHERE deleted_at IS NULL;

--- a/packages/ctrl/tests/files-routes.test.ts
+++ b/packages/ctrl/tests/files-routes.test.ts
@@ -46,6 +46,11 @@ process.env.FILES_ROOT = FILES_ROOT;
 // above the 32-byte sample blobs the other tests upload.
 process.env.FILES_QUOTA_HARD_BYTES = String(1024 * 1024);
 process.env.FILES_QUOTA_SOFT_BYTES = String(512 * 1024);
+// #114 Lane B — disable the fire-and-forget FileExtractionWorkflow
+// trigger. The test harness has no temporal CLI to dispatch to; the
+// catch-and-warn would log noisily on every upload assertion. The
+// trigger is unit-tested separately in the extraction.test.ts file.
+process.env.FILES_EXTRACTION_ENABLED = "false";
 
 // ── module imports (after env is set) ──────────────────────────────────────
 
@@ -881,6 +886,172 @@ describe("/api/v1/files/* — PR 1", () => {
         "/api/v1/files/01HFAKEULIDFAKEULIDFAKEUL/purge",
       );
       assert.equal(purge.status, 404);
+    });
+  });
+
+  // ─── #114 Lane B — extraction surface ────────────────────────────────────
+  //
+  // The FileExtractionWorkflow runs out-of-process and PATCHes back
+  // here. These tests cover the route shape: what shapes are accepted
+  // on the wire, how the row reflects after a stamp, the soft-delete
+  // tombstone guard, the cap enforcement, and the operator re-fire
+  // entry point. The fire-and-forget trigger itself is short-circuited
+  // by FILES_EXTRACTION_ENABLED=false at the top of this file.
+
+  describe("PATCH /:file_id/extraction — Lane B", () => {
+    it("stamps alfred_read_at + summary on a fresh row", async () => {
+      const up = await uploadBlob(
+        "contract.txt",
+        Buffer.from("contract body"),
+        "text/plain",
+      );
+      assert.equal(up.status, 201);
+      // Default columns are null at upload time.
+      assert.equal(up.payload.alfred_read_at ?? null, null);
+      assert.equal(up.payload.summary ?? null, null);
+      assert.equal(up.payload.extraction_error ?? null, null);
+
+      const patch = await invokeRoute(
+        "PATCH",
+        `/api/v1/files/${up.payload.id}/extraction`,
+        {
+          body: {
+            alfred_read_at: 1717000000000,
+            summary: "A short contract draft — one paragraph.",
+            extraction_error: null,
+          },
+        },
+      );
+      assert.equal(patch.status, 200);
+      assert.equal(patch.payload.alfred_read_at, 1717000000000);
+      assert.equal(
+        patch.payload.summary,
+        "A short contract draft — one paragraph.",
+      );
+      assert.equal(patch.payload.extraction_error, null);
+      // The list-row carries the same shape.
+      const list = await invokeRoute("GET", "/api/v1/files/list");
+      const listed = list.payload.items.find((r: any) => r.id === up.payload.id);
+      assert.ok(listed, "row should appear in /list");
+      assert.equal(listed.alfred_read_at, 1717000000000);
+      assert.equal(listed.summary, "A short contract draft — one paragraph.");
+    });
+
+    it("stamps extraction_error on a failure path", async () => {
+      const up = await uploadBlob("img.bin", Buffer.from("img"), "image/png");
+      const patch = await invokeRoute(
+        "PATCH",
+        `/api/v1/files/${up.payload.id}/extraction`,
+        {
+          body: {
+            alfred_read_at: null,
+            summary: null,
+            extraction_error: "unsupported_mime",
+          },
+        },
+      );
+      assert.equal(patch.status, 200);
+      assert.equal(patch.payload.alfred_read_at, null);
+      assert.equal(patch.payload.summary, null);
+      assert.equal(patch.payload.extraction_error, "unsupported_mime");
+    });
+
+    it("rejects a tombstoned file with 409", async () => {
+      const up = await uploadBlob("tomb.txt", Buffer.from("t"), "text/plain");
+      // Soft-delete.
+      const del = await invokeRoute(
+        "DELETE",
+        `/api/v1/files/${up.payload.path}`,
+      );
+      assert.equal(del.status, 200);
+      const patch = await invokeRoute(
+        "PATCH",
+        `/api/v1/files/${up.payload.id}/extraction`,
+        { body: { summary: "should not land" } },
+      );
+      assert.equal(patch.status, 409);
+    });
+
+    it("404s on an unknown file_id", async () => {
+      const patch = await invokeRoute(
+        "PATCH",
+        "/api/v1/files/01HNOSUCHFILE000000000000/extraction",
+        { body: { summary: "x" } },
+      );
+      assert.equal(patch.status, 404);
+    });
+
+    it("rejects a summary above the 4 KiB cap with 400", async () => {
+      const up = await uploadBlob("big.txt", Buffer.from("big"), "text/plain");
+      const huge = "x".repeat(4100);
+      const patch = await invokeRoute(
+        "PATCH",
+        `/api/v1/files/${up.payload.id}/extraction`,
+        { body: { summary: huge } },
+      );
+      assert.equal(patch.status, 400);
+    });
+
+    it("partial PATCH leaves untouched columns alone", async () => {
+      const up = await uploadBlob("p.txt", Buffer.from("p"), "text/plain");
+      // First, stamp a success.
+      await invokeRoute(
+        "PATCH",
+        `/api/v1/files/${up.payload.id}/extraction`,
+        {
+          body: {
+            alfred_read_at: 1717111111111,
+            summary: "first summary",
+            extraction_error: null,
+          },
+        },
+      );
+      // Then, send a partial PATCH that only sets extraction_error —
+      // summary should survive.
+      const patch = await invokeRoute(
+        "PATCH",
+        `/api/v1/files/${up.payload.id}/extraction`,
+        { body: { extraction_error: "stamp_failed" } },
+      );
+      assert.equal(patch.status, 200);
+      assert.equal(patch.payload.summary, "first summary");
+      assert.equal(patch.payload.extraction_error, "stamp_failed");
+      assert.equal(patch.payload.alfred_read_at, 1717111111111);
+    });
+  });
+
+  describe("POST /:file_id/extract — Lane B operator re-fire", () => {
+    it("returns 202 and clears any prior extraction_error", async () => {
+      const up = await uploadBlob("r.txt", Buffer.from("r"), "text/plain");
+      // First stamp an error to verify it gets cleared.
+      await invokeRoute(
+        "PATCH",
+        `/api/v1/files/${up.payload.id}/extraction`,
+        { body: { extraction_error: "summariser_failed" } },
+      );
+      const refire = await invokeRoute(
+        "POST",
+        `/api/v1/files/${up.payload.id}/extract`,
+      );
+      assert.equal(refire.status, 202);
+      assert.equal(refire.payload.ok, true);
+      assert.equal(refire.payload.file_id, up.payload.id);
+      // The error column is back to null even though the trigger is
+      // disabled in this test (the route clears it eagerly).
+      const row = getStateDb()
+        .prepare(`SELECT extraction_error FROM files WHERE id = ?`)
+        .get(up.payload.id) as { extraction_error: string | null };
+      assert.equal(row.extraction_error, null);
+    });
+
+    it("rejects a tombstoned file with 409", async () => {
+      const up = await uploadBlob("rt.txt", Buffer.from("rt"), "text/plain");
+      await invokeRoute("DELETE", `/api/v1/files/${up.payload.path}`);
+      const refire = await invokeRoute(
+        "POST",
+        `/api/v1/files/${up.payload.id}/extract`,
+      );
+      assert.equal(refire.status, 409);
     });
   });
 });

--- a/packages/ctrl/tests/migrate.test.ts
+++ b/packages/ctrl/tests/migrate.test.ts
@@ -36,16 +36,16 @@ describe("state.db migration runner", () => {
     const db = new DatabaseSync(":memory:");
     db.exec(schema);
     const v = runMigrations(db);
-    // Latest version moves as new migrations land. Today: 15
+    // Latest version moves as new migrations land. Today: 16
     // (0001_fix_pack + 0002_alfred_journal + 0003_tailscale_connection
     // + 0004_channel_tokens + 0005_ha_channel + 0006_files_table
     // + 0007_recall + 0008_ha_event_subscription
     // + 0009_ha_registry_vanished + 0010_files_cold_archive
     // + 0011_ha_tier4 + 0012_ha_integration_ref_removed_at
     // + 0013_recall_realtime + 0014_tool_disposition
-    // + 0015_composio_user_defaults).
-    assert.equal(v, 15, "migrated to latest version");
-    assert.equal(userVersion(db), 15);
+    // + 0015_composio_user_defaults + 0016_files_extraction).
+    assert.equal(v, 16, "migrated to latest version");
+    assert.equal(userVersion(db), 16);
     assert.ok(cols(db, "observation").includes("processed_at"), "0001: processed_at present after migrate");
     // 0002: alfred_journal + alfred_principal tables present.
     const tables = (
@@ -247,6 +247,21 @@ describe("state.db migration runner", () => {
       );
     }
 
+    // 0016: files.{alfred_read_at, summary, extraction_error} present.
+    // These are the three columns the FileExtractionWorkflow writes
+    // back via PATCH /api/v1/files/:id/extraction (#114 Lane B).
+    const filesColsAfter = cols(db, "files");
+    for (const required of [
+      "alfred_read_at",
+      "summary",
+      "extraction_error",
+    ]) {
+      assert.ok(
+        filesColsAfter.includes(required),
+        `0016: files.${required} present`,
+      );
+    }
+
     db.close();
   });
 
@@ -255,7 +270,7 @@ describe("state.db migration runner", () => {
     db.exec(schema);
     runMigrations(db);
     const v2 = runMigrations(db);
-    assert.equal(v2, 15);
+    assert.equal(v2, 16);
     assert.equal(
       cols(db, "observation").filter((c) => c === "processed_at").length,
       1,

--- a/packages/learn/requirements.txt
+++ b/packages/learn/requirements.txt
@@ -18,3 +18,16 @@ tsfresh==0.21.1
 hdbscan==0.8.40
 pyod==2.0.2
 lifetimes==0.11.3
+
+# File-extraction pipeline (#114 Lane B). Pure-Python extractors keep
+# the image small + portable:
+#   * pypdf       — PDF text extraction (no native deps).
+#   * python-docx — DOCX paragraph/table extraction.
+#   * openpyxl    — XLSX sheet/cell extraction (read_only mode keeps RAM
+#                   bounded on multi-MB spreadsheets).
+# Images / audio / video are intentionally unsupported in Lane B —
+# the workflow marks them `extraction_error="unsupported_mime"`. OCR
+# (tesseract) + Groq Whisper land in a follow-up.
+pypdf==5.0.1
+python-docx==1.1.2
+openpyxl==3.1.5

--- a/packages/learn/src/activities/file_extraction.py
+++ b/packages/learn/src/activities/file_extraction.py
@@ -1,0 +1,532 @@
+"""file_extraction — activities for the FileExtractionWorkflow.
+
+Background
+----------
+
+Issue #114 Lane B closes the load-bearing UX promise of §14 step 3:
+after a principal drops a file on /files, Alfred has 30 seconds to
+read it and surface a one-paragraph summary + an "Alfred read it"
+badge. The audit at /tmp/orchestrator-114-coverage.md flagged this as
+the only blocker for steps #3–#5 of the cold-start test.
+
+This module is the alfred-learn glue. ctrl-api owns the blob volume
+and the SQL writes; we read the bytes back over HTTP, run the
+per-mime extractor, ask the workers gateway for a one-paragraph
+summary, and PATCH the result back via
+``/api/v1/files/:id/extraction``. Same discipline ``files_cold_archive``
+already follows.
+
+Three activities
+----------------
+
+* ``read_file_metadata(file_id)`` — pulls the canonical row from
+  ctrl-api so the workflow knows the mime + path. Cheap GET.
+* ``fetch_and_extract_text(file_id, content_type, path)`` — fetches
+  the blob bytes and dispatches to the right extractor by mime.
+  Returns ``{text, char_count, extractor, truncated_for_summary}``
+  on success or raises a classified ``ExtractionError`` with a short
+  reason code on failure.
+* ``summarise_extracted_text(...)`` — workers gateway one-shot summary.
+* ``stamp_extraction_result(file_id, alfred_read_at, summary,
+  extraction_error)`` — write-back PATCH.
+
+Per-mime extractor matrix (Lane B scope)
+----------------------------------------
+
+| Mime                                                                              | Extractor    |
+|-----------------------------------------------------------------------------------|--------------|
+| ``text/*``, ``application/json``, ``application/xml``, ``application/x-yaml``     | direct utf-8 |
+| ``application/pdf``                                                                | pypdf        |
+| ``application/vnd.openxmlformats-officedocument.wordprocessingml.document``        | python-docx  |
+| ``application/vnd.openxmlformats-officedocument.spreadsheetml.sheet``              | openpyxl     |
+| everything else                                                                    | unsupported  |
+
+OCR (tesseract) + audio (Groq Whisper) are intentionally outside Lane
+B's scope — the spec calls for them but they each merit their own PR
+(image OCR is a separate apt package; Whisper is a Groq quota line
+item). The workflow marks them ``extraction_error="unsupported_mime"``
+so the dashboard's subtle-error state can render a "Alfred can't read
+this yet" affordance.
+
+Environment
+-----------
+
+* ``ALFRED_CTRL_URL`` — the tenant ctrl-api base URL. Defaults to
+  ``http://alfred-ctrl:3100``. Same knob ``StateClient`` /
+  ``VaultClient`` honour.
+* ``AAS_API_KEY`` — the operator bearer token. Required.
+* ``FILES_EXTRACTION_MAX_CHARS`` — soft cap on extractor output handed
+  to the summariser (default 60_000, ~15 K tokens of input). Bigger
+  files are truncated; the summariser is told.
+"""
+from __future__ import annotations
+
+import io
+import logging
+import os
+from typing import Any
+
+import httpx
+from temporalio import activity
+
+logger = logging.getLogger("alfred-learn")
+
+
+# Same env knob StateClient / VaultClient honour.
+_DEFAULT_CTRL_URL = "http://alfred-ctrl:3100"
+
+# Soft cap on extracted-text length handed to the summariser. The
+# workers gateway is generous (clerk.py allows 31 K output tokens) but
+# the INPUT side competes with every other autonomous job for the same
+# gateway; cap at ~60 KB (~15 K tokens) so a 100-page PDF doesn't
+# starve the rest of the queue. A truncation notice is appended so the
+# summariser doesn't hallucinate completeness.
+_MAX_CHARS_FOR_SUMMARY = int(os.environ.get("FILES_EXTRACTION_MAX_CHARS", "60000"))
+
+# Tightish blob fetch — a multi-MB PDF on a fresh tenant downloads in
+# <1s over localhost loopback. 30s is the same envelope ctrl-api gives
+# itself for the cold-promote sweep.
+_BLOB_FETCH_TIMEOUT_S = 30.0
+
+# Mime classes the extractor can handle directly. The workflow uses
+# these constants to short-circuit "unsupported" before paying for a
+# blob fetch.
+_TEXT_MIMES = (
+    "text/",
+    "application/json",
+    "application/xml",
+    "application/x-yaml",
+    "application/yaml",
+)
+_PDF_MIME = "application/pdf"
+_DOCX_MIME = (
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+)
+_XLSX_MIME = (
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+)
+
+
+# ── error taxonomy ─────────────────────────────────────────────────────
+
+
+class ExtractionError(Exception):
+    """An expected, recoverable extraction failure.
+
+    The ``code`` attribute is the short reason that lands in
+    ``files.extraction_error``; it's what the dashboard's tooltip
+    will read. ``str(exc)`` always starts with ``code + ": "`` so a
+    Temporal-wrapped error envelope can recover the code via a simple
+    head-split even when the original ``code`` attribute didn't
+    survive serialisation.
+    """
+
+    def __init__(self, code: str, message: str = "") -> None:
+        # Always emit ``"<code>: <message>"`` (or just ``"<code>"`` if no
+        # message) so the workflow's ``_extraction_error_code`` recovery
+        # path can split on the first colon. This is the contract the
+        # workflow's wrap-handling relies on — keep it stable.
+        wire = f"{code}: {message}" if message else code
+        super().__init__(wire)
+        self.code = code
+
+
+# ── helpers ────────────────────────────────────────────────────────────
+
+
+def _ctrl_base_url() -> str:
+    return os.environ.get("ALFRED_CTRL_URL", _DEFAULT_CTRL_URL)
+
+
+def _auth_headers() -> dict[str, str]:
+    key = os.environ.get("AAS_API_KEY", "")
+    return {"Authorization": f"Bearer {key}"} if key else {}
+
+
+def classify_mime(content_type: str | None) -> str:
+    """Return a short token describing how the workflow should handle
+    this mime. One of ``"text"``, ``"pdf"``, ``"docx"``, ``"xlsx"``,
+    ``"unsupported"``.
+
+    Pure: no httpx, no filesystem. Tested directly.
+    """
+    ct = (content_type or "").strip().lower()
+    if not ct:
+        return "unsupported"
+    # Strip any "; charset=…" tail.
+    head = ct.split(";", 1)[0].strip()
+    if head == _PDF_MIME:
+        return "pdf"
+    if head == _DOCX_MIME:
+        return "docx"
+    if head == _XLSX_MIME:
+        return "xlsx"
+    for prefix in _TEXT_MIMES:
+        if head.startswith(prefix):
+            return "text"
+    return "unsupported"
+
+
+def _truncate_for_summary(text: str) -> tuple[str, bool]:
+    """Truncate ``text`` to the summariser cap, returning the trimmed
+    string + a flag indicating whether truncation happened."""
+    if len(text) <= _MAX_CHARS_FOR_SUMMARY:
+        return text, False
+    head = text[:_MAX_CHARS_FOR_SUMMARY]
+    return head, True
+
+
+# ── extractors ─────────────────────────────────────────────────────────
+
+
+def extract_text_blob(content_type: str | None, blob: bytes) -> str:
+    """Pure extractor dispatch.
+
+    ``blob`` is the file bytes; the function returns the extracted
+    plain text or raises ``ExtractionError`` with a short reason code.
+
+    Tested directly against fixture bytes — no httpx, no Temporal.
+    """
+    kind = classify_mime(content_type)
+    if kind == "unsupported":
+        raise ExtractionError(
+            "unsupported_mime",
+            f"no Lane-B extractor for content_type={content_type!r}",
+        )
+    try:
+        if kind == "text":
+            return _extract_text(blob, content_type)
+        if kind == "pdf":
+            return _extract_pdf(blob)
+        if kind == "docx":
+            return _extract_docx(blob)
+        if kind == "xlsx":
+            return _extract_xlsx(blob)
+    except ExtractionError:
+        raise
+    except Exception as exc:  # noqa: BLE001 — extractor wrappers are noisy
+        raise ExtractionError(
+            "extractor_failed",
+            f"{kind} extractor raised: {exc}",
+        ) from exc
+    # Defensive — classify_mime guarantees one of the above.
+    raise ExtractionError("extractor_failed", f"unknown extractor kind={kind!r}")
+
+
+def _extract_text(blob: bytes, content_type: str | None) -> str:
+    """UTF-8 decode with a small fallback chain. Stops short of full
+    chardet — text/* files in the wild are overwhelmingly UTF-8 today,
+    and the cost of guessing wrong on a binary blob is much worse than
+    a one-off 'extractor_failed' on a Latin-1 file.
+    """
+    # Cheap fast path.
+    try:
+        return blob.decode("utf-8")
+    except UnicodeDecodeError:
+        pass
+    # Tolerate Latin-1 / Windows-1252 by replacing unmappable bytes.
+    try:
+        return blob.decode("utf-8", errors="replace")
+    except Exception as exc:  # noqa: BLE001
+        raise ExtractionError(
+            "extractor_failed",
+            f"text decode failed (ct={content_type!r}): {exc}",
+        ) from exc
+
+
+def _extract_pdf(blob: bytes) -> str:
+    """pypdf page-by-page text extraction.
+
+    pypdf is pure Python (no native poppler dep) and handles the
+    common-case PDF in a few hundred ms per page. Scanned PDFs (no
+    embedded text layer) return empty strings per page — we surface
+    that as a distinct ``empty_pdf`` error code so the dashboard can
+    say "no text layer; OCR needed" rather than "extraction failed".
+    """
+    try:
+        from pypdf import PdfReader  # local import — keeps cold start fast
+    except ImportError as exc:  # pragma: no cover — defensive
+        raise ExtractionError(
+            "extractor_failed",
+            f"pypdf import failed: {exc}",
+        ) from exc
+
+    try:
+        reader = PdfReader(io.BytesIO(blob))
+    except Exception as exc:  # noqa: BLE001
+        raise ExtractionError(
+            "extractor_failed", f"pypdf could not parse PDF: {exc}",
+        ) from exc
+
+    pieces: list[str] = []
+    for i, page in enumerate(reader.pages):
+        try:
+            chunk = page.extract_text() or ""
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "file_extraction: pdf page %d extract_text raised: %s", i, exc
+            )
+            chunk = ""
+        if chunk:
+            pieces.append(chunk.strip())
+    out = "\n\n".join(p for p in pieces if p)
+    if not out.strip():
+        raise ExtractionError(
+            "empty_pdf",
+            "PDF has no embedded text layer (scanned image — OCR needed)",
+        )
+    return out
+
+
+def _extract_docx(blob: bytes) -> str:
+    """python-docx paragraph + table text. Drops images / shapes — the
+    summariser cares about prose, not formatting."""
+    try:
+        from docx import Document  # local import
+    except ImportError as exc:  # pragma: no cover — defensive
+        raise ExtractionError(
+            "extractor_failed",
+            f"python-docx import failed: {exc}",
+        ) from exc
+    try:
+        doc = Document(io.BytesIO(blob))
+    except Exception as exc:  # noqa: BLE001
+        raise ExtractionError(
+            "extractor_failed", f"python-docx could not parse: {exc}",
+        ) from exc
+    pieces: list[str] = []
+    for para in doc.paragraphs:
+        if para.text and para.text.strip():
+            pieces.append(para.text.strip())
+    for table in doc.tables:
+        for row in table.rows:
+            cells = [c.text.strip() for c in row.cells if c.text.strip()]
+            if cells:
+                pieces.append(" | ".join(cells))
+    out = "\n".join(pieces)
+    if not out.strip():
+        raise ExtractionError(
+            "empty_docx", "DOCX has no extractable paragraph or table text",
+        )
+    return out
+
+
+def _extract_xlsx(blob: bytes) -> str:
+    """openpyxl read_only sheet scan. Each sheet contributes a banner
+    line + one CSV-ish row per non-empty row. read_only mode keeps RAM
+    bounded on multi-MB spreadsheets."""
+    try:
+        from openpyxl import load_workbook  # local import
+    except ImportError as exc:  # pragma: no cover — defensive
+        raise ExtractionError(
+            "extractor_failed",
+            f"openpyxl import failed: {exc}",
+        ) from exc
+    try:
+        wb = load_workbook(io.BytesIO(blob), read_only=True, data_only=True)
+    except Exception as exc:  # noqa: BLE001
+        raise ExtractionError(
+            "extractor_failed", f"openpyxl could not parse: {exc}",
+        ) from exc
+    pieces: list[str] = []
+    for sheet_name in wb.sheetnames:
+        ws = wb[sheet_name]
+        pieces.append(f"## Sheet: {sheet_name}")
+        for row in ws.iter_rows(values_only=True):
+            non_empty = [str(v) for v in row if v not in (None, "")]
+            if non_empty:
+                pieces.append(",".join(non_empty))
+    try:
+        wb.close()
+    except Exception:  # noqa: BLE001
+        pass
+    # An XLSX with zero non-empty cells is still a degenerate-but-valid
+    # input — fail it the same way pdf/docx do.
+    body = "\n".join(p for p in pieces if not p.startswith("## Sheet"))
+    if not body.strip():
+        raise ExtractionError(
+            "empty_xlsx", "XLSX has no non-empty cells",
+        )
+    return "\n".join(pieces)
+
+
+# ── activity wrappers ──────────────────────────────────────────────────
+
+
+@activity.defn
+async def read_file_metadata(file_id: str) -> dict[str, Any]:
+    """Pull one row's metadata from ctrl-api by file id.
+
+    Used by the workflow to learn the mime + path before deciding
+    whether to even fetch the blob (unsupported mimes short-circuit).
+    """
+    # ctrl-api has no GET-by-id surface today — the existing list
+    # endpoint already supports pagination but no id filter, so we
+    # fetch a tight slice and filter client-side. This keeps Lane B
+    # from coupling to a not-yet-shipped /by-id route.
+    url = f"{_ctrl_base_url()}/api/v1/files/list"
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.get(
+            url,
+            params={"limit": "500"},
+            headers=_auth_headers(),
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+    items = payload.get("items") or []
+    for item in items:
+        if str(item.get("id") or "") == file_id:
+            return item
+    raise ExtractionError("not_found", f"file_id={file_id} not in /list")
+
+
+@activity.defn
+async def fetch_and_extract_text(
+    file_id: str, content_type: str | None, path: str,
+) -> dict[str, Any]:
+    """Fetch the blob + extract text. Returns
+    ``{text, char_count, extractor, truncated_for_summary}``.
+
+    ``ExtractionError`` raises propagate to the workflow's stamp step
+    — they're classified failures, not Temporal retryable errors.
+    """
+    kind = classify_mime(content_type)
+    if kind == "unsupported":
+        raise ExtractionError(
+            "unsupported_mime",
+            f"Lane-B does not handle content_type={content_type!r}",
+        )
+    # URL-encode each path segment defensively (the blob route
+    # registered as `/blob/*` takes the literal tail). urllib's
+    # quote(safe="") gives us per-segment control without rebuilding
+    # the absolute URL.
+    from urllib.parse import quote
+
+    encoded_path = "/".join(
+        quote(seg, safe="") for seg in path.split("/") if seg
+    )
+    blob_url = f"{_ctrl_base_url()}/api/v1/files/blob/{encoded_path}"
+    async with httpx.AsyncClient(timeout=_BLOB_FETCH_TIMEOUT_S) as client:
+        resp = await client.get(blob_url, headers=_auth_headers())
+        resp.raise_for_status()
+        blob = resp.content
+    text = extract_text_blob(content_type, blob)
+    truncated_text, truncated = _truncate_for_summary(text)
+    return {
+        "text": truncated_text,
+        "char_count": len(text),
+        "extractor": kind,
+        "truncated_for_summary": truncated,
+    }
+
+
+def _build_summary_prompt(
+    *,
+    text: str,
+    original_filename: str | None,
+    content_type: str | None,
+    truncated: bool,
+) -> str:
+    """Render the one-paragraph summary prompt for the workers gateway.
+
+    Kept as a module-level helper so it's unit-testable + so the
+    activity body stays linear.
+    """
+    name_line = (
+        f"FILENAME: {original_filename}\n" if original_filename else ""
+    )
+    truncate_line = (
+        "\nNote: the file was truncated to fit the summariser's input "
+        "budget; the body below is the first portion of the document.\n"
+        if truncated
+        else ""
+    )
+    return f"""You are summarising a file the principal just dropped into their personal file store. Write ONE short paragraph (3-5 sentences, <=600 chars) describing what this file is and what's in it — the kind of thing a butler would whisper while handing over the document.
+
+Rules:
+- Plain prose, no markdown, no bullet lists.
+- Lead with what the document IS (invoice, contract, screenshot, code listing, ...).
+- Then the one or two facts a reader would want next (parties, dates, amounts, totals).
+- No filler ("This document contains ..."). No hedging.
+- If the body is empty or gibberish, say so plainly.
+
+Return JSON only:
+{{"summary": "<the paragraph>"}}
+
+{name_line}CONTENT_TYPE: {content_type or "unknown"}
+{truncate_line}
+BODY:
+{text}
+"""
+
+
+@activity.defn
+async def summarise_extracted_text(
+    file_id: str,
+    extracted_text: str,
+    original_filename: str | None,
+    content_type: str | None,
+    truncated: bool,
+) -> str:
+    """Ask the workers gateway for the one-paragraph summary.
+
+    Routes through ``clerk._call_clerk`` so the Temporal activity gets
+    the heartbeat + per-call billing classification the rest of the
+    learn pipeline already enjoys.
+    """
+    # Lazy import — avoids the clerk module being loaded by tests that
+    # exercise the pure extractor only.
+    from src.activities.clerk import _call_clerk
+
+    prompt = _build_summary_prompt(
+        text=extracted_text,
+        original_filename=original_filename,
+        content_type=content_type,
+        truncated=truncated,
+    )
+    try:
+        result = await _call_clerk(prompt, agent_id=f"file-extract-{file_id}")
+    except Exception as exc:  # noqa: BLE001
+        raise ExtractionError(
+            "summariser_failed", f"workers gateway raised: {exc}",
+        ) from exc
+    summary: Any = None
+    if isinstance(result, dict):
+        summary = result.get("summary")
+    elif isinstance(result, str):
+        summary = result
+    if not isinstance(summary, str) or not summary.strip():
+        raise ExtractionError(
+            "summariser_failed", "workers gateway returned no summary text",
+        )
+    # Hard cap (the ctrl-api PATCH route caps at 4 KiB; we trim earlier
+    # so a chatty model never breaches it).
+    summary = summary.strip()
+    if len(summary) > 4096:
+        summary = summary[:4093] + "..."
+    return summary
+
+
+@activity.defn
+async def stamp_extraction_result(
+    file_id: str,
+    alfred_read_at: int | None,
+    summary: str | None,
+    extraction_error: str | None,
+) -> dict[str, Any]:
+    """PATCH the result back to ctrl-api.
+
+    Always emits all three columns — the route accepts partial
+    patches but a fresh extraction always wants to clear any prior
+    error and stamp the new state in one shot.
+    """
+    url = f"{_ctrl_base_url()}/api/v1/files/{file_id}/extraction"
+    body = {
+        "alfred_read_at": alfred_read_at,
+        "summary": summary,
+        "extraction_error": extraction_error,
+    }
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        resp = await client.patch(url, json=body, headers=_auth_headers())
+        resp.raise_for_status()
+        return resp.json()

--- a/packages/learn/src/worker.py
+++ b/packages/learn/src/worker.py
@@ -31,6 +31,7 @@ from src.workflows.fleet_audit import FleetAuditWorkflow
 from src.workflows.files_cold_archive import (
     FilesColdArchiveWorkflow,
 )
+from src.workflows.file_extraction import FileExtractionWorkflow
 from src.workflows.composio_reconnect_cleanup import (
     ComposioReconnectCleanupWorkflow,
 )
@@ -413,6 +414,17 @@ from src.activities.files_cold_archive import (
     promote_to_cold,
 )
 
+# File content extraction (#114 Lane B) — one-shot per-upload pipeline.
+# Triggered fire-and-forget by ctrl-api's POST /api/v1/files/upload
+# route; runs the per-mime extractor + workers-gateway summary + stamps
+# the row so the /files page can render the "Alfred read it" badge.
+from src.activities.file_extraction import (
+    fetch_and_extract_text,
+    read_file_metadata,
+    stamp_extraction_result,
+    summarise_extracted_text,
+)
+
 # Phase 2 #23: the openclaw .bak-* session reaper activity
 # (sweep_openclaw_bak_sessions) was DELETED — Hermes' SQLite
 # SessionStore removes the O(N) readdir leak it existed to mop up.
@@ -734,6 +746,7 @@ _STATIC_WORKFLOWS = [
     FleetAuditWorkflow,
     ComposioReconnectCleanupWorkflow,
     FilesColdArchiveWorkflow,
+    FileExtractionWorkflow,
     # OpenclawSessionSweepWorkflow removed — Phase 2 #23.
     # StewardWorkflow kept registered as a tombstone (#52): no longer
     # scheduled per-matter, but callable ad-hoc and harmless to register.
@@ -1011,6 +1024,12 @@ ALL_ACTIVITIES = [
     # Files cold-archive sweep (#114 PR 5)
     find_cold_candidates,
     promote_to_cold,
+    # File extraction pipeline (#114 Lane B) — one-shot per-upload
+    # FileExtractionWorkflow chains these four activities.
+    read_file_metadata,
+    fetch_and_extract_text,
+    summarise_extracted_text,
+    stamp_extraction_result,
     # sweep_openclaw_bak_sessions removed — Phase 2 #23.
     # Plane reverse sync (#536 B7)
     plane_reverse_sync_is_enabled,

--- a/packages/learn/src/workflows/file_extraction.py
+++ b/packages/learn/src/workflows/file_extraction.py
@@ -1,0 +1,359 @@
+"""FileExtractionWorkflow — one-shot per-upload extraction pipeline.
+
+Background
+----------
+
+Issue #114 Lane B closes the principal-visible UX promise of §14
+step 3: a file dropped on /files gets read by Alfred within 30 seconds,
+a one-paragraph summary appears, and the "Alfred read it" badge lights
+up on the row.
+
+This workflow is a **one-shot, fire-and-forget** chain triggered by
+ctrl-api's upload route (``triggerFileExtraction`` in
+``packages/ctrl/src/api/routes/files.ts``). It is not on a Temporal
+Schedule — there is one workflow execution per file. The workflow id is
+``file-extract-<file_id>``, so a duplicate trigger on the same upload
+is a no-op (Temporal rejects with ALREADY_EXISTS, which the trigger
+swallows).
+
+Flow
+----
+
+1. ``read_file_metadata(file_id)`` — fetch the row's mime + path. If
+   the file is gone (404) or the mime is unsupported, jump to step 3
+   with ``extraction_error="unsupported_mime"``.
+2. ``fetch_and_extract_text(file_id, content_type, path)`` — fetch the
+   blob bytes, run the per-mime extractor, return the trimmed text.
+3. ``summarise_extracted_text(...)`` — workers gateway one-shot
+   summary. Returns a single short paragraph.
+4. ``stamp_extraction_result(file_id, alfred_read_at, summary,
+   extraction_error)`` — PATCH the row.
+
+Any step that raises ``ExtractionError`` (the classified taxonomy from
+``src.activities.file_extraction``) routes straight to step 4 with the
+corresponding error code. Genuine Temporal-retryable failures
+(network, 5xx) leverage the activity's default RetryPolicy until the
+envelope expires.
+
+Design notes
+------------
+
+* Pure orchestration — all blob / clerk / state.db interaction lives
+  in the activity layer, exactly as ``FilesColdArchiveWorkflow``
+  follows.
+* Idempotent — workflow id keyed on ``file_id``. A duplicate trigger
+  is silently rejected by Temporal. A re-fire via
+  ``POST /api/v1/files/:file_id/extract`` uses a fresh start (ctrl-api
+  side clears the prior error first; the workflow id collides only
+  while the previous run is still in flight, which is the desired
+  semantics — one extraction at a time per file).
+* Bounded — the whole run has to land inside 30s of wall-clock for
+  the §14 promise. The summary call dominates; we give it the same
+  900s clerk budget as every other workers-gateway shot, but the
+  typical case is single-digit seconds for a small PDF.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+with workflow.unsafe.imports_passed_through():
+    from src.activities.clerk import (
+        CLERK_ACTIVITY_HEARTBEAT_SECONDS,
+        CLERK_ACTIVITY_TIMEOUT_SECONDS,
+    )
+    from src.activities.file_extraction import (
+        fetch_and_extract_text,
+        read_file_metadata,
+        stamp_extraction_result,
+        summarise_extracted_text,
+    )
+
+
+@dataclass
+class FileExtractionInput:
+    """Workflow argument shape.
+
+    ctrl-api's trigger sends ``{file_id: "<ULID>"}``; the dataclass
+    keeps the schema explicit + future-proofs for adding a forced
+    re-extract flag later.
+    """
+
+    file_id: str
+
+
+@dataclass
+class FileExtractionResult:
+    file_id: str
+    alfred_read_at: int | None = None
+    summary: str | None = None
+    extraction_error: str | None = None
+    extractor: str | None = None
+    char_count: int = 0
+
+
+# Light retry policy for the meta + stamp activities — both are quick
+# ctrl-api HTTP calls. The extraction + summariser activities each
+# manage their own retry envelope (extraction is mostly pure; summariser
+# uses the clerk timeout).
+_QUICK_RETRY = RetryPolicy(
+    maximum_attempts=3,
+    initial_interval=timedelta(seconds=1),
+    backoff_coefficient=2.0,
+    maximum_interval=timedelta(seconds=5),
+)
+
+
+def _is_extraction_error(exc: BaseException) -> bool:
+    """Match the activity's ``ExtractionError`` even after Temporal
+    rewraps it as an ApplicationError. The error's ``type`` survives
+    the wrap, and the message carries the code at the head."""
+    cls = type(exc).__name__
+    if cls == "ExtractionError":
+        return True
+    # Temporal wraps activity failures in ActivityError; the cause
+    # exposes the original ApplicationError whose `type` attribute equals
+    # the original class name.
+    cause = getattr(exc, "cause", None)
+    if cause is not None:
+        cause_type = getattr(cause, "type", None) or type(cause).__name__
+        if cause_type == "ExtractionError":
+            return True
+    return False
+
+
+def _extraction_error_code(exc: BaseException) -> str:
+    """Extract the short `code` from an ExtractionError or its
+    Temporal-wrapped envelope. Falls back to ``extractor_failed``.
+
+    ``ExtractionError.__str__`` is contracted to emit ``"<code>: <msg>"``
+    (or just ``"<code>"`` if no message), so a head-split before the
+    first colon always recovers the original code. We walk a chain of
+    candidate sources in order: the direct ``.code`` attr, the
+    ``.cause.code`` attr (Temporal's ActivityError wraps an
+    ApplicationError), then the head-split fallbacks on each str.
+    """
+    code = getattr(exc, "code", None)
+    if isinstance(code, str) and code:
+        return code
+    cause = getattr(exc, "cause", None)
+    if cause is not None:
+        c2 = getattr(cause, "code", None)
+        if isinstance(c2, str) and c2:
+            return c2
+        # The wrapped message tends to look like "unsupported_mime: ...".
+        msg = str(cause).strip()
+        head = _split_code_head(msg)
+        if head:
+            return head
+    head = _split_code_head(str(exc).strip())
+    if head:
+        return head
+    return "extractor_failed"
+
+
+_VALID_CODE_HEADS = (
+    "unsupported_mime",
+    "extractor_failed",
+    "empty_pdf",
+    "empty_docx",
+    "empty_xlsx",
+    "empty_extraction",
+    "summariser_failed",
+    "stamp_failed",
+    "metadata_fetch_failed",
+    "missing_path",
+    "missing_file_id",
+    "not_found",
+)
+
+
+def _split_code_head(s: str) -> str | None:
+    """Take the head of ``s`` before the first colon and return it
+    if it looks like one of our known reason codes.
+
+    The Temporal-wrapped str typically looks like::
+
+        "ExtractionError: unsupported_mime: test mime"
+
+    So we walk colon-splits and return the first head that matches
+    the known set."""
+    if not s:
+        return None
+    parts = [p.strip() for p in s.split(":")]
+    for p in parts:
+        if p in _VALID_CODE_HEADS:
+            return p
+    return None
+
+
+@workflow.defn(name="FileExtractionWorkflow")
+class FileExtractionWorkflow:
+    """Single-pass extract → summarise → stamp chain."""
+
+    @workflow.run
+    async def run(self, arg: FileExtractionInput | dict) -> FileExtractionResult:
+        # ctrl-api sends a plain dict over the wire (temporal CLI
+        # serialises the --input JSON verbatim); the test harness uses
+        # the dataclass. Accept both.
+        if isinstance(arg, dict):
+            file_id = str(arg.get("file_id") or "")
+        else:
+            file_id = arg.file_id
+        if not file_id:
+            return FileExtractionResult(
+                file_id="",
+                extraction_error="missing_file_id",
+            )
+
+        workflow.logger.info("file_extraction.start file_id=%s", file_id)
+        result = FileExtractionResult(file_id=file_id)
+
+        # ── step 1: read metadata ────────────────────────────────────
+        try:
+            row = await workflow.execute_activity(
+                read_file_metadata,
+                args=[file_id],
+                start_to_close_timeout=timedelta(seconds=15),
+                retry_policy=_QUICK_RETRY,
+            )
+        except Exception as exc:  # noqa: BLE001
+            workflow.logger.warning(
+                "file_extraction: metadata fetch failed for %s: %s",
+                file_id, exc,
+            )
+            code = (
+                _extraction_error_code(exc)
+                if _is_extraction_error(exc)
+                else "metadata_fetch_failed"
+            )
+            return await self._stamp_error(file_id, code, result)
+
+        content_type = row.get("content_type") if isinstance(row, dict) else None
+        path = row.get("path") if isinstance(row, dict) else None
+        original_filename = (
+            row.get("original_filename") if isinstance(row, dict) else None
+        )
+        if not isinstance(path, str) or not path:
+            return await self._stamp_error(file_id, "missing_path", result)
+
+        # ── step 2: fetch + extract ─────────────────────────────────
+        try:
+            extracted = await workflow.execute_activity(
+                fetch_and_extract_text,
+                args=[file_id, content_type, path],
+                # Extraction is mostly pure Python over a bounded blob;
+                # 90s envelope covers a multi-page PDF on a small VM.
+                start_to_close_timeout=timedelta(seconds=90),
+                retry_policy=RetryPolicy(maximum_attempts=2),
+            )
+        except Exception as exc:  # noqa: BLE001
+            code = (
+                _extraction_error_code(exc)
+                if _is_extraction_error(exc)
+                else "extractor_failed"
+            )
+            workflow.logger.info(
+                "file_extraction: extract failed for %s (code=%s): %s",
+                file_id, code, exc,
+            )
+            return await self._stamp_error(file_id, code, result)
+
+        text = str(extracted.get("text") or "")
+        char_count = int(extracted.get("char_count") or 0)
+        truncated = bool(extracted.get("truncated_for_summary"))
+        extractor = str(extracted.get("extractor") or "")
+        result.char_count = char_count
+        result.extractor = extractor
+        if not text.strip():
+            return await self._stamp_error(file_id, "empty_extraction", result)
+
+        # ── step 3: summarise via workers gateway ───────────────────
+        try:
+            summary = await workflow.execute_activity(
+                summarise_extracted_text,
+                args=[file_id, text, original_filename, content_type, truncated],
+                start_to_close_timeout=timedelta(
+                    seconds=int(CLERK_ACTIVITY_TIMEOUT_SECONDS),
+                ),
+                heartbeat_timeout=timedelta(
+                    seconds=int(CLERK_ACTIVITY_HEARTBEAT_SECONDS),
+                ),
+                retry_policy=RetryPolicy(
+                    # The clerk classifies 401/402/403/billing as
+                    # non-retryable already; one extra attempt covers
+                    # transient gateway 5xx.
+                    maximum_attempts=2,
+                    initial_interval=timedelta(seconds=2),
+                    backoff_coefficient=2.0,
+                ),
+            )
+        except Exception as exc:  # noqa: BLE001
+            code = (
+                _extraction_error_code(exc)
+                if _is_extraction_error(exc)
+                else "summariser_failed"
+            )
+            workflow.logger.info(
+                "file_extraction: summarise failed for %s (code=%s): %s",
+                file_id, code, exc,
+            )
+            return await self._stamp_error(file_id, code, result)
+
+        # ── step 4: stamp success ───────────────────────────────────
+        # workflow.now() is the deterministic clock; convert to unix
+        # milliseconds for ctrl-api parity.
+        now_ms = int(workflow.now().timestamp() * 1000)
+        try:
+            await workflow.execute_activity(
+                stamp_extraction_result,
+                args=[file_id, now_ms, summary, None],
+                start_to_close_timeout=timedelta(seconds=15),
+                retry_policy=_QUICK_RETRY,
+            )
+        except Exception as exc:  # noqa: BLE001
+            # Stamp failure is the WORST — we did the work but couldn't
+            # write the result. Log loudly; the row will retry on the
+            # operator's next manual extract.
+            workflow.logger.error(
+                "file_extraction: stamp failed for %s: %s", file_id, exc,
+            )
+            result.extraction_error = "stamp_failed"
+            return result
+
+        result.alfred_read_at = now_ms
+        result.summary = summary
+        workflow.logger.info(
+            "file_extraction.done file_id=%s extractor=%s chars=%d summary_chars=%d",
+            file_id, extractor, char_count, len(summary),
+        )
+        return result
+
+    async def _stamp_error(
+        self,
+        file_id: str,
+        code: str,
+        result: FileExtractionResult,
+    ) -> FileExtractionResult:
+        """Record a classified failure on the row.
+
+        The stamp itself is best-effort; if even THAT fails we just
+        return the in-memory result so Temporal records the run.
+        """
+        result.extraction_error = code
+        try:
+            await workflow.execute_activity(
+                stamp_extraction_result,
+                args=[file_id, None, None, code],
+                start_to_close_timeout=timedelta(seconds=15),
+                retry_policy=_QUICK_RETRY,
+            )
+        except Exception as exc:  # noqa: BLE001
+            workflow.logger.warning(
+                "file_extraction: error-stamp failed for %s (code=%s): %s",
+                file_id, code, exc,
+            )
+        return result

--- a/packages/learn/tests/test_file_extraction.py
+++ b/packages/learn/tests/test_file_extraction.py
@@ -1,0 +1,584 @@
+"""Tests for FileExtractionWorkflow + file_extraction activities.
+
+Covered surfaces
+----------------
+
+* Pure extractor dispatch (classify_mime + extract_text_blob):
+  - utf-8 text round-trips identically.
+  - PDF fixture is parsed (single-page, embedded text) by pypdf.
+  - DOCX fixture is parsed by python-docx.
+  - XLSX fixture is parsed by openpyxl.
+  - Unsupported mime raises ExtractionError("unsupported_mime").
+  - PDF with no text layer raises ExtractionError("empty_pdf").
+  - Binary garbage on a text/* mime is decoded with replacement (no
+    crash); on a pdf mime it raises extractor_failed.
+
+* Activity wrappers via ``ActivityEnvironment`` with httpx stubbed:
+  - read_file_metadata locates the row in the /list response.
+  - stamp_extraction_result PATCHes the right body shape.
+
+* Workflow via WorkflowEnvironment.start_time_skipping() with stub
+  activities:
+  - happy path: success stamp with alfred_read_at + summary, no error.
+  - unsupported mime short-circuits at fetch_and_extract_text.
+  - empty extraction stamps the error code.
+  - summariser failure stamps "summariser_failed".
+  - stamp failure still returns a result (no exception).
+"""
+from __future__ import annotations
+
+import asyncio
+import io
+import uuid
+from typing import Any
+
+import httpx
+import pytest
+from temporalio import activity
+from temporalio.client import Client
+from temporalio.testing import ActivityEnvironment, WorkflowEnvironment
+from temporalio.worker import Worker
+
+from src.activities.file_extraction import (
+    ExtractionError,
+    classify_mime,
+    extract_text_blob,
+    fetch_and_extract_text,
+    read_file_metadata,
+    stamp_extraction_result,
+)
+from src.workflows.file_extraction import (
+    FileExtractionResult,
+    FileExtractionWorkflow,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders — keep them in-test so the fixtures dir doesn't bloat.
+# ---------------------------------------------------------------------------
+
+
+def _build_min_pdf_with_text(text: str) -> bytes:
+    """Build the minimum possible PDF that pypdf will extract `text` from.
+
+    Hand-rolled (~600 bytes) so the test stays hermetic — no fixture
+    file, no external generator. The structure follows ISO 32000-1's
+    "minimum file" example: 1 page, 1 font, a single Tj operator.
+    """
+    objs: list[bytes] = []
+    objs.append(b"<< /Type /Catalog /Pages 2 0 R >>")
+    objs.append(b"<< /Type /Pages /Count 1 /Kids [3 0 R] >>")
+    objs.append(
+        b"<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 4 0 R >> >> "
+        b"/MediaBox [0 0 200 200] /Contents 5 0 R >>"
+    )
+    objs.append(b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>")
+    safe = text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+    stream = (
+        b"BT /F1 12 Tf 50 100 Td (" + safe.encode("ascii", errors="replace") + b") Tj ET"
+    )
+    obj5 = b"<< /Length " + str(len(stream)).encode() + b" >>\nstream\n" + stream + b"\nendstream"
+    objs.append(obj5)
+
+    out = io.BytesIO()
+    out.write(b"%PDF-1.4\n")
+    offsets: list[int] = []
+    for i, body in enumerate(objs, start=1):
+        offsets.append(out.tell())
+        out.write(f"{i} 0 obj\n".encode())
+        out.write(body)
+        out.write(b"\nendobj\n")
+    xref_off = out.tell()
+    out.write(b"xref\n")
+    out.write(f"0 {len(objs) + 1}\n".encode())
+    out.write(b"0000000000 65535 f \n")
+    for off in offsets:
+        out.write(f"{off:010d} 00000 n \n".encode())
+    out.write(b"trailer\n")
+    out.write(f"<< /Size {len(objs) + 1} /Root 1 0 R >>\n".encode())
+    out.write(b"startxref\n")
+    out.write(f"{xref_off}\n".encode())
+    out.write(b"%%EOF\n")
+    return out.getvalue()
+
+
+def _build_min_pdf_no_text_layer() -> bytes:
+    """An "image-only" PDF with one page and zero text operators —
+    pypdf returns '' for every page."""
+    out = io.BytesIO()
+    out.write(b"%PDF-1.4\n")
+    objs = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>",
+        b"<< /Length 0 >>\nstream\n\nendstream",
+    ]
+    offsets: list[int] = []
+    for i, body in enumerate(objs, start=1):
+        offsets.append(out.tell())
+        out.write(f"{i} 0 obj\n".encode())
+        out.write(body)
+        out.write(b"\nendobj\n")
+    xref_off = out.tell()
+    out.write(b"xref\n")
+    out.write(f"0 {len(objs) + 1}\n".encode())
+    out.write(b"0000000000 65535 f \n")
+    for off in offsets:
+        out.write(f"{off:010d} 00000 n \n".encode())
+    out.write(b"trailer\n")
+    out.write(f"<< /Size {len(objs) + 1} /Root 1 0 R >>\n".encode())
+    out.write(b"startxref\n")
+    out.write(f"{xref_off}\n".encode())
+    out.write(b"%%EOF\n")
+    return out.getvalue()
+
+
+def _build_min_docx(text: str) -> bytes:
+    """python-docx writes via the ``docx.Document`` API; use that
+    directly to spit out a minimum DOCX containing a single paragraph.
+    """
+    from docx import Document
+
+    doc = Document()
+    doc.add_paragraph(text)
+    buf = io.BytesIO()
+    doc.save(buf)
+    return buf.getvalue()
+
+
+def _build_min_xlsx(values: list[list[Any]]) -> bytes:
+    """openpyxl helper — single-sheet workbook with the given rows."""
+    from openpyxl import Workbook
+
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Sheet1"
+    for row in values:
+        ws.append(row)
+    buf = io.BytesIO()
+    wb.save(buf)
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# 1. Pure extractor dispatch — no temporal, no httpx.
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyMime:
+    @pytest.mark.parametrize(
+        "ct,expected",
+        [
+            ("text/plain", "text"),
+            ("text/markdown; charset=utf-8", "text"),
+            ("application/json", "text"),
+            ("application/xml", "text"),
+            ("application/yaml", "text"),
+            ("application/pdf", "pdf"),
+            (
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                "docx",
+            ),
+            (
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                "xlsx",
+            ),
+            ("image/png", "unsupported"),
+            ("audio/mpeg", "unsupported"),
+            ("", "unsupported"),
+            (None, "unsupported"),
+        ],
+    )
+    def test_dispatch(self, ct, expected):
+        assert classify_mime(ct) == expected
+
+
+class TestExtractText:
+    def test_utf8_round_trips(self):
+        body = "Hello Alfred — the audit probe at 03:42.\nLine 2."
+        out = extract_text_blob("text/plain", body.encode("utf-8"))
+        assert out == body
+
+    def test_text_with_garbage_uses_replacement(self):
+        body = b"Hello \xff World"
+        out = extract_text_blob("text/plain", body)
+        assert "Hello" in out and "World" in out
+
+
+class TestExtractPdf:
+    def test_extracts_embedded_text(self):
+        pdf = _build_min_pdf_with_text("Quarterly contract")
+        out = extract_text_blob("application/pdf", pdf)
+        assert "Quarterly contract" in out
+
+    def test_empty_pdf_raises_empty_pdf(self):
+        pdf = _build_min_pdf_no_text_layer()
+        with pytest.raises(ExtractionError) as ei:
+            extract_text_blob("application/pdf", pdf)
+        assert ei.value.code == "empty_pdf"
+
+    def test_garbage_bytes_raise_extractor_failed(self):
+        with pytest.raises(ExtractionError) as ei:
+            extract_text_blob("application/pdf", b"not a pdf at all")
+        assert ei.value.code == "extractor_failed"
+
+
+class TestExtractDocx:
+    def test_extracts_paragraph(self):
+        docx = _build_min_docx("Letterpress briefing for 2026-05-30")
+        out = extract_text_blob(
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            docx,
+        )
+        assert "Letterpress briefing" in out
+
+
+class TestExtractXlsx:
+    def test_extracts_cells(self):
+        xlsx = _build_min_xlsx([["Q1", "Q2"], [100, 200]])
+        out = extract_text_blob(
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            xlsx,
+        )
+        assert "Q1" in out
+        assert "Q2" in out
+        assert "100" in out
+
+
+class TestUnsupportedMime:
+    def test_image_raises(self):
+        with pytest.raises(ExtractionError) as ei:
+            extract_text_blob("image/png", b"\x89PNG\r\n\x1a\n...")
+        assert ei.value.code == "unsupported_mime"
+
+
+# ---------------------------------------------------------------------------
+# 2. Activity isolation — stub httpx.
+# ---------------------------------------------------------------------------
+
+
+class _StubTransport(httpx.AsyncBaseTransport):
+    def __init__(self) -> None:
+        self.queued: list[httpx.Response] = []
+        self.requests: list[httpx.Request] = []
+
+    def queue(
+        self,
+        status: int = 200,
+        json_payload: dict[str, Any] | list[Any] | None = None,
+        content: bytes | None = None,
+    ) -> None:
+        if content is not None:
+            self.queued.append(httpx.Response(status, content=content))
+        else:
+            self.queued.append(httpx.Response(status, json=json_payload or {}))
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:  # type: ignore[override]
+        self.requests.append(request)
+        if not self.queued:
+            return httpx.Response(500, json={"error": "no stub queued"})
+        return self.queued.pop(0)
+
+
+@pytest.fixture
+def stub_transport(monkeypatch):
+    transport = _StubTransport()
+    real_init = httpx.AsyncClient.__init__
+
+    def patched_init(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        kwargs["transport"] = transport
+        real_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(httpx.AsyncClient, "__init__", patched_init)
+    monkeypatch.setenv("ALFRED_CTRL_URL", "http://stub-ctrl:3100")
+    monkeypatch.setenv("AAS_API_KEY", "test-key")
+    return transport
+
+
+class TestReadFileMetadata:
+    def test_locates_matching_row(self, stub_transport):
+        stub_transport.queue(
+            200,
+            {
+                "items": [
+                    {"id": "f-other", "content_type": "image/png"},
+                    {
+                        "id": "f-target",
+                        "content_type": "application/pdf",
+                        "path": "01H/foo.pdf",
+                        "original_filename": "foo.pdf",
+                    },
+                ],
+            },
+        )
+        env = ActivityEnvironment()
+        row = asyncio.run(env.run(read_file_metadata, "f-target"))
+        assert row["id"] == "f-target"
+        assert row["content_type"] == "application/pdf"
+
+    def test_missing_id_raises(self, stub_transport):
+        stub_transport.queue(200, {"items": []})
+        env = ActivityEnvironment()
+        with pytest.raises(ExtractionError) as ei:
+            asyncio.run(env.run(read_file_metadata, "nope"))
+        assert ei.value.code == "not_found"
+
+
+class TestFetchAndExtractText:
+    def test_fetches_blob_and_decodes(self, stub_transport):
+        stub_transport.queue(200, content=b"Hello extracted body")
+        env = ActivityEnvironment()
+        out = asyncio.run(
+            env.run(
+                fetch_and_extract_text,
+                "f-1",
+                "text/plain",
+                "01H/foo.txt",
+            )
+        )
+        assert out["text"] == "Hello extracted body"
+        assert out["extractor"] == "text"
+        # The request encoded each path segment.
+        req = stub_transport.requests[0]
+        assert "01H/foo.txt" in str(req.url)
+
+    def test_unsupported_mime_short_circuits(self, stub_transport):
+        # No blob fetch should happen.
+        env = ActivityEnvironment()
+        with pytest.raises(ExtractionError) as ei:
+            asyncio.run(
+                env.run(
+                    fetch_and_extract_text,
+                    "f-1",
+                    "image/png",
+                    "01H/foo.png",
+                )
+            )
+        assert ei.value.code == "unsupported_mime"
+        assert stub_transport.requests == []
+
+
+class TestStampExtractionResult:
+    def test_patches_correct_body(self, stub_transport):
+        stub_transport.queue(
+            200,
+            {
+                "id": "f-1",
+                "alfred_read_at": 12345,
+                "summary": "ok",
+                "extraction_error": None,
+            },
+        )
+        env = ActivityEnvironment()
+        resp = asyncio.run(
+            env.run(
+                stamp_extraction_result,
+                "f-1",
+                12345,
+                "ok",
+                None,
+            )
+        )
+        assert resp["alfred_read_at"] == 12345
+        req = stub_transport.requests[0]
+        assert req.method == "PATCH"
+        assert "/api/v1/files/f-1/extraction" in str(req.url)
+        # Body carries all three keys verbatim.
+        import json as _json
+        body = _json.loads(req.content.decode())
+        assert body == {
+            "alfred_read_at": 12345,
+            "summary": "ok",
+            "extraction_error": None,
+        }
+
+
+# ---------------------------------------------------------------------------
+# 3. Workflow tests — stub activities; no httpx call at all.
+# ---------------------------------------------------------------------------
+
+
+def _make_stubs(
+    *,
+    metadata_row: dict[str, Any] | None = None,
+    extract_payload: dict[str, Any] | None = None,
+    extract_raises: BaseException | None = None,
+    summary: str | None = None,
+    summary_raises: BaseException | None = None,
+    stamp_raises: BaseException | None = None,
+    stamp_recorder: list[dict[str, Any]] | None = None,
+):
+    @activity.defn(name="read_file_metadata")
+    async def stub_read(file_id: str) -> dict[str, Any]:
+        return metadata_row or {
+            "id": file_id,
+            "content_type": "text/plain",
+            "path": "01H/foo.txt",
+            "original_filename": "foo.txt",
+        }
+
+    @activity.defn(name="fetch_and_extract_text")
+    async def stub_extract(
+        file_id: str, content_type: str | None, path: str,
+    ) -> dict[str, Any]:
+        if extract_raises is not None:
+            raise extract_raises
+        return extract_payload or {
+            "text": "Hello body",
+            "char_count": 10,
+            "extractor": "text",
+            "truncated_for_summary": False,
+        }
+
+    @activity.defn(name="summarise_extracted_text")
+    async def stub_summary(
+        file_id: str,
+        extracted_text: str,
+        original_filename: str | None,
+        content_type: str | None,
+        truncated: bool,
+    ) -> str:
+        if summary_raises is not None:
+            raise summary_raises
+        return summary or "A short summary."
+
+    @activity.defn(name="stamp_extraction_result")
+    async def stub_stamp(
+        file_id: str,
+        alfred_read_at: int | None,
+        summary_text: str | None,
+        extraction_error: str | None,
+    ) -> dict[str, Any]:
+        if stamp_recorder is not None:
+            stamp_recorder.append(
+                {
+                    "file_id": file_id,
+                    "alfred_read_at": alfred_read_at,
+                    "summary": summary_text,
+                    "extraction_error": extraction_error,
+                }
+            )
+        if stamp_raises is not None:
+            raise stamp_raises
+        return {
+            "id": file_id,
+            "alfred_read_at": alfred_read_at,
+            "summary": summary_text,
+            "extraction_error": extraction_error,
+        }
+
+    return [stub_read, stub_extract, stub_summary, stub_stamp]
+
+
+async def _run_workflow(
+    stubs, file_id: str = "f-1",
+) -> FileExtractionResult:
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        client: Client = env.client
+        tq = f"file-extract-test-{uuid.uuid4()}"
+        worker = Worker(
+            client,
+            task_queue=tq,
+            workflows=[FileExtractionWorkflow],
+            activities=stubs,
+        )
+        async with worker:
+            return await client.execute_workflow(
+                FileExtractionWorkflow.run,
+                {"file_id": file_id},
+                id=f"file-extract-run-{uuid.uuid4()}",
+                task_queue=tq,
+            )
+
+
+def _to_dict(result: Any) -> dict[str, Any]:
+    """Temporal can return either a FileExtractionResult or a dict
+    depending on Python version + dataclass support; this normalises."""
+    if isinstance(result, dict):
+        return result
+    return result.__dict__
+
+
+class TestHappyPath:
+    def test_stamps_alfred_read_at_and_summary(self):
+        recorder: list[dict[str, Any]] = []
+        stubs = _make_stubs(
+            summary="The probe document — 2 lines of utf-8.",
+            stamp_recorder=recorder,
+        )
+        result = asyncio.run(_run_workflow(stubs))
+        d = _to_dict(result)
+        assert d["alfred_read_at"] is not None
+        assert d["alfred_read_at"] > 0
+        assert "probe document" in d["summary"]
+        assert d["extraction_error"] is None
+        # The stamp was called exactly once with the success shape.
+        assert len(recorder) == 1
+        assert recorder[0]["extraction_error"] is None
+        assert recorder[0]["summary"] == d["summary"]
+
+
+class TestUnsupportedMimeShortCircuit:
+    def test_stamps_unsupported_mime_when_extract_raises(self):
+        recorder: list[dict[str, Any]] = []
+        stubs = _make_stubs(
+            extract_raises=ExtractionError("unsupported_mime", "test mime"),
+            stamp_recorder=recorder,
+        )
+        result = asyncio.run(_run_workflow(stubs))
+        d = _to_dict(result)
+        assert d["alfred_read_at"] is None
+        assert d["summary"] is None
+        assert d["extraction_error"] == "unsupported_mime"
+        # The stamp recorded the error code.
+        assert recorder[0]["extraction_error"] == "unsupported_mime"
+
+
+class TestEmptyExtractionShortCircuit:
+    def test_empty_text_routes_to_empty_extraction(self):
+        recorder: list[dict[str, Any]] = []
+        stubs = _make_stubs(
+            extract_payload={
+                "text": "   ",  # whitespace only
+                "char_count": 0,
+                "extractor": "text",
+                "truncated_for_summary": False,
+            },
+            stamp_recorder=recorder,
+        )
+        result = asyncio.run(_run_workflow(stubs))
+        d = _to_dict(result)
+        assert d["extraction_error"] == "empty_extraction"
+        assert d["alfred_read_at"] is None
+        assert recorder[0]["extraction_error"] == "empty_extraction"
+
+
+class TestSummariserFailure:
+    def test_summariser_failure_stamps_error(self):
+        recorder: list[dict[str, Any]] = []
+        stubs = _make_stubs(
+            summary_raises=ExtractionError("summariser_failed", "boom"),
+            stamp_recorder=recorder,
+        )
+        result = asyncio.run(_run_workflow(stubs))
+        d = _to_dict(result)
+        assert d["extraction_error"] == "summariser_failed"
+        assert d["alfred_read_at"] is None
+        assert recorder[0]["extraction_error"] == "summariser_failed"
+
+
+class TestStampFailureIsRecorded:
+    def test_stamp_failure_still_returns_result(self):
+        # The success stamp itself raises — the workflow logs it and
+        # returns the in-memory result with extraction_error="stamp_failed".
+        recorder: list[dict[str, Any]] = []
+        stubs = _make_stubs(
+            stamp_raises=RuntimeError("ctrl-api went away"),
+            stamp_recorder=recorder,
+        )
+        result = asyncio.run(_run_workflow(stubs))
+        d = _to_dict(result)
+        assert d["extraction_error"] == "stamp_failed"
+        # And the original stamp attempt was recorded with the success
+        # payload (proving we tried).
+        assert recorder[0]["alfred_read_at"] is not None

--- a/packages/web/src/dashboard/FilesPage.tsx
+++ b/packages/web/src/dashboard/FilesPage.tsx
@@ -36,7 +36,9 @@ import {
 } from "wasp/client/operations";
 import { Frame } from "../client/components/ab/Frame";
 import {
+  badgeLabel,
   buildPrefixTree,
+  deriveBadgeState,
   deriveQuotaView,
   derivePreviewMode,
   formatBytes,
@@ -47,6 +49,7 @@ import {
   shortSha,
   shouldRejectUpload,
   uploadPercent,
+  type BadgeState,
   type FileRow,
   type FilesUsage,
   type LabelEditState,
@@ -679,8 +682,11 @@ export default function FilesPage() {
                             : "transparent",
                         }}
                       >
-                        <td className="py-2 pr-3 truncate max-w-[260px]">
-                          {row.original_filename ?? row.path}
+                        <td className="py-2 pr-3 max-w-[300px]">
+                          <span className="truncate inline-block align-bottom max-w-[200px]">
+                            {row.original_filename ?? row.path}
+                          </span>
+                          <AlfredReadBadge row={row} />
                         </td>
                         <td
                           className="py-2 pr-3 text-right font-mono text-[11px]"
@@ -808,6 +814,96 @@ export default function FilesPage() {
 
 // ── upload row ─────────────────────────────────────────────────────────────
 
+// #114 Lane B — the "Alfred read it" badge.
+//
+// State machine (deriveBadgeState):
+//   * settled — brass pill, summary tooltip on hover.
+//   * pending — soft pulse + "Reading…" label (≤2 min after upload).
+//   * stale   — render nothing (a row Alfred never got around to).
+//   * errored — muted "Couldn't read" pill, reason_code on hover.
+//
+// Kept as a separate component so the row table stays readable.
+function AlfredReadBadge({ row }: { row: FileRow }) {
+  const state: BadgeState = deriveBadgeState(row);
+  if (state === "stale") return null;
+  const label = badgeLabel(state);
+  const tooltip =
+    state === "settled"
+      ? row.summary ?? "Alfred read this file."
+      : state === "errored"
+        ? `Couldn't read: ${row.extraction_error ?? "unknown reason"}`
+        : "Alfred is reading this file…";
+  const bg =
+    state === "settled"
+      ? "color-mix(in oklab, var(--brass) 14%, transparent)"
+      : state === "errored"
+        ? "color-mix(in oklab, var(--marginalia) 18%, transparent)"
+        : "color-mix(in oklab, var(--brass) 8%, transparent)";
+  const fg =
+    state === "settled"
+      ? "var(--brass)"
+      : state === "errored"
+        ? "var(--marginalia)"
+        : "var(--brass)";
+  const pulse = state === "pending" ? "animate-pulse" : "";
+  return (
+    <span
+      className={`inline-flex items-center px-1.5 py-[1px] ml-2 font-mono text-[9px] uppercase tracking-[0.18em] rounded-sm ${pulse}`}
+      style={{ background: bg, color: fg }}
+      title={tooltip}
+    >
+      {label}
+    </span>
+  );
+}
+
+// #114 Lane B — side-panel summary block.
+//
+// Renders the full extraction summary (settled) or a short reason
+// line (errored). Hidden for `pending`/`stale` rows — the badge in
+// the row already carries the affordance and the side panel stays
+// quiet until Alfred has something to say.
+function AlfredReadSummary({ row }: { row: FileRow }) {
+  const state: BadgeState = deriveBadgeState(row);
+  if (state === "settled" && row.summary) {
+    return (
+      <div className="border border-rule px-3 py-2 mt-3" style={{ borderColor: "var(--rule)" }}>
+        <div
+          className="font-mono text-[9px] uppercase tracking-[0.22em] mb-1"
+          style={{ color: "var(--brass)" }}
+        >
+          Alfred read it
+        </div>
+        <p className="font-body text-[13px] leading-snug" style={{ color: "var(--ink)" }}>
+          {row.summary}
+        </p>
+      </div>
+    );
+  }
+  if (state === "errored") {
+    return (
+      <div
+        className="border border-dashed px-3 py-2 mt-3"
+        style={{ borderColor: "var(--rule)" }}
+      >
+        <div
+          className="font-mono text-[9px] uppercase tracking-[0.22em] mb-1"
+          style={{ color: "var(--marginalia)" }}
+        >
+          Couldn't read
+        </div>
+        <p
+          className="font-mono text-[11px]"
+          style={{ color: "var(--marginalia)" }}
+        >
+          {row.extraction_error}
+        </p>
+      </div>
+    );
+  }
+  return null;
+}
+
 function UploadRow({ item }: { item: UploadItem }) {
   const pct = Math.round(uploadPercent(item));
   const isDone = item.status === "completed";
@@ -872,6 +968,12 @@ function PreviewPane({
       <div className="font-mono text-[11px]" style={{ color: "var(--marginalia)" }}>
         {formatBytes(stat_size)} · {formatUploadedAt(stat_uploaded)}
       </div>
+
+      {/* #114 Lane B — "Alfred read it" affordance. The badge appears
+          inline in the row; the side panel surfaces the full summary
+          (when present) and the reason code (when extraction failed). */}
+      <AlfredReadSummary row={stat ?? row} />
+
 
       {mode === "image" && (
         <img

--- a/packages/web/src/dashboard/FilesPageCore.test.ts
+++ b/packages/web/src/dashboard/FilesPageCore.test.ts
@@ -12,7 +12,9 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  badgeLabel,
   buildPrefixTree,
+  deriveBadgeState,
   deriveQuotaView,
   derivePreviewMode,
   filterByPrefix,
@@ -20,6 +22,7 @@ import {
   formatUploadedAt,
   labelDraftFor,
   makeDebounceController,
+  PENDING_STALE_AFTER_MS,
   reduceLabelEdit,
   shortSha,
   shouldRejectUpload,
@@ -353,6 +356,50 @@ test("shortSha: 12-char column display, safe on short or null-ish inputs", () =>
   assert.equal(shortSha("deadbeefcafebabe1234"), "deadbeefcafe");
   assert.equal(shortSha("abc"), "abc");
   assert.equal(shortSha(""), "");
+});
+
+// ── #114 Lane B — "Alfred read it" badge derivation ───────────────────────
+
+test("deriveBadgeState: alfred_read_at flips the row to settled", () => {
+  const now = FROZEN_NOW.getTime();
+  const row = rowAt(now - 60_000, "01/a.txt", {
+    alfred_read_at: now - 50_000,
+    summary: "A short prose paragraph.",
+  });
+  assert.equal(deriveBadgeState(row, now), "settled");
+  assert.equal(badgeLabel("settled"), "Alfred read it");
+});
+
+test("deriveBadgeState: extraction_error trumps fresh-row pulse", () => {
+  const now = FROZEN_NOW.getTime();
+  const row = rowAt(now - 10_000, "01/img.png", {
+    extraction_error: "unsupported_mime",
+  });
+  assert.equal(deriveBadgeState(row, now), "errored");
+  assert.equal(badgeLabel("errored"), "Couldn't read");
+});
+
+test("deriveBadgeState: a fresh, unstamped row is pending", () => {
+  const now = FROZEN_NOW.getTime();
+  const row = rowAt(now - 30_000, "01/p.txt");
+  assert.equal(deriveBadgeState(row, now), "pending");
+  assert.equal(badgeLabel("pending"), "Reading…");
+});
+
+test("deriveBadgeState: an old unstamped row is stale (no pulse)", () => {
+  const now = FROZEN_NOW.getTime();
+  const row = rowAt(now - (PENDING_STALE_AFTER_MS + 1000), "01/o.txt");
+  assert.equal(deriveBadgeState(row, now), "stale");
+  assert.equal(badgeLabel("stale"), "");
+});
+
+test("deriveBadgeState: row exactly at the stale-after boundary stays pending", () => {
+  // Equality with the threshold is treated as pending; the +1ms case
+  // tips to stale. This is the contract the React layer relies on so
+  // a row uploaded "right at the boundary" doesn't flicker.
+  const now = FROZEN_NOW.getTime();
+  const row = rowAt(now - PENDING_STALE_AFTER_MS, "01/edge.txt");
+  assert.equal(deriveBadgeState(row, now), "pending");
 });
 
 test("formatUploadedAt: relative buckets up to a week, then ISO date", () => {

--- a/packages/web/src/dashboard/FilesPageCore.ts
+++ b/packages/web/src/dashboard/FilesPageCore.ts
@@ -35,6 +35,67 @@ export interface FileRow {
   uploaded_at: number;
   last_accessed_at: number | null;
   deleted_at: number | null;
+  // #114 Lane B — extraction columns. `alfred_read_at` flips
+  // null → unix-ms once the FileExtractionWorkflow finishes; drives
+  // the "Alfred read it" badge. `summary` is the one-paragraph
+  // description shown in the row's hover tooltip + side panel.
+  // `extraction_error` is the subtle-error state (null on success or
+  // while pending). All three are optional so existing rows + the
+  // pre-Lane-B ctrl-api response shape stay assignable.
+  alfred_read_at?: number | null;
+  summary?: string | null;
+  extraction_error?: string | null;
+}
+
+// #114 Lane B — visual state machine for the "Alfred read it" badge.
+// Derived purely from the three extraction columns + the row's age:
+//
+//   * "settled" — extraction succeeded; show the brass-coloured
+//                 "Alfred read it" pill + the summary tooltip.
+//   * "pending" — extraction hasn't stamped yet AND the row is fresh
+//                 (uploaded <2 min ago). Show a soft "Reading…" pulse.
+//   * "stale"   — extraction hasn't stamped and the row is older than
+//                 2 min. Either the workflow never fired (e.g. tenant
+//                 booted without alfred-learn) or it dropped silently.
+//                 Show nothing — no pulse, no badge.
+//   * "errored" — `extraction_error` is set. Show the muted-rust
+//                 "Alfred couldn't read this" affordance with the
+//                 reason code as the tooltip.
+export type BadgeState = "settled" | "pending" | "stale" | "errored";
+
+/** Stale-after threshold for the "Reading…" pulse. Two minutes is
+ *  comfortably above the §14 promise of 30s and accounts for a cold
+ *  tenant warm-up (Hermes hit, first clerk call). */
+export const PENDING_STALE_AFTER_MS = 2 * 60_000;
+
+/** Derive the badge state from a row. `now` is injectable for tests. */
+export function deriveBadgeState(
+  row: FileRow,
+  now: number = Date.now(),
+): BadgeState {
+  if (row.alfred_read_at && row.alfred_read_at > 0) return "settled";
+  if (row.extraction_error && row.extraction_error.length > 0) {
+    return "errored";
+  }
+  const age = now - (row.uploaded_at ?? 0);
+  if (age <= PENDING_STALE_AFTER_MS) return "pending";
+  return "stale";
+}
+
+/** Render the principal-readable label for the badge state. The
+ *  "settled" copy is the row's tooltip on hover; this function returns
+ *  the short pill text. */
+export function badgeLabel(state: BadgeState): string {
+  switch (state) {
+    case "settled":
+      return "Alfred read it";
+    case "pending":
+      return "Reading…";
+    case "errored":
+      return "Couldn't read";
+    case "stale":
+      return "";
+  }
 }
 
 export interface FilesUsage {


### PR DESCRIPTION
Closes the §14 step 3 promise from #114: drop a file on `/files`, Alfred reads it within ~30 s, a one-paragraph summary appears, the "Alfred read it" badge lights up. Steps #4 and #5 (Telegram / voice summarisation) come along for free once `summary` is on the row.

Refs #114 (Lane B — three other lanes remain open before #114 can close).

## What this PR adds

### Migration 0016 (`files_extraction.sql`)

Three new nullable columns on `files`:

| Column | Type | Meaning |
|---|---|---|
| `alfred_read_at` | INTEGER (unix ms) | Null = unread. Drives the badge. |
| `summary` | TEXT | One-paragraph description. |
| `extraction_error` | TEXT | Short reason code on failure. |

Partial index on `alfred_read_at` over live rows for the dashboard's aggregate.

### ctrl-api routes

- `PATCH /api/v1/files/:file_id/extraction` — write-back surface. Validates each field, caps `summary` at 4 KiB, refuses tombstoned rows (409), 404s on unknown id. **Keyed by `file_id` (not the dedupe-rewritable path)** and registered before the wildcard `PATCH /api/v1/files/*` (principal_label) so the specific path wins.
- `POST /api/v1/files/:file_id/extract` — operator re-fire. Clears `extraction_error` eagerly + re-triggers the workflow. Returns 202 + eta=30s.
- `POST /api/v1/files/upload` — now fires a one-shot `FileExtractionWorkflow` via `docker compose exec temporal temporal workflow start` after responding. Workflow-id `file-extract-<file_id>`, so a duplicate trigger is silently rejected (ALREADY_EXISTS). Bypassable via `FILES_EXTRACTION_ENABLED=false` (used by the route test harness).

### `alfred-learn` — FileExtractionWorkflow

One-shot orchestration: `read_file_metadata → fetch_and_extract_text → summarise_extracted_text → stamp_extraction_result`. Pure orchestration, all HTTP / clerk / state.db lives in activities (same discipline `FilesColdArchiveWorkflow` follows).

**Per-mime extractor matrix:**

| Mime | Tool |
|---|---|
| `text/*`, `application/json`, `application/xml`, `application/x-yaml` | direct utf-8 decode (replace-on-error fallback) |
| `application/pdf` | `pypdf` (pure Python, no native deps) |
| `application/vnd.openxmlformats-…wordprocessingml.document` | `python-docx` (paragraphs + tables) |
| `application/vnd.openxmlformats-…spreadsheetml.sheet` | `openpyxl` (`read_only=True` keeps RAM bounded) |
| Everything else | `extraction_error="unsupported_mime"` |

OCR (tesseract) + audio (Groq Whisper) are **intentionally outside Lane B** — each merits its own PR (image OCR is an apt package; Whisper is a Groq quota line item). The workflow marks them `unsupported_mime` so the dashboard's subtle-error state can render the "Alfred can't read this yet" affordance.

**Error taxonomy:** `ExtractionError(code, message)` with `__str__` contracted to emit `"<code>: <message>"` so a Temporal-wrapped envelope (`ActivityError → ApplicationError`) survives serialisation. The workflow's `_extraction_error_code()` walks the chain and recovers the code via head-split against a known-codes whitelist.

**Three new Python deps:** `pypdf==5.0.1`, `python-docx==1.1.2`, `openpyxl==3.1.5`. All pure-Python; no apt changes.

### web — Lane B UI

- `FilesPageCore.ts` — new pure helpers `deriveBadgeState()` + `badgeLabel()` with a 4-state machine: `settled` (success), `pending` (fresh upload, <2 min, no stamp), `stale` (older than 2 min and still no stamp — silent), `errored`.
- `FilesPage.tsx` — new `<AlfredReadBadge>` inline pill on every row + new `<AlfredReadSummary>` block in the side preview pane. Pending shows a soft pulse for 2 min then goes quiet. Errored renders a muted "Couldn't read" affordance with the reason code as the tooltip.
- Wasp `Promise<T>` trap is not a concern here — no new Wasp ops were added; the existing `getFilesList` / `getFileStat` carry the new columns through transparently.

## Test coverage

| Surface | Tests | Status |
|---|---|---|
| `learn/tests/test_file_extraction.py` | 30 (classify_mime parametric, four-mime extractor round-trips with hermetic hand-rolled PDF/DOCX/XLSX fixtures, empty-PDF / garbage-bytes failure codes, ActivityEnvironment isolation with httpx stubbed, WorkflowEnvironment end-to-end with stub activities) | 30/30 pass |
| `ctrl/tests/files-routes.test.ts` | 7 new (PATCH `/extraction` fresh stamp + error stamp + tombstone 409 + 404 + 4-KiB cap + partial-PATCH; POST `/extract` 202 + tombstone 409) | 27/27 files-routes tests pass |
| `ctrl/tests/migrate.test.ts` | user_version bumped to 16; new column assertions added | 3/3 pass |
| `web/src/dashboard/FilesPageCore.test.ts` | 5 new (`deriveBadgeState`: settled, errored, pending, stale, boundary) | 31/31 pass |

`ctrl/tests` aggregate: **51/51 across files-routes + files-cold-archive + files-dedupe + migrate**.

`tsc --noEmit` clean for the changed files. `npm run build` succeeds for ctrl-api.

## Caveats

- The fire-and-forget trigger uses `docker compose exec temporal temporal workflow start` — same pattern `POST /channels/ha/registry/refresh` already uses (channels_ha.ts). It is **bypassed in the route test harness via `FILES_EXTRACTION_ENABLED=false`** — without that, every upload assertion would warn-log a "temporal CLI not found" line.
- The pypdf path is **text-layer only**. Scanned-image PDFs surface as `empty_pdf` with the tooltip "no text layer; OCR needed". Lane B chose not to bundle tesseract on the ctrl-api image; the OCR follow-up will need to either (a) extend this workflow with a tesseract step on `empty_pdf` rows or (b) route through a separate `FileOcrWorkflow`. To be decided in the follow-up issue.
- `read_file_metadata` uses `GET /api/v1/files/list?limit=500` + client-side filter rather than a dedicated `/by-id` route (which doesn't exist yet). Cheap for the typical tenant (≤a few hundred files) and avoids coupling Lane B to a not-yet-shipped surface. The follow-up #114 lane that adds `move`/`describe` MCP tools is the natural place to ship `/by-id` if it ever becomes a hotspot.
- The PATCH route does **partial-replacement**: a body omitting a key leaves that column unchanged. A retry that wants to clear `extraction_error` must explicitly send `"extraction_error": null`. Documented in the route comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)