### PR TITLE
feat(hermes): publish main gateway on host loopback + bake edge-tts into image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -306,16 +306,26 @@ services:
   # Hermes /v1 API directly.
   hermes:
     image: ssdavidai00/alfred-black-hermes:latest
-    # No `ports:` — hermes binds 0.0.0.0 inside the container on the four
-    # reserved ports (18789/18790/18791/18793) PLUS any registry-allocated
-    # user-facing profile port (18794..18799 per #120 Lane II). All of
-    # these are reachable ONLY via the compose default network as
-    # `http://hermes:<port>` from sibling containers (ctrl-api, paperclip,
-    # alfred-learn, voice-bridge). They are intentionally NOT host-published
-    # so the only external surface is Caddy ingress on :443, which in turn
-    # routes through ctrl-api's auth-gated proxy. Adding user-facing profile
-    # ports to a `ports:` block would expose them on the VM's public IP
-    # without any TLS or auth wrapping.
+    # Gateway ports bind 0.0.0.0 inside the container on the four reserved
+    # ports (18789/18790/18791/18793) PLUS any registry-allocated user-facing
+    # profile port (18794..18799 per #120 Lane II). These are reachable via
+    # the compose default network as `http://hermes:<port>` from sibling
+    # containers (ctrl-api, paperclip, alfred-learn, voice-bridge). They are
+    # NOT published on the VM's public interface — the only external surface
+    # is Caddy ingress on :443 through ctrl-api's auth-gated proxy. Binding
+    # user-facing profile ports to the public IP would expose them with no
+    # TLS or auth wrapping.
+    #
+    # EXCEPTION — the `main` gateway (18789) is published on the HOST LOOPBACK
+    # only (127.0.0.1). This lets an operator/principal reach the main chat
+    # profile from their own machine via an SSH local-forward — e.g.
+    # `ssh -L 8642:localhost:18789 root@<host>` then point Hermes Desktop at
+    # http://localhost:8642/v1 — without chasing the container's bridge IP
+    # (which changes on restart). 127.0.0.1 binding keeps it off the public
+    # interface: reachable only from on the VM (i.e. through SSH), never from
+    # the internet, and the gateway still requires the Bearer API_SERVER_KEY.
+    ports:
+      - "127.0.0.1:18789:18789"
     depends_on:
       init:
         condition: service_completed_successfully

--- a/packages/hermes/Dockerfile
+++ b/packages/hermes/Dockerfile
@@ -394,6 +394,13 @@ COPY packages/hermes/SOUL.codex-builder.md /opt/hermes-assets/SOUL.codex-builder
 # render_registry.py is NOT baked here — supervisor reads the registry JSON
 # ctrl-api already wrote (no state.db mount in the hermes runtime).
 RUN pip install --no-cache-dir "jinja2==3.1.6" "ruamel.yaml==0.18.6"
+
+# edge-tts — text-to-speech (Microsoft Edge online voices) used by the voice
+# surface. Previously pip-installed by hand into running hermes containers
+# (observed hot-installed on zsolt 2026-06), so it vanished on every image
+# redeploy. Baked here so it survives recreates. `edge-playback` ships in the
+# same package. Pinned to the version that was running in the field.
+RUN pip install --no-cache-dir "edge-tts==7.2.7"
 COPY packages/hermes/init/render_hermes.py       /opt/hermes-init/render_hermes.py
 COPY packages/hermes/init/render_mcp_servers.py  /opt/hermes-init/render_mcp_servers.py
 COPY packages/hermes/hermes-config.yaml.njk      /opt/hermes-init/templates/hermes-config.yaml.njk


### PR DESCRIPTION
## Why
Lets a principal/operator attach **Hermes Desktop** to a tenant's **main** chat profile over an SSH tunnel, durably — and fixes a latent fleet fragility.

## Changes
**1. `docker-compose.yaml` — publish `main` gateway (18789) on `127.0.0.1` only.**
Hermes Desktop has no built-in SSH tunnel; you forward a local port to the gateway and point Desktop at it:
```
ssh -L 8642:localhost:18789 root@<tenant-host>
# Hermes Desktop → http://localhost:8642/v1  (Bearer = main profile API_SERVER_KEY)
```
Previously the only host-side target was the container's **Docker bridge IP** (e.g. `172.18.0.16`), which **changes on every hermes restart** — so the tunnel kept breaking. Binding to `127.0.0.1` keeps it **off the public interface** (reachable only on the VM / via SSH), and the gateway still requires the Bearer key. All other gateway ports stay internal-only.

**2. `packages/hermes/Dockerfile` — bake `edge-tts==7.2.7`.**
It was being pip-installed **by hand into running hermes containers** (found hot-installed on zsolt), so it silently vanished on every image redeploy. Baking it in makes the voice TTS dep survive recreates fleet-wide.

## Deploy
- `build-hermes` rebuilds the image (edge-tts) → `deploy-fleet` pulls + recreates hermes.
- `deploy-compose` scp's the new compose (loopback port) → `up -d`.
- Both recreate hermes per tenant (brief gateway blip). The codex auth + profiles live in the `hermes_data` volume, so they survive the recreate.

## Verify after deploy
- `docker port alfred-black-hermes-1` shows `18789 → 127.0.0.1:18789` on each tenant.
- `ssh -L 8642:localhost:18789 …` + Hermes Desktop connects to main.
- `docker exec alfred-black-hermes-1 pip show edge-tts` → 7.2.7 (now from the image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)