### PR TITLE
feat(ctrl): #206 Lane I — channel_identity table + Q5 bootstrap render

### DIFF
--- a/packages/ctrl/src/api/routes/channel_identity.ts
+++ b/packages/ctrl/src/api/routes/channel_identity.ts
@@ -1,0 +1,426 @@
+// channel_identity — per-(profile, channel_kind) display_name + avatar HTTP.
+//
+// Companion to routes/profiles.ts. Route map:
+//   GET    /api/v1/agent-profiles/:slug/channel-identities
+//   GET    /api/v1/agent-profiles/:slug/channel-identities/:kind
+//   PUT    /api/v1/agent-profiles/:slug/channel-identities/:kind
+//   DELETE /api/v1/agent-profiles/:slug/channel-identities/:kind
+//
+// PUT is multipart/form-data only. The text field `display_name` is
+// optional; the binary field `avatar` is optional (image/png|jpeg|webp,
+// ≤2 MB). At least one of the two must be present.
+//
+// JSON GET endpoints stay JSON. Errors:
+//   404 — unknown slug or (GET-one) no identity row
+//   409 — slug is reserved or archived
+//   400 — unknown channel_kind, no fields supplied, avatar too large, wrong mime
+//   422 — display_name > 64 chars OR contains newlines
+
+import fs from "node:fs";
+import path from "node:path";
+import type { IncomingMessage } from "node:http";
+import { addRoute } from "../server.js";
+import {
+  sendJson,
+  ValidationError,
+  NotFoundError,
+  ConflictError,
+  ApiError,
+} from "../errors.js";
+import { getStateDb } from "../../db/state.js";
+import {
+  KNOWN_CHANNEL_KINDS,
+  HERMES_PROFILE_BASE_DIR,
+  getProfile,
+} from "../../db/agentProfiles.js";
+import {
+  ALLOWED_AVATAR_MIMES,
+  assertKnownChannelKind,
+  assertWritableIdentityProfile,
+  avatarExtForMime,
+  avatarPathFor,
+  deleteChannelIdentity,
+  getChannelIdentity,
+  listChannelIdentities,
+  upsertChannelIdentity,
+} from "../../db/channelIdentity.js";
+
+const AVATAR_MAX_BYTES = 2 * 1024 * 1024; // 2 MiB
+const DISPLAY_NAME_MAX = 64;
+
+/** Map helper-thrown Errors to the right ApiError subclass. */
+function _classifyIdentity(err: unknown): never {
+  if (err instanceof ApiError) throw err;
+  if (!(err instanceof Error)) throw err as Error;
+  const m = err.message;
+  if (m.startsWith("profile '") && m.endsWith("not found")) {
+    throw new NotFoundError(m);
+  }
+  if (m.includes("is reserved") || m.includes("is archived")) {
+    throw new ConflictError(m);
+  }
+  if (m.includes("not a known channel")) {
+    throw new ValidationError(m);
+  }
+  throw new ValidationError(m);
+}
+
+// ── multipart parser ───────────────────────────────────────────────────────
+//
+// Tuned for the small-payload case: an avatar ≤ 2 MB and one short text
+// field. Drains the whole body into RAM (bounded by AVATAR_MAX_BYTES * 2
+// for headroom), then peels parts off. Streamed-to-disk parsing lives in
+// routes/files.ts for the multi-GB upload path; we don't need that here.
+
+interface MultipartPart {
+  name: string;
+  filename: string | null;
+  contentType: string | null;
+  data: Buffer;
+}
+
+function parseBoundary(contentType: string): string | null {
+  const m = /boundary=("?)([^";]+)\1/i.exec(contentType);
+  return m ? m[2] : null;
+}
+
+function parseContentDisposition(value: string): {
+  name: string | null;
+  filename: string | null;
+} {
+  let name: string | null = null;
+  let filename: string | null = null;
+  const nameMatch = /name=("?)([^";]+)\1/i.exec(value);
+  if (nameMatch) name = nameMatch[2];
+  const fnMatch = /filename=("?)([^"]*)\1/i.exec(value);
+  if (fnMatch) filename = fnMatch[2];
+  return { name, filename };
+}
+
+function readBody(req: IncomingMessage, maxBytes: number): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    req.on("data", (chunk: Buffer) => {
+      total += chunk.length;
+      if (total > maxBytes) {
+        reject(
+          new ApiError(
+            400,
+            "UPLOAD_TOO_LARGE",
+            `multipart payload exceeds ${maxBytes} bytes`,
+          ),
+        );
+        try {
+          req.destroy();
+        } catch {
+          /* noop */
+        }
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => resolve(Buffer.concat(chunks)));
+    req.on("error", reject);
+  });
+}
+
+function splitParts(body: Buffer, boundary: string): MultipartPart[] {
+  const delim = Buffer.from(`--${boundary}`);
+  const headerSep = Buffer.from("\r\n\r\n");
+  const parts: MultipartPart[] = [];
+
+  // Find every delimiter position.
+  const positions: number[] = [];
+  let from = 0;
+  while (true) {
+    const idx = body.indexOf(delim, from);
+    if (idx < 0) break;
+    positions.push(idx);
+    from = idx + delim.length;
+  }
+  // We need at least the opening + closing delimiter.
+  if (positions.length < 2) return parts;
+  for (let i = 0; i < positions.length - 1; i++) {
+    // Each part begins right after a delimiter+CRLF and ends right before
+    // the next \r\n--boundary.
+    const startBoundary = positions[i];
+    const partStart = startBoundary + delim.length;
+    // Skip the CRLF after the boundary
+    let afterCrlf = partStart;
+    if (
+      body.length >= afterCrlf + 2 &&
+      body[afterCrlf] === 0x0d &&
+      body[afterCrlf + 1] === 0x0a
+    ) {
+      afterCrlf += 2;
+    } else if (
+      body.length >= afterCrlf + 2 &&
+      body[afterCrlf] === 0x2d &&
+      body[afterCrlf + 1] === 0x2d
+    ) {
+      // closing delimiter at this position — done
+      break;
+    } else {
+      // unexpected — skip
+      continue;
+    }
+    // End of this part: right before the next \r\n--boundary.
+    const nextBoundary = positions[i + 1];
+    // Strip the \r\n that precedes the next boundary.
+    let partEnd = nextBoundary;
+    if (
+      partEnd >= 2 &&
+      body[partEnd - 2] === 0x0d &&
+      body[partEnd - 1] === 0x0a
+    ) {
+      partEnd -= 2;
+    }
+    // Header / body split.
+    const headerEnd = body.indexOf(headerSep, afterCrlf);
+    if (headerEnd < 0 || headerEnd > partEnd) continue;
+    const headerBlock = body.slice(afterCrlf, headerEnd).toString("utf-8");
+    const data = body.slice(headerEnd + headerSep.length, partEnd);
+    // Parse headers.
+    let name: string | null = null;
+    let filename: string | null = null;
+    let contentType: string | null = null;
+    for (const line of headerBlock.split("\r\n")) {
+      const colon = line.indexOf(":");
+      if (colon < 0) continue;
+      const k = line.slice(0, colon).trim().toLowerCase();
+      const v = line.slice(colon + 1).trim();
+      if (k === "content-disposition") {
+        const cd = parseContentDisposition(v);
+        name = cd.name;
+        filename = cd.filename;
+      } else if (k === "content-type") {
+        contentType = v;
+      }
+    }
+    if (!name) continue;
+    parts.push({ name, filename, contentType, data });
+  }
+  return parts;
+}
+
+// ── route registration ─────────────────────────────────────────────────────
+
+export function registerChannelIdentityRoutes(): void {
+  const db = getStateDb;
+
+  // GET list — one row per kind for this profile.
+  addRoute(
+    "GET",
+    "/api/v1/agent-profiles/:slug/channel-identities",
+    async ({ res, params }) => {
+      try {
+        const slug = params.slug;
+        const profile = getProfile(db(), slug);
+        if (!profile) throw new NotFoundError(`profile '${slug}' not found`);
+        const identities = listChannelIdentities(db(), slug);
+        sendJson(res, 200, { identities });
+      } catch (err) {
+        _classifyIdentity(err);
+      }
+    },
+  );
+
+  // GET one — 404 if there's no row for this (slug, kind).
+  addRoute(
+    "GET",
+    "/api/v1/agent-profiles/:slug/channel-identities/:kind",
+    async ({ res, params }) => {
+      try {
+        const slug = params.slug;
+        const kind = params.kind;
+        const profile = getProfile(db(), slug);
+        if (!profile) throw new NotFoundError(`profile '${slug}' not found`);
+        assertKnownChannelKind(kind);
+        const row = getChannelIdentity(db(), slug, kind);
+        if (!row) {
+          throw new NotFoundError(
+            `channel_identity for profile '${slug}' kind '${kind}' not found`,
+          );
+        }
+        sendJson(res, 200, row);
+      } catch (err) {
+        _classifyIdentity(err);
+      }
+    },
+  );
+
+  // PUT — multipart/form-data upsert. Accepts `display_name` (text, optional)
+  // and `avatar` (file, optional). At least one must be present.
+  addRoute(
+    "PUT",
+    "/api/v1/agent-profiles/:slug/channel-identities/:kind",
+    async ({ req, res, params }) => {
+      try {
+        const slug = params.slug;
+        const kind = params.kind;
+
+        // Lookup + guards (404, 409, 400 — in that order).
+        const profile = getProfile(db(), slug);
+        if (!profile) throw new NotFoundError(`profile '${slug}' not found`);
+        if (profile.is_reserved) {
+          throw new ConflictError(`profile '${slug}' is reserved`);
+        }
+        if (profile.archived_at != null) {
+          throw new ConflictError(`profile '${slug}' is archived`);
+        }
+        assertKnownChannelKind(kind);
+
+        // Multipart parse.
+        const ct = String(req.headers["content-type"] ?? "");
+        if (!ct.toLowerCase().startsWith("multipart/form-data")) {
+          throw new ValidationError(
+            "Content-Type must be multipart/form-data",
+          );
+        }
+        const boundary = parseBoundary(ct);
+        if (!boundary) {
+          throw new ValidationError("multipart/form-data boundary= missing");
+        }
+        // Generous outer cap so a too-large avatar still surfaces our 400.
+        const raw = await readBody(req, AVATAR_MAX_BYTES + 32 * 1024);
+        const parts = splitParts(raw, boundary);
+
+        let display_name: string | null | undefined;
+        let avatar_bytes: Buffer | null = null;
+        let avatar_mime: string | null = null;
+        for (const p of parts) {
+          if (p.name === "display_name") {
+            // Treat empty-string as "clear it" — but PUT semantics require
+            // at least one non-empty field, so check below.
+            display_name = p.data.toString("utf-8");
+          } else if (p.name === "avatar") {
+            // An empty file part (e.g. user submitted with no file selected)
+            // is silently ignored — treat as not provided.
+            if (p.data.length > 0) {
+              avatar_bytes = p.data;
+              avatar_mime = p.contentType;
+            }
+          }
+        }
+
+        // At least one of {display_name, avatar} must be present + non-empty.
+        const has_display_name =
+          display_name !== undefined && display_name.trim().length > 0;
+        const has_avatar = avatar_bytes != null;
+        if (!has_display_name && !has_avatar) {
+          throw new ValidationError(
+            "at least one of {display_name, avatar} is required",
+          );
+        }
+
+        // Validate display_name shape.
+        let final_display_name: string | undefined;
+        if (has_display_name) {
+          const trimmed = display_name!.trim();
+          if (trimmed.includes("\n") || trimmed.includes("\r")) {
+            throw new ApiError(
+              422,
+              "DISPLAY_NAME_INVALID",
+              "display_name must not contain newlines",
+            );
+          }
+          if (trimmed.length > DISPLAY_NAME_MAX) {
+            throw new ApiError(
+              422,
+              "DISPLAY_NAME_TOO_LONG",
+              `display_name exceeds ${DISPLAY_NAME_MAX} characters`,
+            );
+          }
+          final_display_name = trimmed;
+        }
+
+        // Validate avatar shape.
+        let final_avatar_path: string | undefined;
+        let final_avatar_mime: string | undefined;
+        if (has_avatar) {
+          if (avatar_bytes!.length > AVATAR_MAX_BYTES) {
+            throw new ValidationError(
+              `avatar exceeds ${AVATAR_MAX_BYTES} bytes`,
+            );
+          }
+          if (!avatar_mime || !ALLOWED_AVATAR_MIMES.has(avatar_mime)) {
+            throw new ValidationError(
+              `avatar mime '${avatar_mime ?? "<missing>"}' not allowed (image/png|image/jpeg|image/webp)`,
+            );
+          }
+          const ext = avatarExtForMime(avatar_mime);
+          if (!ext) {
+            throw new ValidationError(`avatar mime '${avatar_mime}' not allowed`);
+          }
+          // Replace any prior avatar (regardless of ext) with the new one.
+          const existing = getChannelIdentity(db(), slug, kind);
+          if (existing?.avatar_path && existing.avatar_path !== avatarPathFor(slug, kind, ext)) {
+            try {
+              fs.unlinkSync(existing.avatar_path);
+            } catch {
+              /* best-effort */
+            }
+          }
+          const dest = avatarPathFor(slug, kind, ext);
+          fs.mkdirSync(path.dirname(dest), { recursive: true });
+          // Write to tmp + rename for atomicity.
+          const tmp = dest + ".tmp";
+          fs.writeFileSync(tmp, avatar_bytes!, { mode: 0o644 });
+          fs.renameSync(tmp, dest);
+          final_avatar_path = dest;
+          final_avatar_mime = avatar_mime;
+        }
+
+        assertWritableIdentityProfile(db(), slug);
+        const row = upsertChannelIdentity(db(), slug, kind, {
+          display_name: final_display_name,
+          avatar_path: final_avatar_path,
+          avatar_mime: final_avatar_mime,
+        });
+        sendJson(res, 200, row);
+      } catch (err) {
+        _classifyIdentity(err);
+      }
+    },
+  );
+
+  // DELETE — drop the row + unlink avatar file. 204 on success; 404 if no
+  // row existed. Reserved/archived profile → 409 (so the UI sees the same
+  // surface as PUT).
+  addRoute(
+    "DELETE",
+    "/api/v1/agent-profiles/:slug/channel-identities/:kind",
+    async ({ res, params }) => {
+      try {
+        const slug = params.slug;
+        const kind = params.kind;
+        const profile = getProfile(db(), slug);
+        if (!profile) throw new NotFoundError(`profile '${slug}' not found`);
+        if (profile.is_reserved) {
+          throw new ConflictError(`profile '${slug}' is reserved`);
+        }
+        if (profile.archived_at != null) {
+          throw new ConflictError(`profile '${slug}' is archived`);
+        }
+        assertKnownChannelKind(kind);
+        const removed = deleteChannelIdentity(db(), slug, kind);
+        if (!removed) {
+          throw new NotFoundError(
+            `channel_identity for profile '${slug}' kind '${kind}' not found`,
+          );
+        }
+        // 204 No Content — same idiom file delete uses.
+        res.statusCode = 204;
+        res.end();
+      } catch (err) {
+        _classifyIdentity(err);
+      }
+    },
+  );
+
+  // Suppress unused-import warning when tests don't exercise HERMES_PROFILE_BASE_DIR
+  // directly — the avatarPathFor helper consumes it transitively.
+  void HERMES_PROFILE_BASE_DIR;
+  void KNOWN_CHANNEL_KINDS;
+}

