### PR TITLE
feat(ctrl): #120 Lane IV — channel routes resolve target profile

### DIFF
--- a/packages/ctrl/src/api/routes/alfredDeliver.ts
+++ b/packages/ctrl/src/api/routes/alfredDeliver.ts
@@ -60,6 +60,7 @@ import {
   markJournalDelivered,
   resolvePrincipal,
 } from "../../db/alfredJournal.js";
+import { resolveProfileContextForChannel } from "../../db/agentProfiles.js";
 import { resolveDeliveryTarget } from "../hermes-sessions.js";
 import { dockerExec } from "../helpers.js";
 import { slackPostMessage } from "./slack.js";
@@ -94,20 +95,26 @@ interface DeliveryResult {
  * Telegram delivery — direct Bot API call (api.telegram.org).
  *
  * The bot token lives in the hermes container's per-profile .env
- * (`$HERMES_HOME/profiles/main/.env` — TELEGRAM_BOT_TOKEN). We read it
- * via `docker exec hermes cat`. Telegram receives the bytes on the
- * chat_id; from Sir's phone it looks like @alfred_black_the_butler_bot
- * sent the message — same as inbound replies.
+ * (`$HERMES_HOME/profiles/<slug>/.env` — TELEGRAM_BOT_TOKEN), where <slug>
+ * is the profile bound to (`telegram`, chat_id) per the channel_profile_binding
+ * registry. Lane I default seed keeps every channel pointing at `main` until
+ * Lane III's UI rebinds explicitly. We read via `docker exec hermes cat`.
+ * Telegram receives the bytes on the chat_id; from Sir's phone it looks like
+ * the bot sent the message — same as inbound replies.
  */
 async function deliverTelegram(
+  profile: string,
   chatId: string,
   text: string,
 ): Promise<DeliveryResult> {
-  // Lazy-read the token. Cache for 60s — restart-bouncing the hermes
-  // container shouldn't slow every send.
-  const token = await getTelegramBotToken();
+  // Lazy-read the token. Cache for 60s per profile — restart-bouncing the
+  // hermes container shouldn't slow every send.
+  const token = await getTelegramBotToken(profile);
   if (!token) {
-    return { ok: false, error: "no TELEGRAM_BOT_TOKEN in hermes main profile .env" };
+    return {
+      ok: false,
+      error: `no TELEGRAM_BOT_TOKEN in hermes ${profile} profile .env`,
+    };
   }
   try {
     const r = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
@@ -133,25 +140,32 @@ async function deliverTelegram(
   }
 }
 
-let _tgTokenCache: { value: string; at: number } | null = null;
+// One bot-token cache per profile slug. The map is unbounded but each entry
+// is a (string, number) — 6 user-facing + 4 infra profiles is a hard cap, so
+// memory is bounded by the registry's port range.
+const _tgTokenCache: Map<string, { value: string; at: number }> = new Map();
 const TG_TOKEN_TTL_MS = 60_000;
 
-async function getTelegramBotToken(): Promise<string | null> {
+async function getTelegramBotToken(profile: string): Promise<string | null> {
   const now = Date.now();
-  if (_tgTokenCache && now - _tgTokenCache.at < TG_TOKEN_TTL_MS) {
-    return _tgTokenCache.value || null;
+  const cached = _tgTokenCache.get(profile);
+  if (cached && now - cached.at < TG_TOKEN_TTL_MS) {
+    return cached.value || null;
   }
   try {
     const stdout = await dockerExec("hermes", [
       "sh",
       "-c",
-      "grep ^TELEGRAM_BOT_TOKEN= $HERMES_HOME/profiles/main/.env 2>/dev/null | cut -d= -f2-",
+      `grep ^TELEGRAM_BOT_TOKEN= $HERMES_HOME/profiles/${profile}/.env 2>/dev/null | cut -d= -f2-`,
     ]);
     const token = stdout.trim().replace(/^["']|["']$/g, "");
-    _tgTokenCache = { value: token, at: now };
+    _tgTokenCache.set(profile, { value: token, at: now });
     return token || null;
   } catch (e) {
-    console.warn("[alfred-deliver] failed to read telegram bot token:", e);
+    console.warn(
+      `[alfred-deliver] failed to read telegram bot token (${profile}):`,
+      e,
+    );
     return null;
   }
 }
@@ -160,22 +174,24 @@ async function getTelegramBotToken(): Promise<string | null> {
  * Slack delivery — direct chat.postMessage call.
  *
  * The bot token lives in the hermes container's per-profile .env
- * (`$HERMES_HOME/profiles/main/.env` — `SLACK_BOT_TOKEN`). We read it via
- * `docker exec hermes cat` (60s cache, same shape as the Telegram adapter).
- * Slack receives the bytes on `chat_id` (channel id, user id for DM-to-self,
- * or group id); the bot must already be a member of the channel for posts
- * to land. Failure surfaces as `{ ok: false, error }` so the journal
- * records the truth.
+ * (`$HERMES_HOME/profiles/<slug>/.env` — `SLACK_BOT_TOKEN`), where <slug>
+ * is the profile bound to (`slack`, chat_id) per the channel_profile_binding
+ * registry. We read it via `docker exec hermes cat` (60s cache, same shape as
+ * the Telegram adapter). Slack receives the bytes on `chat_id` (channel id,
+ * user id for DM-to-self, or group id); the bot must already be a member of
+ * the channel for posts to land. Failure surfaces as `{ ok: false, error }`
+ * so the journal records the truth.
  */
 async function deliverSlack(
+  profile: string,
   chatId: string,
   text: string,
 ): Promise<DeliveryResult> {
-  const token = await getSlackBotToken();
+  const token = await getSlackBotToken(profile);
   if (!token) {
     return {
       ok: false,
-      error: "no SLACK_BOT_TOKEN in hermes main profile .env",
+      error: `no SLACK_BOT_TOKEN in hermes ${profile} profile .env`,
     };
   }
   const r = await slackPostMessage(token, chatId, text);
@@ -183,30 +199,35 @@ async function deliverSlack(
   return { ok: false, error: r.error };
 }
 
-let _slackTokenCache: { value: string; at: number } | null = null;
+const _slackTokenCache: Map<string, { value: string; at: number }> = new Map();
 const SLACK_TOKEN_TTL_MS = 60_000;
 
-async function getSlackBotToken(): Promise<string | null> {
+async function getSlackBotToken(profile: string): Promise<string | null> {
   const now = Date.now();
-  if (_slackTokenCache && now - _slackTokenCache.at < SLACK_TOKEN_TTL_MS) {
-    return _slackTokenCache.value || null;
+  const cached = _slackTokenCache.get(profile);
+  if (cached && now - cached.at < SLACK_TOKEN_TTL_MS) {
+    return cached.value || null;
   }
   try {
     const stdout = await dockerExec("hermes", [
       "sh",
       "-c",
-      "grep ^SLACK_BOT_TOKEN= $HERMES_HOME/profiles/main/.env 2>/dev/null | cut -d= -f2-",
+      `grep ^SLACK_BOT_TOKEN= $HERMES_HOME/profiles/${profile}/.env 2>/dev/null | cut -d= -f2-`,
     ]);
     const token = stdout.trim().replace(/^["']|["']$/g, "");
-    _slackTokenCache = { value: token, at: now };
+    _slackTokenCache.set(profile, { value: token, at: now });
     return token || null;
   } catch (e) {
-    console.warn("[alfred-deliver] failed to read slack bot token:", e);
+    console.warn(
+      `[alfred-deliver] failed to read slack bot token (${profile}):`,
+      e,
+    );
     return null;
   }
 }
 
 async function deliverEmail(
+  _profile: string,
   _chatId: string,
   _text: string,
 ): Promise<DeliveryResult> {
@@ -218,16 +239,17 @@ async function deliverEmail(
 
 async function deliverByChannel(
   channel: string,
+  profile: string,
   chatId: string,
   text: string,
 ): Promise<DeliveryResult> {
   switch (channel) {
     case "telegram":
-      return deliverTelegram(chatId, text);
+      return deliverTelegram(profile, chatId, text);
     case "slack":
-      return deliverSlack(chatId, text);
+      return deliverSlack(profile, chatId, text);
     case "email":
-      return deliverEmail(chatId, text);
+      return deliverEmail(profile, chatId, text);
     case "webchat":
       return {
         ok: false,
@@ -319,6 +341,13 @@ export function registerAlfredDeliverRoutes(): void {
       }
     }
 
+    // Lane IV — resolve the target Hermes profile for this (channel, chat_id).
+    // The default-binding seeds in 0017_agent_profiles keep every channel
+    // pointing at 'main' until Lane III's UI rebinds explicitly. After
+    // rebinding, an outbound to a bound chat_id reads tokens from THAT
+    // profile's .env and journal entries scope to THAT profile.
+    const profileCtx = resolveProfileContextForChannel(db, channel, to);
+
     const pending = appendJournal(db, {
       channel,
       chat_id: to,
@@ -327,6 +356,7 @@ export function registerAlfredDeliverRoutes(): void {
       status: "pending",
       source_kind: typeof b.source_kind === "string" ? b.source_kind : null,
       source_ref: typeof b.source_ref === "string" ? b.source_ref : null,
+      hermes_profile: profileCtx.journal_scope_key,
       metadata: {
         urgency,
         principal_note:
@@ -341,7 +371,12 @@ export function registerAlfredDeliverRoutes(): void {
     });
 
     // ── Deliver the bytes via the channel adapter.
-    const result = await deliverByChannel(channel, to, message);
+    const result = await deliverByChannel(
+      channel,
+      profileCtx.slug,
+      to,
+      message,
+    );
 
     if (!result.ok) {
       const updated = markJournalDelivered(db, pending.id, {

--- a/packages/ctrl/src/api/routes/alfredJournal.ts
+++ b/packages/ctrl/src/api/routes/alfredJournal.ts
@@ -105,11 +105,17 @@ export function registerAlfredJournalRoutes(): void {
     sendJson(res, 201, entry);
   });
 
-  // GET /api/v1/alfred-journal/recent?channel=…&chat_id=…&limit=…&within_hours=…
-  //   OR ?principal_id=…&limit=…&within_hours=…
+  // GET /api/v1/alfred-journal/recent?channel=…&chat_id=…&limit=…&within_hours=…[&profile=…]
+  //   OR ?principal_id=…&limit=…&within_hours=…[&profile=…]
   //
   // Hot path: the Hermes pre_gateway_dispatch hook calls this on every
   // inbound message. Indexed query, <5ms typical.
+  //
+  // Lane IV — optional `profile` filter so the One-Alfred plugin can pull
+  // only the target profile's continuity. When omitted, every profile's
+  // history is returned (legacy behaviour, no regression for `main`-only
+  // tenants). Pass `profile=<slug>` to scope. Special token `profile=__none__`
+  // returns only pre-Lane-IV rows (hermes_profile IS NULL).
   addRoute("GET", "/api/v1/alfred-journal/recent", async ({ res, query }) => {
     const limit = Number(query.get("limit") ?? 20);
     const withinHours = Number(query.get("within_hours") ?? 24);
@@ -117,6 +123,7 @@ export function registerAlfredJournalRoutes(): void {
     const principalId = query.get("principal_id");
     const channel = query.get("channel");
     const chatId = query.get("chat_id");
+    const profileParam = query.get("profile");
 
     if (!principalId && !(channel && chatId)) {
       throw new ValidationError(
@@ -124,22 +131,40 @@ export function registerAlfredJournalRoutes(): void {
       );
     }
 
+    // Translate the URL param into queryRecentJournal's hermes_profile arg.
+    //   missing  → undefined → no scoping
+    //   __none__ → null      → hermes_profile IS NULL (pre-Lane-IV rows only)
+    //   <slug>   → <slug>    → exact match
+    let hermesProfile: string | null | undefined;
+    if (profileParam === null) {
+      hermesProfile = undefined;
+    } else if (profileParam === "__none__") {
+      hermesProfile = null;
+    } else {
+      hermesProfile = profileParam;
+    }
+
     const db = getStateDb();
     const entries = principalId
       ? queryRecentJournal(db, { principal_id: principalId }, {
           limit,
           within_hours: withinHours,
+          hermes_profile: hermesProfile,
         })
       : queryRecentJournal(
           db,
           { channel: channel as string, chat_id: chatId as string },
-          { limit, within_hours: withinHours },
+          { limit, within_hours: withinHours, hermes_profile: hermesProfile },
         );
 
     sendJson(res, 200, {
       entries,
       count: entries.length,
-      window: { limit, within_hours: withinHours },
+      window: {
+        limit,
+        within_hours: withinHours,
+        ...(profileParam !== null ? { profile: profileParam } : {}),
+      },
     });
   });
 

--- a/packages/ctrl/src/api/routes/channelsEmail.ts
+++ b/packages/ctrl/src/api/routes/channelsEmail.ts
@@ -35,15 +35,44 @@ import fs from "node:fs";
 
 import { addRoute } from "../server.js";
 import { sendJson, ValidationError } from "../errors.js";
+import { getStateDb } from "../../db/state.js";
+import {
+  resolveProfileContextForChannel,
+  type ProfileChannelContext,
+} from "../../db/agentProfiles.js";
 
 const HERMES_GATEWAY_URL =
   process.env.HERMES_GATEWAY_URL ||
   process.env.OPENCLAW_GATEWAY_URL ||
   "http://hermes:18789";
+const HERMES_HOST =
+  (() => {
+    try {
+      return new URL(HERMES_GATEWAY_URL).hostname;
+    } catch {
+      return "hermes";
+    }
+  })();
+const HERMES_PROTOCOL =
+  (() => {
+    try {
+      return new URL(HERMES_GATEWAY_URL).protocol;
+    } catch {
+      return "http:";
+    }
+  })();
 const GATEWAY_TOKEN_FILE =
   process.env.OPENCLAW_GATEWAY_TOKEN_FILE || "/alfred-data/.gateway-token";
 
-function getGatewayToken(): string {
+/**
+ * Resolve the Hermes token for a target profile. Precedence:
+ *   1. The profile's API_SERVER_KEY read from /hermes-state/profiles/<slug>/.env
+ *      (Lane IV — the only place Hermes' /v1 actually validates).
+ *   2. HERMES_API_KEY / OPENCLAW_GATEWAY_TOKEN env (legacy main-only fallback).
+ *   3. The gateway-token file (back-compat with openclaw-era deployments).
+ */
+function gatewayTokenFor(ctx: ProfileChannelContext): string {
+  if (ctx.api_server_key) return ctx.api_server_key;
   const envToken = (
     process.env.HERMES_API_KEY || process.env.OPENCLAW_GATEWAY_TOKEN || ""
   ).trim();
@@ -53,6 +82,23 @@ function getGatewayToken(): string {
   } catch {
     return "";
   }
+}
+
+function hermesBaseUrlFor(ctx: ProfileChannelContext): string {
+  return `${HERMES_PROTOCOL}//${HERMES_HOST}:${ctx.api_server_port}`;
+}
+
+/**
+ * Resolve the target profile for an inbound email. The channel identity is
+ * the principal-facing recipient address (the first entry in the AgentMail
+ * `to` array — that's the inbox the email was actually delivered to). If
+ * `to` is empty, falls back to the default email binding.
+ */
+function resolveEmailContext(message: any): ProfileChannelContext {
+  const to = Array.isArray(message?.to) ? message.to : [];
+  const identity =
+    (typeof to[0] === "string" && to[0].trim().toLowerCase()) || null;
+  return resolveProfileContextForChannel(getStateDb(), "email", identity);
 }
 
 function buildChannelPrompt(message: any): string {
@@ -222,7 +268,9 @@ export function registerChannelsEmailRoutes(): void {
       return;
     }
 
-    const token = getGatewayToken();
+    // Lane IV — resolve which profile owns this recipient address.
+    const profileCtx = resolveEmailContext(b.message);
+    const token = gatewayTokenFor(profileCtx);
     if (!token) {
       throw new ValidationError(
         "Hermes gateway token not available — cannot start run",
@@ -231,13 +279,15 @@ export function registerChannelsEmailRoutes(): void {
 
     const prompt = buildChannelPrompt(b.message);
 
-    // Fire-and-forget Hermes run on the main profile. We intentionally don't
-    // await the response — the run takes tens of seconds to minutes and
+    // Fire-and-forget Hermes run on the resolved profile. We intentionally
+    // don't await the response — the run takes tens of seconds to minutes and
     // AgentMail has a 5s webhook budget upstream. `session_id` correlates the
-    // run to the email thread so a follow-up reply on the same thread chains
-    // the conversation.
-    const sessionId = `email-${b.message?.thread_id ?? b.message?.message_id ?? b.event_id ?? Date.now()}`;
-    const run = fetch(`${HERMES_GATEWAY_URL}/v1/runs`, {
+    // run to the email thread + profile so cross-profile replies on the same
+    // thread don't accidentally collide (a Sentinel-bound recipient and a
+    // main-bound recipient on different inboxes get different sessions).
+    const sessionId =
+      `agent:${profileCtx.slug}:email-${b.message?.thread_id ?? b.message?.message_id ?? b.event_id ?? Date.now()}`;
+    const run = fetch(`${hermesBaseUrlFor(profileCtx)}/v1/runs`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${token}`,
@@ -260,6 +310,32 @@ export function registerChannelsEmailRoutes(): void {
     // Don't await — let it run in the background.
     void run;
 
-    sendJson(res, 202, { accepted: true, message_id: b.message?.message_id ?? null });
+    sendJson(res, 202, {
+      accepted: true,
+      message_id: b.message?.message_id ?? null,
+      profile: profileCtx.slug,
+    });
   });
+
+  // GET /resolve?to=<address> — Lane IV debug surface.
+  addRoute(
+    "GET",
+    "/api/v1/channels/email/resolve",
+    async ({ res, query }) => {
+      const to = query.get("to")?.trim().toLowerCase() || null;
+      const ctx = resolveProfileContextForChannel(getStateDb(), "email", to);
+      sendJson(res, 200, {
+        channel_kind: "email",
+        channel_identity: to,
+        profile: ctx.slug,
+        bound_profile: ctx.bound_slug,
+        cascaded: ctx.cascaded,
+        api_server_port: ctx.api_server_port,
+        api_server_key_present: ctx.api_server_key != null,
+        profile_dir: ctx.profile_dir,
+        journal_scope: ctx.journal_scope_key,
+        gateway_url: hermesBaseUrlFor(ctx),
+      });
+    },
+  );
 }

--- a/packages/ctrl/src/api/routes/channels_paperclip.ts
+++ b/packages/ctrl/src/api/routes/channels_paperclip.ts
@@ -56,9 +56,33 @@ import { addRoute } from "../server.js";
 import { sendJson, ValidationError, ApiError } from "../errors.js";
 import { getStateDb } from "../../db/state.js";
 import { appendJournal } from "../../db/alfredJournal.js";
+import {
+  resolveProfileContextForChannel,
+  type ProfileChannelContext,
+} from "../../db/agentProfiles.js";
 
-const HERMES_MAIN_URL =
+// Legacy default base URL for the main profile. Used as a fallback when the
+// profile registry hasn't been seeded (should not happen post-Lane-I) and
+// for build-time docs. Per-request URLs are derived from the resolved
+// profile's `api_server_port`.
+const HERMES_DEFAULT_BASE =
   process.env.HERMES_GATEWAY_URL ?? "http://hermes:18789";
+const HERMES_HOST =
+  (() => {
+    try {
+      return new URL(HERMES_DEFAULT_BASE).hostname;
+    } catch {
+      return "hermes";
+    }
+  })();
+const HERMES_PROTOCOL =
+  (() => {
+    try {
+      return new URL(HERMES_DEFAULT_BASE).protocol;
+    } catch {
+      return "http:";
+    }
+  })();
 const HERMES_TIMEOUT_MS = 90_000;
 const REPLAY_WINDOW_SECS = 300;
 const SELF_TEST_HEADER = "x-paperclip-test";
@@ -297,47 +321,39 @@ function extractHermesText(resp: unknown): string {
   return "";
 }
 
-/** Read API_SERVER_KEY for the main Hermes profile out of its rendered
- *  .env. Matches the pattern in hermes.ts `readHermesApiKey()` — the
- *  per-profile key is the one Hermes' gateway actually validates against;
- *  /opt/alfred/.env's HERMES_API_SERVER_KEY is a *seed* for first-boot
- *  but Hermes regenerates it per profile if absent (we observed a
- *  mismatch live: opt/.env=64 chars, profile/.env=43 chars). The .env
- *  file is the source of truth at runtime. ctrl-api has hermes_data
- *  bind-mounted at /hermes-state.
- *
- *  Override via HERMES_CONFIG_DIR for tests (mirrors hermes.ts:387). */
-function readHermesMainApiKey(): string | null {
-  const baseDir = process.env.HERMES_CONFIG_DIR ?? "/hermes-state/profiles";
-  const envPath = `${baseDir}/main/.env`;
-  let raw: string;
-  try {
-    raw = fs.readFileSync(envPath, "utf-8");
-  } catch {
-    return null;
-  }
-  for (const line of raw.split("\n")) {
-    const t = line.trim();
-    if (!t || t.startsWith("#")) continue;
-    const eq = t.indexOf("=");
-    if (eq < 0) continue;
-    if (t.slice(0, eq).trim() === "API_SERVER_KEY") {
-      return t.slice(eq + 1).trim();
-    }
-  }
-  return null;
+/**
+ * Resolve the target Hermes profile for a Paperclip heartbeat. Lane I keys
+ * paperclip bindings by `channel_identity = paperclipAgentId` (the same
+ * value Paperclip's HTTP adapter uses to identify the employee). Until a
+ * principal rebinds via Lane III's UI, every binding resolves to `main`.
+ */
+function resolvePaperclipContext(
+  paperclipAgentId: string | null,
+): ProfileChannelContext {
+  return resolveProfileContextForChannel(
+    getStateDb(),
+    "paperclip",
+    paperclipAgentId,
+  );
+}
+
+/** Build the Hermes /v1 base URL for a resolved profile. */
+function hermesBaseUrlFor(ctx: ProfileChannelContext): string {
+  return `${HERMES_PROTOCOL}//${HERMES_HOST}:${ctx.api_server_port}`;
 }
 
 async function callHermes(
+  ctx: ProfileChannelContext,
   sessionKey: string,
   input: string,
 ): Promise<HermesCallResult | HermesCallFailure> {
-  const url = `${HERMES_MAIN_URL}/v1/responses`;
+  const url = `${hermesBaseUrlFor(ctx)}/v1/responses`;
   // Hermes' /v1/responses validates the Bearer against
-  // /hermes-state/profiles/main/.env's API_SERVER_KEY — NOT /opt/alfred/
-  // .env's HERMES_API_SERVER_KEY. Same key-resolution pattern as
-  // hermes.ts `readHermesApiKey()`.
-  const apiKey = readHermesMainApiKey() ?? "";
+  // /hermes-state/profiles/<slug>/.env's API_SERVER_KEY — NOT /opt/alfred/
+  // .env's HERMES_API_SERVER_KEY (live-observed mismatch 64 vs 43 chars).
+  // The per-profile key is read in resolveProfileContextForChannel via
+  // readHermesProfileApiKey (src/db/agentProfiles.ts).
+  const apiKey = ctx.api_server_key ?? "";
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     "X-Hermes-Session-Key": sessionKey,
@@ -393,7 +409,14 @@ async function callHermes(
 // "in"/"out"). chat_id = paperclip-<paperclipAgentId>, matching the
 // X-Hermes-Session-Key so the journal pivots cleanly off the session.
 
+function paperclipSessionId(ctx: ProfileChannelContext, paperclipAgentId: string): string {
+  return ctx.slug === "main"
+    ? `paperclip-${paperclipAgentId}`
+    : `agent:${ctx.slug}:paperclip:${paperclipAgentId}`;
+}
+
 function journalIn(
+  ctx: ProfileChannelContext,
   paperclipAgentId: string,
   message: string,
   runId: string,
@@ -406,8 +429,8 @@ function journalIn(
       message,
       source_kind: "paperclip-heartbeat",
       source_ref: runId,
-      hermes_session_id: `paperclip-${paperclipAgentId}`,
-      hermes_profile: "main",
+      hermes_session_id: paperclipSessionId(ctx, paperclipAgentId),
+      hermes_profile: ctx.journal_scope_key,
       status: "received",
     });
   } catch (e) {
@@ -419,6 +442,7 @@ function journalIn(
 }
 
 function journalOut(
+  ctx: ProfileChannelContext,
   paperclipAgentId: string,
   message: string,
   runId: string,
@@ -433,8 +457,8 @@ function journalOut(
       message,
       source_kind: "paperclip-reply",
       source_ref: runId,
-      hermes_session_id: `paperclip-${paperclipAgentId}`,
-      hermes_profile: "main",
+      hermes_session_id: paperclipSessionId(ctx, paperclipAgentId),
+      hermes_profile: ctx.journal_scope_key,
       status,
       delivery_error: deliveryError,
     });
@@ -463,10 +487,19 @@ async function processHeartbeat(
   opts: { skipJournal: boolean },
 ): Promise<HeartbeatProcessOutcome> {
   const started = Date.now();
-  const sessionKey = `paperclip-${body.paperclip.paperclipAgentId}`;
+  // Lane IV — resolve which Hermes profile owns this paperclip agent. The
+  // session-key shape carries the profile slug ONLY when we're routing to a
+  // non-main profile, so an existing main-bound paperclip employee keeps
+  // its `paperclip-<id>` session (no Hermes session migration needed). A
+  // newly-bound Sentinel paperclip employee gets `agent:sentinel:paperclip:<id>`.
+  const ctx = resolvePaperclipContext(body.paperclip.paperclipAgentId);
+  const sessionKey =
+    ctx.slug === "main"
+      ? `paperclip-${body.paperclip.paperclipAgentId}`
+      : `agent:${ctx.slug}:paperclip:${body.paperclip.paperclipAgentId}`;
 
   if (!opts.skipJournal) {
-    journalIn(body.paperclip.paperclipAgentId, body.message, body.paperclip.runId);
+    journalIn(ctx, body.paperclip.paperclipAgentId, body.message, body.paperclip.runId);
   }
 
   if (!body.deliver) {
@@ -484,10 +517,11 @@ async function processHeartbeat(
     // Fire-and-forget Hermes call. We swallow errors here because the
     // caller has already been told the heartbeat was accepted (202).
     void (async () => {
-      const result = await callHermes(sessionKey, body.message);
+      const result = await callHermes(ctx, sessionKey, body.message);
       if (!opts.skipJournal) {
         if (result.ok) {
           journalOut(
+            ctx,
             body.paperclip.paperclipAgentId,
             result.text,
             body.paperclip.runId,
@@ -495,6 +529,7 @@ async function processHeartbeat(
           );
         } else {
           journalOut(
+            ctx,
             body.paperclip.paperclipAgentId,
             "",
             body.paperclip.runId,
@@ -512,7 +547,7 @@ async function processHeartbeat(
   }
 
   // Sync mode: await Hermes and ship its text back to Paperclip.
-  const result = await callHermes(sessionKey, body.message);
+  const result = await callHermes(ctx, sessionKey, body.message);
   if (!result.ok) {
     const status = result.code === "HERMES_TIMEOUT" ? 504 : 502;
     const recent: RecentRun = {
@@ -526,6 +561,7 @@ async function processHeartbeat(
     recordRun(recent);
     if (!opts.skipJournal) {
       journalOut(
+        ctx,
         body.paperclip.paperclipAgentId,
         "",
         body.paperclip.runId,
@@ -550,6 +586,7 @@ async function processHeartbeat(
 
   if (!opts.skipJournal) {
     journalOut(
+      ctx,
       body.paperclip.paperclipAgentId,
       result.text,
       body.paperclip.runId,
@@ -873,6 +910,32 @@ async function probeSetupState(): Promise<SetupProbeResult> {
 // ── Routes ────────────────────────────────────────────────────────────────
 
 export function registerPaperclipChannelRoutes(): void {
+  // GET /resolve?paperclip_agent_id=<id> — Lane IV debug surface.
+  addRoute(
+    "GET",
+    "/api/v1/channels/paperclip/resolve",
+    async ({ res, query }) => {
+      const id = query.get("paperclip_agent_id")?.trim() || null;
+      const ctx = resolvePaperclipContext(id);
+      sendJson(res, 200, {
+        channel_kind: "paperclip",
+        channel_identity: id,
+        profile: ctx.slug,
+        bound_profile: ctx.bound_slug,
+        cascaded: ctx.cascaded,
+        api_server_port: ctx.api_server_port,
+        api_server_key_present: ctx.api_server_key != null,
+        profile_dir: ctx.profile_dir,
+        journal_scope: ctx.journal_scope_key,
+        gateway_url: hermesBaseUrlFor(ctx),
+        session_key_prefix:
+          ctx.slug === "main"
+            ? "paperclip-"
+            : `agent:${ctx.slug}:paperclip:`,
+      });
+    },
+  );
+
   // GET /status — always 200; operator card needs every field populated.
   // setup_state extends the original P2 contract (configured/has_signing_secret
   // stay for back-compat); the card uses setup_state to drive the new

--- a/packages/ctrl/src/api/routes/slack.ts
+++ b/packages/ctrl/src/api/routes/slack.ts
@@ -46,14 +46,40 @@ import {
   dockerComposeCmd,
   HERMES_CONTAINER,
 } from "../helpers.js";
+import { getStateDb } from "../../db/state.js";
+import { resolveProfileForChannel } from "../../db/agentProfiles.js";
 
 const VAULT_CLI_URL = process.env.VAULT_CLI_URL || "http://vault-cli:8087";
 const HERMES_HOME =
   process.env.HERMES_HOME_IN_CONTAINER || "/hermes-state";
-const MAIN_PROFILE_DIR = `${HERMES_HOME}/profiles/main`;
-const PROFILE_ENV_PATH = `${MAIN_PROFILE_DIR}/.env`;
 const VAULT_BOT_ITEM_NAME = "Slack Bot Token";
 const VAULT_APP_ITEM_NAME = "Slack App Token";
+
+// Lane IV — per-profile paths. The legacy MAIN_PROFILE_DIR / PROFILE_ENV_PATH
+// constants were the only thing keeping every slack route pointed at main.
+// Each route now resolves a profile per request (?profile=<slug> or fallback
+// to the channel-default binding).
+interface SlackProfilePaths {
+  profileSlug: string;
+  profileDir: string;
+  envPath: string;
+}
+
+function pathsForProfile(slug: string): SlackProfilePaths {
+  const profileDir = `${HERMES_HOME}/profiles/${slug}`;
+  return {
+    profileSlug: slug,
+    profileDir,
+    envPath: `${profileDir}/.env`,
+  };
+}
+
+function resolveSlackProfile(query?: URLSearchParams): SlackProfilePaths {
+  const explicit = query?.get("profile")?.trim() || null;
+  if (explicit) return pathsForProfile(explicit);
+  const slug = resolveProfileForChannel(getStateDb(), "slack", null);
+  return pathsForProfile(slug);
+}
 
 // Slack token shapes (canonical):
 //   Bot User OAuth Token:  xoxb-<team_id>-<bot_id>-<secret>
@@ -221,11 +247,13 @@ const SLACK_ENV_KEYS = [
 ] as const;
 type SlackEnvKey = (typeof SLACK_ENV_KEYS)[number];
 
-async function readProfileEnv(): Promise<Record<string, string>> {
+async function readProfileEnv(
+  paths: SlackProfilePaths,
+): Promise<Record<string, string>> {
   const raw = await dockerExec(HERMES_CONTAINER, [
     "sh",
     "-c",
-    `cat ${PROFILE_ENV_PATH} 2>/dev/null || true`,
+    `cat ${paths.envPath} 2>/dev/null || true`,
   ]);
   const out: Record<string, string> = {};
   for (const line of raw.split("\n")) {
@@ -248,12 +276,13 @@ async function readProfileEnv(): Promise<Record<string, string>> {
 }
 
 async function writeProfileEnvKeys(
+  paths: SlackProfilePaths,
   updates: Partial<Record<SlackEnvKey, string | null>>,
 ): Promise<void> {
   const raw = await dockerExec(HERMES_CONTAINER, [
     "sh",
     "-c",
-    `cat ${PROFILE_ENV_PATH} 2>/dev/null || true`,
+    `cat ${paths.envPath} 2>/dev/null || true`,
   ]);
   const lines = raw === "" ? [] : raw.split("\n");
   if (lines.length && lines[lines.length - 1] === "") lines.pop();
@@ -282,13 +311,13 @@ async function writeProfileEnvKeys(
   }
   const content = out.join("\n") + "\n";
 
-  const tmp = `${PROFILE_ENV_PATH}.tmp.${process.pid}.${Date.now()}`;
+  const tmp = `${paths.envPath}.tmp.${process.pid}.${Date.now()}`;
   await dockerExecWithStdin(
     HERMES_CONTAINER,
     [
       "sh",
       "-c",
-      `mkdir -p ${MAIN_PROFILE_DIR} && cat > ${tmp} && mv ${tmp} ${PROFILE_ENV_PATH}`,
+      `mkdir -p ${paths.profileDir} && cat > ${tmp} && mv ${tmp} ${paths.envPath}`,
     ],
     content,
     30_000,
@@ -465,12 +494,37 @@ async function getSlackManifest(): Promise<string> {
 // ── Routes ────────────────────────────────────────────────────────────────
 
 export function registerSlackRoutes(): void {
+  // GET /resolve?channel_id=<id> — Lane IV debug surface.
+  addRoute("GET", "/api/v1/channels/slack/resolve", async ({ res, query }) => {
+    const channelId = query.get("channel_id")?.trim() || null;
+    const { resolveProfileContextForChannel } = await import(
+      "../../db/agentProfiles.js"
+    );
+    const ctx = resolveProfileContextForChannel(
+      getStateDb(),
+      "slack",
+      channelId,
+    );
+    sendJson(res, 200, {
+      channel_kind: "slack",
+      channel_identity: channelId,
+      profile: ctx.slug,
+      bound_profile: ctx.bound_slug,
+      cascaded: ctx.cascaded,
+      api_server_port: ctx.api_server_port,
+      api_server_key_present: ctx.api_server_key != null,
+      profile_dir: ctx.profile_dir,
+      journal_scope: ctx.journal_scope_key,
+    });
+  });
+
   // GET /status — fail-soft. NEVER 5xx (dashboard polls it).
-  addRoute("GET", "/api/v1/channels/slack/status", async ({ res }) => {
+  addRoute("GET", "/api/v1/channels/slack/status", async ({ res, query }) => {
+    const paths = resolveSlackProfile(query);
     let envMap: Record<string, string> = {};
     let envErr: string | null = null;
     try {
-      envMap = await readProfileEnv();
+      envMap = await readProfileEnv(paths);
     } catch (e) {
       envErr = e instanceof Error ? e.message : String(e);
     }
@@ -571,8 +625,12 @@ export function registerSlackRoutes(): void {
   });
 
   // PUT /tokens — write bot + app tokens + opts to .env + vault, restart hermes.
-  addRoute("PUT", "/api/v1/channels/slack/tokens", async ({ res, body }) => {
-    const b = (body ?? {}) as Record<string, unknown>;
+  addRoute(
+    "PUT",
+    "/api/v1/channels/slack/tokens",
+    async ({ res, body, query }) => {
+      const paths = resolveSlackProfile(query);
+      const b = (body ?? {}) as Record<string, unknown>;
 
     const botToken =
       typeof b.bot_token === "string" ? b.bot_token.trim() : "";
@@ -591,53 +649,60 @@ export function registerSlackRoutes(): void {
       );
     }
 
-    // Optional Phase-2 fields.
-    const updates: Partial<Record<SlackEnvKey, string | null>> = {
-      SLACK_BOT_TOKEN: botToken,
-      SLACK_APP_TOKEN: appToken,
-    };
-    if (typeof b.allowed_users === "string") {
-      updates.SLACK_ALLOWED_USERS = b.allowed_users.trim() || null;
-    }
-    if (typeof b.home_channel === "string") {
-      updates.SLACK_HOME_CHANNEL = b.home_channel.trim() || null;
-    }
-    if (typeof b.allowed_channels === "string") {
-      updates.SLACK_ALLOWED_CHANNELS = b.allowed_channels.trim() || null;
-    }
+      // Optional Phase-2 fields.
+      const updates: Partial<Record<SlackEnvKey, string | null>> = {
+        SLACK_BOT_TOKEN: botToken,
+        SLACK_APP_TOKEN: appToken,
+      };
+      if (typeof b.allowed_users === "string") {
+        updates.SLACK_ALLOWED_USERS = b.allowed_users.trim() || null;
+      }
+      if (typeof b.home_channel === "string") {
+        updates.SLACK_HOME_CHANNEL = b.home_channel.trim() || null;
+      }
+      if (typeof b.allowed_channels === "string") {
+        updates.SLACK_ALLOWED_CHANNELS = b.allowed_channels.trim() || null;
+      }
 
-    // Vaultwarden = canonical store. Two items (bot + app). Both must succeed
-    // before we touch the .env so a vault outage doesn't leave us with the
-    // tokens half-saved (.env set, vault missing).
-    await upsertVaultItem(VAULT_BOT_ITEM_NAME, botToken);
-    await upsertVaultItem(VAULT_APP_ITEM_NAME, appToken);
-    await writeProfileEnvKeys(updates);
-    // Drop the auth.test cache so /status reflects the new token immediately.
-    _authTestCache = null;
-    restartHermes();
-    sendJson(res, 200, { ok: true, state: "configured_starting" });
-  });
+      // Vaultwarden = canonical store. Two items (bot + app). Both must succeed
+      // before we touch the .env so a vault outage doesn't leave us with the
+      // tokens half-saved (.env set, vault missing).
+      await upsertVaultItem(VAULT_BOT_ITEM_NAME, botToken);
+      await upsertVaultItem(VAULT_APP_ITEM_NAME, appToken);
+      await writeProfileEnvKeys(paths, updates);
+      // Drop the auth.test cache so /status reflects the new token immediately.
+      _authTestCache = null;
+      restartHermes();
+      sendJson(res, 200, { ok: true, state: "configured_starting" });
+    },
+  );
 
   // DELETE /tokens — wipe vault items + drop all SLACK_* env keys + restart.
-  addRoute("DELETE", "/api/v1/channels/slack/tokens", async ({ res }) => {
-    await deleteVaultItem(VAULT_BOT_ITEM_NAME);
-    await deleteVaultItem(VAULT_APP_ITEM_NAME);
-    await writeProfileEnvKeys({
-      SLACK_BOT_TOKEN: null,
-      SLACK_APP_TOKEN: null,
-      SLACK_ALLOWED_USERS: null,
-      SLACK_HOME_CHANNEL: null,
-      SLACK_ALLOWED_CHANNELS: null,
-    });
-    _authTestCache = null;
-    restartHermes();
-    sendJson(res, 200, { ok: true, state: "unconfigured" });
-  });
+  addRoute(
+    "DELETE",
+    "/api/v1/channels/slack/tokens",
+    async ({ res, query }) => {
+      const paths = resolveSlackProfile(query);
+      await deleteVaultItem(VAULT_BOT_ITEM_NAME);
+      await deleteVaultItem(VAULT_APP_ITEM_NAME);
+      await writeProfileEnvKeys(paths, {
+        SLACK_BOT_TOKEN: null,
+        SLACK_APP_TOKEN: null,
+        SLACK_ALLOWED_USERS: null,
+        SLACK_HOME_CHANNEL: null,
+        SLACK_ALLOWED_CHANNELS: null,
+      });
+      _authTestCache = null;
+      restartHermes();
+      sendJson(res, 200, { ok: true, state: "unconfigured" });
+    },
+  );
 
   // POST /test — send a real test message via Slack Web API.
   // Target: SLACK_HOME_CHANNEL if set, else the bot's own user_id (DM-to-self).
-  addRoute("POST", "/api/v1/channels/slack/test", async ({ res }) => {
-    const envMap = await readProfileEnv().catch(() => ({}) as Record<string, string>);
+  addRoute("POST", "/api/v1/channels/slack/test", async ({ res, query }) => {
+    const paths = resolveSlackProfile(query);
+    const envMap = await readProfileEnv(paths).catch(() => ({}) as Record<string, string>);
     const botToken = envMap.SLACK_BOT_TOKEN ?? "";
     if (!botToken) {
       throw new ValidationError(

--- a/packages/ctrl/src/api/routes/sms.ts
+++ b/packages/ctrl/src/api/routes/sms.ts
@@ -42,12 +42,36 @@ import {
   dockerComposeCmd,
   HERMES_CONTAINER,
 } from "../helpers.js";
+import { getStateDb } from "../../db/state.js";
+import { resolveProfileForChannel } from "../../db/agentProfiles.js";
 
 const VAULT_CLI_URL = process.env.VAULT_CLI_URL || "http://vault-cli:8087";
 const HERMES_HOME =
   process.env.HERMES_HOME_IN_CONTAINER || "/hermes-state";
-const MAIN_PROFILE_DIR = `${HERMES_HOME}/profiles/main`;
-const PROFILE_ENV_PATH = `${MAIN_PROFILE_DIR}/.env`;
+
+// Lane IV — per-profile paths. Each request resolves which profile owns the
+// SMS channel (?profile=<slug> or the channel-default binding).
+interface SmsProfilePaths {
+  profileSlug: string;
+  profileDir: string;
+  envPath: string;
+}
+
+function pathsForProfile(slug: string): SmsProfilePaths {
+  const profileDir = `${HERMES_HOME}/profiles/${slug}`;
+  return {
+    profileSlug: slug,
+    profileDir,
+    envPath: `${profileDir}/.env`,
+  };
+}
+
+function resolveSmsProfile(query?: URLSearchParams): SmsProfilePaths {
+  const explicit = query?.get("profile")?.trim() || null;
+  if (explicit) return pathsForProfile(explicit);
+  const slug = resolveProfileForChannel(getStateDb(), "sms", null);
+  return pathsForProfile(slug);
+}
 
 const VAULT_SID_ITEM_NAME = "Twilio Account SID";
 const VAULT_TOKEN_ITEM_NAME = "Twilio Auth Token";
@@ -230,11 +254,13 @@ function smsWebhookUrl(): string {
   return dom ? `https://sms.${dom}/webhooks/twilio` : "";
 }
 
-async function readProfileEnv(): Promise<Record<string, string>> {
+async function readProfileEnv(
+  paths: SmsProfilePaths,
+): Promise<Record<string, string>> {
   const raw = await dockerExec(HERMES_CONTAINER, [
     "sh",
     "-c",
-    `cat ${PROFILE_ENV_PATH} 2>/dev/null || true`,
+    `cat ${paths.envPath} 2>/dev/null || true`,
   ]);
   const out: Record<string, string> = {};
   for (const line of raw.split("\n")) {
@@ -257,12 +283,13 @@ async function readProfileEnv(): Promise<Record<string, string>> {
 }
 
 async function writeProfileEnvKeys(
+  paths: SmsProfilePaths,
   updates: Partial<Record<SmsEnvKey, string | null>>,
 ): Promise<void> {
   const raw = await dockerExec(HERMES_CONTAINER, [
     "sh",
     "-c",
-    `cat ${PROFILE_ENV_PATH} 2>/dev/null || true`,
+    `cat ${paths.envPath} 2>/dev/null || true`,
   ]);
   const lines = raw === "" ? [] : raw.split("\n");
   if (lines.length && lines[lines.length - 1] === "") lines.pop();
@@ -291,13 +318,13 @@ async function writeProfileEnvKeys(
   }
   const content = out.join("\n") + "\n";
 
-  const tmp = `${PROFILE_ENV_PATH}.tmp.${process.pid}.${Date.now()}`;
+  const tmp = `${paths.envPath}.tmp.${process.pid}.${Date.now()}`;
   await dockerExecWithStdin(
     HERMES_CONTAINER,
     [
       "sh",
       "-c",
-      `mkdir -p ${MAIN_PROFILE_DIR} && cat > ${tmp} && mv ${tmp} ${PROFILE_ENV_PATH}`,
+      `mkdir -p ${paths.profileDir} && cat > ${tmp} && mv ${tmp} ${paths.envPath}`,
     ],
     content,
     30_000,
@@ -452,10 +479,18 @@ async function twilioSendMessage(
 export async function smsSend(
   text: string,
   to?: string,
+  profileSlug?: string,
 ): Promise<{ ok: true; sid: string } | { ok: false; error: string }> {
+  // Lane IV — resolve which profile's Twilio creds to use. The caller can
+  // pin a profile explicitly; otherwise we read the SMS channel's default
+  // binding (`main` until Lane III rebinds).
+  const slug =
+    profileSlug?.trim() ||
+    resolveProfileForChannel(getStateDb(), "sms", to ?? null);
+  const paths = pathsForProfile(slug);
   let env: Record<string, string>;
   try {
-    env = await readProfileEnv();
+    env = await readProfileEnv(paths);
   } catch (e) {
     return {
       ok: false,
@@ -516,12 +551,37 @@ function maskAccountSid(sid: string): string {
 // ── Routes ────────────────────────────────────────────────────────────────
 
 export function registerSmsRoutes(): void {
+  // GET /resolve?phone=<E.164> — Lane IV debug surface.
+  addRoute("GET", "/api/v1/channels/sms/resolve", async ({ res, query }) => {
+    const phone = query.get("phone")?.trim() || null;
+    const { resolveProfileContextForChannel } = await import(
+      "../../db/agentProfiles.js"
+    );
+    const ctx = resolveProfileContextForChannel(
+      getStateDb(),
+      "sms",
+      phone,
+    );
+    sendJson(res, 200, {
+      channel_kind: "sms",
+      channel_identity: phone,
+      profile: ctx.slug,
+      bound_profile: ctx.bound_slug,
+      cascaded: ctx.cascaded,
+      api_server_port: ctx.api_server_port,
+      api_server_key_present: ctx.api_server_key != null,
+      profile_dir: ctx.profile_dir,
+      journal_scope: ctx.journal_scope_key,
+    });
+  });
+
   // GET /status — fail-soft. NEVER 5xx (dashboard polls it).
-  addRoute("GET", "/api/v1/channels/sms/status", async ({ res }) => {
+  addRoute("GET", "/api/v1/channels/sms/status", async ({ res, query }) => {
+    const paths = resolveSmsProfile(query);
     let envMap: Record<string, string> = {};
     let envErr: string | null = null;
     try {
-      envMap = await readProfileEnv();
+      envMap = await readProfileEnv(paths);
     } catch (e) {
       envErr = e instanceof Error ? e.message : String(e);
     }
@@ -588,35 +648,44 @@ export function registerSmsRoutes(): void {
   // PUT /allowlist — set SMS_ALLOWED_USERS + SMS_ALLOW_ALL_USERS without
   // re-validating credentials. Lets the UI toggle inbound-sender policy
   // independently from a credential rotation.
-  addRoute("PUT", "/api/v1/channels/sms/allowlist", async ({ res, body }) => {
-    const b = (body ?? {}) as Record<string, unknown>;
-    const allowAll = b.allow_all === true;
-    let allowedUsers: string | null = null;
-    if (!allowAll) {
-      const raw = typeof b.allowed_users === "string" ? b.allowed_users.trim() : "";
-      if (raw) {
-        const parts = raw.split(",").map((s) => s.trim()).filter(Boolean);
-        for (const p of parts) {
-          if (!E164_RE.test(p)) {
-            throw new ValidationError(
-              `allowed_users must be comma-separated E.164 numbers — "${p}" is not`,
-            );
+  addRoute(
+    "PUT",
+    "/api/v1/channels/sms/allowlist",
+    async ({ res, body, query }) => {
+      const paths = resolveSmsProfile(query);
+      const b = (body ?? {}) as Record<string, unknown>;
+      const allowAll = b.allow_all === true;
+      let allowedUsers: string | null = null;
+      if (!allowAll) {
+        const raw = typeof b.allowed_users === "string" ? b.allowed_users.trim() : "";
+        if (raw) {
+          const parts = raw.split(",").map((s) => s.trim()).filter(Boolean);
+          for (const p of parts) {
+            if (!E164_RE.test(p)) {
+              throw new ValidationError(
+                `allowed_users must be comma-separated E.164 numbers — "${p}" is not`,
+              );
+            }
           }
+          allowedUsers = parts.join(",");
         }
-        allowedUsers = parts.join(",");
       }
-    }
-    await writeProfileEnvKeys({
-      SMS_ALLOWED_USERS: allowedUsers,
-      SMS_ALLOW_ALL_USERS: allowAll ? "true" : null,
-    });
-    restartHermes();
-    sendJson(res, 200, { ok: true, allow_all: allowAll, allowed_users: allowedUsers ?? "" });
-  });
+      await writeProfileEnvKeys(paths, {
+        SMS_ALLOWED_USERS: allowedUsers,
+        SMS_ALLOW_ALL_USERS: allowAll ? "true" : null,
+      });
+      restartHermes();
+      sendJson(res, 200, { ok: true, allow_all: allowAll, allowed_users: allowedUsers ?? "" });
+    },
+  );
 
   // PUT /credentials — validate against Twilio + vault upsert (3 items) +
   // .env upsert (4 keys) + debounced hermes restart.
-  addRoute("PUT", "/api/v1/channels/sms/credentials", async ({ res, body }) => {
+  addRoute(
+    "PUT",
+    "/api/v1/channels/sms/credentials",
+    async ({ res, body, query }) => {
+      const paths = resolveSmsProfile(query);
     const b = (body ?? {}) as Record<string, unknown>;
 
     const sid = typeof b.account_sid === "string" ? b.account_sid.trim() : "";
@@ -688,33 +757,40 @@ export function registerSmsRoutes(): void {
     if (typeof b.allowed_users === "string") {
       updates.SMS_ALLOWED_USERS = allowedUsers;
     }
-    await writeProfileEnvKeys(updates);
-    // Drop the probe cache so /status reflects the new creds immediately.
-    _accountProbeCache = null;
-    restartHermes();
-    sendJson(res, 200, { ok: true, state: "configured_starting" });
-  });
+      await writeProfileEnvKeys(paths, updates);
+      // Drop the probe cache so /status reflects the new creds immediately.
+      _accountProbeCache = null;
+      restartHermes();
+      sendJson(res, 200, { ok: true, state: "configured_starting" });
+    },
+  );
 
   // DELETE /credentials — wipe all 3 vault items, drop all 4 env keys, restart.
-  addRoute("DELETE", "/api/v1/channels/sms/credentials", async ({ res }) => {
-    await deleteVaultItem(VAULT_SID_ITEM_NAME);
-    await deleteVaultItem(VAULT_TOKEN_ITEM_NAME);
-    await deleteVaultItem(VAULT_PHONE_ITEM_NAME);
-    await writeProfileEnvKeys({
-      TWILIO_ACCOUNT_SID: null,
-      TWILIO_AUTH_TOKEN: null,
-      TWILIO_PHONE_NUMBER: null,
-      SMS_ALLOWED_USERS: null,
-    });
-    _accountProbeCache = null;
-    restartHermes();
-    sendJson(res, 200, { ok: true, state: "unconfigured" });
-  });
+  addRoute(
+    "DELETE",
+    "/api/v1/channels/sms/credentials",
+    async ({ res, query }) => {
+      const paths = resolveSmsProfile(query);
+      await deleteVaultItem(VAULT_SID_ITEM_NAME);
+      await deleteVaultItem(VAULT_TOKEN_ITEM_NAME);
+      await deleteVaultItem(VAULT_PHONE_ITEM_NAME);
+      await writeProfileEnvKeys(paths, {
+        TWILIO_ACCOUNT_SID: null,
+        TWILIO_AUTH_TOKEN: null,
+        TWILIO_PHONE_NUMBER: null,
+        SMS_ALLOWED_USERS: null,
+      });
+      _accountProbeCache = null;
+      restartHermes();
+      sendJson(res, 200, { ok: true, state: "unconfigured" });
+    },
+  );
 
   // POST /test — send a real test message via Twilio. Target: the first
   // entry in SMS_ALLOWED_USERS, mirroring smsSend()'s default recipient.
-  addRoute("POST", "/api/v1/channels/sms/test", async ({ res }) => {
-    const env = await readProfileEnv().catch(
+  addRoute("POST", "/api/v1/channels/sms/test", async ({ res, query }) => {
+    const paths = resolveSmsProfile(query);
+    const env = await readProfileEnv(paths).catch(
       () => ({}) as Record<string, string>,
     );
     const sid = env.TWILIO_ACCOUNT_SID ?? "";

--- a/packages/ctrl/src/api/routes/telegram.ts
+++ b/packages/ctrl/src/api/routes/telegram.ts
@@ -45,15 +45,47 @@ import {
   HERMES_CMD,
   HERMES_CONTAINER,
 } from "../helpers.js";
+import { getStateDb } from "../../db/state.js";
+import { resolveProfileForChannel } from "../../db/agentProfiles.js";
 
 const VAULT_CLI_URL = process.env.VAULT_CLI_URL || "http://vault-cli:8087";
 // Path INSIDE the hermes runtime container. HERMES_HOME=/hermes-state in
 // docker-compose; profiles live at $HERMES_HOME/profiles/<name>/.
 const HERMES_HOME = process.env.HERMES_HOME_IN_CONTAINER || "/hermes-state";
-const MAIN_PROFILE_DIR = `${HERMES_HOME}/profiles/main`;
-const PROFILE_ENV_PATH = `${MAIN_PROFILE_DIR}/.env`;
-const GATEWAY_STATE_PATH = `${MAIN_PROFILE_DIR}/gateway_state.json`;
-const CHANNEL_DIR_PATH = `${MAIN_PROFILE_DIR}/channel_directory.json`;
+
+// Lane IV — per-profile file paths. The legacy MAIN_PROFILE_DIR etc. used
+// to be module-level constants pointing at .../profiles/main; they're now
+// derived per-request from the channel→profile binding.
+interface TelegramProfilePaths {
+  profileSlug: string;
+  profileDir: string;
+  envPath: string;
+  gatewayStatePath: string;
+  channelDirPath: string;
+}
+
+function pathsForProfile(slug: string): TelegramProfilePaths {
+  const profileDir = `${HERMES_HOME}/profiles/${slug}`;
+  return {
+    profileSlug: slug,
+    profileDir,
+    envPath: `${profileDir}/.env`,
+    gatewayStatePath: `${profileDir}/gateway_state.json`,
+    channelDirPath: `${profileDir}/channel_directory.json`,
+  };
+}
+
+/**
+ * Resolve which profile this telegram request targets. The principal can
+ * pin a specific profile via `?profile=<slug>`; otherwise we fall back to
+ * the channel's default binding (`telegram` → main by Lane I seed).
+ */
+function resolveTelegramProfile(query?: URLSearchParams): TelegramProfilePaths {
+  const explicit = query?.get("profile")?.trim() ?? null;
+  if (explicit) return pathsForProfile(explicit);
+  const slug = resolveProfileForChannel(getStateDb(), "telegram", null);
+  return pathsForProfile(slug);
+}
 const VAULT_ITEM_NAME = "Telegram Bot Token";
 // BotFather token shape: <bot_id digits>:<secret>. The original BotFather
 // format was 8-12 digits + exactly 35 char secret; Telegram has since
@@ -195,11 +227,13 @@ const TELEGRAM_ENV_KEYS = [
 ] as const;
 type TelegramEnvKey = (typeof TELEGRAM_ENV_KEYS)[number];
 
-async function readProfileEnv(): Promise<Record<string, string>> {
+async function readProfileEnv(
+  paths: TelegramProfilePaths,
+): Promise<Record<string, string>> {
   // `cat` returns non-zero if the file is missing; tolerate that by reading
   // through `sh -c` and forcing exit 0 on ENOENT — an absent file = no keys.
   const raw = await dockerExec(HERMES_CONTAINER, [
-    "sh", "-c", `cat ${PROFILE_ENV_PATH} 2>/dev/null || true`,
+    "sh", "-c", `cat ${paths.envPath} 2>/dev/null || true`,
   ]);
   const out: Record<string, string> = {};
   for (const line of raw.split("\n")) {
@@ -228,11 +262,12 @@ async function readProfileEnv(): Promise<Record<string, string>> {
  * file appears atomically to anyone reading it (the gateway's reload path).
  */
 async function writeProfileEnvKeys(
+  paths: TelegramProfilePaths,
   updates: Partial<Record<TelegramEnvKey, string | null>>,
 ): Promise<void> {
   // Read existing content as TEXT, so we preserve comments / ordering.
   const raw = await dockerExec(HERMES_CONTAINER, [
-    "sh", "-c", `cat ${PROFILE_ENV_PATH} 2>/dev/null || true`,
+    "sh", "-c", `cat ${paths.envPath} 2>/dev/null || true`,
   ]);
   const lines = raw === "" ? [] : raw.split("\n");
   // Drop a trailing empty token that comes from a final newline so we don't
@@ -263,14 +298,14 @@ async function writeProfileEnvKeys(
   }
   const content = out.join("\n") + "\n";
 
-  const tmp = `${PROFILE_ENV_PATH}.tmp.${process.pid}.${Date.now()}`;
+  const tmp = `${paths.envPath}.tmp.${process.pid}.${Date.now()}`;
   // `mkdir -p` the profile dir so a brand-new profile (no .env yet) still
   // accepts the write — `tee` would otherwise fail on the missing parent.
   await dockerExecWithStdin(
     HERMES_CONTAINER,
     [
       "sh", "-c",
-      `mkdir -p ${MAIN_PROFILE_DIR} && cat > ${tmp} && mv ${tmp} ${PROFILE_ENV_PATH}`,
+      `mkdir -p ${paths.profileDir} && cat > ${tmp} && mv ${tmp} ${paths.envPath}`,
     ],
     content,
     30_000,
@@ -426,9 +461,12 @@ async function sendTelegramMessage(
 // .env is the allowlist the gateway enforces on incoming messages. To
 // actually revoke someone we strip them from BOTH and bounce Hermes so the
 // next message from that chat is rejected.
-async function revokeChatFromDirectory(userId: string): Promise<void> {
+async function revokeChatFromDirectory(
+  paths: TelegramProfilePaths,
+  userId: string,
+): Promise<void> {
   // 1) drop from channel_directory.json
-  const dirBlob = await readJsonFromContainer(CHANNEL_DIR_PATH);
+  const dirBlob = await readJsonFromContainer(paths.channelDirPath);
   if (dirBlob && typeof dirBlob === "object") {
     const root = dirBlob as Record<string, unknown>;
     const platforms = root.platforms as Record<string, unknown> | undefined;
@@ -443,10 +481,10 @@ async function revokeChatFromDirectory(userId: string): Promise<void> {
       if (platforms && filtered.length !== list.length) {
         platforms.telegram = filtered;
         (root as Record<string, unknown>).updated_at = new Date().toISOString();
-        const tmp = `${CHANNEL_DIR_PATH}.tmp.${process.pid}.${Date.now()}`;
+        const tmp = `${paths.channelDirPath}.tmp.${process.pid}.${Date.now()}`;
         await dockerExecWithStdin(
           HERMES_CONTAINER,
-          ["sh", "-c", `cat > ${tmp} && mv ${tmp} ${CHANNEL_DIR_PATH}`],
+          ["sh", "-c", `cat > ${tmp} && mv ${tmp} ${paths.channelDirPath}`],
           JSON.stringify(root, null, 2) + "\n",
           15_000,
         );
@@ -454,7 +492,7 @@ async function revokeChatFromDirectory(userId: string): Promise<void> {
     }
   }
   // 2) drop from the .env allowlist (TELEGRAM_ALLOWED_USERS is comma-separated)
-  const envMap: Record<string, string> = await readProfileEnv().catch(
+  const envMap: Record<string, string> = await readProfileEnv(paths).catch(
     () => ({}) as Record<string, string>,
   );
   const current = envMap.TELEGRAM_ALLOWED_USERS ?? "";
@@ -465,7 +503,7 @@ async function revokeChatFromDirectory(userId: string): Promise<void> {
       .filter((s: string) => s && s !== userId)
       .join(",");
     if (next !== current) {
-      await writeProfileEnvKeys({
+      await writeProfileEnvKeys(paths, {
         TELEGRAM_ALLOWED_USERS: next || null,
       });
     }
@@ -475,12 +513,41 @@ async function revokeChatFromDirectory(userId: string): Promise<void> {
 // ── Routes ────────────────────────────────────────────────────────────────
 
 export function registerTelegramRoutes(): void {
+  // GET /resolve?chat_id=<id> — Lane IV debug surface. Returns the resolved
+  // profile context for a given chat_id without side effects. Used by the
+  // smoke runbook to prove channel→profile binding works end-to-end.
+  addRoute("GET", "/api/v1/channels/telegram/resolve", async ({ res, query }) => {
+    const chatId = query.get("chat_id")?.trim() || null;
+    // Import lazily to avoid a circular dep with state.js at module init.
+    const { resolveProfileContextForChannel } = await import(
+      "../../db/agentProfiles.js"
+    );
+    const ctx = resolveProfileContextForChannel(
+      getStateDb(),
+      "telegram",
+      chatId,
+    );
+    sendJson(res, 200, {
+      channel_kind: "telegram",
+      channel_identity: chatId,
+      profile: ctx.slug,
+      bound_profile: ctx.bound_slug,
+      cascaded: ctx.cascaded,
+      api_server_port: ctx.api_server_port,
+      api_server_key_present: ctx.api_server_key != null,
+      profile_dir: ctx.profile_dir,
+      journal_scope: ctx.journal_scope_key,
+    });
+  });
+
   // GET /status — fail-soft. NEVER 5xx (dashboard polls it).
-  addRoute("GET", "/api/v1/channels/telegram/status", async ({ res }) => {
+  // Accepts ?profile=<slug>; defaults to the default binding for telegram.
+  addRoute("GET", "/api/v1/channels/telegram/status", async ({ res, query }) => {
+    const paths = resolveTelegramProfile(query);
     let envMap: Record<string, string> = {};
     let envErr: string | null = null;
     try {
-      envMap = await readProfileEnv();
+      envMap = await readProfileEnv(paths);
     } catch (e) {
       envErr = e instanceof Error ? e.message : String(e);
     }
@@ -505,8 +572,8 @@ export function registerTelegramRoutes(): void {
 
     // Configured — pull live state + directory + resolve handle (best effort).
     const [stateBlob, dirBlob, handle] = await Promise.all([
-      readJsonFromContainer(GATEWAY_STATE_PATH),
-      readJsonFromContainer(CHANNEL_DIR_PATH),
+      readJsonFromContainer(paths.gatewayStatePath),
+      readJsonFromContainer(paths.channelDirPath),
       resolveBotHandle(token),
     ]);
     const tg = parseGatewayState(stateBlob);
@@ -545,97 +612,112 @@ export function registerTelegramRoutes(): void {
   });
 
   // PUT /token — write to vault + per-profile .env, restart hermes.
-  addRoute("PUT", "/api/v1/channels/telegram/token", async ({ res, body }) => {
-    const b = (body ?? {}) as {
-      token?: unknown;
-      allowed_users?: unknown;
-      home_channel?: unknown;
-    };
-    if (typeof b.token !== "string" || !BOT_TOKEN_RE.test(b.token.trim())) {
-      throw new ValidationError(
-        "token must match BotFather shape: <8-12 digits>:<35 chars [A-Za-z0-9_-]>",
-      );
-    }
-    const token = b.token.trim();
-    const updates: Partial<Record<TelegramEnvKey, string | null>> = {
-      TELEGRAM_BOT_TOKEN: token,
-    };
-    if (typeof b.allowed_users === "string") {
-      updates.TELEGRAM_ALLOWED_USERS = b.allowed_users;
-    }
-    if (typeof b.home_channel === "string") {
-      updates.TELEGRAM_HOME_CHANNEL = b.home_channel;
-    }
+  addRoute(
+    "PUT",
+    "/api/v1/channels/telegram/token",
+    async ({ res, body, query }) => {
+      const paths = resolveTelegramProfile(query);
+      const b = (body ?? {}) as {
+        token?: unknown;
+        allowed_users?: unknown;
+        home_channel?: unknown;
+      };
+      if (typeof b.token !== "string" || !BOT_TOKEN_RE.test(b.token.trim())) {
+        throw new ValidationError(
+          "token must match BotFather shape: <8-12 digits>:<35 chars [A-Za-z0-9_-]>",
+        );
+      }
+      const token = b.token.trim();
+      const updates: Partial<Record<TelegramEnvKey, string | null>> = {
+        TELEGRAM_BOT_TOKEN: token,
+      };
+      if (typeof b.allowed_users === "string") {
+        updates.TELEGRAM_ALLOWED_USERS = b.allowed_users;
+      }
+      if (typeof b.home_channel === "string") {
+        updates.TELEGRAM_HOME_CHANNEL = b.home_channel;
+      }
 
-    await upsertTelegramVaultItem(token);    // canonical store
-    await writeProfileEnvKeys(updates);      // the file Hermes actually reads
-    restartHermes();                         // background
-    sendJson(res, 200, { ok: true, state: "configured_starting" });
-  });
+      await upsertTelegramVaultItem(token);    // canonical store
+      await writeProfileEnvKeys(paths, updates); // the file Hermes actually reads
+      restartHermes();                         // background
+      sendJson(res, 200, { ok: true, state: "configured_starting" });
+    },
+  );
 
   // DELETE /token — wipe vault + drop the 3 .env keys + restart.
-  addRoute("DELETE", "/api/v1/channels/telegram/token", async ({ res }) => {
-    await deleteTelegramVaultItem(); // idempotent
-    await writeProfileEnvKeys({
-      TELEGRAM_BOT_TOKEN: null,
-      TELEGRAM_ALLOWED_USERS: null,
-      TELEGRAM_HOME_CHANNEL: null,
-    });
-    restartHermes();
-    sendJson(res, 200, { ok: true, state: "unconfigured" });
-  });
+  addRoute(
+    "DELETE",
+    "/api/v1/channels/telegram/token",
+    async ({ res, query }) => {
+      const paths = resolveTelegramProfile(query);
+      await deleteTelegramVaultItem(); // idempotent
+      await writeProfileEnvKeys(paths, {
+        TELEGRAM_BOT_TOKEN: null,
+        TELEGRAM_ALLOWED_USERS: null,
+        TELEGRAM_HOME_CHANNEL: null,
+      });
+      restartHermes();
+      sendJson(res, 200, { ok: true, state: "unconfigured" });
+    },
+  );
 
   // POST /test — send a one-shot test message to TELEGRAM_HOME_CHANNEL via
   // the Telegram bot API. Used by the /channels "Send test message" button so
   // the user can confirm the bot can actually deliver. We deliberately don't
   // route through Hermes — this is a pure liveness check.
-  addRoute("POST", "/api/v1/channels/telegram/test", async ({ res }) => {
-    const envMap: Record<string, string> = await readProfileEnv().catch(
-      () => ({}) as Record<string, string>,
-    );
-    const token = envMap.TELEGRAM_BOT_TOKEN ?? "";
-    if (!token) {
-      throw new ValidationError(
-        "telegram is not configured (no bot token in the hermes profile)",
+  addRoute(
+    "POST",
+    "/api/v1/channels/telegram/test",
+    async ({ res, query }) => {
+      const paths = resolveTelegramProfile(query);
+      const envMap: Record<string, string> = await readProfileEnv(paths).catch(
+        () => ({}) as Record<string, string>,
       );
-    }
-    // Prefer TELEGRAM_HOME_CHANNEL; fall back to the first paired chat we
-    // know about so a user who set up via DM-pairing alone still gets a test.
-    let chatId = envMap.TELEGRAM_HOME_CHANNEL ?? "";
-    if (!chatId) {
-      const dirBlob = await readJsonFromContainer(CHANNEL_DIR_PATH);
-      const paired = parseChannelDirectory(dirBlob);
-      if (paired.length > 0) chatId = String(paired[0].id);
-    }
-    if (!chatId) {
-      sendJson(res, 200, {
-        ok: false,
-        error:
-          "no chat to send to — DM the bot once from your phone so it knows your chat_id, then try again",
+      const token = envMap.TELEGRAM_BOT_TOKEN ?? "";
+      if (!token) {
+        throw new ValidationError(
+          "telegram is not configured (no bot token in the hermes profile)",
+        );
+      }
+      // Prefer TELEGRAM_HOME_CHANNEL; fall back to the first paired chat we
+      // know about so a user who set up via DM-pairing alone still gets a test.
+      let chatId = envMap.TELEGRAM_HOME_CHANNEL ?? "";
+      if (!chatId) {
+        const dirBlob = await readJsonFromContainer(paths.channelDirPath);
+        const paired = parseChannelDirectory(dirBlob);
+        if (paired.length > 0) chatId = String(paired[0].id);
+      }
+      if (!chatId) {
+        sendJson(res, 200, {
+          ok: false,
+          error:
+            "no chat to send to — DM the bot once from your phone so it knows your chat_id, then try again",
+        });
+        return;
+      }
+      const stamp = new Date().toLocaleTimeString("en-GB", {
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
       });
-      return;
-    }
-    const stamp = new Date().toLocaleTimeString("en-GB", {
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-    });
-    const result = await sendTelegramMessage(
-      token,
-      chatId,
-      `🤵 Test message from your Alfred dashboard · ${stamp}`,
-    );
-    if (result.ok) {
-      sendJson(res, 200, {
-        ok: true,
-        chat_id: chatId,
-        message_id: result.message_id,
-        sent_at: new Date().toISOString(),
-      });
-    } else {
-      sendJson(res, 200, { ok: false, error: result.description });
-    }
-  });
+      const result = await sendTelegramMessage(
+        token,
+        chatId,
+        `🤵 Test message from your Alfred dashboard · ${stamp}`,
+      );
+      if (result.ok) {
+        sendJson(res, 200, {
+          ok: true,
+          chat_id: chatId,
+          message_id: result.message_id,
+          sent_at: new Date().toISOString(),
+        });
+      } else {
+        sendJson(res, 200, { ok: false, error: result.description });
+      }
+    },
+  );
 
   // DELETE /chats/:user_id — revoke a paired chat. Removes from
   // channel_directory.json AND from TELEGRAM_ALLOWED_USERS, then bounces
@@ -643,12 +725,13 @@ export function registerTelegramRoutes(): void {
   addRoute(
     "DELETE",
     "/api/v1/channels/telegram/chats/:user_id",
-    async ({ res, params }) => {
+    async ({ res, params, query }) => {
+      const paths = resolveTelegramProfile(query);
       const userId = String(params.user_id ?? "").trim();
       if (!userId || !/^[0-9-]{1,20}$/.test(userId)) {
         throw new ValidationError("user_id must be a numeric Telegram chat id");
       }
-      await revokeChatFromDirectory(userId);
+      await revokeChatFromDirectory(paths, userId);
       restartHermes();
       sendJson(res, 200, { ok: true, revoked: userId });
     },

--- a/packages/ctrl/src/db/agentProfiles.ts
+++ b/packages/ctrl/src/db/agentProfiles.ts
@@ -30,11 +30,23 @@
 //     fallback table never has a hole. The principal CAN rebind the default
 //     (via bindChannel with channel_identity=null and the same kind), which
 //     UPSERTs the existing row rather than inserting a new one.
+import fs from "node:fs";
 import type { DatabaseSync } from "node:sqlite";
 import { ulid } from "./ulid.js";
 
 export const PORT_RANGE_USER_LO = 18794;
 export const PORT_RANGE_USER_HI = 18799;
+
+// HERMES_HOME inside the runtime container is `/hermes-state`. ctrl-api has
+// the hermes_data volume bind-mounted at this path (see docker-compose.yaml
+// ctrl-api service). Channel routes use it both as the path they read the
+// per-profile .env from (via fs) and as the path they prefix in `docker exec
+// hermes …` commands (the same path is valid in both containers).
+//
+// `HERMES_CONFIG_DIR` is an override for tests so resolveProfileContextForChannel
+// can be exercised without touching the real /hermes-state.
+export const HERMES_PROFILE_BASE_DIR = (): string =>
+  process.env.HERMES_CONFIG_DIR ?? "/hermes-state/profiles";
 
 export const RESERVED_SLUGS: ReadonlySet<string> = new Set([
   "main",
@@ -468,6 +480,121 @@ export function bindChannel(
     )
     .get(id) as BindingRow;
   return _row2binding(row);
+}
+
+// ── Lane IV: channel-route context resolver ───────────────────────────────
+//
+// The full lookup chain every channel route needs. Single round-trip with
+// the registry — slug → profile row + port + api_server_key from disk.
+//
+// Archived-target cascade:
+//   * resolveProfileForChannel can return a slug that points at an archived
+//     profile (Lane III could archive a profile that still has explicit
+//     bindings; Lane II's cleanup may not have rebinded them yet). When the
+//     resolved profile is archived, we cascade to `main` so the channel
+//     stays alive rather than 404ing on dispatch.
+//   * If `main` itself is archived (shouldn't happen — it's reserved), we
+//     surface the original archived profile with `archived=true` and let
+//     the caller decide whether to 503.
+//
+// The api_server_key read can fail in legitimate ways: the profile dir
+// doesn't exist yet (Lane II hasn't activated the profile), or the .env is
+// missing API_SERVER_KEY (first-boot before render_hermes seeded it). Both
+// cases return `api_server_key=null`; the caller decides how to respond
+// (typically: 503 "profile not yet activated").
+
+export interface ProfileChannelContext {
+  /** Final resolved profile slug (after archived-target cascade). */
+  slug: string;
+  /** The profile slug the binding pointed at BEFORE the archived cascade.
+   *  Equal to `slug` on the happy path. Useful for diagnostics. */
+  bound_slug: string;
+  /** True iff `bound_slug !== slug` (we cascaded). */
+  cascaded: boolean;
+  /** Hermes /v1 port for the resolved profile. */
+  api_server_port: number;
+  /** API_SERVER_KEY read from <profile_dir>/.env; null if unreadable
+   *  (the profile dir doesn't exist yet, or .env lacks the key). */
+  api_server_key: string | null;
+  /** Absolute path of the profile dir (e.g. /hermes-state/profiles/sentinel).
+   *  Used by channel routes that read/write gateway_state.json,
+   *  channel_directory.json, and the per-profile .env. */
+  profile_dir: string;
+  /** alfred_journal.hermes_profile scoping key. Same as `slug` today; broken
+   *  out so future schemes (e.g. principal-scoped) can change one place. */
+  journal_scope_key: string;
+}
+
+/**
+ * Read `API_SERVER_KEY` from a per-profile .env. Extracted from the
+ * duplicated readers in agents.ts / hermes.ts / channels_paperclip.ts /
+ * channels_ha.ts so Lane IV's channel routes resolve through one path.
+ */
+export function readHermesProfileApiKey(profileDir: string): string | null {
+  const envPath = `${profileDir}/.env`;
+  let raw: string;
+  try {
+    raw = fs.readFileSync(envPath, "utf-8");
+  } catch {
+    return null;
+  }
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq < 0) continue;
+    if (trimmed.slice(0, eq).trim() === "API_SERVER_KEY") {
+      return trimmed.slice(eq + 1).trim();
+    }
+  }
+  return null;
+}
+
+export function resolveProfileContextForChannel(
+  db: DatabaseSync,
+  channel_kind: string,
+  channel_identity: string | null,
+): ProfileChannelContext {
+  const boundSlug = resolveProfileForChannel(db, channel_kind, channel_identity);
+  const bound = getProfile(db, boundSlug);
+
+  // If the bound profile is archived, cascade to 'main' so the channel
+  // remains live. Lane III's UI is expected to rebind before archiving in
+  // the normal case; this cascade is a backstop, not the happy path.
+  let slug = boundSlug;
+  let row = bound;
+  let cascaded = false;
+  if (bound && bound.archived_at != null) {
+    cascaded = true;
+    slug = "main";
+    row = getProfile(db, "main");
+  }
+  // If the bound slug doesn't exist at all (stale binding pointing at a
+  // hard-deleted profile — shouldn't be possible because archive doesn't
+  // delete, but be defensive), also fall back to main.
+  if (!row) {
+    cascaded = boundSlug !== "main";
+    slug = "main";
+    row = getProfile(db, "main");
+  }
+
+  // If 'main' itself is missing (the migration would have failed; this is
+  // really "should never happen"), surface a synthetic 18789-on-main shape
+  // so the caller can fail honestly downstream rather than crashing here.
+  const port = row?.api_server_port ?? 18789;
+  const baseDir = HERMES_PROFILE_BASE_DIR();
+  const profileDir = `${baseDir}/${slug}`;
+  const apiKey = readHermesProfileApiKey(profileDir);
+
+  return {
+    slug,
+    bound_slug: boundSlug,
+    cascaded,
+    api_server_port: port,
+    api_server_key: apiKey,
+    profile_dir: profileDir,
+    journal_scope_key: slug,
+  };
 }
 
 export function unbindChannel(db: DatabaseSync, id: string): void {

--- a/packages/ctrl/src/db/alfredJournal.ts
+++ b/packages/ctrl/src/db/alfredJournal.ts
@@ -202,33 +202,89 @@ export function queryRecentJournal(
   scope:
     | { principal_id: string }
     | { channel: string; chat_id: string },
-  opts: { limit?: number; within_hours?: number } = {},
+  opts: { limit?: number; within_hours?: number; hermes_profile?: string | null } = {},
 ): JournalEntry[] {
   const limit = Math.max(1, Math.min(50, opts.limit ?? 20));
   const withinHours = Math.max(0.1, opts.within_hours ?? 24);
   const cutoff = new Date(Date.now() - withinHours * 3600 * 1000).toISOString();
 
+  // Lane IV — optional per-profile filter so the Hermes one-alfred plugin can
+  // pull only the target profile's continuity. When a Sentinel profile asks
+  // for recent journal entries, it shouldn't see Alfred-main's outbound.
+  // When `hermes_profile` is undefined (the default), no scoping is applied —
+  // legacy callers see all profiles. When it's null, only rows with a NULL
+  // hermes_profile match (pre-Lane-IV rows). Pass a slug to filter to it.
+  const profileFilter = opts.hermes_profile;
+
   let rows: RawJournalRow[];
   if ("principal_id" in scope) {
-    rows = db
-      .prepare(
-        `SELECT * FROM alfred_journal
-           WHERE principal_id = ?
-             AND ts >= ?
-           ORDER BY ts DESC, rowid DESC
-           LIMIT ?`,
-      )
-      .all(scope.principal_id, cutoff, limit) as RawJournalRow[];
+    if (profileFilter === undefined) {
+      rows = db
+        .prepare(
+          `SELECT * FROM alfred_journal
+             WHERE principal_id = ?
+               AND ts >= ?
+             ORDER BY ts DESC, rowid DESC
+             LIMIT ?`,
+        )
+        .all(scope.principal_id, cutoff, limit) as RawJournalRow[];
+    } else if (profileFilter === null) {
+      rows = db
+        .prepare(
+          `SELECT * FROM alfred_journal
+             WHERE principal_id = ?
+               AND ts >= ?
+               AND hermes_profile IS NULL
+             ORDER BY ts DESC, rowid DESC
+             LIMIT ?`,
+        )
+        .all(scope.principal_id, cutoff, limit) as RawJournalRow[];
+    } else {
+      rows = db
+        .prepare(
+          `SELECT * FROM alfred_journal
+             WHERE principal_id = ?
+               AND ts >= ?
+               AND hermes_profile = ?
+             ORDER BY ts DESC, rowid DESC
+             LIMIT ?`,
+        )
+        .all(scope.principal_id, cutoff, profileFilter, limit) as RawJournalRow[];
+    }
   } else {
-    rows = db
-      .prepare(
-        `SELECT * FROM alfred_journal
-           WHERE channel = ? AND chat_id = ?
-             AND ts >= ?
-           ORDER BY ts DESC, rowid DESC
-           LIMIT ?`,
-      )
-      .all(scope.channel, scope.chat_id, cutoff, limit) as RawJournalRow[];
+    if (profileFilter === undefined) {
+      rows = db
+        .prepare(
+          `SELECT * FROM alfred_journal
+             WHERE channel = ? AND chat_id = ?
+               AND ts >= ?
+             ORDER BY ts DESC, rowid DESC
+             LIMIT ?`,
+        )
+        .all(scope.channel, scope.chat_id, cutoff, limit) as RawJournalRow[];
+    } else if (profileFilter === null) {
+      rows = db
+        .prepare(
+          `SELECT * FROM alfred_journal
+             WHERE channel = ? AND chat_id = ?
+               AND ts >= ?
+               AND hermes_profile IS NULL
+             ORDER BY ts DESC, rowid DESC
+             LIMIT ?`,
+        )
+        .all(scope.channel, scope.chat_id, cutoff, limit) as RawJournalRow[];
+    } else {
+      rows = db
+        .prepare(
+          `SELECT * FROM alfred_journal
+             WHERE channel = ? AND chat_id = ?
+               AND ts >= ?
+               AND hermes_profile = ?
+             ORDER BY ts DESC, rowid DESC
+             LIMIT ?`,
+        )
+        .all(scope.channel, scope.chat_id, cutoff, profileFilter, limit) as RawJournalRow[];
+    }
   }
   return rows.map(rowToEntry);
 }

--- a/packages/ctrl/tests/agent-profiles-channel-context.test.ts
+++ b/packages/ctrl/tests/agent-profiles-channel-context.test.ts
@@ -1,0 +1,208 @@
+// agentProfiles — Lane IV channel-context resolver tests.
+//
+// Lane IV adds `resolveProfileContextForChannel(db, kind, identity?)` — the
+// helper every channel route uses to figure out (a) which Hermes profile owns
+// this inbound, (b) which port that profile's gateway is on, (c) which .env
+// the API_SERVER_KEY lives in, (d) the journal scoping key. This test
+// exercises that helper end-to-end against the seeded registry + the on-disk
+// profile dir layout (overridden via HERMES_CONFIG_DIR for hermeticity).
+//
+// What's covered:
+//   * happy path — bound profile, .env present → context complete
+//   * default binding (per-kind NULL) → falls back to 'main'
+//   * archived-target cascade — bound profile is archived → cascade to main
+//   * missing .env — api_server_key=null, no exception
+//   * journal_scope_key matches slug
+//   * port resolution honours per-profile api_server_port
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import schema from "../src/db/schema.sql";
+import { runMigrations } from "../src/db/migrate.js";
+import {
+  bindChannel,
+  createProfile,
+  archiveProfile,
+  resolveProfileContextForChannel,
+} from "../src/db/agentProfiles.js";
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lane-iv-ctx-"));
+process.env.HERMES_CONFIG_DIR = TMP;
+
+function freshDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  db.exec(schema);
+  runMigrations(db);
+  return db;
+}
+
+function writeProfileEnv(slug: string, body: string): void {
+  const dir = path.join(TMP, slug);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, ".env"), body);
+}
+
+describe("resolveProfileContextForChannel — Lane IV", () => {
+  before(() => {
+    // Seed the 'main' profile's .env so api_server_key reads succeed.
+    writeProfileEnv(
+      "main",
+      "# managed by render_hermes.py\nAPI_SERVER_KEY=main-key-43char-xxxxxxxxxxxxxxxxxxxxxx\nFOO=bar\n",
+    );
+  });
+
+  after(() => {
+    fs.rmSync(TMP, { recursive: true, force: true });
+  });
+
+  it("happy path — default binding returns main context", () => {
+    const db = freshDb();
+    const ctx = resolveProfileContextForChannel(db, "telegram", null);
+    assert.equal(ctx.slug, "main");
+    assert.equal(ctx.bound_slug, "main");
+    assert.equal(ctx.cascaded, false);
+    assert.equal(ctx.api_server_port, 18789);
+    assert.equal(
+      ctx.api_server_key,
+      "main-key-43char-xxxxxxxxxxxxxxxxxxxxxx",
+    );
+    assert.ok(ctx.profile_dir.endsWith("/main"));
+    assert.equal(ctx.journal_scope_key, "main");
+    db.close();
+  });
+
+  it("exact-match binding routes to a user-facing profile", () => {
+    const db = freshDb();
+    createProfile(db, {
+      slug: "sentinel",
+      label: "Sentinel",
+      model: "x-ai/grok-4.3",
+    });
+    bindChannel(db, {
+      channel_kind: "telegram",
+      channel_identity: "55555",
+      profile_slug: "sentinel",
+    });
+    writeProfileEnv("sentinel", "API_SERVER_KEY=sentinel-secret\n");
+
+    const ctx = resolveProfileContextForChannel(db, "telegram", "55555");
+    assert.equal(ctx.slug, "sentinel");
+    assert.equal(ctx.bound_slug, "sentinel");
+    assert.equal(ctx.cascaded, false);
+    assert.equal(ctx.api_server_port, 18794); // first user-facing port
+    assert.equal(ctx.api_server_key, "sentinel-secret");
+    assert.equal(ctx.journal_scope_key, "sentinel");
+    db.close();
+  });
+
+  it("unbound chat_id falls back to the per-kind default binding", () => {
+    const db = freshDb();
+    createProfile(db, {
+      slug: "sentinel",
+      label: "Sentinel",
+      model: "x-ai/grok-4.3",
+    });
+    // Only 55555 is bound; 99999 should fall to the default → main.
+    bindChannel(db, {
+      channel_kind: "telegram",
+      channel_identity: "55555",
+      profile_slug: "sentinel",
+    });
+
+    const ctx = resolveProfileContextForChannel(db, "telegram", "99999");
+    assert.equal(ctx.slug, "main");
+    assert.equal(ctx.bound_slug, "main");
+    assert.equal(ctx.cascaded, false);
+    db.close();
+  });
+
+  it("archived bound profile cascades to main", () => {
+    const db = freshDb();
+    createProfile(db, {
+      slug: "sentinel",
+      label: "Sentinel",
+      model: "x-ai/grok-4.3",
+    });
+    bindChannel(db, {
+      channel_kind: "telegram",
+      channel_identity: "55555",
+      profile_slug: "sentinel",
+    });
+    // Now archive sentinel WITHOUT unbinding (Lane III is expected to
+    // rebind first; we test the backstop).
+    archiveProfile(db, "sentinel");
+
+    const ctx = resolveProfileContextForChannel(db, "telegram", "55555");
+    assert.equal(ctx.slug, "main");
+    assert.equal(ctx.bound_slug, "sentinel");
+    assert.equal(ctx.cascaded, true);
+    assert.equal(ctx.api_server_port, 18789);
+    db.close();
+  });
+
+  it("missing per-profile .env returns api_server_key=null without throwing", () => {
+    const db = freshDb();
+    createProfile(db, {
+      slug: "ghost",
+      label: "Ghost",
+      model: "x-ai/grok-4.3",
+    });
+    bindChannel(db, {
+      channel_kind: "slack",
+      channel_identity: "T123:C456",
+      profile_slug: "ghost",
+    });
+    // NB: we deliberately do NOT writeProfileEnv("ghost") — its dir is missing.
+
+    const ctx = resolveProfileContextForChannel(db, "slack", "T123:C456");
+    assert.equal(ctx.slug, "ghost");
+    assert.equal(ctx.api_server_key, null);
+    assert.ok(ctx.profile_dir.endsWith("/ghost"));
+    db.close();
+  });
+
+  it("journal_scope_key matches the resolved slug (Lane IV contract)", () => {
+    const db = freshDb();
+    const cases = [
+      ["telegram", null, "main"],
+      ["slack", null, "main"],
+      ["paperclip", null, "main"],
+      ["email", null, "main"],
+    ] as const;
+    for (const [kind, ident, expectedSlug] of cases) {
+      const ctx = resolveProfileContextForChannel(db, kind, ident);
+      assert.equal(
+        ctx.journal_scope_key,
+        expectedSlug,
+        `${kind}:${ident} should scope as ${expectedSlug}`,
+      );
+    }
+    db.close();
+  });
+
+  it("per-kind defaults route independently", () => {
+    const db = freshDb();
+    createProfile(db, {
+      slug: "sentinel",
+      label: "Sentinel",
+      model: "x-ai/grok-4.3",
+    });
+    // Rebind ONLY slack to sentinel; telegram should still default to main.
+    bindChannel(db, {
+      channel_kind: "slack",
+      channel_identity: null,
+      profile_slug: "sentinel",
+    });
+
+    const slackCtx = resolveProfileContextForChannel(db, "slack", null);
+    assert.equal(slackCtx.slug, "sentinel");
+
+    const tgCtx = resolveProfileContextForChannel(db, "telegram", null);
+    assert.equal(tgCtx.slug, "main");
+    db.close();
+  });
+});

--- a/packages/ctrl/tests/alfred-journal.test.ts
+++ b/packages/ctrl/tests/alfred-journal.test.ts
@@ -294,4 +294,125 @@ describe("queryRecentJournal", () => {
     );
     db.close();
   });
+
+  // ── Lane IV: hermes_profile filter ────────────────────────────────────
+  it("filters by hermes_profile when set (Lane IV plugin scoping)", () => {
+    const db = makeDb();
+    // Three rows: two with hermes_profile='main', one with 'sentinel'.
+    appendJournal(db, {
+      channel: "telegram",
+      chat_id: "100",
+      direction: "outbound",
+      message: "main 1",
+      hermes_profile: "main",
+    });
+    appendJournal(db, {
+      channel: "telegram",
+      chat_id: "100",
+      direction: "outbound",
+      message: "main 2",
+      hermes_profile: "main",
+    });
+    appendJournal(db, {
+      channel: "telegram",
+      chat_id: "100",
+      direction: "outbound",
+      message: "sentinel 1",
+      hermes_profile: "sentinel",
+    });
+
+    // No filter → all 3.
+    const all = queryRecentJournal(db, {
+      channel: "telegram",
+      chat_id: "100",
+    });
+    assert.equal(all.length, 3);
+
+    // hermes_profile=main → 2.
+    const main = queryRecentJournal(
+      db,
+      { channel: "telegram", chat_id: "100" },
+      { hermes_profile: "main" },
+    );
+    assert.equal(main.length, 2);
+    assert.ok(main.every((e) => e.hermes_profile === "main"));
+
+    // hermes_profile=sentinel → 1.
+    const sentinel = queryRecentJournal(
+      db,
+      { channel: "telegram", chat_id: "100" },
+      { hermes_profile: "sentinel" },
+    );
+    assert.equal(sentinel.length, 1);
+    assert.equal(sentinel[0].message, "sentinel 1");
+
+    db.close();
+  });
+
+  it("hermes_profile=null returns only pre-Lane-IV rows (IS NULL)", () => {
+    const db = makeDb();
+    appendJournal(db, {
+      channel: "slack",
+      chat_id: "U1",
+      direction: "outbound",
+      message: "untagged (pre-Lane-IV)",
+      // hermes_profile omitted → NULL.
+    });
+    appendJournal(db, {
+      channel: "slack",
+      chat_id: "U1",
+      direction: "outbound",
+      message: "main-tagged",
+      hermes_profile: "main",
+    });
+
+    const untagged = queryRecentJournal(
+      db,
+      { channel: "slack", chat_id: "U1" },
+      { hermes_profile: null },
+    );
+    assert.equal(untagged.length, 1);
+    assert.equal(untagged[0].message, "untagged (pre-Lane-IV)");
+    assert.equal(untagged[0].hermes_profile, null);
+
+    db.close();
+  });
+
+  it("hermes_profile filter combines with principal_id scope", () => {
+    const db = makeDb();
+    bindPrincipalChannel(db, "telegram", "100", "owner");
+    bindPrincipalChannel(db, "slack", "U1", "owner");
+    appendJournal(db, {
+      channel: "telegram",
+      chat_id: "100",
+      direction: "outbound",
+      message: "tg main",
+      hermes_profile: "main",
+    });
+    appendJournal(db, {
+      channel: "slack",
+      chat_id: "U1",
+      direction: "outbound",
+      message: "slack sentinel",
+      hermes_profile: "sentinel",
+    });
+
+    const main = queryRecentJournal(
+      db,
+      { principal_id: "owner" },
+      { hermes_profile: "main" },
+    );
+    assert.equal(main.length, 1);
+    assert.equal(main[0].message, "tg main");
+
+    const sentinel = queryRecentJournal(
+      db,
+      { principal_id: "owner" },
+      { hermes_profile: "sentinel" },
+    );
+    assert.equal(sentinel.length, 1);
+    assert.equal(sentinel[0].message, "slack sentinel");
+
+    db.close();
+  });
 });


### PR DESCRIPTION
Channel routes thread `resolveProfileContextForChannel(channel_kind, channel_identity)` through the per-request path so an inbound bound to a non-main profile dispatches to that profile's port + reads that profile's per-channel credentials. After this lane the channel-route layer is profile-aware end-to-end; before this lane every channel hard-coded `/profiles/main/` + `:18789`.

Refs #120 (Lane IV — channel-side rewiring).

## What lands

### `src/db/agentProfiles.ts`
- `resolveProfileContextForChannel(db, kind, identity?)` returns `{ slug, bound_slug, cascaded, api_server_port, api_server_key, profile_dir, journal_scope_key }`.
- Honors the **archived-target cascade**: if the bound profile is archived, `cascaded=true` and `slug` falls back to `main`. Backstop for the case where Lane III archives without rebinding first.
- `readHermesProfileApiKey(profileDir)` — extracted from the four duplicated readers (`agents.ts` / `hermes.ts` / `channels_paperclip.ts` / `channels_ha.ts`) so Lane IV channel routes resolve through one path.

### `src/db/alfredJournal.ts`
- `queryRecentJournal` now takes `opts.hermes_profile`:
  - `undefined` (default) — no scoping; main-only tenants see zero regression.
  - `null` — `WHERE hermes_profile IS NULL` (pre-Lane-IV rows only).
  - `<slug>` — `WHERE hermes_profile = <slug>`.

### `src/api/routes/alfredJournal.ts`
- `GET /api/v1/alfred-journal/recent?profile=<slug>` — translates to `queryRecentJournal`'s `hermes_profile` arg. Special token `profile=__none__` selects the IS NULL case.

### `src/api/routes/alfredDeliver.ts`
- Resolves the target profile per-request from `(channel, chat_id)`.
- Journal row carries `hermes_profile = resolved slug`.
- Per-channel token caches keyed by profile (one cache entry per slug instead of one global cache).
- `deliverByChannel` + `deliverTelegram` + `deliverSlack` + `deliverEmail` all take the resolved profile slug so they read the right `.env`.

### `src/api/routes/telegram.ts`, `slack.ts`, `sms.ts`
- `MAIN_PROFILE_DIR` / `PROFILE_ENV_PATH` module constants → per-request `resolveTelegramProfile` / `resolveSlackProfile` / `resolveSmsProfile` helpers.
- `readProfileEnv` / `writeProfileEnvKeys` take a profile-paths arg rather than reading module-level constants.
- Each route accepts `?profile=<slug>`; default = the channel's default binding (`resolveProfileForChannel(..., null)`).
- `GET /resolve` added on each channel for the Lane IV smoke test.

### `src/api/routes/channels_paperclip.ts`
- Dispatch URL derived from `ctx.api_server_port` (was: `HERMES_MAIN_URL` env override hardcoded at `:18789`).
- Bearer key from `ctx.api_server_key` (read once via the resolver).
- Session-key shape preserves back-compat: `paperclip-<id>` on `main`, `agent:<slug>:paperclip:<id>` on non-main profiles. Existing main-bound paperclip employees keep their Hermes session intact (no Hermes session migration needed).
- Journal rows scope to `ctx.journal_scope_key` + use the new session shape for `hermes_session_id`.

### `src/api/routes/channelsEmail.ts`
- Resolves the target profile from the first `to` address of the AgentMail inbound (the recipient inbox).
- Hermes `/v1/runs` URL derived from the resolved profile's port.
- Bearer precedence: profile's `API_SERVER_KEY` → legacy env → `/alfred-data/.gateway-token` (back-compat).
- 202 response surfaces `profile` so the operator UI can see which Hermes profile owns the conversation.

### Tests

- `tests/agent-profiles-channel-context.test.ts` (NEW, 7 cases) — happy path, exact-match binding, default fallback, archived-target cascade, missing `.env`, `journal_scope_key` contract, per-kind defaults route independently.
- `tests/alfred-journal.test.ts` (extended, +3 cases) — `hermes_profile` filter, IS NULL case, combination with `principal_id` scope.

## NOT in this lane

- Hermes-side one-alfred plugin filter by `hermes_profile` — Hermes concern (TODO upstream, tracked in Lane VI).
- UI for binding management — Lane III.
- `voice.ts`, `channels_ha*.ts`, `channels_omi.ts`, `channels_recall.ts`, `channels_tailscale.ts` — these don't dispatch through Hermes profiles (voice-bridge is a separate sibling, HA/OMI/Recall write streams, tailscale is infra-only). They stay on main by design.

## Tests run

Scoped suite (173 tests across the touched files):

```
tests 173
suites 28
pass 173
fail 0
duration_ms 1999.99675
```

Builds clean:

```
$ npm run build
Build complete — dist/api.mjs
```

## Smoke

Inline in the PR-merge runbook (Lane IV section). The `/resolve` debug routes on each channel return the resolved `(profile, api_server_port, journal_scope, api_server_key_present)` for the bound `channel_identity`, so the smoke can prove end-to-end binding before live Hermes traffic arrives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)