### PR TITLE
ci: wire alfred-code Tier 2 — notify, PR review gate, fleet deploy

### DIFF
--- a/.github/workflows/deploy-fleet.yml
+++ b/.github/workflows/deploy-fleet.yml
@@ -1,0 +1,128 @@
+# Roll new images to every tenant in the fleet on every push to main that
+# touches a buildable package.
+#
+# Required repo secrets:
+#   FLEET_SSH_KEY            — private key matching ~/.ssh/alfred-black-verify
+#                              on each tenant. (You already have this; memory
+#                              `harden-vm-deploy-state` references it.)
+#   ALFRED_CODE_BOT_TOKEN    — Telegram bot for rollout summary
+#   ALFRED_CODE_CHAT_ID      — Sir's Telegram chat_id
+#
+# Required repo variables:
+#   ALFRED_FLEET_HOSTS       — newline-separated list of tenant hosts
+#                              (default below if unset)
+#
+# Per-tenant ordering: serial, not parallel. One failure shouldn't take down
+# the whole rollout, and serial makes the log easy to read.
+
+name: deploy-fleet
+
+on:
+  workflow_run:
+    # Fire after one of the build pipelines successfully published :latest.
+    workflows:
+      - build-ctrl-api
+      - build-web
+      - build-learn
+      - build-mcp-server
+      - build-hermes
+      - build-init
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      services:
+        description: 'Comma-separated services to pull (default: all six)'
+        default: 'ctrl-api,alfred-learn,web,web-client,mcp-server,hermes'
+        required: false
+      hosts:
+        description: 'Comma-separated hosts (default: full fleet)'
+        default: 'home,rj,joe,zsolt,miguel,rami'
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  rollout:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          echo "${{ secrets.FLEET_SSH_KEY }}" > ~/.ssh/alfred-black-verify
+          chmod 600 ~/.ssh/alfred-black-verify
+          cat <<'EOF' > ~/.ssh/config
+          Host *.alfred.black
+            IdentityFile ~/.ssh/alfred-black-verify
+            IdentityAgent none
+            BatchMode yes
+            StrictHostKeyChecking no
+            UserKnownHostsFile /dev/null
+            LogLevel ERROR
+          EOF
+          chmod 600 ~/.ssh/config
+
+      - name: Determine services + hosts
+        id: target
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            services="${{ github.event.inputs.services }}"
+            hosts="${{ github.event.inputs.hosts }}"
+          else
+            # Infer the service from the triggering workflow name.
+            wf="${{ github.event.workflow_run.name }}"
+            case "$wf" in
+              build-ctrl-api)   services="ctrl-api" ;;
+              build-web)        services="web,web-client" ;;
+              build-learn)      services="alfred-learn" ;;
+              build-mcp-server) services="mcp-server" ;;
+              build-hermes)     services="hermes" ;;
+              build-init)       services="init" ;;
+              *) echo "::error::unknown trigger workflow: $wf"; exit 1 ;;
+            esac
+            hosts="${{ vars.ALFRED_FLEET_HOSTS || 'home,rj,joe,zsolt,miguel,rami' }}"
+          fi
+          services_space="${services//,/ }"
+          hosts_space="${hosts//,/ }"
+          echo "services=$services_space" >> "$GITHUB_OUTPUT"
+          echo "hosts=$hosts_space" >> "$GITHUB_OUTPUT"
+          echo "  services: $services_space"
+          echo "  hosts:    $hosts_space"
+
+      - name: Pull + restart on each host (serial)
+        id: rollout
+        env:
+          SERVICES: ${{ steps.target.outputs.services }}
+          HOSTS:    ${{ steps.target.outputs.hosts }}
+        run: |
+          set -uo pipefail
+          declare -a RESULTS=()
+          for host in $HOSTS; do
+            echo "═══ $host.alfred.black ═══"
+            if ssh "root@$host.alfred.black" \
+              "cd /opt/alfred && docker compose -p alfred-black pull $SERVICES 2>&1 | grep -E 'Pulled|up to date' | head ; docker compose -p alfred-black up -d $SERVICES 2>&1 | tail -5" ; then
+              RESULTS+=("$host:OK")
+              echo "  ✓ $host"
+            else
+              RESULTS+=("$host:FAIL")
+              echo "  ✗ $host"
+            fi
+          done
+          # Emit a comma-separated summary so the next step can post it.
+          summary=$(IFS=, ; echo "${RESULTS[*]}")
+          echo "summary=$summary" >> "$GITHUB_OUTPUT"
+
+      - name: Notify Sir on Telegram
+        env:
+          BOT_TOKEN: ${{ secrets.ALFRED_CODE_BOT_TOKEN }}
+          CHAT_ID:   ${{ secrets.ALFRED_CODE_CHAT_ID }}
+          SERVICES:  ${{ steps.target.outputs.services }}
+          SUMMARY:   ${{ steps.rollout.outputs.summary }}
+        if: env.BOT_TOKEN != '' && env.CHAT_ID != ''
+        run: |
+          msg=$(printf "🚀 *Fleet rollout*: %s\n%s" "$SERVICES" "$SUMMARY" | sed 's/,/\n  /g')
+          curl -sS -X POST "https://api.telegram.org/bot${BOT_TOKEN}/sendMessage" \
+            --data-urlencode "chat_id=${CHAT_ID}" \
+            --data-urlencode "text=${msg}" \
+            --data-urlencode "parse_mode=Markdown" >/dev/null

