### PR TITLE
feat(ctrl,web): #120 Lane Vb2 — per-profile AgentMail email inboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and the `alfred-vault` package adheres to [Semantic Versioning](https://semver.o
 
 ## [2026-05-31]
 
+**Lane Vb2** (follow-on to Lane V) closes the email half of the
+per-profile-channels promise. Lane V shipped the FULL per-profile
+channels page but explicitly punted **Email (AgentMail)** with the note
+"AgentMail provisions one inbox per VM today; per-profile addressing is
+a follow-up." Sir's clarification — *"email MUST be per profile.
+AgentMail's API provisions inboxes; that's an API call, not a manual
+provisioning step. Just call it."* — is exactly the work this lane does.
+ctrl-api now exposes four new routes (`GET /channels/email/status`,
+`POST /channels/email/provision`, `DELETE /channels/email/inbox`, `POST
+/channels/email/test`), all scoped by `?profile=<slug>`. The provision
+route calls AgentMail's real API (`POST /pods/<pod>/inboxes` then `POST
+/inboxes/<id>/api-keys`) using `AGENTMAIL_MASTER_API_KEY` from the
+tenant `.env`; on success the inbox creds (`AGENTMAIL_INBOX_ID`,
+`AGENTMAIL_INBOX_ADDRESS`, `AGENTMAIL_API_KEY`) land in the profile's
+`/hermes-state/profiles/<slug>/.env` and a
+`(channel_kind=email, channel_identity=<address>, profile=<slug>)` row
+is written to `channel_profile_binding`. Inbound mail to that address
+arrives at the existing AgentMail webhook → the recipient-based
+resolver picks the right profile; the only thing that was missing was
+the binding row. Outbound `/api/v1/email/{send,reply,forward,…}` now
+honour `?profile=<slug>` and pull credentials from the profile's `.env`
+rather than the tenant-wide env — so Sentinel's replies go from
+Sentinel's "From:" address with Sentinel's inbox-scoped key. DELETE
+releases the inbox at AgentMail (best-effort upstream delete; binding +
+.env keys wiped unconditionally so routing falls back to main cleanly).
+The `/profiles/:slug/channels` Email card flips from the Lane V
+"instance-level notice" to a real provision / test / disconnect form. A
+new `getProfileEmailStatus` query plus three new actions
+(`provisionProfileEmailInbox`, `clearProfileEmailInbox`,
+`sendProfileEmailTest`) wire the UI to the routes. 14 new helper +
+route unit tests covering the happy path, the no-master-key honest
+failure, the archived-profile guard, idempotent DELETE, and the
+inbound-routing decision (provisioned address → sentinel, unbound
+address → main fallback). **Operator step**: tenants that want
+per-profile email must set `AGENTMAIL_MASTER_API_KEY` +
+`AGENTMAIL_SHARED_POD_ID` in `/opt/alfred/.env` and restart ctrl-api;
+without the master key the route returns a clean 400 with code
+`master_key_missing` and the UI shows the operator hint instead of the
+provision button.
+
 **Lane V** (this release) lands the per-profile FULL channels surface.
 Until tonight, the new `/profiles/:slug` page from Lane III could bind a
 channel to a profile (the inbound side — "this Telegram chat speaks to

--- a/packages/ctrl/src/api/routes/channelsEmail.ts
+++ b/packages/ctrl/src/api/routes/channelsEmail.ts
@@ -38,8 +38,21 @@ import { sendJson, ValidationError } from "../errors.js";
 import { getStateDb } from "../../db/state.js";
 import {
   resolveProfileContextForChannel,
+  resolveProfileForChannel,
+  assertWritableProfile,
+  bindChannel,
+  listAllBindings,
+  unbindChannel,
+  resolveProfileEnvPath,
   type ProfileChannelContext,
 } from "../../db/agentProfiles.js";
+import {
+  dockerExec,
+  dockerExecWithStdin,
+  HERMES_CONTAINER,
+} from "../helpers.js";
+import { appendAudit } from "./state.js";
+import { restartProfile } from "../../hermes/supervisor.js";
 
 const HERMES_GATEWAY_URL =
   process.env.HERMES_GATEWAY_URL ||
@@ -156,6 +169,227 @@ function buildChannelPrompt(message: any): string {
   ].join("\n");
 }
 
+// ── #120 Lane Vb2 — per-profile AgentMail provisioning ──────────────────────
+//
+// Lane V intentionally punted email to /channels (single-tenant). Sir's
+// clarification: "email MUST be per profile." Each profile owns its own
+// AgentMail inbox (e.g. `alfred@home.alfred.black` for main,
+// `sentinel-<slug>@…` for Sentinel); inbound emails route to the right
+// profile via the (email, <to-address>) channel binding.
+//
+// Provisioning calls AgentMail's API directly (POST /v0/pods/<podId>/inboxes
+// + POST /v0/inboxes/<id>/api-keys). The master key lives in
+// `AGENTMAIL_MASTER_API_KEY` (operator-set in /opt/alfred/.env); without it
+// /provision returns 400 `master_key_missing` and the operator is told
+// exactly which env var to set. The inbox-scoped key returned from minting
+// is persisted into the profile's `.env` (Sentinel's outbound /api/v1/email/*
+// then auths with HER inbox-scoped key, not main's).
+//
+// The webhook URL we register with AgentMail is the same shared SaaS
+// receiver every other inbox already uses — `<SAAS_HOST>/webhooks/agentmail`
+// — so we don't need per-inbox public DNS. The SaaS receiver forwards
+// inbound emails back to this tenant's `/api/v1/channels/email/inbound`,
+// where the to-address resolves which profile (binding row written at
+// /provision time).
+
+const AGENTMAIL_BASE_URL = (
+  process.env.AGENTMAIL_BASE_URL || "https://api.agentmail.to/v0"
+).replace(/\/$/, "");
+const SAAS_HOST = (process.env.SAAS_HOST ?? "https://alfred.black").replace(
+  /\/$/,
+  "",
+);
+const AGENTMAIL_DOMAIN =
+  process.env.AGENTMAIL_DOMAIN || "mail.alfred.black";
+const AGENTMAIL_SHARED_POD_ID = (
+  process.env.AGENTMAIL_SHARED_POD_ID || ""
+).trim();
+// Tenant-side webhook target. Matches deploy/agentmail-bootstrap.sh + the
+// SaaS receiver pattern used by the single-tenant `email.ts` path.
+const AGENTMAIL_TENANT_WEBHOOK_URL = `${SAAS_HOST}/webhooks/agentmail`;
+
+type AgentMailResponse = { status: number; body: any };
+
+async function agentMailFetch(
+  apiKey: string,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<AgentMailResponse> {
+  const init: RequestInit = {
+    method,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    signal: AbortSignal.timeout(30_000),
+  };
+  if (body !== undefined) init.body = JSON.stringify(body);
+  const res = await fetch(`${AGENTMAIL_BASE_URL}${path}`, init);
+  let parsed: any = null;
+  try {
+    parsed = await res.json();
+  } catch {
+    parsed = null;
+  }
+  return { status: res.status, body: parsed };
+}
+
+function masterKey(): string | null {
+  const k = (process.env.AGENTMAIL_MASTER_API_KEY || "").trim();
+  return k || null;
+}
+
+// Sanity: a prefix becomes the inbox local-part. Lowercase alnum + dashes +
+// dots, 2..40 chars. Mirrors AgentMail's username acceptance.
+const _PREFIX_RE = /^[a-z][a-z0-9.-]{1,39}$/;
+
+function validatePrefix(p: unknown, slug: string): string {
+  if (typeof p === "string" && p.trim()) {
+    const candidate = p.trim().toLowerCase();
+    if (!_PREFIX_RE.test(candidate)) {
+      throw new ValidationError(
+        `prefix '${candidate}' must match ${_PREFIX_RE.source}`,
+      );
+    }
+    return candidate;
+  }
+  // Default: derive from slug. `alfred.<slug>` so it sorts next to the
+  // SaaS-side default and the principal sees the profile name in the
+  // address.
+  const candidate = `alfred.${slug}`.toLowerCase();
+  if (!_PREFIX_RE.test(candidate)) {
+    throw new ValidationError(
+      `derived prefix '${candidate}' is invalid; pass an explicit prefix`,
+    );
+  }
+  return candidate;
+}
+
+// ─ per-profile .env (lives INSIDE the hermes container volume) ────────────
+//
+// Reuses the docker-exec pattern Telegram/Slack/SMS use — hermes_data is a
+// named volume bind-mounted into ctrl-api too (HERMES_CONFIG_DIR), but
+// writes go through `docker exec hermes ...` so the file's owner/perm match
+// the runtime container's view (hermes UID 10000). Reads work either way;
+// we use docker-exec for both for symmetry.
+
+const AGENTMAIL_ENV_KEYS = [
+  "AGENTMAIL_INBOX_ID",
+  "AGENTMAIL_INBOX_ADDRESS",
+  "AGENTMAIL_API_KEY",
+] as const;
+type AgentMailEnvKey = (typeof AGENTMAIL_ENV_KEYS)[number];
+
+interface ProfileEmailPaths {
+  profileSlug: string;
+  profileDir: string;
+  envPath: string;
+}
+
+function pathsForEmailProfile(slug: string): ProfileEmailPaths {
+  const envPath = resolveProfileEnvPath(slug);
+  return {
+    profileSlug: slug,
+    profileDir: envPath.replace(/\/\.env$/, ""),
+    envPath,
+  };
+}
+
+async function readProfileEmailEnv(
+  paths: ProfileEmailPaths,
+): Promise<Record<string, string>> {
+  const raw = await dockerExec(HERMES_CONTAINER, [
+    "sh",
+    "-c",
+    `cat ${paths.envPath} 2>/dev/null || true`,
+  ]);
+  const out: Record<string, string> = {};
+  for (const line of raw.split("\n")) {
+    const t = line.replace(/^﻿/, "");
+    if (!t || t.trimStart().startsWith("#")) continue;
+    const eq = t.indexOf("=");
+    if (eq <= 0) continue;
+    const k = t.slice(0, eq).trim();
+    let v = t.slice(eq + 1);
+    if (v.endsWith("\r")) v = v.slice(0, -1);
+    if (
+      (v.startsWith('"') && v.endsWith('"')) ||
+      (v.startsWith("'") && v.endsWith("'"))
+    ) {
+      v = v.slice(1, -1);
+    }
+    out[k] = v;
+  }
+  return out;
+}
+
+async function writeProfileEmailEnvKeys(
+  paths: ProfileEmailPaths,
+  updates: Partial<Record<AgentMailEnvKey, string | null>>,
+): Promise<void> {
+  const raw = await dockerExec(HERMES_CONTAINER, [
+    "sh",
+    "-c",
+    `cat ${paths.envPath} 2>/dev/null || true`,
+  ]);
+  const lines = raw === "" ? [] : raw.split("\n");
+  if (lines.length && lines[lines.length - 1] === "") lines.pop();
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const line of lines) {
+    const t = line.replace(/^﻿/, "");
+    const eq = t.indexOf("=");
+    const key = eq > 0 ? t.slice(0, eq).trim() : "";
+    if (key && key in updates) {
+      seen.add(key);
+      const v = updates[key as AgentMailEnvKey];
+      if (v === null || v === undefined) continue; // drop
+      out.push(`${key}=${v}`);
+      continue;
+    }
+    out.push(line);
+  }
+  for (const k of AGENTMAIL_ENV_KEYS) {
+    if (seen.has(k)) continue;
+    if (!(k in updates)) continue;
+    const v = updates[k];
+    if (v === null || v === undefined) continue;
+    out.push(`${k}=${v}`);
+  }
+  const content = out.join("\n") + "\n";
+  const tmp = `${paths.envPath}.tmp.${process.pid}.${Date.now()}`;
+  await dockerExecWithStdin(
+    HERMES_CONTAINER,
+    [
+      "sh",
+      "-c",
+      `mkdir -p ${paths.profileDir} && cat > ${tmp} && mv ${tmp} ${paths.envPath}`,
+    ],
+    content,
+    30_000,
+  );
+}
+
+// Find the ULID binding row for this profile + email address so we can
+// surface it in /status + drop it on /inbox DELETE. The seeded
+// 'binding-default-email' row is for the per-kind default (channel_identity
+// IS NULL); we never touch it from here.
+function findEmailBindingFor(
+  slug: string,
+  address: string,
+): { id: string } | null {
+  const all = listAllBindings(getStateDb());
+  const match = all.find(
+    (b) =>
+      b.channel_kind === "email" &&
+      b.profile_slug === slug &&
+      (b.channel_identity || "").toLowerCase() === address.toLowerCase() &&
+      !b.id.startsWith("binding-default-"),
+  );
+  return match ? { id: match.id } : null;
+}
+
 // Match RFC 2822 local-parts (case-insensitive) that indicate an automated
 // sender — Hermes' native email adapter drops these silently. The address
 // is parsed by `extractLocalPart`, so we match on local-part alone.
@@ -207,12 +441,30 @@ function hasBulkHeader(headers: Record<string, string> | undefined): boolean {
 }
 
 function isSelfLoop(from: string): boolean {
-  const ourAddr = (process.env.AGENTMAIL_INBOX_ADDRESS || "").trim().toLowerCase();
-  if (!ourAddr) return false;
-  // Compare local-part@host of the from-address against ours.
+  // Self-loop check now considers both the main-profile tenant-wide address
+  // (`AGENTMAIL_INBOX_ADDRESS`, unchanged) AND every per-profile inbox that
+  // has a (channel_kind=email, channel_identity=<address>) binding row in
+  // state.db. The binding is the canonical source of "addresses Alfred
+  // currently owns" — if the from-address matches one, it's our own
+  // outbound landing back in the inbox and gets dropped.
   const m = from.match(/<([^>]+)>/);
   const fromEmail = (m ? m[1] : from).trim().toLowerCase();
-  return fromEmail === ourAddr;
+  if (!fromEmail) return false;
+  const envAddr = (process.env.AGENTMAIL_INBOX_ADDRESS || "")
+    .trim()
+    .toLowerCase();
+  if (envAddr && fromEmail === envAddr) return true;
+  try {
+    const bindings = listAllBindings(getStateDb());
+    for (const b of bindings) {
+      if (b.channel_kind !== "email") continue;
+      const id = (b.channel_identity || "").trim().toLowerCase();
+      if (id && id === fromEmail) return true;
+    }
+  } catch {
+    // best-effort — if state.db is unavailable, fall back to env-only.
+  }
+  return false;
 }
 
 export function registerChannelsEmailRoutes(): void {
@@ -335,6 +587,464 @@ export function registerChannelsEmailRoutes(): void {
         profile_dir: ctx.profile_dir,
         journal_scope: ctx.journal_scope_key,
         gateway_url: hermesBaseUrlFor(ctx),
+      });
+    },
+  );
+
+  // ── #120 Lane Vb2 — per-profile email inbox routes ──────────────────────
+
+  // GET /api/v1/channels/email/status?profile=<slug>
+  // Per-profile inbox state. Mirrors the Telegram /status fail-soft shape:
+  // never 5xx — the UI polls it. Reads the per-profile .env to see whether
+  // an inbox has been provisioned; if AGENTMAIL_MASTER_API_KEY is unset
+  // surfaces { provision_available: false, reason } so the UI can show the
+  // honest "operator action required" hint.
+  addRoute(
+    "GET",
+    "/api/v1/channels/email/status",
+    async ({ res, query }) => {
+      const slug =
+        (query.get("profile") || "").trim() ||
+        resolveProfileForChannel(getStateDb(), "email", null);
+      const paths = pathsForEmailProfile(slug);
+      let envMap: Record<string, string> = {};
+      let envErr: string | null = null;
+      try {
+        envMap = await readProfileEmailEnv(paths);
+      } catch (e) {
+        envErr = e instanceof Error ? e.message : String(e);
+      }
+      const inboxAddress = envMap.AGENTMAIL_INBOX_ADDRESS ?? null;
+      const inboxId = envMap.AGENTMAIL_INBOX_ID ?? null;
+      const configured = Boolean(inboxAddress && inboxId);
+      const provisionAvailable = masterKey() !== null;
+      const binding =
+        inboxAddress != null ? findEmailBindingFor(slug, inboxAddress) : null;
+      sendJson(res, 200, {
+        configured,
+        profile: slug,
+        inbox_address: inboxAddress,
+        inbox_id: inboxId,
+        binding_id: binding?.id ?? null,
+        provision_available: provisionAvailable,
+        provision_unavailable_reason: provisionAvailable
+          ? null
+          : "AGENTMAIL_MASTER_API_KEY not set on this tenant — operator must set it in /opt/alfred/.env before per-profile inboxes can be provisioned",
+        env_error: envErr,
+      });
+    },
+  );
+
+  // POST /api/v1/channels/email/provision?profile=<slug>
+  // The load-bearing route. Calls AgentMail's API to (a) create a new inbox
+  // in the tenant's shared pod, (b) mint an inbox-scoped API key, then
+  // persists the credentials into the profile's .env and writes the
+  // (email, <address>) → <slug> channel binding so inbound mail to that
+  // address routes here.
+  //
+  // Body: { prefix?: string }      — explicit local-part; defaults to
+  //                                  `alfred.<slug>`.
+  // Returns { ok, address, inbox_id, binding_id, restart_scope }.
+  addRoute(
+    "POST",
+    "/api/v1/channels/email/provision",
+    async ({ res, body, query }) => {
+      const slug = (query.get("profile") || "").trim();
+      if (!slug) {
+        throw new ValidationError("query ?profile=<slug> is required");
+      }
+      try {
+        assertWritableProfile(getStateDb(), slug);
+      } catch (e) {
+        throw new ValidationError(e instanceof Error ? e.message : String(e));
+      }
+      const mkey = masterKey();
+      if (!mkey) {
+        sendJson(res, 400, {
+          ok: false,
+          code: "master_key_missing",
+          error:
+            "AGENTMAIL_MASTER_API_KEY is not set on this tenant. " +
+            "Set it in /opt/alfred/.env (operator step) and restart ctrl-api.",
+        });
+        return;
+      }
+      if (!AGENTMAIL_SHARED_POD_ID) {
+        sendJson(res, 400, {
+          ok: false,
+          code: "pod_id_missing",
+          error:
+            "AGENTMAIL_SHARED_POD_ID is not set on this tenant. Set it in /opt/alfred/.env alongside AGENTMAIL_MASTER_API_KEY.",
+        });
+        return;
+      }
+
+      const b = (body ?? {}) as Record<string, unknown>;
+      const prefix = validatePrefix(b.prefix, slug);
+      const displayName =
+        typeof b.display_name === "string" && b.display_name.trim()
+          ? b.display_name.trim()
+          : `Alfred · ${slug}`;
+      // client_id de-duplicates a retry into the same inbox — make it
+      // profile-scoped so two slugs don't collide on the same prefix.
+      const clientId = `profile-${slug}`;
+
+      // 1. Create the inbox.
+      const created = await agentMailFetch(mkey, "POST", `/pods/${encodeURIComponent(AGENTMAIL_SHARED_POD_ID)}/inboxes`, {
+        username: prefix,
+        domain: AGENTMAIL_DOMAIN,
+        display_name: displayName,
+        client_id: clientId,
+      });
+      if (created.status < 200 || created.status >= 300) {
+        sendJson(res, 502, {
+          ok: false,
+          code: "agentmail_create_failed",
+          error: `AgentMail inbox create failed (status=${created.status})`,
+          upstream_status: created.status,
+          upstream_body: created.body,
+        });
+        return;
+      }
+      const inboxId: string | undefined = created.body?.inbox_id;
+      const inboxAddress: string | undefined = created.body?.email;
+      if (!inboxId || !inboxAddress) {
+        sendJson(res, 502, {
+          ok: false,
+          code: "agentmail_create_invalid_response",
+          error: "AgentMail returned no inbox_id/email",
+          upstream_body: created.body,
+        });
+        return;
+      }
+
+      // 2. Mint an inbox-scoped API key. AgentMail returns the plaintext
+      //    key exactly once — persist it immediately.
+      const keyRes = await agentMailFetch(mkey, "POST", `/inboxes/${encodeURIComponent(inboxId)}/api-keys`, {
+        name: `${clientId}-${Date.now()}`,
+      });
+      if (
+        keyRes.status < 200 ||
+        keyRes.status >= 300 ||
+        !keyRes.body?.api_key
+      ) {
+        sendJson(res, 502, {
+          ok: false,
+          code: "agentmail_api_key_failed",
+          error: `AgentMail api-key mint failed (status=${keyRes.status})`,
+          upstream_status: keyRes.status,
+          upstream_body: keyRes.body,
+        });
+        return;
+      }
+      const inboxApiKey: string = keyRes.body.api_key;
+
+      // 3. Best-effort: register the tenant webhook for this inbox so AgentMail
+      //    delivers inbound mail to the shared SaaS receiver. Mirrors the
+      //    single-tenant /api/v1/email/provision pattern; failure here is a
+      //    warning, not a hard error (the SaaS-side master webhook also
+      //    catches messages).
+      let webhookRegistered = false;
+      try {
+        const existing = await agentMailFetch(inboxApiKey, "GET", "/webhooks");
+        const list = Array.isArray(existing.body?.webhooks)
+          ? existing.body.webhooks
+          : [];
+        const match = list.some(
+          (h: any) => h?.url === AGENTMAIL_TENANT_WEBHOOK_URL,
+        );
+        if (match) {
+          webhookRegistered = true;
+        } else {
+          const create = await agentMailFetch(
+            inboxApiKey,
+            "POST",
+            "/webhooks",
+            {
+              url: AGENTMAIL_TENANT_WEBHOOK_URL,
+              event_types: ["message.received"],
+              inbox_ids: [inboxId],
+            },
+          );
+          webhookRegistered = create.status >= 200 && create.status < 300;
+        }
+      } catch (err) {
+        console.warn(
+          `[channels-email] webhook register failed for ${inboxAddress}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+
+      // 4. Persist creds to the profile's .env (the file Hermes' inbox-scoped
+      //    outbound and the channel-email handler both read at runtime).
+      const paths = pathsForEmailProfile(slug);
+      await writeProfileEmailEnvKeys(paths, {
+        AGENTMAIL_INBOX_ID: inboxId,
+        AGENTMAIL_INBOX_ADDRESS: inboxAddress,
+        AGENTMAIL_API_KEY: inboxApiKey,
+      });
+
+      // 5. Write the channel binding so inbound mail to this address routes
+      //    to this profile. Idempotent — re-provisioning the same prefix
+      //    on the same slug rebinds the existing row.
+      let bindingId: string;
+      try {
+        const binding = bindChannel(getStateDb(), {
+          channel_kind: "email",
+          channel_identity: inboxAddress.toLowerCase(),
+          profile_slug: slug,
+        });
+        bindingId = binding.id;
+      } catch (e) {
+        // The inbox is already provisioned at AgentMail's end; refuse to
+        // claim success when the binding write failed (otherwise inbound
+        // routing would silently fall back to main).
+        sendJson(res, 500, {
+          ok: false,
+          code: "binding_write_failed",
+          error: `failed to write channel binding: ${e instanceof Error ? e.message : String(e)}`,
+          inbox_address: inboxAddress,
+          inbox_id: inboxId,
+          provisioned_at_agentmail: true,
+        });
+        return;
+      }
+
+      // 6. Audit the mutation with the profile slug + channel identity.
+      appendAudit({
+        action_type: "channel_email_inbox_provisioned",
+        actor: "principal",
+        source: "channels/email/provision",
+        target_path: "channels/email/provision",
+        target_kind: "channel",
+        subject_ref: slug,
+        summary: `AgentMail inbox '${inboxAddress}' provisioned on profile '${slug}'`,
+        payload: {
+          profile_slug: slug,
+          channel_kind: "email",
+          inbox_id: inboxId,
+          inbox_address: inboxAddress,
+          binding_id: bindingId,
+          webhook_registered: webhookRegistered,
+        },
+      });
+
+      // 7. Restart scope. The new .env keys are read at request time by the
+      //    /api/v1/email/* routes — no Hermes restart strictly required for
+      //    outbound to work. We still drop a per-profile flag-file via
+      //    restartProfile so any future Hermes-side adapter that loads its
+      //    inbox config at boot will pick it up on the next reconcile.
+      const restart = restartProfile(slug, { allowComposeFallback: false });
+
+      sendJson(res, 200, {
+        ok: true,
+        profile: slug,
+        address: inboxAddress,
+        inbox_address: inboxAddress,
+        inbox_id: inboxId,
+        binding_id: bindingId,
+        webhook_registered: webhookRegistered,
+        restart_scope: restart.scope,
+        restart_warning: restart.warning,
+      });
+    },
+  );
+
+  // DELETE /api/v1/channels/email/inbox?profile=<slug>
+  // Releases the AgentMail inbox (best-effort), wipes the profile's email
+  // env keys, and removes the channel binding so inbound mail to the freed
+  // address falls back to main.
+  addRoute(
+    "DELETE",
+    "/api/v1/channels/email/inbox",
+    async ({ res, query }) => {
+      const slug = (query.get("profile") || "").trim();
+      if (!slug) {
+        throw new ValidationError("query ?profile=<slug> is required");
+      }
+      try {
+        assertWritableProfile(getStateDb(), slug);
+      } catch (e) {
+        throw new ValidationError(e instanceof Error ? e.message : String(e));
+      }
+
+      const paths = pathsForEmailProfile(slug);
+      let envMap: Record<string, string> = {};
+      try {
+        envMap = await readProfileEmailEnv(paths);
+      } catch {
+        /* tolerated — DELETE is idempotent */
+      }
+      const inboxId = envMap.AGENTMAIL_INBOX_ID ?? null;
+      const inboxAddress = envMap.AGENTMAIL_INBOX_ADDRESS ?? null;
+
+      // Best-effort: tell AgentMail to release the inbox. AgentMail's
+      // delete-inbox endpoint requires the master key (inbox-scoped keys
+      // can't delete the inbox they're for). If the master key is unset we
+      // skip the upstream call and let the orphan inbox sit — the binding
+      // write below is what actually breaks routing.
+      let upstreamReleased: "ok" | "skipped" | "failed" = "skipped";
+      let upstreamStatus: number | null = null;
+      const mkey = masterKey();
+      if (mkey && inboxId) {
+        try {
+          const del = await agentMailFetch(
+            mkey,
+            "DELETE",
+            `/inboxes/${encodeURIComponent(inboxId)}`,
+          );
+          upstreamStatus = del.status;
+          upstreamReleased =
+            del.status >= 200 && del.status < 300 ? "ok" : "failed";
+        } catch (err) {
+          console.warn(
+            `[channels-email] AgentMail inbox release failed for ${inboxId}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+          upstreamReleased = "failed";
+        }
+      }
+
+      // Wipe the profile's .env keys (or no-op when the dir is missing).
+      try {
+        await writeProfileEmailEnvKeys(paths, {
+          AGENTMAIL_INBOX_ID: null,
+          AGENTMAIL_INBOX_ADDRESS: null,
+          AGENTMAIL_API_KEY: null,
+        });
+      } catch (err) {
+        console.warn(
+          `[channels-email] failed to wipe profile .env for ${slug}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+
+      // Drop the binding row so future inbound mail to this address falls
+      // back to the default (main).
+      let bindingRemoved = false;
+      if (inboxAddress) {
+        const found = findEmailBindingFor(slug, inboxAddress);
+        if (found) {
+          try {
+            unbindChannel(getStateDb(), found.id);
+            bindingRemoved = true;
+          } catch (err) {
+            console.warn(
+              `[channels-email] unbindChannel(${found.id}) failed: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+        }
+      }
+
+      appendAudit({
+        action_type: "channel_email_inbox_released",
+        actor: "principal",
+        source: "channels/email/inbox",
+        target_path: "channels/email/inbox",
+        target_kind: "channel",
+        subject_ref: slug,
+        summary: `AgentMail inbox '${inboxAddress ?? "<unknown>"}' released on profile '${slug}'`,
+        payload: {
+          profile_slug: slug,
+          channel_kind: "email",
+          inbox_id: inboxId,
+          inbox_address: inboxAddress,
+          binding_removed: bindingRemoved,
+          upstream_released: upstreamReleased,
+          upstream_status: upstreamStatus,
+        },
+      });
+
+      const restart = restartProfile(slug, { allowComposeFallback: false });
+
+      sendJson(res, 200, {
+        ok: true,
+        profile: slug,
+        inbox_address: inboxAddress,
+        inbox_id: inboxId,
+        binding_removed: bindingRemoved,
+        upstream_released: upstreamReleased,
+        restart_scope: restart.scope,
+        restart_warning: restart.warning,
+      });
+    },
+  );
+
+  // POST /api/v1/channels/email/test?profile=<slug>
+  // Send a test email from this profile's inbox via AgentMail. Target
+  // defaults to the operator's verified address surfaced in the body
+  // (`{ to?: string }`); otherwise sends to the SaaS operator email when
+  // available.
+  addRoute(
+    "POST",
+    "/api/v1/channels/email/test",
+    async ({ res, body, query }) => {
+      const slug = (query.get("profile") || "").trim();
+      if (!slug) {
+        throw new ValidationError("query ?profile=<slug> is required");
+      }
+      try {
+        assertWritableProfile(getStateDb(), slug);
+      } catch (e) {
+        throw new ValidationError(e instanceof Error ? e.message : String(e));
+      }
+      const b = (body ?? {}) as Record<string, unknown>;
+      const to =
+        typeof b.to === "string" && b.to.trim() ? b.to.trim() : null;
+      if (!to) {
+        sendJson(res, 400, {
+          ok: false,
+          code: "missing_recipient",
+          error:
+            "pass body.to=<recipient> — no fallback operator address configured",
+        });
+        return;
+      }
+
+      const paths = pathsForEmailProfile(slug);
+      const envMap = await readProfileEmailEnv(paths).catch(
+        () => ({}) as Record<string, string>,
+      );
+      const inboxId = envMap.AGENTMAIL_INBOX_ID ?? "";
+      const inboxApiKey = envMap.AGENTMAIL_API_KEY ?? "";
+      const inboxAddress = envMap.AGENTMAIL_INBOX_ADDRESS ?? "";
+      if (!inboxId || !inboxApiKey) {
+        sendJson(res, 400, {
+          ok: false,
+          code: "not_configured",
+          error: `profile '${slug}' has no AgentMail inbox provisioned`,
+        });
+        return;
+      }
+      const subject =
+        typeof b.subject === "string" && b.subject.trim()
+          ? b.subject.trim()
+          : `Test from ${inboxAddress || slug}`;
+      const text =
+        typeof b.text === "string" && b.text.trim()
+          ? b.text.trim()
+          : `Test email from profile '${slug}' (${inboxAddress}). ` +
+            "If you see this, per-profile outbound is working.";
+
+      const send = await agentMailFetch(
+        inboxApiKey,
+        "POST",
+        `/inboxes/${encodeURIComponent(inboxId)}/messages/send`,
+        { to: [to], subject, text },
+      );
+      if (send.status < 200 || send.status >= 300) {
+        sendJson(res, 502, {
+          ok: false,
+          code: "send_failed",
+          error: `AgentMail send failed (status=${send.status})`,
+          upstream_status: send.status,
+          upstream_body: send.body,
+        });
+        return;
+      }
+      sendJson(res, 200, {
+        ok: true,
+        profile: slug,
+        from: inboxAddress,
+        to,
+        message_id: send.body?.message_id ?? null,
       });
     },
   );

--- a/packages/ctrl/src/api/routes/email.ts
+++ b/packages/ctrl/src/api/routes/email.ts
@@ -13,6 +13,7 @@ import path from "node:path";
 
 import { addRoute } from "../server.js";
 import { sendJson, ValidationError, NotFoundError } from "../errors.js";
+import { resolveProfileEnvPath } from "../../db/agentProfiles.js";
 
 const AGENTMAIL_API = "https://api.agentmail.to/v0";
 const FALLBACK_FILE =
@@ -65,7 +66,59 @@ async function ensureInboundWebhook(creds: AgentMailCreds): Promise<boolean> {
   }
 }
 
-function getCreds(): AgentMailCreds {
+// Read per-profile AgentMail creds from /hermes-state/profiles/<slug>/.env.
+// Returns null when the .env is missing or has no AGENTMAIL_INBOX_ID. Used
+// by getCreds() when a `?profile=<slug>` query is present on the outbound
+// routes — Lane Vb2 per-profile email.
+function readProfileCreds(slug: string): AgentMailCreds | null {
+  let envPath: string;
+  try {
+    envPath = resolveProfileEnvPath(slug);
+  } catch {
+    return null;
+  }
+  let raw: string;
+  try {
+    raw = fs.readFileSync(envPath, "utf-8");
+  } catch {
+    return null;
+  }
+  const map: Record<string, string> = {};
+  for (const line of raw.split("\n")) {
+    const t = line.replace(/^﻿/, "").trim();
+    if (!t || t.startsWith("#")) continue;
+    const eq = t.indexOf("=");
+    if (eq <= 0) continue;
+    const k = t.slice(0, eq).trim();
+    let v = t.slice(eq + 1);
+    if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) {
+      v = v.slice(1, -1);
+    }
+    map[k] = v;
+  }
+  const apiKey = (map.AGENTMAIL_API_KEY || "").trim();
+  const inboxId = (map.AGENTMAIL_INBOX_ID || "").trim();
+  const address = (map.AGENTMAIL_INBOX_ADDRESS || "").trim();
+  if (!apiKey || !inboxId) return null;
+  return { api_key: apiKey, inbox_id: inboxId, inbox_address: address };
+}
+
+function getCreds(profileSlug?: string | null): AgentMailCreds {
+  // Lane Vb2: when an explicit profile is supplied, read its per-profile
+  // .env first. Fall back to the legacy env/file path so existing callers
+  // (the alfred-email-channel skill, the SaaS provision route) still work.
+  if (profileSlug && profileSlug.trim()) {
+    const slug = profileSlug.trim();
+    const perProfile = readProfileCreds(slug);
+    if (perProfile) return perProfile;
+    // Explicit profile but no per-profile inbox → don't silently fall back
+    // to main's creds (that would send Sentinel's reply with main's "from").
+    if (slug !== "main") {
+      throw new ValidationError(
+        `profile '${slug}' has no AgentMail inbox provisioned — call POST /api/v1/channels/email/provision?profile=${slug} first`,
+      );
+    }
+  }
   const envKey = (process.env.AGENTMAIL_API_KEY || "").trim();
   const envInboxId = (process.env.AGENTMAIL_INBOX_ID || "").trim();
   const envAddress = (process.env.AGENTMAIL_INBOX_ADDRESS || "").trim();
@@ -87,8 +140,14 @@ function getCreds(): AgentMailCreds {
   } catch {
     /* fallthrough */
   }
+  // Main profile may have its inbox in /hermes-state/profiles/main/.env too
+  // (Lane Vb2 provisioning persists there). Try as a last resort.
+  if (!profileSlug || profileSlug === "main") {
+    const mainProfile = readProfileCreds("main");
+    if (mainProfile) return mainProfile;
+  }
   throw new ValidationError(
-    "AgentMail is not configured on this tenant. Set AGENTMAIL_API_KEY and AGENTMAIL_INBOX_ID in /opt/alfred/compose/.env.",
+    "AgentMail is not configured on this tenant. Set AGENTMAIL_API_KEY and AGENTMAIL_INBOX_ID in /opt/alfred/compose/.env, or call POST /api/v1/channels/email/provision?profile=<slug>.",
   );
 }
 
@@ -203,7 +262,8 @@ export function registerEmailRoutes(): void {
   // Send a new message (new thread).
   // Body: { to, subject, text, html?, cc?, bcc?, reply_to?, labels?, attachments? }
   // attachments: Array<{content: base64, filename?, content_type?}>
-  addRoute("POST", "/api/v1/email/send", async ({ res, body }) => {
+  // Query: ?profile=<slug> — Lane Vb2; sends with the profile's inbox creds.
+  addRoute("POST", "/api/v1/email/send", async ({ res, body, query }) => {
     const b = (body ?? {}) as Record<string, unknown>;
     const to = stringArray(b.to);
     if (!to || to.length === 0) throw new ValidationError("`to` is required");
@@ -212,7 +272,7 @@ export function registerEmailRoutes(): void {
     if (typeof b.text !== "string" || !b.text)
       throw new ValidationError("`text` is required");
 
-    const creds = getCreds();
+    const creds = getCreds(query.get("profile"));
     const payload: Record<string, unknown> = { to, subject: b.subject, text: b.text };
     if (typeof b.html === "string") payload.html = b.html;
     const cc = stringArray(b.cc);
@@ -231,14 +291,15 @@ export function registerEmailRoutes(): void {
 
   // Reply to a message (same thread).
   // Body: { message_id, text, html?, reply_all?: boolean, attachments? }
-  addRoute("POST", "/api/v1/email/reply", async ({ res, body }) => {
+  // Query: ?profile=<slug> — Lane Vb2.
+  addRoute("POST", "/api/v1/email/reply", async ({ res, body, query }) => {
     const b = (body ?? {}) as Record<string, unknown>;
     if (typeof b.message_id !== "string" || !b.message_id)
       throw new ValidationError("`message_id` is required");
     if (typeof b.text !== "string" || !b.text)
       throw new ValidationError("`text` is required");
 
-    const creds = getCreds();
+    const creds = getCreds(query.get("profile"));
     const payload: Record<string, unknown> = { text: b.text };
     if (typeof b.html === "string") payload.html = b.html;
     if (Array.isArray(b.attachments)) payload.attachments = b.attachments;
@@ -253,14 +314,15 @@ export function registerEmailRoutes(): void {
 
   // Forward a message.
   // Body: { message_id, to, subject?, text?, html?, attachments? }
-  addRoute("POST", "/api/v1/email/forward", async ({ res, body }) => {
+  // Query: ?profile=<slug> — Lane Vb2.
+  addRoute("POST", "/api/v1/email/forward", async ({ res, body, query }) => {
     const b = (body ?? {}) as Record<string, unknown>;
     if (typeof b.message_id !== "string" || !b.message_id)
       throw new ValidationError("`message_id` is required");
     const to = stringArray(b.to);
     if (!to || to.length === 0) throw new ValidationError("`to` is required");
 
-    const creds = getCreds();
+    const creds = getCreds(query.get("profile"));
     const payload: Record<string, unknown> = { to };
     if (typeof b.subject === "string") payload.subject = b.subject;
     if (typeof b.text === "string") payload.text = b.text;
@@ -279,10 +341,11 @@ export function registerEmailRoutes(): void {
 
   // Fetch a single message — used by the channel handler to pull full
   // body when the webhook payload was >1MB and text/html were stripped.
-  addRoute("GET", "/api/v1/email/message/:message_id", async ({ res, params }) => {
+  // Query: ?profile=<slug> — Lane Vb2.
+  addRoute("GET", "/api/v1/email/message/:message_id", async ({ res, params, query }) => {
     const messageId = decodeURIComponent(params["message_id"] ?? "");
     if (!messageId) throw new ValidationError("message_id required");
-    const creds = getCreds();
+    const creds = getCreds(query.get("profile"));
     const r = await am(
       creds,
       "GET",
@@ -295,10 +358,11 @@ export function registerEmailRoutes(): void {
 
   // Fetch a full thread — Alfred uses this to assemble context before
   // composing replies.
-  addRoute("GET", "/api/v1/email/thread/:thread_id", async ({ res, params }) => {
+  // Query: ?profile=<slug> — Lane Vb2.
+  addRoute("GET", "/api/v1/email/thread/:thread_id", async ({ res, params, query }) => {
     const threadId = decodeURIComponent(params["thread_id"] ?? "");
     if (!threadId) throw new ValidationError("thread_id required");
-    const creds = getCreds();
+    const creds = getCreds(query.get("profile"));
     const r = await am(
       creds,
       "GET",
@@ -310,12 +374,13 @@ export function registerEmailRoutes(): void {
   });
 
   // Download an attachment by id.
+  // Query: ?profile=<slug> — Lane Vb2.
   addRoute(
     "GET",
     "/api/v1/email/attachment/:message_id/:attachment_id",
-    async ({ req, res, params }) => {
+    async ({ req, res, params, query }) => {
       void req;
-      const creds = getCreds();
+      const creds = getCreds(query.get("profile"));
       const messageId = decodeURIComponent(params["message_id"] ?? "");
       const attachmentId = decodeURIComponent(params["attachment_id"] ?? "");
       if (!messageId || !attachmentId)

--- a/packages/ctrl/tests/channels-email-lane-vb2.test.ts
+++ b/packages/ctrl/tests/channels-email-lane-vb2.test.ts
@@ -1,0 +1,674 @@
+// #120 Lane Vb2 — per-profile AgentMail inbox routes.
+//
+// Covers the four new routes on /api/v1/channels/email/*:
+//   * GET    /status?profile=<slug>            — fail-soft per-profile shape
+//   * POST   /provision?profile=<slug>         — calls AgentMail + writes binding
+//   * DELETE /inbox?profile=<slug>             — releases inbox + clears env
+//   * POST   /test?profile=<slug>              — uses the profile's inbox creds
+//
+// AgentMail's HTTP API is mocked via a fetch stub keyed off URL path. The
+// per-profile .env is written via docker-exec (mocked here to read/write an
+// in-memory map).
+
+import { mock, describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// ── env + path setup ─────────────────────────────────────────────────────
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "lane-vb2-email-"));
+process.env.STATE_DB_PATH = path.join(tmp, "state.db");
+process.env.SQLITE_VEC_PATH = "";
+process.env.VAULT_PATH = path.join(tmp, "vault");
+fs.mkdirSync(process.env.VAULT_PATH, { recursive: true });
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.HERMES_CONFIG_DIR = path.join(tmp, "hermes-state", "profiles");
+process.env.HERMES_STATE_DIR_CTRL_VIEW = path.join(tmp, "hermes-state");
+fs.mkdirSync(process.env.HERMES_CONFIG_DIR, { recursive: true });
+process.env.AGENTMAIL_MASTER_API_KEY = "am_master_test_key";
+process.env.AGENTMAIL_SHARED_POD_ID = "pod_test";
+process.env.AGENTMAIL_DOMAIN = "test.alfred.black";
+process.env.SAAS_HOST = "https://alfred.black";
+process.env.AGENTMAIL_BASE_URL = "https://stub.agentmail.test/v0";
+
+// ── AgentMail mock state ─────────────────────────────────────────────────
+const agentMailState = {
+  inboxes: new Map<string, { inbox_id: string; email: string }>(),
+  apiKeys: new Map<string, string>(), // inbox_id → plaintext api_key
+  inboxesById: new Map<string, { inbox_id: string; email: string }>(),
+  webhooksByKey: new Map<string, { url: string; inbox_ids: string[] }[]>(),
+  callLog: [] as Array<{
+    method: string;
+    path: string;
+    auth: string;
+    body: any;
+  }>,
+  failCreate: false,
+  failKey: false,
+  failDelete: false,
+  failSend: false,
+  nextSendStatus: 200,
+  nextSendBody: { message_id: "msg_abc" } as any,
+};
+
+function resetAgentMail(): void {
+  agentMailState.inboxes.clear();
+  agentMailState.apiKeys.clear();
+  agentMailState.inboxesById.clear();
+  agentMailState.webhooksByKey.clear();
+  agentMailState.callLog = [];
+  agentMailState.failCreate = false;
+  agentMailState.failKey = false;
+  agentMailState.failDelete = false;
+  agentMailState.failSend = false;
+  agentMailState.nextSendStatus = 200;
+  agentMailState.nextSendBody = { message_id: "msg_abc" };
+}
+
+// Clear the sentinel profile's .env and binding row so each test starts
+// from a clean slate. Used by the suites that share the same sentinel.
+function resetSentinel(): void {
+  const envPath = path.join(
+    process.env.HERMES_CONFIG_DIR!,
+    "lane-vb2-sentinel",
+    ".env",
+  );
+  try {
+    fs.unlinkSync(envPath);
+  } catch {
+    /* idempotent */
+  }
+  // Also strip any prior email bindings for this slug.
+  // (Use the db directly — there's no public unbind-by-slug helper.)
+  // Imported lazily inside the actual reset call.
+}
+
+globalThis.fetch = (async (url: any, init?: any) => {
+  const u = String(url);
+  const m = (init?.method ?? "GET").toUpperCase();
+  const auth = String(init?.headers?.Authorization || "");
+  const body = init?.body ? JSON.parse(init.body) : null;
+  agentMailState.callLog.push({ method: m, path: u, auth, body });
+
+  // POST /pods/<pod>/inboxes — create inbox
+  const createMatch = u.match(/\/pods\/([^/]+)\/inboxes$/);
+  if (createMatch && m === "POST") {
+    if (agentMailState.failCreate) {
+      return new Response(JSON.stringify({ error: "boom" }), { status: 500 });
+    }
+    const username = body?.username;
+    const domain = body?.domain;
+    const inboxId = `inbox_${username}`;
+    const email = `${username}@${domain}`;
+    const rec = { inbox_id: inboxId, email };
+    agentMailState.inboxes.set(username, rec);
+    agentMailState.inboxesById.set(inboxId, rec);
+    return new Response(JSON.stringify(rec), { status: 201 });
+  }
+
+  // POST /inboxes/<id>/api-keys — mint
+  const keyMatch = u.match(/\/inboxes\/([^/]+)\/api-keys$/);
+  if (keyMatch && m === "POST") {
+    if (agentMailState.failKey) {
+      return new Response(JSON.stringify({ error: "boom" }), { status: 500 });
+    }
+    const inboxId = keyMatch[1];
+    const apiKey = `am_inbox_${inboxId}_key`;
+    agentMailState.apiKeys.set(inboxId, apiKey);
+    return new Response(JSON.stringify({ api_key: apiKey }), { status: 201 });
+  }
+
+  // GET /webhooks — list
+  if (/\/webhooks$/.test(u) && m === "GET") {
+    const list = agentMailState.webhooksByKey.get(auth) ?? [];
+    return new Response(JSON.stringify({ webhooks: list }), { status: 200 });
+  }
+
+  // POST /webhooks — create
+  if (/\/webhooks$/.test(u) && m === "POST") {
+    const list = agentMailState.webhooksByKey.get(auth) ?? [];
+    list.push({ url: body.url, inbox_ids: body.inbox_ids });
+    agentMailState.webhooksByKey.set(auth, list);
+    return new Response(JSON.stringify({ ok: true }), { status: 201 });
+  }
+
+  // DELETE /inboxes/<id>
+  const delMatch = u.match(/\/inboxes\/([^/]+)$/);
+  if (delMatch && m === "DELETE") {
+    if (agentMailState.failDelete) {
+      return new Response(JSON.stringify({ error: "boom" }), { status: 500 });
+    }
+    const id = delMatch[1];
+    const rec = agentMailState.inboxesById.get(id);
+    if (rec) {
+      agentMailState.inboxesById.delete(id);
+      // best-effort: scrub username-keyed map too
+      for (const [u2, r] of agentMailState.inboxes.entries()) {
+        if (r.inbox_id === id) agentMailState.inboxes.delete(u2);
+      }
+    }
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  }
+
+  // POST /inboxes/<id>/messages/send
+  const sendMatch = u.match(/\/inboxes\/([^/]+)\/messages\/send$/);
+  if (sendMatch && m === "POST") {
+    if (agentMailState.failSend) {
+      return new Response(JSON.stringify({ error: "boom" }), { status: 500 });
+    }
+    return new Response(JSON.stringify(agentMailState.nextSendBody), {
+      status: agentMailState.nextSendStatus,
+    });
+  }
+
+  return new Response("not-stubbed: " + u, { status: 501 });
+}) as typeof globalThis.fetch;
+
+// ── docker-exec mock — back the per-profile .env with the local FS ──────
+//
+// Lane V's other tests mock the docker exec helpers similarly. The .env
+// file lives at process.env.HERMES_CONFIG_DIR/<slug>/.env on the local
+// filesystem; we shell out to `sh -c "cat ... || true"` and
+// `sh -c "mkdir -p ... && cat > tmp && mv tmp dst"` — both compile down
+// to fs ops here.
+
+mock.module("../src/api/helpers.js", {
+  namedExports: {
+    HERMES_CONTAINER: "hermes",
+    HERMES_CMD: ["hermes"],
+    ALFRED_CMD: ["alfred", "--config", "/app/data/config.yaml"],
+    OPENCLAW_CMD: ["hermes"],
+    OPENCLAW_CONTAINER: "hermes",
+    COMPOSE_DIR: "/srv/alfred-black",
+    execAsync: async () => ({ stdout: "", stderr: "" }),
+    hostExec: async () => "",
+    sudoExec: async () => "",
+    parseJsonLines: (_raw: string) => [],
+    getQuery: (url: string) => new URLSearchParams(url.split("?")[1] || ""),
+    validateServiceName: (_name: string) => {},
+    dockerComposeCmd: async (_args: string[]) => "",
+    dockerExec: async (_container: string, command: string[]) => {
+      // We support 'sh -c "cat <path> 2>/dev/null || true"'
+      if (command[0] === "sh" && command[1] === "-c") {
+        const script = command[2];
+        const catMatch = script.match(/^cat (\S+) 2>\/dev\/null \|\| true$/);
+        if (catMatch) {
+          const p = catMatch[1];
+          try {
+            return fs.readFileSync(p, "utf-8");
+          } catch {
+            return "";
+          }
+        }
+      }
+      return "";
+    },
+    dockerExecWithStdin: async (
+      _container: string,
+      command: string[],
+      stdin: string,
+    ) => {
+      // 'sh -c "mkdir -p <dir> && cat > tmp && mv tmp <path>"'
+      if (command[0] === "sh" && command[1] === "-c") {
+        const script = command[2];
+        // Match: mkdir -p <dir> && cat > <tmp> && mv <tmp> <dst>
+        const m = script.match(
+          /^mkdir -p (\S+) && cat > (\S+) && mv \S+ (\S+)$/,
+        );
+        if (m) {
+          const [, dir, , dst] = m;
+          fs.mkdirSync(dir, { recursive: true });
+          fs.writeFileSync(dst, stdin, "utf-8");
+          return "";
+        }
+        // Match: cat > <tmp> && mv <tmp> <dst>
+        const m2 = script.match(/^cat > (\S+) && mv \S+ (\S+)$/);
+        if (m2) {
+          const [, , dst] = m2;
+          fs.writeFileSync(dst, stdin, "utf-8");
+          return "";
+        }
+      }
+      return "";
+    },
+  },
+});
+
+// Seed main's .env so api_server_key reads succeed for the inbound handler.
+fs.mkdirSync(path.join(process.env.HERMES_CONFIG_DIR!, "main"), {
+  recursive: true,
+});
+fs.writeFileSync(
+  path.join(process.env.HERMES_CONFIG_DIR!, "main/.env"),
+  "API_SERVER_KEY=main-key-test\n",
+);
+
+const { matchRoute } = await import("../src/api/server.js");
+const { registerChannelsEmailRoutes } = await import(
+  "../src/api/routes/channelsEmail.js"
+);
+const { createProfile, archiveProfile, listAllBindings, resolveProfileForChannel } =
+  await import("../src/db/agentProfiles.js");
+const { getStateDb } = await import("../src/db/state.js");
+
+registerChannelsEmailRoutes();
+
+async function call(
+  method: string,
+  pathStr: string,
+  body?: unknown,
+): Promise<{ status: number; data: any }> {
+  // Strip query string for matchRoute, hand the parsed URLSearchParams in.
+  const [pure, qs] = pathStr.split("?");
+  const matched = matchRoute(method, pure);
+  assert.ok(matched, `no route ${method} ${pure}`);
+  let status = 0;
+  let data: any = null;
+  const res: any = {
+    writeHead(s: number) {
+      status = s;
+    },
+    end(j: string) {
+      try {
+        data = JSON.parse(j);
+      } catch {
+        data = j;
+      }
+    },
+  };
+  try {
+    await matched.handler({
+      res,
+      params: matched.params,
+      body,
+      query: new URLSearchParams(qs || ""),
+      req: {} as any,
+    });
+  } catch (e: any) {
+    // The real ctrl-api server.ts catches thrown ApiErrors and translates
+    // them to HTTP responses; the test harness mimics that translation here.
+    const code = typeof e?.statusCode === "number" ? e.statusCode : 500;
+    status = code;
+    data = {
+      error:
+        typeof e?.message === "string"
+          ? e.message
+          : String(e ?? "unknown error"),
+      code: e?.code ?? null,
+    };
+  }
+  return { status, data };
+}
+
+describe("#120 Lane Vb2 — per-profile email status", () => {
+  before(() => {
+    const db = getStateDb();
+    // 'main' is seeded by the migration; create a user-facing profile
+    // we can test against.
+    try {
+      createProfile(db, {
+        slug: "lane-vb2-sentinel",
+        label: "Sentinel",
+        model: "stub-model",
+      });
+    } catch {
+      /* already created on previous run in same process */
+    }
+  });
+
+  beforeEach(() => {
+    resetAgentMail();
+    resetSentinel();
+    // Strip ALL email bindings (default + per-address). The migration's
+    // 'binding-default-email' row is re-seeded below for routing.
+    const db = getStateDb();
+    db.exec(`DELETE FROM channel_profile_binding WHERE channel_kind='email'`);
+    db.exec(
+      `INSERT OR IGNORE INTO channel_profile_binding
+        (id, channel_kind, channel_identity, profile_slug, created_at)
+       VALUES
+        ('binding-default-email', 'email', NULL, 'main', strftime('%s','now')*1000)`,
+    );
+  });
+
+  it("status unconfigured → {configured:false, provision_available:true}", async () => {
+    const r = await call(
+      "GET",
+      "/api/v1/channels/email/status?profile=lane-vb2-sentinel",
+    );
+    assert.equal(r.status, 200);
+    assert.equal(r.data.configured, false);
+    assert.equal(r.data.profile, "lane-vb2-sentinel");
+    assert.equal(r.data.provision_available, true);
+  });
+
+  it("status surfaces provision_available:false when AGENTMAIL_MASTER_API_KEY is unset", async () => {
+    const saved = process.env.AGENTMAIL_MASTER_API_KEY;
+    delete process.env.AGENTMAIL_MASTER_API_KEY;
+    try {
+      const r = await call(
+        "GET",
+        "/api/v1/channels/email/status?profile=lane-vb2-sentinel",
+      );
+      assert.equal(r.data.provision_available, false);
+      assert.match(r.data.provision_unavailable_reason ?? "", /MASTER_API_KEY/);
+    } finally {
+      process.env.AGENTMAIL_MASTER_API_KEY = saved;
+    }
+  });
+});
+
+describe("#120 Lane Vb2 — provision route happy path", () => {
+  beforeEach(() => {
+    resetAgentMail();
+    resetSentinel();
+    // Strip ALL email bindings (default + per-address). The migration's
+    // 'binding-default-email' row is re-seeded below for routing.
+    const db = getStateDb();
+    db.exec(`DELETE FROM channel_profile_binding WHERE channel_kind='email'`);
+    db.exec(
+      `INSERT OR IGNORE INTO channel_profile_binding
+        (id, channel_kind, channel_identity, profile_slug, created_at)
+       VALUES
+        ('binding-default-email', 'email', NULL, 'main', strftime('%s','now')*1000)`,
+    );
+  });
+
+  it("calls AgentMail to create inbox + mint key, writes .env, writes binding, audits", async () => {
+    const r = await call(
+      "POST",
+      "/api/v1/channels/email/provision?profile=lane-vb2-sentinel",
+      { prefix: "sentinel-test" },
+    );
+    assert.equal(r.status, 200, JSON.stringify(r.data));
+    assert.equal(r.data.ok, true);
+    assert.equal(r.data.address, "sentinel-test@test.alfred.black");
+    assert.equal(r.data.inbox_id, "inbox_sentinel-test");
+    assert.ok(r.data.binding_id);
+    assert.notEqual(r.data.binding_id, "binding-default-email");
+
+    // .env contains the new keys
+    const envPath = path.join(
+      process.env.HERMES_CONFIG_DIR!,
+      "lane-vb2-sentinel",
+      ".env",
+    );
+    const env = fs.readFileSync(envPath, "utf-8");
+    assert.match(env, /^AGENTMAIL_INBOX_ID=inbox_sentinel-test$/m);
+    assert.match(env, /^AGENTMAIL_INBOX_ADDRESS=sentinel-test@test\.alfred\.black$/m);
+    assert.match(env, /^AGENTMAIL_API_KEY=am_inbox_inbox_sentinel-test_key$/m);
+
+    // Binding row exists for the new address
+    const bindings = listAllBindings(getStateDb());
+    const row = bindings.find(
+      (b) =>
+        b.channel_kind === "email" &&
+        (b.channel_identity || "").toLowerCase() ===
+          "sentinel-test@test.alfred.black",
+    );
+    assert.ok(row, "expected email binding for sentinel-test address");
+    assert.equal(row!.profile_slug, "lane-vb2-sentinel");
+
+    // The resolver returns sentinel for the provisioned address
+    const resolved = resolveProfileForChannel(
+      getStateDb(),
+      "email",
+      "sentinel-test@test.alfred.black",
+    );
+    assert.equal(resolved, "lane-vb2-sentinel");
+
+    // Main's default binding still says 'main'
+    const mainDefault = resolveProfileForChannel(getStateDb(), "email", null);
+    assert.equal(mainDefault, "main");
+
+    // AgentMail was called: 1) inbox create  2) key mint  3) webhook GET 4) webhook POST
+    const calls = agentMailState.callLog;
+    assert.ok(
+      calls.some(
+        (c) => c.method === "POST" && /\/pods\/pod_test\/inboxes$/.test(c.path),
+      ),
+      "expected inbox-create call",
+    );
+    assert.ok(
+      calls.some(
+        (c) =>
+          c.method === "POST" &&
+          /\/inboxes\/inbox_sentinel-test\/api-keys$/.test(c.path),
+      ),
+      "expected api-key mint call",
+    );
+  });
+
+  it("404s when the profile doesn't exist", async () => {
+    const r = await call(
+      "POST",
+      "/api/v1/channels/email/provision?profile=no-such-profile",
+      { prefix: "ghost" },
+    );
+    assert.ok(r.status >= 400 && r.status < 500, `got ${r.status}`);
+  });
+
+  it("refuses to provision when AGENTMAIL_MASTER_API_KEY is unset", async () => {
+    const saved = process.env.AGENTMAIL_MASTER_API_KEY;
+    delete process.env.AGENTMAIL_MASTER_API_KEY;
+    try {
+      const r = await call(
+        "POST",
+        "/api/v1/channels/email/provision?profile=lane-vb2-sentinel",
+        { prefix: "blocked" },
+      );
+      assert.equal(r.status, 400);
+      assert.equal(r.data.code, "master_key_missing");
+    } finally {
+      process.env.AGENTMAIL_MASTER_API_KEY = saved;
+    }
+  });
+
+  it("refuses to provision for an archived profile", async () => {
+    const db = getStateDb();
+    try {
+      createProfile(db, {
+        slug: "lane-vb2-archived",
+        label: "Archived",
+        model: "stub-model",
+      });
+    } catch {
+      /* idempotent */
+    }
+    archiveProfile(db, "lane-vb2-archived");
+    const r = await call(
+      "POST",
+      "/api/v1/channels/email/provision?profile=lane-vb2-archived",
+      {},
+    );
+    assert.ok(r.status >= 400 && r.status < 500);
+  });
+});
+
+describe("#120 Lane Vb2 — DELETE inbox", () => {
+  beforeEach(() => {
+    resetAgentMail();
+    resetSentinel();
+    // Strip ALL email bindings (default + per-address). The migration's
+    // 'binding-default-email' row is re-seeded below for routing.
+    const db = getStateDb();
+    db.exec(`DELETE FROM channel_profile_binding WHERE channel_kind='email'`);
+    db.exec(
+      `INSERT OR IGNORE INTO channel_profile_binding
+        (id, channel_kind, channel_identity, profile_slug, created_at)
+       VALUES
+        ('binding-default-email', 'email', NULL, 'main', strftime('%s','now')*1000)`,
+    );
+  });
+
+  it("releases the AgentMail inbox, wipes the .env, removes the binding", async () => {
+    // Re-provision so we have an inbox to delete.
+    const prov = await call(
+      "POST",
+      "/api/v1/channels/email/provision?profile=lane-vb2-sentinel",
+      { prefix: "sentinel-delete-me" },
+    );
+    assert.equal(prov.status, 200, JSON.stringify(prov.data));
+    const address = prov.data.address;
+
+    const r = await call(
+      "DELETE",
+      "/api/v1/channels/email/inbox?profile=lane-vb2-sentinel",
+    );
+    assert.equal(r.status, 200, JSON.stringify(r.data));
+    assert.equal(r.data.ok, true);
+    assert.equal(r.data.inbox_address, address);
+    assert.equal(r.data.binding_removed, true);
+    assert.equal(r.data.upstream_released, "ok");
+
+    // .env keys gone
+    const envPath = path.join(
+      process.env.HERMES_CONFIG_DIR!,
+      "lane-vb2-sentinel",
+      ".env",
+    );
+    const env = fs.existsSync(envPath) ? fs.readFileSync(envPath, "utf-8") : "";
+    assert.doesNotMatch(env, /^AGENTMAIL_INBOX_ID=/m);
+    assert.doesNotMatch(env, /^AGENTMAIL_INBOX_ADDRESS=/m);
+
+    // Binding gone — resolver falls back to main
+    const resolved = resolveProfileForChannel(getStateDb(), "email", address);
+    assert.equal(resolved, "main");
+  });
+
+  it("is idempotent on a profile with no inbox", async () => {
+    // Profile created in earlier test; fresh resetAgentMail; no inbox.
+    const r = await call(
+      "DELETE",
+      "/api/v1/channels/email/inbox?profile=lane-vb2-sentinel",
+    );
+    assert.equal(r.status, 200);
+    assert.equal(r.data.ok, true);
+  });
+});
+
+describe("#120 Lane Vb2 — test send", () => {
+  beforeEach(() => {
+    resetAgentMail();
+    resetSentinel();
+    // Strip ALL email bindings (default + per-address). The migration's
+    // 'binding-default-email' row is re-seeded below for routing.
+    const db = getStateDb();
+    db.exec(`DELETE FROM channel_profile_binding WHERE channel_kind='email'`);
+    db.exec(
+      `INSERT OR IGNORE INTO channel_profile_binding
+        (id, channel_kind, channel_identity, profile_slug, created_at)
+       VALUES
+        ('binding-default-email', 'email', NULL, 'main', strftime('%s','now')*1000)`,
+    );
+  });
+
+  it("uses the profile's inbox creds (not main's) for outbound", async () => {
+    const prov = await call(
+      "POST",
+      "/api/v1/channels/email/provision?profile=lane-vb2-sentinel",
+      { prefix: "sentinel-tst" },
+    );
+    assert.equal(prov.status, 200);
+    // Reset call log so we observe ONLY the test send.
+    agentMailState.callLog = [];
+
+    const r = await call(
+      "POST",
+      "/api/v1/channels/email/test?profile=lane-vb2-sentinel",
+      { to: "ops@example.com" },
+    );
+    assert.equal(r.status, 200, JSON.stringify(r.data));
+    assert.equal(r.data.ok, true);
+    assert.equal(r.data.from, "sentinel-tst@test.alfred.black");
+    assert.equal(r.data.to, "ops@example.com");
+
+    // The send call MUST have used the inbox-scoped key, not the master key.
+    const sendCall = agentMailState.callLog.find((c) =>
+      /\/inboxes\/inbox_sentinel-tst\/messages\/send$/.test(c.path),
+    );
+    assert.ok(sendCall, "expected send call");
+    assert.equal(
+      sendCall!.auth,
+      "Bearer am_inbox_inbox_sentinel-tst_key",
+      "send must auth with profile's inbox key, not master",
+    );
+  });
+
+  it("refuses test on a profile with no inbox", async () => {
+    // No provision in this test — fresh slate.
+    const r = await call(
+      "POST",
+      "/api/v1/channels/email/test?profile=lane-vb2-sentinel",
+      { to: "ops@example.com" },
+    );
+    assert.equal(r.status, 400);
+    assert.equal(r.data.code, "not_configured");
+  });
+});
+
+describe("#120 Lane Vb2 — inbound route honours per-profile binding", () => {
+  beforeEach(() => {
+    resetAgentMail();
+    process.env.AGENTMAIL_WEBHOOK_TOKEN = "test-token";
+    // Inbound handler reads API_SERVER_KEY from the resolved profile's .env
+    // to auth its fire-and-forget POST /v1/runs. Seed both main + sentinel
+    // so neither path falls off the end. The .env file is preserved by the
+    // provision route's writeProfileEmailEnvKeys which keeps unrelated keys.
+    const sentDir = path.join(process.env.HERMES_CONFIG_DIR!, "lane-vb2-sentinel");
+    fs.mkdirSync(sentDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(sentDir, ".env"),
+      "API_SERVER_KEY=sentinel-key-test\n",
+    );
+  });
+
+  it("inbound to the provisioned address resolves to the sentinel profile", async () => {
+    const prov = await call(
+      "POST",
+      "/api/v1/channels/email/provision?profile=lane-vb2-sentinel",
+      { prefix: "sentinel-route" },
+    );
+    assert.equal(prov.status, 200);
+    const address = prov.data.address;
+
+    // Webhook fetch is fire-and-forget; we just check the 202 + profile.
+    const r = await call(
+      "POST",
+      "/api/v1/channels/email/inbound?token=test-token",
+      {
+        message: {
+          to: [address],
+          from_: ["smoke@example.com"],
+          subject: "test",
+          text: "hi",
+          message_id: "m1",
+          thread_id: "t1",
+        },
+      },
+    );
+    assert.equal(r.status, 202);
+    assert.equal(r.data.accepted, true);
+    assert.equal(r.data.profile, "lane-vb2-sentinel");
+  });
+
+  it("inbound to a not-bound address falls back to main", async () => {
+    const r = await call(
+      "POST",
+      "/api/v1/channels/email/inbound?token=test-token",
+      {
+        message: {
+          to: ["ghost@test.alfred.black"],
+          from_: ["smoke@example.com"],
+          subject: "test",
+          text: "hi",
+          message_id: "m2",
+          thread_id: "t2",
+        },
+      },
+    );
+    assert.equal(r.status, 202);
+    assert.equal(r.data.profile, "main");
+  });
+});

--- a/packages/web/main.wasp
+++ b/packages/web/main.wasp
@@ -1272,6 +1272,30 @@ action clearProfileChannelToken {
   entities: []
 }
 
+// #120 Lane Vb2 — per-profile AgentMail inbox provisioning. Sir's
+// clarification: "email MUST be per profile." These ops wire the
+// /profiles/:slug/channels Email card to ctrl-api's
+// /api/v1/channels/email/{status,provision,inbox,test}?profile=<slug>.
+query getProfileEmailStatus {
+  fn: import { getProfileEmailStatus } from "@src/dashboard/operations",
+  entities: []
+}
+
+action provisionProfileEmailInbox {
+  fn: import { provisionProfileEmailInbox } from "@src/dashboard/operations",
+  entities: []
+}
+
+action clearProfileEmailInbox {
+  fn: import { clearProfileEmailInbox } from "@src/dashboard/operations",
+  entities: []
+}
+
+action sendProfileEmailTest {
+  fn: import { sendProfileEmailTest } from "@src/dashboard/operations",
+  entities: []
+}
+
 query getAgentConfig {
   fn: import { getAgentConfig } from "@src/dashboard/operations",
   entities: []

--- a/packages/web/src/dashboard/ProfileChannelsPage.tsx
+++ b/packages/web/src/dashboard/ProfileChannelsPage.tsx
@@ -770,10 +770,10 @@ function ProfileEmailSection({ slug }: { slug: string }) {
       ? `No inbox yet. Provision one and AgentMail mints a fresh address scoped to '${slug}'.`
       : "Per-profile inbox provisioning is unavailable on this tenant — see the operator hint below.";
   const cardStatus: ChannelStatus = configured
-    ? "connected"
+    ? "active"
     : provisionAvailable
       ? "available"
-      : "unavailable";
+      : "error";
 
   return (
     <ChannelCard

--- a/packages/web/src/dashboard/ProfileChannelsPage.tsx
+++ b/packages/web/src/dashboard/ProfileChannelsPage.tsx
@@ -5,12 +5,17 @@
 // profile slug, side-by-side with a clear back-link to the main /channels
 // page.
 //
-// What this page CAN configure per profile (Lane IV + Lane V on ctrl-api):
+// What this page CAN configure per profile (Lane IV + Lane V + Lane Vb2 on ctrl-api):
 //
 //   * Telegram   — token (PUT), status (GET), revoke chat
 //   * Slack      — bot/app tokens (PUT), status (GET)
 //   * SMS        — Twilio creds (PUT), status (GET)
 //   * Paperclip  — API key (POST), status (GET)
+//   * Email      — Lane Vb2; provision (POST), status (GET), disconnect
+//                  (DELETE), send-test (POST). AgentMail's API is called
+//                  on the tenant: a fresh inbox is minted per profile + a
+//                  channel binding (email, <address>) → <slug> is written
+//                  so inbound mail routes to the right profile.
 //
 // What this page CANNOT configure per profile and why (honest partial):
 //
@@ -23,9 +28,6 @@
 //     integration. Configure on /channels.
 //   * Recall.ai — one calendar bot account. Single-instance integration.
 //     Configure on /channels.
-//   * Email (AgentMail) — provisioning a per-profile address requires an
-//     external provider call we don't make automatically here. Configure
-//     on /channels.
 //   * Tailscale / Terminal — instance-level (single VM ↔ single tailnet ↔
 //     single SSH host). NOT a channel in the per-profile sense.
 //
@@ -40,6 +42,10 @@ import {
   getProfileChannelStatuses,
   setProfileChannelToken,
   clearProfileChannelToken,
+  getProfileEmailStatus,
+  provisionProfileEmailInbox,
+  clearProfileEmailInbox,
+  sendProfileEmailTest,
 } from "wasp/client/operations";
 import { Frame, PageHeading } from "../client/components/ab/Frame";
 import { ChannelCard, type ChannelStatus } from "./ChannelsPage";
@@ -670,7 +676,227 @@ function ProfilePaperclipSection({
 }
 
 // --------------------------------------------------------------------------
-// InstanceLevelNotice. For voice / email / OMI / HA / Recall / Tailscale /
+// #120 Lane Vb2 — per-profile Email (AgentMail) section. Reads
+// /api/v1/channels/email/status?profile=<slug>; renders provision /
+// disconnect / send-test as a single ChannelCard. Lives in its own query
+// (getProfileEmailStatus) rather than the consolidator so the operator
+// can independently refetch after a provision.
+// --------------------------------------------------------------------------
+interface ProfileEmailStatus {
+  configured: boolean;
+  profile: string;
+  inbox_address: string | null;
+  inbox_id: string | null;
+  binding_id: string | null;
+  provision_available: boolean;
+  provision_unavailable_reason: string | null;
+  env_error: string | null;
+}
+
+function ProfileEmailSection({ slug }: { slug: string }) {
+  const statusQ = useQuery(getProfileEmailStatus, { slug });
+  const status = (statusQ.data as ProfileEmailStatus | undefined) ?? null;
+  const [prefix, setPrefix] = useState("");
+  const [testTo, setTestTo] = useState("");
+  const [busy, setBusy] = useState<null | "provision" | "disconnect" | "test">(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [lastResp, setLastResp] = useState<any>(null);
+
+  const configured = Boolean(status?.configured);
+  const provisionAvailable = status?.provision_available !== false;
+
+  async function doProvision() {
+    if (busy) return;
+    setBusy("provision");
+    setErr(null);
+    try {
+      const resp = await provisionProfileEmailInbox({
+        slug,
+        prefix: prefix.trim() || undefined,
+      });
+      setLastResp(resp);
+      setPrefix("");
+      statusQ.refetch();
+    } catch (e: any) {
+      setErr(e?.message ?? "Couldn't provision the inbox.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function doDisconnect() {
+    if (busy) return;
+    if (
+      !window.confirm(
+        `Release ${status?.inbox_address ?? "this inbox"}? Inbound emails to that address will stop being delivered to ${slug}.`,
+      )
+    ) {
+      return;
+    }
+    setBusy("disconnect");
+    setErr(null);
+    try {
+      const resp = await clearProfileEmailInbox({ slug });
+      setLastResp(resp);
+      statusQ.refetch();
+    } catch (e: any) {
+      setErr(e?.message ?? "Couldn't release the inbox.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function doTest() {
+    if (busy || !testTo.trim()) return;
+    setBusy("test");
+    setErr(null);
+    try {
+      const resp = await sendProfileEmailTest({ slug, to: testTo.trim() });
+      setLastResp(resp);
+      setTestTo("");
+    } catch (e: any) {
+      setErr(e?.message ?? "Test send failed.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  const address = configured
+    ? (status?.inbox_address as string)
+    : "Not yet provisioned";
+  const note = configured
+    ? `Inbox '${status?.inbox_address}' is bound to '${slug}'. Inbound mail routes here; outbound replies use this inbox's credentials.`
+    : provisionAvailable
+      ? `No inbox yet. Provision one and AgentMail mints a fresh address scoped to '${slug}'.`
+      : "Per-profile inbox provisioning is unavailable on this tenant — see the operator hint below.";
+  const cardStatus: ChannelStatus = configured
+    ? "connected"
+    : provisionAvailable
+      ? "available"
+      : "unavailable";
+
+  return (
+    <ChannelCard
+      name="Email"
+      address={address}
+      note={note}
+      status={cardStatus}
+    >
+      <div className="mt-5 space-y-3">
+        {status?.env_error && (
+          <p
+            className="font-body italic text-[13px]"
+            style={{ color: "var(--brass)" }}
+          >
+            Could not read the profile's .env: {status.env_error}
+          </p>
+        )}
+        {!configured && (
+          <>
+            <div
+              className="font-mono text-[10px] uppercase tracking-[0.22em]"
+              style={{ color: "var(--marginalia)" }}
+            >
+              Provision new inbox · for {slug}
+            </div>
+            {!provisionAvailable && status?.provision_unavailable_reason && (
+              <p
+                className="font-body italic text-[13px]"
+                style={{ color: "var(--marginalia)" }}
+              >
+                {status.provision_unavailable_reason}
+              </p>
+            )}
+            <div className="flex gap-2 items-baseline">
+              <input
+                type="text"
+                value={prefix}
+                onChange={(e) => setPrefix(e.target.value)}
+                placeholder={`alfred.${slug} (default)`}
+                disabled={!provisionAvailable || busy === "provision"}
+                className="flex-1 bg-transparent border border-rule px-2 py-1 font-mono text-[12px]"
+              />
+              <button
+                onClick={doProvision}
+                disabled={!provisionAvailable || busy === "provision"}
+                className="btn-ghost"
+              >
+                {busy === "provision" ? "…" : "Provision"}
+              </button>
+            </div>
+          </>
+        )}
+        {configured && (
+          <>
+            <div
+              className="font-mono text-[10px] uppercase tracking-[0.22em]"
+              style={{ color: "var(--marginalia)" }}
+            >
+              Send a test email
+            </div>
+            <div className="flex gap-2 items-baseline">
+              <input
+                type="email"
+                value={testTo}
+                onChange={(e) => setTestTo(e.target.value)}
+                placeholder="recipient@example.com"
+                disabled={busy === "test"}
+                className="flex-1 bg-transparent border border-rule px-2 py-1 font-mono text-[12px]"
+              />
+              <button
+                onClick={doTest}
+                disabled={busy === "test" || !testTo.trim()}
+                className="btn-ghost"
+              >
+                {busy === "test" ? "…" : "Send"}
+              </button>
+            </div>
+            <div className="pt-2">
+              <button
+                onClick={doDisconnect}
+                disabled={busy === "disconnect"}
+                className="btn-link"
+                style={{ color: "var(--brass)" }}
+              >
+                {busy === "disconnect" ? "…" : "Disconnect inbox"}
+              </button>
+            </div>
+          </>
+        )}
+        {err && (
+          <p
+            className="font-body italic text-[13px]"
+            style={{ color: "var(--brass)" }}
+          >
+            {err}
+          </p>
+        )}
+        {lastResp?.ok && lastResp.address && (
+          <p
+            className="font-body italic text-[13px]"
+            style={{ color: "var(--marginalia)" }}
+          >
+            Provisioned {lastResp.address}.
+            {lastResp.webhook_registered === false &&
+              " AgentMail webhook registration failed — inbound may need a manual hook."}
+          </p>
+        )}
+        {lastResp?.message_id && (
+          <p
+            className="font-body italic text-[13px]"
+            style={{ color: "var(--marginalia)" }}
+          >
+            Test sent (message_id: {String(lastResp.message_id).slice(0, 12)}…).
+          </p>
+        )}
+      </div>
+      <RestartScopeWarning scope={lastResp?.restart_scope} warning={lastResp?.restart_warning} />
+    </ChannelCard>
+  );
+}
+
+// --------------------------------------------------------------------------
+// InstanceLevelNotice. For voice / OMI / HA / Recall / Tailscale /
 // Terminal we render a small read-only card pointing at /channels.
 // --------------------------------------------------------------------------
 function InstanceLevelNotice({
@@ -849,15 +1075,12 @@ export default function ProfileChannelsPage() {
           <ProfileSlackSection slug={slug} entry={entryFor<SlackStatus>("slack")} refetch={refetch} />
           <ProfileSmsSection slug={slug} entry={entryFor<SmsStatus>("sms")} refetch={refetch} />
           <ProfilePaperclipSection slug={slug} entry={entryFor<PaperclipStatus>("paperclip")} refetch={refetch} />
+          <ProfileEmailSection slug={slug} />
 
           {/* Honest partials — these channels are instance-level by design. */}
           <InstanceLevelNotice
             name="Voice"
             reason="Voice-bridge is a single compose sibling. One Twilio number + one OPENAI key per VM."
-          />
-          <InstanceLevelNotice
-            name="Email"
-            reason="AgentMail provisions one inbox per VM today. Per-profile addressing is a follow-up."
           />
           <InstanceLevelNotice
             name="Home Assistant"

--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -3779,6 +3779,107 @@ export const getProfileChannelStatuses = async (
   };
 };
 
+// ── #120 Lane Vb2 — per-profile AgentMail inbox provisioning ─────────────
+//
+// Sir's clarification: "email MUST be per profile." These three ops thin-
+// proxy to the ctrl-api /api/v1/channels/email/{status,provision,inbox}
+// routes Lane Vb2 added. The shape matches the other Lane V channel ops
+// (slug → ctrl-api ?profile=<slug>). entities: []; uses the same
+// `Promise<any>` plain-async shape per the Wasp `Promise<T>` trap memory.
+
+/** Fetch the per-profile email-inbox status. */
+export const getProfileEmailStatus = async (
+  args: { slug: string },
+  context: any,
+): Promise<any> => {
+  if (!context.user) throw new HttpError(401, "Not authenticated");
+  const slug = _validateSlugArg(args?.slug);
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    path: "/api/v1/channels/email/status",
+    query: { profile: slug },
+  });
+};
+
+/**
+ * Provision a fresh AgentMail inbox for the given profile. Calls AgentMail's
+ * real API (POST /pods/<id>/inboxes + POST /inboxes/<id>/api-keys) on the
+ * tenant; the inbox creds land in the profile's .env and a channel binding
+ * (email, <address>) → <slug> is written so inbound mail routes to it.
+ *
+ * `prefix` is optional — defaults to `alfred.<slug>` on the ctrl-api side.
+ */
+export const provisionProfileEmailInbox = async (
+  args: { slug: string; prefix?: string; display_name?: string },
+  context: any,
+): Promise<any> => {
+  if (!context.user) throw new HttpError(401, "Not authenticated");
+  const slug = _validateSlugArg(args?.slug);
+  const body: Record<string, unknown> = {};
+  if (typeof args?.prefix === "string" && args.prefix.trim()) {
+    body.prefix = args.prefix.trim();
+  }
+  if (typeof args?.display_name === "string" && args.display_name.trim()) {
+    body.display_name = args.display_name.trim();
+  }
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    method: "POST",
+    path: "/api/v1/channels/email/provision",
+    query: { profile: slug },
+    body,
+  });
+};
+
+/**
+ * Release the AgentMail inbox bound to the profile. Best-effort upstream
+ * delete (the ctrl-api side falls through to "binding-removed only" when
+ * AGENTMAIL_MASTER_API_KEY is missing or the upstream call fails); always
+ * wipes the .env keys + drops the channel binding row.
+ */
+export const clearProfileEmailInbox = async (
+  args: { slug: string },
+  context: any,
+): Promise<any> => {
+  if (!context.user) throw new HttpError(401, "Not authenticated");
+  const slug = _validateSlugArg(args?.slug);
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    method: "DELETE",
+    path: "/api/v1/channels/email/inbox",
+    query: { profile: slug },
+  });
+};
+
+/**
+ * Send a test email from this profile's inbox to verify outbound auth
+ * end-to-end. The recipient is mandatory (operator's address, typically).
+ */
+export const sendProfileEmailTest = async (
+  args: { slug: string; to: string; subject?: string; text?: string },
+  context: any,
+): Promise<any> => {
+  if (!context.user) throw new HttpError(401, "Not authenticated");
+  const slug = _validateSlugArg(args?.slug);
+  if (typeof args?.to !== "string" || !args.to.trim()) {
+    throw new HttpError(400, "`to` recipient is required");
+  }
+  const body: Record<string, unknown> = { to: args.to.trim() };
+  if (typeof args?.subject === "string" && args.subject.trim()) {
+    body.subject = args.subject.trim();
+  }
+  if (typeof args?.text === "string" && args.text.trim()) {
+    body.text = args.text.trim();
+  }
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    method: "POST",
+    path: "/api/v1/channels/email/test",
+    query: { profile: slug },
+    body,
+  });
+};
+
 // ── decision_ref minter ──────────────────────────────────────────────────
 //
 // Crockford base32, 26 chars — the ULID shape PR4's


### PR DESCRIPTION
Follow-on to Lane V (#207). Sir's clarification — *"email MUST be per profile. AgentMail's API provisions inboxes; that's an API call, not a manual provisioning step. Just call it."* — closes the email half Lane V explicitly punted.

## What lands

### ctrl-api — 4 new routes scoped by `?profile=<slug>`

| Route | What it does |
|---|---|
| `GET /api/v1/channels/email/status` | Fail-soft state per profile + `provision_available` flag (false when AGENTMAIL_MASTER_API_KEY is unset, with the operator-hint inline) |
| `POST /api/v1/channels/email/provision` | Calls AgentMail's real API (`POST /v0/pods/<pod>/inboxes` + `POST /v0/inboxes/<id>/api-keys`), persists creds into the profile's `.env`, writes the `(email, <address>) → <slug>` channel binding, best-effort-registers the tenant webhook |
| `DELETE /api/v1/channels/email/inbox` | Releases the AgentMail inbox (best-effort); wipes `.env` keys + drops the binding row unconditionally so routing falls back to main |
| `POST /api/v1/channels/email/test` | Auths with the PROFILE's inbox-scoped key (not master); sends a real test email from that inbox |

`assertWritableProfile` gates every mutation. Archived / infrastructure profiles refuse the call. Every mutation appends an audit row with `payload.profile_slug` + the inbox address.

The existing `POST /api/v1/channels/email/inbound` already resolved the to-address through the binding table — Lane Vb2 is what actually populates the binding row. Self-loop drop now also considers every per-profile bound inbox.

Outbound `/api/v1/email/{send,reply,forward,message,thread,attachment}` now honour `?profile=<slug>` and pull credentials from the profile's `.env`. Sentinel's replies go from Sentinel's "From:" address with Sentinel's inbox-scoped key. Without `?profile=` the routes preserve single-tenant behaviour.

### web — 4 new Wasp ops + Email card

All `Promise<any>` plain-async per the Wasp `Promise<T>` trap memory:

- `getProfileEmailStatus({slug})`
- `provisionProfileEmailInbox({slug, prefix?, display_name?})`
- `clearProfileEmailInbox({slug})`
- `sendProfileEmailTest({slug, to, subject?, text?})`

`ProfileChannelsPage`: the Email card flips from Lane V's "instance-level notice" to a real `ProfileEmailSection` form — Provision (or operator-hint when the master key is missing), Send-test, Disconnect.

## Tests

`channels-email-lane-vb2.test.ts` — 12 cases, all green:

- status: unconfigured + master-key-missing honest-failure
- provision: happy path (AgentMail calls + .env keys + binding row + resolver shape + main untouched), 404 on missing profile, 400 `master_key_missing`, refuse archived profile
- DELETE: releases inbox + clears env + drops binding + main fallback; idempotent
- test send: auths with the profile's inbox key (not master); refuses no-inbox
- inbound routing: provisioned address → sentinel, unbound address → main

Existing `email-provision.test.ts` still green — the per-profile shim is back-compat.

## Architecture choice — single-API-key tenant

`AGENTMAIL_MASTER_API_KEY` is set on the tenant (operator step), not minted per-profile. AgentMail's auth requires the master key to create inboxes — inbox-scoped keys can't create new ones. Keeping the master on the tenant simplifies the call path (ctrl-api → AgentMail, no SaaS hop). Operator unsets the master key to disable per-profile provisioning.

## Operator step

Tenants that want per-profile email must add to `/opt/alfred/.env`:

```
AGENTMAIL_MASTER_API_KEY=<from AgentMail dashboard>
AGENTMAIL_SHARED_POD_ID=<the tenant's pod>
AGENTMAIL_DOMAIN=mail.alfred.black   # or wherever you've configured DNS
```

Without `AGENTMAIL_MASTER_API_KEY` the provision route returns a clean 400 with code `master_key_missing` and the UI shows the operator hint instead of the provision button. Existing single-tenant inboxes keep working through the unchanged `email.ts` getCreds() fallback path.

References #120 (Lane III closed it; Lane V finished the per-profile-channels promise for Telegram/Slack/SMS/Paperclip; this lane finishes it for Email).

🤖 Generated with [Claude Code](https://claude.com/claude-code)