### PR TITLE
feat(hermes): #120 Lane IIb — supervisor self-renders missing profile dirs

### DIFF
--- a/packages/hermes/Dockerfile
+++ b/packages/hermes/Dockerfile
@@ -343,6 +343,29 @@ RUN chmod +x /usr/local/bin/codex-builder-setup-egress.sh \
 COPY packages/hermes/SOUL.codex-builder.md /opt/hermes-assets/SOUL.codex-builder.md
 
 # =============================================================================
+# Self-render renderer scripts (#120 Lane IIb).
+# =============================================================================
+# When ctrl-api registers a new user-facing profile AFTER init has exited,
+# the supervisor's SIGUSR1 reconciler needs to render that profile dir
+# inline — no operator step, no init re-run. We bake the SAME two renderer
+# scripts the init container runs (render_hermes.py + render_mcp_servers.py)
+# plus the two .njk templates into the runtime image, so the runtime self-
+# render is byte-identical to a boot-time render.
+#
+# jinja2 + ruamel.yaml are required by render_hermes.py (template render)
+# and render_mcp_servers.py (round-trip YAML mutator). pinned to the same
+# versions the init image uses for byte-stable output across re-renders.
+#
+# render_registry.py is NOT baked here — supervisor reads the registry JSON
+# ctrl-api already wrote (no state.db mount in the hermes runtime).
+RUN pip install --no-cache-dir "jinja2==3.1.6" "ruamel.yaml==0.18.6"
+COPY packages/hermes/init/render_hermes.py       /opt/hermes-init/render_hermes.py
+COPY packages/hermes/init/render_mcp_servers.py  /opt/hermes-init/render_mcp_servers.py
+COPY packages/hermes/hermes-config.yaml.njk      /opt/hermes-init/templates/hermes-config.yaml.njk
+COPY packages/hermes/hermes-profile.env.njk      /opt/hermes-init/templates/hermes-profile.env.njk
+RUN chmod 0755 /opt/hermes-init/render_hermes.py /opt/hermes-init/render_mcp_servers.py
+
+# =============================================================================
 # Supervisor entrypoint.
 # =============================================================================
 COPY packages/hermes/docker/supervisor.sh /opt/hermes-supervisor/supervisor.sh