--- a/.github/workflows/notify-telegram.yml
+++ b/.github/workflows/notify-telegram.yml
@@ -1,0 +1,119 @@
+# Notify Sir on Telegram when notable repo events happen.
+#
+# Trigger menu:
+#   - pull_request: opened, closed, reopened, ready_for_review
+#   - issues:       opened, closed, reopened
+#   - workflow_run: any workflow that finished (we filter to failures + the
+#                   build pipelines worth knowing about)
+#
+# Required repo secrets:
+#   ALFRED_CODE_BOT_TOKEN   — the BotFather token for @alfred_code_bot
+#   ALFRED_CODE_CHAT_ID     — Sir's Telegram chat_id with the bot
+#
+# Optional repo variables:
+#   ALFRED_CODE_QUIET       — set to "true" to skip notifications temporarily
+#
+# Drop this file into `.github/workflows/notify-telegram.yml` in your alfred
+# (or any other) monorepo and add the two secrets via:
+#   gh secret set ALFRED_CODE_BOT_TOKEN
+#   gh secret set ALFRED_CODE_CHAT_ID
+#
+# Cost: $0. Uses Telegram's free Bot API. Latency: ~1-3 seconds from event
+# to message landing on your phone.
+
+name: notify-telegram
+
+on:
+  pull_request:
+    types: [opened, closed, reopened, ready_for_review]
+  issues:
+    types: [opened, closed, reopened]
+  workflow_run:
+    workflows: ['*']
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+  actions: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    if: vars.ALFRED_CODE_QUIET != 'true'
+    steps:
+      - name: Compose + send
+        env:
+          BOT_TOKEN: ${{ secrets.ALFRED_CODE_BOT_TOKEN }}
+          CHAT_ID:   ${{ secrets.ALFRED_CODE_CHAT_ID }}
+          EVENT:     ${{ toJSON(github.event) }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPO:      ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$BOT_TOKEN" || -z "$CHAT_ID" ]]; then
+            echo "::warning::ALFRED_CODE_BOT_TOKEN or ALFRED_CODE_CHAT_ID missing; skipping notify."
+            exit 0
+          fi
+          case "$EVENT_NAME" in
+            pull_request)
+              action=$(echo "$EVENT" | jq -r '.action')
+              num=$(echo "$EVENT" | jq -r '.pull_request.number')
+              title=$(echo "$EVENT" | jq -r '.pull_request.title')
+              url=$(echo "$EVENT" | jq -r '.pull_request.html_url')
+              merged=$(echo "$EVENT" | jq -r '.pull_request.merged // false')
+              actor=$(echo "$EVENT" | jq -r '.sender.login')
+              icon="📥"
+              [[ "$action" == "opened" ]] && icon="🟢"
+              if [[ "$action" == "closed" && "$merged" == "true" ]]; then
+                icon="✅"; action="merged"
+              elif [[ "$action" == "closed" && "$merged" == "false" ]]; then
+                icon="⚪️"; action="closed (unmerged)"
+              fi
+              [[ "$action" == "reopened" ]] && icon="🔄"
+              [[ "$action" == "ready_for_review" ]] && icon="👀"
+              MESSAGE=$(printf '%s *PR #%s* %s by %s\n%s\n%s' "$icon" "$num" "$action" "$actor" "$title" "$url")
+              ;;
+            issues)
+              action=$(echo "$EVENT" | jq -r '.action')
+              num=$(echo "$EVENT" | jq -r '.issue.number')
+              title=$(echo "$EVENT" | jq -r '.issue.title')
+              url=$(echo "$EVENT" | jq -r '.issue.html_url')
+              actor=$(echo "$EVENT" | jq -r '.sender.login')
+              icon="📋"
+              [[ "$action" == "opened" ]] && icon="🆕"
+              [[ "$action" == "closed" ]] && icon="🏁"
+              [[ "$action" == "reopened" ]] && icon="🔄"
+              MESSAGE=$(printf '%s *Issue #%s* %s by %s\n%s\n%s' "$icon" "$num" "$action" "$actor" "$title" "$url")
+              ;;
+            workflow_run)
+              conclusion=$(echo "$EVENT" | jq -r '.workflow_run.conclusion // "in_progress"')
+              wfname=$(echo "$EVENT" | jq -r '.workflow_run.name')
+              wfurl=$(echo "$EVENT" | jq -r '.workflow_run.html_url')
+              wfbranch=$(echo "$EVENT" | jq -r '.workflow_run.head_branch')
+              if [[ "$conclusion" == "failure" ]]; then
+                MESSAGE=$(printf '🔴 *%s* FAILED on `%s`\n%s' "$wfname" "$wfbranch" "$wfurl")
+              elif [[ "$conclusion" == "success" && ( "$wfname" == build-* || "$wfname" == deploy-* ) ]]; then
+                MESSAGE=$(printf '🟢 *%s* OK on `%s`' "$wfname" "$wfbranch")
+              else
+                echo "::notice::skipping notify for $wfname $conclusion"
+                exit 0
+              fi
+              ;;
+            *)
+              echo "::warning::unknown event: $EVENT_NAME"
+              exit 0
+              ;;
+          esac
+          response=$(curl -sS -X POST "https://api.telegram.org/bot${BOT_TOKEN}/sendMessage" \
+            --data-urlencode "chat_id=${CHAT_ID}" \
+            --data-urlencode "text=${MESSAGE}" \
+            --data-urlencode "parse_mode=Markdown" \
+            --data-urlencode "disable_web_page_preview=false")
+          ok=$(echo "$response" | jq -r '.ok')
+          if [[ "$ok" != "true" ]]; then
+            echo "::error::Telegram sendMessage failed: $response"
+            exit 1
+          fi
+          echo "✓ notified Sir"

