### PR TITLE
feat(ctrl): #204 Lane I — per-profile MCP catalog routes

### DIFF
--- a/packages/ctrl/src/api/routes/profiles.ts
+++ b/packages/ctrl/src/api/routes/profiles.ts
@@ -17,6 +17,10 @@
 //   POST   /api/v1/agent-profiles/:slug/bindings
 //   DELETE /api/v1/agent-profiles/:slug/bindings/:binding_id
 //
+//   GET    /api/v1/admin/profiles/:slug/mcp                (#204 Lane I)
+//   POST   /api/v1/admin/profiles/:slug/mcp                (#204 Lane I)
+//   DELETE /api/v1/admin/profiles/:slug/mcp/:name          (#204 Lane I)
+//
 // POST returns 202 Accepted (not 201) because the Hermes-side activation is
 // deferred to Lane II — the registry row writes immediately but no gateway
 // is started yet. Lane II flips status from 'pending' to 'running'.
@@ -29,6 +33,9 @@
 // (not in the lib) means Lane II/IV callers can catch and inspect the raw
 // helper errors without a `statusCode` shim.
 
+import fs from "node:fs";
+import path from "node:path";
+import yaml from "js-yaml";
 import { addRoute } from "../server.js";
 import {
   sendJson,
@@ -42,6 +49,8 @@ import {
   PORT_RANGE_USER_LO,
   PORT_RANGE_USER_HI,
   KNOWN_CHANNEL_KINDS,
+  RESERVED_SLUGS,
+  HERMES_PROFILE_BASE_DIR,
   validateSlug,
   listAllProfiles,
   listUserProfiles,
@@ -440,6 +449,250 @@ export function registerProfileRoutes(): void {
         if (!profile) throw new NotFoundError(`profile '${slug}' not found`);
         unbindChannel(db(), params.binding_id);
         sendJson(res, 200, { ok: true, binding_id: params.binding_id });
+      } catch (err) {
+        _classify(err);
+      }
+    },
+  );
+
+  // ─────────────────────────────────────────────────────────────
+  // Per-profile MCP catalog (#204 Lane I — C1 contract)
+  //
+  // Source of truth: each profile's config.yaml `mcp_servers` block
+  // (same volume the hermes runtime reads). We read/write directly via
+  // the filesystem rather than the CLI because `hermes mcp` has no
+  // `-p <slug>` flag and `hermes mcp add` is interactive (prompts).
+  //
+  // Reserved profiles: GET is read-only and works on all slugs.
+  //                    POST and DELETE refuse reserved slugs → 409.
+  // ─────────────────────────────────────────────────────────────
+
+  /** Resolved path to a profile's config.yaml (via the ctrl-api volume view). */
+  function profileConfigPath(slug: string): string {
+    return path.join(HERMES_PROFILE_BASE_DIR(), slug, "config.yaml");
+  }
+
+  /** Load + parse a profile config.yaml. Returns {} if unreadable. */
+  function loadProfileConfig(slug: string): Record<string, unknown> {
+    try {
+      const raw = fs.readFileSync(profileConfigPath(slug), "utf-8");
+      const parsed = yaml.load(raw);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      /* unreadable / unparseable — caller handles {} */
+    }
+    return {};
+  }
+
+  /**
+   * Derive the canonical wire shape for one mcp_servers entry.
+   * The config.yaml block can be null (disabled), or an object with
+   * optional `command`/`args`/`url`/`enabled` fields — we normalise to
+   * the C1 contract shape.
+   */
+  function _mcpServerShape(
+    name: string,
+    block: unknown,
+  ): { name: string; type: "stdio" | "http"; command_or_url: string; enabled: boolean } {
+    if (!block || typeof block !== "object" || Array.isArray(block)) {
+      // null / disabled block — show as stdio placeholder
+      return { name, type: "stdio", command_or_url: "", enabled: false };
+    }
+    const b = block as Record<string, unknown>;
+    const hasUrl = typeof b["url"] === "string" && (b["url"] as string).trim();
+    const type: "stdio" | "http" = hasUrl ? "http" : "stdio";
+    let command_or_url = "";
+    if (hasUrl) {
+      command_or_url = (b["url"] as string).trim();
+    } else if (typeof b["command"] === "string") {
+      const args =
+        Array.isArray(b["args"])
+          ? (b["args"] as string[]).join(" ")
+          : "";
+      command_or_url = args
+        ? `${(b["command"] as string).trim()} ${args}`.trimEnd()
+        : (b["command"] as string).trim();
+    }
+    // `enabled` is true by default; null block or explicit `enabled: false` disables.
+    const enabled = b["enabled"] !== false;
+    return { name, type, command_or_url, enabled };
+  }
+
+  /** MCP server name must be a safe identifier (no shell injection). */
+  const MCP_NAME_RE = /^[a-z][a-z0-9_-]{0,40}$/;
+
+  // GET /api/v1/admin/profiles/:slug/mcp
+  addRoute(
+    "GET",
+    "/api/v1/admin/profiles/:slug/mcp",
+    async ({ res, params }) => {
+      try {
+        const slug = params.slug;
+        const profile = getProfile(db(), slug);
+        if (!profile) throw new NotFoundError(`profile '${slug}' not found`);
+
+        const cfg = loadProfileConfig(slug);
+        const rawServers = (cfg["mcp_servers"] ?? {}) as Record<string, unknown>;
+        const servers = Object.entries(rawServers).map(([name, block]) =>
+          _mcpServerShape(name, block),
+        );
+
+        sendJson(res, 200, {
+          slug,
+          reserved: RESERVED_SLUGS.has(slug),
+          servers,
+        });
+      } catch (err) {
+        _classify(err);
+      }
+    },
+  );
+
+  // POST /api/v1/admin/profiles/:slug/mcp
+  addRoute(
+    "POST",
+    "/api/v1/admin/profiles/:slug/mcp",
+    async ({ res, params, body }) => {
+      try {
+        const slug = params.slug;
+        if (RESERVED_SLUGS.has(slug)) {
+          throw new ConflictError("reserved_profile");
+        }
+        const profile = getProfile(db(), slug);
+        if (!profile) throw new NotFoundError(`profile '${slug}' not found`);
+
+        const b = asObj(body);
+        const name = reqStr(b, "name");
+        if (!MCP_NAME_RE.test(name)) {
+          throw new ValidationError(
+            "name must match ^[a-z][a-z0-9_-]{0,40}$ (lowercase, start with letter)",
+          );
+        }
+        const url = optStr(b, "url");
+        const command = optStr(b, "command");
+        if (url && command) {
+          throw new ValidationError("provide url OR command, not both");
+        }
+        if (!url && !command) {
+          throw new ValidationError("one of url or command is required");
+        }
+        const auth_header = optStr(b, "auth_header");
+        const auth_value = optStr(b, "auth_value");
+
+        // Load existing config and add / replace the server entry.
+        const cfgPath = profileConfigPath(slug);
+        let cfg: Record<string, unknown> = {};
+        let rawYaml = "";
+        try {
+          rawYaml = fs.readFileSync(cfgPath, "utf-8");
+          const parsed = yaml.load(rawYaml);
+          if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            cfg = parsed as Record<string, unknown>;
+          }
+        } catch {
+          /* config doesn't exist yet — start fresh */
+        }
+
+        // Build the new server block.
+        const newBlock: Record<string, unknown> = {};
+        if (url) {
+          newBlock["url"] = url;
+          if (auth_header && auth_value) {
+            newBlock["auth"] = {
+              type: "header",
+              header: auth_header,
+              value: auth_value,
+            };
+          }
+        } else {
+          // stdio: split command string on spaces for args
+          const parts = (command as string).trim().split(/\s+/);
+          newBlock["command"] = parts[0];
+          if (parts.length > 1) {
+            newBlock["args"] = parts.slice(1);
+          }
+        }
+
+        if (!cfg["mcp_servers"] || typeof cfg["mcp_servers"] !== "object") {
+          cfg["mcp_servers"] = {};
+        }
+        (cfg["mcp_servers"] as Record<string, unknown>)[name] = newBlock;
+
+        // Atomic write — yaml.dump + rename.
+        const newYaml = yaml.dump(cfg, { lineWidth: 120, quotingType: '"' });
+        const tmpPath = cfgPath + ".tmp";
+        fs.mkdirSync(path.dirname(cfgPath), { recursive: true });
+        fs.writeFileSync(tmpPath, newYaml, { encoding: "utf-8", mode: 0o644 });
+        fs.renameSync(tmpPath, cfgPath);
+
+        // Nudge the supervisor so the profile's gateway picks up the new server.
+        try {
+          nudgeHermesSupervisor();
+        } catch (err) {
+          console.warn(
+            `[profiles/mcp] supervisor nudge after add('${slug}/${name}') failed:`,
+            err instanceof Error ? err.message : err,
+          );
+        }
+
+        sendJson(res, 201, { ok: true, name });
+      } catch (err) {
+        _classify(err);
+      }
+    },
+  );
+
+  // DELETE /api/v1/admin/profiles/:slug/mcp/:name
+  addRoute(
+    "DELETE",
+    "/api/v1/admin/profiles/:slug/mcp/:name",
+    async ({ res, params }) => {
+      try {
+        const slug = params.slug;
+        if (RESERVED_SLUGS.has(slug)) {
+          throw new ConflictError("reserved_profile");
+        }
+        const profile = getProfile(db(), slug);
+        if (!profile) throw new NotFoundError(`profile '${slug}' not found`);
+
+        const name = params.name;
+        const cfgPath = profileConfigPath(slug);
+        let cfg: Record<string, unknown> = {};
+        try {
+          const raw = fs.readFileSync(cfgPath, "utf-8");
+          const parsed = yaml.load(raw);
+          if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            cfg = parsed as Record<string, unknown>;
+          }
+        } catch {
+          throw new NotFoundError(`profile '${slug}' has no config (config.yaml unreadable)`);
+        }
+
+        const servers = cfg["mcp_servers"] as Record<string, unknown> | undefined;
+        if (!servers || !(name in servers)) {
+          throw new NotFoundError(`MCP server '${name}' not found in profile '${slug}'`);
+        }
+        delete servers[name];
+        cfg["mcp_servers"] = servers;
+
+        const newYaml = yaml.dump(cfg, { lineWidth: 120, quotingType: '"' });
+        const tmpPath = cfgPath + ".tmp";
+        fs.writeFileSync(tmpPath, newYaml, { encoding: "utf-8", mode: 0o644 });
+        fs.renameSync(tmpPath, cfgPath);
+
+        // Nudge supervisor.
+        try {
+          nudgeHermesSupervisor();
+        } catch (err) {
+          console.warn(
+            `[profiles/mcp] supervisor nudge after remove('${slug}/${name}') failed:`,
+            err instanceof Error ? err.message : err,
+          );
+        }
+
+        sendJson(res, 200, { ok: true });
       } catch (err) {
         _classify(err);
       }

--- a/packages/ctrl/tests/profiles-mcp-catalog.test.ts
+++ b/packages/ctrl/tests/profiles-mcp-catalog.test.ts
@@ -1,0 +1,351 @@
+// profiles-mcp-catalog — unit tests for #204 Lane I per-profile MCP routes.
+//
+// Routes under test:
+//   GET    /api/v1/admin/profiles/:slug/mcp
+//   POST   /api/v1/admin/profiles/:slug/mcp
+//   DELETE /api/v1/admin/profiles/:slug/mcp/:name
+//
+// All filesystem I/O goes to a per-test tmp dir (HERMES_CONFIG_DIR).
+// nudgeHermesSupervisor is mocked so no docker calls are made.
+
+import { describe, it, before, after, mock } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// ── isolate state.db + hermes-state ──────────────────────────────────────────
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "profiles-mcp-test-"));
+process.env.STATE_DB_PATH = path.join(TMP, "state.db");
+process.env.SQLITE_VEC_PATH = "";
+process.env.VAULT_PATH = path.join(TMP, "vault");
+process.env.ALFRED_DATA_DIR = TMP;
+process.env.HERMES_CONFIG_DIR = path.join(TMP, "profiles");
+process.env.HERMES_STATE_DIR_CTRL_VIEW = path.join(TMP, "hermes-state");
+process.env.INGEST_DB_PATH = path.join(TMP, "ingest.db");
+fs.mkdirSync(process.env.HERMES_CONFIG_DIR, { recursive: true });
+
+// ── mock nudgeHermesSupervisor (no docker calls) ──────────────────────────────
+const nudgeCalls: string[] = [];
+
+mock.module("../src/hermes/supervisor.js", {
+  namedExports: {
+    writeSupervisorRegistry: () => {},
+    nudgeHermesSupervisor: () => {
+      nudgeCalls.push("nudged");
+      return true;
+    },
+    restartProfile: () => ({
+      scope: "per-profile",
+      attempted: true,
+      warning: null,
+    }),
+    REGISTRY_PATH: path.join(TMP, "hermes-state", "profiles", "_registry.json"),
+  },
+});
+
+// ── import route layer ─────────────────────────────────────────────────────
+const { matchRoute } = await import("../src/api/server.js");
+const { registerProfileRoutes } = await import("../src/api/routes/profiles.js");
+const { handleError } = await import("../src/api/errors.js");
+const { getStateDb } = await import("../src/db/state.js");
+const { createProfile } = await import("../src/db/agentProfiles.js");
+
+registerProfileRoutes();
+
+// ── http test helper ───────────────────────────────────────────────────────
+// Mirrors the server.ts dispatch loop: wraps the handler in try/catch and
+// calls handleError() on thrown ApiErrors so the test sees the HTTP status
+// rather than an unhandled rejection.
+function invokeRoute(
+  method: string,
+  url: string,
+  params: Record<string, string> = {},
+  body?: unknown,
+): Promise<{ status: number; body: any }> {
+  const matched = matchRoute(method, url);
+  assert.ok(matched, `${method} ${url} must be registered`);
+  return new Promise((resolve, reject) => {
+    const bodyChunks: any[] = [];
+    let status = 200;
+    const res: any = {
+      statusCode: 200,
+      setHeader() {},
+      writeHead(s: number) {
+        status = s;
+      },
+      end(chunk?: any) {
+        if (chunk !== undefined) bodyChunks.push(chunk);
+        try {
+          const raw = Buffer.concat(
+            bodyChunks.map((c) =>
+              Buffer.isBuffer(c) ? c : Buffer.from(String(c)),
+            ),
+          ).toString();
+          resolve({ status, body: raw ? JSON.parse(raw) : {} });
+        } catch (e) {
+          reject(e);
+        }
+      },
+      write(chunk: any) {
+        bodyChunks.push(chunk);
+      },
+    };
+    const resolvedParams = matched!.params ?? {};
+    // Merge explicit params over matched wildcard params.
+    const mergedParams = { ...resolvedParams, ...params };
+    Promise.resolve(
+      matched!.handler({
+        req: {} as any,
+        res,
+        params: mergedParams,
+        query: new URLSearchParams(),
+        body: body ?? undefined,
+      }),
+    ).catch((err) => {
+      // Mirror server.ts: ApiErrors become structured HTTP responses.
+      try {
+        handleError(res, err);
+      } catch (e2) {
+        reject(e2);
+      }
+    });
+  });
+}
+
+// ── helpers ────────────────────────────────────────────────────────────────
+function writeConfig(slug: string, content: string): void {
+  const dir = path.join(process.env.HERMES_CONFIG_DIR!, slug);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "config.yaml"), content, "utf-8");
+}
+
+function readConfig(slug: string): string {
+  return fs.readFileSync(
+    path.join(process.env.HERMES_CONFIG_DIR!, slug, "config.yaml"),
+    "utf-8",
+  );
+}
+
+// ── setup ─────────────────────────────────────────────────────────────────
+const SENTINEL_SLUG = "mcp-test-sentinel";
+
+before(() => {
+  // Seed a non-reserved user profile in state.db for the tests.
+  const db = getStateDb();
+  createProfile(db, {
+    slug: SENTINEL_SLUG,
+    label: "MCP Test Sentinel",
+    model: "gpt-4.1",
+  });
+  nudgeCalls.length = 0;
+});
+
+after(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
+});
+
+// ── GET tests ─────────────────────────────────────────────────────────────
+
+describe("GET /api/v1/admin/profiles/:slug/mcp", () => {
+  it("returns 404 for an unknown slug", async () => {
+    const { status, body } = await invokeRoute(
+      "GET",
+      "/api/v1/admin/profiles/:slug/mcp",
+      { slug: "no-such-profile" },
+    );
+    assert.equal(status, 404);
+    assert.match(body.error.message ?? body.error, /not found/i);
+  });
+
+  it("returns 200 with empty servers when config.yaml absent", async () => {
+    const { status, body } = await invokeRoute(
+      "GET",
+      "/api/v1/admin/profiles/:slug/mcp",
+      { slug: SENTINEL_SLUG },
+    );
+    assert.equal(status, 200);
+    assert.equal(body.slug, SENTINEL_SLUG);
+    assert.equal(body.reserved, false);
+    assert.deepEqual(body.servers, []);
+  });
+
+  it("returns 200 with server list parsed from config.yaml", async () => {
+    writeConfig(
+      SENTINEL_SLUG,
+      `mcp_servers:\n  my-http-server:\n    url: "http://example.invalid"\n  my-stdio:\n    command: node\n    args:\n    - /opt/mcp/stdio.js\n`,
+    );
+    const { status, body } = await invokeRoute(
+      "GET",
+      "/api/v1/admin/profiles/:slug/mcp",
+      { slug: SENTINEL_SLUG },
+    );
+    assert.equal(status, 200);
+    assert.equal(body.servers.length, 2);
+    const httpSrv = body.servers.find((s: any) => s.name === "my-http-server");
+    assert.ok(httpSrv, "my-http-server must appear");
+    assert.equal(httpSrv.type, "http");
+    assert.equal(httpSrv.command_or_url, "http://example.invalid");
+    assert.equal(httpSrv.enabled, true);
+    const stdioSrv = body.servers.find((s: any) => s.name === "my-stdio");
+    assert.ok(stdioSrv, "my-stdio must appear");
+    assert.equal(stdioSrv.type, "stdio");
+    assert.match(stdioSrv.command_or_url, /node/);
+  });
+
+  it("returns reserved=true for 'main'", async () => {
+    const { status, body } = await invokeRoute(
+      "GET",
+      "/api/v1/admin/profiles/:slug/mcp",
+      { slug: "main" },
+    );
+    assert.equal(status, 200);
+    assert.equal(body.reserved, true);
+  });
+});
+
+// ── POST tests ────────────────────────────────────────────────────────────
+
+describe("POST /api/v1/admin/profiles/:slug/mcp", () => {
+  it("returns 409 for a reserved profile (main)", async () => {
+    const { status, body } = await invokeRoute(
+      "POST",
+      "/api/v1/admin/profiles/:slug/mcp",
+      { slug: "main" },
+      { name: "cdsk-test", url: "http://example.invalid" },
+    );
+    assert.equal(status, 409);
+    assert.match(body.error.message ?? body.error, /reserved_profile/);
+  });
+
+  it("returns 404 for an unknown slug", async () => {
+    const { status, body } = await invokeRoute(
+      "POST",
+      "/api/v1/admin/profiles/:slug/mcp",
+      { slug: "no-such-profile" },
+      { name: "cdsk-test", url: "http://example.invalid" },
+    );
+    assert.equal(status, 404);
+    assert.match(body.error.message ?? body.error, /not found/i);
+  });
+
+  it("returns 400 when name is missing", async () => {
+    const { status } = await invokeRoute(
+      "POST",
+      "/api/v1/admin/profiles/:slug/mcp",
+      { slug: SENTINEL_SLUG },
+      { url: "http://example.invalid" },
+    );
+    assert.equal(status, 400);
+  });
+
+  it("returns 400 when name is malformed (uppercase)", async () => {
+    const { status, body } = await invokeRoute(
+      "POST",
+      "/api/v1/admin/profiles/:slug/mcp",
+      { slug: SENTINEL_SLUG },
+      { name: "BadName", url: "http://example.invalid" },
+    );
+    assert.equal(status, 400);
+    assert.match(body.error.message ?? body.error, /name must match/i);
+  });
+
+  it("returns 400 when both url and command are provided", async () => {
+    const { status } = await invokeRoute(
+      "POST",
+      "/api/v1/admin/profiles/:slug/mcp",
+      { slug: SENTINEL_SLUG },
+      { name: "cdsk-test", url: "http://example.invalid", command: "node /opt/x.js" },
+    );
+    assert.equal(status, 400);
+  });
+
+  it("returns 400 when neither url nor command is provided", async () => {
+    const { status } = await invokeRoute(
+      "POST",
+      "/api/v1/admin/profiles/:slug/mcp",
+      { slug: SENTINEL_SLUG },
+      { name: "cdsk-test" },
+    );
+    assert.equal(status, 400);
+  });
+
+  it("adds an HTTP MCP server and returns 201; nudges supervisor", async () => {
+    nudgeCalls.length = 0;
+    const { status, body } = await invokeRoute(
+      "POST",
+      "/api/v1/admin/profiles/:slug/mcp",
+      { slug: SENTINEL_SLUG },
+      { name: "cdsk-added", url: "http://example.invalid" },
+    );
+    assert.equal(status, 201);
+    assert.equal(body.ok, true);
+    assert.equal(body.name, "cdsk-added");
+    assert.ok(nudgeCalls.length > 0, "supervisor was nudged");
+    // Verify config.yaml contains the new server.
+    const yaml = readConfig(SENTINEL_SLUG);
+    assert.match(yaml, /cdsk-added/);
+    assert.match(yaml, /http:\/\/example\.invalid/);
+  });
+
+  it("adds a stdio MCP server with command split into args", async () => {
+    const { status, body } = await invokeRoute(
+      "POST",
+      "/api/v1/admin/profiles/:slug/mcp",
+      { slug: SENTINEL_SLUG },
+      { name: "cdsk-stdio", command: "node /opt/mcp/server.js --port 9999" },
+    );
+    assert.equal(status, 201);
+    assert.equal(body.name, "cdsk-stdio");
+    const yaml = readConfig(SENTINEL_SLUG);
+    assert.match(yaml, /cdsk-stdio/);
+    assert.match(yaml, /node/);
+  });
+});
+
+// ── DELETE tests ──────────────────────────────────────────────────────────
+
+describe("DELETE /api/v1/admin/profiles/:slug/mcp/:name", () => {
+  it("returns 409 for a reserved profile (workers)", async () => {
+    const { status, body } = await invokeRoute(
+      "DELETE",
+      "/api/v1/admin/profiles/:slug/mcp/:name",
+      { slug: "workers", name: "something" },
+    );
+    assert.equal(status, 409);
+    assert.match(body.error.message ?? body.error, /reserved_profile/);
+  });
+
+  it("returns 404 if the MCP server name is absent from the profile", async () => {
+    // Ensure config.yaml exists but does not contain the target server.
+    writeConfig(SENTINEL_SLUG, `mcp_servers:\n  other-srv:\n    url: "http://x"\n`);
+    const { status, body } = await invokeRoute(
+      "DELETE",
+      "/api/v1/admin/profiles/:slug/mcp/:name",
+      { slug: SENTINEL_SLUG, name: "no-such-server" },
+    );
+    assert.equal(status, 404);
+    assert.match(body.error.message ?? body.error, /not found/i);
+  });
+
+  it("removes the server and returns 200; nudges supervisor", async () => {
+    // First add a server to remove.
+    writeConfig(
+      SENTINEL_SLUG,
+      `mcp_servers:\n  to-delete:\n    url: "http://to-delete.invalid"\n  keep-me:\n    url: "http://keep.invalid"\n`,
+    );
+    nudgeCalls.length = 0;
+    const { status, body } = await invokeRoute(
+      "DELETE",
+      "/api/v1/admin/profiles/:slug/mcp/:name",
+      { slug: SENTINEL_SLUG, name: "to-delete" },
+    );
+    assert.equal(status, 200);
+    assert.equal(body.ok, true);
+    assert.ok(nudgeCalls.length > 0, "supervisor was nudged after delete");
+    // Verify to-delete is gone; keep-me survives.
+    const yaml = readConfig(SENTINEL_SLUG);
+    assert.doesNotMatch(yaml, /to-delete/);
+    assert.match(yaml, /keep-me/);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds 3 routes to `packages/ctrl/src/api/routes/profiles.ts` under `/api/v1/admin/profiles/:slug/mcp` (C1 contract, issue #204)
- GET reads the profile's `config.yaml` `mcp_servers` block directly (same filesystem volume the hermes runtime uses); works for all slugs including reserved ones (read-only)
- POST adds an MCP server entry to `config.yaml` via atomic write-then-rename + supervisor SIGUSR1 nudge; reserved slugs → 409
- DELETE removes an entry from `config.yaml` + supervisor nudge; reserved slugs → 409
- 15 unit tests in `packages/ctrl/tests/profiles-mcp-catalog.test.ts` covering all 3 routes and error paths

**Implementation note (CLI → direct YAML patching)**: The contract spec says to use `hermes mcp add/remove -p <slug>`. After probing the live tenant the hermes CLI has no `-p <slug>` flag for `mcp` subcommands, and `hermes mcp add` is interactive (prompts "Enable all N tools? [y/N]"). Direct config.yaml patching is the correct approach — it's the same mechanism used by `render_mcp_servers.py` and `migrate-paperclip-board-key.sh` in the hermes init layer. Atomic writes (tmp + POSIX rename) prevent torn-file reads by the supervisor.

References #204. Does NOT use `Closes` — Lane III carries that.

## Smoke evidence

**Live tenant unreachable from worktree for new routes** (not yet deployed). Smoke run against in-process ctrl-api built from this PR (`dist/api.mjs`, `AAS_PORT=3199`).

**1. Baseline — GET /api/v1/agent-profiles (existing route, ctrl-api healthy)**

```
$ curl -s http://localhost:3199/api/v1/agent-profiles -H 'Authorization: Bearer smoke-test-key-204'
{"profiles":[{"slug":"main","label":"Alfred","description":"Your conversational Alfred on every channel (Slack/Telegram/SMS), with memory.","model":"x-ai/grok-4.3","deployment_shape":"supervised","api_server_port":18789,"persona_template":null,"status":"running","is_user_facing":true,"is_reserved":true,"created_at":1780236540000,"updated_at":1780236540000,"archived_at":null}],"port_range":{"lo":18794,"hi":18799},"free_slots":6}
```

**2. Setup — create test profile mcp-test-204**

```
$ curl -s -X POST http://localhost:3199/api/v1/agent-profiles \
  -H 'Authorization: Bearer smoke-test-key-204' \
  -H 'Content-Type: application/json' \
  -d '{"slug":"mcp-test-204","label":"MCP Test 204","model":"gpt-4.1","description":"Smoke test profile for #204"}'
{"profile":{"slug":"mcp-test-204","label":"MCP Test 204","description":"Smoke test profile for #204","model":"gpt-4.1","deployment_shape":"supervised","api_server_port":18794,"persona_template":null,"status":"pending","is_user_facing":true,"is_reserved":false,"created_at":1780236566247,"updated_at":1780236566247,"archived_at":null},"note":"Registry row written (status='pending'). Supervisor nudged; gateway should respond on the allocated port within ~30s."}
```

**3. Mutation — POST MCP server to mcp-test-204**

```
$ curl -s -X POST http://localhost:3199/api/v1/admin/profiles/mcp-test-204/mcp \
  -H 'Authorization: Bearer smoke-test-key-204' \
  -H 'Content-Type: application/json' \
  -d '{"name":"cdsk-test","url":"http://example.invalid"}'
{"ok":true,"name":"cdsk-test"}
```

**4. Isolation assertion — main profile MCP servers unchanged before and after mutation**

```
BEFORE:
{"slug":"main","reserved":true,"servers":[{"name":"alfred","type":"stdio","command_or_url":"node /opt/mcp/alfred.js","enabled":true},{"name":"sure","type":"stdio","command_or_url":"node /opt/mcp/sure.js","enabled":true}]}

AFTER:
{"slug":"main","reserved":true,"servers":[{"name":"alfred","type":"stdio","command_or_url":"node /opt/mcp/alfred.js","enabled":true},{"name":"sure","type":"stdio","command_or_url":"node /opt/mcp/sure.js","enabled":true}]}
```

Main profile is identical before and after mutation to mcp-test-204. No clobber.

**5. Audit-row presence — GET mcp-test-204/mcp shows cdsk-test**

```
$ curl -s http://localhost:3199/api/v1/admin/profiles/mcp-test-204/mcp \
  -H 'Authorization: Bearer smoke-test-key-204'
{"slug":"mcp-test-204","reserved":false,"servers":[{"name":"cdsk-test","type":"http","command_or_url":"http://example.invalid","enabled":true}]}
```

**6. Cleanup — DELETE server, verify empty, reserved-profile 409, archive profile**

```
=== DELETE cdsk-test ===
{"ok":true}

=== GET after delete (should be empty) ===
{"slug":"mcp-test-204","reserved":false,"servers":[]}

=== reserved profile POST → 409 ===
{"error":{"code":"CONFLICT","message":"reserved_profile"}}

=== ARCHIVE test profile ===
{"profile":{"slug":"mcp-test-204","label":"MCP Test 204",...,"status":"archived","archived_at":1780236600397},"note":"Registry row archived. ..."}
```

Deleted server no longer appears. Reserved profile correctly returns 409. Test profile archived cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)