### PR TITLE
feat(web): #204 Lane III — /profiles/:slug MCP section. Closes #204

### DIFF
--- a/packages/web/main.wasp
+++ b/packages/web/main.wasp
@@ -1251,6 +1251,25 @@ action unbindChannelFromProfile {
   entities: []
 }
 
+// #204 Lane III — per-profile MCP catalog (query + 2 mutations).
+// Reserved profiles (main/workers/heavy/codex-builder) return 409 on
+// mutations; the UI enforces this client-side (read-only on reserved).
+
+query getProfileMcp {
+  fn: import { getProfileMcp } from "@src/dashboard/operations",
+  entities: []
+}
+
+action addProfileMcp {
+  fn: import { addProfileMcp } from "@src/dashboard/operations",
+  entities: []
+}
+
+action removeProfileMcp {
+  fn: import { removeProfileMcp } from "@src/dashboard/operations",
+  entities: []
+}
+
 // #120 Lane V — per-profile FULL channels surface ops.
 //
 // The three consolidator ops the /profiles/:slug/channels page wires up. They

--- a/packages/web/src/dashboard/ProfileDetailPage.tsx
+++ b/packages/web/src/dashboard/ProfileDetailPage.tsx
@@ -23,6 +23,9 @@ import {
   restoreAgentProfile,
   bindChannelToProfile,
   unbindChannelFromProfile,
+  getProfileMcp,
+  addProfileMcp,
+  removeProfileMcp,
 } from "wasp/client/operations";
 import { Frame, PageHeading } from "../client/components/ab/Frame";
 
@@ -41,6 +44,14 @@ const CHANNEL_KINDS: { value: string; label: string; placeholder: string }[] = [
   { value: "terminal", label: "Terminal", placeholder: "session id" },
   { value: "tailscale", label: "Tailscale", placeholder: "node id" },
 ];
+
+// C1 JSON shape from FIX-CONTRACTS.md #204
+interface McpServer {
+  name: string;
+  type: "stdio" | "http";
+  command_or_url: string;
+  enabled: boolean;
+}
 
 interface ProfileRow {
   slug: string;
@@ -120,6 +131,23 @@ export default function ProfileDetailPage() {
   const [lifecycleBusy, setLifecycleBusy] = useState(false);
   const [lifecycleError, setLifecycleError] = useState<string | null>(null);
   const [confirmArchive, setConfirmArchive] = useState(false);
+
+  // MCP section state
+  const {
+    data: mcpData,
+    isLoading: mcpLoading,
+    refetch: refetchMcp,
+  } = useQuery(getProfileMcp, { slug }, { enabled: !!slug });
+  const mcpServers = ((mcpData as any)?.servers ?? []) as McpServer[];
+  const mcpReserved = (mcpData as any)?.reserved === true;
+
+  const [mcpName, setMcpName] = useState("");
+  const [mcpUrl, setMcpUrl] = useState("");
+  const [mcpAuthHeader, setMcpAuthHeader] = useState("");
+  const [mcpAuthValue, setMcpAuthValue] = useState("");
+  const [mcpAddBusy, setMcpAddBusy] = useState(false);
+  const [mcpError, setMcpError] = useState<string | null>(null);
+  const [mcpConfirmRemove, setMcpConfirmRemove] = useState<string | null>(null);
 
   // Poll status while pending; stop once we hit a terminal-for-display
   // status. The Lane IIb smoke shows ~17s to running on a fresh tenant,
@@ -204,6 +232,53 @@ export default function ProfileDetailPage() {
       );
     } finally {
       setLifecycleBusy(false);
+    }
+  }
+
+  async function onAddMcp() {
+    if (mcpAddBusy || !slug) return;
+    const name = mcpName.trim();
+    const url = mcpUrl.trim();
+    if (!name) {
+      setMcpError("Server name is required.");
+      return;
+    }
+    if (!url) {
+      setMcpError("URL is required.");
+      return;
+    }
+    setMcpAddBusy(true);
+    setMcpError(null);
+    try {
+      await addProfileMcp({
+        slug,
+        name,
+        url,
+        auth_header: mcpAuthHeader.trim() || undefined,
+        auth_value: mcpAuthValue.trim() || undefined,
+      });
+      setMcpName("");
+      setMcpUrl("");
+      setMcpAuthHeader("");
+      setMcpAuthValue("");
+      await refetchMcp();
+    } catch (e: any) {
+      setMcpError(String(e?.message || e || "Couldn't add the MCP server."));
+    } finally {
+      setMcpAddBusy(false);
+    }
+  }
+
+  async function onRemoveMcp(name: string) {
+    if (!slug) return;
+    setMcpError(null);
+    try {
+      await removeProfileMcp({ slug, name });
+      setMcpConfirmRemove(null);
+      await refetchMcp();
+    } catch (e: any) {
+      setMcpError(String(e?.message || e || "Couldn't remove the MCP server."));
+      setMcpConfirmRemove(null);
     }
   }
 
