### PR TITLE
feat(ctrl): #120 Lane I — agent_profile registry + CRUD routes

### DIFF
--- a/packages/ctrl/src/api/routes/profiles.ts
+++ b/packages/ctrl/src/api/routes/profiles.ts
@@ -1,0 +1,323 @@
+// profiles — multi-profile Hermes registry HTTP surface (#120 Lane I).
+//
+// CRUD + binding management for the agent_profile / channel_profile_binding
+// tables. Registry-only — Lane II hooks the Hermes-side activation, Lane IV
+// rewires channel routes to honour the bindings, Lane III adds the UI.
+//
+// Route map:
+//   GET    /api/v1/agent-profiles
+//   GET    /api/v1/agent-profiles/all
+//   GET    /api/v1/agent-profiles/resolve?channel_kind=&channel_identity=
+//   GET    /api/v1/agent-profiles/:slug
+//   POST   /api/v1/agent-profiles                         (202)
+//   DELETE /api/v1/agent-profiles/:slug
+//   GET    /api/v1/agent-profiles/:slug/bindings
+//   POST   /api/v1/agent-profiles/:slug/bindings
+//   DELETE /api/v1/agent-profiles/:slug/bindings/:binding_id
+//
+// POST returns 202 Accepted (not 201) because the Hermes-side activation is
+// deferred to Lane II — the registry row writes immediately but no gateway
+// is started yet. Lane II flips status from 'pending' to 'running'.
+//
+// DELETE archives the row (status='archived', archived_at stamped); the
+// port is freed for reuse. Reserved profiles refuse archive with 409.
+//
+// Error classification: helper messages thrown by the lib are mapped to
+// ApiError statuses by _classify(). Keeping that mapping at the route layer
+// (not in the lib) means Lane II/IV callers can catch and inspect the raw
+// helper errors without a `statusCode` shim.
+
+import { addRoute } from "../server.js";
+import {
+  sendJson,
+  ValidationError,
+  NotFoundError,
+  ConflictError,
+  ApiError,
+} from "../errors.js";
+import { getStateDb } from "../../db/state.js";
+import {
+  PORT_RANGE_USER_LO,
+  PORT_RANGE_USER_HI,
+  KNOWN_CHANNEL_KINDS,
+  validateSlug,
+  listAllProfiles,
+  listUserProfiles,
+  getProfile,
+  createProfile,
+  archiveProfile,
+  listBindingsForProfile,
+  resolveProfileForChannel,
+  bindChannel,
+  unbindChannel,
+} from "../../db/agentProfiles.js";
+import type { AgentProfile } from "../../db/agentProfiles.js";
+
+function asObj(body: unknown): Record<string, unknown> {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new ValidationError("JSON object body required");
+  }
+  return body as Record<string, unknown>;
+}
+
+function reqStr(o: Record<string, unknown>, key: string): string {
+  const v = o[key];
+  if (typeof v !== "string" || !v.trim()) {
+    throw new ValidationError(`${key} (non-empty string) is required`);
+  }
+  return v.trim();
+}
+
+function optStr(o: Record<string, unknown>, key: string): string | null {
+  const v = o[key];
+  return typeof v === "string" && v.trim() ? v.trim() : null;
+}
+
+// Map a lib-thrown Error to the right ApiError subclass.
+//
+// The library throws plain Error with stable message prefixes; we match on
+// those prefixes here so the surface stays:
+//   400 — input shape (slug doesn't match regex, missing required field, …)
+//   404 — referenced row missing
+//   409 — collision / reserved / port-range exhausted / archived target
+function _classify(err: unknown): never {
+  if (err instanceof ApiError) throw err;
+  if (!(err instanceof Error)) {
+    throw err as Error;
+  }
+  const m = err.message;
+  // 409 — collisions and reserved-state errors.
+  if (m.endsWith("already exists")) throw new ConflictError(m);
+  if (m.includes("is reserved")) throw new ConflictError(m);
+  if (m.startsWith("no free user-facing port")) throw new ConflictError(m);
+  if (m.includes("is archived")) throw new ConflictError(m);
+  if (m.includes("is a default and cannot be unbound")) {
+    throw new ConflictError(m);
+  }
+  if (m.includes("not supported in v1")) throw new ConflictError(m);
+  // 404 — missing rows.
+  if (m.startsWith("profile '") && m.endsWith("not found")) {
+    throw new NotFoundError(m);
+  }
+  if (m.startsWith("binding '") && m.endsWith("not found")) {
+    throw new NotFoundError(m);
+  }
+  // 400 — everything else (input shape).
+  throw new ValidationError(m);
+}
+
+function _portRangeMeta(profiles: AgentProfile[]): {
+  port_range: { lo: number; hi: number };
+  free_slots: number;
+} {
+  const usedInRange = new Set<number>();
+  for (const p of profiles) {
+    if (p.archived_at != null) continue;
+    if (
+      p.api_server_port >= PORT_RANGE_USER_LO &&
+      p.api_server_port <= PORT_RANGE_USER_HI
+    ) {
+      usedInRange.add(p.api_server_port);
+    }
+  }
+  const total = PORT_RANGE_USER_HI - PORT_RANGE_USER_LO + 1;
+  return {
+    port_range: { lo: PORT_RANGE_USER_LO, hi: PORT_RANGE_USER_HI },
+    free_slots: total - usedInRange.size,
+  };
+}
+
+export function registerProfileRoutes(): void {
+  // state.db is opened lazily on first request — see registerStateRoutes
+  // for the same pattern. Route registration stays side-effect-free so
+  // tests can register without a real DB.
+  const db = getStateDb;
+
+  // ─────────────────────────────────────────────────────────────
+  // Profile CRUD
+  // ─────────────────────────────────────────────────────────────
+
+  // User-facing list (default — what /profiles UI shows).
+  addRoute("GET", "/api/v1/agent-profiles", async ({ res }) => {
+    try {
+      const profiles = listUserProfiles(db());
+      const meta = _portRangeMeta(listAllProfiles(db()));
+      sendJson(res, 200, { profiles, ...meta });
+    } catch (err) {
+      _classify(err);
+    }
+  });
+
+  // Admin/all list — includes hidden infra rows + archived rows.
+  addRoute("GET", "/api/v1/agent-profiles/all", async ({ res }) => {
+    try {
+      const profiles = listAllProfiles(db());
+      const meta = _portRangeMeta(profiles);
+      sendJson(res, 200, { profiles, ...meta });
+    } catch (err) {
+      _classify(err);
+    }
+  });
+
+  // Resolver — side-effect-free precedence lookup. Used by Lane IV's
+  // channel routes once they migrate off hard-coded 'main'.
+  addRoute("GET", "/api/v1/agent-profiles/resolve", async ({ res, query }) => {
+    try {
+      const channel_kind = query.get("channel_kind");
+      if (!channel_kind) {
+        throw new ValidationError("channel_kind (query param) is required");
+      }
+      const channel_identity = query.get("channel_identity");
+      const slug = resolveProfileForChannel(db(), channel_kind, channel_identity);
+      sendJson(res, 200, {
+        channel_kind,
+        channel_identity,
+        profile_slug: slug,
+      });
+    } catch (err) {
+      _classify(err);
+    }
+  });
+
+  addRoute("GET", "/api/v1/agent-profiles/:slug", async ({ res, params }) => {
+    try {
+      const slug = params.slug;
+      const profile = getProfile(db(), slug);
+      if (!profile) throw new NotFoundError(`profile '${slug}' not found`);
+      const bindings = listBindingsForProfile(db(), slug);
+      sendJson(res, 200, { profile, bindings });
+    } catch (err) {
+      _classify(err);
+    }
+  });
+
+  // POST — create. Returns 202 because Hermes-side activation is Lane II.
+  addRoute("POST", "/api/v1/agent-profiles", async ({ res, body }) => {
+    try {
+      const b = asObj(body);
+      // We DO NOT call validateSlug here — createProfile does it internally,
+      // and the route layer's job is just to coax the body into the right
+      // shape and surface the error.
+      const slug = reqStr(b, "slug");
+      const label = reqStr(b, "label");
+      const model = reqStr(b, "model");
+      const description = optStr(b, "description");
+      const persona_template = optStr(b, "persona_template");
+      const shape_raw = optStr(b, "deployment_shape");
+      const deployment_shape =
+        shape_raw === "supervised" || shape_raw === "sibling"
+          ? shape_raw
+          : undefined;
+
+      // Surface "invalid slug shape" as 400 even before we hit the lib
+      // — gives a clean message and is exactly what the smoke contract
+      // says ("CREATE with bad slug → 400, NOT 500").
+      try {
+        validateSlug(slug);
+      } catch (err) {
+        // validateSlug throws "slug ... is reserved" → 409 via _classify,
+        // and shape errors → 400 via _classify. Let it propagate.
+        _classify(err);
+      }
+
+      const profile = createProfile(db(), {
+        slug,
+        label,
+        model,
+        description,
+        persona_template,
+        deployment_shape,
+      });
+      sendJson(res, 202, {
+        profile,
+        note:
+          "Registry row written (status='pending'). Hermes-side activation lands in Lane II.",
+      });
+    } catch (err) {
+      _classify(err);
+    }
+  });
+
+  // DELETE — archive. Idempotent on already-archived; refuses reserved.
+  addRoute("DELETE", "/api/v1/agent-profiles/:slug", async ({ res, params }) => {
+    try {
+      const profile = archiveProfile(db(), params.slug);
+      sendJson(res, 200, {
+        profile,
+        note:
+          "Registry row archived. Hermes-side teardown + Vaultwarden tidy land in Lane II / Lane VI.",
+      });
+    } catch (err) {
+      _classify(err);
+    }
+  });
+
+  // ─────────────────────────────────────────────────────────────
+  // Channel bindings
+  // ─────────────────────────────────────────────────────────────
+
+  addRoute(
+    "GET",
+    "/api/v1/agent-profiles/:slug/bindings",
+    async ({ res, params }) => {
+      try {
+        const slug = params.slug;
+        const profile = getProfile(db(), slug);
+        if (!profile) throw new NotFoundError(`profile '${slug}' not found`);
+        const bindings = listBindingsForProfile(db(), slug);
+        sendJson(res, 200, { profile_slug: slug, bindings });
+      } catch (err) {
+        _classify(err);
+      }
+    },
+  );
+
+  // POST :slug/bindings — bind (or rebind) (channel_kind, channel_identity)
+  // to this profile. UPSERT semantics — if the channel is already bound,
+  // the existing row is updated rather than duplicated. The
+  // 'binding-default-<kind>' rows are seeded with channel_identity=NULL;
+  // POST with no channel_identity overwrites the default cleanly.
+  addRoute(
+    "POST",
+    "/api/v1/agent-profiles/:slug/bindings",
+    async ({ res, params, body }) => {
+      try {
+        const slug = params.slug;
+        const b = asObj(body);
+        const channel_kind = reqStr(b, "channel_kind");
+        const channel_identity = optStr(b, "channel_identity");
+        if (!KNOWN_CHANNEL_KINDS.has(channel_kind)) {
+          throw new ValidationError(
+            `channel_kind '${channel_kind}' is not known (allowed: ${[...KNOWN_CHANNEL_KINDS].join(", ")})`,
+          );
+        }
+        const profile = getProfile(db(), slug);
+        if (!profile) throw new NotFoundError(`profile '${slug}' not found`);
+        const binding = bindChannel(db(), {
+          channel_kind,
+          channel_identity,
+          profile_slug: slug,
+        });
+        sendJson(res, 200, { binding });
+      } catch (err) {
+        _classify(err);
+      }
+    },
+  );
+
+  addRoute(
+    "DELETE",
+    "/api/v1/agent-profiles/:slug/bindings/:binding_id",
+    async ({ res, params }) => {
+      try {
+        const slug = params.slug;
+        const profile = getProfile(db(), slug);
+        if (!profile) throw new NotFoundError(`profile '${slug}' not found`);
+        unbindChannel(db(), params.binding_id);
+        sendJson(res, 200, { ok: true, binding_id: params.binding_id });
+      } catch (err) {
+        _classify(err);
+      }
+    },
+  );
+}

