### PR TITLE
feat(ctrl,web): #114 Lane C — files restore route + audit ledger writes

### DIFF
--- a/packages/ctrl/src/api/routes/files.ts
+++ b/packages/ctrl/src/api/routes/files.ts
@@ -63,6 +63,47 @@ import { getStateDb } from "../../db/state.js";
 import { appendAudit } from "./state.js";
 import { dockerExec } from "../helpers.js";
 
+// ── Actor-derivation contract ──────────────────────────────────────────────
+//
+// Every mutation in /api/v1/files/* writes one row to the `audit` ledger
+// via appendAudit (the same plumbing decisions.ts, attention.ts, and
+// stateChanges.ts already use — there is no parallel audit path here).
+// The `actor` field follows the same convention the rest of the codebase
+// uses:
+//
+//   * `principal` — Sir clicked through the /files dashboard. Default
+//     when the body/header carries nothing else.
+//   * `alfred`    — an MCP tool fired the call (files__write, etc.).
+//   * `system`    — a cron/workflow ran (cold-archive sweep).
+//   * arbitrary   — the caller explicitly named themselves (e.g.
+//     "chore:weekly-statements").
+//
+// Resolution order: explicit `body.actor` > header `x-alfred-actor` >
+// `principal`. The bridge layer (SaaS proxyToTenant) is free to attach
+// the header; MCP-driven callers attach the body field. The upload
+// path keeps the legacy `uploaded_by` text-field name for backwards
+// compatibility but folds it into the same actor-resolution.
+
+const VALID_ACTOR_RE = /^[a-zA-Z0-9_:.-]{1,64}$/;
+
+function resolveActor(
+  req: IncomingMessage,
+  bodyField: unknown,
+  fallback = "principal",
+): string {
+  const headerRaw = req.headers["x-alfred-actor"];
+  const headerStr = Array.isArray(headerRaw) ? headerRaw[0] : headerRaw;
+  const candidates: unknown[] = [bodyField, headerStr];
+  for (const v of candidates) {
+    if (typeof v !== "string") continue;
+    const trimmed = v.trim();
+    if (!trimmed) continue;
+    if (!VALID_ACTOR_RE.test(trimmed)) continue;
+    return trimmed;
+  }
+  return fallback;
+}
+
 // ── Configuration ──────────────────────────────────────────────────────────
 
 /** Root of the blob volume inside the ctrl-api container. The
@@ -948,6 +989,36 @@ export function registerFilesRoutes(): void {
       now,
     );
 
+    // §8 audit ledger — every files mutation writes one row through the
+    // shared appendAudit helper (best-effort; the upload's primary write
+    // is the `files` INSERT above, so a failed audit mirror logs +
+    // swallows rather than aborting the request). The actor here is the
+    // legacy `uploaded_by` text field so the uploader's identity (Sir,
+    // an MCP tool, a chore) flows into both `files.uploaded_by` AND
+    // `audit.actor`. `target_path` is the canonical files surface
+    // (`files/<ULID>`) so a downstream `GET /api/v1/state/audit?target=files/<id>`
+    // round-trips. Issue #114 §14 step 8 — "verify every read + write
+    // is in the audit ledger".
+    appendAudit({
+      action_type: "files_upload",
+      actor: uploadedBy,
+      source: "ctrl-api",
+      target_path: `files/${id}`,
+      target_kind: "file",
+      subject_ref: relPath,
+      summary: `files_upload: ${originalFilename} (${parsed.size} bytes${deduped ? ", deduped" : ""})`,
+      payload: {
+        id,
+        path: relPath,
+        size_bytes: parsed.size,
+        sha256: parsed.sha256,
+        content_type: contentType,
+        original_filename: originalFilename,
+        principal_label: principalLabel,
+        deduped,
+      },
+    });
+
     sendJson(res, 201, {
       id,
       path: relPath,
@@ -1116,7 +1187,7 @@ export function registerFilesRoutes(): void {
     sendJson(res, 202, { ok: true, file_id: row.id, eta: "30s" });
   });
 
-  // GET /api/v1/files/list?prefix=&q=&limit=&offset=
+  // GET /api/v1/files/list?prefix=&q=&limit=&offset=&include_deleted=&only_deleted=
   //
   // Paginated, deleted_at-aware list. Three orthogonal filters, each
   // optional and combined with AND:
@@ -1127,6 +1198,12 @@ export function registerFilesRoutes(): void {
   //                the `files__search` MCP tool. Content indexing comes
   //                in PR 4.
   //   * `limit` / `offset` — pagination (limit default 100, max 1000)
+  //   * `include_deleted=true`  — return live AND soft-deleted rows together
+  //   * `only_deleted=true`     — return ONLY soft-deleted rows whose
+  //                                `deleted_at` falls within the last
+  //                                `trash_window_ms` (default 30 days).
+  //                                Powers the /files "Recently deleted"
+  //                                expander + the §7 restore round-trip.
   //
   // PR 1 doesn't yet expose a virtual `parent_dir` (that's PR 3).
   addRoute("GET", "/api/v1/files/list", async ({ res, query }) => {
@@ -1134,6 +1211,23 @@ export function registerFilesRoutes(): void {
     const q = (query.get("q") ?? "").trim();
     const limitRaw = Number(query.get("limit") ?? "100");
     const offsetRaw = Number(query.get("offset") ?? "0");
+    const includeDeleted = /^(1|true|yes)$/i.test(
+      String(query.get("include_deleted") ?? ""),
+    );
+    const onlyDeleted = /^(1|true|yes)$/i.test(
+      String(query.get("only_deleted") ?? ""),
+    );
+    // 30-day default trash window — matches the §11 "hard-delete after
+    // 30d" spec line. The window is configurable per request so an
+    // operator querying for "everything in the last year" doesn't have
+    // to swallow the default.
+    const trashWindowRaw = Number(
+      query.get("trash_window_ms") ?? String(30 * 24 * 60 * 60 * 1000),
+    );
+    const trashWindowMs =
+      Number.isFinite(trashWindowRaw) && trashWindowRaw >= 0
+        ? trashWindowRaw
+        : 30 * 24 * 60 * 60 * 1000;
     const limit =
       Number.isFinite(limitRaw) && limitRaw > 0
         ? Math.min(1000, Math.floor(limitRaw))
@@ -1141,14 +1235,26 @@ export function registerFilesRoutes(): void {
     const offset =
       Number.isFinite(offsetRaw) && offsetRaw >= 0 ? Math.floor(offsetRaw) : 0;
 
-    // Build the WHERE clause dynamically — `deleted_at IS NULL` is always
-    // present; prefix and q each contribute an additional clause +
-    // bound parameter. SQLite's LIKE is case-sensitive by default for
+    // Build the WHERE clause dynamically — `deleted_at IS NULL` is the
+    // default. `include_deleted=true` drops that filter; `only_deleted=true`
+    // flips it and adds a `deleted_at >= cutoff` window so a stale
+    // tombstone (after the 30d hard-delete sweep lands) doesn't pollute
+    // the recycle bin. SQLite's LIKE is case-sensitive by default for
     // BLOBs and case-insensitive for TEXT; we go belt-and-braces by
     // lower()'ing both sides for the `q` keyword scan so principal
     // labels written in mixed case still match.
-    const clauses: string[] = ["deleted_at IS NULL"];
+    const clauses: string[] = [];
+    if (onlyDeleted) {
+      const cutoff = Date.now() - trashWindowMs;
+      clauses.push("deleted_at IS NOT NULL");
+      clauses.push("deleted_at >= ?");
+    } else if (!includeDeleted) {
+      clauses.push("deleted_at IS NULL");
+    }
     const args: unknown[] = [];
+    if (onlyDeleted) {
+      args.push(Date.now() - trashWindowMs);
+    }
     if (prefix) {
       clauses.push("path LIKE ?");
       args.push(`${prefix}%`);
@@ -1160,14 +1266,21 @@ export function registerFilesRoutes(): void {
       );
       args.push(needle, needle, needle);
     }
-    const where = clauses.join(" AND ");
+    // `include_deleted=true` with no other filters yields an empty
+    // clause list — fall back to `1=1` so the WHERE remains syntactically
+    // valid without forcing a per-branch SQL template.
+    const where = clauses.length === 0 ? "1=1" : clauses.join(" AND ");
+    // Trash-bin views sort by `deleted_at DESC` so the most recently
+    // tombstoned row is on top (matches the "Recently deleted" UX). The
+    // default live view keeps the existing `uploaded_at DESC` order.
+    const orderBy = onlyDeleted ? "deleted_at DESC" : "uploaded_at DESC";
 
     const db = getStateDb();
     const rows = db
       .prepare(
         `SELECT * FROM files
           WHERE ${where}
-          ORDER BY uploaded_at DESC
+          ORDER BY ${orderBy}
           LIMIT ? OFFSET ?`,
       )
       .all(...args, limit, offset) as Record<string, unknown>[];
@@ -1327,7 +1440,7 @@ export function registerFilesRoutes(): void {
   //
   // Returns the full updated row. Soft-deleted rows are not patchable
   // (404, mirroring stat / blob).
-  addRoute("PATCH", "/api/v1/files/*", async ({ res, params, body }) => {
+  addRoute("PATCH", "/api/v1/files/*", async ({ req, res, params, body }) => {
     const relPath = params.path ?? "";
     if (!relPath) throw new ValidationError("path is required");
     const db = getStateDb();
@@ -1364,6 +1477,22 @@ export function registerFilesRoutes(): void {
         nextLabel,
         row.id,
       );
+      // §8 audit ledger — `file_patch` carries the before/after of every
+      // writable column so /study#audit's UI can render the diff. We
+      // only emit when something actually changed; a no-op PATCH (which
+      // still 200s for forward-compat) leaves the ledger quiet.
+      appendAudit({
+        action_type: "files_patch",
+        actor: resolveActor(req, patch.actor),
+        source: "ctrl-api",
+        target_path: `files/${row.id}`,
+        target_kind: "file",
+        subject_ref: row.path,
+        summary: `files_patch: principal_label on ${row.original_filename ?? row.path}`,
+        changes: {
+          principal_label: { before: row.principal_label, after: nextLabel },
+        },
+      });
     }
 
     const after = db
@@ -1380,9 +1509,16 @@ export function registerFilesRoutes(): void {
   // live `files.id` rows would suddenly point at a missing blob. The
   // `files` row stays for the audit trail either way.
   //
+  // The soft-delete is REVERSIBLE for as long as another `files` row
+  // shares the sha256 (the bytes are still on disk) — see the
+  // /restore/:file_id route below. If this was the sole reference, the
+  // blob has been reaped and only the row's metadata can be undeleted;
+  // the restore route 410s in that case rather than fabricating a
+  // missing blob.
+  //
   // Cold blobs are unlinked from FILES_COLD_ROOT instead of
   // FILES_ROOT when their ref_count hits zero.
-  addRoute("DELETE", "/api/v1/files/*", async ({ res, params }) => {
+  addRoute("DELETE", "/api/v1/files/*", async ({ req, res, params, body }) => {
     const relPath = params.path ?? "";
     if (!relPath) throw new ValidationError("path is required");
     const db = getStateDb();
@@ -1396,6 +1532,12 @@ export function registerFilesRoutes(): void {
     const now = Date.now();
     // Soft-delete the principal-facing row.
     db.prepare(`UPDATE files SET deleted_at = ? WHERE id = ?`).run(now, row.id);
+    const actor = resolveActor(
+      req,
+      body && typeof body === "object" && !Array.isArray(body)
+        ? (body as Record<string, unknown>).actor
+        : undefined,
+    );
     // Decrement the canonical blob's ref_count, then physically unlink
     // only if it just hit zero. INSERT-or-IGNORE on upload guarantees
     // exactly one `file_blobs` row per sha256, so this UPDATE +
@@ -1440,15 +1582,33 @@ export function registerFilesRoutes(): void {
       }
       db.prepare(`DELETE FROM file_blobs WHERE sha256 = ?`).run(row.sha256);
     }
+    // §8 audit ledger — `files_soft_delete` is the principal-visible
+    // tombstone event. The `undo` recipe points at the restore route
+    // (added in this PR) so a future "Undo" pill on the Desk audit feed
+    // can roll it back without the operator having to memorise the
+    // inverse URL. The `payload.blob_reaped` flag lets a reader detect
+    // "the bytes are gone, restore will 410" before they try.
+    const blobReaped = !!(blob && blob.ref_count <= 0);
     appendAudit({
       action_type: "files_soft_delete",
-      actor: "principal",
+      actor,
       source: "ctrl-api",
-      target_path: row.path,
+      target_path: `files/${row.id}`,
       target_kind: "file",
-      subject_ref: row.id,
-      summary: `soft-deleted file ${row.original_filename ?? row.path}`,
-      payload: { id: row.id, sha256: row.sha256, size_bytes: row.size_bytes },
+      subject_ref: row.path,
+      summary: `files_soft_delete: ${row.original_filename ?? row.path}`,
+      changes: { deleted_at: { before: null, after: now } },
+      undo: {
+        method: "POST",
+        path: `/api/v1/files/restore/${row.id}`,
+      },
+      payload: {
+        id: row.id,
+        path: row.path,
+        sha256: row.sha256,
+        size_bytes: row.size_bytes,
+        blob_reaped: blobReaped,
+      },
     });
     sendJson(res, 200, { id: row.id, path: row.path, deleted_at: now });
   });
@@ -1714,7 +1874,167 @@ export function registerFilesRoutes(): void {
   // (ref_count > 1 — possible when a duplicate upload pointed at the
   // same canonical blob), the on-disk bytes stay and only the
   // per-file row vanishes.
-  addRoute("POST", "/api/v1/files/:file_id/purge", async ({ res, params }) => {
+  // POST /api/v1/files/restore/:file_id — undo a soft-delete.
+  //
+  // The symmetric inverse of the DELETE route. Steps:
+  //
+  //   1. Look the row up by id (no `deleted_at IS NULL` filter — we're
+  //      looking for tombstoned rows here).
+  //   2. Refuse with 409 NOT_DELETED if the row isn't actually
+  //      tombstoned (an idempotent no-op would be friendlier but masks
+  //      operator mistakes — the explicit 409 lets a caller retry-safely
+  //      and the UI banner is unambiguous).
+  //   3. If the canonical `file_blobs` row still exists, the bytes are
+  //      live on disk — clear `deleted_at`, bump `file_blobs.ref_count`
+  //      back up, return the restored row.
+  //   4. If the `file_blobs` row is gone, the blob was reaped at delete
+  //      time and the bytes are unrecoverable. Return 410 BLOB_REAPED
+  //      so the caller surfaces a clear "this can't be restored" rather
+  //      than a half-restored ghost row pointing at nothing on disk.
+  //
+  // The undelete is dedupe-safe: if a duplicate was uploaded after the
+  // tombstone landed, that upload's `INSERT OR IGNORE` already raced
+  // the canonical blob back into existence with `ref_count = 1`. The
+  // restore here just bumps it to 2 and clears the tombstone — both
+  // `files` rows now point at the shared blob.
+  //
+  // Audit (§8): every restore writes a `files_restore` row with the
+  // inverse `undo` recipe pointing back at DELETE so the audit feed
+  // tells a clean two-event story (delete → restore) the principal can
+  // read at /study#audit. Issue #114 §14 step 7.
+  addRoute("POST", "/api/v1/files/restore/:file_id", async ({ req, res, params, body }) => {
+    const fileId = params.file_id ?? "";
+    if (!fileId) throw new ValidationError("file_id is required");
+    const db = getStateDb();
+    const raw = db
+      .prepare(`SELECT * FROM files WHERE id = ? LIMIT 1`)
+      .get(fileId) as Record<string, unknown> | undefined;
+    if (!raw) throw new NotFoundError(`file not found: ${fileId}`);
+    const row = rowFromDb(raw);
+    if (row.deleted_at == null) {
+      throw new ApiError(
+        409,
+        "NOT_DELETED",
+        `file ${fileId} is not soft-deleted (nothing to restore)`,
+      );
+    }
+    const blob = db
+      .prepare(
+        `SELECT path, ref_count, cold_promoted_at, size_bytes
+           FROM file_blobs WHERE sha256 = ?`,
+      )
+      .get(row.sha256) as
+      | {
+          path: string;
+          ref_count: number;
+          cold_promoted_at: number | null;
+          size_bytes: number;
+        }
+      | undefined;
+    if (!blob) {
+      // The bytes were reaped when the last reference dropped on the
+      // original DELETE — there is nothing on disk to restore.
+      throw new ApiError(
+        410,
+        "BLOB_REAPED",
+        `file ${fileId} cannot be restored: the underlying blob was reaped on delete (no remaining references at the time)`,
+      );
+    }
+    // Belt-and-braces: even if the SQL row exists, double-check the on-disk
+    // blob is actually present. A missing file here means a previous
+    // unlink failed but the SQL state survived — surface it cleanly.
+    const abs = isColdPath(blob.path)
+      ? resolveColdBlobPath(blob.path)
+      : resolveBlobPath(blob.path);
+    if (!fs.existsSync(abs)) {
+      throw new ApiError(
+        410,
+        "BLOB_MISSING",
+        `file ${fileId} cannot be restored: the blob at ${blob.path} is gone from disk`,
+      );
+    }
+
+    const restoredAt = Date.now();
+    const previousDeletedAt = row.deleted_at;
+    // Atomic restore: clear the tombstone + bump ref_count in one txn so
+    // a crash between the two leaves the row consistent with the blob's
+    // reference count. SQLite's serializable per-statement semantics
+    // make BEGIN/COMMIT around these two writes sufficient.
+    db.exec("BEGIN");
+    try {
+      db.prepare(`UPDATE files SET deleted_at = NULL WHERE id = ?`).run(row.id);
+      db.prepare(
+        `UPDATE file_blobs SET ref_count = ref_count + 1 WHERE sha256 = ?`,
+      ).run(row.sha256);
+      db.exec("COMMIT");
+    } catch (err) {
+      db.exec("ROLLBACK");
+      throw err;
+    }
+
+    const actor = resolveActor(
+      req,
+      body && typeof body === "object" && !Array.isArray(body)
+        ? (body as Record<string, unknown>).actor
+        : undefined,
+    );
+    appendAudit({
+      action_type: "files_restore",
+      actor,
+      source: "ctrl-api",
+      target_path: `files/${row.id}`,
+      target_kind: "file",
+      subject_ref: row.path,
+      summary: `files_restore: ${row.original_filename ?? row.path}`,
+      changes: { deleted_at: { before: previousDeletedAt, after: null } },
+      undo: {
+        method: "DELETE",
+        path: `/api/v1/files/${row.path}`,
+      },
+      payload: {
+        id: row.id,
+        path: row.path,
+        sha256: row.sha256,
+        previous_deleted_at: previousDeletedAt,
+        restored_at: restoredAt,
+      },
+    });
+
+    // Return the fresh row so the UI can swap the deleted row for the
+    // restored one without a separate fetch.
+    const after = db
+      .prepare(`SELECT * FROM files WHERE id = ? LIMIT 1`)
+      .get(row.id) as Record<string, unknown>;
+    sendJson(res, 200, {
+      ...rowToJson(rowFromDb(after)),
+      restored_at: restoredAt,
+      previous_deleted_at: previousDeletedAt,
+    });
+  });
+
+  // POST /api/v1/files/:file_id/purge — hard delete (issue #114 Lane D₁).
+  //
+  // The principal-facing "permanently empty the recycle bin" surface.
+  // Refuses to purge a row that is NOT already soft-deleted — the
+  // soft-delete step is a deliberate two-stage gate (one click to send
+  // to recycle bin, a second to flush) and the MCP tool mirrors that
+  // shape.
+  //
+  // Behaviour:
+  //   * 409 PURGE_REQUIRES_SOFT_DELETE if the row's `deleted_at IS NULL`.
+  //   * 404 if the id doesn't exist at all.
+  //   * 200 + `{id, path, purged_at}` on success.
+  //
+  // On success the `files` row is DELETED outright (the principal said
+  // "really, get rid of it"). The audit row stays — the audit ledger
+  // outlives the file. If the file's sha256 was the last reference and
+  // its bytes are still on-disk (we soft-delete with ref_count
+  // bookkeeping, so this is the common case), the bytes are unlinked
+  // and the `file_blobs` row deleted too. If the bytes are shared
+  // (ref_count > 1 — possible when a duplicate upload pointed at the
+  // same canonical blob), the on-disk bytes stay and only the
+  // per-file row vanishes.
+  addRoute("POST", "/api/v1/files/:file_id/purge", async ({ req, res, params, body }) => {
     const fileId = params.file_id ?? "";
     if (!fileId) throw new ValidationError("file_id is required");
     const db = getStateDb();
@@ -1770,14 +2090,23 @@ export function registerFilesRoutes(): void {
     }
 
     const purgedAt = Date.now();
+    // §8 audit ledger — `files_purge` is a permanent, principal-driven
+    // event. Actor defaults to `principal` (this is the explicit
+    // "empty recycle bin" click); MCP-driven calls can name themselves.
+    const actor = resolveActor(
+      req,
+      body && typeof body === "object" && !Array.isArray(body)
+        ? (body as Record<string, unknown>).actor
+        : undefined,
+    );
     appendAudit({
       action_type: "files_purge",
-      actor: "principal",
+      actor,
       source: "ctrl-api",
-      target_path: row.path,
+      target_path: `files/${row.id}`,
       target_kind: "file",
-      subject_ref: row.id,
-      summary: `hard-deleted file ${row.original_filename ?? row.path}`,
+      subject_ref: row.path,
+      summary: `files_purge: ${row.original_filename ?? row.path}`,
       payload: {
         id: row.id,
         sha256: row.sha256,
@@ -1856,7 +2185,7 @@ export function registerFilesRoutes(): void {
   // row (`cold_promoted_at IS NOT NULL`) and the orphan can be reaped
   // by ops. Better that than rolling back the DB and re-promoting on
   // every sweep tick.
-  addRoute("POST", "/api/v1/files/cold-promote/:file_id", async ({ res, params }) => {
+  addRoute("POST", "/api/v1/files/cold-promote/:file_id", async ({ req, res, params, body }) => {
     const fileId = params.file_id ?? "";
     if (!fileId) throw new ValidationError("file_id is required");
     const db = getStateDb();
@@ -2004,6 +2333,36 @@ export function registerFilesRoutes(): void {
         `[files] cold-promote: could not unlink live ${liveAbs}: ${(err as Error).message}`,
       );
     }
+    // §8 audit ledger — cold-promote is system-driven (the daily
+    // workflow), so the default actor is `system` unless an operator
+    // passed something explicit. Logs both the live → cold path swap
+    // and the bytes-saved ratio so /study#audit can show "Alfred
+    // archived these N files today, saved X MB".
+    appendAudit({
+      action_type: "files_cold_promote",
+      actor: resolveActor(
+        req,
+        body && typeof body === "object" && !Array.isArray(body)
+          ? (body as Record<string, unknown>).actor
+          : undefined,
+        "system",
+      ),
+      source: "ctrl-api",
+      target_path: `files/${row.id}`,
+      target_kind: "file",
+      subject_ref: coldRelPath,
+      summary: `files_cold_promote: ${row.original_filename ?? row.path} (${blob.size_bytes} → ${compressedSize} bytes)`,
+      changes: {
+        path: { before: blob.path, after: coldRelPath },
+        cold_promoted_at: { before: null, after: promotedAt },
+      },
+      payload: {
+        id: row.id,
+        sha256: row.sha256,
+        live_bytes: blob.size_bytes,
+        cold_bytes: compressedSize,
+      },
+    });
     sendJson(res, 200, {
       id: row.id,
       sha256: row.sha256,
@@ -2027,7 +2386,7 @@ export function registerFilesRoutes(): void {
   // This is operator-only; the read path (GET /blob/*) intentionally
   // does NOT auto-restore on access so cold-promoted files stay cold
   // until the operator explicitly opts in.
-  addRoute("POST", "/api/v1/files/cold-restore/:file_id", async ({ res, params }) => {
+  addRoute("POST", "/api/v1/files/cold-restore/:file_id", async ({ req, res, params, body }) => {
     const fileId = params.file_id ?? "";
     if (!fileId) throw new ValidationError("file_id is required");
     const db = getStateDb();
@@ -2135,6 +2494,35 @@ export function registerFilesRoutes(): void {
         `[files] cold-restore: could not unlink cold ${coldAbs}: ${(err as Error).message}`,
       );
     }
+    // §8 audit ledger — symmetric to cold-promote. `system` is the
+    // default actor when an automated workflow trips this (no such
+    // workflow exists today; cold-restore is operator-driven). The
+    // changes diff captures the path swap so /study#audit can render
+    // "this file moved back from cold storage".
+    appendAudit({
+      action_type: "files_cold_restore",
+      actor: resolveActor(
+        req,
+        body && typeof body === "object" && !Array.isArray(body)
+          ? (body as Record<string, unknown>).actor
+          : undefined,
+        "principal",
+      ),
+      source: "ctrl-api",
+      target_path: `files/${row.id}`,
+      target_kind: "file",
+      subject_ref: liveRelPath,
+      summary: `files_cold_restore: ${row.original_filename ?? row.path}`,
+      changes: {
+        path: { before: blob.path, after: liveRelPath },
+        cold_promoted_at: { before: blob.cold_promoted_at, after: null },
+      },
+      payload: {
+        id: row.id,
+        sha256: row.sha256,
+        restored_bytes: blob.size_bytes,
+      },
+    });
     sendJson(res, 200, {
       id: row.id,
       sha256: row.sha256,

--- a/packages/ctrl/tests/files-routes.test.ts
+++ b/packages/ctrl/tests/files-routes.test.ts
@@ -876,7 +876,7 @@ describe("/api/v1/files/* — PR 1", () => {
         .prepare(
           `SELECT * FROM audit WHERE subject_ref = ? AND action_type = 'files_purge' LIMIT 1`,
         )
-        .get(up.payload.id) as { id: string; summary: string } | undefined;
+        .get(up.payload.path) as { id: string; summary: string } | undefined;
       assert.ok(audit, "audit row must exist for files_purge");
     });
 
@@ -1052,6 +1052,390 @@ describe("/api/v1/files/* — PR 1", () => {
         `/api/v1/files/${up.payload.id}/extract`,
       );
       assert.equal(refire.status, 409);
+    });
+  });
+
+  // ─── #114 §7 + §8 — restore route + audit ledger writes ──────────────
+  //
+  // The restore route is the symmetric inverse of soft-delete. We exercise:
+  //
+  //   * dedupe-shared bytes (two uploads of the same content) survive
+  //     delete + restore — the blob stays on disk because the other ref
+  //     holds it, restore clears the tombstone, list shows it again
+  //   * sole-reference delete reaps the blob → restore 410s with
+  //     BLOB_REAPED (the row is preserved for the audit trail but the
+  //     bytes are gone, so we surface the limit clearly)
+  //   * an already-live row → restore 409s with NOT_DELETED (idempotent
+  //     no-op would mask operator mistakes)
+  //   * the list route honours `include_deleted=true` and `only_deleted=true`
+  //
+  // The audit-ledger block exercises every mutation route and asserts a
+  // matching row landed in the `audit` table. We assert against a real
+  // appendAudit call (not a mock) — appendAudit writes to the same
+  // state.db this test fixture wires up at the top of the file, so a
+  // SELECT round-trip is the contract. Issue #114 §14 step 8.
+
+  describe("POST /restore/:file_id — #114 §7", () => {
+    it("undeletes a row whose blob is still on disk (dedupe path)", async () => {
+      // Two uploads of the same content → ref_count=2 on the canonical
+      // file_blobs row.
+      const content = Buffer.from("shared-bytes-for-dedupe");
+      const a = await uploadBlob("a.txt", content, "text/plain");
+      const b = await uploadBlob("b.txt", content, "text/plain");
+      assert.equal(a.status, 201);
+      assert.equal(b.status, 201);
+      assert.equal(b.payload.deduped, true);
+
+      // Delete one — the bytes survive because the OTHER row still
+      // points at them.
+      const del = await invokeRoute(
+        "DELETE",
+        `/api/v1/files/${a.payload.path}`,
+      );
+      assert.equal(del.status, 200);
+      const sharedAbs = path.join(FILES_ROOT, b.payload.path);
+      assert.ok(
+        fs.existsSync(sharedAbs),
+        "blob must survive delete when another row shares it",
+      );
+
+      // Restore — the tombstone clears, ref_count bumps back up.
+      const restored = await invokeRoute(
+        "POST",
+        `/api/v1/files/restore/${a.payload.id}`,
+      );
+      assert.equal(restored.status, 200);
+      assert.equal(restored.payload.id, a.payload.id);
+      assert.equal(restored.payload.deleted_at, null);
+      assert.ok(typeof restored.payload.restored_at === "number");
+
+      // List excluding deleted now contains BOTH rows again.
+      const list = await invokeRoute("GET", "/api/v1/files/list");
+      assert.equal(list.payload.total, 2);
+    });
+
+    it("410 BLOB_REAPED when the sole-reference blob was reaped on delete", async () => {
+      const up = await uploadBlob(
+        "lonely.txt",
+        Buffer.from("only-copy"),
+        "text/plain",
+      );
+      assert.equal(up.status, 201);
+      // Sole-reference delete → file_blobs row removed, bytes unlinked.
+      const del = await invokeRoute(
+        "DELETE",
+        `/api/v1/files/${up.payload.path}`,
+      );
+      assert.equal(del.status, 200);
+      const blobRow = getStateDb()
+        .prepare(`SELECT * FROM file_blobs WHERE sha256 = ?`)
+        .get(up.payload.sha256) as any;
+      assert.equal(
+        blobRow,
+        undefined,
+        "file_blobs row must be reaped when ref_count hits 0",
+      );
+
+      const restored = await invokeRoute(
+        "POST",
+        `/api/v1/files/restore/${up.payload.id}`,
+      );
+      assert.equal(restored.status, 410);
+      assert.equal(restored.payload.error.code, "BLOB_REAPED");
+    });
+
+    it("409 NOT_DELETED when the file is still live", async () => {
+      const up = await uploadBlob("live.txt", Buffer.from("x"), "text/plain");
+      const restored = await invokeRoute(
+        "POST",
+        `/api/v1/files/restore/${up.payload.id}`,
+      );
+      assert.equal(restored.status, 409);
+      assert.equal(restored.payload.error.code, "NOT_DELETED");
+    });
+
+    it("404 when the file_id doesn't exist", async () => {
+      const restored = await invokeRoute(
+        "POST",
+        "/api/v1/files/restore/01HFAKEULIDFAKEULIDFAKEUL",
+      );
+      assert.equal(restored.status, 404);
+    });
+
+    it("round-trip: delete then restore yields original row state", async () => {
+      // Make the content shared so the blob survives the delete.
+      const content = Buffer.from("round-trip-bytes");
+      const keep = await uploadBlob(
+        "keep.txt",
+        content,
+        "text/plain",
+        { original_filename: "keep.txt", principal_label: "keeper" },
+      );
+      const trip = await uploadBlob(
+        "trip.txt",
+        content,
+        "text/plain",
+        { original_filename: "trip.txt", principal_label: "tripper" },
+      );
+      assert.equal(trip.payload.deduped, true);
+
+      const before = getStateDb()
+        .prepare(`SELECT * FROM files WHERE id = ?`)
+        .get(trip.payload.id) as any;
+
+      await invokeRoute("DELETE", `/api/v1/files/${trip.payload.path}`);
+      await invokeRoute(
+        "POST",
+        `/api/v1/files/restore/${trip.payload.id}`,
+      );
+
+      const after = getStateDb()
+        .prepare(`SELECT * FROM files WHERE id = ?`)
+        .get(trip.payload.id) as any;
+
+      // Every field except deleted_at (null → null) is unchanged.
+      assert.equal(after.id, before.id);
+      assert.equal(after.path, before.path);
+      assert.equal(after.size_bytes, before.size_bytes);
+      assert.equal(after.sha256, before.sha256);
+      assert.equal(after.content_type, before.content_type);
+      assert.equal(after.original_filename, before.original_filename);
+      assert.equal(after.principal_label, before.principal_label);
+      assert.equal(after.uploaded_by, before.uploaded_by);
+      assert.equal(after.uploaded_at, before.uploaded_at);
+      assert.equal(after.deleted_at, null);
+
+      // keep.txt was unaffected.
+      void keep;
+    });
+  });
+
+  describe("GET /list?include_deleted= + ?only_deleted= — #114 §7", () => {
+    it("excludes tombstoned rows by default", async () => {
+      const a = await uploadBlob("a.txt", Buffer.from("a"), "text/plain");
+      const b = await uploadBlob("b.txt", Buffer.from("b"), "text/plain");
+      await invokeRoute("DELETE", `/api/v1/files/${a.payload.path}`);
+      const r = await invokeRoute("GET", "/api/v1/files/list");
+      assert.equal(r.status, 200);
+      assert.equal(r.payload.total, 1);
+      assert.equal(r.payload.items[0].id, b.payload.id);
+    });
+
+    it("include_deleted=true returns live + tombstoned together", async () => {
+      const a = await uploadBlob("a.txt", Buffer.from("a"), "text/plain");
+      const b = await uploadBlob("b.txt", Buffer.from("b"), "text/plain");
+      await invokeRoute("DELETE", `/api/v1/files/${a.payload.path}`);
+      const r = await invokeRoute("GET", "/api/v1/files/list", {
+        url: "/api/v1/files/list?include_deleted=true",
+      });
+      assert.equal(r.status, 200);
+      assert.equal(r.payload.total, 2);
+      const ids = r.payload.items.map((x: any) => x.id).sort();
+      assert.deepEqual(ids, [a.payload.id, b.payload.id].sort());
+    });
+
+    it("only_deleted=true returns ONLY tombstoned rows in the 30d window", async () => {
+      const a = await uploadBlob("a.txt", Buffer.from("a"), "text/plain");
+      const b = await uploadBlob("b.txt", Buffer.from("b"), "text/plain");
+      await invokeRoute("DELETE", `/api/v1/files/${a.payload.path}`);
+      const r = await invokeRoute("GET", "/api/v1/files/list", {
+        url: "/api/v1/files/list?only_deleted=true",
+      });
+      assert.equal(r.status, 200);
+      assert.equal(r.payload.total, 1);
+      assert.equal(r.payload.items[0].id, a.payload.id);
+      assert.ok(r.payload.items[0].deleted_at);
+      // sanity: b is live, not in this view.
+      void b;
+    });
+
+    it("only_deleted=true honours the trash_window_ms cutoff", async () => {
+      const a = await uploadBlob("old.txt", Buffer.from("o"), "text/plain");
+      await invokeRoute("DELETE", `/api/v1/files/${a.payload.path}`);
+      // Backdate the tombstone to 60 days ago, then query with a 30d
+      // window — the row must NOT come back.
+      const sixtyDaysAgo = Date.now() - 60 * 24 * 60 * 60 * 1000;
+      getStateDb()
+        .prepare(`UPDATE files SET deleted_at = ? WHERE id = ?`)
+        .run(sixtyDaysAgo, a.payload.id);
+      const r = await invokeRoute("GET", "/api/v1/files/list", {
+        url: "/api/v1/files/list?only_deleted=true",
+      });
+      assert.equal(r.payload.total, 0);
+      // … but a longer window picks it up.
+      const r2 = await invokeRoute("GET", "/api/v1/files/list", {
+        url: `/api/v1/files/list?only_deleted=true&trash_window_ms=${
+          90 * 24 * 60 * 60 * 1000
+        }`,
+      });
+      assert.equal(r2.payload.total, 1);
+    });
+  });
+
+  describe("audit ledger — #114 §8", () => {
+    // Each mutation in /api/v1/files/* must write one row to the `audit`
+    // table via appendAudit (the shared helper in state.ts). We assert
+    // the row landed by SELECTing on `target_path = files/<id>` —
+    // matching the `GET /api/v1/audit?target=files/<id>` round-trip the
+    // /study#audit feed will use. Beforehand we clear the audit table so
+    // each case's WHERE returns exactly the rows it produced.
+    beforeEach(() => {
+      getStateDb().exec("DELETE FROM audit");
+    });
+
+    function auditRowsFor(fileId: string): any[] {
+      return getStateDb()
+        .prepare(
+          `SELECT * FROM audit WHERE target_path = ? ORDER BY ts ASC, id ASC`,
+        )
+        .all(`files/${fileId}`) as any[];
+    }
+
+    it("upload writes a files_upload audit row", async () => {
+      const up = await uploadBlob(
+        "audited.txt",
+        Buffer.from("hi"),
+        "text/plain",
+      );
+      const rows = auditRowsFor(up.payload.id);
+      assert.equal(rows.length, 1);
+      assert.equal(rows[0].action_type, "files_upload");
+      // Default actor = `principal` because the multipart didn't set
+      // `uploaded_by`.
+      assert.equal(rows[0].actor, "principal");
+      assert.equal(rows[0].target_kind, "file");
+      assert.equal(rows[0].subject_ref, up.payload.path);
+      const payload = JSON.parse(rows[0].payload_json);
+      assert.equal(payload.id, up.payload.id);
+      assert.equal(payload.size_bytes, 2);
+    });
+
+    it("upload honours the `uploaded_by` text field as the actor", async () => {
+      const up = await uploadBlob(
+        "by-alfred.txt",
+        Buffer.from("a"),
+        "text/plain",
+        { uploaded_by: "alfred" },
+      );
+      const rows = auditRowsFor(up.payload.id);
+      assert.equal(rows[0].actor, "alfred");
+    });
+
+    it("PATCH writes a files_patch row with before/after", async () => {
+      const up = await uploadBlob(
+        "to-label.txt",
+        Buffer.from("x"),
+        "text/plain",
+      );
+      // Drain the upload row so we only assert on the patch one.
+      getStateDb().exec("DELETE FROM audit");
+      await invokeRoute("PATCH", `/api/v1/files/${up.payload.path}`, {
+        body: { principal_label: "after-label" },
+      });
+      const rows = auditRowsFor(up.payload.id);
+      assert.equal(rows.length, 1);
+      assert.equal(rows[0].action_type, "files_patch");
+      const changes = JSON.parse(rows[0].changes_json);
+      assert.equal(changes.principal_label.before, null);
+      assert.equal(changes.principal_label.after, "after-label");
+    });
+
+    it("DELETE writes a files_soft_delete row with an undo recipe", async () => {
+      const up = await uploadBlob(
+        "deleting.txt",
+        Buffer.from("d"),
+        "text/plain",
+      );
+      getStateDb().exec("DELETE FROM audit");
+      await invokeRoute("DELETE", `/api/v1/files/${up.payload.path}`);
+      const rows = auditRowsFor(up.payload.id);
+      assert.equal(rows.length, 1);
+      assert.equal(rows[0].action_type, "files_soft_delete");
+      const undo = JSON.parse(rows[0].undo_json);
+      assert.equal(undo.method, "POST");
+      assert.equal(undo.path, `/api/v1/files/restore/${up.payload.id}`);
+      // payload.blob_reaped flags whether the bytes survived.
+      const payload = JSON.parse(rows[0].payload_json);
+      assert.equal(payload.blob_reaped, true);
+    });
+
+    it("DELETE flags blob_reaped=false when another row shares the sha256", async () => {
+      const content = Buffer.from("survives-delete");
+      const a = await uploadBlob("a.txt", content, "text/plain");
+      await uploadBlob("b.txt", content, "text/plain");
+      getStateDb().exec("DELETE FROM audit");
+      await invokeRoute("DELETE", `/api/v1/files/${a.payload.path}`);
+      const rows = auditRowsFor(a.payload.id);
+      const payload = JSON.parse(rows[0].payload_json);
+      assert.equal(payload.blob_reaped, false);
+    });
+
+    it("restore writes a files_restore row with an inverse undo recipe", async () => {
+      const content = Buffer.from("keep-blob-alive");
+      const a = await uploadBlob("a.txt", content, "text/plain");
+      await uploadBlob("b.txt", content, "text/plain");
+      await invokeRoute("DELETE", `/api/v1/files/${a.payload.path}`);
+      getStateDb().exec("DELETE FROM audit");
+      const restored = await invokeRoute(
+        "POST",
+        `/api/v1/files/restore/${a.payload.id}`,
+      );
+      assert.equal(restored.status, 200);
+      const rows = auditRowsFor(a.payload.id);
+      assert.equal(rows.length, 1);
+      assert.equal(rows[0].action_type, "files_restore");
+      const undo = JSON.parse(rows[0].undo_json);
+      assert.equal(undo.method, "DELETE");
+      assert.equal(undo.path, `/api/v1/files/${a.payload.path}`);
+      const changes = JSON.parse(rows[0].changes_json);
+      assert.ok(typeof changes.deleted_at.before === "number");
+      assert.equal(changes.deleted_at.after, null);
+    });
+
+    it("PATCH actor resolution falls back to x-alfred-actor header", async () => {
+      const up = await uploadBlob(
+        "hdr.txt",
+        Buffer.from("h"),
+        "text/plain",
+      );
+      getStateDb().exec("DELETE FROM audit");
+      await invokeRoute("PATCH", `/api/v1/files/${up.payload.path}`, {
+        body: { principal_label: "hdr-label" },
+        headers: { "x-alfred-actor": "chore:weekly-sync" },
+      });
+      const rows = auditRowsFor(up.payload.id);
+      assert.equal(rows[0].actor, "chore:weekly-sync");
+    });
+
+    it("DELETE body { actor: 'alfred' } overrides the header default", async () => {
+      const up = await uploadBlob(
+        "via-mcp.txt",
+        Buffer.from("m"),
+        "text/plain",
+      );
+      getStateDb().exec("DELETE FROM audit");
+      await invokeRoute("DELETE", `/api/v1/files/${up.payload.path}`, {
+        body: { actor: "alfred" },
+        headers: { "content-type": "application/json" },
+      });
+      const rows = auditRowsFor(up.payload.id);
+      assert.equal(rows[0].actor, "alfred");
+    });
+
+    it("invalid actor strings fall back to the default", async () => {
+      const up = await uploadBlob(
+        "bad-actor.txt",
+        Buffer.from("b"),
+        "text/plain",
+      );
+      getStateDb().exec("DELETE FROM audit");
+      await invokeRoute("DELETE", `/api/v1/files/${up.payload.path}`, {
+        body: { actor: "naughty;DROP TABLE users" },
+        headers: { "content-type": "application/json" },
+      });
+      const rows = auditRowsFor(up.payload.id);
+      // Default fallback when the candidate fails the VALID_ACTOR_RE.
+      assert.equal(rows[0].actor, "principal");
     });
   });
 });

--- a/packages/web/main.wasp
+++ b/packages/web/main.wasp
@@ -579,6 +579,25 @@ action deleteFile {
   entities: []
 }
 
+// #114 §7+§8 — Recycle-bin view + symmetric restore.
+//
+// `listDeletedFiles` powers the "Recently deleted" expander on /files,
+// surfacing soft-deleted rows whose tombstone falls inside the 30-day
+// restore window. `restoreFile` clears the tombstone (atomically, with
+// `file_blobs.ref_count` bumped back up) and writes a `file_restore`
+// row to the audit ledger via appendAudit — the inverse undo recipe
+// points back at DELETE so /study#audit reads the two-event story
+// cleanly.
+query listDeletedFiles {
+  fn: import { listDeletedFiles } from "@src/dashboard/operations",
+  entities: []
+}
+
+action restoreFile {
+  fn: import { restoreFile } from "@src/dashboard/operations",
+  entities: []
+}
+
 // STATE-MUTATION Phase E (#893) — briefings index + single. Wraps the
 // ctrl-api endpoints written by the alfred-learn BriefingWorkflow.
 // Powers /brief (most-recent) and /briefings (chronological list).

--- a/packages/web/src/dashboard/FilesPage.tsx
+++ b/packages/web/src/dashboard/FilesPage.tsx
@@ -33,6 +33,8 @@ import {
   getFileStat,
   updateFileLabel,
   deleteFile,
+  listDeletedFiles,
+  restoreFile,
 } from "wasp/client/operations";
 import { Frame } from "../client/components/ab/Frame";
 import {
@@ -321,8 +323,56 @@ export default function FilesPage() {
       if (selectedPath === row.path) setSelectedPath(null);
       refetchList();
       refetchUsage();
+      // The recycle bin's count changes too — refetch so the expander
+      // header label updates in lockstep.
+      refetchDeleted();
     } catch (err: any) {
       addBanner("error", `Delete failed: ${err?.message ?? "error"}`);
+    }
+  }
+
+  // ── Recently-deleted expander (#114 §7 + §8) ──────────────────────────
+  //
+  // The /files surface gains a collapsed-by-default panel listing files
+  // soft-deleted in the last 30 days. Each row carries a Restore button
+  // that calls the new POST /api/v1/files/restore/:file_id route; the
+  // 410 BLOB_REAPED case (sole reference reaped at delete time, bytes
+  // gone) surfaces verbatim so Sir sees a clear "this can't be restored"
+  // banner rather than a silent no-op.
+  const [showDeleted, setShowDeleted] = useState(false);
+  const {
+    data: deletedData,
+    refetch: refetchDeleted,
+  } = useQuery(
+    listDeletedFiles,
+    { limit: 100 },
+    { retry: false, enabled: showDeleted },
+  );
+  const deletedRows: FileRow[] = useMemo(() => {
+    const items = (deletedData as any)?.items;
+    return Array.isArray(items) ? (items as FileRow[]) : [];
+  }, [deletedData]);
+  const restoreAction = useAction(restoreFile);
+  const [restoringId, setRestoringId] = useState<string | null>(null);
+  async function onRestore(row: FileRow) {
+    if (restoringId) return;
+    setRestoringId(row.id);
+    try {
+      await restoreAction({ file_id: row.id });
+      addBanner(
+        "success",
+        `Restored ${row.original_filename ?? row.path}`,
+      );
+      refetchList();
+      refetchUsage();
+      refetchDeleted();
+    } catch (err: any) {
+      addBanner(
+        "error",
+        `Restore failed: ${err?.message ?? "error"}`,
+      );
+    } finally {
+      setRestoringId(null);
     }
   }
 
@@ -782,6 +832,109 @@ export default function FilesPage() {
               </p>
             )}
           </aside>
+        </div>
+
+        {/* Recently deleted — collapsed-by-default expander. The query
+            fires only when expanded so a quiet /files page doesn't pay
+            for an extra round-trip. Each row gets a Restore button that
+            calls POST /api/v1/files/restore/:file_id. Issue #114 §7. */}
+        <div className="border-t border-rule pt-6 mt-8">
+          <button
+            type="button"
+            onClick={() => setShowDeleted((v) => !v)}
+            className="flex items-baseline gap-2 font-mono text-[10px] uppercase tracking-[0.22em]"
+            style={{ color: "var(--marginalia)" }}
+            aria-expanded={showDeleted}
+            data-testid="files-recently-deleted-toggle"
+          >
+            <span style={{ color: "var(--brass)" }}>
+              {showDeleted ? "▾" : "▸"}
+            </span>
+            <span>Recently deleted</span>
+            {showDeleted && deletedData ? (
+              <span style={{ color: "var(--marginalia)" }}>
+                ({(deletedData as any).total ?? deletedRows.length} within 30 days)
+              </span>
+            ) : null}
+          </button>
+          {showDeleted && (
+            <div className="mt-3 border border-rule p-3">
+              {deletedRows.length === 0 ? (
+                <p
+                  className="font-body italic text-[14px]"
+                  style={{ color: "var(--marginalia)" }}
+                >
+                  Nothing recently deleted.
+                </p>
+              ) : (
+                <table className="w-full font-body text-[13px]">
+                  <thead>
+                    <tr
+                      className="font-mono text-[10px] uppercase tracking-[0.18em]"
+                      style={{ color: "var(--marginalia)" }}
+                    >
+                      <th className="text-left py-2 pr-3">Name</th>
+                      <th className="text-right py-2 pr-3">Size</th>
+                      <th className="text-left py-2 pr-3">Deleted</th>
+                      <th className="text-left py-2 pr-3">SHA-256</th>
+                      <th className="w-24"></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {deletedRows.map((row) => (
+                      <tr
+                        key={row.id}
+                        style={{ borderTop: "1px solid var(--rule)" }}
+                        data-testid={`files-deleted-row-${row.id}`}
+                      >
+                        <td className="py-2 pr-3 truncate max-w-[260px]">
+                          {row.original_filename ?? row.path}
+                        </td>
+                        <td
+                          className="py-2 pr-3 text-right font-mono text-[11px]"
+                          style={{ color: "var(--marginalia)" }}
+                        >
+                          {formatBytes(row.size_bytes)}
+                        </td>
+                        <td
+                          className="py-2 pr-3 font-mono text-[11px]"
+                          style={{ color: "var(--marginalia)" }}
+                        >
+                          {row.deleted_at
+                            ? formatUploadedAt(row.deleted_at)
+                            : ""}
+                        </td>
+                        <td
+                          className="py-2 pr-3 font-mono text-[11px]"
+                          style={{ color: "var(--marginalia)" }}
+                        >
+                          {shortSha(row.sha256)}
+                        </td>
+                        <td>
+                          <button
+                            type="button"
+                            onClick={() => onRestore(row)}
+                            disabled={restoringId === row.id}
+                            className="font-mono text-[10px] uppercase tracking-[0.22em]"
+                            style={{
+                              color:
+                                restoringId === row.id
+                                  ? "var(--marginalia)"
+                                  : "var(--brass)",
+                            }}
+                            data-testid={`files-restore-${row.id}`}
+                            title="Restore this file"
+                          >
+                            {restoringId === row.id ? "Restoring…" : "↩ Restore"}
+                          </button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          )}
         </div>
 
         {/* Banners */}

--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -2940,6 +2940,54 @@ export const deleteFile = async (
   });
 };
 
+/** GET /api/v1/files/list?only_deleted=true — the trash bin view.
+ *
+ *  Used by the /files "Recently deleted" expander to render a list of
+ *  soft-deleted files inside the 30-day restore window. The shape
+ *  matches getFilesList; we pass `only_deleted=true` on the wire so the
+ *  ctrl-api side flips the WHERE clause without exposing the SQL knob
+ *  to the dashboard. Issue #114 §14 step 7.
+ *
+ *  Annotation `Promise<any>` — the Wasp Payload trap. */
+export const listDeletedFiles = async (
+  args: { limit?: number } | undefined,
+  context: any,
+): Promise<any> => {
+  if (!context.user) throw new HttpError(401, "Not authenticated");
+  const instance = await getUserInstance(context);
+  const query: Record<string, string> = { only_deleted: "true" };
+  if (typeof args?.limit === "number" && args.limit > 0) {
+    query.limit = String(Math.floor(args.limit));
+  }
+  return proxyToTenant(instance, {
+    path: "/api/v1/files/list",
+    query,
+  });
+};
+
+/** POST /api/v1/files/restore/:file_id — undo a soft-delete.
+ *
+ *  Closes the §14 step 7 loop ("Restore it. Telegram answers again.").
+ *  ctrl-api 410s with `BLOB_REAPED` if the blob was reaped at delete
+ *  time (sole reference, dedupe ref_count dropped to zero) — the UI
+ *  surfaces the message verbatim so Sir can tell why a restore failed.
+ *
+ *  Annotation `Promise<any>` — the Wasp Payload trap. */
+export const restoreFile = async (
+  args: { file_id: string },
+  context: any,
+): Promise<any> => {
+  if (!context.user) throw new HttpError(401, "Not authenticated");
+  if (typeof args?.file_id !== "string" || !args.file_id.trim()) {
+    throw new HttpError(400, "file_id required");
+  }
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    method: "POST",
+    path: `/api/v1/files/restore/${encodeURIComponent(args.file_id.trim())}`,
+  });
+};
+
 // ============================================================
 // Wave C — HA conversation setup card (#111 PR3) and Voice
 // satellites / wake-words card (#112 PR3). Both cards land on


### PR DESCRIPTION
Closes the §7 (restore) and §8 (audit ledger) gaps in #114. References #114.

## Summary

Two operational-integrity gaps the §14 acceptance criteria flagged:

- **§7 restore** — soft-delete worked, undelete didn't exist. Telegram could go from \"summarise the contract\" → \"I can't find it\" but the principal had no way to bring it back.
- **§8 audit ledger** — file mutations skipped \`appendAudit()\` entirely. The /study#audit feed could not show file ops; the spec line \"every write is mirrored to the audit table via appendAudit()\" was unmet.

Both fixed in one PR. No schema change — the `audit` table and the `files.deleted_at` tombstone column carry everything we need.

## ctrl-api changes

**`POST /api/v1/files/restore/:file_id`** — symmetric inverse of the DELETE route. Clears `files.deleted_at` + bumps `file_blobs.ref_count` back up atomically. Returns the fresh row + a `restored_at` ms timestamp.

| Code | Reason |
|---|---|
| 200 | restored — body is the rehydrated row |
| 404 | unknown file_id |
| 409 NOT_DELETED | the row isn't tombstoned (nothing to restore) |
| 410 BLOB_REAPED | sole-reference delete already reaped the blob; bytes unrecoverable |
| 410 BLOB_MISSING | sql row OK but the file on disk is gone |

Dedupe-safe: if a duplicate was re-uploaded after the tombstone landed, `INSERT OR IGNORE` on `file_blobs` already raced the canonical blob back into existence with `ref_count=1`. Restore bumps it to 2 and clears the tombstone — both rows now share the blob.

**`GET /api/v1/files/list`** — two new query flags powering the /files \"Recently deleted\" expander:

- `include_deleted=true` — drop the `deleted_at IS NULL` filter, return live + tombstoned together
- `only_deleted=true` — flip the filter to `deleted_at IS NOT NULL AND deleted_at >= now - trash_window_ms` (default 30d). Orders by `deleted_at DESC` so the most recent tombstone is on top.

**Audit ledger writes** — every mutation route now writes one row through the shared `appendAudit()` helper. No parallel audit path — this is the same plumbing decisions.ts / attention.ts / stateChanges.ts already use. Action types unified on `files_*` plural to match PR #193's `files_move` + `files_purge` convention:

| Route | action_type | undo recipe |
|---|---|---|
| `POST /upload` | `files_upload` | — |
| `PATCH /:path` | `files_patch` | — |
| `DELETE /:path` | `files_soft_delete` | `POST /restore/:id` |
| `POST /restore/:id` | `files_restore` | `DELETE /:path` |
| `POST /:id/purge` | `files_purge` | — |
| `POST /:id/move` | `files_move` | — |
| `POST /cold-promote/:id` | `files_cold_promote` | — |
| `POST /cold-restore/:id` | `files_cold_restore` | — |

`target_path` is `files/<id>` so a downstream `GET /api/v1/audit?target=files/<id>` round-trips and /study#audit can show the principal-visible Files surface.

**Actor resolution** (centralised in one `resolveActor()` helper): explicit `body.actor` → `x-alfred-actor` header → `\"principal\"` fallback. Uploads keep the legacy multipart `uploaded_by` text field name but feed it through the same resolver. Actor strings are validated against `/^[a-zA-Z0-9_:.-]{1,64}$/` to keep injection out of `audit.actor`.

## web changes

- **Wasp ops** `listDeletedFiles` (query) + `restoreFile` (action) — plain async + explicit `Promise<any>` for the Wasp Payload trap.
- **`FilesPage.tsx`** gains a collapsed-by-default \"Recently deleted\" expander after the three-pane grid. Lazy-loaded (the query fires only on expand). Each row has a single \"↩ Restore\" button that hits the new route, refetches list + usage + the trash bin, and surfaces a success banner on completion or the verbatim error message on 410 BLOB_REAPED.

## Tests

18 new ctrl-api test cases covering:

- **Restore round-trip** (5) — dedupe-survives delete + restore (blob alive); sole-reference delete reaps blob → restore 410 BLOB_REAPED; already-live → 409 NOT_DELETED; missing → 404; row-state round-trip (every field except `deleted_at` is identical before/after).
- **List filters** (4) — default excludes tombstoned; `include_deleted=true` returns both; `only_deleted=true` returns only tombstoned; `trash_window_ms` cutoff respected.
- **Audit ledger** (9) — every mutation writes the expected row; `payload.blob_reaped` flag flips on sole vs shared sha256; `undo` recipe round-trips; actor resolves through body / header / fallback; invalid actor strings fall back safely.

All 48 cases in `files-routes.test.ts` pass (was 30, +18). The 12 upstream PR #193 lane-D₁ cases (describe / move / purge) continue to pass — the merge unified their `files_*` action_type convention across the existing soft-delete + the new restore path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)