### PR TITLE
feat(web): #205 Lane III — /profiles/:slug Skills section. Closes #205

### DIFF
--- a/packages/web/main.wasp
+++ b/packages/web/main.wasp
@@ -1271,6 +1271,21 @@ action removeProfileMcp {
   entities: []
 }
 
+// #205 Lane III — per-profile skill catalogue (Q4 from #120). Mirrors the
+// Q3 MCP-ops shape; GET is a query (read), PUT is an action (toggle).
+// `entities: []` for the same reason as the MCP ops above — the source of
+// truth is the Hermes profile's filesystem catalogue + config.yaml read and
+// written via the ctrl-api.
+query getProfileSkills {
+  fn: import { getProfileSkills } from "@src/dashboard/operations",
+  entities: []
+}
+
+action setProfileSkillEnabled {
+  fn: import { setProfileSkillEnabled } from "@src/dashboard/operations",
+  entities: []
+}
+
 // #120 Lane V — per-profile FULL channels surface ops.
 //
 // The three consolidator ops the /profiles/:slug/channels page wires up. They

--- a/packages/web/src/dashboard/ProfileDetailPage.tsx
+++ b/packages/web/src/dashboard/ProfileDetailPage.tsx
@@ -1,14 +1,17 @@
 // ProfileDetailPage — single profile + its channel bindings + lifecycle.
-// (#120 Lane III, #204 Lane III MCP section)
+// (#120 Lane III, #204 Lane III MCP section, #205 Lane III Skills section)
 //
 // Backend wire shape from ctrl-api (Lane I):
 //   GET /api/v1/agent-profiles/:slug → { profile: {...}, bindings: [...] }
 //   GET /api/v1/admin/profiles/:slug/mcp → { slug, reserved, servers: [...] }
+//   GET /api/v1/admin/profiles/:slug/skills → { slug, reserved, skills: [...] }
+//   PUT /api/v1/admin/profiles/:slug/skills/:name { enabled }
 //
 // Sections:
 //   * Header     — label · status pill · port · model · last-active
 //   * Channels   — list bindings (kind + identity) + a "Bind channel" form
 //   * MCP        — list registered MCP servers + add/remove (non-reserved only)
+//   * Skills     — list installed skill catalogue + enable/disable toggles
 //   * Persona    — read-only persona_template (edit lives in a follow-up)
 //   * Lifecycle  — Archive (user-facing non-reserved) or Restore (archived)
 //
@@ -22,12 +25,14 @@ import {
   useQuery,
   getAgentProfile,
   getProfileMcp,
+  getProfileSkills,
   archiveAgentProfile,
   restoreAgentProfile,
   bindChannelToProfile,
   unbindChannelFromProfile,
   addProfileMcp,
   removeProfileMcp,
+  setProfileSkillEnabled,
 } from "wasp/client/operations";
 import { Frame, PageHeading } from "../client/components/ab/Frame";
 
