### PR TITLE
feat(ctrl,voice-bridge,web): #120 Lane Vb — voice (Twilio phone) per-profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and the `alfred-vault` package adheres to [Semantic Versioning](https://semver.o
 
 ## [2026-05-31]
 
+**Lane Vb** (this release) makes **voice (Twilio phone)** per-profile.
+Lane V's earlier punt — "voice-bridge is a single compose sibling per
+VM, not a Hermes profile" — was a punt, not a constraint. The container
+stays singular but its routing becomes multi-tenant: the Twilio webhook
+URL the principal pastes into the Twilio Console for a profile-specific
+number is now `https://voice.<domain>/twiml/inbound?profile=<slug>`, and
+voice-bridge resolves the slug at TwiML-emission time. The WSS endpoint
+`/voice/<slug>` carries the routing key downstream into VoiceCall;
+`fetchTenantContext` queries ctrl-api's per-profile voice status to
+learn the calling number, and a new scoped-bearer endpoint
+`GET /api/v1/channels/voice/internal/openai-key?profile=<slug>` returns
+the profile's OPENAI key (when set) so the Realtime session bills
+against the right account. Falls back to main's instance-shared
+`OPENAI_API_KEY` when a non-main profile leaves the key blank. Sir's
+spec: *"voice MUST be per profile. it isn't realistic that I would
+interact with multiple profiles and want them in separate channels."*
+
+Per-profile credentials in the profile's `.env`: `TWILIO_ACCOUNT_SID`,
+`TWILIO_AUTH_TOKEN`, `TWILIO_VOICE_FROM_NUMBER`, optional
+`OPENAI_API_KEY`, plus the existing `VOICE_ALLOWED_CALLERS` /
+`VOICE_ALLOW_ALL_CALLERS` allowlist toggles. Five new ctrl-api routes
+under `/api/v1/channels/voice/*` — `status` / `credentials` (PUT/DELETE)
+/ `test` / `allowlist` / `inbound` / `internal/openai-key` — all accept
+`?profile=<slug>`, all run through `assertWritableProfile`, all append
+`channel_token_set` / `channel_token_cleared` audit rows with
+`profile_slug` in the payload (matching Lane V's Telegram / Slack / SMS
+shape verbatim). voice-bridge does NOT need a restart on credential
+rotation: it reads per-call. The `restart_scope: "per-profile"` shape
+on the response is honest about that — the next inbound call picks up
+the new creds. The `/profiles/:slug/channels` Voice card is now a real
+configuration form (matching the SMS card's Twilio triple + an optional
+OpenAI override) with the per-profile webhook URL displayed for the
+operator to paste into Twilio. Two new explicit Wasp ops
+(`setProfileVoiceCredentials` / `clearProfileVoiceCredentials`) layer on
+top of Lane V's `setProfileChannelToken` consolidator so call sites that
+only need voice have a named entry point. References #120; closes the
+Lane V voice honest-partial. 10 new ctrl-api unit tests (PUT validation,
+DELETE wipe, audit-row shape, TwiML routing, internal-key fallback) all
+green.
+
+The operator step Sir owns: in the Twilio Console, set each profile's
+phone number's "A call comes in" webhook to that profile's URL surfaced
+on its `/profiles/:slug/channels` Voice card (copy-button included).
+That's the routing key — voice-bridge reads it off the URL query.
+
 **Lane Vb2** (follow-on to Lane V) closes the email half of the
 per-profile-channels promise. Lane V shipped the FULL per-profile
 channels page but explicitly punted **Email (AgentMail)** with the note

--- a/packages/ctrl/src/api/auth.ts
+++ b/packages/ctrl/src/api/auth.ts
@@ -156,6 +156,20 @@ const VOICE_BRIDGE_ALLOWLIST: ReadonlySet<string> = new Set([
   // speaks AS ALFRED (the RP butler persona enforced in voice-bridge's
   // buildMeetingPrefix), never as the principal.
   "POST:/api/v1/voice-bridge/recall-turn",
+  // ── #120 Lane Vb: per-profile voice routing ─────────────────────────
+  // voice-bridge fetches the resolved profile's calling number + key set
+  // via /status?profile=<slug> on every inbound call so a creds rotation
+  // applies without a container restart. The status route does NOT return
+  // the OpenAI key value; the internal helper below does. Both queries
+  // include ?profile=<slug>; auth.ts compares against the pathname only,
+  // and the query is matched in the route handler.
+  "GET:/api/v1/channels/voice/status",
+  // The bridge needs the per-profile OPENAI_API_KEY value to open the
+  // Realtime socket against the right account. ctrl-api exposes this only
+  // to the voice-bridge bearer; the route reads the per-profile .env via
+  // dockerExec. Allowed paths return the raw value; non-voice-bridge
+  // callers 401.
+  "GET:/api/v1/channels/voice/internal/openai-key",
 ]);
 
 /**

--- a/packages/ctrl/src/api/routes/voice.ts
+++ b/packages/ctrl/src/api/routes/voice.ts
@@ -1,52 +1,111 @@
-// Lane I — voice-bridge deploy-readiness status route.
+// #120 Lane Vb — per-profile voice channel routes (/api/v1/channels/voice/*).
 //
-//   GET /api/v1/channels/voice/status
+// Sir's spec: "voice MUST be per profile. it isn't realistic that I would
+// interact with multiple profiles and want them in separate channels."
 //
-// A read-only status endpoint for the Phase-2 voice card. There is NO
-// PUT / DELETE / test on this surface — voice's only operator-facing
-// setting (OPENAI_API_KEY) is set via PATCH /api/v1/admin/credentials,
-// the same path every other credential takes. The status endpoint
-// surfaces `openai_key_set` so the UI can render an inline input when
-// it's missing instead of pointing the operator at /study.
+// Lane V's Voice card was a partial — voice-bridge stayed a single compose
+// sibling per VM, and Twilio creds + OpenAI key lived in the compose .env.
+// Lane Vb wires per-profile routing on top: the container stays singular,
+// but its Twilio webhook + WSS handler resolve the profile slug at call
+// time, and each profile owns its own Twilio number + creds in its own
+// /hermes-state/profiles/<slug>/.env.
 //
-// Resolution table:
+// Routes:
+//   GET    /api/v1/channels/voice/status?profile=<slug>      — per-profile config snapshot
+//   PUT    /api/v1/channels/voice/credentials?profile=<slug> — set Twilio + (optional) OpenAI creds
+//   DELETE /api/v1/channels/voice/credentials?profile=<slug> — wipe per-profile creds
+//   POST   /api/v1/channels/voice/test?profile=<slug>        — validate creds via Twilio probe
+//   PUT    /api/v1/channels/voice/allowlist?profile=<slug>   — per-profile caller allowlist
+//   POST   /api/v1/channels/voice/inbound                    — Twilio webhook landing pad
+//                                                              (mock TwiML emitter — Sir's
+//                                                              actual Twilio number points
+//                                                              at voice-bridge/twiml/inbound;
+//                                                              this route is for smoke/test
+//                                                              + future routing decisions)
 //
-//   compose_service_exists=false                                          → state="unconfigured"
-//   compose_service_exists=true  && !configured                          → state="unconfigured"
-//   compose_service_exists=true  && configured && !openai_key_set        → state="unconfigured"  (UI shows the OpenAI input)
-//   compose_service_exists=true  && configured && openai_key_set && healthy   → state="configured_running"
-//   compose_service_exists=true  && configured && openai_key_set && starting  → state="configured_starting"
-//   compose_service_exists=true  && configured && openai_key_set && unhealthy → state="error"
+// PER-PROFILE .env keys (mirror sms.ts):
+//   TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_VOICE_FROM_NUMBER
+//   OPENAI_API_KEY (optional — falls back to main's if blank)
 //
-// `configured`     = TWILIO_PHONE_NUMBER is set in the hermes-main /.env.
-// `openai_key_set` = OPENAI_API_KEY is set in the compose /.env (the file
-//                    PATCH /admin/credentials writes; voice-bridge reads it
-//                    via env_file).
-// `calling_number` = the value of TWILIO_PHONE_NUMBER (reuses SMS).
+// We intentionally use TWILIO_VOICE_FROM_NUMBER (not TWILIO_PHONE_NUMBER)
+// so a profile can have a separate voice number from its SMS number. When
+// only TWILIO_PHONE_NUMBER is set (SMS configured but voice not separately),
+// /status surfaces the SMS number as the calling_number (back-compat with
+// Lane I's single-number assumption).
 //
-// FAIL-SOFT POLICY: /status MUST NOT 5xx — the dashboard polls it. On any
-// upstream failure return state:"error" with the message in `error`. The
-// "voice-bridge service missing from compose" case specifically is NOT an
-// error — it's the expected pre-deploy state (Phase-2 orchestrator hasn't
-// merged the compose change yet), so it MUST resolve to state="unconfigured"
-// with error=null.
+// FAIL-SOFT POLICY. /status MUST NOT 5xx — the dashboard polls it.
+//
+// AUDIT contract: every mutation appends a row with profile_slug in the
+// payload. action_type uses canonical underscore form
+// (channel_token_set / channel_token_cleared) so Lane V's audit queries
+// keep finding voice writes the same way they find telegram / sms ones.
 
 import fs from "node:fs";
 
 import { addRoute } from "../server.js";
-import { sendJson } from "../errors.js";
-import { dockerExec, dockerComposeCmd, COMPOSE_DIR } from "../helpers.js";
+import { sendJson, ValidationError } from "../errors.js";
+import {
+  dockerExec,
+  dockerExecWithStdin,
+  dockerComposeCmd,
+  HERMES_CONTAINER,
+  COMPOSE_DIR,
+} from "../helpers.js";
+import { getStateDb } from "../../db/state.js";
+import {
+  resolveProfileForChannel,
+  assertWritableProfile,
+} from "../../db/agentProfiles.js";
+import { appendAudit } from "./state.js";
+import { restartProfile } from "../../hermes/supervisor.js";
 
-// Hermes-main per-profile .env path INSIDE the hermes runtime container.
-// Mirrors the SMS / Telegram routes — `HERMES_HOME=/hermes-state` is the
-// canonical mount in docker-compose.yaml.
-const HERMES_CONTAINER = "hermes";
+// Path INSIDE the hermes runtime container. HERMES_HOME=/hermes-state in
+// docker-compose; profiles live at $HERMES_HOME/profiles/<name>/.
 const HERMES_HOME = process.env.HERMES_HOME_IN_CONTAINER || "/hermes-state";
-const MAIN_PROFILE_DIR = `${HERMES_HOME}/profiles/main`;
-const PROFILE_ENV_PATH = `${MAIN_PROFILE_DIR}/.env`;
 
 // The compose service we're probing.
 const VOICE_COMPOSE_SERVICE = "voice-bridge";
+
+// ── Per-profile path resolution (mirrors sms.ts/telegram.ts) ─────────────
+
+interface VoiceProfilePaths {
+  profileSlug: string;
+  profileDir: string;
+  envPath: string;
+}
+
+function pathsForProfile(slug: string): VoiceProfilePaths {
+  const profileDir = `${HERMES_HOME}/profiles/${slug}`;
+  return {
+    profileSlug: slug,
+    profileDir,
+    envPath: `${profileDir}/.env`,
+  };
+}
+
+function resolveVoiceProfile(query?: URLSearchParams): VoiceProfilePaths {
+  const explicit = query?.get("profile")?.trim() || null;
+  if (explicit) return pathsForProfile(explicit);
+  // Defensive: in tests the state.db isn't always available, and the
+  // resolveProfileForChannel default of "main" is the same shape we want
+  // anyway when no explicit profile is given. Surface "main" on any DB
+  // miss rather than 5xx-ing the /status route the dashboard polls.
+  try {
+    const slug = resolveProfileForChannel(getStateDb(), "voice", null);
+    return pathsForProfile(slug);
+  } catch {
+    return pathsForProfile("main");
+  }
+}
+
+// ── Twilio shapes (mirror sms.ts) ────────────────────────────────────────
+
+const ACCOUNT_SID_RE = /^AC[a-f0-9]{32}$/;
+const AUTH_TOKEN_RE = /^[a-f0-9]{32}$/;
+const E164_RE = /^\+[1-9]\d{1,14}$/;
+// OpenAI keys start with sk-; relaxed shape so future formats (sk-proj-…)
+// keep validating. Reject anything with whitespace as a clear typo.
+const OPENAI_KEY_RE = /^sk-[A-Za-z0-9_-]{20,}$/;
 
 type VoiceState =
   | "unconfigured"
@@ -59,126 +118,48 @@ interface VoiceStatus {
   state: VoiceState;
   error: string | null;
   calling_number: string | null;
-  compose_service_exists: boolean;
-  /** True when OPENAI_API_KEY is set in the compose-level .env (read by
-   *  voice-bridge via env_file). The UI surfaces an inline input when this
-   *  is false so the operator can paste the key without leaving /channels. */
+  account_sid_masked: string | null;
+  /** True iff per-profile OPENAI_API_KEY is in the profile's .env. UI surfaces
+   *  a hint when missing (voice falls back to main's key). */
   openai_key_set: boolean;
-  /** Comma-separated E.164 numbers allowed to call Alfred. "" when unset. */
+  /** True iff this is the 'main' profile and the compose-level .env still
+   *  carries OPENAI_API_KEY. For non-main profiles always false (compose .env
+   *  is shared instance state — not a profile-scoped surface). */
+  openai_key_set_compose: boolean;
+  compose_service_exists: boolean;
   allowed_callers: string;
-  /** When true, VOICE_ALLOW_ALL_CALLERS is on — anyone can call the Twilio number. */
   allow_all: boolean;
+  webhook_url: string | null;
+  profile_slug: string;
 }
 
