### PR TITLE
fix(infra): #222 Lane V-b — raise hermes nofile ceiling + early fd-pressure healthcheck

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -383,13 +383,42 @@ services:
       # gateway so the supervisor restarts and picks it up. Surfacing the
       # token as a compose env var here would be misleading dead config —
       # Hermes ignores it and the file in the hermes_data volume wins.
+    # #222 defense-in-depth (Lane V-b): raise the open-files ceiling well
+    # above the 1024 default soft limit. The codex-builder gateway leaks fds
+    # (root cause fixed at source by #222 Lane V-a); under the 1024 default
+    # the leak exhausts the table fast and EVERY subsequent socket/sqlite
+    # open fails with `[Errno 24] Too many open files` — Slack `auth.test`
+    # drops, kanban hits `unable to open database file`, the gateway wedges
+    # silently. A 65536 ceiling buys headroom and, paired with the fd-pressure
+    # healthcheck below, converts a silent wedge into an early UNhealthy.
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
     healthcheck:
       # the hermes image (python:3.12-slim base) ships curl, not wget.
       # Probe BOTH gateways: main :18789 (chat/onboarding) AND workers :18790
       # (clerk/background). alfred-learn depends_on hermes service_healthy, so a
       # dead workers gateway must keep the container UNhealthy — otherwise learn
       # boots against a dead clerk gateway (FAILURE-MODES §Hermes runtime).