--- a/.github/workflows/pr-review-gate.yml
+++ b/.github/workflows/pr-review-gate.yml
@@ -1,0 +1,78 @@
+# PR review gate.
+#
+# Required-check on every PR. Blocks merge unless the PR body has a
+# `## Smoke evidence` section.
+#
+# This is the deterministic half of the smoke-as-truth rule. The agentic half
+# is `/ultrareview <pr#>` (in commands/ultrareview.md) which a human runs
+# locally before tapping merge. Together they keep lint-pass-shipping out of
+# the codebase.
+#
+# To make this a REQUIRED status check that actually blocks merge, add it as a
+# required check in:
+#   Repo Settings → Branches → main → Require status checks before merging
+#                                  → add 'smoke-evidence-check'
+#
+# Override for legitimately-docs-only PRs:
+#   Add `[skip smoke gate]` to the PR title, OR
+#   Put `## Smoke evidence` with the body `N/A — docs-only change` in the PR.
+
+name: pr-review-gate
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, ready_for_review, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  smoke-evidence-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Parse PR body for `## Smoke evidence`
+        env:
+          BODY: ${{ github.event.pull_request.body }}
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+
+          # Title-level override (rare):
+          if echo "$TITLE" | grep -qi '\[skip smoke gate\]'; then
+            echo "::notice::Smoke gate skipped via [skip smoke gate] in title."
+            exit 0
+          fi
+
+          # PR body must include one of these section headers (variations on the same idea):
+          if echo "$BODY" | grep -qE '^##[[:space:]]+Smoke evidence' ; then
+            echo "✓ '## Smoke evidence' section present."
+            exit 0
+          fi
+          if echo "$BODY" | grep -qE '^###[[:space:]]+Smoke evidence' ; then
+            echo "✓ '### Smoke evidence' section present."
+            exit 0
+          fi
+          if echo "$BODY" | grep -qE '^##[[:space:]]+Smoke verification' ; then
+            echo "✓ '## Smoke verification' section present."
+            exit 0
+          fi
+
+          # Neither found. Block.
+          echo "::error::PR body lacks a '## Smoke evidence' section."
+          echo ""
+          echo "Add a section to the PR body with verbatim smoke output."
+          echo "Minimum shape:"
+          echo "  ## Smoke evidence"
+          echo "  Tested on home.alfred.black at <UTC>."
+          echo "  \`\`\`"
+          echo "  §1 baseline: …"
+          echo "  §2 mutation: …"
+          echo "  §3 isolation check: …"
+          echo "  …"
+          echo "  \`\`\`"
+          echo ""
+          echo "For docs-only PRs where smoke doesn't apply:"
+          echo "  ## Smoke evidence"
+          echo "  N/A — docs-only change."
+          exit 1