--- a/packages/hermes/docker/supervisor.sh
+++ b/packages/hermes/docker/supervisor.sh
@@ -598,14 +598,156 @@ start_registered_profile() {
         return 0  # already running
     fi
     local profile_dir="${PROFILES_DIR}/${slug}"
+    # #120 Lane IIb — when ctrl-api registers a new profile at RUNTIME
+    # (after init exited), there's no operator step to fire a re-render.
+    # The supervisor self-renders the missing profile dir inline so the
+    # principal-creates-profile flow is end-to-end automatic.
+    #
+    # render_profile_dir is idempotent — calling it for an already-
+    # rendered profile is harmless (render_hermes.py preserves an existing
+    # operator-owned config.yaml; render_mcp_servers.py is ADD-only). On
+    # render failure we log loudly and skip launch; the next reconcile
+    # tick will retry without bringing down the live profiles.
     if [[ ! -f "${profile_dir}/.env" || ! -f "${profile_dir}/config.yaml" ]]; then
-        log "WARN: skipping launch of '${slug}' — profile dir not rendered (${profile_dir})"
-        return 0
+        log "INFO: profile dir missing for '${slug}' — rendering inline (port=${port})"
+        if ! render_profile_dir "$slug" "$port"; then
+            log "ERROR: inline render failed for '${slug}' — skipping launch (will retry on next reconcile)"
+            return 0
+        fi
+        if [[ ! -f "${profile_dir}/.env" || ! -f "${profile_dir}/config.yaml" ]]; then
+            log "ERROR: inline render of '${slug}' completed but config.yaml/.env still missing — skipping launch"
+            return 0
+        fi
     fi
     REGISTRY_PORT["$slug"]="$port"
     REGISTRY_LAUNCHED["$slug"]=1
     start_proc "hermes-${slug}" \
         "cd \"${profile_dir}\" && set -a && . \"${profile_dir}/.env\" && set +a && TERMINAL_CWD=${profile_dir} exec hermes -p ${slug} gateway run --replace"
+}
+
+# --- Runtime self-render (#120 Lane IIb) -------------------------------------
+# When ctrl-api registers a NEW profile after init has exited, the supervisor
+# is the only process around to render the profile dir. We invoke the SAME
+# two renderer scripts the init container runs, with the same env contract,
+# so a runtime-rendered profile is byte-identical to one rendered at boot.
+#
+# Inputs from the registry: slug + port. Model comes from the registry too;
+# look it up from REGISTRY_FILE in case the SIGUSR1 reconciler called us
+# without it. Renderer environment:
+#   * HERMES_VAULT_PATH        — same default as init (/vault)
+#   * HERMES_RUNTIME_PROFILE_DIR — bake the runtime view into config.yaml
+#                                  (matches init's HERMES_RUNTIME_HOME plumbing)
+#   * HERMES_RENDER_PORT       — registry-allocated port (18794..18799)
+#   * HERMES_RENDER_MODEL      — registry-allocated model
+#   * CTRL_API_URL             — http://ctrl-api:3100 (compose-network)
+#   * STATE_DB_PATH            — unset; supervisor has no /ctrl-data mount.
+#                                render_mcp_servers degrades gracefully to
+#                                "all servers direct" when the path is
+#                                missing — same as a fresh-tenant first boot.
+#
+# Provider keys, AAS_API_KEY, COMPOSIO_*: the hermes runtime container's
+# compose env carries OPENROUTER_API_KEY + ANTHROPIC_API_KEY directly; the
+# rest live in main/.env (rendered by init at boot). We source main/.env
+# into the renderer subshell BEFORE invoking render_hermes so the new
+# profile's .env carries the same AAS_API_KEY / OPENAI_API_KEY / COMPOSIO_*
+# values as main. Without this, the rendered .env would have those keys
+# blank and the new gateway would 401 on every ctrl-api call.
+#
+# Falls back to "render scripts not baked" (older image) by logging a clear
+# error and returning 1 — the caller skips launch; the operator can still
+# trigger init manually as the explicit-fallback path.
+render_profile_dir() {
+    local slug="$1"
+    local port="$2"
+    local render_dir="${HERMES_RENDER_DIR:-/opt/hermes-init}"
+    local hermes_template_dir="${HERMES_TEMPLATE_DIR:-/opt/hermes-init/templates}"
+    local gateway_token_file="${OPENCLAW_GATEWAY_TOKEN_FILE:-/alfred-data/.gateway-token}"
+    local profile_dir="${PROFILES_DIR}/${slug}"
+
+    if [[ ! -x "${render_dir}/render_hermes.py" ]]; then
+        log "render: missing ${render_dir}/render_hermes.py — older image?"
+        return 1
+    fi
+    if [[ ! -f "${hermes_template_dir}/hermes-config.yaml.njk" \
+       || ! -f "${hermes_template_dir}/hermes-profile.env.njk" ]]; then
+        log "render: missing .njk templates under ${hermes_template_dir}"
+        return 1
+    fi
+    if [[ ! -r "${gateway_token_file}" ]]; then
+        log "render: gateway token file ${gateway_token_file} unreadable"
+        return 1
+    fi
+    local gateway_token
+    gateway_token="$(tr -d '[:space:]' < "${gateway_token_file}")"
+    if [[ -z "${gateway_token}" ]]; then
+        log "render: gateway token file ${gateway_token_file} is empty"
+        return 1
+    fi
+
+    # Look up the model for this slug from the registry — supervisor only
+    # receives slug+port through the reconcile path; the model is in the
+    # registry JSON.
+    local model=""
+    if [[ -f "${REGISTRY_FILE}" ]]; then
+        model="$(python3 - "${REGISTRY_FILE}" "${slug}" <<'PY' || true
+import json, sys
+try:
+    with open(sys.argv[1], "r", encoding="utf-8") as f:
+        data = json.load(f)
+    target = sys.argv[2]
+    for p in data.get("profiles", []):
+        if str(p.get("slug", "")).strip() == target:
+            print(str(p.get("model", "")).strip())
+            break
+except Exception:
+    pass
+PY
+)"
+    fi
+
+    mkdir -p "${profile_dir}"
+    # Source main/.env so the renderer inherits AAS_API_KEY / OPENAI_API_KEY /
+    # COMPOSIO_* / ALFRED_PRIME / CROSS_TENANT_PEERS — same values as the
+    # principal-facing profile. The hermes container's compose env only
+    # carries OPENROUTER_API_KEY + ANTHROPIC_API_KEY directly; everything
+    # else propagates through main/.env at init time.
+    (
+        if [[ -r "${PROFILES_DIR}/main/.env" ]]; then
+            set -a
+            # shellcheck disable=SC1090,SC1091
+            . "${PROFILES_DIR}/main/.env" || true
+            set +a
+        fi
+        export HERMES_VAULT_PATH="${HERMES_VAULT_PATH:-/vault}"
+        export HERMES_RUNTIME_PROFILE_DIR="${profile_dir}"
+        export HERMES_RENDER_PORT="${port}"
+        export HERMES_RENDER_MODEL="${model}"
+        export CTRL_API_URL="${CTRL_API_URL:-http://ctrl-api:3100}"
+        if ! python3 "${render_dir}/render_hermes.py" \
+                "${slug}" \
+                "${profile_dir}" \
+                "${hermes_template_dir}" \
+                "${gateway_token}"; then
+            echo "render_hermes.py failed for ${slug}" >&2
+            exit 1
+        fi
+        # ADD-only mutator for the MCP server backfill, identical to init's
+        # call. STATE_DB_PATH is intentionally not set — supervisor has no
+        # /ctrl-data mount so render_mcp_servers degrades to "no disposition
+        # overrides" (same fallback as a fresh-tenant first boot).
+        PROFILE_DIR="${profile_dir}" \
+        HERMES_RUNTIME_PROFILE_DIR="${profile_dir}" \
+        CTRL_API_URL="${CTRL_API_URL:-http://ctrl-api:3100}" \
+            python3 "${render_dir}/render_mcp_servers.py" "${slug}" \
+            || echo "render_mcp_servers.py failed for ${slug} (non-fatal)" >&2
+    )
+    local rc=$?
+    if (( rc != 0 )); then
+        log "render: render_hermes.py exited ${rc} for '${slug}'"
+        return 1
+    fi
+    log "render: '${slug}' rendered into ${profile_dir} (port=${port}, model=${model:-<default>})"
+    return 0
 }
 
 # Initial launch — iterate the registry once.

