### PR TITLE
feat(ctrl): #205 Lane I — per-profile skill catalog routes

### DIFF
--- a/packages/ctrl/src/api/routes/profiles.ts
+++ b/packages/ctrl/src/api/routes/profiles.ts
@@ -21,6 +21,9 @@
 //   POST   /api/v1/admin/profiles/:slug/mcp                (#204 Lane I)
 //   DELETE /api/v1/admin/profiles/:slug/mcp/:name          (#204 Lane I)
 //
+//   GET    /api/v1/admin/profiles/:slug/skills             (#205 Lane I)
+//   PUT    /api/v1/admin/profiles/:slug/skills/:name       (#205 Lane I)
+//
 // POST returns 202 Accepted (not 201) because the Hermes-side activation is
 // deferred to Lane II — the registry row writes immediately but no gateway
 // is started yet. Lane II flips status from 'pending' to 'running'.
@@ -693,6 +696,227 @@ export function registerProfileRoutes(): void {
         }
 
         sendJson(res, 200, { ok: true });
+      } catch (err) {
+        _classify(err);
+      }
+    },
+  );
+
+  // ─────────────────────────────────────────────────────────────
+  // Per-profile skill catalogue (#205 Lane I — C-1 contract)
+  //
+  // Source of truth:
+  //   - Catalogue:   ${HERMES_HOME}/profiles/<slug>/skills/<name>/SKILL.md
+  //   - Enabled set: <slug>/config.yaml `skills.disabled` array (absent ≡ all on)
+  //
+  // GET works for any slug (incl. reserved). PUT refuses reserved slugs (409).
+  // Atomic write + best-effort supervisor nudge — same idiom as the MCP routes
+  // above; do NOT diverge from it.
+  // ─────────────────────────────────────────────────────────────
+
+  /** Resolved path to a profile's skills/ directory (via the ctrl-api volume view). */
+  function profileSkillsDir(slug: string): string {
+    return path.join(HERMES_PROFILE_BASE_DIR(), slug, "skills");
+  }
+
+  /** Skill name must be a safe identifier (no shell injection, matches C-1.2). */
+  const SKILL_NAME_RE = /^[a-z][a-z0-9_-]{0,80}$/;
+
+  /**
+   * Parse the leading `---\n…\n---` YAML frontmatter block from a SKILL.md.
+   * Returns {} if no frontmatter or unparseable. Scalar values only — same
+   * defensive stance as loadProfileConfig().
+   */
+  function _parseSkillFrontmatter(raw: string): Record<string, unknown> {
+    // Frontmatter must be the very first block; allow leading BOM/whitespace.
+    const m = raw.match(/^\s*---\r?\n([\s\S]*?)\r?\n---/);
+    if (!m) return {};
+    try {
+      const parsed = yaml.load(m[1]);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      /* unparseable frontmatter — skip */
+    }
+    return {};
+  }
+
+  // GET /api/v1/admin/profiles/:slug/skills
+  addRoute(
+    "GET",
+    "/api/v1/admin/profiles/:slug/skills",
+    async ({ res, params }) => {
+      try {
+        const slug = params.slug;
+        const profile = getProfile(db(), slug);
+        if (!profile) throw new NotFoundError(`profile '${slug}' not found`);
+
+        // Build the disabled set from config.yaml. Absence ≡ everything enabled.
+        const cfg = loadProfileConfig(slug);
+        const skillsBlock = cfg["skills"];
+        const disabled = new Set<string>();
+        if (skillsBlock && typeof skillsBlock === "object" && !Array.isArray(skillsBlock)) {
+          const raw = (skillsBlock as Record<string, unknown>)["disabled"];
+          if (Array.isArray(raw)) {
+            for (const n of raw) {
+              if (typeof n === "string") disabled.add(n);
+            }
+          }
+        }
+
+        // Enumerate skill dirs from the filesystem. Missing skills/ ≡ [].
+        const skillsDir = profileSkillsDir(slug);
+        const skills: Array<{
+          name: string;
+          description: string | null;
+          enabled: boolean;
+          last_invoked_at: number | null;
+        }> = [];
+        let entries: fs.Dirent[] = [];
+        try {
+          entries = fs.readdirSync(skillsDir, { withFileTypes: true });
+        } catch {
+          /* dir doesn't exist yet — treat as empty catalogue, NOT 500 */
+        }
+        for (const ent of entries) {
+          if (!ent.isDirectory()) continue;
+          const skillMdPath = path.join(skillsDir, ent.name, "SKILL.md");
+          let rawSkill: string;
+          try {
+            rawSkill = fs.readFileSync(skillMdPath, "utf-8");
+          } catch {
+            // No SKILL.md → not a skill (could be a workspace stash). Skip.
+            continue;
+          }
+          const fm = _parseSkillFrontmatter(rawSkill);
+          const description =
+            typeof fm["description"] === "string"
+              ? (fm["description"] as string)
+              : null;
+          skills.push({
+            name: ent.name,
+            description,
+            enabled: !disabled.has(ent.name),
+            last_invoked_at: null, // v1 — no telemetry source yet (see C-1.1)
+          });
+        }
+        // Deterministic order for the UI.
+        skills.sort((a, b) => a.name.localeCompare(b.name));
+
+        sendJson(res, 200, {
+          slug,
+          reserved: RESERVED_SLUGS.has(slug),
+          skills,
+        });
+      } catch (err) {
+        _classify(err);
+      }
+    },
+  );
+
+  // PUT /api/v1/admin/profiles/:slug/skills/:name
+  addRoute(
+    "PUT",
+    "/api/v1/admin/profiles/:slug/skills/:name",
+    async ({ res, params, body }) => {
+      try {
+        const slug = params.slug;
+        if (RESERVED_SLUGS.has(slug)) {
+          throw new ConflictError("reserved_profile");
+        }
+        const profile = getProfile(db(), slug);
+        if (!profile) throw new NotFoundError(`profile '${slug}' not found`);
+
+        const name = params.name;
+        if (!SKILL_NAME_RE.test(name)) {
+          throw new ValidationError("invalid_skill_name");
+        }
+
+        const b = asObj(body);
+        const enabledRaw = b["enabled"];
+        if (typeof enabledRaw !== "boolean") {
+          throw new ValidationError("enabled_required_boolean");
+        }
+
+        // Skill must exist on disk under this profile.
+        const skillDir = path.join(profileSkillsDir(slug), name);
+        try {
+          const stat = fs.statSync(skillDir);
+          if (!stat.isDirectory()) {
+            throw new NotFoundError(`skill '${name}' not found in profile '${slug}'`);
+          }
+        } catch (err: any) {
+          if (err && err.code === "ENOENT") {
+            throw new NotFoundError(`skill '${name}' not found in profile '${slug}'`);
+          }
+          throw err;
+        }
+
+        // Load existing config.yaml (preserve all other keys).
+        const cfgPath = profileConfigPath(slug);
+        let cfg: Record<string, unknown> = {};
+        try {
+          const rawYaml = fs.readFileSync(cfgPath, "utf-8");
+          const parsed = yaml.load(rawYaml);
+          if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            cfg = parsed as Record<string, unknown>;
+          }
+        } catch {
+          /* fresh config */
+        }
+
+        // Ensure skills is an object (preserve siblings like creation_nudge_interval).
+        if (
+          !cfg["skills"] ||
+          typeof cfg["skills"] !== "object" ||
+          Array.isArray(cfg["skills"])
+        ) {
+          cfg["skills"] = {};
+        }
+        const skillsBlock = cfg["skills"] as Record<string, unknown>;
+
+        // Read existing disabled array (defensive: drop non-string entries).
+        const existing: string[] = Array.isArray(skillsBlock["disabled"])
+          ? (skillsBlock["disabled"] as unknown[]).filter(
+              (x): x is string => typeof x === "string",
+            )
+          : [];
+        const disabledSet = new Set<string>(existing);
+
+        if (enabledRaw) {
+          // enabling → remove from disabled set
+          disabledSet.delete(name);
+        } else {
+          // disabling → add to disabled set
+          disabledSet.add(name);
+        }
+
+        if (disabledSet.size === 0) {
+          // Tidy: drop the empty array entirely.
+          delete skillsBlock["disabled"];
+        } else {
+          skillsBlock["disabled"] = Array.from(disabledSet).sort();
+        }
+
+        // Atomic write — yaml.dump + rename. Mirror the MCP POST handler.
+        const newYaml = yaml.dump(cfg, { lineWidth: 120, quotingType: '"' });
+        const tmpPath = cfgPath + ".tmp";
+        fs.mkdirSync(path.dirname(cfgPath), { recursive: true });
+        fs.writeFileSync(tmpPath, newYaml, { encoding: "utf-8", mode: 0o644 });
+        fs.renameSync(tmpPath, cfgPath);
+
+        // Best-effort supervisor nudge.
+        try {
+          nudgeHermesSupervisor();
+        } catch (err) {
+          console.warn(
+            `[profiles/skills] supervisor nudge after toggle('${slug}/${name}') failed:`,
+            err instanceof Error ? err.message : err,
+          );
+        }
+
+        sendJson(res, 200, { ok: true, name, enabled: enabledRaw });
       } catch (err) {
         _classify(err);
       }

--- a/packages/ctrl/tests/profiles-skills-catalog.test.ts
+++ b/packages/ctrl/tests/profiles-skills-catalog.test.ts
@@ -1,0 +1,339 @@
+// profiles-skills-catalog — unit tests for #205 Lane I per-profile skill routes.
+//
+// Routes under test:
+//   GET /api/v1/admin/profiles/:slug/skills
+//   PUT /api/v1/admin/profiles/:slug/skills/:name
+//
+// Same in-process harness as profiles-mcp-catalog.test.ts.
+
+import { describe, it, before, after, mock } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// ── isolate state.db + hermes-state ────────────────────────────────────────
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "profiles-skills-test-"));
+process.env.STATE_DB_PATH = path.join(TMP, "state.db");
+process.env.SQLITE_VEC_PATH = "";
+process.env.VAULT_PATH = path.join(TMP, "vault");
+process.env.ALFRED_DATA_DIR = TMP;
+process.env.HERMES_CONFIG_DIR = path.join(TMP, "profiles");
+process.env.HERMES_STATE_DIR_CTRL_VIEW = path.join(TMP, "hermes-state");
+process.env.INGEST_DB_PATH = path.join(TMP, "ingest.db");
+fs.mkdirSync(process.env.HERMES_CONFIG_DIR, { recursive: true });
+
+// ── mock the supervisor (no docker calls) ──────────────────────────────────
+const nudgeCalls: string[] = [];
+mock.module("../src/hermes/supervisor.js", {
+  namedExports: {
+    writeSupervisorRegistry: () => {},
+    nudgeHermesSupervisor: () => {
+      nudgeCalls.push("nudged");
+      return true;
+    },
+    restartProfile: () => ({ scope: "per-profile", attempted: true, warning: null }),
+    REGISTRY_PATH: path.join(TMP, "hermes-state", "profiles", "_registry.json"),
+  },
+});
+
+const { matchRoute } = await import("../src/api/server.js");
+const { registerProfileRoutes } = await import("../src/api/routes/profiles.js");
+const { handleError } = await import("../src/api/errors.js");
+const { getStateDb } = await import("../src/db/state.js");
+const { createProfile } = await import("../src/db/agentProfiles.js");
+
+registerProfileRoutes();
+
+// ── http test helper (mirror of profiles-mcp-catalog) ─────────────────────
+function invokeRoute(
+  method: string,
+  url: string,
+  params: Record<string, string> = {},
+  body?: unknown,
+): Promise<{ status: number; body: any }> {
+  const matched = matchRoute(method, url);
+  assert.ok(matched, `${method} ${url} must be registered`);
+  return new Promise((resolve, reject) => {
+    const chunks: any[] = [];
+    let status = 200;
+    const res: any = {
+      statusCode: 200,
+      setHeader() {},
+      writeHead(s: number) { status = s; },
+      end(c?: any) {
+        if (c !== undefined) chunks.push(c);
+        try {
+          const raw = Buffer.concat(
+            chunks.map((c) => (Buffer.isBuffer(c) ? c : Buffer.from(String(c)))),
+          ).toString();
+          resolve({ status, body: raw ? JSON.parse(raw) : {} });
+        } catch (e) { reject(e); }
+      },
+      write(c: any) { chunks.push(c); },
+    };
+    const merged = { ...(matched!.params ?? {}), ...params };
+    Promise.resolve(
+      matched!.handler({
+        req: {} as any, res, params: merged,
+        query: new URLSearchParams(), body: body ?? undefined,
+      }),
+    ).catch((err) => {
+      try { handleError(res, err); } catch (e2) { reject(e2); }
+    });
+  });
+}
+
+// ── fixture helpers ────────────────────────────────────────────────────────
+const profDir = (slug: string) => path.join(process.env.HERMES_CONFIG_DIR!, slug);
+const cfgPath = (slug: string) => path.join(profDir(slug), "config.yaml");
+const readCfg = (slug: string) => fs.readFileSync(cfgPath(slug), "utf-8");
+const writeCfg = (slug: string, content: string) => {
+  fs.mkdirSync(profDir(slug), { recursive: true });
+  fs.writeFileSync(cfgPath(slug), content, "utf-8");
+};
+const delCfg = (slug: string) => { try { fs.unlinkSync(cfgPath(slug)); } catch {} };
+const rmSkills = (slug: string) =>
+  fs.rmSync(path.join(profDir(slug), "skills"), { recursive: true, force: true });
+const writeSkill = (slug: string, name: string, desc: string | null) => {
+  const dir = path.join(profDir(slug), "skills", name);
+  fs.mkdirSync(dir, { recursive: true });
+  const body = desc === null ? "Body without frontmatter.\n" :
+    `---\ndescription: "${desc}"\n---\n\nBody.\n`;
+  fs.writeFileSync(path.join(dir, "SKILL.md"), body, "utf-8");
+};
+const writeBareDir = (slug: string, name: string) => {
+  const dir = path.join(profDir(slug), "skills", name);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "README.txt"), "stash\n", "utf-8");
+};
+
+// ── setup ──────────────────────────────────────────────────────────────────
+const SLUG = "skills-test-sentinel";
+
+before(() => {
+  createProfile(getStateDb(), { slug: SLUG, label: "Skills Test", model: "gpt-4.1" });
+  fs.mkdirSync(profDir(SLUG), { recursive: true });
+  nudgeCalls.length = 0;
+});
+
+after(() => { fs.rmSync(TMP, { recursive: true, force: true }); });
+
+// ── GET tests ──────────────────────────────────────────────────────────────
+
+describe("GET /api/v1/admin/profiles/:slug/skills", () => {
+  it("returns 404 for an unknown slug", async () => {
+    const { status, body } = await invokeRoute(
+      "GET", "/api/v1/admin/profiles/:slug/skills", { slug: "no-such" });
+    assert.equal(status, 404);
+    assert.match(body.error.message ?? body.error, /not found/i);
+  });
+
+  it("returns 200 + empty skills when skills/ dir absent", async () => {
+    rmSkills(SLUG); delCfg(SLUG);
+    const { status, body } = await invokeRoute(
+      "GET", "/api/v1/admin/profiles/:slug/skills", { slug: SLUG });
+    assert.equal(status, 200);
+    assert.equal(body.slug, SLUG);
+    assert.equal(body.reserved, false);
+    assert.deepEqual(body.skills, []);
+  });
+
+  it("returns alphabetically-sorted catalogue with descriptions; all enabled by default", async () => {
+    rmSkills(SLUG); delCfg(SLUG);
+    writeSkill(SLUG, "zeta-skill", "Last alpha.");
+    writeSkill(SLUG, "alpha-skill", "First alpha.");
+    writeSkill(SLUG, "middle-skill", null);
+    const { status, body } = await invokeRoute(
+      "GET", "/api/v1/admin/profiles/:slug/skills", { slug: SLUG });
+    assert.equal(status, 200);
+    assert.deepEqual(
+      body.skills.map((s: any) => s.name),
+      ["alpha-skill", "middle-skill", "zeta-skill"],
+    );
+    assert.equal(body.skills[0].description, "First alpha.");
+    assert.equal(body.skills[1].description, null);
+    for (const s of body.skills) {
+      assert.equal(s.enabled, true);
+      assert.equal(s.last_invoked_at, null);
+    }
+  });
+
+  it("merges enabled=false from skills.disabled in config.yaml", async () => {
+    rmSkills(SLUG);
+    writeSkill(SLUG, "foo", "F."); writeSkill(SLUG, "bar", "B.");
+    writeCfg(SLUG, `skills:\n  disabled:\n    - foo\n`);
+    const { body } = await invokeRoute(
+      "GET", "/api/v1/admin/profiles/:slug/skills", { slug: SLUG });
+    const foo = body.skills.find((s: any) => s.name === "foo");
+    const bar = body.skills.find((s: any) => s.name === "bar");
+    assert.equal(foo.enabled, false);
+    assert.equal(bar.enabled, true);
+  });
+
+  it("skips child directories without a SKILL.md", async () => {
+    rmSkills(SLUG); delCfg(SLUG);
+    writeSkill(SLUG, "real-skill", "R.");
+    writeBareDir(SLUG, "not-a-skill");
+    const { body } = await invokeRoute(
+      "GET", "/api/v1/admin/profiles/:slug/skills", { slug: SLUG });
+    assert.equal(body.skills.length, 1);
+    assert.equal(body.skills[0].name, "real-skill");
+  });
+
+  it("returns reserved=true for 'main' and still surfaces the catalogue", async () => {
+    writeSkill("main", "main-only-skill", "On main.");
+    const { status, body } = await invokeRoute(
+      "GET", "/api/v1/admin/profiles/:slug/skills", { slug: "main" });
+    assert.equal(status, 200);
+    assert.equal(body.reserved, true);
+    assert.ok(body.skills.find((s: any) => s.name === "main-only-skill"));
+  });
+});
+
+// ── PUT tests ──────────────────────────────────────────────────────────────
+
+describe("PUT /api/v1/admin/profiles/:slug/skills/:name", () => {
+  it("returns 409 for a reserved profile (main)", async () => {
+    const { status, body } = await invokeRoute(
+      "PUT", "/api/v1/admin/profiles/:slug/skills/:name",
+      { slug: "main", name: "any" }, { enabled: false });
+    assert.equal(status, 409);
+    assert.match(body.error.message ?? body.error, /reserved_profile/);
+  });
+
+  it("returns 404 for an unknown profile slug", async () => {
+    const { status, body } = await invokeRoute(
+      "PUT", "/api/v1/admin/profiles/:slug/skills/:name",
+      { slug: "no-such", name: "any" }, { enabled: false });
+    assert.equal(status, 404);
+    assert.match(body.error.message ?? body.error, /not found/i);
+  });
+
+  it("returns 400 when skill name fails the regex", async () => {
+    const { status, body } = await invokeRoute(
+      "PUT", "/api/v1/admin/profiles/:slug/skills/:name",
+      { slug: SLUG, name: "BadName" }, { enabled: false });
+    assert.equal(status, 400);
+    assert.match(body.error.message ?? body.error, /invalid_skill_name/);
+  });
+
+  it("returns 400 when 'enabled' is missing or non-boolean", async () => {
+    rmSkills(SLUG); writeSkill(SLUG, "some-skill", "ok");
+    const r1 = await invokeRoute(
+      "PUT", "/api/v1/admin/profiles/:slug/skills/:name",
+      { slug: SLUG, name: "some-skill" }, {});
+    assert.equal(r1.status, 400);
+    assert.match(r1.body.error.message ?? r1.body.error, /enabled_required_boolean/);
+    const r2 = await invokeRoute(
+      "PUT", "/api/v1/admin/profiles/:slug/skills/:name",
+      { slug: SLUG, name: "some-skill" }, { enabled: "yes" });
+    assert.equal(r2.status, 400);
+    assert.match(r2.body.error.message ?? r2.body.error, /enabled_required_boolean/);
+  });
+
+  it("returns 404 when skill directory is missing on disk", async () => {
+    rmSkills(SLUG);
+    const { status, body } = await invokeRoute(
+      "PUT", "/api/v1/admin/profiles/:slug/skills/:name",
+      { slug: SLUG, name: "ghost" }, { enabled: false });
+    assert.equal(status, 404);
+    assert.match(body.error.message ?? body.error, /not found/i);
+  });
+
+  it("toggles a skill OFF then ON; empty disabled array is dropped from config", async () => {
+    rmSkills(SLUG); delCfg(SLUG);
+    writeSkill(SLUG, "toggle-skill", "T.");
+    nudgeCalls.length = 0;
+    const off = await invokeRoute(
+      "PUT", "/api/v1/admin/profiles/:slug/skills/:name",
+      { slug: SLUG, name: "toggle-skill" }, { enabled: false });
+    assert.equal(off.status, 200);
+    assert.deepEqual(off.body, { ok: true, name: "toggle-skill", enabled: false });
+    const yamlOff = readCfg(SLUG);
+    assert.match(yamlOff, /disabled:/);
+    assert.match(yamlOff, /toggle-skill/);
+    assert.ok(nudgeCalls.length > 0);
+    const on = await invokeRoute(
+      "PUT", "/api/v1/admin/profiles/:slug/skills/:name",
+      { slug: SLUG, name: "toggle-skill" }, { enabled: true });
+    assert.equal(on.status, 200);
+    assert.equal(on.body.enabled, true);
+    assert.doesNotMatch(readCfg(SLUG), /disabled:/);
+  });
+
+  it("preserves sibling skills.* keys across mutation", async () => {
+    rmSkills(SLUG);
+    writeSkill(SLUG, "pres-skill", "p");
+    writeCfg(SLUG, `skills:\n  creation_nudge_interval: 42\n`);
+    const { status } = await invokeRoute(
+      "PUT", "/api/v1/admin/profiles/:slug/skills/:name",
+      { slug: SLUG, name: "pres-skill" }, { enabled: false });
+    assert.equal(status, 200);
+    const yaml = readCfg(SLUG);
+    assert.match(yaml, /creation_nudge_interval: 42/);
+    assert.match(yaml, /disabled:/);
+  });
+
+  it("preserves other top-level keys (mcp_servers) across mutation", async () => {
+    rmSkills(SLUG);
+    writeSkill(SLUG, "co-skill", "c");
+    writeCfg(SLUG, `mcp_servers:\n  alfred-ctrl:\n    url: "http://ctrl-api:3100"\nskills:\n  creation_nudge_interval: 7\n`);
+    const { status } = await invokeRoute(
+      "PUT", "/api/v1/admin/profiles/:slug/skills/:name",
+      { slug: SLUG, name: "co-skill" }, { enabled: false });
+    assert.equal(status, 200);
+    const yaml = readCfg(SLUG);
+    assert.match(yaml, /mcp_servers:/);
+    assert.match(yaml, /alfred-ctrl:/);
+    assert.match(yaml, /creation_nudge_interval: 7/);
+  });
+
+  it("is idempotent — disabling twice leaves a single entry", async () => {
+    rmSkills(SLUG); delCfg(SLUG);
+    writeSkill(SLUG, "idem-skill", "i");
+    await invokeRoute("PUT", "/api/v1/admin/profiles/:slug/skills/:name",
+      { slug: SLUG, name: "idem-skill" }, { enabled: false });
+    await invokeRoute("PUT", "/api/v1/admin/profiles/:slug/skills/:name",
+      { slug: SLUG, name: "idem-skill" }, { enabled: false });
+    const matches = readCfg(SLUG).match(/idem-skill/g) ?? [];
+    assert.equal(matches.length, 1);
+  });
+
+  it("sorts and dedupes the disabled array deterministically", async () => {
+    rmSkills(SLUG);
+    writeSkill(SLUG, "zeta", "z"); writeSkill(SLUG, "alpha", "a");
+    writeCfg(SLUG, `skills:\n  disabled:\n    - zeta\n    - zeta\n`);
+    const { status } = await invokeRoute(
+      "PUT", "/api/v1/admin/profiles/:slug/skills/:name",
+      { slug: SLUG, name: "alpha" }, { enabled: false });
+    assert.equal(status, 200);
+    const yaml = readCfg(SLUG);
+    const alphaIdx = yaml.indexOf("- alpha");
+    const zetaIdx = yaml.indexOf("- zeta");
+    assert.ok(alphaIdx > 0 && zetaIdx > alphaIdx, "alpha sorted before zeta");
+    assert.equal((yaml.match(/- zeta/g) ?? []).length, 1, "zeta deduped");
+  });
+
+  it("nudges supervisor on every successful mutation", async () => {
+    rmSkills(SLUG); delCfg(SLUG);
+    writeSkill(SLUG, "nudge-skill", "n");
+    nudgeCalls.length = 0;
+    const { status } = await invokeRoute(
+      "PUT", "/api/v1/admin/profiles/:slug/skills/:name",
+      { slug: SLUG, name: "nudge-skill" }, { enabled: false });
+    assert.equal(status, 200);
+    assert.ok(nudgeCalls.length >= 1);
+  });
+
+  it("creates config.yaml when none exists yet (fresh profile path)", async () => {
+    rmSkills(SLUG); delCfg(SLUG);
+    writeSkill(SLUG, "fresh-skill", "f");
+    assert.equal(fs.existsSync(cfgPath(SLUG)), false);
+    const { status } = await invokeRoute(
+      "PUT", "/api/v1/admin/profiles/:slug/skills/:name",
+      { slug: SLUG, name: "fresh-skill" }, { enabled: false });
+    assert.equal(status, 200);
+    assert.match(readCfg(SLUG), /fresh-skill/);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds two routes to `packages/ctrl/src/api/routes/profiles.ts` under `/api/v1/admin/profiles/:slug/skills*` (#205 Q4 polish from #120).
- `GET` enumerates `${HERMES_HOME}/profiles/<slug>/skills/<name>/SKILL.md`, parses minimal YAML frontmatter for `description`, and merges per-skill enabled state from the profile's `config.yaml` `skills.disabled` array. Works for every slug including reserved (read-only).
- `PUT` toggles one skill on/off — mutates only `skills.disabled` (sort + dedupe + drop-when-empty). Atomic write via tmp + rename, then best-effort `nudgeHermesSupervisor()`. Reserved slugs → 409.

**Mirrors PR #215 exactly** — same filesystem source-of-truth (no `hermes` CLI flag, no `-p <slug>` dependency), same idempotency idiom, same error classes (404 missing profile / 404 missing skill on disk / 409 reserved / 400 regex / 400 enabled-must-be-bool). Reuses the existing `profileConfigPath()` and `loadProfileConfig()` helpers introduced by #204 — no re-declaration.

**`last_invoked_at`** returns `null` in v1 — there is no skill-invocation telemetry source yet, and shipping `null` is honest. C-1.1 explicitly permits this; a follow-up issue can wire telemetry when the source exists.

References #205. `Closes #205` is carried by Lane III.

## Smoke evidence

### 1. Baseline — ctrl-api healthy on `:3199`

```
$ curl -s -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer smoke-test-key" http://127.0.0.1:3199/api/v1/agent-profiles
200
```

### 2. Setup — create `smoke-prof` registry row + seed skill fixtures

```
$ curl -s -X POST -H "$H" -H 'Content-Type: application/json' \
    -d '{"slug":"smoke-prof","label":"Smoke Profile","model":"gpt-4.1"}' \
    $BASE/api/v1/agent-profiles
{"profile":{"slug":"smoke-prof","label":"Smoke Profile",...,"api_server_port":18794,"status":"pending",...},"note":"Registry row written..."}

$ tree /tmp/ctrl-205-smoke/profiles
profiles
├── main/skills/main-only-skill/SKILL.md
└── smoke-prof/skills/
    ├── alfred-daily-briefing/SKILL.md  (description: "Compose the morning brief.")
    └── alfred-vault-rescue/SKILL.md    (description: "Rescue orphaned vault files.")
```

### 3. Mutation — exercise both routes across all status branches

```
=== GET smoke-prof skills (non-reserved; 2 skills sorted) ===
HTTP 200
{"slug":"smoke-prof","reserved":false,"skills":[
  {"name":"alfred-daily-briefing","description":"Compose the morning brief.","enabled":true,"last_invoked_at":null},
  {"name":"alfred-vault-rescue","description":"Rescue orphaned vault files.","enabled":true,"last_invoked_at":null}
]}

=== GET main skills (reserved=true; catalogue still surfaces) ===
HTTP 200
{"slug":"main","reserved":true,"skills":[
  {"name":"main-only-skill","description":"Reserved-profile read-only.","enabled":true,"last_invoked_at":null}
]}

=== GET unknown slug → 404 ===
HTTP 404
{"error":{"code":"NOT_FOUND","message":"profile 'no-such' not found"}}

=== PUT toggle OFF ===
HTTP 200
{"ok":true,"name":"alfred-daily-briefing","enabled":false}
$ cat /tmp/ctrl-205-smoke/profiles/smoke-prof/config.yaml
skills:
  disabled:
    - alfred-daily-briefing

=== GET re-reads enabled=false ===
{"skills":[{"name":"alfred-daily-briefing",...,"enabled":false},
           {"name":"alfred-vault-rescue",...,"enabled":true}]}

=== PUT toggle ON (round-trip drops disabled key entirely) ===
HTTP 200
{"ok":true,"name":"alfred-daily-briefing","enabled":true}
$ cat config.yaml
skills: {}

=== Reserved 'main' refuses writes ===
HTTP 409  {"error":{"code":"CONFLICT","message":"reserved_profile"}}

=== Invalid skill name regex ===
HTTP 400  {"error":{"code":"VALIDATION_ERROR","message":"invalid_skill_name"}}

=== Non-boolean enabled ===
HTTP 400  {"error":{"code":"VALIDATION_ERROR","message":"enabled_required_boolean"}}

=== Skill not on disk ===
HTTP 404  {"error":{"code":"NOT_FOUND","message":"skill 'no-such-skill' not found in profile 'smoke-prof'"}}

=== Slug not in registry ===
HTTP 404  {"error":{"code":"NOT_FOUND","message":"profile 'no-such-profile' not found"}}
```

Every status branch (200 × 2, 400 × 2, 404 × 2, 409 × 1) confirmed live against `dist/api.mjs` running on `127.0.0.1:3199`.

### 4. Isolation assertion — only Lane I files touched

```
$ git show --stat HEAD
 packages/ctrl/src/api/routes/profiles.ts           | 224 ++++++++++++++
 packages/ctrl/tests/profiles-skills-catalog.test.ts | 339 +++++++++++++++++++++
 2 files changed, 563 insertions(+)
```

Zero files outside `packages/ctrl/`. Both files inside Lane I's allowed glob (`packages/ctrl/**`). Existing routes in `profiles.ts` unchanged (additive — appended after MCP DELETE handler).

### 5. Audit row — test pass output + sibling test still green

```
$ cd packages/ctrl && node --experimental-sqlite --experimental-test-module-mocks \
    --import tsx/esm --experimental-loader ./tests/text-loader.mjs \
    --test tests/profiles-skills-catalog.test.ts
▶ GET /api/v1/admin/profiles/:slug/skills
  ✔ returns 404 for an unknown slug
  ✔ returns 200 + empty skills when skills/ dir absent
  ✔ returns alphabetically-sorted catalogue with descriptions; all enabled by default
  ✔ merges enabled=false from skills.disabled in config.yaml
  ✔ skips child directories without a SKILL.md
  ✔ returns reserved=true for 'main' and still surfaces the catalogue
▶ PUT /api/v1/admin/profiles/:slug/skills/:name
  ✔ returns 409 for a reserved profile (main)
  ✔ returns 404 for an unknown profile slug
  ✔ returns 400 when skill name fails the regex
  ✔ returns 400 when 'enabled' is missing or non-boolean
  ✔ returns 404 when skill directory is missing on disk
  ✔ toggles a skill OFF then ON; empty disabled array is dropped from config
  ✔ preserves sibling skills.* keys across mutation
  ✔ preserves other top-level keys (mcp_servers) across mutation
  ✔ is idempotent — disabling twice leaves a single entry
  ✔ sorts and dedupes the disabled array deterministically
  ✔ nudges supervisor on every successful mutation
  ✔ creates config.yaml when none exists yet (fresh profile path)
ℹ tests 18  pass 18  fail 0  duration_ms 490
```

Sibling `profiles-mcp-catalog.test.ts` (PR #215) **also still passes 15/15** — confirms no regression to the Q3 routes that share the same file.

### 6. Cleanup — fixture removal

```
$ kill $(cat /tmp/ctrl-205-server.pid); rm -rf /tmp/ctrl-205-smoke
```

## Honest partials

- **`last_invoked_at` is `null` for every skill** — C-1.1 explicitly permits this in v1 ("no skill-invocation telemetry source yet"). A follow-up issue can wire the wire-up when there's a source to read from.
- **`tsc --noEmit` baseline failures exist on `origin/main`** (Node 25 `node:sqlite` types unresolved + a few legacy strict-null spots in unrelated routes). My change adds zero new `tsc` errors — filtering `tsc --noEmit 2>&1 | grep profiles` returns empty. The `.lane` `verify` therefore runs the test command only.
- **Net diff is 563 LOC** (224 route + 339 test) — over the standing 200 LOC default but within the issue brief's explicit budget. Route code alone is 224 LOC, well under the 300 LOC ceiling the brief set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)