### PR TITLE
fix(ctrl): #120 Lane Vb follow-up — public /channels/voice/inbound + skip_validate flag

### DIFF
--- a/packages/ctrl/src/api/routes/voice.ts
+++ b/packages/ctrl/src/api/routes/voice.ts
@@ -661,15 +661,21 @@ export function registerVoiceRoutes(): void {
         );
       }
 
-      // OPTIONAL Twilio probe — confirm the creds are valid before writing.
-      // Anything other than 200 = 400 from us.
-      const probe = await probeTwilioAccount(sid, token);
-      if (!probe.ok) {
-        sendJson(res, 400, {
-          ok: false,
-          error: probe.error ?? "Twilio rejected the credentials",
-        });
-        return;
+      // Twilio probe — confirm the creds are valid before writing. Skip
+      // when ?skip_validate=true is set (smoke + ops dry-run path; the
+      // operator takes responsibility for the creds in that case). Default
+      // is probe-on so a typo doesn't silently land a broken cred in the
+      // profile's .env.
+      const skipValidate = query.get("skip_validate") === "true";
+      if (!skipValidate) {
+        const probe = await probeTwilioAccount(sid, token);
+        if (!probe.ok) {
+          sendJson(res, 400, {
+            ok: false,
+            error: probe.error ?? "Twilio rejected the credentials",
+          });
+          return;
+        }
       }
 
       const updates: Partial<Record<VoiceEnvKey, string | null>> = {

--- a/packages/ctrl/src/api/server.ts
+++ b/packages/ctrl/src/api/server.ts
@@ -306,7 +306,17 @@ export function createApiServer(): http.Server {
         // keyed on RECALL_WEBHOOK_SECRET). Same posture as the Composio
         // entry above — the HMAC validator lives in
         // routes/channels_recall.ts and needs the exact bytes.
-        pathname === "/api/v1/webhooks/recall";
+        pathname === "/api/v1/webhooks/recall" ||
+        // #120 Lane Vb — ctrl-api's voice-inbound TwiML landing pad. The
+        // principal can configure Twilio to point at this URL (alongside
+        // the more-direct voice-bridge /twiml/inbound). The route only
+        // emits routing-decision TwiML — no secrets read, no profile
+        // mutation. In production Sir should still set TWILIO_AUTH_TOKEN
+        // per profile so the receiving side (voice-bridge) validates
+        // X-Twilio-Signature on the same body. Smoke endpoints accept the
+        // ?format=json shape so the routing decision can be asserted
+        // without going through Twilio.
+        pathname === "/api/v1/channels/voice/inbound";
       if (!isPublic) {
         // Pass method+pathname so the scoped-token path can check the
         // route allowlist (see auth.ts VOICE_BRIDGE_ALLOWLIST). The master


### PR DESCRIPTION
Two follow-up fixes surfaced during live smoke of PR #209 (Lane Vb voice per-profile) on home.alfred.black:

1. **`POST /api/v1/channels/voice/inbound` must be public.** Twilio cannot send a Bearer header, so the route belongs in server.ts's `isPublic` list. Without it the master-key gate 401s every inbound webhook. (voice-bridge's `/twiml/inbound` is already public via Caddy; this is the alternate ctrl-api path the route comment documented but the server gate never noticed.)

2. **`PUT /api/v1/channels/voice/credentials?…&skip_validate=true` bypasses the Twilio probe.** Lets smoke + ops dry-run scenarios exercise the .env-write path without a real Twilio account. Default remains probe-on (a typo on real creds should still 400 before landing in the profile's .env).

Live-smoke evidence: §3 (.env write), §6/§7 (TwiML routing decision), §10 (DELETE doesn't touch main) all green on home.alfred.black with `skip_validate=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)