@@ -153,6 +158,43 @@ export default function ProfileDetailPage() {
 
   // MCP remove confirm state: holds the server name to confirm removal
   const [confirmRemoveMcp, setConfirmRemoveMcp] = useState<string | null>(null);
+
+  // Skills section state — #205 Lane III
+  const {
+    data: skillsData,
+    refetch: refetchSkills,
+  } = useQuery(getProfileSkills, { slug }, { enabled: !!slug });
+
+  const skills = ((skillsData as any)?.skills ?? []) as Array<{
+    name: string;
+    description: string | null;
+    enabled: boolean;
+    last_invoked_at: number | null;
+  }>;
+  const skillsReserved = (skillsData as any)?.reserved === true;
+
+  // Per-row toggle state — name of the skill currently being toggled,
+  // plus a per-row error (so a failed PUT shows under the row that failed
+  // rather than at the top of the section).
+  const [skillBusyName, setSkillBusyName] = useState<string | null>(null);
+  const [skillError, setSkillError] = useState<{ name: string; message: string } | null>(null);
+
+  async function onToggleSkill(name: string, currentEnabled: boolean) {
+    if (!slug || skillBusyName) return;
+    setSkillBusyName(name);
+    setSkillError(null);
+    try {
+      await setProfileSkillEnabled({ slug, name, enabled: !currentEnabled });
+      await refetchSkills();
+    } catch (e: any) {
+      setSkillError({
+        name,
+        message: String(e?.message || e || "Couldn't toggle the skill."),
+      });
+    } finally {
+      setSkillBusyName(null);
+    }
+  }
 
   async function onAddMcp() {
     if (mcpBusy || !slug) return;
@@ -750,6 +792,113 @@ export default function ProfileDetailPage() {
                   {mcpError}
                 </div>
               )}
+            </div>
+          )}
+        </section>
+
+        {/* Skills — #205 Lane III */}
+        <section className="mb-16">
+          <div
+            className="font-mono text-[10px] uppercase tracking-[0.28em] mb-3"
+            style={{ color: "var(--brass)" }}
+          >
+            Skills
+          </div>
+          <h2 className="font-display text-3xl tracking-tight mb-6">
+            The skill catalogue installed for this profile.
+          </h2>
+
+          {(skillsReserved || profile.is_reserved) && (
+            <p
+              className="font-body italic mb-4"
+              style={{ color: "var(--marginalia)" }}
+            >
+              Reserved profile — skills managed by operators.
+            </p>
+          )}
+
+          {skills.length === 0 && (
+            <p
+              className="font-body italic mb-6"
+              style={{ color: "var(--marginalia)" }}
+            >
+              No skills installed for this profile yet.
+            </p>
+          )}
+
+          {skills.length > 0 && (
+            <div className="border-t border-rule mb-6">
+              {skills.map((sk) => {
+                const isReserved = skillsReserved || profile.is_reserved;
+                const isBusy = skillBusyName === sk.name;
+                const rowErr = skillError?.name === sk.name ? skillError.message : null;
+                return (
+                  <div
+                    key={sk.name}
+                    className="py-4 border-b border-rule"
+                  >
+                    <div className="grid grid-cols-[1fr_auto] items-start gap-4">
+                      <div className="min-w-0">
+                        <div
+                          className="font-mono text-[12px] font-medium truncate"
+                          style={{ color: "var(--ink)" }}
+                        >
+                          {sk.name}
+                        </div>
+                        <div
+                          className="font-body italic text-[12px] mt-1"
+                          style={{ color: "var(--marginalia)" }}
+                        >
+                          {sk.description || "—"}
+                        </div>
+                        <div
+                          className="font-mono text-[10px] uppercase tracking-[0.18em] mt-2"
+                          style={{ color: "var(--marginalia)" }}
+                        >
+                          last invoked: {fmtRelative(sk.last_invoked_at)}
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-3 shrink-0">
+                        <span
+                          className="font-mono text-[10px] uppercase tracking-[0.18em]"
+                          style={{
+                            color: sk.enabled ? "#3D7B4F" : "var(--marginalia)",
+                          }}
+                        >
+                          {sk.enabled ? "on" : "off"}
+                        </span>
+                        {!isReserved && (
+                          <button
+                            onClick={() => onToggleSkill(sk.name, sk.enabled)}
+                            disabled={isBusy}
+                            className="font-mono text-[10px] uppercase tracking-[0.18em]"
+                            style={{
+                              color: sk.enabled ? "#B85C5C" : "var(--brass)",
+                              opacity: isBusy ? 0.5 : 1,
+                            }}
+                          >
+                            {isBusy
+                              ? sk.enabled
+                                ? "Disabling…"
+                                : "Enabling…"
+                              : sk.enabled
+                                ? "Disable"
+                                : "Enable"}
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                    {rowErr && (
+                      <div
+                        className="mt-2 font-body italic text-sm"
+                        style={{ color: "#B85C5C" }}
+                      >
+                        {rowErr}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
             </div>
           )}
         </section>

--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -3683,6 +3683,59 @@ export const removeProfileMcp = async (
   });
 };
 
+// ── #205 Lane III — per-profile skill catalogue (C-1.1 / C-1.2 contract) ──
+//
+// Two thin proxies to ctrl-api /api/v1/admin/profiles/:slug/skills.
+// GET     → { slug, reserved, skills: [{ name, description, enabled, last_invoked_at }] }
+// PUT /:name → 200 { ok, name, enabled }   body: { enabled }
+//
+// Reserved profiles (main|workers|heavy|codex-builder): mutations return
+// 409 from ctrl-api; the UI layer renders the catalogue read-only and
+// suppresses the toggle controls.
+//
+// `Promise<any>` annotation is REQUIRED — Wasp Payload trap (PRs #139 #145
+// #182 #184 #186 #214). Never replace with a typed return.
+
+// Skill directory names are slug-ish: lowercase, hyphen/underscore allowed,
+// longer cap than MCP server names (skill slugs run long — see C-1.2).
+const SKILL_NAME_RE = /^[a-z][a-z0-9_-]{0,80}$/;
+
+export const getProfileSkills = async (
+  args: { slug: string },
+  context: any,
+): Promise<any> => {
+  if (!context.user) throw new HttpError(401, "Not authenticated");
+  const slug = String(args?.slug ?? "").trim();
+  if (!slug) throw new HttpError(400, "slug required");
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    path: `/api/v1/admin/profiles/${encodeURIComponent(slug)}/skills`,
+  });
+};
+
+export const setProfileSkillEnabled = async (
+  args: { slug: string; name: string; enabled: boolean },
+  context: any,
+): Promise<any> => {
+  if (!context.user) throw new HttpError(401, "Not authenticated");
+  const slug = String(args?.slug ?? "").trim();
+  const name = String(args?.name ?? "").trim();
+  if (!slug) throw new HttpError(400, "slug required");
+  if (!name) throw new HttpError(400, "name required");
+  if (!SKILL_NAME_RE.test(name)) {
+    throw new HttpError(400, "name must match ^[a-z][a-z0-9_-]{0,80}$");
+  }
+  if (typeof args?.enabled !== "boolean") {
+    throw new HttpError(400, "enabled (boolean) required");
+  }
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    method: "PUT",
+    path: `/api/v1/admin/profiles/${encodeURIComponent(slug)}/skills/${encodeURIComponent(name)}`,
+    body: { enabled: args.enabled },
+  });
+};
+
 // ── #120 Lane V — per-profile FULL channels surface ──────────────────────
 //
 // Three consolidator ops that route through Lane IV's ?profile=<slug> shape


### PR DESCRIPTION
## Summary

Adds a **Skills** section to `/profiles/:slug` (`ProfileDetailPage`) that
surfaces the per-profile skill catalogue and a per-row Enable/Disable
toggle. Mirrors the Q3 MCP-section shape (PR #214) exactly — same
Wasp-op pattern, same reserved-banner UX, same `Promise<any>` Payload
trap avoidance.

- Two new Wasp ops in `packages/web/main.wasp`:
  - `query getProfileSkills` — proxies `GET /api/v1/admin/profiles/:slug/skills`
  - `action setProfileSkillEnabled` — proxies `PUT /api/v1/admin/profiles/:slug/skills/:name`
- New section in `ProfileDetailPage.tsx` placed between MCP and Persona
  (page order: Header → Channels → MCP → **Skills** → Persona → Lifecycle).
- Reserved profiles (`main` / `workers` / `heavy` / `codex-builder`)
  render the catalogue read-only with the banner
  `"Reserved profile — skills managed by operators."`. Toggle controls
  are suppressed (gate: `skillsReserved || profile.is_reserved`).
- Per-row error state under the failing row, mirroring the Q3 `mcpError`
  pattern.
- `Promise<any>` returns on both ops to dodge the Wasp Payload trap
  (PRs #139/#145/#182/#184/#186/#214).

Lane I is being built in parallel on `lane-i/205-skills-catalog-routes`
(routes + tests on `packages/ctrl/**`). This lane codes against the
frozen wire shape in `/tmp/orchestrator-205-contracts.md` (C-1.1 / C-1.2)
and does not touch any ctrl/learn/hermes files.

## Smoke evidence

Six sections per the lane-smoke template. Per the Lane III brief and
PR #214 precedent, sections 1–3 are satisfied by static analysis because
Lane I's routes only exist on the parallel branch — the live tenant
runs `:latest` and would 404 on `/api/v1/admin/profiles/:slug/skills`.
This is honest partial smoke; the network-level smoke runs once both
PRs merge and the image redeploys.

### 1. Baseline — pre-change tree healthy
Branch cut from `origin/main` (`480038a9` — Q3 MCP section PR #214,
already merged). The Q3 MCP section is the canonical sibling shape
this PR mirrors. No regression — Skills is purely additive.

### 2. Setup — fixture / shape inventory (static)
Frozen wire shape per `/tmp/orchestrator-205-contracts.md`:
- `GET /api/v1/admin/profiles/:slug/skills` → `{ slug, reserved, skills: [{ name, description, enabled, last_invoked_at }] }`
- `PUT /api/v1/admin/profiles/:slug/skills/:name` body `{ enabled }` → `{ ok, name, enabled }`

`getProfileSkills` (operations.ts) issues GET to
`/api/v1/admin/profiles/${encodeURIComponent(slug)}/skills` with no body.
`setProfileSkillEnabled` (operations.ts) issues PUT to
`/api/v1/admin/profiles/${encodeURIComponent(slug)}/skills/${encodeURIComponent(name)}`
with body `{ enabled: args.enabled }`. Method, path, and body keys
match the C-1.1 / C-1.2 contract exactly.

### 3. Mutation — the actual change
Per-skill enable/disable wired through `onToggleSkill(name, currentEnabled)`,
which calls `setProfileSkillEnabled({ slug, name, enabled: !currentEnabled })`
then `refetchSkills()`. Confirmed by static grep:
```
166:  } = useQuery(getProfileSkills, { slug }, { enabled: !!slug });
187:      await setProfileSkillEnabled({ slug, name, enabled: !currentEnabled });
```

### 4. Isolation assertion
Staged diff (`git diff --cached --numstat`):
```
15	0	packages/web/main.wasp
150	1	packages/web/src/dashboard/ProfileDetailPage.tsx
53	0	packages/web/src/dashboard/operations.ts
```
Net 218 LOC, three files, all within `packages/web/**` (the Lane III
allowed glob in `scripts/hooks/lanes.json`). Zero touches to
`packages/ctrl/**`, `packages/learn/**`, `packages/hermes/**`,
`packages/mcp-server/**`. Lane gate passed at commit time.

Bracket balance:
- `ProfileDetailPage.tsx`: opens=346 closes=346 diff=0
- `operations.ts`: opens=986 closes=986 diff=0

Reserved-banner gate is JSX-guarded by `skillsReserved || profile.is_reserved`
(line 811) — and the per-row toggle button is gated by `!isReserved` where
`isReserved = skillsReserved || profile.is_reserved` (line 832). Reserved
profiles structurally cannot render toggle controls; the banner string
`"Reserved profile — skills managed by operators."` mirrors PR #214's
banner placement exactly.

### 5. Audit row — Wasp action call shape
`setProfileSkillEnabled` declared as a Wasp `action` in `main.wasp` with
`entities: []` (matches Q3's `addProfileMcp` / `removeProfileMcp`
declarations). On success the call returns `{ ok, name, enabled }` per
C-1.2; on 409/404/400 the proxy surfaces ctrl-api's error body to the
UI, which sets `skillError = { name, message }` and renders an inline
error under the failing row.

### 6. Cleanup
Tree-only — no infra side-effects. No fixture rows on disk; the
catalogue is filesystem-backed in `${HERMES_HOME}/profiles/<slug>/skills/`
and `config.yaml`, both owned by Lane I.

---

Lane I PR (parallel): `lane-i/205-skills-catalog-routes`.

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)