--- a/packages/ctrl/src/api/routes/profiles.ts
+++ b/packages/ctrl/src/api/routes/profiles.ts
@@ -91,6 +91,187 @@ function optStr(o: Record<string, unknown>, key: string): string | null {
   return typeof v === "string" && v.trim() ? v.trim() : null;
 }
 
+// #206 Q5 — profile-bootstrap helpers.
+//
+// At profile-create time the principal can supply three optional fields:
+//   * role            — string ≤ 200, single line (no newlines)
+//   * tone            — string ≤ 64,  single line
+//   * first_actions   — string[] ≤ 10 items, each ≤ 200 chars
+//
+// If `role` OR `tone` is set, render RULES.md.
+// If `first_actions` is non-empty, render daybook.md.
+// If a file already exists at the destination path, SKIP — never clobber.
+//
+// SOUL.md continues to be written by the existing persona_template path
+// (Hermes supervisor consolidates it into HERMES_HOME on boot); these
+// helpers do NOT touch it.
+
+const ROLE_MAX = 200;
+const TONE_MAX = 64;
+const ACTION_MAX = 200;
+const FIRST_ACTIONS_MAX = 10;
+
+interface BootstrapFields {
+  role: string | null;
+  tone: string | null;
+  first_actions: string[];
+}
+
+function _validateLine(value: string, max: number, field: string): string {
+  if (value.includes("\n") || value.includes("\r")) {
+    throw new ApiError(
+      422,
+      "PROMOTION_FAIL",
+      `${field} must be a single line (no newlines)`,
+      { field },
+    );
+  }
+  if (value.length > max) {
+    throw new ApiError(
+      422,
+      "PROMOTION_FAIL",
+      `${field} exceeds ${max} characters`,
+      { field },
+    );
+  }
+  return value;
+}
+
+function _extractBootstrap(b: Record<string, unknown>): BootstrapFields {
+  const role_raw = b["role"];
+  const tone_raw = b["tone"];
+  const role =
+    typeof role_raw === "string" && role_raw.trim()
+      ? _validateLine(role_raw.trim(), ROLE_MAX, "role")
+      : null;
+  const tone =
+    typeof tone_raw === "string" && tone_raw.trim()
+      ? _validateLine(tone_raw.trim(), TONE_MAX, "tone")
+      : null;
+  const fa_raw = b["first_actions"];
+  let first_actions: string[] = [];
+  if (Array.isArray(fa_raw)) {
+    if (fa_raw.length > FIRST_ACTIONS_MAX) {
+      throw new ApiError(
+        422,
+        "PROMOTION_FAIL",
+        `first_actions exceeds ${FIRST_ACTIONS_MAX} items`,
+        { field: "first_actions" },
+      );
+    }
+    for (let i = 0; i < fa_raw.length; i++) {
+      const item = fa_raw[i];
+      if (typeof item !== "string") {
+        throw new ApiError(
+          422,
+          "PROMOTION_FAIL",
+          `first_actions[${i}] must be a string`,
+          { field: "first_actions" },
+        );
+      }
+      const trimmed = item.trim();
+      if (!trimmed) continue; // drop empty entries silently
+      _validateLine(trimmed, ACTION_MAX, `first_actions[${i}]`);
+      first_actions.push(trimmed);
+    }
+  } else if (fa_raw !== undefined && fa_raw !== null) {
+    throw new ApiError(
+      422,
+      "PROMOTION_FAIL",
+      "first_actions must be an array of strings",
+      { field: "first_actions" },
+    );
+  }
+  return { role, tone, first_actions };
+}
+
+function _renderRulesMd(label: string, role: string | null, tone: string | null): string {
+  return [
+    `# Rules for ${label}`,
+    "",
+    "## Role",
+    role ?? "",
+    "",
+    "## Tone",
+    tone ?? "",
+    "",
+    "<!-- Edit me. These are the standing rules the profile honours when it acts. -->",
+    "",
+  ].join("\n");
+}
+
+function _renderDaybookMd(label: string, first_actions: string[]): string {
+  const lines = [
+    `# Daybook — ${label}`,
+    "",
+    "## First actions",
+  ];
+  for (const a of first_actions) lines.push(`- [ ] ${a}`);
+  lines.push("");
+  lines.push("<!-- The day-one work this profile picks up. Tick as completed. -->");
+  lines.push("");
+  return lines.join("\n");
+}
+
+/**
+ * Write RULES.md / daybook.md into the per-profile dir. Idempotent: existing
+ * files are NOT clobbered. SOUL.md is left to the existing render flow.
+ *
+ * Best-effort writes — failures here do NOT block the registry insert (the
+ * profile dir might not exist yet, e.g. in test harnesses with a fake
+ * HERMES_CONFIG_DIR). We log + continue.
+ */
+function _writeBootstrapFiles(
+  slug: string,
+  label: string,
+  fields: BootstrapFields,
+): void {
+  const profileDir = path.join(HERMES_PROFILE_BASE_DIR(), slug);
+  try {
+    fs.mkdirSync(profileDir, { recursive: true });
+  } catch (err) {
+    console.warn(
+      `[profiles] bootstrap mkdir('${profileDir}') failed:`,
+      err instanceof Error ? err.message : err,
+    );
+    return;
+  }
+  // RULES.md — written iff role OR tone is present.
+  if (fields.role || fields.tone) {
+    const dest = path.join(profileDir, "RULES.md");
+    if (!fs.existsSync(dest)) {
+      try {
+        fs.writeFileSync(dest, _renderRulesMd(label, fields.role, fields.tone), {
+          encoding: "utf-8",
+          mode: 0o644,
+        });
+      } catch (err) {
+        console.warn(
+          `[profiles] bootstrap RULES.md write failed:`,
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }
+  }
+  // daybook.md — written iff first_actions is non-empty.
+  if (fields.first_actions.length > 0) {
+    const dest = path.join(profileDir, "daybook.md");
+    if (!fs.existsSync(dest)) {
+      try {
+        fs.writeFileSync(dest, _renderDaybookMd(label, fields.first_actions), {
+          encoding: "utf-8",
+          mode: 0o644,
+        });
+      } catch (err) {
+        console.warn(
+          `[profiles] bootstrap daybook.md write failed:`,
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }
+  }
+}
+
 // Map a lib-thrown Error to the right ApiError subclass.
 //
 // The library throws plain Error with stable message prefixes; we match on
@@ -242,6 +423,12 @@ export function registerProfileRoutes(): void {
         _classify(err);
       }
 
+      // #206 Q5 — extract + validate bootstrap fields BEFORE the registry
+      // insert. If validation throws 422, the row never lands. Validation
+      // happens here at the route layer (not the lib) because the contract
+      // is HTTP-shape, not DB-shape.
+      const bootstrap = _extractBootstrap(b);
+
       const profile = createProfile(db(), {
         slug,
         label,
@@ -250,6 +437,12 @@ export function registerProfileRoutes(): void {
         persona_template,
         deployment_shape,
       });
+
+      // #206 Q5 — render RULES.md / daybook.md into the profile dir. Best-
+      // effort and skip-if-exists. SOUL.md path is unchanged (Hermes
+      // supervisor consolidates persona_template).
+      _writeBootstrapFiles(slug, label, bootstrap);
+
       // Lane II — write the supervisor registry + nudge Hermes so the new
       // profile dir is rendered and a gateway is launched on the allocated
       // port. Best-effort: if the registry write or the docker kill fails

--- a/packages/ctrl/src/api/server.ts
+++ b/packages/ctrl/src/api/server.ts
@@ -72,6 +72,7 @@ import { registerAlfredDeliverRoutes } from "./routes/alfredDeliver.js";
 import { registerFilesRoutes } from "./routes/files.js";
 import { registerChannelsTailscaleRoutes } from "./routes/channels_tailscale.js";
 import { registerProfileRoutes } from "./routes/profiles.js";
+import { registerChannelIdentityRoutes } from "./routes/channel_identity.js";
 
 export interface RouteParams {
   [key: string]: string;
@@ -240,6 +241,10 @@ export function createApiServer(): http.Server {
   // Hermes-side activation yet (Lane II); no channel-route rewiring (Lane IV).
   // See packages/ctrl/src/db/migrations/0017_agent_profiles.sql.
   registerProfileRoutes();
+  // Per-(profile, channel_kind) display_name + avatar (#206 Q6 Lane I).
+  // Consumed by Lane IV adapters at send time via resolveChannelIdentity().
+  // See packages/ctrl/src/db/migrations/0018_channel_identity.sql.
+  registerChannelIdentityRoutes();
 
   const server = http.createServer(async (req: IncomingMessage, res: ServerResponse) => {
     const start = Date.now();

--- a/packages/ctrl/src/db/channelIdentity.ts
+++ b/packages/ctrl/src/db/channelIdentity.ts
@@ -1,0 +1,272 @@
+// channelIdentity — per-(profile, channel_kind) display_name + avatar lib.
+//
+// Backed by the `channel_identity` table added in
+// 0018_channel_identity.sql. Pure DB+fs lib — no HTTP. The HTTP surface
+// (routes/channel_identity.ts) is the only place that translates these
+// helper errors into ApiError statuses; Lane IV consumes
+// resolveChannelIdentity() from here directly.
+//
+// Side-effect contract:
+//   * upsert + delete are the only writers
+//   * resolveChannelIdentity() is side-effect-free — safe inside a hot send loop
+//   * delete unlinks the avatar file from disk if a path was stored
+//
+// Reserved / archived guards:
+//   * A profile with is_reserved=1 (the four seeded infra rows main / workers
+//     / heavy / codex-builder) is for infrastructure — channel identities for
+//     the principal-facing channels live on user-facing profiles only.
+//     PUT/DELETE on a reserved profile returns 409 from the route layer.
+//   * A profile with archived_at IS NOT NULL is soft-deleted; new identity
+//     writes against it are nonsensical and also 409.
+//
+// File layout for avatars:
+//   <HERMES_PROFILE_BASE_DIR>/<slug>/avatars/<channel_kind>.<ext>
+// where ext is derived from the upload mime (image/png → png, etc).
+
+import fs from "node:fs";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import {
+  HERMES_PROFILE_BASE_DIR,
+  getProfile,
+  KNOWN_CHANNEL_KINDS,
+} from "./agentProfiles.js";
+
+export type ResolvedChannelIdentity = {
+  display_name: string | null;
+  avatar_path: string | null;
+  avatar_mime: string | null;
+};
+
+export interface ChannelIdentityRow {
+  channel_kind: string;
+  display_name: string | null;
+  avatar_path: string | null;
+  avatar_mime: string | null;
+  updated_at: string;
+}
+
+export interface UpsertChannelIdentityInput {
+  display_name?: string | null;
+  avatar_path?: string | null;
+  avatar_mime?: string | null;
+}
+
+/** Allowed avatar mime types — matches the route's multipart validator. */
+export const ALLOWED_AVATAR_MIMES: ReadonlySet<string> = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+]);
+
+/** Map an avatar mime to a filesystem extension. */
+export function avatarExtForMime(mime: string): string | null {
+  switch (mime) {
+    case "image/png":
+      return "png";
+    case "image/jpeg":
+      return "jpg";
+    case "image/webp":
+      return "webp";
+    default:
+      return null;
+  }
+}
+
+/** Path the route writes / deletes for an avatar. */
+export function avatarPathFor(slug: string, channel_kind: string, ext: string): string {
+  return path.join(
+    HERMES_PROFILE_BASE_DIR(),
+    slug,
+    "avatars",
+    `${channel_kind}.${ext}`,
+  );
+}
+
+/** Throw if the channel kind is not in the KNOWN_CHANNEL_KINDS allowlist. */
+export function assertKnownChannelKind(kind: string): void {
+  if (!KNOWN_CHANNEL_KINDS.has(kind)) {
+    throw new Error(
+      `channel_kind '${kind}' is not a known channel (allowed: ${[...KNOWN_CHANNEL_KINDS].sort().join(", ")})`,
+    );
+  }
+}
+
+/**
+ * Guard: profile must exist, must NOT be reserved, must NOT be archived.
+ * 404 on missing, 409 on reserved/archived (the route layer maps these by
+ * Error message prefix). Returns the profile row on success.
+ */
+export function assertWritableIdentityProfile(
+  db: DatabaseSync,
+  slug: string,
+): void {
+  const p = getProfile(db, slug);
+  if (!p) {
+    throw new Error(`profile '${slug}' not found`);
+  }
+  if (p.is_reserved) {
+    throw new Error(`profile '${slug}' is reserved`);
+  }
+  if (p.archived_at != null) {
+    throw new Error(`profile '${slug}' is archived`);
+  }
+}
+
+interface Row {
+  channel_kind: string;
+  display_name: string | null;
+  avatar_path: string | null;
+  avatar_mime: string | null;
+  updated_at: string;
+}
+
+function _row2obj(r: Row): ChannelIdentityRow {
+  return {
+    channel_kind: r.channel_kind,
+    display_name: r.display_name,
+    avatar_path: r.avatar_path,
+    avatar_mime: r.avatar_mime,
+    updated_at: r.updated_at,
+  };
+}
+
+/**
+ * Side-effect-free lookup — the only entry-point Lane IV consumes. Returns
+ * `null` iff no row exists for that (slug, kind). Does NOT read the
+ * filesystem; `avatar_path` is whatever the DB row stored.
+ */
+export function resolveChannelIdentity(
+  db: DatabaseSync,
+  profile_slug: string,
+  channel_kind: string,
+): ResolvedChannelIdentity | null {
+  const row = db
+    .prepare(
+      `SELECT display_name, avatar_path, avatar_mime
+       FROM channel_identity
+       WHERE profile_slug = ? AND channel_kind = ?`,
+    )
+    .get(profile_slug, channel_kind) as
+    | {
+        display_name: string | null;
+        avatar_path: string | null;
+        avatar_mime: string | null;
+      }
+    | undefined;
+  if (!row) return null;
+  return {
+    display_name: row.display_name,
+    avatar_path: row.avatar_path,
+    avatar_mime: row.avatar_mime,
+  };
+}
+
+/** List every identity row for one profile, sorted by channel_kind. */
+export function listChannelIdentities(
+  db: DatabaseSync,
+  profile_slug: string,
+): ChannelIdentityRow[] {
+  const rows = db
+    .prepare(
+      `SELECT channel_kind, display_name, avatar_path, avatar_mime, updated_at
+       FROM channel_identity
+       WHERE profile_slug = ?
+       ORDER BY channel_kind ASC`,
+    )
+    .all(profile_slug) as Row[];
+  return rows.map(_row2obj);
+}
+
+/** Get one identity row; null if none. */
+export function getChannelIdentity(
+  db: DatabaseSync,
+  profile_slug: string,
+  channel_kind: string,
+): ChannelIdentityRow | null {
+  const row = db
+    .prepare(
+      `SELECT channel_kind, display_name, avatar_path, avatar_mime, updated_at
+       FROM channel_identity
+       WHERE profile_slug = ? AND channel_kind = ?`,
+    )
+    .get(profile_slug, channel_kind) as Row | undefined;
+  return row ? _row2obj(row) : null;
+}
+
+/**
+ * Upsert one (profile, channel_kind) row. Merges with existing fields:
+ * passing `undefined` for a field leaves it untouched; passing `null`
+ * clears it. The caller (route) MUST have validated the profile is
+ * writable + the kind is known + at least one field is non-empty.
+ */
+export function upsertChannelIdentity(
+  db: DatabaseSync,
+  profile_slug: string,
+  channel_kind: string,
+  input: UpsertChannelIdentityInput,
+): ChannelIdentityRow {
+  const existing = getChannelIdentity(db, profile_slug, channel_kind);
+  const next_display_name =
+    input.display_name === undefined
+      ? (existing?.display_name ?? null)
+      : input.display_name;
+  const next_avatar_path =
+    input.avatar_path === undefined
+      ? (existing?.avatar_path ?? null)
+      : input.avatar_path;
+  const next_avatar_mime =
+    input.avatar_mime === undefined
+      ? (existing?.avatar_mime ?? null)
+      : input.avatar_mime;
+  // Atomic upsert — the PK enforces one row per (profile_slug, channel_kind).
+  db.prepare(
+    `INSERT INTO channel_identity
+       (profile_slug, channel_kind, display_name, avatar_path, avatar_mime, updated_at)
+     VALUES (?, ?, ?, ?, ?, datetime('now'))
+     ON CONFLICT(profile_slug, channel_kind) DO UPDATE
+       SET display_name = excluded.display_name,
+           avatar_path  = excluded.avatar_path,
+           avatar_mime  = excluded.avatar_mime,
+           updated_at   = datetime('now')`,
+  ).run(
+    profile_slug,
+    channel_kind,
+    next_display_name,
+    next_avatar_path,
+    next_avatar_mime,
+  );
+  const row = getChannelIdentity(db, profile_slug, channel_kind);
+  if (!row) {
+    throw new Error(
+      `channel_identity '${profile_slug}/${channel_kind}' not found after upsert`,
+    );
+  }
+  return row;
+}
+
+/**
+ * Delete the (profile, channel_kind) row + unlink any avatar file the row
+ * referenced. Returns true if a row was removed, false if there was nothing
+ * to delete. File unlink is best-effort — a missing file does not error.
+ */
+export function deleteChannelIdentity(
+  db: DatabaseSync,
+  profile_slug: string,
+  channel_kind: string,
+): boolean {
+  const existing = getChannelIdentity(db, profile_slug, channel_kind);
+  if (!existing) return false;
+  db.prepare(
+    `DELETE FROM channel_identity
+     WHERE profile_slug = ? AND channel_kind = ?`,
+  ).run(profile_slug, channel_kind);
+  if (existing.avatar_path) {
+    try {
+      fs.unlinkSync(existing.avatar_path);
+    } catch {
+      /* best-effort — file might already be gone */
+    }
+  }
+  return true;
+}

--- a/packages/ctrl/src/db/migrate.ts
+++ b/packages/ctrl/src/db/migrate.ts
@@ -31,6 +31,7 @@ import m0014 from "./migrations/0014_tool_disposition.sql";
 import m0015 from "./migrations/0015_composio_user_defaults.sql";
 import m0016 from "./migrations/0016_files_extraction.sql";
 import m0017 from "./migrations/0017_agent_profiles.sql";
+import m0018 from "./migrations/0018_channel_identity.sql";
 
 interface Migration {
   version: number;
@@ -57,6 +58,7 @@ const MIGRATIONS: Migration[] = [
   { version: 15, name: "composio_user_defaults", sql: m0015 },
   { version: 16, name: "files_extraction",    sql: m0016 },
   { version: 17, name: "agent_profiles",      sql: m0017 },
+  { version: 18, name: "channel_identity",    sql: m0018 },
 ];
 
 /**

--- a/packages/ctrl/src/db/migrations/0018_channel_identity.sql
+++ b/packages/ctrl/src/db/migrations/0018_channel_identity.sql
@@ -1,0 +1,38 @@
+-- 0018_channel_identity — per-(profile, channel_kind) display name + avatar
+-- (issue #206 Q6).
+--
+-- Sibling to #120 Lane III: while #120 introduced the agent_profile registry +
+-- channel_profile_binding map (which AGENT handles which channel), this
+-- migration captures the channel-side IDENTITY a given profile wears on a
+-- given channel kind — the display name the recipient sees on Telegram /
+-- Slack / SMS / Email, plus an optional avatar.
+--
+-- One row per (profile, channel_kind). Either field may be NULL; a row
+-- with both NULL is allowed in the schema but pruned on DELETE by the
+-- channelIdentity.ts lib (empty rows are pointless).
+--
+-- The avatar_path is the absolute path the ctrl-api route wrote the upload
+-- to under /hermes-state/profiles/<slug>/avatars/<channel_kind>.<ext>.
+-- Lane IV reads this column (via resolveChannelIdentity) at send time and
+-- ships the bytes to the third-party API as part of the outbound message.
+-- Lane IV does NOT write this table — the only writer is the PUT route
+-- in routes/channel_identity.ts.
+--
+-- FK to agent_profile(slug) with ON DELETE CASCADE: if a profile is HARD
+-- deleted (which the API never does — archive is soft), the identity rows
+-- come with it. Archive doesn't delete the profile row, so identity rows
+-- survive archive — restoring a profile preserves its identities.
+
+CREATE TABLE IF NOT EXISTS channel_identity (
+  profile_slug   TEXT NOT NULL,
+  channel_kind   TEXT NOT NULL,
+  display_name   TEXT,
+  avatar_path    TEXT,
+  avatar_mime    TEXT,
+  updated_at     TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (profile_slug, channel_kind),
+  FOREIGN KEY (profile_slug) REFERENCES agent_profile(slug) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_channel_identity_profile
+  ON channel_identity(profile_slug);

--- a/packages/ctrl/tests/alfred-journal.test.ts
+++ b/packages/ctrl/tests/alfred-journal.test.ts
@@ -52,7 +52,7 @@ function tableNames(db: DatabaseSync): string[] {
 describe("alfred_journal migration", () => {
   it("bumps user_version to the latest migration", () => {
     // The runner applies every migration > current version, so the value
-    // naturally tracks the highest registered version. Today: 17
+    // naturally tracks the highest registered version. Today: 18
     // (0001 fix_pack + 0002 alfred_journal + 0003 tailscale_connection
     // + 0004 channel_tokens + 0005 ha_channel + 0006 files_table
     // + 0007 recall + 0008 ha_event_subscription
@@ -60,9 +60,9 @@ describe("alfred_journal migration", () => {
     // + 0011 ha_tier4 + 0012 ha_integration_ref_removed_at
     // + 0013 recall_realtime + 0014 tool_disposition
     // + 0015 composio_user_defaults + 0016 files_extraction
-    // + 0017 agent_profiles).
+    // + 0017 agent_profiles + 0018 channel_identity).
     const db = makeDb();
-    assert.equal(userVersion(db), 17);
+    assert.equal(userVersion(db), 18);
     db.close();
   });
 

--- a/packages/ctrl/tests/channel-identity.test.ts
+++ b/packages/ctrl/tests/channel-identity.test.ts
@@ -1,0 +1,503 @@
+// channel-identity — unit tests for #206 Q6 Lane I per-(profile, channel)
+// display_name + avatar routes.
+//
+// Routes under test:
+//   GET    /api/v1/agent-profiles/:slug/channel-identities
+//   GET    /api/v1/agent-profiles/:slug/channel-identities/:kind
+//   PUT    /api/v1/agent-profiles/:slug/channel-identities/:kind  (multipart)
+//   DELETE /api/v1/agent-profiles/:slug/channel-identities/:kind
+//
+// Same in-process harness as profiles-mcp-catalog.test.ts. Multipart bodies
+// are framed by buildMultipart() — the real ctrl-api consumes them from
+// req.on('data').
+
+import { describe, it, before, after, mock } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Readable } from "node:stream";
+
+// ── isolate state.db + hermes-state ────────────────────────────────────────
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "channel-identity-test-"));
+process.env.STATE_DB_PATH = path.join(TMP, "state.db");
+process.env.SQLITE_VEC_PATH = "";
+process.env.VAULT_PATH = path.join(TMP, "vault");
+process.env.ALFRED_DATA_DIR = TMP;
+process.env.HERMES_CONFIG_DIR = path.join(TMP, "profiles");
+process.env.HERMES_STATE_DIR_CTRL_VIEW = path.join(TMP, "hermes-state");
+process.env.INGEST_DB_PATH = path.join(TMP, "ingest.db");
+fs.mkdirSync(process.env.HERMES_CONFIG_DIR, { recursive: true });
+
+// ── mock supervisor (no docker calls) ──────────────────────────────────────
+mock.module("../src/hermes/supervisor.js", {
+  namedExports: {
+    writeSupervisorRegistry: () => {},
+    nudgeHermesSupervisor: () => true,
+    restartProfile: () => ({ scope: "per-profile", attempted: true, warning: null }),
+    REGISTRY_PATH: path.join(TMP, "hermes-state", "profiles", "_registry.json"),
+  },
+});
+
+const { matchRoute } = await import("../src/api/server.js");
+const { registerProfileRoutes } = await import("../src/api/routes/profiles.js");
+const { registerChannelIdentityRoutes } = await import(
+  "../src/api/routes/channel_identity.js"
+);
+const { handleError } = await import("../src/api/errors.js");
+const { getStateDb } = await import("../src/db/state.js");
+const { createProfile, archiveProfile } = await import("../src/db/agentProfiles.js");
+const { resolveChannelIdentity } = await import("../src/db/channelIdentity.js");
+
+registerProfileRoutes();
+registerChannelIdentityRoutes();
+
+// ── multipart helper ───────────────────────────────────────────────────────
+// Builds a minimal RFC 7578 multipart body. Used to drive the PUT handler.
+function buildMultipart(
+  parts: Array<{
+    name: string;
+    filename?: string;
+    contentType?: string;
+    data: Buffer | string;
+  }>,
+  boundary = "----testboundaryX1Y2Z3",
+): { body: Buffer; contentType: string } {
+  const segs: Buffer[] = [];
+  for (const p of parts) {
+    let header = `--${boundary}\r\nContent-Disposition: form-data; name="${p.name}"`;
+    if (p.filename !== undefined) {
+      header += `; filename="${p.filename}"`;
+    }
+    header += "\r\n";
+    if (p.contentType) header += `Content-Type: ${p.contentType}\r\n`;
+    header += "\r\n";
+    segs.push(Buffer.from(header));
+    segs.push(typeof p.data === "string" ? Buffer.from(p.data) : p.data);
+    segs.push(Buffer.from("\r\n"));
+  }
+  segs.push(Buffer.from(`--${boundary}--\r\n`));
+  return {
+    body: Buffer.concat(segs),
+    contentType: `multipart/form-data; boundary=${boundary}`,
+  };
+}
+
+// PNG fixture — a 1×1 transparent PNG, smallest valid bytes.
+const PNG_BYTES = Buffer.from(
+  "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000d49444154789c6300010000000005000167a2b3e80000000049454e44ae426082",
+  "hex",
+);
+
+// ── http test helper ───────────────────────────────────────────────────────
+function invokeRoute(
+  method: string,
+  url: string,
+  opts: {
+    params?: Record<string, string>;
+    body?: unknown;
+    multipart?: { body: Buffer; contentType: string };
+  } = {},
+): Promise<{ status: number; body: any }> {
+  const matched = matchRoute(method, url);
+  assert.ok(matched, `${method} ${url} must be registered`);
+  return new Promise((resolve, reject) => {
+    const chunks: any[] = [];
+    let writeHeadStatus: number | null = null;
+    const res: any = {
+      statusCode: 200,
+      setHeader() {},
+      writeHead(s: number) {
+        writeHeadStatus = s;
+      },
+      end(c?: any) {
+        if (c !== undefined) chunks.push(c);
+        try {
+          const raw = Buffer.concat(
+            chunks.map((c) => (Buffer.isBuffer(c) ? c : Buffer.from(String(c)))),
+          ).toString();
+          // Honour both writeHead(status) and direct res.statusCode = 204
+          // mutation (the 204 DELETE path uses the latter).
+          const status = writeHeadStatus ?? res.statusCode;
+          resolve({ status, body: raw ? JSON.parse(raw) : {} });
+        } catch (e) {
+          reject(e);
+        }
+      },
+      write(c: any) {
+        chunks.push(c);
+      },
+    };
+    // Build a fake IncomingMessage-ish object: Readable stream + headers.
+    let req: any;
+    if (opts.multipart) {
+      req = Readable.from([opts.multipart.body]);
+      req.headers = { "content-type": opts.multipart.contentType };
+    } else {
+      req = { headers: {} };
+    }
+    const merged = { ...(matched!.params ?? {}), ...(opts.params ?? {}) };
+    Promise.resolve(
+      matched!.handler({
+        req,
+        res,
+        params: merged,
+        query: new URLSearchParams(),
+        body: opts.body ?? undefined,
+      }),
+    ).catch((err) => {
+      try {
+        handleError(res, err);
+      } catch (e2) {
+        reject(e2);
+      }
+    });
+  });
+}
+
+// ── setup ──────────────────────────────────────────────────────────────────
+const SLUG = "ci-test-sentinel";
+const ARCHIVED_SLUG = "ci-test-archived";
+
+before(() => {
+  const db = getStateDb();
+  createProfile(db, { slug: SLUG, label: "Channel Identity Sentinel", model: "gpt-4.1" });
+  createProfile(db, {
+    slug: ARCHIVED_SLUG,
+    label: "Archived Sentinel",
+    model: "gpt-4.1",
+  });
+  archiveProfile(db, ARCHIVED_SLUG);
+});
+
+after(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
+});
+
+// ── GET list ───────────────────────────────────────────────────────────────
+
+describe("GET /api/v1/agent-profiles/:slug/channel-identities", () => {
+  it("returns 404 for an unknown slug", async () => {
+    const { status, body } = await invokeRoute(
+      "GET",
+      "/api/v1/agent-profiles/:slug/channel-identities",
+      { params: { slug: "no-such-profile" } },
+    );
+    assert.equal(status, 404);
+    assert.match(body.error.message ?? body.error, /not found/i);
+  });
+
+  it("returns 200 + empty identities for a fresh profile", async () => {
+    const { status, body } = await invokeRoute(
+      "GET",
+      "/api/v1/agent-profiles/:slug/channel-identities",
+      { params: { slug: SLUG } },
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.identities, []);
+  });
+});
+
+// ── PUT (multipart) ────────────────────────────────────────────────────────
+
+describe("PUT /api/v1/agent-profiles/:slug/channel-identities/:kind", () => {
+  it("returns 404 for an unknown profile", async () => {
+    const mp = buildMultipart([{ name: "display_name", data: "Alfred" }]);
+    const { status, body } = await invokeRoute(
+      "PUT",
+      "/api/v1/agent-profiles/:slug/channel-identities/:kind",
+      { params: { slug: "no-such-profile", kind: "telegram" }, multipart: mp },
+    );
+    assert.equal(status, 404);
+    assert.match(body.error.message ?? body.error, /not found/i);
+  });
+
+  it("returns 409 for a reserved profile (main)", async () => {
+    const mp = buildMultipart([{ name: "display_name", data: "Alfred" }]);
+    const { status, body } = await invokeRoute(
+      "PUT",
+      "/api/v1/agent-profiles/:slug/channel-identities/:kind",
+      { params: { slug: "main", kind: "telegram" }, multipart: mp },
+    );
+    assert.equal(status, 409);
+    assert.match(body.error.message ?? body.error, /reserved/i);
+  });
+
+  it("returns 409 for an archived profile", async () => {
+    const mp = buildMultipart([{ name: "display_name", data: "Alfred" }]);
+    const { status, body } = await invokeRoute(
+      "PUT",
+      "/api/v1/agent-profiles/:slug/channel-identities/:kind",
+      { params: { slug: ARCHIVED_SLUG, kind: "telegram" }, multipart: mp },
+    );
+    assert.equal(status, 409);
+    assert.match(body.error.message ?? body.error, /archived/i);
+  });
+
+  it("returns 400 for an unknown channel kind", async () => {
+    const mp = buildMultipart([{ name: "display_name", data: "Alfred" }]);
+    const { status, body } = await invokeRoute(
+      "PUT",
+      "/api/v1/agent-profiles/:slug/channel-identities/:kind",
+      { params: { slug: SLUG, kind: "carrier-pigeon" }, multipart: mp },
+    );
+    assert.equal(status, 400);
+    assert.match(body.error.message ?? body.error, /not a known channel/i);
+  });
+
+  it("returns 400 when no fields are supplied", async () => {
+    // Send a multipart with no parts. Server should reject.
+    const mp = buildMultipart([]);
+    const { status, body } = await invokeRoute(
+      "PUT",
+      "/api/v1/agent-profiles/:slug/channel-identities/:kind",
+      { params: { slug: SLUG, kind: "telegram" }, multipart: mp },
+    );
+    assert.equal(status, 400);
+    assert.match(body.error.message ?? body.error, /at least one/i);
+  });
+
+  it("returns 422 for a display_name > 64 chars", async () => {
+    const long = "x".repeat(65);
+    const mp = buildMultipart([{ name: "display_name", data: long }]);
+    const { status, body } = await invokeRoute(
+      "PUT",
+      "/api/v1/agent-profiles/:slug/channel-identities/:kind",
+      { params: { slug: SLUG, kind: "telegram" }, multipart: mp },
+    );
+    assert.equal(status, 422);
+    assert.match(body.error.message ?? body.error, /64/);
+  });
+
+  it("returns 400 for an avatar mime that isn't png/jpeg/webp", async () => {
+    const mp = buildMultipart([
+      {
+        name: "avatar",
+        filename: "evil.bmp",
+        contentType: "image/bmp",
+        data: Buffer.from([0x42, 0x4d, 0x00, 0x00]),
+      },
+    ]);
+    const { status, body } = await invokeRoute(
+      "PUT",
+      "/api/v1/agent-profiles/:slug/channel-identities/:kind",
+      { params: { slug: SLUG, kind: "telegram" }, multipart: mp },
+    );
+    assert.equal(status, 400);
+    assert.match(body.error.message ?? body.error, /not allowed|image\/png/i);
+  });
+
+  it("returns 400 for an avatar > 2 MB", async () => {
+    const big = Buffer.alloc(2 * 1024 * 1024 + 1024); // > 2 MiB
+    const mp = buildMultipart([
+      {
+        name: "avatar",
+        filename: "big.png",
+        contentType: "image/png",
+        data: big,
+      },
+    ]);
+    const { status, body } = await invokeRoute(
+      "PUT",
+      "/api/v1/agent-profiles/:slug/channel-identities/:kind",
+      { params: { slug: SLUG, kind: "telegram" }, multipart: mp },
+    );
+    assert.equal(status, 400);
+    assert.match(body.error.message ?? body.error, /exceeds|TOO_LARGE/i);
+  });
+
+  it("upserts display_name only — no avatar file written", async () => {
+    const mp = buildMultipart([{ name: "display_name", data: "Alfred T." }]);
+    const { status, body } = await invokeRoute(
+      "PUT",
+      "/api/v1/agent-profiles/:slug/channel-identities/:kind",
+      { params: { slug: SLUG, kind: "telegram" }, multipart: mp },
+    );
+    assert.equal(status, 200);
+    assert.equal(body.channel_kind, "telegram");
+    assert.equal(body.display_name, "Alfred T.");
+    assert.equal(body.avatar_path, null);
+    assert.equal(body.avatar_mime, null);
+    // No avatar dir created (or empty if it was).
+    const avatarsDir = path.join(
+      process.env.HERMES_CONFIG_DIR!,
+      SLUG,
+      "avatars",
+    );
+    if (fs.existsSync(avatarsDir)) {
+      const entries = fs.readdirSync(avatarsDir);
+      assert.deepEqual(entries, [], "no avatar files written");
+    }
+  });
+
+  it("upserts avatar — writes the PNG into the per-profile avatars dir", async () => {
+    const mp = buildMultipart([
+      {
+        name: "avatar",
+        filename: "av.png",
+        contentType: "image/png",
+        data: PNG_BYTES,
+      },
+    ]);
+    const { status, body } = await invokeRoute(
+      "PUT",
+      "/api/v1/agent-profiles/:slug/channel-identities/:kind",
+      { params: { slug: SLUG, kind: "telegram" }, multipart: mp },
+    );
+    assert.equal(status, 200);
+    assert.equal(body.avatar_mime, "image/png");
+    assert.ok(
+      body.avatar_path.endsWith(`/${SLUG}/avatars/telegram.png`),
+      `avatar_path: ${body.avatar_path}`,
+    );
+    // The text field from the previous PUT was preserved.
+    assert.equal(body.display_name, "Alfred T.");
+    // The file actually exists on disk.
+    assert.ok(fs.existsSync(body.avatar_path), "avatar file must exist on disk");
+    const bytes = fs.readFileSync(body.avatar_path);
+    assert.equal(bytes.length, PNG_BYTES.length);
+  });
+
+  it("upserts BOTH display_name and avatar in one PUT", async () => {
+    const mp = buildMultipart([
+      { name: "display_name", data: "Alfred T. v2" },
+      {
+        name: "avatar",
+        filename: "av2.png",
+        contentType: "image/png",
+        data: PNG_BYTES,
+      },
+    ]);
+    const { status, body } = await invokeRoute(
+      "PUT",
+      "/api/v1/agent-profiles/:slug/channel-identities/:kind",
+      { params: { slug: SLUG, kind: "slack" }, multipart: mp },
+    );
+    assert.equal(status, 200);
+    assert.equal(body.display_name, "Alfred T. v2");
+    assert.equal(body.avatar_mime, "image/png");
+    assert.ok(body.avatar_path.endsWith(`/${SLUG}/avatars/slack.png`));
+  });
+});
+
+// ── GET one ────────────────────────────────────────────────────────────────
+
+describe("GET /api/v1/agent-profiles/:slug/channel-identities/:kind", () => {
+  it("returns 200 with the stored row for an existing identity", async () => {
+    const { status, body } = await invokeRoute(
+      "GET",
+      "/api/v1/agent-profiles/:slug/channel-identities/:kind",
+      { params: { slug: SLUG, kind: "telegram" } },
+    );
+    assert.equal(status, 200);
+    assert.equal(body.channel_kind, "telegram");
+    assert.equal(body.display_name, "Alfred T.");
+    assert.equal(body.avatar_mime, "image/png");
+  });
+
+  it("returns 404 when no row exists for that (slug, kind)", async () => {
+    const { status, body } = await invokeRoute(
+      "GET",
+      "/api/v1/agent-profiles/:slug/channel-identities/:kind",
+      { params: { slug: SLUG, kind: "sms" } },
+    );
+    assert.equal(status, 404);
+    assert.match(body.error.message ?? body.error, /not found/i);
+  });
+});
+
+// ── resolveChannelIdentity (Lane IV consumer entrypoint) ──────────────────
+
+describe("resolveChannelIdentity (Lane IV contract)", () => {
+  it("returns the resolved identity for an existing row", () => {
+    const r = resolveChannelIdentity(getStateDb(), SLUG, "telegram");
+    assert.ok(r, "expected non-null");
+    assert.equal(r!.display_name, "Alfred T.");
+    assert.equal(r!.avatar_mime, "image/png");
+    assert.ok(r!.avatar_path && r!.avatar_path.endsWith(".png"));
+  });
+
+  it("returns null when there is no row for that (slug, kind)", () => {
+    const r = resolveChannelIdentity(getStateDb(), SLUG, "email");
+    assert.equal(r, null);
+  });
+});
+
+// ── DELETE ─────────────────────────────────────────────────────────────────
+
+describe("DELETE /api/v1/agent-profiles/:slug/channel-identities/:kind", () => {
+  it("returns 204 + unlinks the avatar file", async () => {
+    // Snapshot the avatar_path before the delete.
+    const before = await invokeRoute(
+      "GET",
+      "/api/v1/agent-profiles/:slug/channel-identities/:kind",
+      { params: { slug: SLUG, kind: "slack" } },
+    );
+    const avatarPath = before.body.avatar_path;
+    assert.ok(fs.existsSync(avatarPath), "avatar must exist before DELETE");
+
+    const { status } = await invokeRoute(
+      "DELETE",
+      "/api/v1/agent-profiles/:slug/channel-identities/:kind",
+      { params: { slug: SLUG, kind: "slack" } },
+    );
+    assert.equal(status, 204);
+    assert.equal(
+      fs.existsSync(avatarPath),
+      false,
+      "avatar file must be unlinked after DELETE",
+    );
+    // GET must now 404.
+    const after = await invokeRoute(
+      "GET",
+      "/api/v1/agent-profiles/:slug/channel-identities/:kind",
+      { params: { slug: SLUG, kind: "slack" } },
+    );
+    assert.equal(after.status, 404);
+  });
+
+  it("returns 404 when the row never existed", async () => {
+    const { status, body } = await invokeRoute(
+      "DELETE",
+      "/api/v1/agent-profiles/:slug/channel-identities/:kind",
+      { params: { slug: SLUG, kind: "ha" } },
+    );
+    assert.equal(status, 404);
+    assert.match(body.error.message ?? body.error, /not found/i);
+  });
+
+  it("returns 409 for a reserved profile (main)", async () => {
+    const { status, body } = await invokeRoute(
+      "DELETE",
+      "/api/v1/agent-profiles/:slug/channel-identities/:kind",
+      { params: { slug: "main", kind: "telegram" } },
+    );
+    assert.equal(status, 409);
+    assert.match(body.error.message ?? body.error, /reserved/i);
+  });
+});
+
+// ── isolation assertion ───────────────────────────────────────────────────
+
+describe("cross-profile isolation", () => {
+  it("PUT on the sentinel profile never writes outside its own dir", () => {
+    // 'main' profile's avatars dir must NOT exist or, if it exists, be empty.
+    const mainAvatars = path.join(
+      process.env.HERMES_CONFIG_DIR!,
+      "main",
+      "avatars",
+    );
+    if (fs.existsSync(mainAvatars)) {
+      const entries = fs.readdirSync(mainAvatars);
+      assert.deepEqual(entries, [], "main's avatars dir untouched");
+    }
+    // The sentinel's avatars dir DOES exist + contains the telegram.png.
+    const sentinelAvatars = path.join(
+      process.env.HERMES_CONFIG_DIR!,
+      SLUG,
+      "avatars",
+    );
+    const entries = fs.readdirSync(sentinelAvatars).sort();
+    assert.ok(entries.includes("telegram.png"), `expected telegram.png; got ${entries.join(",")}`);
+  });
+});

--- a/packages/ctrl/tests/migrate.test.ts
+++ b/packages/ctrl/tests/migrate.test.ts
@@ -36,7 +36,7 @@ describe("state.db migration runner", () => {
     const db = new DatabaseSync(":memory:");
     db.exec(schema);
     const v = runMigrations(db);
-    // Latest version moves as new migrations land. Today: 17
+    // Latest version moves as new migrations land. Today: 18
     // (0001_fix_pack + 0002_alfred_journal + 0003_tailscale_connection
     // + 0004_channel_tokens + 0005_ha_channel + 0006_files_table
     // + 0007_recall + 0008_ha_event_subscription
@@ -44,9 +44,9 @@ describe("state.db migration runner", () => {
     // + 0011_ha_tier4 + 0012_ha_integration_ref_removed_at
     // + 0013_recall_realtime + 0014_tool_disposition
     // + 0015_composio_user_defaults + 0016_files_extraction
-    // + 0017_agent_profiles).
-    assert.equal(v, 17, "migrated to latest version");
-    assert.equal(userVersion(db), 17);
+    // + 0017_agent_profiles + 0018_channel_identity).
+    assert.equal(v, 18, "migrated to latest version");
+    assert.equal(userVersion(db), 18);
     assert.ok(cols(db, "observation").includes("processed_at"), "0001: processed_at present after migrate");
     // 0002: alfred_journal + alfred_principal tables present.
     const tables = (
@@ -316,6 +316,48 @@ describe("state.db migration runner", () => {
       "0017: channel_tokens.profile_slug column added",
     );
 
+    // 0018: channel_identity table present + (profile_slug, channel_kind) PK
+    // + the five expected columns. The table is empty at fresh-migrate time;
+    // the route layer (PUT /channel-identities/:kind) is the only writer.
+    assert.ok(
+      tables.includes("channel_identity"),
+      "0018: channel_identity table created",
+    );
+    const ciCols = cols(db, "channel_identity");
+    for (const required of [
+      "profile_slug",
+      "channel_kind",
+      "display_name",
+      "avatar_path",
+      "avatar_mime",
+      "updated_at",
+    ]) {
+      assert.ok(
+        ciCols.includes(required),
+        `0018: channel_identity.${required} present`,
+      );
+    }
+    // Composite PK enforces one row per (profile, channel_kind). Insert a
+    // sentinel via the seeded 'main' profile then prove a second insert at
+    // the same PK is rejected.
+    db.prepare(
+      `INSERT INTO channel_identity
+         (profile_slug, channel_kind, display_name, avatar_path, avatar_mime)
+       VALUES ('main', 'telegram', 'Alfred', NULL, NULL)`,
+    ).run();
+    assert.throws(
+      () =>
+        db
+          .prepare(
+            `INSERT INTO channel_identity
+               (profile_slug, channel_kind, display_name)
+             VALUES ('main', 'telegram', 'Alfred (dup)')`,
+          )
+          .run(),
+      /UNIQUE constraint failed|PRIMARY KEY/i,
+      "0018: composite PK rejects a second row for the same (profile, kind)",
+    );
+
     db.close();
   });
 
@@ -324,7 +366,7 @@ describe("state.db migration runner", () => {
     db.exec(schema);
     runMigrations(db);
     const v2 = runMigrations(db);
-    assert.equal(v2, 17);
+    assert.equal(v2, 18);
     assert.equal(
       cols(db, "observation").filter((c) => c === "processed_at").length,
       1,

--- a/packages/ctrl/tests/profiles.bootstrap.test.ts
+++ b/packages/ctrl/tests/profiles.bootstrap.test.ts
@@ -1,0 +1,353 @@
+// profiles.bootstrap — unit tests for #206 Q5 (per-profile bootstrap render).
+//
+// POST /api/v1/agent-profiles with optional {role, tone, first_actions[]}
+// renders RULES.md + daybook.md into the profile dir. SOUL.md is unchanged
+// (Hermes supervisor consolidates persona_template separately).
+//
+// Same in-process harness as profiles-mcp-catalog.test.ts.
+
+import { describe, it, before, after, mock } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// ── isolate state.db + hermes-state ────────────────────────────────────────
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "profiles-bootstrap-"));
+process.env.STATE_DB_PATH = path.join(TMP, "state.db");
+process.env.SQLITE_VEC_PATH = "";
+process.env.VAULT_PATH = path.join(TMP, "vault");
+process.env.ALFRED_DATA_DIR = TMP;
+process.env.HERMES_CONFIG_DIR = path.join(TMP, "profiles");
+process.env.HERMES_STATE_DIR_CTRL_VIEW = path.join(TMP, "hermes-state");
+process.env.INGEST_DB_PATH = path.join(TMP, "ingest.db");
+fs.mkdirSync(process.env.HERMES_CONFIG_DIR, { recursive: true });
+
+// ── mock supervisor ────────────────────────────────────────────────────────
+mock.module("../src/hermes/supervisor.js", {
+  namedExports: {
+    writeSupervisorRegistry: () => {},
+    nudgeHermesSupervisor: () => true,
+    restartProfile: () => ({ scope: "per-profile", attempted: true, warning: null }),
+    REGISTRY_PATH: path.join(TMP, "hermes-state", "profiles", "_registry.json"),
+  },
+});
+
+const { matchRoute } = await import("../src/api/server.js");
+const { registerProfileRoutes } = await import("../src/api/routes/profiles.js");
+const { handleError } = await import("../src/api/errors.js");
+
+registerProfileRoutes();
+
+// ── http test helper ───────────────────────────────────────────────────────
+function invokeRoute(
+  method: string,
+  url: string,
+  body?: unknown,
+  params: Record<string, string> = {},
+): Promise<{ status: number; body: any }> {
+  const matched = matchRoute(method, url);
+  assert.ok(matched, `${method} ${url} must be registered`);
+  return new Promise((resolve, reject) => {
+    const chunks: any[] = [];
+    let status = 200;
+    const res: any = {
+      statusCode: 200,
+      setHeader() {},
+      writeHead(s: number) { status = s; },
+      end(c?: any) {
+        if (c !== undefined) chunks.push(c);
+        try {
+          const raw = Buffer.concat(
+            chunks.map((c) => (Buffer.isBuffer(c) ? c : Buffer.from(String(c)))),
+          ).toString();
+          resolve({ status, body: raw ? JSON.parse(raw) : {} });
+        } catch (e) { reject(e); }
+      },
+      write(c: any) { chunks.push(c); },
+    };
+    const merged = { ...(matched!.params ?? {}), ...params };
+    Promise.resolve(
+      matched!.handler({
+        req: {} as any, res, params: merged,
+        query: new URLSearchParams(), body: body ?? undefined,
+      }),
+    ).catch((err) => {
+      try { handleError(res, err); } catch (e2) { reject(e2); }
+    });
+  });
+}
+
+const profileDir = (slug: string) =>
+  path.join(process.env.HERMES_CONFIG_DIR!, slug);
+
+/**
+ * Helper: archive a profile to free its allocated port slot. The user-port
+ * range is only 18794..18799 (6 slots), so successful creates need to be
+ * cleaned up between tests to avoid `no free user-facing port` 409s.
+ */
+async function archive(slug: string): Promise<void> {
+  await invokeRoute("DELETE", "/api/v1/agent-profiles/:slug", undefined, {
+    slug,
+  });
+}
+
+after(() => { fs.rmSync(TMP, { recursive: true, force: true }); });
+
+// ── tests ──────────────────────────────────────────────────────────────────
+
+describe("POST /api/v1/agent-profiles — Q5 bootstrap render", () => {
+  it("writes RULES.md when role is provided (no daybook.md when first_actions empty)", async () => {
+    const slug = "cratchit-role";
+    const { status } = await invokeRoute(
+      "POST",
+      "/api/v1/agent-profiles",
+      {
+        slug,
+        label: "Cratchit",
+        model: "claude-sonnet-4-6",
+        role: "household bookkeeper",
+      },
+    );
+    assert.equal(status, 202);
+    const rules = path.join(profileDir(slug), "RULES.md");
+    assert.ok(fs.existsSync(rules), "RULES.md must be written");
+    const content = fs.readFileSync(rules, "utf-8");
+    assert.match(content, /# Rules for Cratchit/);
+    assert.match(content, /household bookkeeper/);
+    // daybook.md NOT written.
+    const daybook = path.join(profileDir(slug), "daybook.md");
+    assert.equal(fs.existsSync(daybook), false, "daybook.md must NOT be written");
+    await archive(slug);
+  });
+
+  it("writes RULES.md when tone alone is provided", async () => {
+    const slug = "cratchit-tone";
+    const { status } = await invokeRoute(
+      "POST",
+      "/api/v1/agent-profiles",
+      {
+        slug,
+        label: "Cratchit Tone",
+        model: "claude-sonnet-4-6",
+        tone: "dry",
+      },
+    );
+    assert.equal(status, 202);
+    const rules = path.join(profileDir(slug), "RULES.md");
+    assert.ok(fs.existsSync(rules));
+    const content = fs.readFileSync(rules, "utf-8");
+    assert.match(content, /## Tone\s*\ndry/);
+    await archive(slug);
+  });
+
+  it("writes daybook.md when first_actions is provided", async () => {
+    const slug = "cratchit-actions";
+    const { status } = await invokeRoute(
+      "POST",
+      "/api/v1/agent-profiles",
+      {
+        slug,
+        label: "Cratchit Actions",
+        model: "claude-sonnet-4-6",
+        first_actions: [
+          "Reconcile Sunday's grocery receipts against Sure",
+          "Flag any subscription that auto-renewed this week",
+        ],
+      },
+    );
+    assert.equal(status, 202);
+    const daybook = path.join(profileDir(slug), "daybook.md");
+    assert.ok(fs.existsSync(daybook));
+    const content = fs.readFileSync(daybook, "utf-8");
+    assert.match(content, /# Daybook — Cratchit Actions/);
+    assert.match(content, /- \[ \] Reconcile Sunday's grocery receipts/);
+    assert.match(content, /- \[ \] Flag any subscription/);
+    await archive(slug);
+  });
+
+  it("writes nothing when first_actions is empty AND no role/tone", async () => {
+    const slug = "cratchit-empty";
+    const { status } = await invokeRoute(
+      "POST",
+      "/api/v1/agent-profiles",
+      {
+        slug,
+        label: "Cratchit Empty",
+        model: "claude-sonnet-4-6",
+        first_actions: [],
+      },
+    );
+    assert.equal(status, 202);
+    assert.equal(
+      fs.existsSync(path.join(profileDir(slug), "RULES.md")),
+      false,
+    );
+    assert.equal(
+      fs.existsSync(path.join(profileDir(slug), "daybook.md")),
+      false,
+    );
+    await archive(slug);
+  });
+
+  it("writes BOTH RULES.md AND daybook.md when role + first_actions both given", async () => {
+    const slug = "cratchit-full";
+    const { status } = await invokeRoute(
+      "POST",
+      "/api/v1/agent-profiles",
+      {
+        slug,
+        label: "Cratchit Full",
+        model: "claude-sonnet-4-6",
+        role: "household bookkeeper",
+        tone: "dry",
+        first_actions: ["Reconcile receipts"],
+      },
+    );
+    assert.equal(status, 202);
+    assert.ok(fs.existsSync(path.join(profileDir(slug), "RULES.md")));
+    assert.ok(fs.existsSync(path.join(profileDir(slug), "daybook.md")));
+    await archive(slug);
+  });
+
+  it("does NOT clobber an existing RULES.md", async () => {
+    const slug = "cratchit-preexisting";
+    // Pre-create the profile dir + a hand-edited RULES.md.
+    fs.mkdirSync(profileDir(slug), { recursive: true });
+    const existingPath = path.join(profileDir(slug), "RULES.md");
+    const SENTINEL = "# Hand-edited rules — DO NOT clobber\n";
+    fs.writeFileSync(existingPath, SENTINEL, "utf-8");
+
+    const { status } = await invokeRoute(
+      "POST",
+      "/api/v1/agent-profiles",
+      {
+        slug,
+        label: "Cratchit Pre",
+        model: "claude-sonnet-4-6",
+        role: "should not overwrite",
+      },
+    );
+    assert.equal(status, 202);
+    const after = fs.readFileSync(existingPath, "utf-8");
+    assert.equal(after, SENTINEL, "existing RULES.md must be preserved");
+    await archive(slug);
+  });
+
+  it("does NOT clobber an existing daybook.md", async () => {
+    const slug = "cratchit-preexisting-daybook";
+    fs.mkdirSync(profileDir(slug), { recursive: true });
+    const existingPath = path.join(profileDir(slug), "daybook.md");
+    const SENTINEL = "# Hand-edited daybook\n";
+    fs.writeFileSync(existingPath, SENTINEL, "utf-8");
+
+    const { status } = await invokeRoute(
+      "POST",
+      "/api/v1/agent-profiles",
+      {
+        slug,
+        label: "Cratchit Pre Daybook",
+        model: "claude-sonnet-4-6",
+        first_actions: ["should not appear in file"],
+      },
+    );
+    assert.equal(status, 202);
+    const after = fs.readFileSync(existingPath, "utf-8");
+    assert.equal(after, SENTINEL, "existing daybook.md must be preserved");
+    await archive(slug);
+  });
+});
+
+describe("POST /api/v1/agent-profiles — Q5 validation", () => {
+  it("rejects role > 200 chars with 422", async () => {
+    const { status, body } = await invokeRoute(
+      "POST",
+      "/api/v1/agent-profiles",
+      {
+        slug: "v-role-too-long",
+        label: "V",
+        model: "claude-sonnet-4-6",
+        role: "x".repeat(201),
+      },
+    );
+    assert.equal(status, 422);
+    assert.equal(body.error.code, "PROMOTION_FAIL");
+    assert.equal(body.error.details?.field, "role");
+  });
+
+  it("rejects role with a newline (must be single line) with 422", async () => {
+    const { status, body } = await invokeRoute(
+      "POST",
+      "/api/v1/agent-profiles",
+      {
+        slug: "v-role-newline",
+        label: "V",
+        model: "claude-sonnet-4-6",
+        role: "household\nbookkeeper",
+      },
+    );
+    assert.equal(status, 422);
+    assert.equal(body.error.code, "PROMOTION_FAIL");
+    assert.equal(body.error.details?.field, "role");
+  });
+
+  it("rejects tone > 64 chars with 422", async () => {
+    const { status, body } = await invokeRoute(
+      "POST",
+      "/api/v1/agent-profiles",
+      {
+        slug: "v-tone-too-long",
+        label: "V",
+        model: "claude-sonnet-4-6",
+        tone: "y".repeat(65),
+      },
+    );
+    assert.equal(status, 422);
+    assert.equal(body.error.details?.field, "tone");
+  });
+
+  it("rejects first_actions > 10 items with 422", async () => {
+    const { status, body } = await invokeRoute(
+      "POST",
+      "/api/v1/agent-profiles",
+      {
+        slug: "v-actions-too-many",
+        label: "V",
+        model: "claude-sonnet-4-6",
+        first_actions: new Array(11).fill("an action"),
+      },
+    );
+    assert.equal(status, 422);
+    assert.equal(body.error.details?.field, "first_actions");
+  });
+
+  it("rejects first_actions[i] > 200 chars with 422", async () => {
+    const { status, body } = await invokeRoute(
+      "POST",
+      "/api/v1/agent-profiles",
+      {
+        slug: "v-action-too-long",
+        label: "V",
+        model: "claude-sonnet-4-6",
+        first_actions: ["ok action", "z".repeat(201)],
+      },
+    );
+    assert.equal(status, 422);
+    assert.match(body.error.details?.field, /first_actions/);
+  });
+
+  it("rejects first_actions that isn't an array with 422", async () => {
+    const { status, body } = await invokeRoute(
+      "POST",
+      "/api/v1/agent-profiles",
+      {
+        slug: "v-actions-not-array",
+        label: "V",
+        model: "claude-sonnet-4-6",
+        first_actions: "not an array",
+      },
+    );
+    assert.equal(status, 422);
+    assert.equal(body.error.details?.field, "first_actions");
+  });
+});


### PR DESCRIPTION
## What lands

Ctrl-api half of #206 — issue #206 Q5 + Q6:

**Q5 — per-profile bootstrap render.** `POST /api/v1/agent-profiles`
now accepts three optional fields: `role` (≤200 ch single line),
`tone` (≤64 ch single line), `first_actions[]` (≤10 × ≤200 ch each).
- `role` OR `tone` → render `RULES.md` into the profile dir
- `first_actions` non-empty → render `daybook.md`
- Skip-if-exists. SOUL.md path is unchanged.
- 422 `PROMOTION_FAIL` with `details.field` for over-limit / newline / wrong shape.

**Q6 — channel_identity table + CRUD.** Per-(profile, channel_kind) display
name + avatar override applied at send time. New migration 0018 (bumps
`user_version` 17 → 18). Four routes under
`/api/v1/agent-profiles/:slug/channel-identities[/:kind]`:
- `GET list` / `GET one`
- `PUT :kind` — multipart/form-data, `display_name` text + `avatar` file
  (image/png|jpeg|webp, ≤2 MB). At least one of {display_name, avatar}
  required. Avatar lands at `/hermes-state/profiles/<slug>/avatars/<kind>.<ext>`.
- `DELETE :kind` — 204, unlinks the avatar file.

**Lane IV consumer entrypoint.** Side-effect-free `resolveChannelIdentity(db,
slug, kind)` exported from `packages/ctrl/src/db/channelIdentity.js`
returning `{display_name, avatar_path, avatar_mime} | null`. Lane IV reads
this at send time; this PR does NOT wire the adapters (that's Lane IV).

### Files touched (10)

| Status | Path | Why |
|---|---|---|
| new | `packages/ctrl/src/db/migrations/0018_channel_identity.sql` | Table + index + FK ON DELETE CASCADE |
| new | `packages/ctrl/src/db/channelIdentity.ts` | Typed lib + `resolveChannelIdentity` (Lane IV C4) |
| new | `packages/ctrl/src/api/routes/channel_identity.ts` | The four REST routes + inline multipart parser |
| modified | `packages/ctrl/src/api/routes/profiles.ts` | POST handler extension: Q5 fields + bootstrap render |
| modified | `packages/ctrl/src/db/migrate.ts` | Append 0018 to `MIGRATIONS` array |
| modified | `packages/ctrl/src/api/server.ts` | Register the new route module |
| new | `packages/ctrl/tests/channel-identity.test.ts` | 21 tests: full CRUD, reserved/archived/unknown-kind/too-large/bad-mime/display_name-422, PNG round-trip, file unlinked, isolation |
| new | `packages/ctrl/tests/profiles.bootstrap.test.ts` | 13 tests: Q5 render paths + 6 validation 422 cases + skip-if-exists |
| modified | `packages/ctrl/tests/migrate.test.ts` | Extended with 0018 case (table+cols+composite-PK assertions) |
| modified | `packages/ctrl/tests/alfred-journal.test.ts` | user_version assertion bumped 17 → 18 (keep-the-gate-green nit; same character of edit as #196) |

Net: 1842 insertions / 8 deletions. Scope-cap note: this is a one-PR
provider lane delivery per the orchestrator brief (frozen contracts C1
through C4 in `/tmp/orchestrator-206-contracts.md`); Lane III and Lane IV
each ship their own smaller PRs and consume what's here.

## Smoke evidence

Smoke ran locally — ctrl-api built from this branch, exercised against
`/tmp/smoke-206-rt` (fresh DB + fresh /hermes-state). Real PNG bytes
upserted; real file unlinked on DELETE; real DB rows asserted.

### 1. Baseline

```
$ git fetch origin && git log --oneline origin/main -1
69eddc4f feat(web): #205 Lane III — /profiles/:slug Skills section (#217)

current HEAD: 61f1d54c feat(ctrl): #206 Lane I — channel_identity table + Q5 bootstrap render
```

### 2. Setup — build + start ctrl-api from this branch

```
$ cd packages/ctrl && npm run build
Build complete — dist/api.mjs

$ STATE_DB_PATH=/tmp/smoke-206-rt/state.db
$ HERMES_CONFIG_DIR=/tmp/smoke-206-rt/profiles
$ node --experimental-sqlite dist/api.mjs &
[alfred-state.db] migration 17 (agent_profiles) applied
[alfred-state.db] migration 18 (channel_identity) applied
Alfred tenant API listening on http://127.0.0.1:3100
```

Then create the test profile with the Q5 fields populated:

```
$ curl -X POST http://127.0.0.1:3100/api/v1/agent-profiles -H "$AUTH" \
       -H "Content-Type: application/json" \
       -d '{"slug":"test206","label":"Test206","model":"claude-sonnet-4-6",
            "role":"household bookkeeper","tone":"dry",
            "first_actions":["Reconcile weekend grocery receipts against Sure",
                             "Flag subscriptions that auto-renewed this week",
                             "Draft the monthly household budget memo"]}'
{
  "profile": { "slug":"test206", "status":"pending",
               "api_server_port":18794, ... },
  "note": "Registry row written..."
}
```

Bootstrap files on disk:

```
$ ls -la /tmp/smoke-206-rt/profiles/test206/
RULES.md     145B
daybook.md   262B

$ cat /tmp/smoke-206-rt/profiles/test206/RULES.md
# Rules for Test206

## Role
household bookkeeper

## Tone
dry

<!-- Edit me. These are the standing rules the profile honours when it acts. -->

$ cat /tmp/smoke-206-rt/profiles/test206/daybook.md
# Daybook — Test206

## First actions
- [ ] Reconcile weekend grocery receipts against Sure
- [ ] Flag subscriptions that auto-renewed this week
- [ ] Draft the monthly household budget memo

<!-- The day-one work this profile picks up. Tick as completed. -->
```

### 3. Mutation — PUT channel_identity (multipart with PNG fixture)

```
$ curl -X PUT .../channel-identities/telegram \
       -F "display_name=Cratchit-on-Telegram" \
       -F "avatar=@/tmp/smoke-206-rt/test.png;type=image/png"
{
  "channel_kind": "telegram",
  "display_name": "Cratchit-on-Telegram",
  "avatar_path": "/tmp/smoke-206-rt/profiles/test206/avatars/telegram.png",
  "avatar_mime":  "image/png",
  "updated_at":   "2026-05-31 17:59:03"
}

$ curl .../channel-identities | jq
{
  "identities": [{
    "channel_kind": "telegram",
    "display_name": "Cratchit-on-Telegram",
    "avatar_path":  "/tmp/smoke-206-rt/profiles/test206/avatars/telegram.png",
    "avatar_mime":  "image/png",
    "updated_at":   "2026-05-31 17:59:03"
  }]
}

$ ls -la /tmp/smoke-206-rt/profiles/test206/avatars/
telegram.png  69B

$ shasum -a 256 /tmp/smoke-206-rt/profiles/test206/avatars/telegram.png
b465ca78531273dab99dd97e14691b872f8fabba43f7df128bcde47ca8bf4b22
```

### 4. Isolation assertion — main untouched + no leaked files

```
$ curl .../main/channel-identities | jq
{ "identities": [] }                              # main never written to

$ find /tmp/smoke-206-rt/profiles -type f
/tmp/smoke-206-rt/profiles/test206/RULES.md
/tmp/smoke-206-rt/profiles/test206/avatars/telegram.png
/tmp/smoke-206-rt/profiles/test206/daybook.md
# every file under test206/ — nothing in main/, workers/, heavy/, codex-builder/

$ curl -X PUT .../main/channel-identities/telegram -F display_name=should-fail
HTTP 409
{"error":{"code":"CONFLICT","message":"profile 'main' is reserved"}}
```

### 5. Audit row presence — DB rows match what GET returned

```
$ sqlite3 /tmp/smoke-206-rt/state.db \
    "SELECT profile_slug, channel_kind, display_name, avatar_mime
     FROM channel_identity"
test206|telegram|Cratchit-on-Telegram|image/png
```

Plus the unit-test gate (53 tests across the 4 in-scope files):

```
$ npm test -- tests/channel-identity.test.ts tests/profiles.bootstrap.test.ts \
              tests/migrate.test.ts tests/alfred-journal.test.ts
✔ GET /api/v1/agent-profiles/:slug/channel-identities (2.29ms)
✔ PUT /api/v1/agent-profiles/:slug/channel-identities/:kind (9.00ms)
✔ GET /api/v1/agent-profiles/:slug/channel-identities/:kind (0.44ms)
✔ resolveChannelIdentity (Lane IV contract) (0.18ms)
✔ DELETE /api/v1/agent-profiles/:slug/channel-identities/:kind (1.48ms)
✔ cross-profile isolation (0.71ms)
✔ state.db migration runner (26.74ms)
✔ POST /api/v1/agent-profiles — Q5 bootstrap render (20.71ms)
✔ POST /api/v1/agent-profiles — Q5 validation (0.94ms)
✔ alfred_journal migration / appendJournal / queryRecentJournal
ℹ tests 53
ℹ pass 53
ℹ fail 0
```

### 6. Cleanup — DELETE row + file + archive profile

```
$ curl -X DELETE .../channel-identities/telegram
HTTP 204

$ ls /tmp/smoke-206-rt/profiles/test206/avatars/
(empty)

$ sqlite3 /tmp/smoke-206-rt/state.db "SELECT COUNT(*) FROM channel_identity"
0

$ curl -X DELETE .../agent-profiles/test206
HTTP 200
{ "profile": {"status":"archived", "archived_at": 1780250322879, ...} }
```

Row counts back to baseline (0 channel_identity rows, profile archived).

### Surprises / notes

- **tsc has pre-existing `node:sqlite` type errors** on origin/main too
  (environmental — Node 22 type defs lag the runtime). `npm run build` +
  `npm test` are the real gates and both pass.
- **`archived bound profile cascades to main` test fails on origin/main**
  too (pre-existing flake in `tests/agent-profiles-channel-context.test.ts`
  unrelated to this PR — verified by stashing my diff and re-running).
- **Multipart parser**: the orchestrator brief mentioned reusing the
  parser from `channels_paperclip.ts`, but that file uses no multipart
  parser (it's HMAC + JSON). The streaming parser lives in
  `routes/files.ts` and is tuned for multi-GB uploads. For ≤2 MB avatars
  I wrote an inline parser that reads the body into a bounded buffer
  (AVATAR_MAX_BYTES + 32 KiB headroom) and peels parts off — simpler,
  no shared-state surface, and adequate for the contract.
- **alfred-journal.test.ts** was bumped from `user_version === 17` to
  `=== 18` to keep CI green. The brief specified extending migrate.test
  only, but skipping this would have broken an existing test that the
  orchestrator's own #196 PR already had to bump from 15 → 17 for the
  same reason. Same character of edit.

References #206. **Closes #206 is carried by Lane III** (the
principal-visible flow lands there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
