### PR TITLE
fix(learn): relight observation→instinct loop — steward unbound-client + reflection batch/timeout

### DIFF
--- a/packages/learn/src/activities/steward.py
+++ b/packages/learn/src/activities/steward.py
@@ -2296,8 +2296,14 @@ async def _emit_source_pruned_audit(
             canonical_task_path, name, exc,
         )
         return None
-    finally:
-        await client.close()
+    # NOTE: intentionally NO finally-block closing a VaultClient here — this
+    # function never opens one (it writes the audit via
+    # `async with StateClient(cfg) as sc`, which closes itself). A leftover
+    # finally that closed an undefined `client` raised NameError on EVERY
+    # source-prune: the audit row landed, the activity then failed in the
+    # finally, Temporal retried, and a duplicate audit landed each retry — the
+    # cause of the steward NameError storm and the runaway steward-source-pruned
+    # audit-row count.
 
 
 def _get_no_signal_streak(fm: dict[str, Any]) -> int:

--- a/packages/learn/src/activities/vault.py
+++ b/packages/learn/src/activities/vault.py
@@ -766,8 +766,14 @@ async def fetch_unprocessed_observations() -> list[dict[str, Any]]:
         # list_observation_records doesn't expose it, so query directly.
         from src.utils.signal_state import StateClient, observation_row_to_record
 
+        # Batch capped at 75: clerk_reflect sends every fetched observation to
+        # the LLM in one prompt. At 200 the call blew past clerk_reflect's
+        # StartToClose timeout (the whole ReflectionWorkflow then failed and
+        # marked nothing processed — so a backlog could never drain). 75 keeps a
+        # single reflection comfortably inside the timeout; the backlog drains
+        # across successive runs instead of choking on one oversized batch.
         async with StateClient(config) as sc:
-            rows = await sc.list_observations(status="unprocessed", limit=200)
+            rows = await sc.list_observations(status="unprocessed", limit=75)
         return [observation_row_to_record(r) for r in rows]
     except Exception:  # noqa: BLE001
         return []

--- a/packages/learn/src/workflows/reflection.py
+++ b/packages/learn/src/workflows/reflection.py
@@ -71,7 +71,11 @@ class ReflectionWorkflow:
         proposals = await workflow.execute_activity(
             clerk_reflect,
             args=[observations, instincts, distiller_learnings, janitor_flags],
-            start_to_close_timeout=timedelta(seconds=120),
+            # 300s (was 120s): one LLM pass over the observation batch + the full
+            # instinct set is slow; 120s timed out, failed the whole workflow, and
+            # left every observation unprocessed (a backlog could never drain).
+            # Paired with the batch cap of 75 in fetch_unprocessed_observations.
+            start_to_close_timeout=timedelta(seconds=300),
             retry_policy=RetryPolicy(maximum_attempts=2),
         )
 