-      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:18789/health >/dev/null 2>&1 && curl -fsS http://127.0.0.1:18790/health >/dev/null 2>&1 || exit 1"]
+      #
+      # #222 defense-in-depth (Lane V-b): the HTTP probes below only flip the
+      # container UNhealthy AFTER a gateway socket actually dies of fd
+      # starvation — by which point Slack `auth.test` has already dropped and
+      # kanban sqlite has hit `unable to open database file`. They are a
+      # LAGGING indicator. The fd-pressure gate that runs first is the LEADING
+      # one: it walks every running `… gateway run` process (procps `pgrep` is
+      # installed), reads each one's live open-fd count (`/proc/<pid>/fd`)
+      # against its own soft limit (`/proc/<pid>/limits` -> "Max open files"),
+      # and trips the container UNhealthy at >=90% utilisation — BEFORE the
+      # first `[Errno 24] Too many open files` surfaces downstream. Cheap (a
+      # /proc walk over ~2-4 pids, no forks beyond pgrep/awk/ls/wc), POSIX-sh,
+      # runs every interval. With the ulimits.nofile raise above the soft
+      # limit is 65536, so the trip point is ~58982 fds: the upstream leak's
+      # climb is now visible as an early UNhealthy instead of a silent wedge.
+      # Note: `$$` escapes `$` for compose interpolation -> the container sees
+      # a single `$` (real shell variables, not compose vars).
+      test: ["CMD-SHELL", "for p in $$(pgrep -f 'gateway run'); do l=$$(awk '/Max open files/{print $$4}' /proc/$$p/limits 2>/dev/null); [ -z \"$$l\" ] && continue; [ \"$$l\" = unlimited ] && continue; n=$$(ls /proc/$$p/fd 2>/dev/null | wc -l); [ \"$$n\" -ge $$((l * 9 / 10)) ] && exit 1; done; curl -fsS http://127.0.0.1:18789/health >/dev/null 2>&1 && curl -fsS http://127.0.0.1:18790/health >/dev/null 2>&1 || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 30


### PR DESCRIPTION
## What & why

Defense-in-depth for the `codex-builder` fd leak (#222). The **root-cause fix lands in Lane V-a** (the root-cause closer); this PR raises the ceiling and surfaces fd-exhaustion *earlier* so the `[Errno 24] Too many open files` condition can't silently wedge the gateway (Slack `auth.test` drops, kanban sqlite `unable to open database file`).

Two changes, **`hermes` service only**:

1. **`ulimits.nofile` soft+hard `65536`** — lifts the 1024 default soft limit the leak exhausts fast.
2. **Healthcheck augmented with a LEADING fd-pressure gate**, evaluated *before* the existing HTTP probes: walk every `gateway run` process, compare its live `/proc/<pid>/fd` count to its own soft limit (`/proc/<pid>/limits` → "Max open files"), trip UNhealthy at ≥90% utilisation. The existing HTTP probes (main :18789 + workers :18790) are unchanged, so `alfred-learn`'s `depends_on … service_healthy` still gates on both gateways. POSIX-sh, `procps`/`awk`/`ls`/`wc` already in the image; defensive on `unlimited`/unreadable/empty-pid cases (no false trips).

Why not a log-grep healthcheck: the gateway processes write to the supervisor's stdout (captured by Docker's json-file driver), not to a file inside the container — there is no in-container log to grep. The `/proc` fd-count check is file-independent and a true leading indicator (it climbs as fds leak, before any socket actually fails).

## Smoke evidence

**1. Baseline** — `docker compose config -q` green on the branch (before edit):
```
BASELINE_GREEN
```

**2. Setup** — current `hermes` healthcheck (lagging HTTP-only) + the 1024 default soft limit context. The existing healthcheck probed only `:18789`+`:18790/health`; no fd guard. `python:3.12-slim` ships `procps` (`pgrep`), `awk`, `ls`, `wc`, `curl` (Dockerfile:64-71).

**3. Mutation** — compose diff (30 insertions, 1 deletion = ~29 net LOC):
```
 docker-compose.yaml | 31 ++++++++++++++++++++++++++++++-
 1 file changed, 30 insertions(+), 1 deletion(-)
```

**4. Isolation assertion** — `docker compose config` rendered output: ONLY the `hermes` service gained the change. Cross-service grep:
```
=== count of 'soft: 65536' blocks across ALL services (expect 1) ===
1
=== which service owns the 'gateway run' healthcheck (expect 1, hermes) ===
1
  -> service 'hermes' line 374: - for p in $$(pgrep -f 'gateway run'); do l=$$(awk
  -> service 'hermes' line 390: nofile:
  -> service 'hermes' line 391: soft: 65536
```
No other service's ulimits/healthcheck touched.

**5. Audit/tripwire** — `docker compose config` renders the nofile + new healthcheck verbatim:
```yaml
    healthcheck:
      test:
        - CMD-SHELL
        - for p in $$(pgrep -f 'gateway run'); do l=$$(awk '/Max open files/{print $$4}' /proc/$$p/limits 2>/dev/null); [ -z "$$l" ] && continue; [ "$$l" = unlimited ] && continue; n=$$(ls /proc/$$p/fd 2>/dev/null | wc -l); [ "$$n" -ge $$((l * 9 / 10)) ] && exit 1; done; curl -fsS http://127.0.0.1:18789/health >/dev/null 2>&1 && curl -fsS http://127.0.0.1:18790/health >/dev/null 2>&1 || exit 1
      timeout: 5s
      interval: 10s
    ulimits:
      nofile:
        soft: 65536
        hard: 65536
```
(`$$` in rendered output is compose re-escaping; the container shell sees a single `$` → real shell vars.)

fd-pressure logic exercised against synthetic `/proc` fixtures (soft limit 65536, 90% trip = 58982 fds):
```
p100 fds: 62000  p200 fds: 100
--- clean process only (200, ~0.15%): expect PASS ---
rc=0 PASS (healthy)
--- leaking process (100, ~95%): expect TRIP ---
rc=1 TRIP (unhealthy)
--- mixed (200 then 100): expect TRIP (any leaker fails the chain) ---
rc=1 TRIP (unhealthy)
--- unlimited limit: expect PASS (no false trip) ---
rc=0 PASS (healthy)
--- missing/unreadable proc: expect PASS (skip) ---
rc=0 PASS (healthy)
--- no gateway pids at all: expect PASS ---
rc=0 PASS (healthy)
```

**6. Cleanup** — no duplicate/orphan keys; config stable across repeated runs:
```
STABLE_GREEN
```
Working tree clean aside from the tracked change (`.env` gitignored, `.lane` untracked). Commit `c30d4fed` touched only `docker-compose.yaml`.

## Post-merge verification (honest note)

`home.alfred.black` runs released `:latest` — this compose change is **not deployed** by merging. The real-tenant proof (fd ceiling = 65536 inside the live container via `cat /proc/<gw-pid>/limits`, and the healthcheck flipping UNhealthy under fd pressure) is a **post-merge step**: rsync the compose file to a tenant and `docker compose up -d hermes`. **Do NOT redeploy `home`** (Sir's daily driver) for this — verify on `staging.alfred.black` or a throwaway tenant first. Lane V-a's source fix should land alongside so the leak is cured, not merely ceilinged.

References #222 (defense-in-depth — Lane V-a is the closer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)