@@ -434,6 +509,162 @@ export default function ProfileDetailPage() {
                   style={{ color: "#B85C5C" }}
                 >
                   {bindError}
+                </div>
+              )}
+            </div>
+          )}
+        </section>
+
+        {/* MCP servers */}
+        <section className="mb-16">
+          <div
+            className="font-mono text-[10px] uppercase tracking-[0.28em] mb-3"
+            style={{ color: "var(--brass)" }}
+          >
+            MCP Servers
+          </div>
+          <h2 className="font-display text-3xl tracking-tight mb-6">
+            Tool providers registered for this persona.
+          </h2>
+
+          {mcpLoading && (
+            <p className="font-body italic" style={{ color: "var(--marginalia)" }}>
+              Reading MCP catalog…
+            </p>
+          )}
+
+          {!mcpLoading && mcpServers.length === 0 && (
+            <p className="font-body italic mb-6" style={{ color: "var(--marginalia)" }}>
+              No MCP servers are registered for this profile yet.
+            </p>
+          )}
+
+          {!mcpLoading && mcpServers.length > 0 && (
+            <div className="border-t border-rule mb-6">
+              {mcpServers.map((srv) => (
+                <div
+                  key={srv.name}
+                  className="py-4 border-b border-rule grid grid-cols-[1fr_auto] items-center gap-4"
+                >
+                  <div>
+                    <div className="flex items-center gap-3 mb-1">
+                      <span className="font-mono text-[13px]">{srv.name}</span>
+                      <span
+                        className="font-mono text-[10px] uppercase tracking-[0.18em] px-1.5"
+                        style={{ color: "var(--marginalia)", border: "1px solid var(--rule)" }}
+                      >
+                        {srv.type}
+                      </span>
+                      {!srv.enabled && (
+                        <span
+                          className="font-mono text-[10px] uppercase tracking-[0.18em] px-1.5"
+                          style={{ color: "#B85C5C", border: "1px solid #B85C5C" }}
+                        >
+                          disabled
+                        </span>
+                      )}
+                    </div>
+                    <div
+                      className="font-mono text-[11px] break-all"
+                      style={{ color: "var(--marginalia)" }}
+                    >
+                      {srv.command_or_url}
+                    </div>
+                  </div>
+                  {!mcpReserved && (
+                    <div>
+                      {mcpConfirmRemove === srv.name ? (
+                        <div className="flex items-center gap-2">
+                          <button
+                            onClick={() => onRemoveMcp(srv.name)}
+                            className="font-mono text-[10px] uppercase tracking-[0.18em]"
+                            style={{ color: "#B85C5C" }}
+                          >
+                            Confirm
+                          </button>
+                          <button
+                            onClick={() => setMcpConfirmRemove(null)}
+                            className="font-mono text-[10px] uppercase tracking-[0.18em]"
+                            style={{ color: "var(--marginalia)" }}
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      ) : (
+                        <button
+                          onClick={() => setMcpConfirmRemove(srv.name)}
+                          className="font-mono text-[10px] uppercase tracking-[0.18em]"
+                          style={{ color: "#B85C5C" }}
+                        >
+                          Remove
+                        </button>
+                      )}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+
+          {mcpReserved && (
+            <p className="font-body italic mb-6" style={{ color: "var(--marginalia)" }}>
+              This is a reserved profile. MCP servers are managed by the system
+              and cannot be added or removed here.
+            </p>
+          )}
+
+          {!mcpReserved && !isArchived && (
+            <div className="border border-rule p-5">
+              <div
+                className="font-mono text-[10px] uppercase tracking-[0.22em] mb-3"
+                style={{ color: "var(--brass)" }}
+              >
+                Add MCP server
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-3">
+                <input
+                  value={mcpName}
+                  onChange={(e) => setMcpName(e.target.value)}
+                  placeholder="Server name, e.g. my-tools"
+                  className="bg-transparent outline-none border-b font-mono text-[14px] pb-2"
+                  style={{ borderColor: "var(--brass)" }}
+                />
+                <input
+                  value={mcpUrl}
+                  onChange={(e) => setMcpUrl(e.target.value)}
+                  placeholder="URL, e.g. https://my-mcp.example.com"
+                  className="bg-transparent outline-none border-b font-mono text-[14px] pb-2"
+                  style={{ borderColor: "var(--brass)" }}
+                />
+                <input
+                  value={mcpAuthHeader}
+                  onChange={(e) => setMcpAuthHeader(e.target.value)}
+                  placeholder="Auth header (optional), e.g. Authorization"
+                  className="bg-transparent outline-none border-b font-mono text-[14px] pb-2"
+                  style={{ borderColor: "var(--brass)" }}
+                />
+                <input
+                  value={mcpAuthValue}
+                  onChange={(e) => setMcpAuthValue(e.target.value)}
+                  placeholder="Auth value (optional), e.g. Bearer …"
+                  className="bg-transparent outline-none border-b font-mono text-[14px] pb-2"
+                  style={{ borderColor: "var(--brass)" }}
+                />
+              </div>
+              <button
+                onClick={onAddMcp}
+                disabled={mcpAddBusy}
+                className="btn-brass"
+                style={{ opacity: mcpAddBusy ? 0.5 : 1 }}
+              >
+                {mcpAddBusy ? "Adding…" : "Add server"}
+              </button>
+              {mcpError && (
+                <div
+                  className="mt-3 font-body italic text-sm"
+                  style={{ color: "#B85C5C" }}
+                >
+                  {mcpError}
                 </div>
               )}
             </div>

--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -3598,6 +3598,93 @@ export const unbindChannelFromProfile = async (
   });
 };
 
+// ── #204 Lane III — per-profile MCP catalog ──────────────────────────────
+//
+// Three ops that proxy to Lane I's ctrl-api routes under
+// /api/v1/admin/profiles/:slug/mcp. Reserved profiles (main / workers /
+// heavy / codex-builder) return 409 on mutations; the UI enforces this
+// client-side too (no add form, no remove buttons on reserved profiles).
+//
+// Wire shapes (from FIX-CONTRACTS.md C1):
+//   GET    /api/v1/admin/profiles/:slug/mcp
+//     → { slug, reserved, servers: [{ name, type, command_or_url, enabled }] }
+//   POST   /api/v1/admin/profiles/:slug/mcp
+//     body: { name, url?, command?, auth_header?, auth_value? }
+//     → 201 { ok, name }
+//   DELETE /api/v1/admin/profiles/:slug/mcp/:name
+//     → 200 { ok }
+//
+// `Promise<any>` annotation is load-bearing — Wasp Payload trap.
+
+export const getProfileMcp = async (
+  args: { slug: string },
+  context: any,
+): Promise<any> => {
+  if (!context.user) throw new HttpError(401, "Not authenticated");
+  const slug = String(args?.slug ?? "").trim();
+  if (!slug) throw new HttpError(400, "slug required");
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    path: `/api/v1/admin/profiles/${encodeURIComponent(slug)}/mcp`,
+  });
+};
+
+export const addProfileMcp = async (
+  args: {
+    slug: string;
+    name: string;
+    url?: string;
+    command?: string;
+    auth_header?: string;
+    auth_value?: string;
+  },
+  context: any,
+): Promise<any> => {
+  if (!context.user) throw new HttpError(401, "Not authenticated");
+  const slug = String(args?.slug ?? "").trim();
+  const name = String(args?.name ?? "").trim();
+  if (!slug) throw new HttpError(400, "slug required");
+  if (!name) throw new HttpError(400, "name required");
+  const hasUrl =
+    typeof args?.url === "string" && args.url.trim().length > 0;
+  const hasCommand =
+    typeof args?.command === "string" && args.command.trim().length > 0;
+  if (!hasUrl && !hasCommand) {
+    throw new HttpError(400, "url or command required");
+  }
+  const body: Record<string, string> = { name };
+  if (hasUrl) body.url = args.url!.trim();
+  if (hasCommand) body.command = args.command!.trim();
+  if (typeof args?.auth_header === "string" && args.auth_header.trim()) {
+    body.auth_header = args.auth_header.trim();
+  }
+  if (typeof args?.auth_value === "string" && args.auth_value.trim()) {
+    body.auth_value = args.auth_value.trim();
+  }
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    method: "POST",
+    path: `/api/v1/admin/profiles/${encodeURIComponent(slug)}/mcp`,
+    body,
+  });
+};
+
+export const removeProfileMcp = async (
+  args: { slug: string; name: string },
+  context: any,
+): Promise<any> => {
+  if (!context.user) throw new HttpError(401, "Not authenticated");
+  const slug = String(args?.slug ?? "").trim();
+  const name = String(args?.name ?? "").trim();
+  if (!slug) throw new HttpError(400, "slug required");
+  if (!name) throw new HttpError(400, "name required");
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    method: "DELETE",
+    path: `/api/v1/admin/profiles/${encodeURIComponent(slug)}/mcp/${encodeURIComponent(name)}`,
+  });
+};
+
 // ── #120 Lane V — per-profile FULL channels surface ──────────────────────
 //
 // Three consolidator ops that route through Lane IV's ?profile=<slug> shape


### PR DESCRIPTION
## Summary

- Add MCP server catalog section to `ProfileDetailPage.tsx` below the Channels section
- Reserved profiles (main/workers/heavy/codex-builder) render the server list read-only — no add form, no remove buttons — gated on the `reserved` flag from the C1 GET response
- Non-reserved profiles get an Add form (name + URL + optional auth header/value) and per-row Remove with a confirm step

## Files touched

- `packages/web/main.wasp` — declares `getProfileMcp` query and `addProfileMcp`/`removeProfileMcp` actions (entities: [])
- `packages/web/src/dashboard/operations.ts` — three new thin-proxy ops against C1's frozen JSON shapes
- `packages/web/src/dashboard/ProfileDetailPage.tsx` — MCP section (new state, handlers, JSX; imports updated)

## New Wasp ops (C2 wire contract)

| Op | Method | Path | Notes |
|---|---|---|---|
| `getProfileMcp` | GET | `/api/v1/admin/profiles/:slug/mcp` | Returns `{ slug, reserved, servers[] }` |
| `addProfileMcp` | POST | `/api/v1/admin/profiles/:slug/mcp` | Body: `{ name, url?, command?, auth_header?, auth_value? }` |
| `removeProfileMcp` | DELETE | `/api/v1/admin/profiles/:slug/mcp/:name` | Returns `{ ok }` |

Reserved profiles return 409 at the ctrl-api level (Lane I); the UI also enforces client-side by rendering no mutation controls when `reserved === true`.

## Architecture choice

Built as a second `useQuery` call on `getProfileMcp` within the existing `ProfileDetailPage` (same pattern as `getAgentProfile`). Separate query so MCP refetch doesn't trigger a full profile/bindings reload on add/remove.

## Smoke

**Build evidence** (no live tenant reachable from this lane):

```
esbuild parse check — operations.ts:
  /Users/ssd/dev/alfred/packages/web/node_modules/esbuild/bin/esbuild \
    --bundle=false --jsx=preserve --loader:.tsx=tsx \
    packages/web/src/dashboard/operations.ts > /dev/null
  exit: 0  ✓

esbuild parse check — ProfileDetailPage.tsx:
  /Users/ssd/dev/alfred/packages/web/node_modules/esbuild/bin/esbuild \
    --bundle=false --jsx=preserve --loader:.tsx=tsx \
    packages/web/src/dashboard/ProfileDetailPage.tsx > /dev/null
  exit: 0  ✓

git commit gate passed (lane III boundary, scope 337/350 LOC, verify ok)
```

**Render contract** (verified by code inspection against C2):

- For a non-reserved profile: `mcpReserved === false` → "Add MCP server" form renders with 4 inputs (name, URL, auth header, auth value) + "Add server" button; each server row shows a "Remove" button that transitions to "Confirm / Cancel" before calling `removeProfileMcp`
- For `main` (reserved): `mcpReserved === true` → add form is absent; remove buttons are absent; "This is a reserved profile…" notice renders instead
- Loading state: "Reading MCP catalog…" italic while `mcpLoading` is true
- Empty state: "No MCP servers are registered for this profile yet." when list is empty and not loading

No live tenant was reachable from this worktree. The `build-web.yml` CI job runs `wasp build` which is the authoritative TypeScript + Wasp contract check; the esbuild parse pass above confirms no syntax regressions were introduced.

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)