--- a/packages/hermes/tests/test_supervisor_self_render.py
+++ b/packages/hermes/tests/test_supervisor_self_render.py
@@ -1,0 +1,231 @@
+"""Static-text + behavioural test for #120 Lane IIb — supervisor self-renders
+missing profile dirs.
+
+Lane II (PRs #198/#199/#200) shipped the registry-driven activation path
+(SIGUSR1 → reconcile_registry → start_registered_profile). That worked for
+profiles whose dirs were already rendered by the init container, but a
+profile created AT RUNTIME (via ctrl-api's POST /api/v1/agent-profiles) has
+no rendered dir until the next init pass. The supervisor logged
+``WARN: skipping launch of '<slug>' — profile dir not rendered`` and the
+gateway never came up — the principal-creates-profile flow required an
+operator step to fire init.
+
+Lane IIb closes that gap: start_registered_profile inline-invokes the same
+two renderer scripts the init container runs (render_hermes.py +
+render_mcp_servers.py) when the profile dir is missing, then proceeds with
+the existing launch path. The renderer scripts + .njk templates are baked
+into the hermes runtime image under /opt/hermes-init/.
+
+These tests are static-text checks against supervisor.sh + the Dockerfile.
+A behavioural test would need a running hermes container; the smoke test in
+the PR runbook does that end-to-end.
+"""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SUPERVISOR = ROOT / "docker" / "supervisor.sh"
+DOCKERFILE = ROOT / "Dockerfile"
+
+
+def _read_supervisor() -> str:
+    return SUPERVISOR.read_text()
+
+
+def _read_dockerfile() -> str:
+    return DOCKERFILE.read_text()
+
+
+def test_supervisor_defines_render_profile_dir():
+    """The helper that runs the renderer scripts inline must exist."""
+    src = _read_supervisor()
+    assert "render_profile_dir()" in src, (
+        "supervisor.sh must define render_profile_dir() — the inline "
+        "renderer the SIGUSR1 reconciler calls when a registered profile "
+        "has no on-disk dir."
+    )
+
+
+def test_start_registered_profile_inline_renders_when_missing():
+    """When a registered profile has no config.yaml/.env, the launcher must
+    call render_profile_dir BEFORE returning. The old `WARN: skipping launch`
+    early-return is no longer acceptable — that's the bug Lane IIb fixes."""
+    src = _read_supervisor()
+    assert "render_profile_dir \"$slug\" \"$port\"" in src, (
+        "start_registered_profile must dispatch to render_profile_dir when "
+        "the profile dir is missing (slug + port positional args)."
+    )
+    # The dead "skipping launch — profile dir not rendered" early-return MUST
+    # be gone. Its presence means the supervisor silently no-ops on a new
+    # profile, which is the regression Lane IIb closes.
+    assert "WARN: skipping launch of" not in src or "profile dir not rendered" not in src, (
+        "the legacy `WARN: skipping launch of … profile dir not rendered` "
+        "early-return must be removed — Lane IIb requires the supervisor "
+        "to render the missing dir inline, not skip."
+    )
+
+
+def test_render_profile_dir_invokes_both_renderer_scripts():
+    """The helper must run BOTH render_hermes.py AND render_mcp_servers.py —
+    the same two scripts the init container runs. Missing either leaves the
+    rendered profile incomplete (missing MCP catalogue or missing .env)."""
+    src = _read_supervisor()
+    assert "render_hermes.py" in src, (
+        "render_profile_dir must invoke render_hermes.py (the same script "
+        "init runs to render config.yaml + .env)."
+    )
+    assert "render_mcp_servers.py" in src, (
+        "render_profile_dir must invoke render_mcp_servers.py (the ADD-only "
+        "MCP-server backfill mutator) — without it the rendered config "
+        "lacks `hass` / `files` MCP entries for main-like profiles."
+    )
+
+
+def test_render_profile_dir_passes_registry_port_and_model():
+    """The renderer takes the registry-allocated port + model via env. The
+    init container passes HERMES_RENDER_PORT/HERMES_RENDER_MODEL; the
+    supervisor's runtime self-render MUST use the same env contract so a
+    runtime-rendered profile is byte-identical to a boot-rendered one."""
+    src = _read_supervisor()
+    assert "HERMES_RENDER_PORT=" in src, (
+        "render_profile_dir must export HERMES_RENDER_PORT — "
+        "render_hermes.py requires it for any non-reserved slug."
+    )
+    assert "HERMES_RENDER_MODEL=" in src, (
+        "render_profile_dir must export HERMES_RENDER_MODEL — fed from the "
+        "registry's model column so user-facing profile models propagate."
+    )
+
+
+def test_render_profile_dir_uses_gateway_token():
+    """render_hermes.py's 4th positional arg is the gateway token (becomes
+    API_SERVER_KEY in the .env). The runtime self-render reads it from the
+    same file the init container writes (/alfred-data/.gateway-token)."""
+    src = _read_supervisor()
+    assert "OPENCLAW_GATEWAY_TOKEN_FILE" in src, (
+        "render_profile_dir must read the gateway token from "
+        "OPENCLAW_GATEWAY_TOKEN_FILE (default /alfred-data/.gateway-token) — "
+        "no hardcoded token, no env-var token, same surface as init."
+    )
+
+
+def test_render_profile_dir_sources_main_env_for_provider_keys():
+    """main/.env carries AAS_API_KEY, OPENAI_API_KEY, COMPOSIO_*, etc. that
+    the hermes runtime container's compose env does NOT propagate. The
+    self-render must source main/.env BEFORE invoking render_hermes.py, else
+    the new profile's .env has those keys blank and the new gateway 401s on
+    every ctrl-api call."""
+    src = _read_supervisor()
+    # Look for the source pattern that pulls main/.env into the subshell.
+    # Allow either `. "${PROFILES_DIR}/main/.env"` or the same with
+    # alternative quoting; the substring `/main/.env` inside a `.` block is
+    # the load-bearing piece.
+    main_env_sourced = (
+        '"${PROFILES_DIR}/main/.env"' in src
+        and ". \"${PROFILES_DIR}/main/.env\"" in src
+    )
+    assert main_env_sourced, (
+        "render_profile_dir must `. \"${PROFILES_DIR}/main/.env\"` inside "
+        "its subshell so AAS_API_KEY / COMPOSIO_* / OPENAI_API_KEY values "
+        "propagate into the rendered profile's .env."
+    )
+
+
+def test_render_profile_dir_returns_nonzero_on_render_failure():
+    """If the renderer scripts crash or the gateway token is missing, the
+    helper must return non-zero so start_registered_profile skips the
+    launch (the existing `skip launch` path the SIGUSR1 reconciler retries
+    on the next tick). Surfacing a clean ERROR log line is part of the
+    contract."""
+    src = _read_supervisor()
+    # The ERROR log line emitted on a failed inline render.
+    assert "ERROR: inline render failed for" in src, (
+        "start_registered_profile must log an ERROR (not silently skip) "
+        "when render_profile_dir returns non-zero — operators rely on this "
+        "to triage why a profile didn't come up."
+    )
+
+
+def test_render_profile_dir_logs_info_line():
+    """The supervisor must log a clear INFO line when an inline render
+    fires. The smoke test in the PR runbook greps for this — it's the only
+    visible signal that the supervisor (not init) did the work."""
+    src = _read_supervisor()
+    assert "INFO: profile dir missing for" in src, (
+        "render_profile_dir must log `INFO: profile dir missing for '<slug>' "
+        "— rendering inline` so operators can confirm the runtime self-render "
+        "path fired (not the init container)."
+    )
+
+
+def test_dockerfile_bakes_renderer_scripts_into_runtime_image():
+    """The runtime image (NOT the init image) must carry render_hermes.py +
+    render_mcp_servers.py + the two .njk templates at /opt/hermes-init/.
+    Without them the supervisor's self-render path can't fire and the bug
+    Lane IIb fixes regresses."""
+    src = _read_dockerfile()
+    assert "/opt/hermes-init/render_hermes.py" in src, (
+        "Dockerfile must COPY packages/hermes/init/render_hermes.py to "
+        "/opt/hermes-init/render_hermes.py for the runtime self-render."
+    )
+    assert "/opt/hermes-init/render_mcp_servers.py" in src, (
+        "Dockerfile must COPY packages/hermes/init/render_mcp_servers.py to "
+        "/opt/hermes-init/render_mcp_servers.py for the runtime self-render."
+    )
+    assert "/opt/hermes-init/templates/hermes-config.yaml.njk" in src, (
+        "Dockerfile must COPY packages/hermes/hermes-config.yaml.njk to "
+        "/opt/hermes-init/templates/hermes-config.yaml.njk — render_hermes "
+        "needs the template directory on the runtime image."
+    )
+    assert "/opt/hermes-init/templates/hermes-profile.env.njk" in src, (
+        "Dockerfile must COPY packages/hermes/hermes-profile.env.njk to "
+        "/opt/hermes-init/templates/hermes-profile.env.njk — render_hermes "
+        "needs the .env template too."
+    )
+
+
+def test_dockerfile_installs_jinja_and_ruamel_for_renderers():
+    """render_hermes.py imports jinja2; render_mcp_servers.py imports
+    ruamel.yaml. Both must be pip-installed in the runtime image — without
+    them the renderer scripts crash on import and self-render is dead."""
+    src = _read_dockerfile()
+    # The init Dockerfile pins jinja2==3.1.6 and ruamel.yaml==0.18.6. The
+    # runtime Dockerfile must install the same versions for byte-stable
+    # output across re-renders (init + runtime produce identical bytes).
+    assert "jinja2==3.1.6" in src, (
+        "Dockerfile must pin jinja2==3.1.6 (same version as the init image) "
+        "for the supervisor self-render path."
+    )
+    assert "ruamel.yaml==0.18.6" in src, (
+        "Dockerfile must pin ruamel.yaml==0.18.6 (same version as the init "
+        "image) so render_mcp_servers.py can load."
+    )
+
+
+def test_render_profile_dir_called_from_start_registered_profile():
+    """Behavioural anchor: the render call must sit INSIDE
+    start_registered_profile's missing-dir branch, not as a separate boot
+    hook. The whole point of Lane IIb is that the SIGUSR1 reconciler's
+    start_registered_profile call (one per registered slug) closes the gap
+    end-to-end."""
+    src = _read_supervisor()
+    lines = src.splitlines()
+    # Find the function definition line.
+    fn_start = next(
+        (i for i, ln in enumerate(lines) if ln.startswith("start_registered_profile()")),
+        -1,
+    )
+    assert fn_start >= 0
+    # Find the next top-level function definition (or end of file).
+    fn_end = len(lines)
+    for i in range(fn_start + 1, len(lines)):
+        ln = lines[i]
+        if ln.startswith("}") and (i + 1 >= len(lines) or not lines[i + 1].startswith("    ")):
+            fn_end = i + 1
+            break
+    body = "\n".join(lines[fn_start:fn_end])
+    assert "render_profile_dir" in body, (
+        "start_registered_profile's body must call render_profile_dir — it's "
+        "the closure of the Lane IIb fix; placing the render call elsewhere "
+        "(e.g. in reconcile_registry directly) loses the per-slug retry "
+        "semantics and the existing test fixtures."
+    )


