### PR TITLE
fix(hermes): supervisor probe uses AAS_API_KEY not gateway-token

### DIFF
--- a/packages/hermes/docker/supervisor.sh
+++ b/packages/hermes/docker/supervisor.sh
@@ -550,9 +550,16 @@ probe_and_notify() {
     while (( waited < 60 )); do
         if curl -fsS --max-time 2 "http://127.0.0.1:${port}/health" >/dev/null 2>&1; then
             log "probe: '${slug}' /health OK on :${port} after ${waited}s"
+            # ctrl-api authenticates with AAS_API_KEY (64-char value), NOT
+            # the gateway token (/alfred-data/.gateway-token is the 43-char
+            # API_SERVER_KEY for the Hermes gateways themselves, a different
+            # surface). The init container renders AAS_API_KEY into each
+            # profile's .env (hermes-profile.env.njk). Read main's copy so
+            # the supervisor can talk to ctrl-api without taking a dep on
+            # the gateway-token surface.
             local token=""
-            if [[ -r /alfred-data/.gateway-token ]]; then
-                token="$(tr -d '[:space:]' < /alfred-data/.gateway-token)"
+            if [[ -r "${PROFILES_DIR}/main/.env" ]]; then
+                token="$(grep -E '^AAS_API_KEY=' "${PROFILES_DIR}/main/.env" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '[:space:]' | sed -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'$//")"
             fi
             if [[ -n "$token" ]]; then
                 if curl -fsS --max-time 5 \
@@ -567,7 +574,7 @@ probe_and_notify() {
                     log "probe: WARN ctrl-api status notify failed for '${slug}' — registry row stays at last value"
                 fi
             else
-                log "probe: WARN /alfred-data/.gateway-token unreadable — skipping ctrl-api notify for '${slug}'"
+                log "probe: WARN AAS_API_KEY not in main/.env — skipping ctrl-api notify for '${slug}'"
             fi
             return 0
         fi

--- a/packages/hermes/init/render_registry.py
+++ b/packages/hermes/init/render_registry.py
@@ -91,12 +91,14 @@ def _read_profiles_from_state_db(state_db_path: Path) -> list[dict] | None:
     if not state_db_path.exists():
         return None
     try:
-        # mode=ro&immutable=1 — open the file read-only, refuse to apply
-        # any WAL recovery, and never touch the journal. This is the same
-        # posture render_mcp_servers.py uses against the same file (the
-        # mount is :ro so a write would EROFS anyway, but the pragma
-        # cleans up the failure-mode surface).
-        uri = f"file:{state_db_path}?mode=ro&immutable=1"
+        # mode=ro — open the file read-only but ALLOW the WAL to be
+        # consulted. immutable=1 would tell SQLite "ignore the WAL", which
+        # silently misses recently-committed rows (live-observed 2026-05-31
+        # on home: a profile created via POST 30s before init ran was in
+        # state.db but invisible to render_registry because the row was
+        # still in the WAL when init's query ran). The mount is :ro so
+        # write attempts EROFS regardless of this flag.
+        uri = f"file:{state_db_path}?mode=ro"
         conn = sqlite3.connect(uri, uri=True, timeout=5)
         conn.row_factory = sqlite3.Row
         cur = conn.execute(


### PR DESCRIPTION
Live-observed on home 2026-05-31: supervisor probes succeeded on /health but the POST status callback to ctrl-api 401'd because supervisor was sending the 43-char Hermes gateway token (/alfred-data/.gateway-token) instead of the 64-char AAS_API_KEY ctrl-api expects.

Read AAS_API_KEY from main profile's .env (rendered by init).

Refs #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)