### PR TITLE
feat(hermes,ctrl): #120 Lane II — Hermes per-profile activation

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -306,6 +306,16 @@ services:
   # Hermes /v1 API directly.
   hermes:
     image: ssdavidai00/alfred-black-hermes:latest
+    # No `ports:` — hermes binds 0.0.0.0 inside the container on the four
+    # reserved ports (18789/18790/18791/18793) PLUS any registry-allocated
+    # user-facing profile port (18794..18799 per #120 Lane II). All of
+    # these are reachable ONLY via the compose default network as
+    # `http://hermes:<port>` from sibling containers (ctrl-api, paperclip,
+    # alfred-learn, voice-bridge). They are intentionally NOT host-published
+    # so the only external surface is Caddy ingress on :443, which in turn
+    # routes through ctrl-api's auth-gated proxy. Adding user-facing profile
+    # ports to a `ports:` block would expose them on the VM's public IP
+    # without any TLS or auth wrapping.
     depends_on:
       init:
         condition: service_completed_successfully

--- a/packages/ctrl/src/api/routes/profiles.ts
+++ b/packages/ctrl/src/api/routes/profiles.ts
@@ -46,12 +46,15 @@ import {
   getProfile,
   createProfile,
   archiveProfile,
+  setProfileStatus,
   listBindingsForProfile,
   resolveProfileForChannel,
   bindChannel,
   unbindChannel,
+  buildSupervisorRegistry,
 } from "../../db/agentProfiles.js";
-import type { AgentProfile } from "../../db/agentProfiles.js";
+import type { AgentProfile, ProfileStatus } from "../../db/agentProfiles.js";
+import { writeSupervisorRegistry, nudgeHermesSupervisor } from "../../hermes/supervisor.js";
 
 function asObj(body: unknown): Record<string, unknown> {
   if (!body || typeof body !== "object" || Array.isArray(body)) {
@@ -228,10 +231,26 @@ export function registerProfileRoutes(): void {
         persona_template,
         deployment_shape,
       });
+      // Lane II — write the supervisor registry + nudge Hermes so the new
+      // profile dir is rendered and a gateway is launched on the allocated
+      // port. Best-effort: if the registry write or the docker kill fails
+      // (e.g. test harness, hermes not running yet), the registry row is
+      // still durable and the next init/supervisor cycle will reconcile.
+      try {
+        const reg = buildSupervisorRegistry(db());
+        writeSupervisorRegistry(reg);
+        nudgeHermesSupervisor();
+      } catch (err) {
+        // Surface a warning, never block the registry write.
+        console.warn(
+          `[profiles] supervisor nudge after create('${slug}') failed:`,
+          err instanceof Error ? err.message : err,
+        );
+      }
       sendJson(res, 202, {
         profile,
         note:
-          "Registry row written (status='pending'). Hermes-side activation lands in Lane II.",
+          "Registry row written (status='pending'). Supervisor nudged; gateway should respond on the allocated port within ~30s.",
       });
     } catch (err) {
       _classify(err);
@@ -239,18 +258,72 @@ export function registerProfileRoutes(): void {
   });
 
   // DELETE — archive. Idempotent on already-archived; refuses reserved.
+  // Cascades unbind for any non-default binding pointing at this profile
+  // (see agentProfiles.archiveProfile). Default bindings stay so the per-kind
+  // fallback never has a hole.
   addRoute("DELETE", "/api/v1/agent-profiles/:slug", async ({ res, params }) => {
     try {
       const profile = archiveProfile(db(), params.slug);
+      // Lane II — rewrite the supervisor registry without this profile and
+      // nudge Hermes to terminate the gateway. Best-effort like create.
+      try {
+        const reg = buildSupervisorRegistry(db());
+        writeSupervisorRegistry(reg);
+        nudgeHermesSupervisor();
+      } catch (err) {
+        console.warn(
+          `[profiles] supervisor nudge after archive('${params.slug}') failed:`,
+          err instanceof Error ? err.message : err,
+        );
+      }
       sendJson(res, 200, {
         profile,
         note:
-          "Registry row archived. Hermes-side teardown + Vaultwarden tidy land in Lane II / Lane VI.",
+          "Registry row archived. Cascade-unbound non-default channel bindings. Supervisor nudged to stop the gateway.",
       });
     } catch (err) {
       _classify(err);
     }
   });
+
+  // POST :slug/status — supervisor callback. The Hermes supervisor calls
+  // this after each gateway start/stop to flip the registry row's status
+  // ('pending' → 'running' on /health success; 'running' → 'stopped' on a
+  // clean stop). Same auth as the rest of /api/v1/agent-profiles/*.
+  //
+  // Status transitions are NOT validated against the current value — the
+  // supervisor is the authority for whether a process is live, and a stale
+  // ctrl-api write would otherwise pin a stuck status. Archived status is
+  // routed through archiveProfile via the lib so archived_at gets stamped;
+  // it's an error to flip an already-archived profile to a live status.
+  addRoute(
+    "POST",
+    "/api/v1/agent-profiles/:slug/status",
+    async ({ res, params, body }) => {
+      try {
+        const b = asObj(body);
+        const status = reqStr(b, "status");
+        if (
+          status !== "pending" &&
+          status !== "running" &&
+          status !== "stopped" &&
+          status !== "archived"
+        ) {
+          throw new ValidationError(
+            "status must be one of: pending | running | stopped | archived",
+          );
+        }
+        const profile = setProfileStatus(
+          db(),
+          params.slug,
+          status as ProfileStatus,
+        );
+        sendJson(res, 200, { profile });
+      } catch (err) {
+        _classify(err);
+      }
+    },
+  );
 
   // ─────────────────────────────────────────────────────────────
   // Channel bindings

--- a/packages/ctrl/src/db/agentProfiles.ts
+++ b/packages/ctrl/src/db/agentProfiles.ts
@@ -167,6 +167,44 @@ export function validateSlug(slug: unknown): string {
   return slug;
 }
 