--- a/packages/learn/tests/test_relight_learning_loop.py
+++ b/packages/learn/tests/test_relight_learning_loop.py
@@ -1,0 +1,61 @@
+"""Regression guards for the observation→instinct loop relight.
+
+Two distinct bugs starved the loop after the #232 status-vocab fix made
+reflection actually fetch observations:
+
+1. ``steward._emit_source_pruned_audit`` had a leftover
+   ``finally: await client.close()`` over a ``client`` it never defines (it
+   writes via ``async with StateClient(cfg) as sc``). That raised NameError on
+   EVERY source-prune — the audit landed, the activity then failed in the
+   finally, Temporal retried, and a duplicate audit landed each retry (the
+   steward error storm + runaway ``steward-source-pruned`` audit count).
+
+2. ``ReflectionWorkflow`` fetched a 200-observation batch and gave
+   ``clerk_reflect`` a 120s StartToClose timeout. One LLM pass over 200
+   observations + the instinct set blew past 120s → the whole workflow failed →
+   nothing was marked processed → a backlog could never drain.
+
+These are source-level guards (cheap, no network) so the two regressions
+can't silently come back.
+"""
+import inspect
+import re
+
+
+def test_emit_source_pruned_audit_does_not_close_undefined_client():
+    from src.activities import steward
+
+    src = inspect.getsource(steward._emit_source_pruned_audit)
+    # The function uses `async with StateClient(...) as sc` — it must NOT
+    # reference a bare `client` (there is none to close).
+    assert "client.close()" not in src, (
+        "_emit_source_pruned_audit must not close a `client` it never opens — "
+        "that finally raised NameError on every source-prune."
+    )
+    assert "StateClient" in src, "should still write its audit via StateClient"
+
+
+def test_reflection_fetch_batch_is_bounded():
+    from src.activities import vault
+
+    src = inspect.getsource(vault.fetch_unprocessed_observations)
+    m = re.search(r"list_observations\([^)]*limit=(\d+)", src, re.DOTALL)
+    assert m, "fetch_unprocessed_observations must pass an explicit limit"
+    limit = int(m.group(1))
+    # 200 was the value that overflowed clerk_reflect's timeout. Keep the batch
+    # small enough that one reflection comfortably completes.
+    assert limit <= 100, f"reflection batch limit {limit} is too large (was 200)"
+
+
+def test_reflection_clerk_timeout_has_headroom():
+    import src.workflows.reflection as refl
+
+    src = inspect.getsource(refl)
+    # The clerk_reflect activity is the slow LLM step. Find every
+    # start_to_close_timeout=timedelta(seconds=N) and assert the largest one
+    # (the clerk_reflect call) is generous — 120s was the value that failed.
+    seconds = [int(x) for x in re.findall(r"start_to_close_timeout=timedelta\(seconds=(\d+)\)", src)]
+    assert seconds, "reflection workflow should set activity timeouts"
+    assert max(seconds) >= 300, (
+        f"clerk_reflect timeout headroom too small (max={max(seconds)}s); 120s timed out on the backlog"
+    )


### PR DESCRIPTION
## Problem

Even after #232 made `ReflectionWorkflow` *fetch* observations again (status-vocab fix), the observation→instinct loop stayed dead. Two more bugs in the chain:

**1. `steward._emit_source_pruned_audit` — NameError on every source-prune.** The function writes its audit via `async with StateClient(cfg) as sc` but carried a leftover `finally: await client.close()` over a `client` it never opens. Result: the audit row landed, the activity then *failed* in the `finally` (`NameError: name 'client' is not defined`), Temporal retried, and a **duplicate audit landed on each retry**. This is the steward error storm and the runaway `steward-source-pruned` audit-row count. It's the only one of the 8 `client.close()` sites in steward.py that isn't preceded by a `client = VaultClient(...)` binding.

**2. `ReflectionWorkflow` times out on a large batch.** `fetch_unprocessed_observations` pulled **200** observations and `clerk_reflect` had a **120s** StartToClose timeout. One LLM pass over 200 observations + the full instinct set exceeds 120s → the activity times out → the whole workflow fails → `mark_observations_processed` never runs → a backlog can never drain.

## Fix

1. Remove the bogus `finally` in `_emit_source_pruned_audit` (StateClient closes itself).
2. Cap the reflection fetch at **75** and raise the `clerk_reflect` timeout to **300s**. The backlog drains across successive runs instead of choking on one oversized batch.

Both are generic (every tenant), no schema change.

## Smoke evidence

```
$ python3 -c "import ast; [ast.parse(open(f).read()) for f in (
    'src/activities/steward.py','src/activities/vault.py','src/workflows/reflection.py')]"
syntax OK

$ python3 -m pytest tests/test_relight_learning_loop.py -q
...
3 passed in 0.15s
```

Regression guards (`tests/test_relight_learning_loop.py`):
- `_emit_source_pruned_audit` source must not close an undefined `client`.
- reflection fetch `limit` ≤ 100 (was 200).
- `clerk_reflect` timeout ≥ 300s (was 120s).

Live drain verification on the deployed tenant (processed_at climbing off zero) will be confirmed post-merge during the learn-image roll and reported on this PR.