### PR DESCRIPTION
## What

Three GH Action workflows from [`ssdavidai/alfred-code`](https://github.com/ssdavidai/alfred-code) v0.2.0:

- **`notify-telegram.yml`** — observes PR/issue/workflow_run events, posts to Sir's Telegram via @alfredblackcodebot. Reads `ALFRED_CODE_BOT_TOKEN` + `ALFRED_CODE_CHAT_ID` from repo secrets (already set).
- **`pr-review-gate.yml`** — required check: PR body must contain `## Smoke evidence`. Closes the "lint-passing-as-shipping" failure mode.
- **`deploy-fleet.yml`** — fires when a build workflow concludes successfully on main, SSHes to each tenant via `FLEET_SSH_KEY`, runs `docker compose pull && up -d`, posts rollout summary to Telegram. Matrix: home/rj/joe/zsolt/miguel/rami.

## Why

Sir wants to become the architect of the loop, not the orchestrator. He files a GH issue, taps 👍 in Telegram, lane workers ship PRs, taps merge in the GH UI, fleet auto-rolls. These workflows are the GitHub-side of that loop.

## Smoke evidence

- Bot already verified via `getMe` → returns `username: alfredblackcodebot, id: 8822037329, is_bot: true`
- Outbound test message sent successfully to Sir's chat_id (suffix …4090) before this PR was opened — landed on his phone
- All three secrets present on this repo: `gh secret list --repo ssdavidai/alfred | grep ALFRED_CODE` returns 2 entries; `FLEET_SSH_KEY` also set
- YAML validated via `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/notify-telegram.yml'))"` x3 — all clean
- Cost: $0/month. Telegram Bot API is free; GH Actions runs under free tier at moderate volume

## Required follow-up (on Sir, not in this PR)

1. Install Claude Code Desktop from https://claude.com/code (for the scheduled-task heartbeat)
2. In a Claude session: install + configure the Telegram channel plugin (the 4 `/plugin` commands documented in `~/.claude/alfred-code/docs/setup-tutorial.md`)
3. In Claude Code Desktop's Routines panel: set `alfred-code-poll` to run every 5 min on the alfred working folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)