+// Supervisor registry shape — written to /hermes-state/profiles/_registry.json.
+//
+// The Hermes supervisor reads this file on boot (and on every SIGUSR1) to
+// decide which gateway processes to keep alive. Ports + slugs are the
+// load-bearing fields; everything else is informational. We intentionally
+// emit a single `profiles` array (not a map keyed by slug) so the
+// supervisor can iterate deterministically.
+export interface SupervisorRegistryEntry {
+  slug: string;
+  api_server_port: number;
+  model: string;
+  status: ProfileStatus;
+  is_reserved: boolean;
+  is_user_facing: boolean;
+}
+export interface SupervisorRegistry {
+  profiles: SupervisorRegistryEntry[];
+  generated_at: number;
+}
+
+// Build the registry payload the supervisor reads. Excludes archived rows —
+// an archived profile has no live gateway and would only cause a doomed
+// launch attempt in the supervisor's start_proc loop.
+export function buildSupervisorRegistry(db: DatabaseSync): SupervisorRegistry {
+  const all = listAllProfiles(db);
+  const profiles: SupervisorRegistryEntry[] = all
+    .filter((p) => p.archived_at == null && p.status !== "archived")
+    .map((p) => ({
+      slug: p.slug,
+      api_server_port: p.api_server_port,
+      model: p.model,
+      status: p.status,
+      is_reserved: p.is_reserved,
+      is_user_facing: p.is_user_facing,
+    }));
+  return { profiles, generated_at: Date.now() };
+}
+
 export function listAllProfiles(db: DatabaseSync): AgentProfile[] {
   const rows = db
     .prepare(
@@ -305,6 +343,22 @@ export function archiveProfile(db: DatabaseSync, slug: string): AgentProfile {
     return p;
   }
   const now = Date.now();
+  // Cascade-unbind every non-default channel binding pointing at this profile.
+  //
+  // Lane II observation (#120): when a profile is archived, its custom
+  // channel_profile_binding rows still resolve to the archived slug. The
+  // default `(channel_kind, NULL, 'main')` bindings (id prefix
+  // 'binding-default-') are protected by unbindChannel's guard so the
+  // per-kind fallback never has a hole. Any OTHER binding that pointed at
+  // this slug is now stale and gets removed so resolveProfileForChannel
+  // falls back to the default 'main' immediately. We do not retarget to
+  // 'main' explicitly — deleting the row achieves the same end state via
+  // the existing precedence chain (Contract 5 in agentProfiles.ts).
+  db.prepare(
+    `DELETE FROM channel_profile_binding
+     WHERE profile_slug = ?
+       AND id NOT LIKE 'binding-default-%'`,
+  ).run(slug);
   db.prepare(
     `UPDATE agent_profile
        SET status = 'archived', archived_at = ?, updated_at = ?

--- a/packages/ctrl/src/hermes/supervisor.ts
+++ b/packages/ctrl/src/hermes/supervisor.ts
@@ -1,0 +1,84 @@
+// supervisor — the Hermes-side activation bridge for #120 Lane II.
+//
+// Two responsibilities:
+//
+//   1. writeSupervisorRegistry(reg) — atomically write the registry JSON
+//      to /hermes-state/profiles/_registry.json. The Hermes supervisor.sh
+//      reads this file at boot AND on every SIGUSR1 to decide which
+//      gateway processes to keep alive. Write-then-rename so the supervisor
+//      never reads a torn file mid-update.
+//
+//   2. nudgeHermesSupervisor() — send SIGUSR1 to the hermes container's
+//      PID 1 (tini → supervisor.sh) so the supervisor re-reads the
+//      registry without a full container restart. Best-effort: a missing
+//      docker socket or a not-yet-running hermes container is a warn, not
+//      a throw — the registry row is durable and the next supervisor boot
+//      will reconcile.
+//
+// Path layout — the registry file lives at /hermes-state/profiles/_registry.json
+// inside the ctrl-api container (the hermes_data named volume is mounted at
+// the same path in both ctrl-api and hermes — see docker-compose.yaml). The
+// underscore-prefixed name keeps it sorted away from real profile dirs and
+// signals "synthesised by the system, not a profile".
+
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { SupervisorRegistry } from "../db/agentProfiles.js";
+
+const HERMES_STATE_DIR =
+  process.env.HERMES_STATE_DIR_CTRL_VIEW ?? "/hermes-state";
+const REGISTRY_PATH = path.join(
+  HERMES_STATE_DIR,
+  "profiles",
+  "_registry.json",
+);
+
+const HERMES_CONTAINER_NAME =
+  process.env.HERMES_CONTAINER_NAME ?? "alfred-black-hermes-1";
+
+// Atomic write: write to a sibling .tmp file then rename(2) over the target.
+// rename(2) on the same filesystem is atomic on POSIX, so the supervisor
+// either sees the previous valid JSON or the new one — never a half-written
+// file. Idempotent — repeated calls overwrite cleanly.
+export function writeSupervisorRegistry(reg: SupervisorRegistry): void {
+  const dir = path.dirname(REGISTRY_PATH);
+  // ensure the parent dir exists — the init container creates it on first
+  // boot, but on a fresh provision ctrl-api's POST might land before init
+  // has run. mkdirSync({recursive: true}) is a no-op when the dir is there.
+  fs.mkdirSync(dir, { recursive: true });
+  const tmp = REGISTRY_PATH + ".tmp";
+  const payload = JSON.stringify(reg, null, 2) + "\n";
+  fs.writeFileSync(tmp, payload, { encoding: "utf-8", mode: 0o644 });
+  fs.renameSync(tmp, REGISTRY_PATH);
+}
+
+// Best-effort SIGUSR1 to the hermes container. Returns true on success,
+// false on any failure (container not running, docker socket missing,
+// docker CLI absent). Never throws — the caller logs the warning.
+export function nudgeHermesSupervisor(): boolean {
+  try {
+    // `docker kill --signal=SIGUSR1 <container>` delivers the signal to
+    // PID 1 (tini), which forwards to its single child (supervisor.sh).
+    // 5s timeout — `docker kill` is normally <100ms; a stuck docker
+    // daemon is the rare slow-path we want to bound.
+    execFileSync(
+      "docker",
+      ["kill", "--signal=SIGUSR1", HERMES_CONTAINER_NAME],
+      { timeout: 5_000, stdio: "pipe" },
+    );
+    return true;
+  } catch (err) {
+    // Common reasons for failure:
+    //   * hermes container not running (first boot, before depends_on
+    //     resolves) — the next supervisor boot will read the registry
+    //     file we just wrote and start up correctly.
+    //   * docker socket not mounted (test env) — same recovery.
+    //   * docker CLI not installed (test env) — same.
+    // None of these block the registry write; they just delay activation
+    // until the next boot.
+    return false;
+  }
+}
+
+export { REGISTRY_PATH };

--- a/packages/ctrl/tests/agent-profiles-lane-ii.test.ts
+++ b/packages/ctrl/tests/agent-profiles-lane-ii.test.ts
@@ -1,0 +1,148 @@
+// agent-profiles — Lane II coverage (#120).
+//
+// Pins the cascade-unbind on archive + the supervisor registry build/write
+// behaviour. The route layer is intentionally minimal-coverage here because
+// the route just translates lib calls to JSON; the lib is the load-bearing
+// contract.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import schema from "../src/db/schema.sql";
+import { runMigrations } from "../src/db/migrate.js";
+import {
+  createProfile,
+  archiveProfile,
+  bindChannel,
+  listBindingsForProfile,
+  listAllBindings,
+  resolveProfileForChannel,
+  buildSupervisorRegistry,
+} from "../src/db/agentProfiles.js";
+import { writeSupervisorRegistry } from "../src/hermes/supervisor.js";
+
+function freshDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  db.exec(schema);
+  runMigrations(db);
+  return db;
+}
+
+describe("agentProfiles — Lane II cascade unbind on archive", () => {
+  it("removes non-default bindings pointing at the archived profile", () => {
+    const db = freshDb();
+    createProfile(db, { slug: "cratchit", label: "Cratchit", model: "x-ai/grok-4.3" });
+
+    // Bind a specific telegram chat to cratchit.
+    bindChannel(db, {
+      channel_kind: "telegram",
+      channel_identity: "12345",
+      profile_slug: "cratchit",
+    });
+    // Bind a slack workspace to cratchit too.
+    bindChannel(db, {
+      channel_kind: "slack",
+      channel_identity: "T0CRATCHIT",
+      profile_slug: "cratchit",
+    });
+    // Sanity: cratchit has 2 non-default bindings.
+    const before = listBindingsForProfile(db, "cratchit");
+    assert.equal(before.length, 2);
+
+    archiveProfile(db, "cratchit");
+
+    // After archive, the non-default bindings are gone — the cascade
+    // removed them so resolveProfileForChannel falls back to main.
+    const after = listBindingsForProfile(db, "cratchit");
+    assert.equal(after.length, 0);
+
+    // The per-kind default bindings (id 'binding-default-<kind>') are
+    // protected — they still exist (bound to 'main'), so resolution
+    // for the freed (telegram, 12345) tuple cleanly falls through.
+    assert.equal(resolveProfileForChannel(db, "telegram", "12345"), "main");
+    assert.equal(resolveProfileForChannel(db, "slack", "T0CRATCHIT"), "main");
+
+    db.close();
+  });
+
+  it("does NOT remove the per-kind default bindings on archive", () => {
+    const db = freshDb();
+    createProfile(db, { slug: "sentinel", label: "Sentinel", model: "m" });
+    bindChannel(db, {
+      channel_kind: "telegram",
+      channel_identity: "99",
+      profile_slug: "sentinel",
+    });
+
+    const defaultsBefore = listAllBindings(db).filter(
+      (b) => b.id.startsWith("binding-default-"),
+    );
+    archiveProfile(db, "sentinel");
+    const defaultsAfter = listAllBindings(db).filter(
+      (b) => b.id.startsWith("binding-default-"),
+    );
+
+    assert.equal(defaultsAfter.length, defaultsBefore.length);
+    // Each default still points at 'main'.
+    for (const b of defaultsAfter) {
+      assert.equal(b.profile_slug, "main");
+    }
+    db.close();
+  });
+
+  it("idempotent — re-archiving an already-archived profile is a no-op", () => {
+    const db = freshDb();
+    createProfile(db, { slug: "alpha", label: "A", model: "m" });
+    archiveProfile(db, "alpha");
+    // Second archive: must not throw, must keep the cascade outcome.
+    archiveProfile(db, "alpha");
+    db.close();
+  });
+});
+
+describe("agentProfiles — Lane II buildSupervisorRegistry", () => {
+  it("emits the four reserved profiles on a fresh tenant", () => {
+    const db = freshDb();
+    const reg = buildSupervisorRegistry(db);
+    const slugs = reg.profiles.map((p) => p.slug).sort();
+    assert.deepEqual(slugs, ["codex-builder", "heavy", "main", "workers"]);
+    for (const p of reg.profiles) {
+      assert.ok(p.api_server_port >= 18789 && p.api_server_port <= 18793);
+      assert.ok(p.is_reserved);
+    }
+    db.close();
+  });
+
+  it("includes a user-facing profile after createProfile", () => {
+    const db = freshDb();
+    createProfile(db, { slug: "cratchit", label: "Cratchit", model: "m" });
+    const reg = buildSupervisorRegistry(db);
+    const cratchit = reg.profiles.find((p) => p.slug === "cratchit");
+    assert.ok(cratchit, "cratchit must be in the registry");
+    assert.equal(cratchit?.api_server_port, 18794);
+    assert.equal(cratchit?.is_reserved, false);
+    assert.equal(cratchit?.is_user_facing, true);
+    assert.equal(cratchit?.status, "pending");
+    db.close();
+  });
+
+  it("excludes archived profiles", () => {
+    const db = freshDb();
+    createProfile(db, { slug: "alpha", label: "A", model: "m" });
+    createProfile(db, { slug: "bravo", label: "B", model: "m" });
+    archiveProfile(db, "alpha");
+    const reg = buildSupervisorRegistry(db);
+    const slugs = reg.profiles.map((p) => p.slug);
+    assert.ok(!slugs.includes("alpha"));
+    assert.ok(slugs.includes("bravo"));
+    db.close();
+  });
+});
+
+describe("supervisor — module surface", () => {
+  it("writeSupervisorRegistry + nudgeHermesSupervisor are exported", () => {
+    // Static smoke — the route layer imports both names; verify the
+    // module shape doesn't drift out from under it.
+    assert.equal(typeof writeSupervisorRegistry, "function");
+  });
+});

--- a/packages/hermes/docker/supervisor.sh
+++ b/packages/hermes/docker/supervisor.sh
@@ -2,7 +2,9 @@
 # =============================================================================
 # supervisor.sh — alfred-black-hermes process supervisor.
 #
-# Runs THREE long-lived processes in one container and keeps them alive:
+# Reads /hermes-state/profiles/_registry.json (written by the init container
+# + ctrl-api on every profile create/archive — #120 Lane II) and keeps a
+# Hermes gateway alive per registered profile:
 #
 #   1. hermes -p main    gateway run   — user-facing chat (Hermes API :18789)
 #   2. hermes -p workers gateway run   — background agents (Hermes API :18790)
@@ -12,6 +14,16 @@
 #      is always rendered by the init container; this script just decides
 #      whether to launch a gateway against it. Drops to uid 10001 via
 #      `setpriv --reuid 10001`. See docs/codex-builder-runtime.md §2.
+#   5..N. Any user-facing profile created via ctrl-api's POST
+#         /api/v1/agent-profiles. Each gets a gateway on its allocated
+#         port (18794..18799). After /health = 200 the supervisor POSTs
+#         status='running' back to ctrl-api so the registry row reflects
+#         the live state.
+#
+# SIGUSR1 — reconcile against the latest registry without a full restart.
+# ctrl-api sends this signal after every create/archive. The handler diffs
+# the on-disk registry against the live PIDS[] map: missing profiles get
+# spawned, archived profiles get a clean SIGTERM.
 #
 # The hermes-shim was retired in issue #40: the Hermes API server binds the
 # canonical ports (:18789 / :18790 / :18791 / :18793) directly, so callers
@@ -26,8 +38,7 @@
 # and forwards SIGTERM/SIGINT for a graceful compose stop.
 #
 # Profile state (config.yaml, .env, SOUL.md, sessions, skills, the MCP
-# bundle) is rendered/deployed by the init container into
-# ${HERMES_HOME}/profiles/{main,workers,heavy,codex-builder}/ BEFORE this
+# bundle) is rendered/deployed by the init container BEFORE this
 # container starts — `init` is a compose `service_completed_successfully`
 # gate. This script only waits for that state to appear, then launches.
 # =============================================================================
@@ -104,32 +115,154 @@ shutdown() {
 }
 trap shutdown TERM INT
 
+# --- SIGUSR1 reconcile trap (#120 Lane II) -----------------------------------
+# ctrl-api sends SIGUSR1 after every profile create/archive. The handler
+# re-reads /hermes-state/profiles/_registry.json and:
+#   * spawns a hermes-<slug> gateway for any newly-registered profile.
+#   * SIGTERMs the gateway of any registered-but-now-archived profile.
+# Idempotent — running it on a registry that exactly matches the live
+# PIDS[] is a no-op.
+#
+# Implementation note: bash traps run between commands in the main loop,
+# not from anywhere; long-running operations inside a trap can stall the
+# supervise loop's wait -n. We keep the body short and offload the
+# /health probe to a background subshell.
+reconcile_registry() {
+    log "SIGUSR1 received — reconciling registry"
+    local seen_slugs=""
+    while IFS=$'\t' read -r slug port _ _; do
+        [[ -z "$slug" ]] && continue
+        seen_slugs="${seen_slugs} ${slug}"
+        if [[ -z "${REGISTRY_LAUNCHED[$slug]:-}" ]]; then
+            # New profile — spawn it. codex-builder cannot be added at
+            # runtime (the egress-jail + setpriv path runs at boot).
+            if [[ "$slug" == "codex-builder" ]]; then
+                log "reconcile: skipping codex-builder (boot-only launch)"
+                continue
+            fi
+            log "reconcile: spawning new profile '${slug}' on port ${port}"
+            start_registered_profile "$slug" "$port"
+            # Probe + status callback for the new profile in the background.
+            probe_and_notify "$slug" "$port" &
+            disown
+        fi
+    done < <(read_registry)
+
+    # SIGTERM any launched profile that is no longer in the registry.
+    for slug in "${!REGISTRY_LAUNCHED[@]}"; do
+        if [[ "$slug" == "codex-builder" ]]; then
+            continue  # never tear down codex-builder via reconcile
+        fi
+        if [[ " ${seen_slugs} " != *" ${slug} "* ]]; then
+            local proc_name="hermes-${slug}"
+            local pid="${PIDS[$proc_name]:-}"
+            if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+                log "reconcile: SIGTERM '${proc_name}' (pid ${pid}) — profile archived"
+                kill -TERM "$pid" 2>/dev/null || true
+                # Mark as not-launched so a future re-add can spawn fresh.
+                # Don't unset PIDS[] here; the supervise loop walks it on
+                # exit to record the death.
+            fi
+            unset 'REGISTRY_LAUNCHED['"$slug"']'
+            unset 'REGISTRY_PORT['"$slug"']'
+        fi
+    done
+}
+trap reconcile_registry USR1
+
+# --- Registry-driven profile enumeration (#120 Lane II) ----------------------
+# Reads /hermes-state/profiles/_registry.json (written by init container +
+# ctrl-api) and emits tab-separated `slug\tport\tmodel\tis_reserved` per
+# active profile to stdout. Uses python3 (already in the hermes image —
+# Hermes is python). Falls back to the legacy hard-coded 4-profile set on
+# any read failure so a missing-file boot still has known-good defaults.
+REGISTRY_FILE="${PROFILES_DIR}/_registry.json"
+
+read_registry() {
+    if [[ -f "$REGISTRY_FILE" ]]; then
+        python3 - "$REGISTRY_FILE" <<'PY' || _registry_fallback
+import json, sys
+try:
+    with open(sys.argv[1], "r", encoding="utf-8") as f:
+        data = json.load(f)
+    profiles = data.get("profiles", [])
+    for p in profiles:
+        slug = str(p.get("slug", "")).strip()
+        port = int(p.get("api_server_port", 0))
+        model = str(p.get("model", "")).strip()
+        reserved = "1" if p.get("is_reserved") else "0"
+        if not slug or not port:
+            continue
+        print(f"{slug}\t{port}\t{model}\t{reserved}")
+except Exception as e:
+    sys.stderr.write(f"[supervisor] registry read failed: {e}\n")
+    sys.exit(1)
+PY
+    else
+        _registry_fallback
+    fi
+}
+
+_registry_fallback() {
+    log "WARN: registry file ${REGISTRY_FILE} missing — using hard-coded reserved set"
+    echo -e "main\t18789\tx-ai/grok-4.3\t1"
+    echo -e "workers\t18790\topenai/gpt-4.1-nano\t1"
+    echo -e "heavy\t18791\tanthropic/claude-opus-4-6\t1"
+    if (( ENABLE_CODEX_BUILDER == 1 )); then
+        echo -e "codex-builder\t18793\tgpt-5-codex\t1"
+    fi
+}
+
 # --- Wait for the init container's profile output ----------------------------
 # The init container renders config.yaml + .env into each profile dir. If we
 # launch before that exists, Hermes boots with no API key / no MCP config.
 wait_for_profiles() {
     local waited=0
-    local profiles_to_wait=(main workers heavy)
-    if (( ENABLE_CODEX_BUILDER == 1 )); then
-        profiles_to_wait+=(codex-builder)
-    fi
-    for profile in "${profiles_to_wait[@]}"; do
-        local cfg="${PROFILES_DIR}/${profile}/config.yaml"
-        local env="${PROFILES_DIR}/${profile}/.env"
+    # Wait for the registry file first — init writes it before the
+    # per-profile renders below, so its presence is the signal that
+    # rendering has begun. Fall back to the legacy 4-profile wait when
+    # missing for back-compat with an older init image.
+    while [[ ! -f "$REGISTRY_FILE" ]]; do
+        if (( waited == 0 )); then
+            log "waiting for init container to write ${REGISTRY_FILE}..."
+        fi
+        sleep 2
+        waited=$((waited + 2))
+        if (( waited > 60 )); then
+            log "WARN: registry file ${REGISTRY_FILE} did not appear after ${waited}s — proceeding with hard-coded fallback"
+            break
+        fi
+    done
+
+    # Now wait for the per-profile config.yaml + .env to exist for every
+    # slug the registry tells us about.
+    local profiles_seen=""
+    while IFS=$'\t' read -r slug port _ _; do
+        [[ -z "$slug" ]] && continue
+        # codex-builder is a special case — its launch is flag-gated
+        # below; we still want its config rendered, but don't block on
+        # it when the flag is off.
+        if [[ "$slug" == "codex-builder" && "$ENABLE_CODEX_BUILDER" != "1" ]]; then
+            continue
+        fi
+        local cfg="${PROFILES_DIR}/${slug}/config.yaml"
+        local env="${PROFILES_DIR}/${slug}/.env"
+        local profile_wait=0
         while [[ ! -f "$cfg" || ! -f "$env" ]]; do
-            if (( waited == 0 )); then
-                log "waiting for init container to render ${profile} profile..."
+            if (( profile_wait == 0 )); then
+                log "waiting for init container to render ${slug} profile..."
             fi
             sleep 2
-            waited=$((waited + 2))
-            if (( waited > 300 )); then
-                log "FATAL: profile '${profile}' not provisioned after 300s"
+            profile_wait=$((profile_wait + 2))
+            if (( profile_wait > 300 )); then
+                log "FATAL: profile '${slug}' not provisioned after 300s"
                 log "       expected ${cfg} and ${env}"
                 exit 1
             fi
         done
-    done
-    log "all Hermes profiles provisioned under ${PROFILES_DIR} (codex-builder enabled=${ENABLE_CODEX_BUILDER})"
+        profiles_seen="${profiles_seen} ${slug}"
+    done < <(read_registry)
+    log "all Hermes profiles provisioned under ${PROFILES_DIR} (codex-builder enabled=${ENABLE_CODEX_BUILDER}; profiles:${profiles_seen})"
 }
 
 # =============================================================================
@@ -394,9 +527,102 @@ fi
 # Idempotent + crash-loop-safe: `start_proc` re-eval's the full command
 # string on each restart, so a profile .env edited after first boot is
 # picked up the next time the supervisor respawns that gateway.
-start_proc "hermes-main"     "cd \"${PROFILES_DIR}/main\"    && set -a && . \"${PROFILES_DIR}/main/.env\"    && set +a && TERMINAL_CWD=${PROFILES_DIR}/main    exec hermes -p main gateway run --replace"
-start_proc "hermes-workers"  "cd \"${PROFILES_DIR}/workers\" && set -a && . \"${PROFILES_DIR}/workers/.env\" && set +a && TERMINAL_CWD=${PROFILES_DIR}/workers exec hermes -p workers gateway run --replace"
-start_proc "hermes-heavy"    "cd \"${PROFILES_DIR}/heavy\"   && set -a && . \"${PROFILES_DIR}/heavy/.env\"   && set +a && TERMINAL_CWD=${PROFILES_DIR}/heavy   exec hermes -p heavy gateway run --replace"
+# #120 Lane II — registry-driven launch. Build a `hermes-<slug>` start_proc
+# per non-codex-builder profile in the registry, plus track every launched
+# slug so the SIGUSR1 reconciler can diff against the live PIDS set.
+declare -A REGISTRY_PORT=()
+declare -A REGISTRY_LAUNCHED=()  # slug → 1 once start_proc has fired
+
+# probe_and_notify(slug, port) — poll /health on the given port and POST
+# back to ctrl-api when it goes 200, flipping the registry row's status
+# from 'pending' to 'running'. Backgrounded by the caller — runs up to
+# ~60s before giving up (the next supervisor reconcile / restart will
+# retry).
+#
+# Auth: the gateway token at /alfred-data/.gateway-token IS the AAS_API_KEY
+# the rest of the stack uses to call ctrl-api (init writes the same value
+# into both). Read it inline rather than baking it into compose so a token
+# rotation doesn't need a hermes restart.
+probe_and_notify() {
+    local slug="$1"
+    local port="$2"
+    local waited=0
+    while (( waited < 60 )); do
+        if curl -fsS --max-time 2 "http://127.0.0.1:${port}/health" >/dev/null 2>&1; then
+            log "probe: '${slug}' /health OK on :${port} after ${waited}s"
+            local token=""
+            if [[ -r /alfred-data/.gateway-token ]]; then
+                token="$(tr -d '[:space:]' < /alfred-data/.gateway-token)"
+            fi
+            if [[ -n "$token" ]]; then
+                if curl -fsS --max-time 5 \
+                        -X POST \
+                        -H "Authorization: Bearer ${token}" \
+                        -H "Content-Type: application/json" \
+                        -d '{"status":"running"}' \
+                        "http://ctrl-api:3100/api/v1/agent-profiles/${slug}/status" \
+                        >/dev/null 2>&1; then
+                    log "probe: notified ctrl-api '${slug}' status=running"
+                else
+                    log "probe: WARN ctrl-api status notify failed for '${slug}' — registry row stays at last value"
+                fi
+            else
+                log "probe: WARN /alfred-data/.gateway-token unreadable — skipping ctrl-api notify for '${slug}'"
+            fi
+            return 0
+        fi
+        sleep 2
+        waited=$((waited + 2))
+    done
+    log "probe: '${slug}' /health did NOT respond on :${port} within 60s"
+    return 1
+}
+
+start_registered_profile() {
+    local slug="$1"
+    local port="$2"
+    # codex-builder uses a separate setpriv+egress-jail path further
+    # down. Skip here so the generic launcher doesn't race the special
+    # one.
+    if [[ "$slug" == "codex-builder" ]]; then
+        return 0
+    fi
+    if [[ -n "${REGISTRY_LAUNCHED[$slug]:-}" ]]; then
+        return 0  # already running
+    fi
+    local profile_dir="${PROFILES_DIR}/${slug}"
+    if [[ ! -f "${profile_dir}/.env" || ! -f "${profile_dir}/config.yaml" ]]; then
+        log "WARN: skipping launch of '${slug}' — profile dir not rendered (${profile_dir})"
+        return 0
+    fi
+    REGISTRY_PORT["$slug"]="$port"
+    REGISTRY_LAUNCHED["$slug"]=1
+    start_proc "hermes-${slug}" \
+        "cd \"${profile_dir}\" && set -a && . \"${profile_dir}/.env\" && set +a && TERMINAL_CWD=${profile_dir} exec hermes -p ${slug} gateway run --replace"
+}
+
+# Initial launch — iterate the registry once.
+# ANCHOR: BOOT_LAUNCH_LOOP — supervisor tests pin to this comment.
+while IFS=$'\t' read -r slug port _ _; do
+    [[ -z "$slug" ]] && continue
+    start_registered_profile "$slug" "$port"
+done < <(read_registry)
+
+# Fire one probe per launched profile in the background. Each waits for
+# /health and POSTs status=running back to ctrl-api so the agent_profile
+# row reflects the live process. Disowned so the supervise loop's `wait -n`
+# does not catch their completion as a child death.
+for slug in "${!REGISTRY_LAUNCHED[@]}"; do
+    if [[ "$slug" == "codex-builder" ]]; then
+        continue  # codex-builder probe is the special verify_lcm path
+    fi
+    port="${REGISTRY_PORT[$slug]:-}"
+    if [[ -z "$port" ]]; then
+        continue
+    fi
+    probe_and_notify "$slug" "$port" &
+    disown
+done
 
 # --- codex-builder gateway (Sir's decision #2 — flag-gated, home only) -------
 # The 4th profile, only launched when ENABLE_CODEX_BUILDER=1. Renders fleet-
@@ -479,6 +705,10 @@ if (( ENABLE_CODEX_BUILDER == 1 )); then
                        && set -a && . \"${CODEX_HOME_DIR}/.env\" && set +a \
                        && TERMINAL_CWD=\"${CODEX_HOME_DIR}/workspace\" \
                           exec hermes -p codex-builder gateway run --replace'"
+    # #120 Lane II — mark codex-builder as already-launched so the SIGUSR1
+    # reconciler doesn't double-start it via the generic path.
+    REGISTRY_LAUNCHED["codex-builder"]=1
+    REGISTRY_PORT["codex-builder"]=18793
     log "codex-builder gateway enabled (ENABLE_CODEX_BUILDER=1) — launching on :18793 as uid 10001"
 else
     log "codex-builder gateway disabled (ENABLE_CODEX_BUILDER!=1) — profile dir is rendered but no process launched"
@@ -517,6 +747,20 @@ while true; do
             bash -c "${CMDS[$name]}" &
             PIDS["$name"]=$!
             log "restarted '$name' (pid ${PIDS[$name]})"
+
+            # #120 Lane II — re-probe + re-notify after restart so the
+            # registry row's status flips back to 'running' once the
+            # rebooted gateway is healthy. Only for the registry-driven
+            # gateways (hermes-<slug>); codex-builder runs verify_lcm
+            # separately.
+            if [[ "$name" == hermes-* && "$name" != "hermes-codex-builder" ]]; then
+                restart_slug="${name#hermes-}"
+                restart_port="${REGISTRY_PORT[$restart_slug]:-}"
+                if [[ -n "$restart_port" ]]; then
+                    probe_and_notify "$restart_slug" "$restart_port" &
+                    disown
+                fi
+            fi
         fi
     done
 done

--- a/packages/hermes/hermes-config.yaml.njk
+++ b/packages/hermes/hermes-config.yaml.njk
@@ -33,7 +33,11 @@
               Same minimal-memory / no-channels / capped-concurrency posture
               as workers, but on an Opus-class model. API on :18791.
 #}
-{%- set is_main = (profile == "main") -%}
+{#- #120 Lane II — keep an external `is_main` override when the renderer
+    passed one (user-facing profiles render as main-like). Otherwise derive
+    from the slug for back-compat with anyone calling the template
+    directly. -#}
+{%- set is_main = is_main if is_main is defined else (profile == "main") -%}
 {%- set vault_path = vault_path | default("/vault") -%}
 {%- set ctrl_api_url = ctrl_api_url | default("http://ctrl-api:3100") -%}
 {%- set mcp_stdio_dir = mcp_stdio_dir | default("/opt/data/profiles/" + profile + "/mcp-stdio") -%}

--- a/packages/hermes/init/Dockerfile
+++ b/packages/hermes/init/Dockerfile
@@ -78,6 +78,11 @@ RUN pip install --no-cache-dir "jinja2==3.1.6" "ruamel.yaml==0.18.6"
 # repo-relative.
 COPY packages/hermes/init/entrypoint.sh        ./entrypoint.sh
 COPY packages/hermes/init/render_hermes.py     ./render_hermes.py
+# render_registry.py — #120 Lane II. Enumerates the agent_profile registry
+# from ctrl-api's state.db (mounted RO at /ctrl-data/alfred-state.db) and
+# emits the slug:port:model list entrypoint.sh iterates over, plus writes
+# /hermes-state/profiles/_registry.json the supervisor reads at boot.
+COPY packages/hermes/init/render_registry.py   ./render_registry.py
 COPY packages/hermes/init/render_sms_gateway.py ./render_sms_gateway.py
 # render_mcp_servers.py — idempotent ADD-only mutator that backfills new
 # required MCP server entries (e.g. `hass` PR #128, `files` PR #130) into

--- a/packages/hermes/init/entrypoint.sh
+++ b/packages/hermes/init/entrypoint.sh
@@ -42,18 +42,78 @@ HERMES_RUNTIME_HOME="${HERMES_RUNTIME_HOME:-/opt/data}"
 # ENABLE_CODEX_BUILDER=true in the runtime container env. Home flips that
 # flag true; rj/joe/zsolt/miguel leave it unset.
 #
-# PROFILES holds the "regular" profiles that get the full deploy treatment:
-# skills/, MCP bundle, AGENTS.md, SOUL.md. codex-builder is rendered (config
-# + .env + dir scaffold) but does NOT receive any of those — it is a sealed
-# runtime with no MCP catalogue and no skill library. See PROFILES_RENDERED
-# below for the broader set the renderer iterates over.
-PROFILES=(main workers heavy)
+# #120 Lane II — replaced the previous hard-coded
+#     PROFILES=(main workers heavy)
+#     PROFILES_RENDERED=(main workers heavy codex-builder)
+# with a query against state.db. Two derived lists below:
+#   * PROFILES_RENDERED     — every live profile from agent_profile.
+#   * PROFILES_FULL_DEPLOY  — that list minus codex-builder (the sealed
+#                              runtime gets config+.env but no skills/MCP).
+#
 # Every profile we render config + .env for. Each one gets profile_dir +
 # workspace/ + mcp/ created; codex-builder additionally gets its own
 # .codex/ + .ssh/ + workspace/runs/ tree but skips the skills + MCP-bundle
 # deploys further down. The supervisor reads ENABLE_CODEX_BUILDER to decide
 # whether to launch a gateway against the codex-builder dir.
-PROFILES_RENDERED=(main workers heavy codex-builder)
+#
+# #120 Lane II — PROFILES_RENDERED is now sourced from state.db via
+# render_registry.py (the agent_profile table, populated by ctrl-api's
+# 0017 migration + any user-facing POST). Each entry is a `slug:port:model`
+# tuple — entrypoint.sh splits the tuple into PROFILE_NAMES /
+# PROFILE_PORTS / PROFILE_MODELS parallel arrays so the existing
+# `for profile in "${PROFILES_RENDERED[@]}"` loops keep their shape.
+#
+# Fallback path: when state.db is unreachable (fresh tenant, pre-migration,
+# RO mount missing), render_registry.py emits the four reserved profiles
+# with their canonical ports — so this script ALWAYS produces a valid
+# 4-profile render even when ctrl-api hasn't booted yet.
+#
+# render_registry.py ALSO writes the `_registry.json` the supervisor reads
+# at boot. ctrl-api re-writes the same file on every profile create/archive
+# (packages/ctrl/src/hermes/supervisor.ts) and SIGUSR1's the hermes
+# container so the supervisor picks up the change without a full restart.
+echo "[init] Enumerating Hermes profiles from agent_profile registry..."
+mapfile -t PROFILE_TUPLES < <(
+    STATE_DB_PATH="${STATE_DB_PATH:-/ctrl-data/alfred-state.db}" \
+    HERMES_DATA_DIR="${HERMES_DATA_DIR:-/hermes-data}" \
+        python3 /setup/render_registry.py
+)
+if (( ${#PROFILE_TUPLES[@]} == 0 )); then
+    echo "[init] FATAL: render_registry.py returned no profiles — refusing to continue"
+    exit 1
+fi
+PROFILES_RENDERED=()
+declare -A PROFILE_PORTS=()
+declare -A PROFILE_MODELS=()
+for tuple in "${PROFILE_TUPLES[@]}"; do
+    # `slug:port:model` — model is the last field; everything to the right
+    # of the second colon is the model (which CAN contain forward slashes,
+    # not colons, per OpenRouter's `vendor/model` convention).
+    slug="${tuple%%:*}"
+    rest="${tuple#*:}"
+    port="${rest%%:*}"
+    model="${rest#*:}"
+    if [[ -z "$slug" || -z "$port" ]]; then
+        echo "[init] WARN: skipping malformed registry tuple: ${tuple}"
+        continue
+    fi
+    PROFILES_RENDERED+=("$slug")
+    PROFILE_PORTS["$slug"]="$port"
+    PROFILE_MODELS["$slug"]="$model"
+done
+echo "[init] Profiles to render: ${PROFILES_RENDERED[*]}"
+
+# PROFILES_FULL_DEPLOY — the subset that gets skills, MCP bundle, AGENTS.md,
+# TOOLS.md, SOUL.md. codex-builder is excluded by design (sealed runtime,
+# no MCP catalogue, no skill library). Lane II — user-facing profiles get
+# the same conversational kit as `main` (they ARE Alfred variants on a
+# different channel binding), so they ARE in this list.
+PROFILES_FULL_DEPLOY=()
+for slug in "${PROFILES_RENDERED[@]}"; do
+    [[ "$slug" == "codex-builder" ]] && continue
+    PROFILES_FULL_DEPLOY+=("$slug")
+done
+echo "[init] Profiles for full deploy (skills + MCP + AGENTS.md): ${PROFILES_FULL_DEPLOY[*]}"
 
 # Resolve bundled paths via the installed alfred Python package.
 SCAFFOLD_DIR=$(python3 -c "from alfred._data import get_scaffold_dir; print(get_scaffold_dir())")
@@ -138,7 +198,7 @@ done
 # at the Hermes-native location only; this block migrates leftover
 # composio dirs from older deployments and removes the empty parallel
 # tree so it can never re-divide the catalogue.
-for profile in "${PROFILES[@]}"; do
+for profile in "${PROFILES_FULL_DEPLOY[@]}"; do
     LEGACY_SKILLS_DIR="$HERMES_DATA_DIR/profiles/$profile/workspace/skills"
     CANONICAL_SKILLS_DIR="$HERMES_DATA_DIR/profiles/$profile/skills"
     if [[ -d "$LEGACY_SKILLS_DIR" ]]; then
@@ -165,7 +225,7 @@ done
 # From the `alfred` Python package — for the vault-worker daemons. Deployed
 # into BOTH profiles (the workers profile runs them; main carries them too
 # so the user-facing agent can read what they do).
-for profile in "${PROFILES[@]}"; do
+for profile in "${PROFILES_FULL_DEPLOY[@]}"; do
     SKILLS_DST="$HERMES_DATA_DIR/profiles/$profile/skills"
     for skill in vault-curator vault-janitor vault-distiller; do
         SRC_HASH=$(find "$SKILLS_SRC_DIR/$skill" -type f -exec md5sum {} \; | sort | md5sum | cut -d' ' -f1)
@@ -186,7 +246,7 @@ done
 # alfred-prime-federation skill is Prime-only.
 MAIN_SKILLS_SRC="/setup/workspace-template/skills"
 if [[ -d "$MAIN_SKILLS_SRC" ]]; then
-    for profile in "${PROFILES[@]}"; do
+    for profile in "${PROFILES_FULL_DEPLOY[@]}"; do
         SKILLS_DST="$HERMES_DATA_DIR/profiles/$profile/skills"
         for skill_dir in "$MAIN_SKILLS_SRC"/*/; do
             [[ -d "$skill_dir" ]] || continue
@@ -219,7 +279,7 @@ fi
 WORKSPACE_DOCS_SRC="/setup/workspace-template/docs/TOOLS.md"
 if [[ -f "$WORKSPACE_DOCS_SRC" ]]; then
     SRC_HASH=$(md5sum "$WORKSPACE_DOCS_SRC" | cut -d' ' -f1)
-    for profile in "${PROFILES[@]}"; do
+    for profile in "${PROFILES_FULL_DEPLOY[@]}"; do
         WS_DIR="$HERMES_DATA_DIR/profiles/$profile/workspace"
         mkdir -p "$WS_DIR"
         HASH_FILE="$WS_DIR/.TOOLS.md.content-hash"
@@ -237,7 +297,7 @@ fi
 MCP_SRC="/setup/mcp/ctrl-server.mjs"
 if [[ -f "$MCP_SRC" ]]; then
     SRC_HASH=$(md5sum "$MCP_SRC" | cut -d' ' -f1)
-    for profile in "${PROFILES[@]}"; do
+    for profile in "${PROFILES_FULL_DEPLOY[@]}"; do
         MCP_DST="$HERMES_DATA_DIR/profiles/$profile/mcp"
         mkdir -p "$MCP_DST"
         HASH_FILE="$MCP_DST/.ctrl-server.content-hash"
@@ -276,7 +336,7 @@ fi
 # AGENTS.md, SOUL.md — is a build artifact and re-syncs from the image.
 MCP_STDIO_SRC="/setup/mcp-stdio"
 if [[ -d "$MCP_STDIO_SRC" ]]; then
-    for profile in "${PROFILES[@]}"; do
+    for profile in "${PROFILES_FULL_DEPLOY[@]}"; do
         MCP_STDIO_DST="$HERMES_DATA_DIR/profiles/$profile/mcp-stdio"
         mkdir -p "$MCP_STDIO_DST"
         rsync -a --delete "$MCP_STDIO_SRC/" "$MCP_STDIO_DST/"
@@ -292,7 +352,7 @@ fi
 AGENTS_SRC="/setup/AGENTS.md"
 if [[ -f "$AGENTS_SRC" ]]; then
     AGENTS_HASH=$(md5sum "$AGENTS_SRC" | cut -d' ' -f1)
-    for profile in "${PROFILES[@]}"; do
+    for profile in "${PROFILES_FULL_DEPLOY[@]}"; do
         PROFILE_DIR="$HERMES_DATA_DIR/profiles/$profile"
         HASH_FILE="$PROFILE_DIR/.agents-md.content-hash"
         if [[ -f "$HASH_FILE" ]] && [[ "$(cat "$HASH_FILE")" == "$AGENTS_HASH" ]]; then
@@ -329,7 +389,7 @@ else
 fi
 if [[ -n "$SOUL_SRC" ]]; then
     SOUL_HASH=$(md5sum "$SOUL_SRC" | cut -d' ' -f1)
-    for profile in "${PROFILES[@]}"; do
+    for profile in "${PROFILES_FULL_DEPLOY[@]}"; do
         PROFILE_DIR="$HERMES_DATA_DIR/profiles/$profile"
         DST="$PROFILE_DIR/SOUL.md"
         HASH_FILE="$PROFILE_DIR/.soul-md.content-hash"
@@ -500,14 +560,24 @@ for profile in "${PROFILES_RENDERED[@]}"; do
     RUNTIME_PROFILE_DIR="$HERMES_RUNTIME_HOME/profiles/$profile"
     mkdir -p "$INIT_PROFILE_DIR"
 
+    # #120 Lane II — pass the registry-allocated port + model through to
+    # render_hermes.py. For the four reserved profiles these are identical
+    # to the hard-coded fallbacks in render_hermes.py (back-compat); for
+    # user-facing profiles created via ctrl-api they're the dynamically
+    # allocated 18794..18799 port + the operator's chosen model.
+    PROFILE_PORT="${PROFILE_PORTS[$profile]:-}"
+    PROFILE_MODEL="${PROFILE_MODELS[$profile]:-}"
+
     HERMES_VAULT_PATH="/vault" \
     HERMES_RUNTIME_PROFILE_DIR="$RUNTIME_PROFILE_DIR" \
+    HERMES_RENDER_PORT="$PROFILE_PORT" \
+    HERMES_RENDER_MODEL="$PROFILE_MODEL" \
         python3 /setup/render_hermes.py \
             "$profile" \
             "$INIT_PROFILE_DIR" \
             /setup \
             "$GATEWAY_TOKEN"
-    echo "[init] Rendered Hermes profile: $profile"
+    echo "[init] Rendered Hermes profile: $profile (port=$PROFILE_PORT model=$PROFILE_MODEL)"
 
     # --- 6a. Backfill required mcp_servers entries -----------------------
     # render_hermes.py preserves an existing operator-owned config.yaml.
@@ -782,7 +852,16 @@ EOF
             setfacl -m u:10001:--- /alfred-data/.gateway-token 2>/dev/null \
                 && echo "[init] [codex-builder] denied uid 10001 read on /alfred-data/.gateway-token (ACL)"
         fi
-        for p in main workers heavy; do
+        # #120 Lane II — every non-codex-builder profile (reserved infra +
+        # user-facing) gets the same ACL deny. PROFILES_RENDERED is sourced
+        # from state.db so user-facing profiles created via ctrl-api are
+        # covered automatically — without this, a freshly created sentinel
+        # profile would leave a uid-10001-readable .env on disk and the
+        # sandbox would be effective only for the original 4 profiles.
+        for p in "${PROFILES_RENDERED[@]}"; do
+            if [[ "$p" == "codex-builder" ]]; then
+                continue  # owned by uid 10001 — see comment above
+            fi
             P_ENV="$HERMES_DATA_DIR/profiles/$p/.env"
             if [[ -f "$P_ENV" ]]; then
                 setfacl -m u:10001:--- "$P_ENV" 2>/dev/null \
@@ -837,7 +916,10 @@ EOF
             echo "[init] [codex-builder] FAIL: uid 10001 can read /alfred-data/.gateway-token"
             ASSERT_FAILS=$((ASSERT_FAILS + 1))
         fi
-        for p in main workers heavy; do
+        for p in "${PROFILES_RENDERED[@]}"; do
+            if [[ "$p" == "codex-builder" ]]; then
+                continue
+            fi
             P_ENV="$HERMES_DATA_DIR/profiles/$p/.env"
             if [[ -f "$P_ENV" ]] && setpriv --reuid 10001 --regid 10001 --clear-groups \
                    cat "$P_ENV" > /dev/null 2>&1; then

--- a/packages/hermes/init/render_hermes.py
+++ b/packages/hermes/init/render_hermes.py
@@ -12,7 +12,7 @@ render them with Jinja2 directly. No Node/Nunjucks runtime needed in the
 init container.
 
 Usage:
-    render_hermes.py <profile> <profile_dir> <template_dir>
+    render_hermes.py <profile> <profile_dir> <template_dir> <gateway_token>
 
 Environment (read for template variables):
     OPENROUTER_API_KEY, ANTHROPIC_API_KEY, OPENAI_API_KEY
@@ -22,9 +22,19 @@ Environment (read for template variables):
     HERMES_VAULT_PATH        (default /vault)
     CTRL_API_URL             (default http://ctrl-api:3100)
     HERMES_API_CORS_ORIGINS  (optional CORS allowlist)
+    HERMES_RENDER_PORT       (#120 Lane II) override the port for ANY profile;
+                             required for user-facing profiles whose port is
+                             allocated dynamically by ctrl-api's agent_profile
+                             registry (18794..18799).
+    HERMES_RENDER_MODEL      (#120 Lane II) override the model for a user-
+                             facing profile; falls back to the reserved-
+                             profile defaults when absent.
 
 Positional:
-    <profile>       "main" | "workers" | "heavy" | "codex-builder"
+    <profile>       any slug matching ^[a-z][a-z0-9-]{1,30}$ — the four
+                    reserved infra profiles (main / workers / heavy /
+                    codex-builder) plus any user-facing profile created
+                    via ctrl-api's /api/v1/agent-profiles POST.
     <profile_dir>   absolute path where this process WRITES config.yaml +
                     .env (the init container's view of the volume,
                     e.g. /hermes-data/profiles/main)
@@ -32,9 +42,17 @@ Positional:
     <gateway_token> the value of /alfred-data/.gateway-token — becomes
                     API_SERVER_KEY in the profile .env
 
+#120 Lane II — the legacy `_KNOWN_PROFILES` allowlist is gone. Any slug that
+matches the registry regex is accepted; the port is sourced from
+HERMES_RENDER_PORT (the supervisor / entrypoint.sh passes the registry's
+api_server_port). For back-compat with the existing 4 reserved profiles,
+their canonical ports are still hard-coded as a fallback when
+HERMES_RENDER_PORT is unset.
+
 The Hermes API server binds the canonical ports 18789 (main) / 18790
 (workers) / 18791 (heavy) / 18793 (codex-builder) directly — the
-hermes-shim that used to front it was retired in issue #40.
+hermes-shim that used to front it was retired in issue #40. User-facing
+profiles use 18794..18799 (allocated by ctrl-api).
 
 Path-baking: the absolute paths baked INTO the rendered config.yaml
 (mcp-stdio dir, ctrl-server.mjs, NODE_PATH) must be valid in the HERMES
@@ -54,15 +72,16 @@ sessions, memory, skills, or auth.json.
 from __future__ import annotations
 
 import os
+import re
 import sys
 from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 
-# Hermes API server ports — the canonical ports every caller already uses.
-# The hermes-shim was retired (issue #40); the Hermes API server now binds
-# these ports directly. Must match docker/supervisor.sh and the EXPOSE in
-# the Dockerfile.
+# Hermes API server ports — the canonical ports for the four reserved
+# infra profiles. The hermes-shim was retired (issue #40); the Hermes API
+# server now binds these ports directly. Must match docker/supervisor.sh
+# and the EXPOSE in the Dockerfile.
 #
 # codex-builder (:18793) is the sealed-runtime builder profile (PR 2 of the
 # codex-builder build, docs/codex-builder-runtime.md). It is rendered on
@@ -70,16 +89,21 @@ from jinja2 import Environment, FileSystemLoader, StrictUndefined
 # LAUNCHES it when ENABLE_CODEX_BUILDER=true in the per-tenant compose env.
 # So home gets the running gateway; rj/joe/zsolt/miguel get an idle profile
 # dir but no listening process on :18793.
-_API_SERVER_PORT = {
+#
+# #120 Lane II — these are FALLBACK ports used when HERMES_RENDER_PORT is
+# unset. Any user-facing profile created via ctrl-api's POST
+# /api/v1/agent-profiles passes its allocated port (18794..18799) via
+# HERMES_RENDER_PORT.
+_RESERVED_PORT = {
     "main": 18789,
     "workers": 18790,
     "heavy": 18791,
     "codex-builder": 18793,
 }
 
-# Profiles this script knows how to render. Adding a profile is two changes:
-# this set + a port mapping above. Everything else flows from the templates.
-_KNOWN_PROFILES = frozenset(_API_SERVER_PORT.keys())
+# Slug regex — same as the registry's `agent_profile.slug` constraint
+# (packages/ctrl/src/db/agentProfiles.ts: _SLUG_RE).
+_SLUG_RE = re.compile(r"^[a-z][a-z0-9-]{1,30}$")
 
 # The template renders the `model:` block with `provider: openrouter`. Hermes
 # owns provider/model selection natively (`hermes model`, with a live model
@@ -315,15 +339,48 @@ def main() -> int:
     template_dir = Path(sys.argv[3])
     gateway_token = sys.argv[4].strip()
 
-    if profile not in _KNOWN_PROFILES:
-        valid = "|".join(sorted(_KNOWN_PROFILES))
+    # #120 Lane II — accept any slug matching the registry regex. The four
+    # reserved profiles still resolve to their canonical port via
+    # _RESERVED_PORT below; any other slug requires HERMES_RENDER_PORT to
+    # be set (the supervisor passes the registry's api_server_port).
+    if not _SLUG_RE.match(profile):
         print(
-            f"error: profile must be {valid}, got {profile!r}",
+            f"error: profile slug {profile!r} does not match "
+            f"^[a-z][a-z0-9-]{{1,30}}$",
             file=sys.stderr,
         )
         return 2
     if not gateway_token:
         print("error: gateway token is empty", file=sys.stderr)
+        return 2
+
+    # Resolve the API server port.
+    #   1. HERMES_RENDER_PORT env override — required for any non-reserved
+    #      slug; the supervisor passes the registry's allocated port here.
+    #   2. _RESERVED_PORT fallback — used by the existing 4 reserved
+    #      profiles when called without an explicit port (back-compat with
+    #      every pre-Lane-II caller).
+    #   3. Hard error — non-reserved slug with no port is a programmer
+    #      mistake we want to surface loud, not silently default to 18789.
+    port_override = os.environ.get("HERMES_RENDER_PORT", "").strip()
+    if port_override:
+        try:
+            api_server_port = int(port_override)
+        except ValueError:
+            print(
+                f"error: HERMES_RENDER_PORT={port_override!r} is not an integer",
+                file=sys.stderr,
+            )
+            return 2
+    elif profile in _RESERVED_PORT:
+        api_server_port = _RESERVED_PORT[profile]
+    else:
+        print(
+            f"error: profile {profile!r} is not a reserved infra profile and "
+            "HERMES_RENDER_PORT is unset (the user-facing profile's port from "
+            "the agent_profile registry must be passed via HERMES_RENDER_PORT)",
+            file=sys.stderr,
+        )
         return 2
 
     profile_dir.mkdir(parents=True, exist_ok=True)
@@ -364,10 +421,25 @@ def main() -> int:
     )
 
     # --- config.yaml ---------------------------------------------------------
+    # #120 Lane II — user-facing profiles (anything NOT in the reserved set)
+    # render through the same template branch as main: a capable
+    # conversational model via OpenRouter, with the standard agent posture.
+    # The HERMES_RENDER_MODEL env var (set by entrypoint.sh from the registry
+    # row) overrides the template's main_model default — so a profile created
+    # with model="anthropic/claude-opus-4-6" gets that model in its config.
+    is_reserved = profile in _RESERVED_PORT
+    is_main_like = profile == "main" or not is_reserved
+    model_override = os.environ.get("HERMES_RENDER_MODEL", "").strip()
+    main_model_value = (
+        model_override
+        if (is_main_like and model_override)
+        else os.environ.get("HERMES_MAIN_MODEL", "x-ai/grok-4.3")
+    )
+
     config_tmpl = env.get_template("hermes-config.yaml.njk")
     config_out = config_tmpl.render(
         profile=profile,
-        is_main=(profile == "main"),
+        is_main=is_main_like,
         vault_path=vault_path,
         ctrl_api_url=ctrl_api_url,
         mcp_stdio_dir=mcp_stdio_dir,
@@ -379,7 +451,7 @@ def main() -> int:
         # Bare OpenRouter model IDs (no `openrouter/` prefix — `provider:
         # openrouter` + base_url route it). Overridable via .env so a
         # stale model ID is a one-line fix, not a rebuild.
-        main_model=os.environ.get("HERMES_MAIN_MODEL", "x-ai/grok-4.3"),
+        main_model=main_model_value,
         workers_model=os.environ.get("HERMES_WORKERS_MODEL", "openai/gpt-4.1-nano"),
         heavy_model=os.environ.get("HERMES_HEAVY_MODEL", "anthropic/claude-opus-4-6"),
         # codex-builder runs Hermes' supervising agent on the same openai-
@@ -408,8 +480,8 @@ def main() -> int:
     env_tmpl = env.get_template("hermes-profile.env.njk")
     env_out = env_tmpl.render(
         profile=profile,
-        is_main=(profile == "main"),
-        api_server_port=_API_SERVER_PORT[profile],
+        is_main=is_main_like,
+        api_server_port=api_server_port,
         api_server_key=gateway_token,
         # Bind 0.0.0.0 — the Hermes API server is now reached directly over
         # the compose network (the shim that used to front it is gone).

--- a/packages/hermes/init/render_mcp_servers.py
+++ b/packages/hermes/init/render_mcp_servers.py
@@ -109,6 +109,12 @@ _REQUIRED_MCP_SERVERS: dict[str, list[tuple[str, dict]]] = {
     #                 skips this profile entirely (see profile guard below).
 }
 
+# #120 Lane II — known reserved profile names. User-facing profiles (not in
+# this set) get the same MCP-server allowlist as `main` (they're
+# conversational Alfred variants). Heavy stays unaffected via the explicit
+# "unknown-profile" return path below.
+_RESERVED_PROFILES: frozenset[str] = frozenset({"main", "workers", "heavy", "codex-builder"})
+
 # codex-builder's whole identity is "no MCP catalogue". We must NEVER
 # graft `hass` or `files` into its sealed-runtime config — the egress
 # allowlist + UID isolation would let them spawn but the gateway agent
@@ -294,7 +300,16 @@ def ensure_mcp_servers(
 
     required = _REQUIRED_MCP_SERVERS.get(profile)
     if required is None:
-        return "unknown-profile"
+        # Heavy (a reserved profile with no allowlist entries) keeps the
+        # historical "unknown-profile" return — the test pins this exact
+        # outcome so heavy never picks up the principal-facing surfaces.
+        if profile in _RESERVED_PROFILES:
+            return "unknown-profile"
+        # #120 Lane II — user-facing profiles (created via ctrl-api's
+        # /api/v1/agent-profiles POST) fall here. Treat them like `main`:
+        # they're conversational Alfred variants and need the same baseline
+        # MCP catalogue.
+        required = _REQUIRED_MCP_SERVERS["main"]
 
     from ruamel.yaml import YAML
 
@@ -335,11 +350,18 @@ def ensure_mcp_servers(
         )
         added_any = True
 
-    # Phase B: apply DELEGATED disposition to main profile's mcp_servers.
+    # Phase B: apply DELEGATED disposition to main-like profiles' mcp_servers.
     # Workers/heavy stay full-catalogue — the focused-subagent path needs
     # them. codex-builder was sealed above so never lands here.
+    # #120 Lane II — user-facing profiles (anything not in the reserved
+    # workers/heavy/codex-builder set) inherit main's disposition behaviour.
     disposition_mutated = False
-    if profile == "main" and state_db_path is not None:
+    main_like = profile == "main" or profile not in {
+        "workers",
+        "heavy",
+        "codex-builder",
+    }
+    if main_like and state_db_path is not None:
         dispositions = _read_dispositions(state_db_path)
         if dispositions:
             disposition_mutated = _apply_dispositions_to_main(mcp_servers, dispositions)

--- a/packages/hermes/init/render_registry.py
+++ b/packages/hermes/init/render_registry.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""render_registry.py — enumerate live profiles + emit the supervisor registry JSON.
+
+#120 Lane II — replaces the previous hard-coded `PROFILES_RENDERED=(main
+workers heavy codex-builder)` list in entrypoint.sh. Queries the agent_profile
+table in ctrl-api's state.db (mounted read-only at /ctrl-data/alfred-state.db)
+and:
+
+  1. Prints (to stdout) a newline-separated list of `<slug>:<port>:<model>`
+     for the init loop to render. The slug is what entrypoint.sh feeds into
+     render_hermes.py; the port becomes HERMES_RENDER_PORT, the model
+     HERMES_RENDER_MODEL.
+
+  2. Writes a JSON manifest to /hermes-state/profiles/_registry.json the
+     supervisor will read at boot. The shape matches ctrl-api's
+     buildSupervisorRegistry (db/agentProfiles.ts) — one source of truth
+     for the file shape.
+
+  3. Falls back gracefully when state.db is missing OR the table is missing:
+     prints the four reserved profiles + their canonical ports, so a fresh
+     tenant still gets the existing 4-profile layout even if init runs
+     before ctrl-api has applied the 0017 migration.
+
+This script is a READ-ONLY consumer of state.db. ctrl-api remains the SOLE
+writer of the registry rows.
+
+Usage:
+    render_registry.py [--out <registry_json_path>]
+
+Environment:
+    STATE_DB_PATH                 path to state.db (default /ctrl-data/alfred-state.db)
+    HERMES_DATA_DIR               init container's view of hermes_data
+                                  (default /hermes-data) — used as the
+                                  default registry-JSON parent dir.
+    HERMES_REGISTRY_PATH          full registry JSON override; takes
+                                  precedence over --out and HERMES_DATA_DIR.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+# Same fallback layout the supervisor expected before this script existed —
+# matches _RESERVED_PORT in render_hermes.py.
+_FALLBACK_PROFILES = [
+    {
+        "slug": "main",
+        "api_server_port": 18789,
+        "model": "x-ai/grok-4.3",
+        "status": "running",
+        "is_reserved": True,
+        "is_user_facing": True,
+    },
+    {
+        "slug": "workers",
+        "api_server_port": 18790,
+        "model": "openai/gpt-4.1-nano",
+        "status": "running",
+        "is_reserved": True,
+        "is_user_facing": False,
+    },
+    {
+        "slug": "heavy",
+        "api_server_port": 18791,
+        "model": "anthropic/claude-opus-4-6",
+        "status": "running",
+        "is_reserved": True,
+        "is_user_facing": False,
+    },
+    {
+        "slug": "codex-builder",
+        "api_server_port": 18793,
+        "model": "gpt-5-codex",
+        "status": "stopped",
+        "is_reserved": True,
+        "is_user_facing": False,
+    },
+]
+
+
+def _read_profiles_from_state_db(state_db_path: Path) -> list[dict] | None:
+    """Try to enumerate profiles from state.db. Returns None on any failure
+    (file missing, table missing, sqlite locked, …) so the caller can fall
+    back to the hard-coded reserved list."""
+    if not state_db_path.exists():
+        return None
+    try:
+        # mode=ro&immutable=1 — open the file read-only, refuse to apply
+        # any WAL recovery, and never touch the journal. This is the same
+        # posture render_mcp_servers.py uses against the same file (the
+        # mount is :ro so a write would EROFS anyway, but the pragma
+        # cleans up the failure-mode surface).
+        uri = f"file:{state_db_path}?mode=ro&immutable=1"
+        conn = sqlite3.connect(uri, uri=True, timeout=5)
+        conn.row_factory = sqlite3.Row
+        cur = conn.execute(
+            """
+            SELECT slug, api_server_port, model, status,
+                   is_reserved, is_user_facing
+            FROM agent_profile
+            WHERE archived_at IS NULL
+              AND status != 'archived'
+            ORDER BY is_reserved DESC, api_server_port ASC
+            """
+        )
+        rows = cur.fetchall()
+        conn.close()
+    except sqlite3.OperationalError as e:
+        # Table missing (fresh tenant pre-migration) or DB locked. Caller
+        # falls back to _FALLBACK_PROFILES.
+        print(
+            f"[render_registry] state.db query failed ({e}) — falling back to reserved set",
+            file=sys.stderr,
+        )
+        return None
+    if not rows:
+        # Table exists but is empty — shouldn't happen after 0017 seeds the
+        # four reserved profiles, but be defensive: fall back rather than
+        # render a zero-profile container.
+        return None
+    return [
+        {
+            "slug": r["slug"],
+            "api_server_port": int(r["api_server_port"]),
+            "model": r["model"],
+            "status": r["status"],
+            "is_reserved": bool(r["is_reserved"]),
+            "is_user_facing": bool(r["is_user_facing"]),
+        }
+        for r in rows
+    ]
+
+
+def _resolve_registry_path(cli_out: str | None) -> Path:
+    explicit = os.environ.get("HERMES_REGISTRY_PATH", "").strip()
+    if explicit:
+        return Path(explicit)
+    if cli_out:
+        return Path(cli_out)
+    hermes_data_dir = os.environ.get("HERMES_DATA_DIR", "/hermes-data").strip()
+    return Path(hermes_data_dir) / "profiles" / "_registry.json"
+
+
+def _atomic_write_json(path: Path, payload: dict) -> None:
+    """Write `payload` JSON to `path` atomically (write-then-rename).
+    Same semantics as ctrl-api's writeSupervisorRegistry — the supervisor
+    either sees the previous valid JSON or the new one, never a torn file.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    tmp.chmod(0o644)
+    os.replace(tmp, path)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--out",
+        default=None,
+        help="explicit path for the registry JSON output",
+    )
+    ap.add_argument(
+        "--print-only",
+        action="store_true",
+        help="print the slug:port:model list to stdout, do not write JSON",
+    )
+    args = ap.parse_args()
+
+    state_db_path = Path(
+        os.environ.get("STATE_DB_PATH", "/ctrl-data/alfred-state.db")
+    )
+    profiles = _read_profiles_from_state_db(state_db_path)
+    source = "state.db"
+    if profiles is None:
+        profiles = list(_FALLBACK_PROFILES)
+        source = "fallback (reserved profiles only)"
+
+    print(
+        f"[render_registry] resolved {len(profiles)} profile(s) from {source}",
+        file=sys.stderr,
+    )
+    for p in profiles:
+        print(
+            f"[render_registry]   - {p['slug']} port={p['api_server_port']} "
+            f"model={p['model']} status={p['status']} reserved={p['is_reserved']}",
+            file=sys.stderr,
+        )
+
+    # stdout: one line per profile, format `slug:port:model`. entrypoint.sh
+    # loops over this list. Model is the last column so a future colon-in-
+    # slug (impossible per the regex) or colon-in-port (impossible per int)
+    # cannot break the field split.
+    for p in profiles:
+        print(f"{p['slug']}:{p['api_server_port']}:{p['model']}")
+
+    if args.print_only:
+        return 0
+
+    registry_path = _resolve_registry_path(args.out)
+    payload = {
+        "profiles": profiles,
+        "generated_at": int(time.time() * 1000),
+        "source": source,
+    }
+    _atomic_write_json(registry_path, payload)
+    print(
+        f"[render_registry] wrote {registry_path} ({len(profiles)} profiles)",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/hermes/tests/test_render_hermes_lane_ii.py
+++ b/packages/hermes/tests/test_render_hermes_lane_ii.py
@@ -1,0 +1,109 @@
+"""Tests for the #120 Lane II changes to render_hermes.py.
+
+Pins:
+  1. _KNOWN_PROFILES allowlist is gone — any slug matching the regex
+     ^[a-z][a-z0-9-]{1,30}$ is accepted.
+  2. HERMES_RENDER_PORT overrides the canonical port for ANY slug;
+     required for user-facing slugs (those not in _RESERVED_PORT).
+  3. A non-reserved slug WITHOUT HERMES_RENDER_PORT errors out — never
+     silently defaults to a reserved port.
+  4. The four reserved slugs still work without HERMES_RENDER_PORT
+     (back-compat with every existing caller).
+  5. Bad-shape slugs are rejected with a clear error.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+HERMES = Path(__file__).resolve().parent.parent
+SCRIPT = HERMES / "init" / "render_hermes.py"
+
+
+def _run(args: list[str], env_overrides: dict[str, str] | None = None):
+    env = dict(os.environ)
+    # Provide the bare-minimum env so the templates render. Tests do not
+    # need real keys; just non-empty placeholders for the env-block render.
+    env.setdefault("OPENROUTER_API_KEY", "test-or-key")
+    env.setdefault("AAS_API_KEY", "test-aas")
+    if env_overrides:
+        env.update(env_overrides)
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_reserved_main_still_works_without_port_override(tmp_path: Path):
+    """Back-compat: every existing caller passes no HERMES_RENDER_PORT for
+    the reserved profiles. The script must still resolve main → 18789."""
+    out = _run(["main", str(tmp_path), str(HERMES), "test-token"])
+    assert out.returncode == 0, out.stderr
+    env_text = (tmp_path / ".env").read_text(encoding="utf-8")
+    assert "API_SERVER_PORT=18789" in env_text
+
+
+def test_user_facing_slug_with_port_override_renders(tmp_path: Path):
+    """A user-facing profile slug (not in the reserved set) + an explicit
+    HERMES_RENDER_PORT must render successfully."""
+    out = _run(
+        ["cratchit", str(tmp_path), str(HERMES), "test-token"],
+        env_overrides={"HERMES_RENDER_PORT": "18794"},
+    )
+    assert out.returncode == 0, out.stderr
+    env_text = (tmp_path / ".env").read_text(encoding="utf-8")
+    assert "API_SERVER_PORT=18794" in env_text
+    # Conversational profile gets main-like config (provider: openrouter).
+    cfg_text = (tmp_path / "config.yaml").read_text(encoding="utf-8")
+    assert "provider:" in cfg_text
+
+
+def test_user_facing_slug_without_port_override_errors(tmp_path: Path):
+    """A non-reserved slug without HERMES_RENDER_PORT must error with a
+    clear message, not silently default to a reserved port."""
+    out = _run(
+        ["sentinel", str(tmp_path), str(HERMES), "test-token"],
+    )
+    assert out.returncode != 0
+    assert "HERMES_RENDER_PORT" in out.stderr
+    assert "sentinel" in out.stderr
+
+
+def test_invalid_slug_shape_rejected(tmp_path: Path):
+    """A slug not matching ^[a-z][a-z0-9-]{1,30}$ must error fast."""
+    out = _run(
+        ["1bad", str(tmp_path), str(HERMES), "test-token"],
+        env_overrides={"HERMES_RENDER_PORT": "18794"},
+    )
+    assert out.returncode != 0
+    assert "1bad" in out.stderr
+
+
+def test_model_override_lands_in_config(tmp_path: Path):
+    """HERMES_RENDER_MODEL must be the model in the rendered config.yaml
+    for a user-facing profile."""
+    out = _run(
+        ["sentinel", str(tmp_path), str(HERMES), "test-token"],
+        env_overrides={
+            "HERMES_RENDER_PORT": "18795",
+            "HERMES_RENDER_MODEL": "anthropic/claude-opus-4-6",
+        },
+    )
+    assert out.returncode == 0, out.stderr
+    cfg_text = (tmp_path / "config.yaml").read_text(encoding="utf-8")
+    assert "anthropic/claude-opus-4-6" in cfg_text
+
+
+def test_codex_builder_still_renders_with_fallback_port(tmp_path: Path):
+    """codex-builder is reserved at 18793 — back-compat path must keep
+    working without HERMES_RENDER_PORT."""
+    out = _run(["codex-builder", str(tmp_path), str(HERMES), "test-token"])
+    assert out.returncode == 0, out.stderr
+    env_text = (tmp_path / ".env").read_text(encoding="utf-8")
+    assert "API_SERVER_PORT=18793" in env_text

--- a/packages/hermes/tests/test_render_registry.py
+++ b/packages/hermes/tests/test_render_registry.py
@@ -1,0 +1,193 @@
+"""Tests for render_registry.py — the #120 Lane II profile enumerator.
+
+Pins the contract every layer above depends on:
+
+  1. With a fully-seeded state.db (post-0017 migration), render_registry
+     emits all four reserved profiles + any user-facing rows, ordered
+     reserved-first then by api_server_port.
+  2. With a missing state.db, the fallback emits the four reserved
+     profiles with their canonical ports — so a fresh tenant (init
+     boots before ctrl-api has applied the migration) still gets a
+     valid layout.
+  3. The atomic JSON write writes through a `.tmp` rename — never a
+     half-written file.
+  4. The stdout line format is `slug:port:model` — colon-separated,
+     parseable by the entrypoint.sh loop.
+  5. Archived profiles are excluded.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+HERMES = Path(__file__).resolve().parent.parent
+SCRIPT = HERMES / "init" / "render_registry.py"
+
+
+def _seed_state_db(path: Path, *, include_user: bool = False, archive_user: bool = False) -> None:
+    """Create a minimal state.db that mimics the post-0017-migration shape."""
+    conn = sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE agent_profile (
+          slug              TEXT PRIMARY KEY,
+          label             TEXT NOT NULL,
+          description       TEXT,
+          model             TEXT NOT NULL,
+          deployment_shape  TEXT NOT NULL DEFAULT 'supervised',
+          api_server_port   INTEGER NOT NULL,
+          persona_template  TEXT,
+          status            TEXT NOT NULL DEFAULT 'pending',
+          is_user_facing    INTEGER NOT NULL DEFAULT 1,
+          is_reserved       INTEGER NOT NULL DEFAULT 0,
+          created_at        INTEGER NOT NULL,
+          updated_at        INTEGER NOT NULL,
+          archived_at       INTEGER
+        );
+        INSERT INTO agent_profile (slug, label, model, api_server_port, status, is_user_facing, is_reserved, created_at, updated_at) VALUES
+          ('main',          'Alfred',        'x-ai/grok-4.3',             18789, 'running', 1, 1, 0, 0),
+          ('workers',       'Workers',       'openai/gpt-4.1-nano',       18790, 'running', 0, 1, 0, 0),
+          ('heavy',         'Heavy',         'anthropic/claude-opus-4-6', 18791, 'running', 0, 1, 0, 0),
+          ('codex-builder', 'Codex builder', 'gpt-5-codex',               18793, 'stopped', 0, 1, 0, 0);
+        """
+    )
+    if include_user:
+        archived_at = "100" if archive_user else "NULL"
+        status = "'archived'" if archive_user else "'pending'"
+        conn.execute(
+            f"INSERT INTO agent_profile (slug, label, model, api_server_port, status, is_user_facing, is_reserved, created_at, updated_at, archived_at) VALUES "
+            f"('cratchit', 'Cratchit', 'x-ai/grok-4.3', 18794, {status}, 1, 0, 0, 0, {archived_at})"
+        )
+    conn.commit()
+    conn.close()
+
+
+def _run_script(state_db: Path | None, hermes_data_dir: Path | None, args: list[str] | None = None):
+    """Run render_registry.py as a subprocess. Returns (stdout, stderr, rc)."""
+    env = dict(os.environ)
+    env["STATE_DB_PATH"] = str(state_db) if state_db else "/nonexistent.db"
+    if hermes_data_dir:
+        env["HERMES_DATA_DIR"] = str(hermes_data_dir)
+    cmd = [sys.executable, str(SCRIPT)]
+    if args:
+        cmd.extend(args)
+    result = subprocess.run(cmd, env=env, capture_output=True, text=True)
+    return result.stdout, result.stderr, result.returncode
+
+
+def test_emits_four_reserved_profiles_from_seeded_db(tmp_path: Path):
+    state_db = tmp_path / "state.db"
+    hermes_data = tmp_path / "hermes-data"
+    hermes_data.mkdir()
+    _seed_state_db(state_db)
+
+    stdout, stderr, rc = _run_script(state_db, hermes_data)
+    assert rc == 0, stderr
+    lines = [l for l in stdout.strip().splitlines() if l]
+    # 4 reserved profiles, ordered by api_server_port (main:18789 → ... → codex:18793).
+    assert len(lines) == 4
+    slugs = [line.split(":", 1)[0] for line in lines]
+    assert slugs == ["main", "workers", "heavy", "codex-builder"]
+
+
+def test_includes_user_facing_profile(tmp_path: Path):
+    state_db = tmp_path / "state.db"
+    hermes_data = tmp_path / "hermes-data"
+    hermes_data.mkdir()
+    _seed_state_db(state_db, include_user=True)
+
+    stdout, stderr, rc = _run_script(state_db, hermes_data)
+    assert rc == 0, stderr
+    lines = [l for l in stdout.strip().splitlines() if l]
+    assert len(lines) == 5
+    # cratchit allocated on 18794 — last in port-ordered output (reserved
+    # are sorted before user-facing because of is_reserved DESC).
+    assert any("cratchit:18794:" in line for line in lines)
+
+
+def test_archived_user_facing_profile_excluded(tmp_path: Path):
+    state_db = tmp_path / "state.db"
+    hermes_data = tmp_path / "hermes-data"
+    hermes_data.mkdir()
+    _seed_state_db(state_db, include_user=True, archive_user=True)
+
+    stdout, stderr, rc = _run_script(state_db, hermes_data)
+    assert rc == 0, stderr
+    lines = [l for l in stdout.strip().splitlines() if l]
+    assert len(lines) == 4  # archived profile excluded
+    assert not any("cratchit" in line for line in lines)
+
+
+def test_fallback_to_reserved_set_when_state_db_missing(tmp_path: Path):
+    hermes_data = tmp_path / "hermes-data"
+    hermes_data.mkdir()
+
+    stdout, stderr, rc = _run_script(state_db=None, hermes_data_dir=hermes_data)
+    assert rc == 0, stderr
+    lines = [l for l in stdout.strip().splitlines() if l]
+    assert len(lines) == 4
+    slugs = [line.split(":", 1)[0] for line in lines]
+    assert set(slugs) == {"main", "workers", "heavy", "codex-builder"}
+
+
+def test_writes_atomic_registry_json(tmp_path: Path):
+    state_db = tmp_path / "state.db"
+    hermes_data = tmp_path / "hermes-data"
+    hermes_data.mkdir()
+    _seed_state_db(state_db, include_user=True)
+
+    stdout, stderr, rc = _run_script(state_db, hermes_data)
+    assert rc == 0, stderr
+
+    out = hermes_data / "profiles" / "_registry.json"
+    assert out.exists(), f"expected {out} to exist"
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert "profiles" in payload
+    assert "generated_at" in payload
+    assert "source" in payload
+    slugs = {p["slug"] for p in payload["profiles"]}
+    assert {"main", "workers", "heavy", "codex-builder", "cratchit"} <= slugs
+    # The atomic write path uses a .tmp sibling and renames — that .tmp
+    # must NOT survive a clean run.
+    assert not (out.parent / "_registry.json.tmp").exists()
+
+
+def test_print_only_does_not_write_registry(tmp_path: Path):
+    state_db = tmp_path / "state.db"
+    hermes_data = tmp_path / "hermes-data"
+    hermes_data.mkdir()
+    _seed_state_db(state_db)
+
+    stdout, stderr, rc = _run_script(state_db, hermes_data, args=["--print-only"])
+    assert rc == 0, stderr
+    # stdout still has the tuples.
+    assert "main:18789:" in stdout
+    # but no registry file written.
+    assert not (hermes_data / "profiles" / "_registry.json").exists()
+
+
+def test_line_format_is_slug_port_model(tmp_path: Path):
+    state_db = tmp_path / "state.db"
+    hermes_data = tmp_path / "hermes-data"
+    hermes_data.mkdir()
+    _seed_state_db(state_db)
+
+    stdout, _, rc = _run_script(state_db, hermes_data)
+    assert rc == 0
+    for line in stdout.strip().splitlines():
+        if not line:
+            continue
+        # split on first two colons — model can contain slashes (OpenRouter
+        # vendor/model convention) but never colons.
+        slug, rest = line.split(":", 1)
+        port, model = rest.split(":", 1)
+        assert slug and port.isdigit() and model

--- a/packages/hermes/tests/test_supervisor_auth_propagation.py
+++ b/packages/hermes/tests/test_supervisor_auth_propagation.py
@@ -95,15 +95,23 @@ def test_propagation_is_after_sticky_default():
 
 
 def test_propagation_is_before_main_gateway_launch():
-    """The propagation block must run BEFORE the main gateway launches."""
+    """The propagation block must run BEFORE the gateway launch loop.
+
+    #120 Lane II — anchor is the templated registry launch loop's
+    `done < <(read_registry)` line (which replaces the previous trio of
+    per-profile start_proc calls).
+    """
     src = _read()
     cp_line = _line_index(src, 'cp "$MAIN_AUTH" "$P_AUTH"')
-    launch_line = _line_index(src, 'hermes -p main gateway run')
+    launch_line = _line_index(src, "ANCHOR: BOOT_LAUNCH_LOOP")
     assert cp_line >= 0, "expected propagation `cp` line"
-    assert launch_line >= 0, "expected `hermes -p main gateway run` launch line"
+    assert launch_line >= 0, (
+        "expected the registry-driven launch loop's "
+        "`done < <(read_registry)` line — supervisor.sh was restructured"
+    )
     assert cp_line < launch_line, (
         f"propagation `cp` (line {cp_line + 1}) must come BEFORE the "
-        f"`hermes -p main gateway run` launch (line {launch_line + 1}) — "
+        f"registry launch loop (line {launch_line + 1}) — "
         f"the gateways read auth.json on startup, so the per-profile "
         f"files must be in place before any of them boots."
     )

--- a/packages/hermes/tests/test_supervisor_profile_cwd.py
+++ b/packages/hermes/tests/test_supervisor_profile_cwd.py
@@ -1,5 +1,6 @@
-"""Static-text test: each `hermes -p <profile> gateway run` invocation in
-supervisor.sh must launch with the process CWD set to that profile's dir.
+"""Static-text test: the templated `hermes -p <profile> gateway run`
+invocation in supervisor.sh must launch with the process CWD set to that
+profile's dir.
 
 Per the Hermes docs (user-guide/features/context-files), Hermes discovers
 AGENTS.md / CLAUDE.md / .hermes.md / .cursorrules (in that precedence)
@@ -7,6 +8,13 @@ FROM THE PROCESS CWD at gateway boot, NOT from $HERMES_HOME or the profile
 dir. Live evidence on test.alfred.black: each PID's cwd was `/` so the
 per-profile AGENTS.md never loaded. The fix is to `cd` into the profile
 dir before exec'ing hermes.
+
+#120 Lane II — the three per-profile start_proc lines were replaced by a
+single templated start_registered_profile() function called once per slug
+from the registry. We now anchor against:
+  * the start_registered_profile() body (must `cd "${profile_dir}"`),
+  * the registry-iterating launch loop (must call start_registered_profile),
+  * codex-builder's own boot-time launch (still its own block).
 """
 from pathlib import Path
 
@@ -19,103 +27,104 @@ def _read():
     return SUPERVISOR.read_text()
 
 
-def _start_proc_line(profile: str) -> str:
-    """Return the start_proc line for the given profile, or '' if absent."""
-    needle = f"hermes -p {profile} gateway"
-    for line in _read().splitlines():
-        if "start_proc" in line and needle in line:
-            return line
-    return ""
-
-
-def _start_proc_idx(profile: str) -> int:
-    needle = f"hermes -p {profile} gateway"
-    for i, line in enumerate(_read().splitlines()):
-        if "start_proc" in line and needle in line:
-            return i
-    return -1
-
-
-def _cd_anchor_present(profile: str, line: str) -> bool:
-    """Accept either the escaped or unescaped spelling, and the
-    `${PROFILES_DIR}` / `$PROFILES_DIR` / `$HERMES_HOME/profiles/...`
-    variants. The launch is a double-quoted string passed to start_proc,
-    which then runs `bash -c "$cmd"`, so inner quotes are backslash-
-    escaped in the source text."""
-    return any(c in line for c in (
-        f'cd "${{PROFILES_DIR}}/{profile}"',
-        f'cd \\"${{PROFILES_DIR}}/{profile}\\"',
-        f'cd "$PROFILES_DIR/{profile}"',
-        f'cd \\"$PROFILES_DIR/{profile}\\"',
-        f'cd "$HERMES_HOME/profiles/{profile}"',
-        f'cd \\"$HERMES_HOME/profiles/{profile}\\"',
-    ))
-
-
-def test_main_gateway_cd_to_profile_dir():
-    line = _start_proc_line("main")
-    assert line, "expected start_proc for main"
-    assert _cd_anchor_present("main", line), (
-        f"main gateway must `cd` into its profile dir before exec so "
-        f"Hermes auto-discovers profiles/main/AGENTS.md. line: {line!r}"
+def test_start_registered_profile_cd_before_exec():
+    """The templated launcher must `cd "${profile_dir}"` before exec'ing
+    hermes — otherwise the gateway's process CWD is the supervisor's `/`
+    and per-profile AGENTS.md is not loaded."""
+    src = _read()
+    # Find the start_registered_profile function body and assert the
+    # templated launch command does `cd "${profile_dir}" && ... exec hermes`.
+    assert "start_registered_profile()" in src, (
+        "expected start_registered_profile() helper in supervisor.sh"
+    )
+    # The launcher line uses ${profile_dir} (computed inside the function)
+    # plus ${slug} for the -p flag. start_proc takes a double-quoted
+    # command string so the inner quotes around ${profile_dir} are
+    # backslash-escaped in the source text.
+    assert 'cd \\"${profile_dir}\\"' in src, (
+        'templated launcher must `cd \\"${profile_dir}\\"` before exec hermes '
+        "(escaped because the start_proc command is itself double-quoted)"
+    )
+    assert "exec hermes -p ${slug} gateway run --replace" in src, (
+        "templated launcher must end in `exec hermes -p ${slug} gateway "
+        "run --replace`"
     )
 
 
-def test_workers_gateway_cd_to_profile_dir():
-    line = _start_proc_line("workers")
-    assert line, "expected start_proc for workers"
-    assert _cd_anchor_present("workers", line), (
-        f"workers gateway must `cd` into its profile dir. line: {line!r}"
+def test_registry_launch_loop_present():
+    """The registry-driven launch loop must iterate read_registry and
+    call start_registered_profile for each slug — that's how the four
+    reserved profiles + any user-facing profile are spawned at boot."""
+    src = _read()
+    # The initial launch loop reads the registry and dispatches to the
+    # launcher. Both anchors must coexist for the boot to work.
+    assert "read_registry" in src, (
+        "expected read_registry helper to enumerate the registry JSON"
+    )
+    assert "start_registered_profile" in src, (
+        "expected start_registered_profile dispatch from the launch loop"
     )
 
 
-def test_heavy_gateway_cd_to_profile_dir():
-    line = _start_proc_line("heavy")
-    assert line, "expected start_proc for heavy"
-    assert _cd_anchor_present("heavy", line), (
-        f"heavy gateway must `cd` into its profile dir. line: {line!r}"
+def test_codex_builder_still_separate():
+    """codex-builder retains its own boot-time launch (setpriv + egress
+    jail + reset-env) — it is NOT routed through start_registered_profile."""
+    src = _read()
+    assert "ENABLE_CODEX_BUILDER" in src
+    assert "setpriv --reuid=10001" in src, (
+        "codex-builder launch must still drop to uid 10001 via setpriv"
     )
-
-
-def test_each_launch_uses_exec_after_cd():
-    """`exec hermes …` after the cd so the subshell hands the PID directly
-    to hermes — the supervisor's `kill -0 $pid` bookkeeping depends on it."""
-    for profile in ("main", "workers", "heavy"):
-        line = _start_proc_line(profile)
-        assert line, f"expected start_proc for {profile}"
-        assert f"exec hermes -p {profile} gateway" in line, (
-            f"{profile} launch must use `exec hermes -p {profile} gateway`. "
-            f"line: {line!r}"
-        )
+    # And the codex-builder branch should explicitly mark itself in
+    # REGISTRY_LAUNCHED so the SIGUSR1 reconciler doesn't double-start it.
+    assert 'REGISTRY_LAUNCHED["codex-builder"]=1' in src, (
+        "codex-builder must record itself in REGISTRY_LAUNCHED so the "
+        "SIGUSR1 reconciler doesn't try to spawn it via the generic path"
+    )
 
 
 def test_launches_remain_after_existing_boot_steps():
-    """Launches must still come after wait_for_profiles + sticky-default +
-    auth-propagation + the SOUL consolidation introduced in the prior commit."""
+    """The registry-iterating launch loop must still come after
+    wait_for_profiles + sticky-default + auth-propagation + the SOUL
+    consolidation."""
     src = _read()
     lines = src.splitlines()
-    wait_call = max(
-        i for i, line in enumerate(lines)
-        if "wait_for_profiles" in line and not line.lstrip().startswith(("#", "wait_for_profiles()"))
+
+    def _line_with(needle: str) -> int:
+        for i, line in enumerate(lines):
+            if needle in line and not line.lstrip().startswith(("#",)):
+                return i
+        return -1
+
+    wait_call = -1
+    for i, line in enumerate(lines):
+        # the CALL to wait_for_profiles (not the definition or the comment).
+        if "wait_for_profiles" in line:
+            if line.lstrip().startswith(("#", "wait_for_profiles()")):
+                continue
+            wait_call = i
+    sticky = _line_with("hermes profile use main")
+    auth_cp = _line_with('cp "$MAIN_AUTH" "$P_AUTH"')
+    soul_cp = _line_with(
+        'cp "$HERMES_HOME/profiles/main/SOUL.md" "$HERMES_HOME/SOUL.md"'
     )
-    sticky = next(i for i, l in enumerate(lines) if "hermes profile use main" in l)
-    auth_cp = next(i for i, l in enumerate(lines) if 'cp "$MAIN_AUTH" "$P_AUTH"' in l)
-    soul_cp = next(
-        i for i, l in enumerate(lines)
-        if 'cp "$HERMES_HOME/profiles/main/SOUL.md" "$HERMES_HOME/SOUL.md"' in l
-    )
-    earliest_launch = min(
-        _start_proc_idx("main"),
-        _start_proc_idx("workers"),
-        _start_proc_idx("heavy"),
-    )
+    # The boot-time launch loop's `done < <(read_registry)` line. The
+    # phrase appears earlier in reconcile_registry and wait_for_profiles —
+    # we want the LAST occurrence (the launch loop sits at the bottom of
+    # the script, after the boot-time setup).
+    launch_loop = -1
+    for i, line in enumerate(lines):
+        if "ANCHOR: BOOT_LAUNCH_LOOP" in line:
+            launch_loop = i  # keep updating — keep the LAST match
+
+    assert launch_loop >= 0, "expected the registry-driven launch loop"
     for name, idx in (
         ("wait_for_profiles", wait_call),
         ("sticky default", sticky),
         ("auth cp", auth_cp),
         ("SOUL cp", soul_cp),
     ):
-        assert idx < earliest_launch, (
-            f"{name} (line {idx + 1}) must come before the earliest "
-            f"gateway launch (line {earliest_launch + 1})."
+        assert idx >= 0, f"expected anchor: {name}"
+        assert idx < launch_loop, (
+            f"{name} (line {idx + 1}) must come before the registry launch "
+            f"loop (line {launch_loop + 1})."
         )

--- a/packages/hermes/tests/test_supervisor_soul_consolidation.py
+++ b/packages/hermes/tests/test_supervisor_soul_consolidation.py
@@ -119,18 +119,25 @@ def test_soul_consolidation_runs_after_wait_for_profiles():
 
 
 def test_soul_consolidation_runs_before_main_gateway_launch():
-    """The consolidation must run BEFORE the main gateway boots."""
+    """The consolidation must run BEFORE the gateway launch loop.
+
+    #120 Lane II — anchor is the registry-driven launch loop's
+    `done < <(read_registry)` line.
+    """
     src = _read()
     cp_line = _line_index(
         src,
         'cp "$HERMES_HOME/profiles/main/SOUL.md" "$HERMES_HOME/SOUL.md"',
     )
-    launch_line = _line_index(src, "hermes -p main gateway run")
+    launch_line = _line_index(src, "ANCHOR: BOOT_LAUNCH_LOOP")
     assert cp_line >= 0, "expected SOUL consolidation cp line"
-    assert launch_line >= 0, "expected main gateway launch line"
+    assert launch_line >= 0, (
+        "expected the registry-driven launch loop's "
+        "`done < <(read_registry)` line — supervisor.sh was restructured"
+    )
     assert cp_line < launch_line, (
         f"SOUL consolidation `cp` (line {cp_line + 1}) must come BEFORE "
-        f"the `hermes -p main gateway run` launch (line {launch_line + 1}) — "
+        f"the registry launch loop (line {launch_line + 1}) — "
         f"Hermes reads $HERMES_HOME/SOUL.md at gateway boot, so the "
         f"persona must be in place beforehand."
     )

--- a/packages/hermes/tests/test_supervisor_sticky_default.py
+++ b/packages/hermes/tests/test_supervisor_sticky_default.py
@@ -74,16 +74,25 @@ def test_supervisor_sticky_default_is_after_wait_for_profiles():
 
 
 def test_supervisor_sticky_default_is_before_main_gateway_launch():
-    """The call must run BEFORE the main gateway is launched."""
+    """The call must run BEFORE the main gateway is launched.
+
+    #120 Lane II — the literal `hermes -p main gateway run` line was
+    replaced by the templated start_registered_profile function called
+    from the registry loop. The boot-time launch is now anchored at the
+    `done < <(read_registry)` line that closes the initial dispatch loop.
+    """
     src = _read()
     sticky_line = _line_index(src, "hermes profile use main")
-    launch_line = _line_index(src, 'hermes -p main gateway run')
-    assert launch_line >= 0, "expected `hermes -p main gateway run` launch line"
+    launch_line = _line_index(src, "ANCHOR: BOOT_LAUNCH_LOOP")
+    assert launch_line >= 0, (
+        "expected the registry-driven launch loop's `done < <(read_registry)` "
+        "line — supervisor.sh was restructured"
+    )
     assert sticky_line >= 0
     assert sticky_line < launch_line, (
         f"`hermes profile use main` (line {sticky_line + 1}) must come BEFORE "
-        f"the `hermes -p main gateway run` launch (line {launch_line + 1}) — "
-        f"so the pointer is set the moment the container reports ready."
+        f"the registry launch loop (line {launch_line + 1}) — so the pointer "
+        f"is set the moment the container reports ready."
     )
 
 


### PR DESCRIPTION
Wires the activation path from Lane I's `agent_profile` registry to the Hermes runtime. After this lane, a `POST /api/v1/agent-profiles` lands a live gateway on the allocated port within ~30s and the registry row flips `pending` → `running`.

Refs #120

## Flow

```
ctrl-api POST /api/v1/agent-profiles
  → state.db.agent_profile row written (status=pending)
  → /hermes-state/profiles/_registry.json rewritten
  → docker kill -s SIGUSR1 alfred-black-hermes-1
  → supervisor.sh re-reads registry, spawns the new gateway
  → gateway /health goes 200
  → supervisor POSTs /api/v1/agent-profiles/<slug>/status {"status":"running"}
  → registry row flips pending → running
```

DELETE follows the symmetric path: SIGUSR1 reconciler notices the slug is gone, SIGTERMs the gateway, port is freed for re-allocation. Lane I's reserved-profile guard still refuses `main` / `workers` / `heavy` / `codex-builder`.

## What changed

### `packages/hermes` (runtime side)

- **`init/render_registry.py`** (NEW). Reads ctrl-api's `state.db.agent_profile` read-only, emits the `slug:port:model` list `entrypoint.sh` iterates over, AND writes `/hermes-state/profiles/_registry.json` the supervisor reads. Falls back to the four reserved profiles on a fresh tenant where the migration hasn't applied yet.
- **`init/render_hermes.py`** — `_KNOWN_PROFILES` allowlist gone. Accepts any slug matching `^[a-z][a-z0-9-]{1,30}$`. Port comes from `HERMES_RENDER_PORT` (the registry's `api_server_port`); model from `HERMES_RENDER_MODEL`. Reserved profiles still resolve their canonical ports without override for back-compat.
- **`init/render_mcp_servers.py`** — user-facing profiles fall back to `main`'s required MCP catalogue (`hass` + `files`). Heavy still returns `'unknown-profile'` so it stays out of principal-facing surfaces.
- **`init/entrypoint.sh`** — `PROFILES_RENDERED` now sourced from `render_registry`, `PROFILES_FULL_DEPLOY` = same minus `codex-builder`. ACL deny + negative-assert loops iterate the dynamic list so user-facing `.env` files are covered.
- **`docker/supervisor.sh`** — registry-driven launch via `read_registry` + `start_registered_profile`. SIGUSR1 trap reconciles against the on-disk JSON. After each gateway's `/health` goes 200, `probe_and_notify` POSTs `status=running` back to ctrl-api. Pre-existing 3 hard-coded `start_proc` lines collapsed into a single templated launcher.
- **`hermes-config.yaml.njk`** — accept an external `is_main` override so user-facing profiles render with `main`'s conversational config (capable model, full agent posture) instead of falling into the workers branch.

### `packages/ctrl` (registry side)

- **`db/agentProfiles.ts`** — cascade unbind on archive: every non-default `channel_profile_binding` pointing at the archived slug is DELETEd (default `binding-default-<kind>` bindings are protected so the per-kind fallback never has a hole). Added `buildSupervisorRegistry` + `SupervisorRegistry` typed shape.
- **`hermes/supervisor.ts`** (NEW). `writeSupervisorRegistry` (atomic write to `/hermes-state/profiles/_registry.json`) + `nudgeHermesSupervisor` (`docker kill -s SIGUSR1`). Both best-effort: a failure logs a warn but never blocks the registry write.
- **`api/routes/profiles.ts`** — POST/DELETE write the registry JSON + nudge the supervisor after the lib call. NEW `POST /api/v1/agent-profiles/:slug/status` route — the supervisor's status callback. Same auth as the rest of the surface.

### `docker-compose.yaml`

- No `ports:` addition — user-facing profile ports (18794..18799) stay reachable only via the compose default network as `http://hermes:<port>`. Adding them to the host port surface would expose them on the public IP without auth wrapping; the only external entry stays Caddy → ctrl-api. Documented inline.

## Cascade shape (Lane II contract D)

Chose **(i) cascade unbind in the archive route** (cleaner data) over (ii) refuse-to-dispatch on archived. After archive: archived slug gone from `agent_profile`, its non-default bindings deleted, default bindings still 'main'. `resolveProfileForChannel` falls back to main without any code change on the read path.

## Tests

- `packages/hermes/tests/test_render_registry.py` — 7 tests covering state.db reads, fallback, atomic write, archived exclusion, line format.
- `packages/hermes/tests/test_render_hermes_lane_ii.py` — 6 tests for the slug+port+model resolution paths.
- `packages/ctrl/tests/agent-profiles-lane-ii.test.ts` — 7 tests for cascade unbind on archive + `buildSupervisorRegistry`.
- `packages/hermes/tests/test_supervisor_*.py` — 4 existing tests updated to anchor on the new `BOOT_LAUNCH_LOOP` marker comment since the literal `hermes -p main gateway run` line was templated.

**All 140 hermes tests + 41 agent-profiles tests pass.** shellcheck clean on both `supervisor.sh` and `entrypoint.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)