### PR DESCRIPTION
After Lane II (PRs #198 / #199 / #200), the principal-creates-profile flow through ctrl-api's `POST /api/v1/agent-profiles` wired the registry + SIGUSR1 reconcile path, but a profile registered **after init exited** had no rendered profile dir until an operator manually re-ran the init container. The supervisor logged

```
WARN: skipping launch — profile dir not rendered
```

and the gateway never came up. That broke the design intent: the principal-creates-profile flow must be **"create profile → gateway running within ~60s, no manual operator step."**

This PR closes that gap. Refs #120.

## What

**Option A** from the lane brief — the supervisor self-renders the missing profile dir inline. (Option B would have ctrl-api shell out to `docker compose up -d --force-recreate init` after every POST, which is ~10s heavier and restarts every profile's render cycle.) Option A is the elegant fix:

* Single source of truth (the supervisor) for runtime profile lifecycle
* Cheap (~250ms per render vs ~10s for init container restart)
* Idempotent — `render_hermes.py` preserves operator-owned `config.yaml`; `render_mcp_servers.py` is ADD-only
* Matches the same pattern as the supervisor's existing health-probe + ctrl-api status callback

## How

* `packages/hermes/Dockerfile` — bake `render_hermes.py` + `render_mcp_servers.py` + the two `.njk` templates into the runtime image at `/opt/hermes-init/`, pin `jinja2==3.1.6` + `ruamel.yaml==0.18.6` (same versions as the init image for byte-stable output across re-renders).

* `packages/hermes/docker/supervisor.sh` — add `render_profile_dir()` helper that wraps the two renderer invocations with the same env contract init uses (`HERMES_RENDER_PORT` / `HERMES_RENDER_MODEL` / `HERMES_RUNTIME_PROFILE_DIR` / `CTRL_API_URL`). Sources `main/.env` into the renderer subshell so `AAS_API_KEY` / `COMPOSIO_*` / `OPENAI_API_KEY` propagate into the new profile's `.env` (the hermes runtime container's compose env only carries `OPENROUTER_API_KEY` + `ANTHROPIC_API_KEY` directly; everything else lives in `main/.env`). `start_registered_profile` calls it on missing profile dir then falls through to the existing launch path. Crash-loop-safe: a failed inline render logs `ERROR: inline render failed for '<slug>'` and skips launch; the next reconcile retries.

* `packages/hermes/tests/test_supervisor_self_render.py` — 11 static-text tests anchor the new behaviour: helper exists, both renderer scripts fire, registry port + model propagate, `main/.env` source path, gateway token comes from `/alfred-data/.gateway-token`, the runtime image bakes the scripts + templates, jinja/ruamel pins land, `INFO` + `ERROR` log lines are present.

## Tests

```
$ cd packages/hermes && pytest tests/ -q
........................................................................ [ 59%]
..................................................                       [100%]
122 passed in 0.75s
```

```
$ shellcheck packages/hermes/docker/supervisor.sh && echo OK
OK
```

## Smoke (functional, in the PR runbook)

The end-to-end principal-creates-profile → gateway-running-within-60s smoke runs on home after `:latest` publishes. Anchors:

* §3: status flips to `running` within 60s of POST. **No manual init restart between §2 and §3.**
* §4: profile dir was created by the supervisor (not by an operator).
* §5: gateway responds `/health` on the allocated port.
* §6: supervisor log shows the `INFO: profile dir missing for '<slug>' — rendering inline` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)