--- a/packages/ctrl/src/api/server.ts
+++ b/packages/ctrl/src/api/server.ts
@@ -71,6 +71,7 @@ import { registerAlfredJournalRoutes } from "./routes/alfredJournal.js";
 import { registerAlfredDeliverRoutes } from "./routes/alfredDeliver.js";
 import { registerFilesRoutes } from "./routes/files.js";
 import { registerChannelsTailscaleRoutes } from "./routes/channels_tailscale.js";
+import { registerProfileRoutes } from "./routes/profiles.js";
 
 export interface RouteParams {
   [key: string]: string;
@@ -235,6 +236,10 @@ export function createApiServer(): http.Server {
   // PR 3 wires the /connections web card; PR 4 the Caddy + Serve story.
   // See docs/specs/issue-109-tailscale-via-ui.md.
   registerChannelsTailscaleRoutes();
+  // Multi-profile Hermes registry (#120 Lane I). Registry-only — no
+  // Hermes-side activation yet (Lane II); no channel-route rewiring (Lane IV).
+  // See packages/ctrl/src/db/migrations/0017_agent_profiles.sql.
+  registerProfileRoutes();
 
   const server = http.createServer(async (req: IncomingMessage, res: ServerResponse) => {
     const start = Date.now();

--- a/packages/ctrl/src/db/agentProfiles.ts
+++ b/packages/ctrl/src/db/agentProfiles.ts
@@ -1,0 +1,491 @@
+// agentProfiles — multi-profile Hermes registry helpers (#120 Lane I).
+//
+// Backed by the `agent_profile` + `channel_profile_binding` tables added in
+// 0017_agent_profiles.sql. Pure DB lib — no HTTP, no fs, no docker exec. The
+// HTTP surface (routes/profiles.ts) is the only place that translates these
+// helper errors into ApiError statuses; everything else (Lane II supervisor,
+// Lane IV channel routes) calls these helpers directly.
+//
+// Port-allocation rule (Contract 2 in /tmp/orchestrator-120-contracts.md):
+//   * 18789..18793 are RESERVED for the four infra profiles (seeded in the
+//     migration; allocator never touches them).
+//   * 18794..18799 (six slots) are user-facing. allocateUserPort returns the
+//     lowest free port; createProfile rejects when the range is exhausted.
+//
+// Slug rule:
+//   * `^[a-z][a-z0-9-]{1,30}$` — kebab-case, 2..31 chars.
+//   * Reserved set rejects 'main' / 'workers' / 'heavy' / 'codex-builder'
+//     (the seeded infra rows; user must rename to override) plus operational
+//     hot-words ('init', 'system', 'admin', 'root', 'default') so a future
+//     surface that takes a slug as a path segment cannot collide.
+//
+// Reserved-profile guard:
+//   * is_reserved=1 rows cannot be archived. The DB schema does not enforce
+//     this (a stray UPDATE could still flip archived_at); the contract is
+//     "all writes go through archiveProfile / setProfileStatus".
+//
+// Default-binding guard:
+//   * Binding ids starting with 'binding-default-' are the per-kind defaults
+//     seeded by the migration. unbindChannel refuses to delete them so the
+//     fallback table never has a hole. The principal CAN rebind the default
+//     (via bindChannel with channel_identity=null and the same kind), which
+//     UPSERTs the existing row rather than inserting a new one.
+import type { DatabaseSync } from "node:sqlite";
+import { ulid } from "./ulid.js";
+
+export const PORT_RANGE_USER_LO = 18794;
+export const PORT_RANGE_USER_HI = 18799;
+
+export const RESERVED_SLUGS: ReadonlySet<string> = new Set([
+  "main",
+  "workers",
+  "heavy",
+  "codex-builder",
+  "init",
+  "system",
+  "admin",
+  "root",
+  "default",
+]);
+
+export const KNOWN_CHANNEL_KINDS: ReadonlySet<string> = new Set([
+  "telegram",
+  "slack",
+  "sms",
+  "email",
+  "paperclip",
+  "terminal",
+  "voice",
+  "ha",
+  "omi",
+  "recall",
+  "tailscale",
+]);
+
+export type ProfileStatus = "pending" | "running" | "stopped" | "archived";
+export type DeploymentShape = "supervised" | "sibling";
+
+export interface AgentProfile {
+  slug: string;
+  label: string;
+  description: string | null;
+  model: string;
+  deployment_shape: DeploymentShape;
+  api_server_port: number;
+  persona_template: string | null;
+  status: ProfileStatus;
+  is_user_facing: boolean;
+  is_reserved: boolean;
+  created_at: number;
+  updated_at: number;
+  archived_at: number | null;
+}
+
+export interface ChannelProfileBinding {
+  id: string;
+  channel_kind: string;
+  channel_identity: string | null;
+  profile_slug: string;
+  created_at: number;
+}
+
+export interface CreateProfileInput {
+  slug: string;
+  label: string;
+  description?: string | null;
+  model: string;
+  persona_template?: string | null;
+  deployment_shape?: DeploymentShape;
+}
+
+const _SLUG_RE = /^[a-z][a-z0-9-]{1,30}$/;
+
+interface ProfileRow {
+  slug: string;
+  label: string;
+  description: string | null;
+  model: string;
+  deployment_shape: string;
+  api_server_port: number;
+  persona_template: string | null;
+  status: string;
+  is_user_facing: number;
+  is_reserved: number;
+  created_at: number;
+  updated_at: number;
+  archived_at: number | null;
+}
+
+interface BindingRow {
+  id: string;
+  channel_kind: string;
+  channel_identity: string | null;
+  profile_slug: string;
+  created_at: number;
+}
+
+function _row2profile(r: ProfileRow): AgentProfile {
+  return {
+    slug: r.slug,
+    label: r.label,
+    description: r.description,
+    model: r.model,
+    deployment_shape: r.deployment_shape as DeploymentShape,
+    api_server_port: r.api_server_port,
+    persona_template: r.persona_template,
+    status: r.status as ProfileStatus,
+    is_user_facing: r.is_user_facing === 1,
+    is_reserved: r.is_reserved === 1,
+    created_at: r.created_at,
+    updated_at: r.updated_at,
+    archived_at: r.archived_at,
+  };
+}
+
+function _row2binding(r: BindingRow): ChannelProfileBinding {
+  return {
+    id: r.id,
+    channel_kind: r.channel_kind,
+    channel_identity: r.channel_identity,
+    profile_slug: r.profile_slug,
+    created_at: r.created_at,
+  };
+}
+
+export function validateSlug(slug: unknown): string {
+  if (typeof slug !== "string") {
+    throw new Error("slug must be a string");
+  }
+  if (!_SLUG_RE.test(slug)) {
+    throw new Error(
+      `slug must match ${_SLUG_RE.source} (lowercase alnum + hyphens; 2..31 chars; must start with a letter)`,
+    );
+  }
+  if (RESERVED_SLUGS.has(slug)) {
+    throw new Error(`slug '${slug}' is reserved`);
+  }
+  return slug;
+}
+
+export function listAllProfiles(db: DatabaseSync): AgentProfile[] {
+  const rows = db
+    .prepare(
+      `SELECT slug, label, description, model, deployment_shape,
+              api_server_port, persona_template, status,
+              is_user_facing, is_reserved,
+              created_at, updated_at, archived_at
+       FROM agent_profile
+       ORDER BY is_reserved DESC, api_server_port ASC`,
+    )
+    .all() as ProfileRow[];
+  return rows.map(_row2profile);
+}
+
+export function listUserProfiles(db: DatabaseSync): AgentProfile[] {
+  const rows = db
+    .prepare(
+      `SELECT slug, label, description, model, deployment_shape,
+              api_server_port, persona_template, status,
+              is_user_facing, is_reserved,
+              created_at, updated_at, archived_at
+       FROM agent_profile
+       WHERE is_user_facing = 1 AND archived_at IS NULL
+       ORDER BY is_reserved DESC, api_server_port ASC`,
+    )
+    .all() as ProfileRow[];
+  return rows.map(_row2profile);
+}
+
+export function getProfile(db: DatabaseSync, slug: string): AgentProfile | null {
+  const row = db
+    .prepare(
+      `SELECT slug, label, description, model, deployment_shape,
+              api_server_port, persona_template, status,
+              is_user_facing, is_reserved,
+              created_at, updated_at, archived_at
+       FROM agent_profile
+       WHERE slug = ?`,
+    )
+    .get(slug) as ProfileRow | undefined;
+  return row ? _row2profile(row) : null;
+}
+
+// Lowest unused port in 18794..18799 among rows where archived_at IS NULL.
+// Returns null when the range is exhausted.
+export function allocateUserPort(db: DatabaseSync): number | null {
+  const used = new Set<number>(
+    (db
+      .prepare(
+        `SELECT api_server_port FROM agent_profile
+         WHERE archived_at IS NULL
+           AND api_server_port BETWEEN ? AND ?`,
+      )
+      .all(PORT_RANGE_USER_LO, PORT_RANGE_USER_HI) as { api_server_port: number }[]).map(
+      (r) => r.api_server_port,
+    ),
+  );
+  for (let p = PORT_RANGE_USER_LO; p <= PORT_RANGE_USER_HI; p++) {
+    if (!used.has(p)) return p;
+  }
+  return null;
+}
+
+export function createProfile(db: DatabaseSync, input: CreateProfileInput): AgentProfile {
+  // Slug + reserved-set check.
+  const slug = validateSlug(input.slug);
+
+  if (typeof input.label !== "string" || !input.label.trim()) {
+    throw new Error("label (non-empty string) is required");
+  }
+  if (typeof input.model !== "string" || !input.model.trim()) {
+    throw new Error("model (non-empty string) is required");
+  }
+  const shape: DeploymentShape = input.deployment_shape ?? "supervised";
+  if (shape !== "supervised") {
+    // v1 only writes 'supervised'. Sibling-container profiles are registered
+    // out-of-band in Lane VI (Joe's pre-existing cratchit) and the registry
+    // row is inserted there directly, not via this API.
+    throw new Error(
+      `deployment_shape '${shape}' not supported in v1 (sibling-container profiles must be registered via Lane VI's tooling)`,
+    );
+  }
+
+  // Duplicate slug — explicit check beats catching the SQLite UNIQUE error
+  // because we want the message to be route-classifiable as a 409.
+  const existing = db
+    .prepare("SELECT slug FROM agent_profile WHERE slug = ?")
+    .get(slug);
+  if (existing) {
+    throw new Error(`slug '${slug}' already exists`);
+  }
+
+  const port = allocateUserPort(db);
+  if (port == null) {
+    throw new Error(
+      `no free user-facing port (range ${PORT_RANGE_USER_LO}..${PORT_RANGE_USER_HI} exhausted; max 6 user profiles per tenant)`,
+    );
+  }
+
+  const now = Date.now();
+  db.prepare(
+    `INSERT INTO agent_profile
+       (slug, label, description, model, deployment_shape,
+        api_server_port, persona_template, status,
+        is_user_facing, is_reserved,
+        created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', 1, 0, ?, ?)`,
+  ).run(
+    slug,
+    input.label.trim(),
+    input.description?.trim() || null,
+    input.model.trim(),
+    shape,
+    port,
+    input.persona_template ?? null,
+    now,
+    now,
+  );
+
+  const created = getProfile(db, slug);
+  if (!created) {
+    // The INSERT above just succeeded; this branch is "should never happen".
+    throw new Error(`profile '${slug}' not found after insert`);
+  }
+  return created;
+}
+
+export function archiveProfile(db: DatabaseSync, slug: string): AgentProfile {
+  const p = getProfile(db, slug);
+  if (!p) throw new Error(`profile '${slug}' not found`);
+  if (p.is_reserved) {
+    throw new Error(`profile '${slug}' is reserved and cannot be archived`);
+  }
+  if (p.archived_at != null) {
+    // Idempotent — already archived.
+    return p;
+  }
+  const now = Date.now();
+  db.prepare(
+    `UPDATE agent_profile
+       SET status = 'archived', archived_at = ?, updated_at = ?
+     WHERE slug = ?`,
+  ).run(now, now, slug);
+  const after = getProfile(db, slug);
+  if (!after) throw new Error(`profile '${slug}' not found after archive`);
+  return after;
+}
+
+export function setProfileStatus(
+  db: DatabaseSync,
+  slug: string,
+  status: ProfileStatus,
+): AgentProfile {
+  const p = getProfile(db, slug);
+  if (!p) throw new Error(`profile '${slug}' not found`);
+  if (status === "archived") {
+    // Channel through archiveProfile so archived_at gets stamped too.
+    return archiveProfile(db, slug);
+  }
+  const now = Date.now();
+  db.prepare(
+    `UPDATE agent_profile
+       SET status = ?, updated_at = ?
+     WHERE slug = ?`,
+  ).run(status, now, slug);
+  const after = getProfile(db, slug);
+  if (!after) throw new Error(`profile '${slug}' not found after status flip`);
+  return after;
+}
+
+export function listBindingsForProfile(
+  db: DatabaseSync,
+  slug: string,
+): ChannelProfileBinding[] {
+  const rows = db
+    .prepare(
+      `SELECT id, channel_kind, channel_identity, profile_slug, created_at
+       FROM channel_profile_binding
+       WHERE profile_slug = ?
+       ORDER BY channel_kind, channel_identity NULLS FIRST`,
+    )
+    .all(slug) as BindingRow[];
+  return rows.map(_row2binding);
+}
+
+export function listAllBindings(db: DatabaseSync): ChannelProfileBinding[] {
+  const rows = db
+    .prepare(
+      `SELECT id, channel_kind, channel_identity, profile_slug, created_at
+       FROM channel_profile_binding
+       ORDER BY channel_kind, channel_identity NULLS FIRST`,
+    )
+    .all() as BindingRow[];
+  return rows.map(_row2binding);
+}
+
+// Resolve precedence (the runtime read every Lane IV route will use):
+//   1. exact match on (channel_kind, channel_identity) — operator-set binding.
+//   2. default (channel_kind, NULL) — the per-kind fallback seeded by the
+//      migration; can be rebound but never deleted.
+//   3. 'main' — hard fallback. The migration seeds a default for every
+//      KNOWN_CHANNEL_KIND, so this branch is only hit for unknown kinds.
+export function resolveProfileForChannel(
+  db: DatabaseSync,
+  channel_kind: string,
+  channel_identity: string | null,
+): string {
+  if (channel_identity != null) {
+    const exact = db
+      .prepare(
+        `SELECT profile_slug FROM channel_profile_binding
+         WHERE channel_kind = ? AND channel_identity = ?`,
+      )
+      .get(channel_kind, channel_identity) as { profile_slug: string } | undefined;
+    if (exact) return exact.profile_slug;
+  }
+  const def = db
+    .prepare(
+      `SELECT profile_slug FROM channel_profile_binding
+       WHERE channel_kind = ? AND channel_identity IS NULL`,
+    )
+    .get(channel_kind) as { profile_slug: string } | undefined;
+  if (def) return def.profile_slug;
+  return "main";
+}
+
+export function bindChannel(
+  db: DatabaseSync,
+  args: {
+    channel_kind: string;
+    channel_identity: string | null;
+    profile_slug: string;
+  },
+): ChannelProfileBinding {
+  if (typeof args.channel_kind !== "string" || !args.channel_kind.trim()) {
+    throw new Error("channel_kind (non-empty string) is required");
+  }
+  if (!KNOWN_CHANNEL_KINDS.has(args.channel_kind)) {
+    throw new Error(
+      `channel_kind '${args.channel_kind}' is not a known channel (allowed: ${[...KNOWN_CHANNEL_KINDS].join(", ")})`,
+    );
+  }
+  if (typeof args.profile_slug !== "string" || !args.profile_slug.trim()) {
+    throw new Error("profile_slug (non-empty string) is required");
+  }
+  const target = getProfile(db, args.profile_slug);
+  if (!target) {
+    throw new Error(`profile '${args.profile_slug}' not found`);
+  }
+  if (target.archived_at != null) {
+    throw new Error(
+      `profile '${args.profile_slug}' is archived and cannot accept new bindings`,
+    );
+  }
+
+  const identity = args.channel_identity?.trim() || null;
+  const now = Date.now();
+
+  // UPSERT on (channel_kind, channel_identity). NULL is "default" so the
+  // ON CONFLICT clause hits the (kind, NULL) unique index just like a real
+  // identity would. We reuse the existing id (including the
+  // 'binding-default-*' ids the migration seeded) so the unbind guard
+  // keeps working after a rebind.
+  const existing = db
+    .prepare(
+      `SELECT id FROM channel_profile_binding
+       WHERE channel_kind = ? AND ((? IS NULL AND channel_identity IS NULL) OR channel_identity = ?)`,
+    )
+    .get(args.channel_kind, identity, identity) as { id: string } | undefined;
+
+  if (existing) {
+    db.prepare(
+      `UPDATE channel_profile_binding
+         SET profile_slug = ?
+       WHERE id = ?`,
+    ).run(args.profile_slug, existing.id);
+    const row = db
+      .prepare(
+        `SELECT id, channel_kind, channel_identity, profile_slug, created_at
+         FROM channel_profile_binding
+         WHERE id = ?`,
+      )
+      .get(existing.id) as BindingRow;
+    return _row2binding(row);
+  }
+
+  const id = ulid();
+  db.prepare(
+    `INSERT INTO channel_profile_binding
+       (id, channel_kind, channel_identity, profile_slug, created_at)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run(id, args.channel_kind, identity, args.profile_slug, now);
+
+  const row = db
+    .prepare(
+      `SELECT id, channel_kind, channel_identity, profile_slug, created_at
+       FROM channel_profile_binding
+       WHERE id = ?`,
+    )
+    .get(id) as BindingRow;
+  return _row2binding(row);
+}
+
+export function unbindChannel(db: DatabaseSync, id: string): void {
+  if (typeof id !== "string" || !id.trim()) {
+    throw new Error("binding id (non-empty string) is required");
+  }
+  if (id.startsWith("binding-default-")) {
+    // The per-kind defaults must always exist so resolveProfileForChannel
+    // never falls off the end. Rebind them via bindChannel instead.
+    throw new Error(
+      `binding '${id}' is a default and cannot be unbound (rebind it via POST /:slug/bindings instead)`,
+    );
+  }
+  const row = db
+    .prepare("SELECT id FROM channel_profile_binding WHERE id = ?")
+    .get(id);
+  if (!row) {
+    throw new Error(`binding '${id}' not found`);
+  }
+  db.prepare("DELETE FROM channel_profile_binding WHERE id = ?").run(id);
+}

--- a/packages/ctrl/src/db/migrate.ts
+++ b/packages/ctrl/src/db/migrate.ts
@@ -30,6 +30,7 @@ import m0013 from "./migrations/0013_recall_realtime.sql";
 import m0014 from "./migrations/0014_tool_disposition.sql";
 import m0015 from "./migrations/0015_composio_user_defaults.sql";
 import m0016 from "./migrations/0016_files_extraction.sql";
+import m0017 from "./migrations/0017_agent_profiles.sql";
 
 interface Migration {
   version: number;
@@ -55,6 +56,7 @@ const MIGRATIONS: Migration[] = [
   { version: 14, name: "tool_disposition",    sql: m0014 },
   { version: 15, name: "composio_user_defaults", sql: m0015 },
   { version: 16, name: "files_extraction",    sql: m0016 },
+  { version: 17, name: "agent_profiles",      sql: m0017 },
 ];
 
 /**

--- a/packages/ctrl/src/db/migrations/0017_agent_profiles.sql
+++ b/packages/ctrl/src/db/migrations/0017_agent_profiles.sql
@@ -1,0 +1,156 @@
+-- 0017_agent_profiles — multi-profile Hermes registry (issue #120 Lane I).
+--
+-- Today Alfred = one user-facing `main` profile + a handful of background
+-- infra profiles (`workers`, `heavy`, optionally `codex-builder`). The
+-- principal's intent (per issue #120) is to be able to spawn additional
+-- user-facing personas — Joe's tenant did this by hand with a
+-- `docker-compose.override.yaml` sibling container for `cratchit`; this
+-- table is the productized seam that captures intent durably in state.db.
+--
+-- This migration ONLY introduces the registry. It deliberately does NOT
+-- rewire Hermes' supervisor or any channel route — that's Lane II / IV
+-- follow-up work. Until those land, channel routes still hard-code
+-- `main`; the registry just records what the principal asked for.
+--
+-- Tables:
+--   * agent_profile           — one row per Hermes profile (reserved infra
+--                               + user-facing personas).
+--   * channel_profile_binding — which profile a given channel kind (or
+--                               channel identity) is bound to.
+--
+-- Plus a `profile_slug` column added to channel_tokens so token-bearer
+-- channels (HA, future shapes) can carry the binding in the token itself.
+--
+-- Seed rules:
+--   * The four reserved infra slots are seeded so the registry is the
+--     single source of truth from boot. `is_reserved=1` blocks DELETE;
+--     `is_user_facing=0` keeps workers/heavy/codex-builder out of the
+--     UI list. `main` IS surfaced (is_user_facing=1) since it's the
+--     principal-facing conversational agent.
+--   * Each known channel kind seeds a `(channel_kind, NULL, 'main')`
+--     binding so back-compat reads return `main` until the principal
+--     explicitly rebinds via Lane III's UI.
+--
+-- Port allocation rule (enforced in code, not SQL):
+--   18789..18793 reserved for infra; 18794..18799 for user-facing.
+--   Hard cap = 6 user-facing profiles per tenant (port range exhausted).
+
+CREATE TABLE IF NOT EXISTS agent_profile (
+  slug              TEXT PRIMARY KEY,
+                       -- ^[a-z][a-z0-9-]{1,30}$ enforced at the API layer.
+  label             TEXT NOT NULL,
+                       -- Human-friendly name (e.g. "Cratchit", "Alfred").
+  description       TEXT,
+                       -- Short summary the picker shows. Optional.
+  model             TEXT NOT NULL,
+                       -- Provider/model id passed to Hermes config (e.g.
+                       -- "x-ai/grok-4.3", "anthropic/claude-opus-4-6").
+  deployment_shape  TEXT NOT NULL DEFAULT 'supervised',
+                       -- 'supervised' | 'sibling'. v1 only writes
+                       -- 'supervised'; 'sibling' admits Joe's existing
+                       -- override-file rig at registry level (Lane VI).
+  api_server_port   INTEGER NOT NULL,
+                       -- Hermes /v1 port. 18789..18793 infra; 18794..18799
+                       -- user-facing.
+  persona_template  TEXT,
+                       -- Raw SOUL.md seed; written into the profile dir on
+                       -- first render (Lane II). NULL = use Hermes' stock
+                       -- persona.
+  status            TEXT NOT NULL DEFAULT 'pending',
+                       -- 'pending'  — registry written, Hermes side not yet
+                       --              activated.
+                       -- 'running'  — Hermes gateway responding on the port.
+                       -- 'stopped'  — process intentionally not launched
+                       --              (e.g. codex-builder when the flag is
+                       --              off; user-soft-stopped profile).
+                       -- 'archived' — DELETE'd; port freed for reuse.
+  is_user_facing    INTEGER NOT NULL DEFAULT 1,
+                       -- 1 = appears in /profiles list and ProfileSwitcher.
+                       -- 0 = infra; hidden from UI.
+  is_reserved       INTEGER NOT NULL DEFAULT 0,
+                       -- 1 = cannot be deleted; cannot be created via API.
+                       -- The four seeded infra rows.
+  created_at        INTEGER NOT NULL,
+  updated_at        INTEGER NOT NULL,
+  archived_at       INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_profile_status
+  ON agent_profile(status) WHERE archived_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_agent_profile_port
+  ON agent_profile(api_server_port) WHERE archived_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_agent_profile_user_facing
+  ON agent_profile(is_user_facing) WHERE archived_at IS NULL;
+
+-- Seed the four reserved infra slots. is_user_facing=1 on `main` since
+-- the principal does see Alfred on every conversational channel; the
+-- other three (workers/heavy/codex-builder) are background.
+INSERT INTO agent_profile (
+  slug, label, description, model, deployment_shape,
+  api_server_port, status, is_user_facing, is_reserved,
+  created_at, updated_at
+) VALUES
+  ('main',          'Alfred',
+   'Your conversational Alfred on every channel (Slack/Telegram/SMS), with memory.',
+   'x-ai/grok-4.3', 'supervised', 18789, 'running', 1, 1,
+   strftime('%s','now')*1000, strftime('%s','now')*1000),
+  ('workers',       'Workers',
+   'Clerk, curator, janitor, distiller — cheap, high-volume background work.',
+   'openai/gpt-4.1-nano', 'supervised', 18790, 'running', 0, 1,
+   strftime('%s','now')*1000, strftime('%s','now')*1000),
+  ('heavy',         'Heavy',
+   'Onboarding facts/patterns + chore heavy-reasoning — Opus-class, slow and expensive.',
+   'anthropic/claude-opus-4-6', 'supervised', 18791, 'running', 0, 1,
+   strftime('%s','now')*1000, strftime('%s','now')*1000),
+  ('codex-builder', 'Codex builder',
+   'Sealed builder runtime — uid 10001, egress-jailed. Flag-gated; off on most tenants.',
+   'gpt-5-codex', 'supervised', 18793, 'stopped', 0, 1,
+   strftime('%s','now')*1000, strftime('%s','now')*1000)
+ON CONFLICT(slug) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS channel_profile_binding (
+  id              TEXT PRIMARY KEY,
+                       -- 'binding-default-<kind>' for the (kind, NULL)
+                       -- defaults; ULID for everything else. The prefix
+                       -- guards DELETE in the API layer.
+  channel_kind    TEXT NOT NULL,
+                       -- 'telegram'|'slack'|'sms'|'email'|'paperclip'|
+                       -- 'terminal'|'voice'|'ha'|'omi'|'recall'|'tailscale'.
+                       -- Enforced at the API layer (KNOWN_CHANNEL_KINDS).
+  channel_identity TEXT,
+                       -- channel-side identity (e.g. telegram chat id,
+                       -- slack workspace, twilio number); NULL = default
+                       -- binding for the kind.
+  profile_slug    TEXT NOT NULL REFERENCES agent_profile(slug),
+  created_at      INTEGER NOT NULL,
+  UNIQUE (channel_kind, channel_identity)
+);
+
+CREATE INDEX IF NOT EXISTS idx_channel_profile_binding_profile
+  ON channel_profile_binding(profile_slug);
+
+-- Seed: every known channel kind defaults to 'main' for back-compat.
+-- Lane III's UI rebinds these one row at a time.
+INSERT OR IGNORE INTO channel_profile_binding
+  (id, channel_kind, channel_identity, profile_slug, created_at)
+VALUES
+  ('binding-default-telegram',  'telegram',  NULL, 'main', strftime('%s','now')*1000),
+  ('binding-default-slack',     'slack',     NULL, 'main', strftime('%s','now')*1000),
+  ('binding-default-sms',       'sms',       NULL, 'main', strftime('%s','now')*1000),
+  ('binding-default-email',     'email',     NULL, 'main', strftime('%s','now')*1000),
+  ('binding-default-paperclip', 'paperclip', NULL, 'main', strftime('%s','now')*1000),
+  ('binding-default-terminal',  'terminal',  NULL, 'main', strftime('%s','now')*1000),
+  ('binding-default-voice',     'voice',     NULL, 'main', strftime('%s','now')*1000),
+  ('binding-default-ha',        'ha',        NULL, 'main', strftime('%s','now')*1000),
+  ('binding-default-omi',       'omi',       NULL, 'main', strftime('%s','now')*1000),
+  ('binding-default-recall',    'recall',    NULL, 'main', strftime('%s','now')*1000),
+  ('binding-default-tailscale', 'tailscale', NULL, 'main', strftime('%s','now')*1000);
+
+-- Extend channel_tokens with profile pointer (back-compat: nullable,
+-- callers that have not been Lane-IV-updated still implicitly carry 'main').
+ALTER TABLE channel_tokens ADD COLUMN profile_slug TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_channel_tokens_profile
+  ON channel_tokens(profile_slug) WHERE revoked_at IS NULL;

--- a/packages/ctrl/tests/agent-profiles.test.ts
+++ b/packages/ctrl/tests/agent-profiles.test.ts
@@ -1,0 +1,484 @@
+// agent-profiles — registry helper lib unit tests (#120 Lane I).
+//
+// Exercises the typed lib in src/db/agentProfiles.ts against an in-memory
+// state.db with migrations applied. The HTTP surface is tested separately
+// at the route layer; this file covers the contract every Lane (II/III/IV)
+// reads from.
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import schema from "../src/db/schema.sql";
+import { runMigrations } from "../src/db/migrate.js";
+import {
+  PORT_RANGE_USER_LO,
+  PORT_RANGE_USER_HI,
+  RESERVED_SLUGS,
+  KNOWN_CHANNEL_KINDS,
+  validateSlug,
+  listAllProfiles,
+  listUserProfiles,
+  getProfile,
+  allocateUserPort,
+  createProfile,
+  archiveProfile,
+  setProfileStatus,
+  listBindingsForProfile,
+  listAllBindings,
+  resolveProfileForChannel,
+  bindChannel,
+  unbindChannel,
+} from "../src/db/agentProfiles.js";
+
+function freshDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  db.exec(schema);
+  runMigrations(db);
+  return db;
+}
+
+describe("agentProfiles — seed", () => {
+  it("seeds the four reserved infra profiles", () => {
+    const db = freshDb();
+    const all = listAllProfiles(db);
+    const slugs = all.map((p) => p.slug).sort();
+    assert.deepEqual(slugs, ["codex-builder", "heavy", "main", "workers"]);
+    for (const p of all) {
+      assert.equal(p.is_reserved, true, `${p.slug} must be reserved`);
+    }
+    db.close();
+  });
+
+  it("seeds main as the only user-facing profile", () => {
+    const db = freshDb();
+    const user = listUserProfiles(db);
+    assert.equal(user.length, 1);
+    assert.equal(user[0].slug, "main");
+    assert.equal(user[0].is_user_facing, true);
+    db.close();
+  });
+
+  it("seeds reserved profiles on the correct infra ports", () => {
+    const db = freshDb();
+    const portFor = (slug: string) =>
+      getProfile(db, slug)?.api_server_port ?? -1;
+    assert.equal(portFor("main"), 18789);
+    assert.equal(portFor("workers"), 18790);
+    assert.equal(portFor("heavy"), 18791);
+    assert.equal(portFor("codex-builder"), 18793);
+    db.close();
+  });
+
+  it("seeds a (kind, NULL, 'main') default binding for every known channel kind", () => {
+    const db = freshDb();
+    const all = listAllBindings(db);
+    const defaults = all.filter((b) => b.channel_identity === null);
+    assert.equal(
+      defaults.length,
+      KNOWN_CHANNEL_KINDS.size,
+      "one default per known channel kind",
+    );
+    for (const d of defaults) {
+      assert.equal(d.profile_slug, "main");
+      assert.ok(
+        d.id.startsWith("binding-default-"),
+        `default binding id has the expected prefix: ${d.id}`,
+      );
+    }
+    db.close();
+  });
+});
+
+describe("agentProfiles — validateSlug", () => {
+  it("accepts kebab-case slugs", () => {
+    assert.equal(validateSlug("cratchit"), "cratchit");
+    assert.equal(validateSlug("sentinel-2"), "sentinel-2");
+    assert.equal(validateSlug("a1"), "a1");
+  });
+
+  it("rejects malformed slugs", () => {
+    assert.throws(() => validateSlug("Cratchit"), /must match/);
+    assert.throws(() => validateSlug("with_underscore"), /must match/);
+    assert.throws(() => validateSlug("a"), /must match/, "too short");
+    assert.throws(() => validateSlug("1starts-with-digit"), /must match/);
+    assert.throws(() => validateSlug("has space"), /must match/);
+    assert.throws(() => validateSlug(""), /must match/);
+    assert.throws(() => validateSlug("x".repeat(32)), /must match/, "too long");
+    assert.throws(() => validateSlug(123 as unknown), /must be a string/);
+  });
+
+  it("rejects every reserved slug", () => {
+    for (const slug of RESERVED_SLUGS) {
+      assert.throws(
+        () => validateSlug(slug),
+        /reserved/,
+        `${slug} must be reserved`,
+      );
+    }
+  });
+});
+
+describe("agentProfiles — port allocation", () => {
+  it("returns 18794 on a fresh tenant", () => {
+    const db = freshDb();
+    assert.equal(allocateUserPort(db), PORT_RANGE_USER_LO);
+    db.close();
+  });
+
+  it("packs densely as profiles are created", () => {
+    const db = freshDb();
+    const a = createProfile(db, { slug: "alpha", label: "A", model: "m" });
+    const b = createProfile(db, { slug: "bravo", label: "B", model: "m" });
+    const c = createProfile(db, { slug: "charlie", label: "C", model: "m" });
+    assert.equal(a.api_server_port, 18794);
+    assert.equal(b.api_server_port, 18795);
+    assert.equal(c.api_server_port, 18796);
+    assert.equal(allocateUserPort(db), 18797);
+    db.close();
+  });
+
+  it("reuses a freed port after archive", () => {
+    const db = freshDb();
+    createProfile(db, { slug: "alpha", label: "A", model: "m" }); // 18794
+    createProfile(db, { slug: "bravo", label: "B", model: "m" }); // 18795
+    archiveProfile(db, "alpha"); // frees 18794
+    const c = createProfile(db, { slug: "charlie", label: "C", model: "m" });
+    assert.equal(c.api_server_port, 18794, "lowest free port reused");
+    db.close();
+  });
+
+  it("returns null when range is exhausted", () => {
+    const db = freshDb();
+    for (let i = 0; i < 6; i++) {
+      createProfile(db, { slug: `p${i}`, label: `P${i}`, model: "m" });
+    }
+    assert.equal(allocateUserPort(db), null);
+    db.close();
+  });
+});
+
+describe("agentProfiles — createProfile", () => {
+  it("creates a pending user-facing profile and packs the next free port", () => {
+    const db = freshDb();
+    const p = createProfile(db, {
+      slug: "cratchit",
+      label: "Cratchit",
+      model: "x-ai/grok-4.3",
+      description: "Joe's personal assistant",
+    });
+    assert.equal(p.slug, "cratchit");
+    assert.equal(p.label, "Cratchit");
+    assert.equal(p.description, "Joe's personal assistant");
+    assert.equal(p.status, "pending");
+    assert.equal(p.is_user_facing, true);
+    assert.equal(p.is_reserved, false);
+    assert.equal(p.deployment_shape, "supervised");
+    assert.ok(
+      p.api_server_port >= PORT_RANGE_USER_LO &&
+        p.api_server_port <= PORT_RANGE_USER_HI,
+      `port in user range, got ${p.api_server_port}`,
+    );
+    db.close();
+  });
+
+  it("rejects a reserved slug", () => {
+    const db = freshDb();
+    assert.throws(
+      () => createProfile(db, { slug: "main", label: "x", model: "m" }),
+      /reserved/,
+    );
+    db.close();
+  });
+
+  it("rejects a duplicate slug", () => {
+    const db = freshDb();
+    createProfile(db, { slug: "alpha", label: "A", model: "m" });
+    assert.throws(
+      () => createProfile(db, { slug: "alpha", label: "A2", model: "m" }),
+      /already exists/,
+    );
+    db.close();
+  });
+
+  it("rejects 'sibling' deployment shape in v1", () => {
+    const db = freshDb();
+    assert.throws(
+      () =>
+        createProfile(db, {
+          slug: "alpha",
+          label: "A",
+          model: "m",
+          deployment_shape: "sibling",
+        }),
+      /not supported in v1/,
+    );
+    db.close();
+  });
+
+  it("rejects beyond 6 user profiles per tenant", () => {
+    const db = freshDb();
+    for (let i = 0; i < 6; i++) {
+      createProfile(db, { slug: `p${i}`, label: `P${i}`, model: "m" });
+    }
+    assert.throws(
+      () => createProfile(db, { slug: "seven", label: "7", model: "m" }),
+      /no free user-facing port/,
+    );
+    db.close();
+  });
+
+  it("rejects empty label / model", () => {
+    const db = freshDb();
+    assert.throws(
+      () => createProfile(db, { slug: "alpha", label: "", model: "m" }),
+      /label/,
+    );
+    assert.throws(
+      () => createProfile(db, { slug: "alpha", label: "A", model: "" }),
+      /model/,
+    );
+    db.close();
+  });
+});
+
+describe("agentProfiles — archive", () => {
+  it("refuses to archive a reserved profile", () => {
+    const db = freshDb();
+    assert.throws(() => archiveProfile(db, "main"), /reserved/);
+    assert.throws(() => archiveProfile(db, "workers"), /reserved/);
+    db.close();
+  });
+
+  it("archives a user profile and stamps archived_at", () => {
+    const db = freshDb();
+    const before = createProfile(db, {
+      slug: "alpha",
+      label: "A",
+      model: "m",
+    });
+    assert.equal(before.archived_at, null);
+    const after = archiveProfile(db, "alpha");
+    assert.equal(after.status, "archived");
+    assert.ok(after.archived_at != null);
+    db.close();
+  });
+
+  it("is idempotent — re-archiving returns the same row", () => {
+    const db = freshDb();
+    createProfile(db, { slug: "alpha", label: "A", model: "m" });
+    const a = archiveProfile(db, "alpha");
+    const b = archiveProfile(db, "alpha");
+    assert.equal(a.archived_at, b.archived_at);
+    db.close();
+  });
+
+  it("throws on unknown slug", () => {
+    const db = freshDb();
+    assert.throws(() => archiveProfile(db, "nope"), /not found/);
+    db.close();
+  });
+});
+
+describe("agentProfiles — setProfileStatus", () => {
+  it("flips status without touching other fields", () => {
+    const db = freshDb();
+    const before = createProfile(db, {
+      slug: "alpha",
+      label: "A",
+      model: "m",
+    });
+    const after = setProfileStatus(db, "alpha", "running");
+    assert.equal(after.status, "running");
+    assert.equal(after.label, before.label);
+    assert.equal(after.api_server_port, before.api_server_port);
+    db.close();
+  });
+
+  it("routes status='archived' through archiveProfile", () => {
+    const db = freshDb();
+    createProfile(db, { slug: "alpha", label: "A", model: "m" });
+    const after = setProfileStatus(db, "alpha", "archived");
+    assert.equal(after.status, "archived");
+    assert.ok(after.archived_at != null);
+    db.close();
+  });
+});
+
+describe("agentProfiles — channel bindings", () => {
+  it("resolves to the default profile when no exact match exists", () => {
+    const db = freshDb();
+    assert.equal(resolveProfileForChannel(db, "telegram", "12345"), "main");
+    assert.equal(resolveProfileForChannel(db, "telegram", null), "main");
+    db.close();
+  });
+
+  it("overrides the default with bindChannel(kind, NULL)", () => {
+    const db = freshDb();
+    createProfile(db, { slug: "cratchit", label: "C", model: "m" });
+    bindChannel(db, {
+      channel_kind: "telegram",
+      channel_identity: null,
+      profile_slug: "cratchit",
+    });
+    assert.equal(
+      resolveProfileForChannel(db, "telegram", null),
+      "cratchit",
+      "default rebound",
+    );
+    assert.equal(
+      resolveProfileForChannel(db, "telegram", "99999"),
+      "cratchit",
+      "default applies to unbound identities",
+    );
+    db.close();
+  });
+
+  it("exact (kind, id) binding beats default; other ids fall back to default", () => {
+    const db = freshDb();
+    createProfile(db, { slug: "alpha", label: "A", model: "m" });
+    createProfile(db, { slug: "bravo", label: "B", model: "m" });
+    // default 'telegram' → 'main' (seeded)
+    // (telegram, '111') → 'alpha'
+    bindChannel(db, {
+      channel_kind: "telegram",
+      channel_identity: "111",
+      profile_slug: "alpha",
+    });
+    assert.equal(resolveProfileForChannel(db, "telegram", "111"), "alpha");
+    assert.equal(resolveProfileForChannel(db, "telegram", "222"), "main");
+    db.close();
+  });
+
+  it("rejects unknown channel_kind", () => {
+    const db = freshDb();
+    createProfile(db, { slug: "alpha", label: "A", model: "m" });
+    assert.throws(
+      () =>
+        bindChannel(db, {
+          channel_kind: "wibble",
+          channel_identity: null,
+          profile_slug: "alpha",
+        }),
+      /not a known channel/,
+    );
+    db.close();
+  });
+
+  it("rejects binding to an archived profile", () => {
+    const db = freshDb();
+    createProfile(db, { slug: "alpha", label: "A", model: "m" });
+    archiveProfile(db, "alpha");
+    assert.throws(
+      () =>
+        bindChannel(db, {
+          channel_kind: "telegram",
+          channel_identity: "111",
+          profile_slug: "alpha",
+        }),
+      /archived/,
+    );
+    db.close();
+  });
+
+  it("UPSERTs on rebind — no duplicate rows", () => {
+    const db = freshDb();
+    createProfile(db, { slug: "alpha", label: "A", model: "m" });
+    createProfile(db, { slug: "bravo", label: "B", model: "m" });
+    const a1 = bindChannel(db, {
+      channel_kind: "telegram",
+      channel_identity: "111",
+      profile_slug: "alpha",
+    });
+    const a2 = bindChannel(db, {
+      channel_kind: "telegram",
+      channel_identity: "111",
+      profile_slug: "bravo",
+    });
+    assert.equal(a1.id, a2.id, "same row id");
+    assert.equal(a2.profile_slug, "bravo");
+    const rows = listAllBindings(db).filter(
+      (b) => b.channel_kind === "telegram" && b.channel_identity === "111",
+    );
+    assert.equal(rows.length, 1, "no duplicate row");
+    db.close();
+  });
+
+  it("UPSERTing a default binding reuses the binding-default-* id", () => {
+    const db = freshDb();
+    createProfile(db, { slug: "cratchit", label: "C", model: "m" });
+    const b = bindChannel(db, {
+      channel_kind: "telegram",
+      channel_identity: null,
+      profile_slug: "cratchit",
+    });
+    assert.equal(
+      b.id,
+      "binding-default-telegram",
+      "default row id is reused on rebind",
+    );
+    db.close();
+  });
+
+  it("unbindChannel refuses binding-default-*", () => {
+    const db = freshDb();
+    assert.throws(
+      () => unbindChannel(db, "binding-default-telegram"),
+      /default and cannot be unbound/,
+    );
+    db.close();
+  });
+
+  it("unbindChannel removes a non-default binding; resolve falls back to default", () => {
+    const db = freshDb();
+    createProfile(db, { slug: "alpha", label: "A", model: "m" });
+    const binding = bindChannel(db, {
+      channel_kind: "telegram",
+      channel_identity: "111",
+      profile_slug: "alpha",
+    });
+    assert.equal(resolveProfileForChannel(db, "telegram", "111"), "alpha");
+    unbindChannel(db, binding.id);
+    assert.equal(
+      resolveProfileForChannel(db, "telegram", "111"),
+      "main",
+      "falls back to (kind, NULL) default after unbind",
+    );
+    db.close();
+  });
+
+  it("listBindingsForProfile returns just that profile's bindings", () => {
+    const db = freshDb();
+    createProfile(db, { slug: "alpha", label: "A", model: "m" });
+    bindChannel(db, {
+      channel_kind: "telegram",
+      channel_identity: "111",
+      profile_slug: "alpha",
+    });
+    const main = listBindingsForProfile(db, "main");
+    const alpha = listBindingsForProfile(db, "alpha");
+    assert.equal(
+      main.length,
+      KNOWN_CHANNEL_KINDS.size,
+      "main keeps all per-kind defaults",
+    );
+    assert.equal(alpha.length, 1);
+    assert.equal(alpha[0].channel_kind, "telegram");
+    assert.equal(alpha[0].channel_identity, "111");
+    db.close();
+  });
+});
+
+describe("agentProfiles — channel_tokens.profile_slug column", () => {
+  it("is present after migration", () => {
+    const db = freshDb();
+    const colNames = (
+      db.prepare("PRAGMA table_info(channel_tokens)").all() as {
+        name: string;
+      }[]
+    ).map((r) => r.name);
+    assert.ok(
+      colNames.includes("profile_slug"),
+      "channel_tokens.profile_slug column added by 0017",
+    );
+    db.close();
+  });
+});

--- a/packages/ctrl/tests/alfred-journal.test.ts
+++ b/packages/ctrl/tests/alfred-journal.test.ts
@@ -52,16 +52,17 @@ function tableNames(db: DatabaseSync): string[] {
 describe("alfred_journal migration", () => {
   it("bumps user_version to the latest migration", () => {
     // The runner applies every migration > current version, so the value
-    // naturally tracks the highest registered version. Today: 15
+    // naturally tracks the highest registered version. Today: 17
     // (0001 fix_pack + 0002 alfred_journal + 0003 tailscale_connection
     // + 0004 channel_tokens + 0005 ha_channel + 0006 files_table
     // + 0007 recall + 0008 ha_event_subscription
     // + 0009 ha_registry_vanished + 0010 files_cold_archive
     // + 0011 ha_tier4 + 0012 ha_integration_ref_removed_at
     // + 0013 recall_realtime + 0014 tool_disposition
-    // + 0015 composio_user_defaults).
+    // + 0015 composio_user_defaults + 0016 files_extraction
+    // + 0017 agent_profiles).
     const db = makeDb();
-    assert.equal(userVersion(db), 15);
+    assert.equal(userVersion(db), 17);
     db.close();
   });
 

--- a/packages/ctrl/tests/migrate.test.ts
+++ b/packages/ctrl/tests/migrate.test.ts
@@ -36,16 +36,17 @@ describe("state.db migration runner", () => {
     const db = new DatabaseSync(":memory:");
     db.exec(schema);
     const v = runMigrations(db);
-    // Latest version moves as new migrations land. Today: 16
+    // Latest version moves as new migrations land. Today: 17
     // (0001_fix_pack + 0002_alfred_journal + 0003_tailscale_connection
     // + 0004_channel_tokens + 0005_ha_channel + 0006_files_table
     // + 0007_recall + 0008_ha_event_subscription
     // + 0009_ha_registry_vanished + 0010_files_cold_archive
     // + 0011_ha_tier4 + 0012_ha_integration_ref_removed_at
     // + 0013_recall_realtime + 0014_tool_disposition
-    // + 0015_composio_user_defaults + 0016_files_extraction).
-    assert.equal(v, 16, "migrated to latest version");
-    assert.equal(userVersion(db), 16);
+    // + 0015_composio_user_defaults + 0016_files_extraction
+    // + 0017_agent_profiles).
+    assert.equal(v, 17, "migrated to latest version");
+    assert.equal(userVersion(db), 17);
     assert.ok(cols(db, "observation").includes("processed_at"), "0001: processed_at present after migrate");
     // 0002: alfred_journal + alfred_principal tables present.
     const tables = (
@@ -262,6 +263,59 @@ describe("state.db migration runner", () => {
       );
     }
 
+    // 0017: agent_profile + channel_profile_binding tables present, the
+    // four reserved infra rows seeded, the per-channel-kind default
+    // bindings seeded, and channel_tokens.profile_slug column added
+    // (#120 Lane I).
+    assert.ok(
+      tables.includes("agent_profile"),
+      "0017: agent_profile table created",
+    );
+    assert.ok(
+      tables.includes("channel_profile_binding"),
+      "0017: channel_profile_binding table created",
+    );
+    const reservedSlugs = (
+      db
+        .prepare(
+          "SELECT slug FROM agent_profile WHERE is_reserved = 1 ORDER BY slug",
+        )
+        .all() as { slug: string }[]
+    ).map((r) => r.slug);
+    assert.deepEqual(
+      reservedSlugs,
+      ["codex-builder", "heavy", "main", "workers"],
+      "0017: four reserved infra profiles seeded",
+    );
+    const defaultBindingKinds = (
+      db
+        .prepare(
+          "SELECT channel_kind FROM channel_profile_binding WHERE id LIKE 'binding-default-%' ORDER BY channel_kind",
+        )
+        .all() as { channel_kind: string }[]
+    ).map((r) => r.channel_kind);
+    assert.deepEqual(
+      defaultBindingKinds,
+      [
+        "email",
+        "ha",
+        "omi",
+        "paperclip",
+        "recall",
+        "slack",
+        "sms",
+        "tailscale",
+        "telegram",
+        "terminal",
+        "voice",
+      ],
+      "0017: per-channel-kind default bindings seeded",
+    );
+    assert.ok(
+      cols(db, "channel_tokens").includes("profile_slug"),
+      "0017: channel_tokens.profile_slug column added",
+    );
+
     db.close();
   });
 
@@ -270,7 +324,7 @@ describe("state.db migration runner", () => {
     db.exec(schema);
     runMigrations(db);
     const v2 = runMigrations(db);
-    assert.equal(v2, 16);
+    assert.equal(v2, 17);
     assert.equal(
       cols(db, "observation").filter((c) => c === "processed_at").length,
       1,


### PR DESCRIPTION
## Summary

Foundation lane for multi-profile Hermes (#120). This PR introduces the
`agent_profile` registry and the HTTP surface for managing profiles +
channel bindings. **Registry-only — no behaviour change** for any existing
runtime path.

References #120 (Lane III's UI PR is what closes the issue).

## What ships

### state.db migration `0017_agent_profiles`

- `agent_profile` table (slug PK, label, model, deployment_shape,
  api_server_port, persona_template, status, is_user_facing, is_reserved,
  timestamps).
- `channel_profile_binding` table (`(channel_kind, channel_identity)` →
  `profile_slug`, `UNIQUE(channel_kind, channel_identity)`).
- `channel_tokens.profile_slug` column (nullable, back-compat).
- Seed: 4 reserved infra profiles (`main` / `workers` / `heavy` /
  `codex-builder`) on the existing infra ports `18789..18793`.
- Seed: one `(channel_kind, NULL, 'main')` default binding per known
  channel kind so every Lane-IV-aware call returns `'main'` until
  the principal explicitly rebinds.
- `user_version` 16 → 17.

### `src/db/agentProfiles.ts` — typed helper lib

`validateSlug` / `allocateUserPort` / `createProfile` / `archiveProfile` /
`setProfileStatus` / `listAllProfiles` / `listUserProfiles` / `getProfile` /
`listBindingsForProfile` / `listAllBindings` / `bindChannel` / `unbindChannel` /
`resolveProfileForChannel`.

Rules baked in:
- Slug regex `^[a-z][a-z0-9-]{1,30}$` + `RESERVED_SLUGS` set
  (main/workers/heavy/codex-builder/init/system/admin/root/default).
- User-port allocator over `18794..18799`; hard cap **6** user profiles
  per tenant.
- `resolveProfileForChannel` precedence: **(1)** exact `(kind, identity)`,
  **(2)** default `(kind, NULL)`, **(3)** fallback `'main'`.
- `unbindChannel` refuses `binding-default-*` ids so the fallback table
  never has a hole.
- `bindChannel` UPSERTs on `(kind, identity)` and reuses the seeded
  `binding-default-*` id when rebinding a default, so the refuse-delete
  guard keeps working after a rebind.

### `src/api/routes/profiles.ts` — HTTP surface

```
GET    /api/v1/agent-profiles
GET    /api/v1/agent-profiles/all
GET    /api/v1/agent-profiles/resolve?channel_kind=&channel_identity=
GET    /api/v1/agent-profiles/:slug
POST   /api/v1/agent-profiles                                 (202)
DELETE /api/v1/agent-profiles/:slug
GET    /api/v1/agent-profiles/:slug/bindings
POST   /api/v1/agent-profiles/:slug/bindings
DELETE /api/v1/agent-profiles/:slug/bindings/:binding_id
```

Error classification:
- 409 — slug already exists, reserved slug, port range exhausted,
  attempt to unbind a `binding-default-*`, archived target profile,
  `'sibling'` deployment shape (v1 only writes `'supervised'`).
- 404 — referenced profile/binding missing.
- 400 — input shape (bad slug regex, missing required field,
  unknown channel_kind).

`POST` returns **202 Accepted** because Hermes-side activation lands
in Lane II — the registry row writes immediately but no gateway is
started. `DELETE` returns 200 with a `note` because Hermes-side
teardown also lands in Lane II / Lane VI.

## Tests

- `tests/agent-profiles.test.ts` — 33 unit tests covering migration
  seed, slug validation, port allocation (pack densely, reuse on
  archive, range exhaustion), create/archive/setStatus, channel
  binding resolve precedence, UPSERT on rebind, default-binding
  non-deletability, `channel_tokens.profile_slug` column present.
- `tests/migrate.test.ts` — `user_version` 16 → 17, plus 0017
  column/seed assertions.
- `tests/alfred-journal.test.ts` — `user_version` 15 → 17 (this
  assertion was already stale at 15 after PR #194 landed and
  wasn't bumped; fixing it here keeps this PR's CI signal clean).

```
ℹ tests 50  ℹ pass 50  ℹ fail 0
```

Full `npm test` runs the rest of the ctrl-api suite (1076 tests, 1046
pass). The remaining 9 failures are preexisting flakes in
`channels_ha_hacs.test.ts` + `ha_ws_client.test.ts` — neither file
touched in this PR, both failing the same way on `origin/main`.

## What does NOT ship in this lane

| Surface | Lane | Status |
|---|---|---|
| Hermes supervisor/render reads the registry, starts new profiles | II | spec'd, queued |
| `/profiles` UI + ProfileSwitcher | III | spec'd, queued |
| Channel routes (`channels_paperclip.ts`, `telegram.ts`, `slack.ts`,
  `sms.ts`, `alfredDeliver.ts`, `voice.ts`, `channels_ha.ts`) read
  the resolver | IV | spec'd, queued |
| Joe's `cratchit` sibling-container registered as `'sibling'` shape | VI | spec'd, queued |

Lane II flips `status` `'pending' → 'running'`. Lane IV is where
`POST /api/v1/agent-profiles` becomes a real spawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)