-// ── Compose probe ─────────────────────────────────────────────────────────
-//
-// `docker compose ps <service> --format json` is the canonical way to ask
-// "is this service in the project?". Compose ≥ v2.21 returns JSONL (one
-// JSON object per service); older compose throws "no such service" with
-// non-zero exit. We tolerate both:
-//   * throw                → service missing
-//   * empty stdout         → service missing
-//   * stdout with a JSON line → service present, parse State/Health
+// ── Per-profile .env reader + writer (mirror sms.ts shape) ───────────────
 
-interface ComposePsRow {
-  Name?: string;
-  Service?: string;
-  State?: string;   // "running" / "exited" / "restarting" / "created" / "starting"
-  Health?: string;  // "healthy" / "unhealthy" / "starting" / "" / undefined
-}
+const VOICE_ENV_KEYS = [
+  "TWILIO_ACCOUNT_SID",
+  "TWILIO_AUTH_TOKEN",
+  "TWILIO_VOICE_FROM_NUMBER",
+  "OPENAI_API_KEY",
+  "VOICE_ALLOWED_CALLERS",
+  "VOICE_ALLOW_ALL_CALLERS",
+] as const;
+type VoiceEnvKey = (typeof VOICE_ENV_KEYS)[number];
 
-interface ComposeProbe {
-  exists: boolean;
-  row: ComposePsRow | null;
-  // `error` is set ONLY when the compose CLI errored AND the message did
-  // not look like "no such service". Genuinely-missing services return
-  // exists=false / error=null.
-  error: string | null;
-}
-
-function looksLikeNoSuchService(message: string): boolean {
-  const m = message.toLowerCase();
-  return (
-    m.includes("no such service") ||
-    m.includes("service ") && m.includes(" not found") ||
-    m.includes("has no service")
-  );
-}
-
-async function probeComposeService(): Promise<ComposeProbe> {
-  let raw: string;
-  try {
-    raw = await dockerComposeCmd([
-      "ps",
-      VOICE_COMPOSE_SERVICE,
-      "--format",
-      "json",
-    ]);
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    if (looksLikeNoSuchService(msg)) {
-      return { exists: false, row: null, error: null };
-    }
-    // Genuine compose failure — surface it as an error so the UI can
-    // distinguish "voice-bridge not deployed" from "compose itself is
-    // broken".
-    return { exists: false, row: null, error: `compose ps failed: ${msg}` };
-  }
-  const trimmed = raw.trim();
-  if (!trimmed) {
-    // Newer compose: empty stdout = service not in this project.
-    return { exists: false, row: null, error: null };
-  }
-  // JSONL (newer compose) — one object per line. Find the voice-bridge row.
-  for (const line of trimmed.split("\n")) {
-    const t = line.trim();
-    if (!t) continue;
-    try {
-      const parsed = JSON.parse(t) as ComposePsRow | ComposePsRow[];
-      const rows = Array.isArray(parsed) ? parsed : [parsed];
-      for (const row of rows) {
-        if (
-          !row.Service ||
-          row.Service === VOICE_COMPOSE_SERVICE
-        ) {
-          return { exists: true, row, error: null };
-        }
-      }
-    } catch {
-      // not JSON — fall through
-    }
-  }
-  // Stdout had content but nothing we could parse as a row — treat as
-  // present-but-opaque so we don't false-negative the deploy check.
-  return { exists: true, row: null, error: null };
-}
-
-// ── Per-profile .env reader (mirrors telegram.ts / sms.ts) ────────────────
-//
-// We read TWILIO_PHONE_NUMBER from the same source SMS uses so the voice
-// card surfaces the same number — Twilio routes inbound voice + SMS to the
-// same E.164 by default, no separate voice-number provisioning needed.
-
-async function readProfileEnvKey(key: string): Promise<string> {
-  let raw: string;
-  try {
-    raw = await dockerExec(HERMES_CONTAINER, [
-      "sh",
-      "-c",
-      `cat ${PROFILE_ENV_PATH} 2>/dev/null || true`,
-    ]);
-  } catch {
-    // The hermes container is missing too — we can still answer the
-    // question, just with no creds. Treat as "not configured".
-    return "";
-  }
+async function readProfileEnv(
+  paths: VoiceProfilePaths,
+): Promise<Record<string, string>> {
+  const raw = await dockerExec(HERMES_CONTAINER, [
+    "sh",
+    "-c",
+    `cat ${paths.envPath} 2>/dev/null || true`,
+  ]);
+  const out: Record<string, string> = {};
   for (const line of raw.split("\n")) {
-    const t = line.replace(/^﻿/, ""); // strip BOM if any
-    if (!t || t.trimStart().startsWith("#")) continue;
+    const t = line.replace(/^﻿/, "");
     const eq = t.indexOf("=");
     if (eq <= 0) continue;
     const k = t.slice(0, eq).trim();
-    if (k !== key) continue;
+    if (!k || k.startsWith("#")) continue;
     let v = t.slice(eq + 1);
     if (v.endsWith("\r")) v = v.slice(0, -1);
     if (
@@ -187,21 +168,71 @@ async function readProfileEnvKey(key: string): Promise<string> {
     ) {
       v = v.slice(1, -1);
     }
-    return v;
+    out[k] = v;
   }
-  return "";
+  return out;
 }
 
-// ── Compose-level .env reader (the file PATCH /admin/credentials writes) ──
+async function writeProfileEnvKeys(
+  paths: VoiceProfilePaths,
+  updates: Partial<Record<VoiceEnvKey, string | null>>,
+): Promise<void> {
+  const raw = await dockerExec(HERMES_CONTAINER, [
+    "sh",
+    "-c",
+    `cat ${paths.envPath} 2>/dev/null || true`,
+  ]);
+  const lines = raw === "" ? [] : raw.split("\n");
+  if (lines.length && lines[lines.length - 1] === "") lines.pop();
+
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const line of lines) {
+    const t = line.replace(/^﻿/, "");
+    const eq = t.indexOf("=");
+    const key = eq > 0 ? t.slice(0, eq).trim() : "";
+    if (key && key in updates) {
+      seen.add(key);
+      const v = updates[key as VoiceEnvKey];
+      if (v === null || v === undefined) continue; // drop
+      out.push(`${key}=${v}`);
+      continue;
+    }
+    out.push(line);
+  }
+  for (const k of VOICE_ENV_KEYS) {
+    if (seen.has(k)) continue;
+    if (!(k in updates)) continue;
+    const v = updates[k];
+    if (v === null || v === undefined) continue;
+    out.push(`${k}=${v}`);
+  }
+  const content = out.join("\n") + "\n";
+
+  const tmp = `${paths.envPath}.tmp.${process.pid}.${Date.now()}`;
+  await dockerExecWithStdin(
+    HERMES_CONTAINER,
+    [
+      "sh",
+      "-c",
+      `mkdir -p ${paths.profileDir} && cat > ${tmp} && mv ${tmp} ${paths.envPath}`,
+    ],
+    content,
+    30_000,
+  );
+}
+
+// ── Compose-level .env reader (back-compat for main's OPENAI_API_KEY) ────
 //
-// voice-bridge reads OPENAI_API_KEY through compose's `env_file: .env`, so
-// the file at COMPOSE_DIR/.env is the source of truth — NOT process.env on
-// ctrl-api (which only refreshes when ctrl-api itself is recreated). Read
-// the file directly so we see PATCH writes on the next /status poll without
-// a ctrl-api restart.
+// Pre-Lane-Vb voice-bridge read OPENAI_API_KEY from the compose .env via
+// env_file. We keep reading it for main's status so the existing
+// "configure OpenAI on /channels" UI doesn't regress. Non-main profiles
+// MUST set their own per-profile OPENAI key — the compose-level value is
+// instance-shared state, not a profile-scoped surface.
 
 function readComposeEnvKey(key: string): string {
-  const path = `${COMPOSE_DIR}/.env`;
+  const composeDir = process.env.COMPOSE_DIR ?? COMPOSE_DIR;
+  const path = `${composeDir}/.env`;
   let raw: string;
   try {
     raw = fs.readFileSync(path, "utf-8");
@@ -228,27 +259,65 @@ function readComposeEnvKey(key: string): string {
   return "";
 }
 
-// ── Voice allowlist reader ────────────────────────────────────────────────
-//
-// VOICE_ALLOWED_CALLERS / VOICE_ALLOW_ALL_CALLERS live in the compose .env
-// alongside the other voice-bridge env. The bridge reads them via env_file:
-// the TwiML responder (packages/voice-bridge/src/twiml.ts) checks the caller
-// `From` field against the allowlist and rejects disallowed callers with
-// <Reject reason="busy"/>. ctrl-api keeps a read-side view here so the
-// /channels Phone card can surface the current setting.
+// ── Compose probe (unchanged from Lane I) ────────────────────────────────
 
-function readVoiceAllowlist(): {
-  allowed_callers: string;
-  allow_all: boolean;
-} {
-  const allowed = readComposeEnvKey("VOICE_ALLOWED_CALLERS").trim();
-  const allowAll =
-    readComposeEnvKey("VOICE_ALLOW_ALL_CALLERS").trim().toLowerCase() ===
-    "true";
-  return { allowed_callers: allowed, allow_all: allowAll };
+interface ComposePsRow {
+  Name?: string;
+  Service?: string;
+  State?: string;
+  Health?: string;
 }
 
-// ── Container logs tail (for state="error" details) ───────────────────────
+interface ComposeProbe {
+  exists: boolean;
+  row: ComposePsRow | null;
+  error: string | null;
+}
+
+function looksLikeNoSuchService(message: string): boolean {
+  const m = message.toLowerCase();
+  return (
+    m.includes("no such service") ||
+    (m.includes("service ") && m.includes(" not found")) ||
+    m.includes("has no service")
+  );
+}
+
+async function probeComposeService(): Promise<ComposeProbe> {
+  let raw: string;
+  try {
+    raw = await dockerComposeCmd([
+      "ps",
+      VOICE_COMPOSE_SERVICE,
+      "--format",
+      "json",
+    ]);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (looksLikeNoSuchService(msg)) {
+      return { exists: false, row: null, error: null };
+    }
+    return { exists: false, row: null, error: `compose ps failed: ${msg}` };
+  }
+  const trimmed = raw.trim();
+  if (!trimmed) return { exists: false, row: null, error: null };
+  for (const line of trimmed.split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+    try {
+      const parsed = JSON.parse(t) as ComposePsRow | ComposePsRow[];
+      const rows = Array.isArray(parsed) ? parsed : [parsed];
+      for (const row of rows) {
+        if (!row.Service || row.Service === VOICE_COMPOSE_SERVICE) {
+          return { exists: true, row, error: null };
+        }
+      }
+    } catch {
+      // not JSON — fall through
+    }
+  }
+  return { exists: true, row: null, error: null };
+}
 
 async function tailVoiceBridgeLogs(): Promise<string> {
   try {
@@ -265,90 +334,261 @@ async function tailVoiceBridgeLogs(): Promise<string> {
   }
 }
 
-// ── Route ─────────────────────────────────────────────────────────────────
+// ── Twilio account probe (mirror sms.ts) ─────────────────────────────────
+
+function basicAuth(sid: string, token: string): string {
+  return "Basic " + Buffer.from(`${sid}:${token}`).toString("base64");
+}
+
+interface TwilioAccountProbe {
+  ok: boolean;
+  friendly_name: string | null;
+  status: string | null;
+  error: string | null;
+}
+
+let _accountProbeCache:
+  | { sid: string; token: string; result: TwilioAccountProbe; at: number }
+  | null = null;
+const ACCOUNT_PROBE_TTL_MS = 60_000;
+
+async function probeTwilioAccount(
+  sid: string,
+  token: string,
+): Promise<TwilioAccountProbe> {
+  const now = Date.now();
+  if (
+    _accountProbeCache &&
+    _accountProbeCache.sid === sid &&
+    _accountProbeCache.token === token &&
+    now - _accountProbeCache.at < ACCOUNT_PROBE_TTL_MS
+  ) {
+    return _accountProbeCache.result;
+  }
+  const empty: TwilioAccountProbe = {
+    ok: false,
+    friendly_name: null,
+    status: null,
+    error: null,
+  };
+  let r: Response;
+  try {
+    r = await fetch(
+      `https://api.twilio.com/2010-04-01/Accounts/${sid}.json`,
+      {
+        method: "GET",
+        headers: { Authorization: basicAuth(sid, token) },
+        signal: AbortSignal.timeout(8_000),
+      },
+    );
+  } catch (e) {
+    const result: TwilioAccountProbe = {
+      ...empty,
+      error: `Twilio unreachable: ${e instanceof Error ? e.message : String(e)}`,
+    };
+    _accountProbeCache = { sid, token, result, at: now };
+    return result;
+  }
+  if (r.status === 200) {
+    let body: any = null;
+    try {
+      body = await r.json();
+    } catch {
+      /* ignore */
+    }
+    const result: TwilioAccountProbe = {
+      ok: true,
+      friendly_name:
+        typeof body?.friendly_name === "string" ? body.friendly_name : null,
+      status: typeof body?.status === "string" ? body.status : null,
+      error: null,
+    };
+    _accountProbeCache = { sid, token, result, at: now };
+    return result;
+  }
+  let result: TwilioAccountProbe;
+  try {
+    const j = await r.json();
+    result = {
+      ok: false,
+      friendly_name: null,
+      status: null,
+      error: j.message ?? `Twilio returned HTTP ${r.status}`,
+    };
+  } catch {
+    result = {
+      ok: false,
+      friendly_name: null,
+      status: null,
+      error: `Twilio returned HTTP ${r.status}`,
+    };
+  }
+  _accountProbeCache = { sid, token, result, at: now };
+  return result;
+}
+
+// ── Mask + webhook URL helpers ───────────────────────────────────────────
+
+function maskAccountSid(sid: string): string {
+  if (sid.length < 6) return "AC" + "*".repeat(Math.max(0, sid.length - 2));
+  const last4 = sid.slice(-4);
+  const middleLen = sid.length - 2 - 4;
+  return "AC" + "*".repeat(Math.max(4, middleLen)) + last4;
+}
+
+/** Twilio "A CALL COMES IN" webhook the principal pastes into the Twilio
+ *  Console for a profile-specific number. Voice-bridge's /twiml/inbound
+ *  reads `?profile=<slug>` and emits the appropriate per-profile TwiML.
+ *  Empty when DOMAIN isn't set (single-VM bring-up). */
+function voiceWebhookUrl(slug: string): string {
+  const dom = (process.env.DOMAIN || "").trim();
+  if (!dom) return "";
+  return `https://voice.${dom}/twiml/inbound?profile=${encodeURIComponent(slug)}`;
+}
+
+// ── Restart Hermes (used as a fallback path; voice-bridge itself does NOT
+//    need a restart — it reads creds on every inbound call) ───────────────
+
+function restartVoiceBridge(): void {
+  // Voice-bridge reads per-profile creds via ctrl-api on every inbound call
+  // (see voice-bridge/src/tenant.ts) — no env baked in. So credential writes
+  // do NOT require a voice-bridge restart. We intentionally do NOT fire a
+  // compose restart here; restartProfile() drops the per-profile flag and
+  // the next inbound call picks up the new creds.
+}
+void restartVoiceBridge;
+
+// ── Routes ────────────────────────────────────────────────────────────────
 
 export function registerVoiceRoutes(): void {
-  // GET /status — fail-soft. NEVER 5xx (dashboard polls it).
-  addRoute("GET", "/api/v1/channels/voice/status", async ({ res }) => {
-    const probe = await probeComposeService();
-    // OPENAI_API_KEY is required for voice-bridge to talk to gpt-realtime.
-    // Read it eagerly so every return path can include the flag.
-    const openaiKeySet = readComposeEnvKey("OPENAI_API_KEY").length > 0;
-    const allowlist = readVoiceAllowlist();
+  // GET /resolve?to=<E.164> — Lane Vb debug surface, mirrors sms /resolve.
+  // Lets the principal verify which profile a Twilio "To" number resolves to.
+  addRoute("GET", "/api/v1/channels/voice/resolve", async ({ res, query }) => {
+    const toNumber = query.get("to")?.trim() || null;
+    const { resolveProfileContextForChannel } = await import(
+      "../../db/agentProfiles.js"
+    );
+    const ctx = resolveProfileContextForChannel(
+      getStateDb(),
+      "voice",
+      toNumber,
+    );
+    sendJson(res, 200, {
+      channel_kind: "voice",
+      channel_identity: toNumber,
+      profile: ctx.slug,
+      bound_profile: ctx.bound_slug,
+      cascaded: ctx.cascaded,
+      api_server_port: ctx.api_server_port,
+      api_server_key_present: ctx.api_server_key != null,
+      profile_dir: ctx.profile_dir,
+      journal_scope: ctx.journal_scope_key,
+    });
+  });
 
-    // Case 1: voice-bridge service isn't deployed on this VM yet. This is
-    // the "Phase-2 orchestrator hasn't merged the compose change" state —
-    // benign, NOT an error. The UI surfaces a "Voice not deployed" card.
+  // GET /status — fail-soft. NEVER 5xx (dashboard polls it).
+  // Accepts ?profile=<slug>; defaults to the default binding for voice.
+  addRoute("GET", "/api/v1/channels/voice/status", async ({ res, query }) => {
+    const paths = resolveVoiceProfile(query);
+    const probe = await probeComposeService();
+
+    let envMap: Record<string, string> = {};
+    let envErr: string | null = null;
+    try {
+      envMap = await readProfileEnv(paths);
+    } catch (e) {
+      envErr = e instanceof Error ? e.message : String(e);
+    }
+
+    const sid = envMap.TWILIO_ACCOUNT_SID ?? "";
+    const token = envMap.TWILIO_AUTH_TOKEN ?? "";
+    // Prefer the voice-specific from-number; fall back to TWILIO_PHONE_NUMBER
+    // (the SMS one) so a profile with SMS configured but no separate voice
+    // number still surfaces the calling number.
+    const voiceFrom = envMap.TWILIO_VOICE_FROM_NUMBER ?? "";
+    const smsFrom = envMap.TWILIO_PHONE_NUMBER ?? "";
+    const phone = voiceFrom || smsFrom;
+    const allowedCallers = envMap.VOICE_ALLOWED_CALLERS ?? "";
+    const allowAll =
+      (envMap.VOICE_ALLOW_ALL_CALLERS ?? "").toLowerCase() === "true";
+
+    const openaiKeySetProfile = (envMap.OPENAI_API_KEY ?? "").length > 0;
+    const openaiKeySetCompose =
+      paths.profileSlug === "main"
+        ? readComposeEnvKey("OPENAI_API_KEY").length > 0
+        : false;
+    const openaiKeySet = openaiKeySetProfile || openaiKeySetCompose;
+    const webhook_url = voiceWebhookUrl(paths.profileSlug) || null;
+
+    const baseFields = {
+      calling_number: phone || null,
+      account_sid_masked: sid ? maskAccountSid(sid) : null,
+      compose_service_exists: probe.exists,
+      openai_key_set: openaiKeySetProfile,
+      openai_key_set_compose: openaiKeySetCompose,
+      allowed_callers: allowedCallers,
+      allow_all: allowAll,
+      webhook_url,
+      profile_slug: paths.profileSlug,
+    } as const;
+
+    if (envErr) {
+      sendJson(res, 200, {
+        configured: false,
+        state: "error",
+        error: `profile env: ${envErr}`,
+        ...baseFields,
+      } satisfies VoiceStatus);
+      return;
+    }
+
+    // Case 1: voice-bridge service isn't deployed on this VM yet.
     if (!probe.exists && probe.error === null) {
       sendJson(res, 200, {
         configured: false,
         state: "unconfigured",
         error: null,
-        calling_number: null,
-        compose_service_exists: false,
-        openai_key_set: openaiKeySet,
-        allowed_callers: allowlist.allowed_callers,
-        allow_all: allowlist.allow_all,
+        ...baseFields,
       } satisfies VoiceStatus);
       return;
     }
 
-    // Case 1b: compose itself failed (not "no such service"). Surface as
-    // error so the operator knows the probe is broken.
+    // Case 1b: compose itself failed (not "no such service").
     if (probe.error !== null) {
       sendJson(res, 200, {
         configured: false,
         state: "error",
         error: probe.error,
-        calling_number: null,
-        compose_service_exists: false,
-        openai_key_set: openaiKeySet,
-        allowed_callers: allowlist.allowed_callers,
-        allow_all: allowlist.allow_all,
+        ...baseFields,
       } satisfies VoiceStatus);
       return;
     }
 
-    // Service exists — resolve credentials + container health.
-    const phone = (await readProfileEnvKey("TWILIO_PHONE_NUMBER")).trim();
-    const configured = phone.length > 0;
+    const configured = Boolean(sid && token && phone);
 
     if (!configured) {
-      // Deployed but no Twilio number yet — UI shows "Configure SMS first".
       sendJson(res, 200, {
         configured: false,
         state: "unconfigured",
         error: null,
-        calling_number: null,
-        compose_service_exists: true,
-        openai_key_set: openaiKeySet,
-        allowed_callers: allowlist.allowed_callers,
-        allow_all: allowlist.allow_all,
+        ...baseFields,
       } satisfies VoiceStatus);
       return;
     }
 
-    // Configured-but-no-OpenAI-key: voice-bridge will crash-loop on
-    // "OPENAI_API_KEY env var is required". Don't report this as an "error"
-    // (operator-facing error semantically means "I tried, something broke")
-    // — report it as `unconfigured` with openai_key_set=false. The UI
-    // surfaces an inline input so the key can be pasted without leaving
-    // /channels.
     if (!openaiKeySet) {
+      // Configured-but-no-OpenAI: surface as unconfigured so the UI shows the
+      // inline OpenAI input rather than a perpetual spinner.
       sendJson(res, 200, {
         configured: true,
         state: "unconfigured",
         error: null,
-        calling_number: phone,
-        compose_service_exists: true,
-        openai_key_set: false,
-        allowed_callers: allowlist.allowed_callers,
-        allow_all: allowlist.allow_all,
+        ...baseFields,
       } satisfies VoiceStatus);
       return;
     }
 
-    // Configured + OpenAI key set — pivot on container Health / State.
+    // Configured + has an OpenAI key — pivot on container Health / State.
     const health = (probe.row?.Health ?? "").toLowerCase();
     const state = (probe.row?.State ?? "").toLowerCase();
 
@@ -365,11 +605,8 @@ export function registerVoiceRoutes(): void {
     ) {
       voiceState = "configured_starting";
     } else {
-      // unhealthy / exited / dead / unknown
       voiceState = "error";
       const tail = await tailVoiceBridgeLogs();
-      // Prefer the logs tail when we have one — operator-actionable. Fall
-      // back to a synthetic message if logs were empty.
       error = tail
         ? tail.slice(-2000)
         : `voice-bridge state=${state || "unknown"} health=${health || "unknown"}`;
@@ -379,66 +616,412 @@ export function registerVoiceRoutes(): void {
       configured: true,
       state: voiceState,
       error,
-      calling_number: phone,
-      compose_service_exists: true,
-      openai_key_set: true,
-      allowed_callers: allowlist.allowed_callers,
-      allow_all: allowlist.allow_all,
+      ...baseFields,
     } satisfies VoiceStatus);
   });
 
-  // PUT /allowlist — set VOICE_ALLOWED_CALLERS + VOICE_ALLOW_ALL_CALLERS in
-  // the compose .env (the file voice-bridge reads via env_file). voice-bridge
-  // is recreated so the new env is picked up. The TwiML responder enforces
-  // the allowlist on every inbound call.
-  addRoute("PUT", "/api/v1/channels/voice/allowlist", async ({ res, body }) => {
-    const b = (body ?? {}) as Record<string, unknown>;
-    const allowAll = b.allow_all === true;
-    let allowedCallers: string | null = null;
-    const E164 = /^\+[1-9]\d{1,14}$/;
-    if (!allowAll) {
-      const raw =
-        typeof b.allowed_callers === "string" ? b.allowed_callers.trim() : "";
-      if (raw) {
-        const parts = raw
-          .split(",")
-          .map((s) => s.trim())
-          .filter(Boolean);
-        for (const p of parts) {
-          if (!E164.test(p)) {
-            throw new Error(
-              `allowed_callers must be comma-separated E.164 numbers — "${p}" is not`,
-            );
-          }
-        }
-        allowedCallers = parts.join(",");
+  // PUT /credentials — set Twilio + (optional) OpenAI creds on the profile's .env.
+  addRoute(
+    "PUT",
+    "/api/v1/channels/voice/credentials",
+    async ({ res, body, query }) => {
+      const paths = resolveVoiceProfile(query);
+      try {
+        assertWritableProfile(getStateDb(), paths.profileSlug);
+      } catch (e) {
+        throw new ValidationError(e instanceof Error ? e.message : String(e));
       }
+      const b = (body ?? {}) as Record<string, unknown>;
+
+      const sid = typeof b.account_sid === "string" ? b.account_sid.trim() : "";
+      const token = typeof b.auth_token === "string" ? b.auth_token.trim() : "";
+      const fromNumber =
+        typeof b.from_number === "string" ? b.from_number.trim() : "";
+      const openaiKey =
+        typeof b.openai_key === "string" ? b.openai_key.trim() : "";
+
+      if (!ACCOUNT_SID_RE.test(sid)) {
+        throw new ValidationError(
+          "account_sid must be a Twilio Account SID (AC + 32 lowercase hex chars)",
+        );
+      }
+      if (!AUTH_TOKEN_RE.test(token)) {
+        throw new ValidationError(
+          "auth_token must be 32 lowercase hex chars (Twilio Auth Token)",
+        );
+      }
+      if (!E164_RE.test(fromNumber)) {
+        throw new ValidationError(
+          "from_number must be E.164 (e.g. +15551234567)",
+        );
+      }
+      if (openaiKey && !OPENAI_KEY_RE.test(openaiKey)) {
+        throw new ValidationError(
+          "openai_key must look like an OpenAI key (sk-…); leave blank to inherit main's key",
+        );
+      }
+
+      // OPTIONAL Twilio probe — confirm the creds are valid before writing.
+      // Anything other than 200 = 400 from us.
+      const probe = await probeTwilioAccount(sid, token);
+      if (!probe.ok) {
+        sendJson(res, 400, {
+          ok: false,
+          error: probe.error ?? "Twilio rejected the credentials",
+        });
+        return;
+      }
+
+      const updates: Partial<Record<VoiceEnvKey, string | null>> = {
+        TWILIO_ACCOUNT_SID: sid,
+        TWILIO_AUTH_TOKEN: token,
+        TWILIO_VOICE_FROM_NUMBER: fromNumber,
+      };
+      if (openaiKey) {
+        updates.OPENAI_API_KEY = openaiKey;
+      }
+
+      await writeProfileEnvKeys(paths, updates);
+      appendAudit({
+        action_type: "channel_token_set",
+        actor: "principal",
+        source: "channels/voice/credentials",
+        target_path: "channels/voice/credentials",
+        target_kind: "channel",
+        subject_ref: paths.profileSlug,
+        summary: `Voice credentials set on profile '${paths.profileSlug}'`,
+        payload: {
+          profile_slug: paths.profileSlug,
+          channel_kind: "voice",
+          openai_key_set: Boolean(openaiKey),
+        },
+      });
+      _accountProbeCache = null;
+
+      // Voice-bridge does NOT need a restart — it reads creds via ctrl-api on
+      // every inbound call. We still drop a per-profile restart flag so
+      // observers (Lane V tests + supervisor reconcile) see the credential
+      // rotation as a profile-scoped event. The 'noop' scope is the right
+      // wire shape: no gateway needs to bounce.
+      const restart = restartProfile(paths.profileSlug, {
+        allowComposeFallback: false,
+      });
+      sendJson(res, 200, {
+        ok: true,
+        state: "configured_starting",
+        profile: paths.profileSlug,
+        restart_scope: restart.scope,
+        restart_warning: restart.warning,
+      });
+    },
+  );
+
+  // DELETE /credentials — wipe the 3 Twilio keys + the optional OpenAI key.
+  // Compose-level OPENAI_API_KEY (main's instance-shared key) is NOT touched.
+  addRoute(
+    "DELETE",
+    "/api/v1/channels/voice/credentials",
+    async ({ res, query }) => {
+      const paths = resolveVoiceProfile(query);
+      try {
+        assertWritableProfile(getStateDb(), paths.profileSlug);
+      } catch (e) {
+        throw new ValidationError(e instanceof Error ? e.message : String(e));
+      }
+      await writeProfileEnvKeys(paths, {
+        TWILIO_ACCOUNT_SID: null,
+        TWILIO_AUTH_TOKEN: null,
+        TWILIO_VOICE_FROM_NUMBER: null,
+        OPENAI_API_KEY: null,
+      });
+      appendAudit({
+        action_type: "channel_token_cleared",
+        actor: "principal",
+        source: "channels/voice/credentials",
+        target_path: "channels/voice/credentials",
+        target_kind: "channel",
+        subject_ref: paths.profileSlug,
+        summary: `Voice credentials cleared on profile '${paths.profileSlug}'`,
+        payload: { profile_slug: paths.profileSlug, channel_kind: "voice" },
+      });
+      _accountProbeCache = null;
+      const restart = restartProfile(paths.profileSlug, {
+        allowComposeFallback: false,
+      });
+      sendJson(res, 200, {
+        ok: true,
+        state: "unconfigured",
+        profile: paths.profileSlug,
+        restart_scope: restart.scope,
+        restart_warning: restart.warning,
+      });
+    },
+  );
+
+  // POST /test — probe Twilio with the profile's stored creds. Cheap (no
+  // outbound call placed); confirms account_sid + auth_token are valid.
+  addRoute("POST", "/api/v1/channels/voice/test", async ({ res, query }) => {
+    const paths = resolveVoiceProfile(query);
+    const env = await readProfileEnv(paths).catch(
+      () => ({}) as Record<string, string>,
+    );
+    const sid = env.TWILIO_ACCOUNT_SID ?? "";
+    const token = env.TWILIO_AUTH_TOKEN ?? "";
+    if (!sid || !token) {
+      throw new ValidationError(
+        "voice is not configured (no Twilio creds in the hermes profile)",
+      );
+    }
+    const probe = await probeTwilioAccount(sid, token);
+    if (probe.ok) {
+      sendJson(res, 200, {
+        ok: true,
+        account_sid_masked: maskAccountSid(sid),
+        friendly_name: probe.friendly_name,
+        status: probe.status,
+        tested_at: new Date().toISOString(),
+      });
+    } else {
+      sendJson(res, 200, {
+        ok: false,
+        error: probe.error ?? "Twilio rejected the credentials",
+      });
+    }
+  });
+
+  // PUT /allowlist — per-profile caller allowlist (VOICE_ALLOWED_CALLERS /
+  // VOICE_ALLOW_ALL_CALLERS) written to the profile's .env. voice-bridge's
+  // TwiML responder reads these per-call (resolves the profile from the
+  // ?profile= query, then reads its .env keys).
+  addRoute(
+    "PUT",
+    "/api/v1/channels/voice/allowlist",
+    async ({ res, body, query }) => {
+      const paths = resolveVoiceProfile(query);
+      try {
+        assertWritableProfile(getStateDb(), paths.profileSlug);
+      } catch (e) {
+        throw new ValidationError(e instanceof Error ? e.message : String(e));
+      }
+      const b = (body ?? {}) as Record<string, unknown>;
+      const allowAll = b.allow_all === true;
+      let allowedCallers: string | null = null;
+      if (!allowAll) {
+        const raw =
+          typeof b.allowed_callers === "string"
+            ? b.allowed_callers.trim()
+            : "";
+        if (raw) {
+          const parts = raw
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean);
+          for (const p of parts) {
+            if (!E164_RE.test(p)) {
+              throw new ValidationError(
+                `allowed_callers must be comma-separated E.164 numbers — "${p}" is not`,
+              );
+            }
+          }
+          allowedCallers = parts.join(",");
+        }
+      }
+      await writeProfileEnvKeys(paths, {
+        VOICE_ALLOWED_CALLERS: allowedCallers,
+        VOICE_ALLOW_ALL_CALLERS: allowAll ? "true" : null,
+      });
+      appendAudit({
+        action_type: "channel_settings_updated",
+        actor: "principal",
+        source: "channels/voice/allowlist",
+        target_path: "channels/voice/allowlist",
+        target_kind: "channel",
+        subject_ref: paths.profileSlug,
+        summary: `Voice allowlist updated on profile '${paths.profileSlug}'`,
+        payload: {
+          profile_slug: paths.profileSlug,
+          channel_kind: "voice",
+          allow_all: allowAll,
+        },
+      });
+      sendJson(res, 200, {
+        ok: true,
+        allow_all: allowAll,
+        allowed_callers: allowedCallers ?? "",
+        profile: paths.profileSlug,
+      });
+    },
+  );
+
+  // GET /internal/openai-key?profile=<slug> — voice-bridge-only.
+  //
+  // The bridge calls this on every inbound call to learn which OPENAI_API_KEY
+  // to use for the Realtime session. ctrl-api's auth.ts allowlist scopes the
+  // VOICE_BRIDGE bearer to this exact pathname; any other caller 401s. The
+  // pre-Vb behaviour stays — the boot-time OPENAI key in voice-bridge's env
+  // is the fallback when this returns null (e.g. non-main profile without
+  // its own key).
+  addRoute(
+    "GET",
+    "/api/v1/channels/voice/internal/openai-key",
+    async ({ res, query }) => {
+      const paths = resolveVoiceProfile(query);
+      const env = await readProfileEnv(paths).catch(
+        () => ({}) as Record<string, string>,
+      );
+      const key = env.OPENAI_API_KEY?.trim() || null;
+      // Non-main profiles intentionally do NOT inherit the compose-level
+      // key here — voice-bridge already has it from its boot env and uses
+      // it as the fallback. Returning null is the signal to use the
+      // fallback. Main returns the compose key as a back-compat path so
+      // the pre-Vb deployment with OPENAI_API_KEY in the compose .env keeps
+      // working without re-pasting the key into main's per-profile .env.
+      let resolvedKey = key;
+      if (!resolvedKey && paths.profileSlug === "main") {
+        const composeKey = readComposeEnvKey("OPENAI_API_KEY");
+        if (composeKey) resolvedKey = composeKey;
+      }
+      sendJson(res, 200, {
+        profile: paths.profileSlug,
+        openai_api_key: resolvedKey,
+      });
+    },
+  );
+
+  // POST /inbound — Twilio webhook landing pad + routing decision endpoint.
+  //
+  // In production the principal points Twilio at
+  //   https://voice.<domain>/twiml/inbound?profile=<slug>
+  // which lands on voice-bridge directly (faster TwiML, no extra hop).
+  //
+  // This ctrl-api route exists for THREE reasons:
+  //   1. Smoke testing — assert the routing decision without Twilio.
+  //   2. Operators who'd rather configure ctrl-api as the webhook and
+  //      have ctrl-api emit TwiML (one less surface to remember).
+  //   3. Future routing decisions that need state.db access (allow-
+  //      list lookups, per-To dispatch) before reaching voice-bridge.
+  //
+  // Accepts:
+  //   - ?profile=<slug> (preferred, explicit)
+  //   - OR form field "To"=<E.164> → resolved via channel_profile_binding
+  //   - OR no hint → falls back to main
+  // Returns TwiML that points at voice-bridge's WSS endpoint with the
+  // resolved profile slug embedded in the path.
+  addRoute("POST", "/api/v1/channels/voice/inbound", async ({ req, res, body, query }) => {
+    // Twilio POSTs application/x-www-form-urlencoded. ctrl-api's default
+    // body parser short-circuits on non-JSON, so `body` arrives as undefined
+    // for the wire shape Twilio actually sends. Read the raw body inline
+    // here when body is undefined; otherwise accept JSON (smoke tests POST
+    // JSON for clarity).
+    let toNumber: string | null = null;
+    let fromNumber: string | null = null;
+    let callSid: string | null = null;
+
+    const contentType = (req.headers?.["content-type"] as string | undefined) ?? "";
+    if (body && typeof body === "object") {
+      const b = body as Record<string, unknown>;
+      if (typeof b.To === "string") toNumber = b.To;
+      if (typeof b.From === "string") fromNumber = b.From;
+      if (typeof b.CallSid === "string") callSid = b.CallSid;
+    } else if (typeof body === "string") {
+      const params = new URLSearchParams(body);
+      toNumber = params.get("To");
+      fromNumber = params.get("From");
+      callSid = params.get("CallSid");
+    } else if (contentType.includes("application/x-www-form-urlencoded")) {
+      // Drain the raw body — parseBody bailed on the non-JSON content-type.
+      const raw = await new Promise<string>((resolve, reject) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => resolve(Buffer.concat(chunks).toString()));
+        req.on("error", reject);
+      });
+      const params = new URLSearchParams(raw);
+      toNumber = params.get("To");
+      fromNumber = params.get("From");
+      callSid = params.get("CallSid");
     }
 
-    // Write directly to COMPOSE_DIR/.env via the credentials.ts merge writer.
-    // We import the helper lazily to avoid a top-level dep cycle.
-    const { patchEnv } = await import("./credentials.js");
-    patchEnv({
-      VOICE_ALLOWED_CALLERS: allowedCallers,
-      VOICE_ALLOW_ALL_CALLERS: allowAll ? "true" : null,
-    });
+    // Resolve the profile. Precedence:
+    //   1. explicit ?profile=<slug> in the URL (Sir's chosen routing key)
+    //   2. binding lookup by Twilio "To" form field
+    //   3. main (default)
+    const explicit = query.get("profile")?.trim() || null;
+    let resolved: string;
+    let resolvedBy: "query" | "to-binding" | "default";
+    if (explicit) {
+      resolved = explicit;
+      resolvedBy = "query";
+    } else if (toNumber) {
+      const bound = resolveProfileForChannel(getStateDb(), "voice", toNumber);
+      resolved = bound;
+      resolvedBy = "to-binding";
+    } else {
+      resolved = resolveProfileForChannel(getStateDb(), "voice", null);
+      resolvedBy = "default";
+    }
 
-    // Recreate voice-bridge so the new env lands. `--no-deps --force-recreate`
-    // limits the blast radius to the one container.
-    dockerComposeCmd([
-      "up",
-      "-d",
-      "--no-deps",
-      "--force-recreate",
-      VOICE_COMPOSE_SERVICE,
-    ]).catch((err) => {
-      console.error("[voice/allowlist] recreate failed:", err);
-    });
+    // Build the TwiML response. Voice-bridge's WSS handler will read the
+    // profile slug from the path segment.
+    const domain = (process.env.DOMAIN || "").trim();
+    const wssHost = domain ? `voice.${domain}` : "voice.example";
+    const wssUrl = `wss://${wssHost}/voice/${encodeURIComponent(resolved)}`;
+    const escapedTo = (toNumber ?? "").replace(/[&<>"']/g, (c) =>
+      c === "&"
+        ? "&amp;"
+        : c === "<"
+          ? "&lt;"
+          : c === ">"
+            ? "&gt;"
+            : c === '"'
+              ? "&quot;"
+              : "&apos;",
+    );
+    const escapedFrom = (fromNumber ?? "").replace(/[&<>"']/g, (c) =>
+      c === "&"
+        ? "&amp;"
+        : c === "<"
+          ? "&lt;"
+          : c === ">"
+            ? "&gt;"
+            : c === '"'
+              ? "&quot;"
+              : "&apos;",
+    );
 
-    sendJson(res, 200, {
-      ok: true,
-      allow_all: allowAll,
-      allowed_callers: allowedCallers ?? "",
-    });
+    const twiml =
+      '<?xml version="1.0" encoding="UTF-8"?>\n' +
+      "<Response>\n" +
+      "  <Connect>\n" +
+      `    <Stream url="${wssUrl}">\n` +
+      `      <Parameter name="profile" value="${resolved}"/>\n` +
+      `      <Parameter name="from" value="${escapedFrom}"/>\n` +
+      `      <Parameter name="to" value="${escapedTo}"/>\n` +
+      "    </Stream>\n" +
+      "  </Connect>\n" +
+      "</Response>\n";
+
+    // Smoke endpoints want a JSON view. Default = TwiML XML (so Sir CAN
+    // point Twilio at this endpoint). Toggle via Accept header or ?format=
+    // (smoke tests pass ?format=json).
+    const wantsJson =
+      query.get("format") === "json" ||
+      (req.headers?.["accept"] as string | undefined)?.includes(
+        "application/json",
+      );
+    if (wantsJson) {
+      sendJson(res, 200, {
+        ok: true,
+        resolved_profile: resolved,
+        resolved_by: resolvedBy,
+        wss_url: wssUrl,
+        twiml,
+        twilio: { To: toNumber, From: fromNumber, CallSid: callSid },
+      });
+      return;
+    }
+
+    res.writeHead(200, { "Content-Type": "application/xml; charset=utf-8" });
+    res.end(twiml);
   });
 }

--- a/packages/ctrl/tests/voice-routes-lane-vb.test.ts
+++ b/packages/ctrl/tests/voice-routes-lane-vb.test.ts
@@ -1,0 +1,471 @@
+// #120 Lane Vb — per-profile voice routes (PUT/DELETE/test/inbound).
+//
+// Lane I's voice-routes.test.ts covers /status; this file covers the
+// per-profile credential surface added in Lane Vb. We mirror the SMS test
+// shape (docker exec + Twilio API + assertWritableProfile mocks) so the
+// surface stays consistent.
+
+import { mock, describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "voice-vb-"));
+process.env.COMPOSE_DIR = tmp;
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.VAULT_PATH = path.join(tmp, "vault");
+process.env.STATE_DB_PATH = path.join(tmp, "state.db");
+process.env.SQLITE_VEC_PATH = "";
+process.env.VAULT_CLI_URL = "http://vault-cli-stub:8087";
+process.env.HERMES_HOME_IN_CONTAINER = "/hermes-state";
+process.env.DOMAIN = "home.alfred.black";
+
+const SENTINEL_PROFILE_DIR = "/hermes-state/profiles/sentinel-vb";
+const SENTINEL_ENV_PATH = `${SENTINEL_PROFILE_DIR}/.env`;
+const MAIN_PROFILE_DIR = "/hermes-state/profiles/main";
+const MAIN_ENV_PATH = `${MAIN_PROFILE_DIR}/.env`;
+
+const VALID_SID = "AC" + "1".repeat(32);
+const VALID_TOKEN = "1".repeat(32);
+const VALID_FROM = "+15552222222";
+const VALID_OPENAI = "sk-test_lane_vb_per_profile_key_value_12345";
+
+// ── docker exec mock state ───────────────────────────────────────────────
+let containerFiles: Record<string, string> = {};
+const dockerExecCalls: { service: string; command: string[] }[] = [];
+const dockerExecWithStdinCalls: {
+  service: string;
+  command: string[];
+  stdin: string;
+}[] = [];
+const dockerComposeCalls: string[][] = [];
+
+function defaultDockerExec(_service: string, command: string[]): string {
+  if (command[0] === "sh" && command[1] === "-c") {
+    const script = command[2] ?? "";
+    const catMatch = script.match(/^cat\s+(\S+)\s+2>\/dev\/null\s+\|\|\s+true$/);
+    if (catMatch) return containerFiles[catMatch[1]] ?? "";
+    return "";
+  }
+  return "";
+}
+
+const realHelpers = await import("../src/api/helpers.js");
+mock.module("../src/api/helpers.js", {
+  namedExports: {
+    ...realHelpers,
+    dockerExec: async (service: string, command: string[]) => {
+      dockerExecCalls.push({ service, command: [...command] });
+      return defaultDockerExec(service, command);
+    },
+    dockerExecWithStdin: async (
+      service: string,
+      command: string[],
+      stdin: string,
+    ) => {
+      dockerExecWithStdinCalls.push({ service, command: [...command], stdin });
+      const script = command[2] ?? "";
+      const mvMatch = script.match(/mv\s+\S+\s+(\S+)$/);
+      if (mvMatch) containerFiles[mvMatch[1]] = stdin;
+      return { stdout: "", stderr: "" };
+    },
+    dockerComposeCmd: async (args: string[]) => {
+      dockerComposeCalls.push([...args]);
+      // ps voice-bridge — return empty (service missing) so /status's compose
+      // probe doesn't crash. Tests that need a present service override
+      // later via mock.fn().
+      if (args[0] === "ps" && args[1] === "voice-bridge") return "";
+      return "";
+    },
+  },
+});
+
+// ── Twilio account probe mock ────────────────────────────────────────────
+
+let twilioAccountsOk = true;
+const originalFetch = globalThis.fetch;
+function makeJsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+globalThis.fetch = (async (input: any, _init?: any) => {
+  const url = typeof input === "string" ? input : (input.url ?? String(input));
+  const acctMatch = url.match(
+    /^https:\/\/api\.twilio\.com\/2010-04-01\/Accounts\/(AC[a-f0-9]+)\.json$/,
+  );
+  if (acctMatch) {
+    if (!twilioAccountsOk) {
+      return makeJsonResponse(
+        { code: 20003, message: "Authentication Error" },
+        401,
+      );
+    }
+    return makeJsonResponse(
+      { sid: acctMatch[1], friendly_name: "Sentinel Test", status: "active" },
+      200,
+    );
+  }
+  throw new Error(`unexpected fetch in voice-vb test: ${url}`);
+}) as typeof fetch;
+
+// ── agentProfiles mock: writability + binding default ────────────────────
+//
+// assertWritableProfile must succeed for sentinel-vb; resolveProfileForChannel
+// returns "main" as the default binding (matching the real seed). We mock
+// the whole module so tests don't need a real state.db.
+
+const realAgentProfiles = await import("../src/db/agentProfiles.js");
+let profileExists = true;
+let profileIsArchived = false;
+mock.module("../src/db/agentProfiles.js", {
+  namedExports: {
+    ...realAgentProfiles,
+    assertWritableProfile: (_db: any, slug: string) => {
+      if (!profileExists) {
+        throw new Error(`profile '${slug}' not found`);
+      }
+      if (profileIsArchived) {
+        throw new Error(`profile '${slug}' is archived`);
+      }
+      return { slug, label: slug, status: "running" };
+    },
+    resolveProfileForChannel: (_db: any, _kind: string, _id: any) => "main",
+    resolveProfileContextForChannel: (
+      _db: any,
+      _kind: string,
+      identity: any,
+    ) => ({
+      slug: "main",
+      bound_slug: "main",
+      cascaded: false,
+      api_server_port: 18789,
+      api_server_key: null,
+      profile_dir: "/hermes-state/profiles/main",
+      journal_scope_key: "main",
+    }),
+  },
+});
+
+// Audit rows land in the real state.db via appendAudit. We open it to query
+// rows after each mutation rather than mocking the import (which races
+// voice.ts's top-level import). The state.db path is the per-test tmpdir
+// (set above), so the rows are scoped to this file.
+
+const { registerVoiceRoutes } = await import("../src/api/routes/voice.js");
+const { getStateDb } = await import("../src/db/state.js");
+
+function queryAuditRows(targetPath: string): any[] {
+  try {
+    const db = getStateDb();
+    const rows = db
+      .prepare(
+        "SELECT action_type, actor, source, target_path, target_kind, subject_ref, summary, payload_json FROM audit WHERE target_path = ? ORDER BY id DESC LIMIT 50",
+      )
+      .all(targetPath) as any[];
+    return rows.map((r) => ({
+      ...r,
+      payload: r.payload_json ? JSON.parse(r.payload_json) : null,
+    }));
+  } catch {
+    return [];
+  }
+}
+const { matchRoute } = await import("../src/api/server.js");
+registerVoiceRoutes();
+
+interface CallResult {
+  status: number;
+  payload: any;
+  rawBody?: string;
+  contentType?: string;
+}
+
+async function call(
+  method: string,
+  p: string,
+  body?: unknown,
+  opts: { contentType?: string; rawBody?: string } = {},
+): Promise<CallResult> {
+  const [pathOnly, queryRaw] = p.split("?");
+  const m = matchRoute(method, pathOnly);
+  assert.ok(m, `${method} ${pathOnly} must be registered`);
+  let status = 0;
+  let payload: any;
+  let rawBody: string | undefined;
+  let contentType: string | undefined;
+  const headers: Record<string, string> = {};
+  const res: any = {
+    statusCode: 0,
+    setHeader(name: string, val: string) {
+      headers[String(name).toLowerCase()] = val;
+    },
+    writeHead(c: number, h?: Record<string, string>) {
+      status = c;
+      if (h) {
+        for (const [k, v] of Object.entries(h)) {
+          headers[k.toLowerCase()] = v;
+        }
+      }
+      contentType = headers["content-type"];
+    },
+    end(j?: string) {
+      rawBody = j;
+      try {
+        payload = j ? JSON.parse(j) : undefined;
+      } catch {
+        payload = undefined;
+      }
+    },
+  };
+  const req: any = {
+    method,
+    headers: { "content-type": opts.contentType ?? "application/json" },
+  };
+  if (opts.rawBody && opts.contentType?.includes("urlencoded")) {
+    // Simulate the request stream for the inbound route's raw-body reader.
+    const { Readable } = await import("node:stream");
+    const stream = Readable.from([Buffer.from(opts.rawBody)]);
+    Object.assign(req, {
+      on: stream.on.bind(stream),
+      pipe: stream.pipe.bind(stream),
+    });
+  }
+  try {
+    await m!.handler({
+      req,
+      res,
+      params: {},
+      body: opts.rawBody && opts.contentType?.includes("urlencoded") ? undefined : body,
+      query: new URLSearchParams(queryRaw ?? ""),
+    });
+  } catch (e: any) {
+    if (e?.statusCode) {
+      status = e.statusCode;
+      payload = { error: { code: e.code, message: e.message } };
+    } else {
+      throw e;
+    }
+  }
+  return { status: status || res.statusCode, payload, rawBody, contentType };
+}
+
+describe("/api/v1/channels/voice/* — per-profile (Lane Vb)", () => {
+  beforeEach(() => {
+    containerFiles = {};
+    dockerExecCalls.length = 0;
+    dockerExecWithStdinCalls.length = 0;
+    dockerComposeCalls.length = 0;
+    twilioAccountsOk = true;
+    // Wipe any prior audit rows so this test's assertions are scoped to
+    // its own writes. The state.db is a per-suite tmpdir file so this is
+    // a cheap rm.
+    try {
+      const db = getStateDb();
+      db.prepare("DELETE FROM audit WHERE target_path LIKE 'channels/voice/%'").run();
+    } catch {
+      /* ignore — state.db not initialised yet */
+    }
+    profileExists = true;
+    profileIsArchived = false;
+  });
+
+  it("GET /status?profile=sentinel-vb returns webhook_url + profile_slug echoed", async () => {
+    containerFiles[SENTINEL_ENV_PATH] = "# empty\n";
+    const r = await call(
+      "GET",
+      "/api/v1/channels/voice/status?profile=sentinel-vb",
+    );
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.profile_slug, "sentinel-vb");
+    assert.equal(
+      r.payload.webhook_url,
+      "https://voice.home.alfred.black/twiml/inbound?profile=sentinel-vb",
+    );
+    assert.equal(r.payload.configured, false);
+  });
+
+  it("PUT /credentials valid triple → writes per-profile .env + audit + Twilio probe", async () => {
+    const r = await call(
+      "PUT",
+      "/api/v1/channels/voice/credentials?profile=sentinel-vb",
+      {
+        account_sid: VALID_SID,
+        auth_token: VALID_TOKEN,
+        from_number: VALID_FROM,
+        openai_key: VALID_OPENAI,
+      },
+    );
+    assert.equal(r.status, 200, JSON.stringify(r.payload));
+    assert.equal(r.payload.ok, true);
+    assert.equal(r.payload.profile, "sentinel-vb");
+
+    const wrote = dockerExecWithStdinCalls.find((c) =>
+      c.command[2]?.includes(SENTINEL_ENV_PATH),
+    );
+    assert.ok(wrote, "dockerExecWithStdin should have written sentinel-vb's .env");
+    assert.equal(wrote.service, "hermes");
+    assert.match(wrote.stdin, new RegExp(`TWILIO_ACCOUNT_SID=${VALID_SID}`));
+    assert.match(wrote.stdin, new RegExp(`TWILIO_AUTH_TOKEN=${VALID_TOKEN}`));
+    assert.match(
+      wrote.stdin,
+      new RegExp(`TWILIO_VOICE_FROM_NUMBER=\\${VALID_FROM}`),
+    );
+    assert.match(wrote.stdin, /OPENAI_API_KEY=sk-test_lane_vb/);
+
+    // The .env write target is sentinel-vb's, never main's.
+    const wroteToMain = dockerExecWithStdinCalls.find((c) =>
+      c.command[2]?.includes(MAIN_ENV_PATH),
+    );
+    assert.equal(
+      wroteToMain,
+      undefined,
+      "credentials write must NOT touch main's .env",
+    );
+
+    // Audit row with profile_slug = sentinel-vb (persisted via real
+    // state.db).
+    const rows = queryAuditRows("channels/voice/credentials");
+    const setRow = rows.find((r) => r.action_type === "channel_token_set");
+    assert.ok(setRow, "expected channel_token_set audit row");
+    assert.equal(setRow.subject_ref, "sentinel-vb");
+    assert.equal(setRow.payload.profile_slug, "sentinel-vb");
+    assert.equal(setRow.payload.channel_kind, "voice");
+    assert.equal(setRow.payload.openai_key_set, true);
+  });
+
+  it("PUT /credentials rejects malformed SID → 400, no .env write, no audit", async () => {
+    const r = await call(
+      "PUT",
+      "/api/v1/channels/voice/credentials?profile=sentinel-vb",
+      {
+        account_sid: "not-a-sid",
+        auth_token: VALID_TOKEN,
+        from_number: VALID_FROM,
+      },
+    );
+    assert.equal(r.status, 400);
+    assert.equal(
+      dockerExecWithStdinCalls.length,
+      0,
+      "no .env write on validation failure",
+    );
+    const rowsAfterFail = queryAuditRows("channels/voice/credentials");
+    assert.equal(rowsAfterFail.length, 0, "no audit row on validation failure");
+  });
+
+  it("PUT /credentials rejects archived profile → 400", async () => {
+    profileIsArchived = true;
+    const r = await call(
+      "PUT",
+      "/api/v1/channels/voice/credentials?profile=sentinel-vb",
+      {
+        account_sid: VALID_SID,
+        auth_token: VALID_TOKEN,
+        from_number: VALID_FROM,
+      },
+    );
+    assert.equal(r.status, 400);
+  });
+
+  it("DELETE /credentials wipes the 4 voice .env keys + audit row", async () => {
+    containerFiles[SENTINEL_ENV_PATH] =
+      `TWILIO_ACCOUNT_SID=${VALID_SID}\n` +
+      `TWILIO_AUTH_TOKEN=${VALID_TOKEN}\n` +
+      `TWILIO_VOICE_FROM_NUMBER=${VALID_FROM}\n` +
+      `OPENAI_API_KEY=${VALID_OPENAI}\n` +
+      `OTHER_KEEP_ME=preserved\n`;
+
+    const r = await call(
+      "DELETE",
+      "/api/v1/channels/voice/credentials?profile=sentinel-vb",
+    );
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.ok, true);
+
+    const wrote = dockerExecWithStdinCalls.find((c) =>
+      c.command[2]?.includes(SENTINEL_ENV_PATH),
+    );
+    assert.ok(wrote, "dockerExecWithStdin must have rewritten sentinel's .env");
+    assert.doesNotMatch(wrote.stdin, /^TWILIO_ACCOUNT_SID=/m);
+    assert.doesNotMatch(wrote.stdin, /^TWILIO_AUTH_TOKEN=/m);
+    assert.doesNotMatch(wrote.stdin, /^TWILIO_VOICE_FROM_NUMBER=/m);
+    assert.doesNotMatch(wrote.stdin, /^OPENAI_API_KEY=/m);
+    assert.match(wrote.stdin, /OTHER_KEEP_ME=preserved/);
+
+    const rowsAfterDelete = queryAuditRows("channels/voice/credentials");
+    const clearRow = rowsAfterDelete.find(
+      (r) => r.action_type === "channel_token_cleared",
+    );
+    assert.ok(clearRow);
+    assert.equal(clearRow.subject_ref, "sentinel-vb");
+  });
+
+  it("POST /test probes Twilio with the profile's stored creds", async () => {
+    containerFiles[SENTINEL_ENV_PATH] =
+      `TWILIO_ACCOUNT_SID=${VALID_SID}\n` +
+      `TWILIO_AUTH_TOKEN=${VALID_TOKEN}\n` +
+      `TWILIO_VOICE_FROM_NUMBER=${VALID_FROM}\n`;
+
+    const r = await call(
+      "POST",
+      "/api/v1/channels/voice/test?profile=sentinel-vb",
+    );
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.ok, true);
+    assert.match(r.payload.account_sid_masked, /^AC\*+[0-9a-f]{4}$/);
+  });
+
+  it("POST /inbound?profile=sentinel-vb&format=json resolves to sentinel-vb in TwiML wss URL", async () => {
+    const r = await call(
+      "POST",
+      "/api/v1/channels/voice/inbound?profile=sentinel-vb&format=json",
+      { To: "+15552222222", From: "+15555550100", CallSid: "CAtest-vb" },
+    );
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.resolved_profile, "sentinel-vb");
+    assert.equal(r.payload.resolved_by, "query");
+    assert.match(r.payload.wss_url, /\/voice\/sentinel-vb$/);
+    assert.match(r.payload.twiml, /<Parameter name="profile" value="sentinel-vb"/);
+  });
+
+  it("POST /inbound without ?profile= falls back to main (default binding)", async () => {
+    const r = await call(
+      "POST",
+      "/api/v1/channels/voice/inbound?format=json",
+      { To: "+15551111111", From: "+15555550100", CallSid: "CAtest-vb-main" },
+    );
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.resolved_profile, "main");
+    assert.equal(r.payload.resolved_by, "to-binding");
+    assert.match(r.payload.wss_url, /\/voice\/main$/);
+  });
+
+  it("GET /internal/openai-key?profile=sentinel-vb returns the profile's key", async () => {
+    containerFiles[SENTINEL_ENV_PATH] = `OPENAI_API_KEY=${VALID_OPENAI}\n`;
+    const r = await call(
+      "GET",
+      "/api/v1/channels/voice/internal/openai-key?profile=sentinel-vb",
+    );
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.profile, "sentinel-vb");
+    assert.equal(r.payload.openai_api_key, VALID_OPENAI);
+  });
+
+  it("GET /internal/openai-key for sentinel-vb without per-profile key returns null (no main fallback)", async () => {
+    containerFiles[SENTINEL_ENV_PATH] = "# no openai\n";
+    const r = await call(
+      "GET",
+      "/api/v1/channels/voice/internal/openai-key?profile=sentinel-vb",
+    );
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.openai_api_key, null);
+  });
+});
+
+process.on("exit", () => {
+  globalThis.fetch = originalFetch;
+});

--- a/packages/ctrl/tests/voice-routes.test.ts
+++ b/packages/ctrl/tests/voice-routes.test.ts
@@ -314,8 +314,15 @@ describe("GET /api/v1/channels/voice/status", () => {
 
   it("reports state=error with a non-null error string when the service is unhealthy", async () => {
     fake.composeService = "unhealthy";
-    fake.envText = "TWILIO_PHONE_NUMBER=+15550100\n";
-    // PR #42: OPENAI_API_KEY required for state="error" too (otherwise the
+    // #120 Lane Vb: voice is now per-profile and `configured=true` requires
+    // SID + TOKEN + phone, mirroring the SMS card. The test seeds all three
+    // so the resolution falls through to the health probe (which the test
+    // controls via `fake.composeService`).
+    fake.envText =
+      "TWILIO_ACCOUNT_SID=AC00000000000000000000000000000000\n" +
+      "TWILIO_AUTH_TOKEN=00000000000000000000000000000000\n" +
+      "TWILIO_PHONE_NUMBER=+15550100\n";
+    // OPENAI_API_KEY required for state="error" too (otherwise the
     // openai-key-missing path swallows it as state="unconfigured").
     fake.composeEnvText = "OPENAI_API_KEY=sk-test-dummy\n";
     fake.logsTail =

--- a/packages/voice-bridge/src/openai-realtime.ts
+++ b/packages/voice-bridge/src/openai-realtime.ts
@@ -96,8 +96,15 @@ export class OpenAIRealtimeClient {
   // response` error we hit on Sir's 2026-05-27 home call.
   private activeResponseId: string | null = null;
 
-  constructor(callId: string) {
+  // #120 Lane Vb — optional per-profile OpenAI key override. Threaded in
+  // from voice-call.ts so per-profile credentials route the Realtime
+  // session to the right account. Null/undefined keeps the boot-time
+  // `config.openaiApiKey` behaviour.
+  private apiKeyOverride: string | null;
+
+  constructor(callId: string, opts: { apiKeyOverride?: string | null } = {}) {
     this.callId = callId;
+    this.apiKeyOverride = opts.apiKeyOverride ?? null;
   }
 
   get isOpen(): boolean {
@@ -126,9 +133,10 @@ export class OpenAIRealtimeClient {
       // GA endpoint does NOT want the `OpenAI-Beta: realtime=v1` header — it
       // silently flips the session into a compat mode that rejects GA-shape
       // session.update payloads.
+      const apiKey = this.apiKeyOverride || config.openaiApiKey;
       const ws = new WsSocket(url, {
         headers: {
-          Authorization: `Bearer ${config.openaiApiKey}`,
+          Authorization: `Bearer ${apiKey}`,
         },
       });
       this.ws = ws;

--- a/packages/voice-bridge/src/tenant.ts
+++ b/packages/voice-bridge/src/tenant.ts
@@ -56,6 +56,16 @@ export interface TenantContext {
   tailscaleHost: string;
   aasApiKey: string;
   phoneNumber: string | null;
+  /** #120 Lane Vb — resolved profile slug for this call. The TwiML responder
+   *  passes the profile through in the WSS path; voice-call.ts surfaces it
+   *  here so downstream code (instruction builder, MCP allowlist, transcript
+   *  ingest) knows which profile to scope to. */
+  profileSlug?: string;
+  /** #120 Lane Vb — per-profile OPENAI_API_KEY override. When set, this
+   *  takes precedence over the boot-time OPENAI_API_KEY in voice-bridge's
+   *  env. When null/undefined we fall back to the boot-time key (main's
+   *  instance-shared key, the pre-Vb behaviour). */
+  openaiApiKey?: string | null;
 }
 
 export interface VoiceContextBundle {
@@ -79,6 +89,32 @@ export interface VoiceContextBundle {
   generatedAt: string;
 }
 
+/**
+ * #120 Lane Vb — fetch the per-profile OPENAI_API_KEY from ctrl-api's
+ * scoped internal endpoint. The voice-bridge bearer is the only caller
+ * that can read this surface (auth.ts allowlist). Returns null on any
+ * failure or when the profile has no key of its own — the caller falls
+ * back to the boot-time `config.openaiApiKey`.
+ */
+async function _fetchProfileOpenaiKey(
+  slug: string,
+): Promise<string | null> {
+  try {
+    const url = `${config.saasInternalUrl}/api/v1/channels/voice/internal/openai-key?profile=${encodeURIComponent(slug)}`;
+    const r = await fetch(url, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${config.internalToken}` },
+      signal: AbortSignal.timeout(2_000),
+    });
+    if (!r.ok) return null;
+    const body = (await r.json()) as { openai_api_key?: string | null };
+    const key = typeof body.openai_api_key === "string" ? body.openai_api_key.trim() : "";
+    return key || null;
+  } catch {
+    return null;
+  }
+}
+
 export async function fetchTenantContext(
   tenantId: string,
 ): Promise<TenantContext> {
@@ -89,11 +125,49 @@ export async function fetchTenantContext(
   // hold the ctrl-api master key on the monorepo build — ctrlApiAuthToken()
   // routes through internalToken instead (see auth.ts allowlist).
   if (singleVmMode()) {
-    return {
+    // #120 Lane Vb — the tenantId is the resolved profile slug coming out
+    // of the TwiML responder. For the pre-Vb "owner" default we treat it
+    // as main and leave profileSlug undefined (back-compat); for an
+    // explicit slug we fetch the per-profile voice config from ctrl-api
+    // so the OpenAI key + phone number can override the boot-time defaults.
+    const ctx: TenantContext = {
       tailscaleHost: "local",
       aasApiKey: "",
       phoneNumber: config.ownerPhoneNumber || null,
     };
+    if (tenantId && tenantId !== "owner") {
+      // Best-effort. Failures fall back to the instance-shared config
+      // so a momentary ctrl-api hiccup doesn't drop the call.
+      try {
+        const url = `${config.saasInternalUrl}/api/v1/channels/voice/status?profile=${encodeURIComponent(tenantId)}`;
+        const r = await fetch(url, {
+          method: "GET",
+          headers: { Authorization: `Bearer ${config.internalToken}` },
+          signal: AbortSignal.timeout(2_500),
+        });
+        if (r.ok) {
+          const body = (await r.json()) as {
+            calling_number?: string | null;
+            openai_key_set?: boolean;
+            profile_slug?: string;
+          };
+          ctx.profileSlug = body.profile_slug ?? tenantId;
+          if (body.calling_number) ctx.phoneNumber = body.calling_number;
+          // The status route does NOT return the OpenAI key value (that
+          // would be a leak). voice-bridge's adapter reads the key out of
+          // the per-profile .env directly via the internal helper below.
+          ctx.openaiApiKey = body.openai_key_set
+            ? await _fetchProfileOpenaiKey(tenantId)
+            : null;
+        }
+      } catch {
+        // logged loudly so a regression doesn't go unnoticed
+        console.warn(
+          `[tenant] per-profile voice config lookup failed for slug=${tenantId} — falling back to main`,
+        );
+      }
+    }
+    return ctx;
   }
 
   const url = `${config.saasInternalUrl}/api/internal/voice-bridge/tenant/${encodeURIComponent(tenantId)}`;

--- a/packages/voice-bridge/src/twiml.ts
+++ b/packages/voice-bridge/src/twiml.ts
@@ -57,12 +57,32 @@ import { config } from "./config.js";
 export const TWIML_INBOUND_PATH = "/twiml/inbound";
 
 /**
- * Tenant id used on this VM. alfred-black is single-VM, so the WSS path
- * `/voice/<id>` doesn't actually scope multi-tenancy — but it still has to
- * be a non-empty segment. Use the canonical principal slug for symmetry
+ * Default tenant id used on this VM. alfred-black is single-VM, so the WSS
+ * path `/voice/<id>` doesn't actually scope multi-tenancy — but it still has
+ * to be a non-empty segment. Use the canonical principal slug for symmetry
  * with the alfred_journal binding ("owner").
+ *
+ * #120 Lane Vb — when the inbound webhook URL carries `?profile=<slug>`,
+ * we route to `/voice/<slug>` instead so the WSS handler can resolve the
+ * profile context (per-profile OPENAI key + Twilio creds + persona) at
+ * session-open time. The "owner" default applies only to the pre-Vb wire
+ * shape where no profile hint is present.
  */
-const TENANT_ID = "owner";
+const DEFAULT_TENANT_ID = "owner";
+
+/**
+ * Validate a slug pulled out of the inbound URL. Mirrors the server-side
+ * regex in ctrl-api's agentProfiles.validateSlug — refuse anything that
+ * doesn't look like a kebab-case lowercase slug so the WSS path segment
+ * remains a safe identifier (no path traversal, no special chars).
+ */
+const _SLUG_RE = /^[a-z][a-z0-9-]{1,30}$/;
+function safeSlug(s: string | null | undefined): string | null {
+  if (!s) return null;
+  const t = s.trim();
+  if (!t) return null;
+  return _SLUG_RE.test(t) ? t : null;
+}
 
 interface TwilioCallParams {
   From: string;
@@ -278,14 +298,27 @@ export async function handleTwimlInbound(
     return;
   }
 
+  // #120 Lane Vb — per-profile routing. The principal configures the
+  // Twilio webhook URL as
+  //   https://voice.<domain>/twiml/inbound?profile=<slug>
+  // so the slug arrives in the URL query (parsed off req.url). When
+  // absent we fall back to the "owner" tenant id, which the WSS handler
+  // resolves to the `main` profile via the channel_profile_binding
+  // default. The sig is HMAC over whatever slug we routed to — so a
+  // profile rebinding in ctrl-api cannot mint a valid sig for the wrong
+  // routing key.
+  const reqUrl = new URL(req.url ?? "/", "http://localhost");
+  const profileFromQuery = safeSlug(reqUrl.searchParams.get("profile"));
+  const tenantId = profileFromQuery ?? DEFAULT_TENANT_ID;
+
   // Build the wss URL. Twilio strips query strings from <Stream url=...>,
   // so the sig must travel inside <Parameter>, not the URL.
   const host =
     (req.headers["x-forwarded-host"] as string | undefined) ||
     (req.headers.host as string | undefined) ||
     "voice.example";
-  const wssUrl = `wss://${host}/voice/${TENANT_ID}`;
-  const sig = generateSig(TENANT_ID);
+  const wssUrl = `wss://${host}/voice/${tenantId}`;
+  const sig = generateSig(tenantId);
   const twiml = renderTwiml({
     wssUrl,
     sig,
@@ -294,7 +327,7 @@ export async function handleTwimlInbound(
   });
 
   console.log(
-    `[twiml] inbound call from=${callParams.From} to=${callParams.To} sid=${callParams.CallSid} → ${wssUrl}`,
+    `[twiml] inbound call from=${callParams.From} to=${callParams.To} sid=${callParams.CallSid} profile=${tenantId} → ${wssUrl}`,
   );
 
   res.writeHead(200, { "Content-Type": "application/xml; charset=utf-8" });

--- a/packages/voice-bridge/src/voice-call.ts
+++ b/packages/voice-bridge/src/voice-call.ts
@@ -126,7 +126,12 @@ export class VoiceCall {
     this.voiceCtx = await fetchVoiceContext(this.tenantCtx);
 
     // Open OpenAI Realtime and wire its events.
-    this.realtime = new OpenAIRealtimeClient(this.callId);
+    // #120 Lane Vb — thread the per-profile OPENAI_API_KEY (if any) into
+    // the client so the Realtime session bills against the resolved
+    // profile's OpenAI account, not the boot-time instance default.
+    this.realtime = new OpenAIRealtimeClient(this.callId, {
+      apiKeyOverride: this.tenantCtx.openaiApiKey ?? null,
+    });
     this.realtime.on((event) => this.onRealtimeEvent(event));
     const voiceMcpTools = getVoiceMcpToolDefs();
     const totalTools = ALL_TOOLS.length + FILES_TOOLS.length + voiceMcpTools.length;

--- a/packages/web/main.wasp
+++ b/packages/web/main.wasp
@@ -1296,6 +1296,20 @@ action sendProfileEmailTest {
   entities: []
 }
 
+// #120 Lane Vb — explicit voice-credentials wrappers. Delegate to
+// setProfileChannelToken / clearProfileChannelToken under the hood; named
+// here so call sites that only handle voice don't have to remember the
+// channel-kind string.
+action setProfileVoiceCredentials {
+  fn: import { setProfileVoiceCredentials } from "@src/dashboard/operations",
+  entities: []
+}
+
+action clearProfileVoiceCredentials {
+  fn: import { clearProfileVoiceCredentials } from "@src/dashboard/operations",
+  entities: []
+}
+
 query getAgentConfig {
   fn: import { getAgentConfig } from "@src/dashboard/operations",
   entities: []

--- a/packages/web/src/dashboard/ProfileChannelsPage.tsx
+++ b/packages/web/src/dashboard/ProfileChannelsPage.tsx
@@ -5,12 +5,15 @@
 // profile slug, side-by-side with a clear back-link to the main /channels
 // page.
 //
-// What this page CAN configure per profile (Lane IV + Lane V + Lane Vb2 on ctrl-api):
+// What this page CAN configure per profile (Lane IV + Lane V + Lane Vb + Lane Vb2 on ctrl-api):
 //
 //   * Telegram   — token (PUT), status (GET), revoke chat
 //   * Slack      — bot/app tokens (PUT), status (GET)
 //   * SMS        — Twilio creds (PUT), status (GET)
 //   * Paperclip  — API key (POST), status (GET)
+//   * Voice      — Twilio voice creds + (optional) OpenAI key per profile
+//                  (#120 Lane Vb). voice-bridge resolves the profile on every
+//                  inbound call via ?profile=<slug> in the Twilio webhook URL.
 //   * Email      — Lane Vb2; provision (POST), status (GET), disconnect
 //                  (DELETE), send-test (POST). AgentMail's API is called
 //                  on the tenant: a fresh inbox is minted per profile + a
@@ -18,10 +21,6 @@
 //                  so inbound mail routes to the right profile.
 //
 // What this page CANNOT configure per profile and why (honest partial):
-//
-//   * Voice (voice-bridge sibling) — one Twilio number + one OPENAI key per
-//     VM. Voice-bridge isn't a Hermes profile; it's a separate compose
-//     service. Configure on /channels.
 //   * OMI — one device, one Groq key consumed by alfred-learn (not Hermes).
 //     The Vault item is global. Configure on /channels.
 //   * Home Assistant — one household, one HA URL + LLAT. Single-instance
@@ -66,6 +65,10 @@ import {
   derivePaperclipCardState,
   type PaperclipStatus,
 } from "./paperclipCardCore";
+import {
+  deriveVoiceCardState,
+  type VoiceStatus,
+} from "./voiceCardCore";
 
 interface ProfileRow {
   slug: string;
@@ -80,7 +83,7 @@ interface ProfileRow {
 }
 
 interface ChannelStatusEntry<TStatus = unknown> {
-  kind: "telegram" | "slack" | "sms" | "paperclip";
+  kind: "telegram" | "slack" | "sms" | "paperclip" | "voice";
   ok: boolean;
   status: TStatus | null;
   error?: string;
@@ -890,14 +893,241 @@ function ProfileEmailSection({ slug }: { slug: string }) {
           </p>
         )}
       </div>
+    </ChannelCard>
+  );
+}
+
+// --------------------------------------------------------------------------
+// VoiceSection — #120 Lane Vb. Per-profile Twilio + (optional) OpenAI creds.
+//
+// Each profile owns its own Twilio number; the webhook URL the principal
+// pastes into the Twilio Console is profile-specific, surfaced here with a
+// copy button. OpenAI key is optional — when blank, voice-bridge falls back
+// to main's instance-shared key.
+// --------------------------------------------------------------------------
+function ProfileVoiceSection({
+  slug,
+  entry,
+  refetch,
+}: {
+  slug: string;
+  entry: ChannelStatusEntry<VoiceStatus> | null;
+  refetch: () => void;
+}) {
+  const status = entry?.ok ? (entry.status as VoiceStatus | null) : null;
+  const card = deriveVoiceCardState({ status });
+  const [sid, setSid] = useState("");
+  const [authToken, setAuthToken] = useState("");
+  const [from, setFrom] = useState("");
+  const [openaiKey, setOpenaiKey] = useState("");
+  const [show, setShow] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [lastResp, setLastResp] = useState<any>(null);
+  const [copyOk, setCopyOk] = useState(false);
+
+  // Surface the per-profile webhook URL directly off the status payload (set
+  // by ctrl-api). When DOMAIN isn't set yet the field is null and we hide
+  // the row rather than emit a half-baked URL.
+  const webhookUrl = (status as any)?.webhook_url ?? null;
+
+  const validRequired =
+    /^AC[a-f0-9]{32}$/.test(sid.trim()) &&
+    /^[a-f0-9]{32}$/.test(authToken.trim()) &&
+    /^\+[1-9]\d{1,14}$/.test(from.trim());
+  const validOptional =
+    !openaiKey.trim() || /^sk-[A-Za-z0-9_-]{20,}$/.test(openaiKey.trim());
+  const valid = validRequired && validOptional;
+
+  async function save() {
+    if (!valid || busy) return;
+    setBusy(true);
+    setErr(null);
+    try {
+      const payload: Record<string, string> = {
+        account_sid: sid.trim(),
+        auth_token: authToken.trim(),
+        from_number: from.trim(),
+      };
+      if (openaiKey.trim()) payload.openai_key = openaiKey.trim();
+      const resp = await setProfileChannelToken({
+        slug,
+        channel_kind: "voice",
+        payload,
+      });
+      setLastResp(resp);
+      setSid("");
+      setAuthToken("");
+      setFrom("");
+      setOpenaiKey("");
+      refetch();
+    } catch (e: any) {
+      setErr(e?.message ?? "Couldn't save the credentials.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function disconnect() {
+    if (busy) return;
+    setBusy(true);
+    setErr(null);
+    try {
+      const resp = await clearProfileChannelToken({
+        slug,
+        channel_kind: "voice",
+      });
+      setLastResp(resp);
+      refetch();
+    } catch (e: any) {
+      setErr(e?.message ?? "Couldn't disconnect.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function copyWebhook() {
+    if (!webhookUrl) return;
+    try {
+      await navigator.clipboard.writeText(webhookUrl);
+      setCopyOk(true);
+      setTimeout(() => setCopyOk(false), 1500);
+    } catch {
+      /* clipboard denied — user can select-and-copy manually */
+    }
+  }
+
+  const address =
+    card.state === "configured_running"
+      ? card.callingNumber ?? card.heading
+      : card.state === "configured_starting"
+        ? "Restarting…"
+        : card.state === "error"
+          ? "Voice bridge needs attention"
+          : "Not yet configured";
+
+  return (
+    <ChannelCard
+      name="Voice"
+      address={address}
+      note={`Twilio number + OpenAI key scoped to '${slug}'.`}
+      status={card.pill}
+    >
+      {webhookUrl && (
+        <div className="mt-4 space-y-1">
+          <div
+            className="font-mono text-[10px] uppercase tracking-[0.22em]"
+            style={{ color: "var(--marginalia)" }}
+          >
+            Twilio webhook · paste this into the number's "A call comes in"
+          </div>
+          <div className="flex gap-2 items-center">
+            <code
+              className="flex-1 font-mono text-[11px] px-2 py-1 border border-rule overflow-x-auto"
+              style={{ color: "var(--marginalia)" }}
+            >
+              {webhookUrl}
+            </code>
+            <button onClick={copyWebhook} className="btn-link">
+              {copyOk ? "Copied!" : "Copy"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {card.state === "unconfigured" && (
+        <div className="mt-5 space-y-3">
+          <div
+            className="font-mono text-[10px] uppercase tracking-[0.22em]"
+            style={{ color: "var(--marginalia)" }}
+          >
+            Twilio · for {slug}
+          </div>
+          <input
+            type={show ? "text" : "password"}
+            value={sid}
+            onChange={(e) => setSid(e.target.value)}
+            placeholder="Account SID (AC…)"
+            className="w-full bg-transparent border border-rule px-2 py-1 font-mono text-[12px]"
+          />
+          <input
+            type={show ? "text" : "password"}
+            value={authToken}
+            onChange={(e) => setAuthToken(e.target.value)}
+            placeholder="Auth token (32 hex)"
+            className="w-full bg-transparent border border-rule px-2 py-1 font-mono text-[12px]"
+          />
+          <input
+            type="text"
+            value={from}
+            onChange={(e) => setFrom(e.target.value)}
+            placeholder="+15551234567 (this profile's voice number)"
+            className="w-full bg-transparent border border-rule px-2 py-1 font-mono text-[12px]"
+          />
+          <div
+            className="font-mono text-[10px] uppercase tracking-[0.22em] pt-2"
+            style={{ color: "var(--marginalia)" }}
+          >
+            OpenAI key · optional · falls back to main's if blank
+          </div>
+          <input
+            type={show ? "text" : "password"}
+            value={openaiKey}
+            onChange={(e) => setOpenaiKey(e.target.value)}
+            placeholder="sk-… (optional)"
+            className="w-full bg-transparent border border-rule px-2 py-1 font-mono text-[12px]"
+          />
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => setShow((s) => !s)}
+              className="btn-link"
+            >
+              {show ? "Hide" : "Show"}
+            </button>
+            <button
+              onClick={save}
+              disabled={busy || !valid}
+              className="btn-ghost"
+            >
+              {busy ? "…" : "Save"}
+            </button>
+          </div>
+          {err && (
+            <p
+              className="font-body italic text-[13px]"
+              style={{ color: "var(--brass)" }}
+            >
+              {err}
+            </p>
+          )}
+        </div>
+      )}
+      {(card.state === "configured_running" ||
+        card.state === "configured_starting" ||
+        card.state === "error") && (
+        <div className="mt-5 space-y-2">
+          <button onClick={disconnect} disabled={busy} className="btn-ghost">
+            {busy ? "…" : "Disconnect"}
+          </button>
+          {err && (
+            <p
+              className="font-body italic text-[13px]"
+              style={{ color: "var(--brass)" }}
+            >
+              {err}
+            </p>
+          )}
+        </div>
+      )}
       <RestartScopeWarning scope={lastResp?.restart_scope} warning={lastResp?.restart_warning} />
     </ChannelCard>
   );
 }
 
 // --------------------------------------------------------------------------
-// InstanceLevelNotice. For voice / OMI / HA / Recall / Tailscale /
-// Terminal we render a small read-only card pointing at /channels.
+// InstanceLevelNotice. For OMI / HA / Recall / Tailscale / Terminal we
+// render a small read-only card pointing at /channels.
 // --------------------------------------------------------------------------
 function InstanceLevelNotice({
   name,
@@ -1076,12 +1306,9 @@ export default function ProfileChannelsPage() {
           <ProfileSmsSection slug={slug} entry={entryFor<SmsStatus>("sms")} refetch={refetch} />
           <ProfilePaperclipSection slug={slug} entry={entryFor<PaperclipStatus>("paperclip")} refetch={refetch} />
           <ProfileEmailSection slug={slug} />
+          <ProfileVoiceSection slug={slug} entry={entryFor<VoiceStatus>("voice")} refetch={refetch} />
 
           {/* Honest partials — these channels are instance-level by design. */}
-          <InstanceLevelNotice
-            name="Voice"
-            reason="Voice-bridge is a single compose sibling. One Twilio number + one OPENAI key per VM."
-          />
           <InstanceLevelNotice
             name="Home Assistant"
             reason="One household, one HA URL + LLAT. Configure once."

--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -3616,14 +3616,19 @@ export const unbindChannelFromProfile = async (
 //   * paperclip — api-key (POST), status (GET — main-only, see note)
 //
 // Channels intentionally NOT per-profile in this lane (instance-level):
-//   * voice / omi / ha / recall / tailscale / terminal / email
+//   * omi / ha / recall / tailscale / terminal
 //   The honest reasons are documented inline on /profiles/:slug/channels.
+// (voice → per-profile in Lane Vb; email → per-profile in Lane Vb2.)
 
 const PROFILE_AWARE_CHANNEL_KINDS = [
   "telegram",
   "slack",
   "sms",
   "paperclip",
+  // #120 Lane Vb — voice is now per-profile (see channels/voice/credentials).
+  // Each profile owns its own Twilio number + creds; voice-bridge routes the
+  // inbound call to the resolved profile's persona + OPENAI key.
+  "voice",
 ] as const;
 type ProfileAwareChannelKind = (typeof PROFILE_AWARE_CHANNEL_KINDS)[number];
 
@@ -3662,6 +3667,7 @@ const _CHANNEL_TOKEN_ROUTE: Record<
   slack: { method: "PUT", path: "/api/v1/channels/slack/tokens" },
   sms: { method: "PUT", path: "/api/v1/channels/sms/credentials" },
   paperclip: { method: "POST", path: "/api/v1/channels/paperclip/api-key" },
+  voice: { method: "PUT", path: "/api/v1/channels/voice/credentials" },
 };
 
 const _CHANNEL_CLEAR_ROUTE: Record<
@@ -3675,6 +3681,7 @@ const _CHANNEL_CLEAR_ROUTE: Record<
   // now (the operator can paste a different key over the top). Returns
   // { ok: true, noop: true } to keep the UI's branchless call shape.
   paperclip: null,
+  voice: { method: "DELETE", path: "/api/v1/channels/voice/credentials" },
 };
 
 const _CHANNEL_STATUS_ROUTE: Record<ProfileAwareChannelKind, string> = {
@@ -3682,6 +3689,7 @@ const _CHANNEL_STATUS_ROUTE: Record<ProfileAwareChannelKind, string> = {
   slack: "/api/v1/channels/slack/status",
   sms: "/api/v1/channels/sms/status",
   paperclip: "/api/v1/channels/paperclip/status",
+  voice: "/api/v1/channels/voice/status",
 };
 
 /**
@@ -3879,6 +3887,80 @@ export const sendProfileEmailTest = async (
     body,
   });
 };
+
+// ── #120 Lane Vb — explicit voice-credentials wrappers ──────────────────
+//
+// The generic setProfileChannelToken/clearProfileChannelToken ops above
+// already cover voice (kind="voice" maps to /api/v1/channels/voice/
+// credentials in the route tables). These two explicit wrappers exist so
+// that (a) Sir's spec mention of `setProfileVoiceCredentials` / `clear
+// ProfileVoiceCredentials` lands as named ops in main.wasp, and (b) call
+// sites that only need voice don't need to remember the channel-kind
+// string. Both delegate to the generic op so there's a single ctrl-api
+// route in play.
+//
+// `Promise<any>` annotation is load-bearing — see the Wasp Promise<T>
+// trap note above.
+
+export const setProfileVoiceCredentials = async (
+  args: {
+    slug: string;
+    twilio_sid: string;
+    twilio_auth_token: string;
+    twilio_from_number: string;
+    openai_key?: string;
+  },
+  context: any,
+): Promise<any> => {
+  if (!context.user) throw new HttpError(401, "Not authenticated");
+  const slug = _validateSlugArg(args?.slug);
+  const sid = typeof args?.twilio_sid === "string" ? args.twilio_sid.trim() : "";
+  const token =
+    typeof args?.twilio_auth_token === "string" ? args.twilio_auth_token.trim() : "";
+  const from =
+    typeof args?.twilio_from_number === "string"
+      ? args.twilio_from_number.trim()
+      : "";
+  if (!/^AC[a-f0-9]{32}$/.test(sid)) {
+    throw new HttpError(400, "twilio_sid must be a Twilio Account SID");
+  }
+  if (!/^[a-f0-9]{32}$/.test(token)) {
+    throw new HttpError(400, "twilio_auth_token must be 32 lowercase hex chars");
+  }
+  if (!/^\+[1-9]\d{1,14}$/.test(from)) {
+    throw new HttpError(400, "twilio_from_number must be E.164");
+  }
+  const payload: Record<string, string> = {
+    account_sid: sid,
+    auth_token: token,
+    from_number: from,
+  };
+  if (typeof args?.openai_key === "string" && args.openai_key.trim()) {
+    payload.openai_key = args.openai_key.trim();
+  }
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    method: "PUT",
+    path: "/api/v1/channels/voice/credentials",
+    query: { profile: slug },
+    body: payload,
+  });
+};
+
+export const clearProfileVoiceCredentials = async (
+  args: { slug: string },
+  context: any,
+): Promise<any> => {
+  if (!context.user) throw new HttpError(401, "Not authenticated");
+  const slug = _validateSlugArg(args?.slug);
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    method: "DELETE",
+    path: "/api/v1/channels/voice/credentials",
+    query: { profile: slug },
+  });
+};
+
 
 // ── decision_ref minter ──────────────────────────────────────────────────
 //

--- a/packages/web/src/dashboard/voiceCardCore.ts
+++ b/packages/web/src/dashboard/voiceCardCore.ts
@@ -37,12 +37,23 @@ export interface VoiceStatus {
   calling_number: string | null;
   /** True when the voice-bridge compose service is present on this VM. */
   compose_service_exists: boolean;
-  /** True when OPENAI_API_KEY is set in the compose .env. */
+  /** True when OPENAI_API_KEY is set in the profile's .env (#120 Lane Vb). */
   openai_key_set: boolean;
+  /** True when OPENAI_API_KEY is set in the compose-level .env. Main-only. */
+  openai_key_set_compose?: boolean;
+  /** Masked Twilio Account SID — "AC********…<last4>". Null when unset. */
+  account_sid_masked?: string | null;
   /** Comma-separated E.164 numbers permitted to call the bridge. "" if unset. */
   allowed_callers: string;
   /** True when any caller is allowed (default-open policy, no env vars set). */
   allow_all: boolean;
+  /** The "A call comes in" webhook URL for THIS profile. Sir pastes this
+   *  into the profile's Twilio number in the Twilio Console. Null when
+   *  DOMAIN isn't set (single-VM bring-up). #120 Lane Vb. */
+  webhook_url?: string | null;
+  /** Resolved profile slug. Echoes the ?profile=<slug> query the route
+   *  was called with, or the default binding for voice. #120 Lane Vb. */
+  profile_slug?: string;
 }
 
 export interface VoiceCardState {
@@ -146,6 +157,14 @@ export function deriveVoiceCardState(args: {
         };
       }
       // Configured + deployed, missing OpenAI key — the inline-input case.
+      // #120 Lane Vb: per-profile contexts inherit main's compose-level
+      // OPENAI key when their own is blank. `openai_key_set_compose=true`
+      // means "main has the instance key" — non-main profiles without their
+      // own key fall back to that, so they're NOT in the needsOpenaiKey
+      // state; they're just configured-running.
+      const hasOpenaiFallback =
+        status.openai_key_set === true ||
+        status.openai_key_set_compose === true;
       return {
         state: "unconfigured",
         heading: "Add your OpenAI key",
@@ -156,7 +175,7 @@ export function deriveVoiceCardState(args: {
         callingNumber: formatPhoneNumber(status.calling_number) || null,
         pill: "available",
         needsSmsFirst: false,
-        needsOpenaiKey: !status.openai_key_set,
+        needsOpenaiKey: !hasOpenaiFallback,
       };
   }
 }


### PR DESCRIPTION
Sir's spec: *"voice MUST be per profile. it isn't realistic that I would interact with multiple profiles and want them in separate channels."*

Lane V's earlier punt — *"voice-bridge is a single compose sibling per VM, not a Hermes profile"* — was a punt, not a constraint. The container stays singular but its routing becomes multi-tenant.

## What lands

**Per-profile routing flow:**

1. **Twilio webhook URL is per-profile.** Sir configures his profile's Twilio number for `https://voice.<domain>/twiml/inbound?profile=<slug>`.
2. **voice-bridge** parses the slug at TwiML-emission time, emits a WSS URL pointing at `/voice/<slug>` with the HMAC sig over the slug.
3. **WSS handler** routes the tenantId (= slug) through `fetchTenantContext`, which queries ctrl-api's per-profile voice status + the scoped-bearer `/internal/openai-key` endpoint to learn the calling number + OpenAI key for THIS profile.
4. **OpenAIRealtimeClient** now accepts `apiKeyOverride` so the Realtime session bills against the resolved profile's account.

**Per-profile credentials in `/hermes-state/profiles/<slug>/.env`:**

- `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_VOICE_FROM_NUMBER`
- `OPENAI_API_KEY` (optional; falls back to main's compose-level key when blank)
- `VOICE_ALLOWED_CALLERS` / `VOICE_ALLOW_ALL_CALLERS`

## ctrl-api routes (all accept `?profile=<slug>`)

| Method | Path |
|---|---|
| GET | `/api/v1/channels/voice/resolve` |
| GET | `/api/v1/channels/voice/status` |
| PUT | `/api/v1/channels/voice/credentials` |
| DELETE | `/api/v1/channels/voice/credentials` |
| POST | `/api/v1/channels/voice/test` |
| PUT | `/api/v1/channels/voice/allowlist` |
| POST | `/api/v1/channels/voice/inbound` |
| GET | `/api/v1/channels/voice/internal/openai-key` (voice-bridge bearer only) |

All mutations: `assertWritableProfile` (no archived/reserved profiles), audit row with `profile_slug` in payload, `restart_scope: "per-profile"` (no Hermes restart needed — voice-bridge reads per inbound call).

## Why no Hermes restart

voice-bridge does NOT bake Twilio creds into env. Instead it fetches them via ctrl-api on every inbound call (`fetchTenantContext` → `/api/v1/channels/voice/status?profile=<slug>`). A credential rotation lands on the next call, no container bounce. The `restart_scope: "per-profile"` shape on the response is honest about that.

## Voice-bridge changes (minimal surgery)

- `twiml.ts` — parses `?profile=<slug>` off `req.url`, emits WSS URL with the slug as the routing key, sig is HMAC over the slug.
- `tenant.ts` — `fetchTenantContext` for non-default tenantIds calls ctrl-api for the per-profile calling number + OpenAI key; falls back to instance-shared config on failure.
- `openai-realtime.ts` — `OpenAIRealtimeClient` accepts `apiKeyOverride`.
- `voice-call.ts` — threads the per-profile OpenAI key into the Realtime client.

## Web (Wasp)

- `ProfileChannelsPage` Voice card is now a real configuration form (mirrors SMS): Twilio SID/token/from-number + optional OpenAI key + copy-button for the per-profile webhook URL.
- Two new Wasp ops: `setProfileVoiceCredentials`, `clearProfileVoiceCredentials` (delegate to the generic Lane V `setProfileChannelToken` consolidator).
- `voiceCardCore.ts` — `VoiceStatus` extended with `webhook_url` + `profile_slug` + `openai_key_set_compose`; `deriveVoiceCardState` honours the compose-level OPENAI fallback for non-main profiles.
- `operations.ts` — `"voice"` added to `PROFILE_AWARE_CHANNEL_KINDS` so `getProfileChannelStatuses` fetches it alongside telegram/slack/sms/paperclip in one round-trip.

## Tests

10 new ctrl-api tests in `tests/voice-routes-lane-vb.test.ts`:

- GET `/status?profile=` surfaces `webhook_url` + `profile_slug`
- PUT `/credentials` writes per-profile `.env` + audit row with `profile_slug`, never touches main's `.env`
- PUT `/credentials` malformed SID → 400 no side effects
- PUT `/credentials` archived profile → 400
- DELETE `/credentials` wipes the 4 keys, preserves unrelated keys
- POST `/test` probes Twilio with the profile's stored creds
- POST `/inbound?profile=` resolves to the profile's WSS URL
- POST `/inbound` without `?profile=` falls back to main (default binding)
- GET `/internal/openai-key` returns the profile's key
- non-main profile without per-profile key → null (no main fallback)

Existing `voice-routes.test.ts` (Lane I `/status`) updated to set all three Twilio keys so the `configured=true` gate (Lane Vb requires sid+token+phone) is satisfied.

**All 104 relevant ctrl-api tests pass** (voice + voice-vb + sms + telegram + slack + agent-profiles-{lane-v,base} + auth scoped voice-bridge + auth).

## Operator step (Sir's task — can't be automated)

For each profile with a Twilio number, in the Twilio Console set the number's *"A call comes in"* webhook to that profile's URL surfaced on its `/profiles/:slug/channels` Voice card (copy-button included). That's the routing key — voice-bridge reads it off the URL query. A real-call smoke is gated on this step.

References #120; closes the Lane V voice honest-partial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)