### PR TITLE
fix(ctrl): observations status=unprocessed must mean "not yet processed" (relight the learning loop)

### DIFF
--- a/packages/ctrl/src/api/routes/learning.ts
+++ b/packages/ctrl/src/api/routes/learning.ts
@@ -485,7 +485,12 @@ export function registerLearningRoutes(): void {
       enabled,
       observations: {
         total: observations.length,
-        unprocessed: observations.filter((r) => r.status === "unprocessed").length,
+        // "unprocessed" is semantic (anything reflection hasn't consumed), not a
+        // stored status — rows are written 'open'. Count by exclusion so this
+        // matches the GET /observations?status=unprocessed contract.
+        unprocessed: observations.filter(
+          (r) => r.status !== "processed" && r.status !== "invalid",
+        ).length,
         processed: observations.filter((r) => r.status === "processed").length,
         invalid: observations.filter((r) => r.status === "invalid").length,
       },

--- a/packages/ctrl/src/api/routes/state.ts
+++ b/packages/ctrl/src/api/routes/state.ts
@@ -275,12 +275,22 @@ export function registerStateRoutes(): void {
   addRoute("GET", "/api/v1/state/observations", async ({ res, query }) => {
     const limit = clampLimit(query);
     const offset = Math.max(0, parseInt(query.get("offset") ?? "0", 10) || 0);
+    // `status=unprocessed` is a SEMANTIC filter, not a literal value: rows are
+    // written `status='open'` (POST default) and only become `'processed'` once
+    // ReflectionWorkflow consumes them. An equality match on "unprocessed" would
+    // return nothing, which is exactly what silently starved the learning loop
+    // (ReflectionWorkflow.fetch_unprocessed_observations asks for "unprocessed",
+    // got 0 rows every run, never distilled any instinct). Map it to "anything
+    // not yet processed" so producer (open) and consumer (unprocessed) agree.
+    const statusParam = query.get("status");
+    const unprocessed = statusParam === "unprocessed";
     const r = queryCrossTier("observation", {
       filters: {
         kind: query.get("kind"),
         subject: query.get("subject"),
-        status: query.get("status"),
+        status: unprocessed ? null : statusParam,
       },
+      not: unprocessed ? { col: "status", value: "processed" } : null,
       since: query.get("since"),
       until: query.get("until"),
       limit,

--- a/packages/ctrl/src/db/coldRead.ts
+++ b/packages/ctrl/src/db/coldRead.ts
@@ -267,6 +267,14 @@ export interface GenericQuery {
   // Optional OR-of-equality predicate: matches when ANY listed column equals
   // `value`. Used by the link route's `ref` param ("all edges touching X").
   anyOf?: { cols: string[]; value: string } | null;
+  // Optional negated-equality predicate: matches rows whose `col` is NOT
+  // `value` (NULLs treated as not-equal so they're included). Used by the
+  // observations route's `status=unprocessed` semantic filter — "unprocessed"
+  // is NOT a stored status value (rows are written `status='open'` and only
+  // become `'processed'` once ReflectionWorkflow consumes them), so an equality
+  // match on it returns nothing. This expresses the real intent: "everything
+  // reflection hasn't processed yet."
+  not?: { col: string; value: string } | null;
   limit: number;
   offset: number;
 }
@@ -309,6 +317,12 @@ export function queryCrossTier(table: string, q: GenericQuery): CrossTierResult 
         where.push("(" + cols.map((c) => `${c} = ?`).join(" OR ") + ")");
         for (const _ of cols) args.push(q.anyOf.value);
       }
+    }
+    if (q.not && cfg.filterCols.includes(q.not.col)) {
+      // COALESCE so NULL statuses are treated as "not equal" (included),
+      // matching SQLite's three-valued-logic where `col != ?` would drop NULLs.
+      where.push(`COALESCE(${q.not.col}, '') != ?`);
+      args.push(q.not.value);
     }
     return { sql: where.length ? "WHERE " + where.join(" AND ") : "", args };
   }

--- a/packages/ctrl/tests/observation-unprocessed-filter.test.ts
+++ b/packages/ctrl/tests/observation-unprocessed-filter.test.ts
@@ -1,0 +1,89 @@
+// Learning-loop relight — `status=unprocessed` must mean "not yet processed".
+//
+// The bug: observations are written `status='open'` (POST /observations default)
+// and only become `'processed'` once ReflectionWorkflow consumes them. But the
+// consumer (fetch_unprocessed_observations → list_observations(status=
+// "unprocessed")) queried for the literal value "unprocessed", which is NEVER
+// stored — so reflection fetched 0 rows every run and the instinct-distillation
+// stage silently no-op'd on every tenant (observations piled up `open` forever,
+// processed_at stayed NULL, no new instincts).
+//
+// The fix makes "unprocessed" a SEMANTIC filter (status != 'processed', NULLs
+// included) via queryCrossTier's new `not` predicate. This test proves the
+// query layer surfaces open/active/draft/NULL observations under the
+// "unprocessed" filter and excludes processed ones.
+import { describe, it, before } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "obs-unprocessed-"));
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.STATE_DB_PATH = path.join(tmp, "state.db");
+process.env.COLD_DB_PATH = path.join(tmp, "cold.db");
+process.env.VAULT_PATH = path.join(tmp, "vault");
+process.env.SQLITE_VEC_PATH = "";
+
+const { getStateDb } = await import("../src/db/state.js");
+const { queryCrossTier } = await import("../src/db/coldRead.js");
+
+// `observation.status` is `TEXT NOT NULL DEFAULT 'open'`, so NULL can't occur
+// in practice — the COALESCE in coldRead's `not` predicate is harmless defence.
+const ROWS: Array<{ id: string; status: string }> = [
+  { id: "obs-open-1", status: "open" }, // the POST default — must be returned
+  { id: "obs-open-2", status: "open" },
+  { id: "obs-active", status: "active" }, // other non-terminal state — returned
+  { id: "obs-processed", status: "processed" }, // terminal — must be EXCLUDED
+];
+
+before(() => {
+  const db = getStateDb();
+  let i = 0;
+  for (const r of ROWS) {
+    db.prepare(
+      `INSERT INTO observation (id, ts, subject, kind, summary, status)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(r.id, `2026-06-02T10:0${i}:00.000Z`, "principal", "decision", "x", r.status);
+    i++;
+  }
+});
+
+describe("observation status=unprocessed is semantic (not a literal match)", () => {
+  it("the old literal equality match returns nothing (reproduces the bug)", () => {
+    const r = queryCrossTier("observation", {
+      filters: { status: "unprocessed" },
+      since: null,
+      until: null,
+      limit: 100,
+      offset: 0,
+    });
+    assert.equal(r.entries.length, 0, "no row is stored with literal status='unprocessed'");
+  });
+
+  it("the `not: status!=processed` predicate returns every non-processed row", () => {
+    const r = queryCrossTier("observation", {
+      filters: {},
+      not: { col: "status", value: "processed" },
+      since: null,
+      until: null,
+      limit: 100,
+      offset: 0,
+    });
+    const ids = r.entries.map((e) => e.id).sort();
+    assert.deepEqual(ids, ["obs-active", "obs-open-1", "obs-open-2"]);
+    assert.ok(!ids.includes("obs-processed"), "processed rows must be excluded");
+  });
+
+  it("a `not` on a column the table doesn't filter is ignored (no crash, no effect)", () => {
+    const r = queryCrossTier("observation", {
+      filters: {},
+      not: { col: "not_a_real_col", value: "x" },
+      since: null,
+      until: null,
+      limit: 100,
+      offset: 0,
+    });
+    assert.equal(r.entries.length, ROWS.length, "unknown not-column is a no-op");
+  });
+});


### PR DESCRIPTION
## Problem

The observation → instinct stage of the intelligence loop silently no-op's.

Observations are written `status='open'` (the `POST /api/v1/state/observations` default in `state.ts`) and only flip to `'processed'` once `ReflectionWorkflow` consumes them. But the consumer — `fetch_unprocessed_observations` → `list_observations(status="unprocessed")` (learn `vault.py`) — queries for the **literal** value `"unprocessed"`, which is never written to the column.

So the nightly reflection fetches **0 rows** every run, marks nothing processed (`processed_at` stays NULL), and distils no new instincts. Observations accumulate correctly but are never digested; with no instincts to match, judgment punts effectively every signal to the human. The first four stages of the loop work; this fifth stage was dead on arrival. Producer and consumer disagreed on a single word.

## Fix

Make `unprocessed` a **semantic** filter ("anything not yet processed") instead of a literal match nothing stores:

- **`coldRead.queryCrossTier`** gains an optional `not: { col, value }` predicate — emits `COALESCE(col,'') != ?` so it's valid across hot **and** cold tiers and never drops NULLs. Unknown columns are ignored (no-op).
- **`GET /api/v1/state/observations`** maps `status=unprocessed` → `not: {col:'status', value:'processed'}`. Any other `status=` value stays a literal equality filter — unchanged.
- **`learning.ts`** summary counts `unprocessed` by exclusion (`!== processed && !== invalid`).

No producer change, no schema change — `status='open'` stays the default the UI/Desk read.

## Test

`tests/observation-unprocessed-filter.test.ts`: reproduces the zero-row bug, proves the `not` predicate returns open/active + excludes processed, and that an unknown `not`-column is a safe no-op. All 14 existing cross-tier tests still pass; esbuild bundle compiles.

## Smoke evidence

`node build.mjs` (the ctrl-api bundle the image ships):
```
Build complete — dist/api.mjs
```

New test — reproduces the bug + proves the fix:
```
▶ observation status=unprocessed is semantic (not a literal match)
  ✔ the old literal equality match returns nothing (reproduces the bug)
  ✔ the `not: status!=processed` predicate returns every non-processed row
  ✔ a `not` on a column the table doesn't filter is ignored (no crash, no effect)
ℹ tests 3  ℹ pass 3  ℹ fail 0
```

Existing cross-tier tests still green (no regression in the shared query layer):
```
tests/cold-cross-tier-tables.test.ts + tests/cold-cross-tier-total-dedup.test.ts
ℹ tests 14  ℹ pass 14  ℹ fail 0
```

Live end-to-end verification (observation backlog draining → `processed_at` advancing on a real tenant after the ctrl-api image rolls) will be confirmed post-merge during the fleet redeploy and reported on this PR.