### PR TITLE
GH #253 — Vaultwarden to Paperclip secret sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,7 +43,7 @@ COMPOSIO_API_KEY=
 # in a secret yet. Set this in production.
 COMPOSIO_WEBHOOK_SECRET=
 
-# ════════════════════════════════════════════════════════════════════════
+# ════════════════════════════════════════════════════════════════════
 # USER MUST FILL — optional. Leave blank to disable the feature.
 # ════════════════════════════════════════════════════════════════════
 
@@ -94,8 +94,8 @@ SURE_ENABLED=true
 
 # The principal's primary email address. Load-bearing across the stack: the
 # first-brief email sender + sender-allowlist, the cross-tenant ingest guard,
-# and Sure's first-boot owner account all key of it. The code reads
-# OOWNER_EMAIL (compose mirrors it into ALFRED_OWNER_EMAIL too). Set this —
+# and Sure's first-boot owner account all key off it. The code reads
+# OWNER_EMAIL (compose mirrors it into ALFRED_OWNER_EMAIL too). Set this —
 # leaving it blank fails the first-brief email open and the ingest guard
 # fails open. (C9.)
 OWNER_EMAIL=
@@ -120,7 +120,7 @@ AGENTMAIL_INBOX_ADDRESS=
 #   AGENTMAIL_MASTER_API_KEY=     # master key that owns the shared pod
 #   AGENTMAIL_SHARED_POD_ID=      # pod the per-tenant inboxes are created in
 #   AGENTMAIL_DOMAIN=mail.alfred.black
-#   AGENTMAIL_WEBHOOK_SECRET=     # svix-tyle secret viverifying inbound mail
+#   AGENTMAIL_WEBHOOK_SECRET=     # svix-style secret verifying inbound mail
 
 # OMI ambient transcription — the OmiAudioProcessorWorkflow (alfred-learn)
 # transcribes captured wearable audio via Groq Whisper. Without a key every
@@ -163,9 +163,9 @@ SAAS_HOST=https://${DOMAIN}
 # device on login.tailscale.com once. The sidecar joins the principal's own
 # tailnet; the public *.alfred.black hostname keeps working unchanged.
 # Full opt-in runbook in deploy/README.md "Enabling Tailscale on an
-# existing tenant"; design overview in CLAUDE.md £15.11.
+# existing tenant"; design overview in CLAUDE.md §15.11.
 TAILSCALE_ENABLED=false
-# Optional —path A (pre-shared auth-key) bootstrap. Leave blank to use
+# Optional — path A (pre-shared auth-key) bootstrap. Leave blank to use
 # path C (device-style auth URL), which is the recommended flow.
 TAILSCALE_AUTHKEY=
 # Tailnet device hostname. Blank → bootstrap.sh derives it from $DOMAIN

--- a/.env.example
+++ b/.env.example
@@ -43,7 +43,7 @@ COMPOSIO_API_KEY=
 # in a secret yet. Set this in production.
 COMPOSIO_WEBHOOK_SECRET=
 
-# ════════════════════════════════════════════════════════════════════
+# ════════════════════════════════════════════════════════════════════════
 # USER MUST FILL — optional. Leave blank to disable the feature.
 # ════════════════════════════════════════════════════════════════════
 
@@ -75,6 +75,12 @@ GOOGLE_CLIENT_SECRET=
 # Leave blank to disable email sending (signup still works via dev mode).
 SENDGRID_API_KEY=
 
+# Paperclip secret sync — optional. Default off until PAPERCLIP_SECRET_SYNC_COMPANY_ID
+# is set in a cron/scheduler command. Vaultwarden folder `paperclip` is the
+# authoritative source; Paperclip receives local_encrypted read replicas.
+PAPERCLIP_SECRET_SYNC_COMPANY_ID=
+PAPERCLIP_SECRET_SYNC_FOLDER=paperclip
+
 # Mailgun — the web app's configured email provider. The app boots even
 # with placeholder values here, but verification / password-reset emails
 # only deliver with a real key + domain. Get them at mailgun.com.
@@ -88,8 +94,8 @@ SURE_ENABLED=true
 
 # The principal's primary email address. Load-bearing across the stack: the
 # first-brief email sender + sender-allowlist, the cross-tenant ingest guard,
-# and Sure's first-boot owner account all key off it. The code reads
-# OWNER_EMAIL (compose mirrors it into ALFRED_OWNER_EMAIL too). Set this —
+# and Sure's first-boot owner account all key of it. The code reads
+# OOWNER_EMAIL (compose mirrors it into ALFRED_OWNER_EMAIL too). Set this —
 # leaving it blank fails the first-brief email open and the ingest guard
 # fails open. (C9.)
 OWNER_EMAIL=
@@ -114,7 +120,7 @@ AGENTMAIL_INBOX_ADDRESS=
 #   AGENTMAIL_MASTER_API_KEY=     # master key that owns the shared pod
 #   AGENTMAIL_SHARED_POD_ID=      # pod the per-tenant inboxes are created in
 #   AGENTMAIL_DOMAIN=mail.alfred.black
-#   AGENTMAIL_WEBHOOK_SECRET=     # svix-style secret verifying inbound mail
+#   AGENTMAIL_WEBHOOK_SECRET=     # svix-tyle secret viverifying inbound mail
 
 # OMI ambient transcription — the OmiAudioProcessorWorkflow (alfred-learn)
 # transcribes captured wearable audio via Groq Whisper. Without a key every
@@ -157,9 +163,9 @@ SAAS_HOST=https://${DOMAIN}
 # device on login.tailscale.com once. The sidecar joins the principal's own
 # tailnet; the public *.alfred.black hostname keeps working unchanged.
 # Full opt-in runbook in deploy/README.md "Enabling Tailscale on an
-# existing tenant"; design overview in CLAUDE.md §15.11.
+# existing tenant"; design overview in CLAUDE.md £15.11.
 TAILSCALE_ENABLED=false
-# Optional — path A (pre-shared auth-key) bootstrap. Leave blank to use
+# Optional —path A (pre-shared auth-key) bootstrap. Leave blank to use
 # path C (device-style auth URL), which is the recommended flow.
 TAILSCALE_AUTHKEY=
 # Tailnet device hostname. Blank → bootstrap.sh derives it from $DOMAIN

--- a/docs/operators/paperclip-secret-sync.md
+++ b/docs/operators/paperclip-secret-sync.md
@@ -1,3 +1,73 @@
 # Paperclip secret sync
 
-Vaultwarden is authoritative. Paperclip 
+Vaultwarden is authoritative. Paperclip `local_encrypted` secrets are a read-replica written one way from Vaultwarden.
+
+## Selection
+
+Create a Vaultwarden folder named `paperclip` (override with `PAPERCLIP_SECRET_SYNC_FOLDER`). Put login items in that folder. The login password is the secret value.
+
+Item names map deterministically to Paperclip keys:
+
+- `OPENAI_API_KEY` syncs to the target company passed in the trigger.
+- `<company-id>/OPENAI_API_KEY` syncs only when the route target is that company id. This is the disambiguation form for a shared Vaultwarden folder.
+
+Secret keys must match `^[A-Za-z_][A-Za-z0-9_.-]{0,127}$`.
+
+## Direction and deletion policy
+
+Vaultwarden always wins. The sync never reads Paperclip as authoritative and never writes Paperclip values back to Vaultwarden.
+
+Default behavior is additive/upsert-only:
+
+- A selected Vaultwarden item creates or overwrites the Paperclip copy.
+- A removed Vaultwarden item does not delete the Paperclip copy.
+- `prune=true` is deliberately rejected by the ctrl-api route until a separate deletion gate exists.
+
+## Safety
+
+The route returns key names, counts, and skip reasons only. It never returns secret values. The trigger script prints the same safe response envelope.
+
+## Manual trigger
+
+From the ctrl package/container:
+
+```bash
+PAPERCLIP_SECRET_SYNC_COMPANY_ID=<company-id> \
+AAS_API_KEY=<ctrl-api-key> \
+CTRL_API_URL=http://ctrl-api:3100 \
+npm run paperclip:secret-sync
+```
+
+Dry-run:
+
+```bash
+PAPERCLIP_SECRET_SYNC_COMPANY_ID=<company-id> \
+AAS_API_KEY=<ctrl-api-key> \
+PAPERCLIP_SECRET_SYNC_DRY_RUN=1 \
+npm run paperclip:secret-sync
+```
+
+Direct API shape:
+
+```bash
+POST /api/v1/paperclip/admin/companies/:companyId/secrets/sync
+Authorization: Bearer <AAS_API_KEY>
+Content-Type: application/json
+
+{"dry_run": false}
+```
+
+## Scheduled run
+
+Default is off. To schedule it, run the same command from the tenant's preferred cron/scheduler with `PAPERCLIP_SECRET_SYNC_COMPANY_ID` set. The sync is idempotent: unchanged values upsert to the same target keys and response logs remain value-free.
+
+Recommended cadence: every 15 minutes after Vaultwarden is configured.
+
+## Smoke plan
+
+1. Create a disposable login item in Vaultwarden folder `paperclip` named `PCP_SYNC_SMOKE` with a sentinel password.
+2. Run the sync once and verify Paperclip can read `PCP_SYNC_SMOKE`.
+3. Mutate the Paperclip copy only.
+4. Run the sync again and verify Paperclip is restored to the Vaultwarden value.
+5. Run with `PAPERCLIP_SECRET_SYNC_DRY_RUN=1`; confirm only key names/counts appear.
+6. Remove the Vaultwarden disposable item and confirm no deletion occurs by default.

--- a/docs/operators/paperclip-secret-sync.md
+++ b/docs/operators/paperclip-secret-sync.md
@@ -1,0 +1,3 @@
+# Paperclip secret sync
+
+Vaultwarden is authoritative. Paperclip 

--- a/packages/ctrl/package.json
+++ b/packages/ctrl/package.json
@@ -9,6 +9,7 @@
     "dev": "node build.mjs --watch",
     "start": "node --experimental-sqlite dist/api.mjs",
     "test": "node --experimental-sqlite --experimental-test-module-mocks --import tsx/esm --experimental-loader ./tests/text-loader.mjs --test tests/*.test.ts",
+    "paperclip:secret-sync": "tsx scripts/paperclip-secret-sync.ts",
     "evidence:paperclip-github": "tsx scripts/paperclip-github-evidence.ts"
   },
   "dependencies": {

--- a/packages/ctrl/scripts/paperclip-secret-sync.ts
+++ b/packages/ctrl/scripts/paperclip-secret-sync.ts
@@ -1,0 +1,37 @@
+#!/usr/bin/env tsx
+export {};
+// Manual / cron-safe trigger for the one-way Vaultwarden → Paperclip secret sync.
+// Values never appear in this script's stdout; ctrl-api returns key names only.
+
+const companyId = process.env.PAPERCLIP_SECRET_SYNC_COMPANY_ID || process.argv[2];
+if (!companyId) {
+  console.error("Usage: PAPERCLIP_SECRET_SYNC_COMPANY_ID=<company-id> AAS_API_KEY=<key> tsx scripts/paperclip-secret-sync.ts [company-id]");
+  process.exit(2);
+}
+
+const base = (process.env.CTRL_API_URL || "http://ctrl-api:3100").replace(/\/+$/, "");
+const apiKey = process.env.AAS_API_KEY || process.env.CTRL_API_KEY;
+if (!apiKey) {
+  console.error("AAS_API_KEY or CTRL_API_KEY is required");
+  process.exit(2);
+}
+
+const dryRun = process.env.PAPERCLIP_SECRET_SYNC_DRY_RUN === "1" || process.argv.includes("--dry-run");
+const url = `${base}/api/v1/paperclip/admin/companies/${encodeURIComponent(companyId)}/secrets/sync`;
+
+const res = await fetch(url, {
+  method: "POST",
+  headers: {
+    authorization: `Bearer ${apiKey}`,
+    "content-type": "application/json",
+  },
+  body: JSON.stringify({ dry_run: dryRun }),
+});
+const text = await res.text();
+let body: any = text;
+try { body = text ? JSON.parse(text) : null; } catch {}
+if (!res.ok) {
+  console.error(JSON.stringify({ ok: false, status: res.status, error: body }, null, 2));
+  process.exit(1);
+}
+console.log(JSON.stringify(body, null, 2));

--- a/packages/ctrl/src/api/routes/paperclip_admin.ts
+++ b/packages/ctrl/src/api/routes/paperclip_admin.ts
@@ -323,6 +323,200 @@ function requireString(v: unknown, field: string): string {
   return v;
 }
 
+
+
+// ── Vaultwarden → Paperclip secret sync ─────────────────────────────────────
+
+const VAULT_CLI_URL = process.env.VAULT_CLI_URL || "http://vault-cli:8087";
+const PAPERCLIP_SECRET_FOLDER = process.env.PAPERCLIP_SECRET_SYNC_FOLDER || "paperclip";
+
+async function vaultFetch(path: string, init: RequestInit = {}): Promise<{ status: number; body: unknown }> {
+  const r = await fetch(`${VAULT_CLI_URL}${path}`, {
+    ...init,
+    headers: {
+      "content-type": "application/json",
+      ...(init.headers ?? {}),
+    },
+    signal: AbortSignal.timeout(15_000),
+  });
+  const text = await r.text();
+  let body: unknown = text;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    // keep raw text
+  }
+  return { status: r.status, body };
+}
+
+function unwrapVault(body: unknown): unknown {
+  if (typeof body !== "object" || body === null) return body;
+  const env = body as Record<string, unknown>;
+  if (env.success === false) {
+    const message = typeof env.message === "string" ? env.message : "vault-cli error";
+    throw new ApiError(502, "VAULTWARDEN_SYNC_FAILED", message);
+  }
+  if (env.success === true && "data" in env) return env.data;
+  return body;
+}
+
+function listFromVault(body: unknown): Record<string, unknown>[] {
+  const data = unwrapVault(body);
+  if (Array.isArray(data)) {
+    return data.filter((x): x is Record<string, unknown> => typeof x === "object" && x !== null);
+  }
+  if (typeof data === "object" && data !== null) {
+    const nested = (data as Record<string, unknown>).data;
+    if (Array.isArray(nested)) {
+      return nested.filter((x): x is Record<string, unknown> => typeof x === "object" && x !== null);
+    }
+  }
+  return [];
+}
+
+function paperclipSecretKeyForItem(name: string, companyId: string): string | null {
+  const trimmed = name.trim();
+  if (!trimmed) return null;
+  const slash = trimmed.indexOf("/");
+  if (slash >= 0) {
+    const prefix = trimmed.slice(0, slash).trim();
+    const key = trimmed.slice(slash + 1).trim();
+    if (prefix !== companyId) return null;
+    return key || null;
+  }
+  return trimmed;
+}
+
+function validatePaperclipSecretKey(key: string): void {
+  if (!/^[A-Za-z_][A-Za-z0-9_.-]{0,127}$/.test(key)) {
+    throw new ValidationError(`invalid Paperclip secret key: ${key}`);
+  }
+}
+
+function vaultItemPassword(item: Record<string, unknown>): string | null {
+  const login = item.login;
+  if (typeof login === "object" && login !== null) {
+    const password = (login as Record<string, unknown>).password;
+    if (typeof password === "string" && password.length > 0) return password;
+  }
+  return null;
+}
+
+interface PaperclipSecretRecord extends Record<string, unknown> {
+  id?: string;
+  name?: string;
+  key?: string;
+  latestVersion?: number;
+  providerMetadata?: Record<string, unknown> | null;
+}
+
+interface VaultSecretSource {
+  itemId: string;
+  itemName: string;
+  revisionDate: string | null;
+}
+
+function paperclipSecretSyncMetadata(source: VaultSecretSource, paperclipLatestVersion: number | null): Record<string, unknown> {
+  return {
+    source: "vaultwarden",
+    sourceFolder: PAPERCLIP_SECRET_FOLDER,
+    vaultwardenItemId: source.itemId,
+    vaultwardenItemName: source.itemName,
+    vaultwardenRevisionDate: source.revisionDate,
+    paperclipLatestVersion,
+    syncedBy: "alfred.ctrl.paperclip_secret_sync",
+  };
+}
+
+async function listPaperclipSecrets(session: PaperclipSession, companyId: string): Promise<PaperclipSecretRecord[]> {
+  const resp = await session.call("GET", `/api/companies/${encodeURIComponent(companyId)}/secrets`);
+  if (resp.status < 200 || resp.status >= 300) {
+    throw new ApiError(502, "PAPERCLIP_SECRET_LIST_FAILED", "paperclip secret list failed", {
+      detail: bodyDetail(resp.body),
+    });
+  }
+  return asList(resp.body) as PaperclipSecretRecord[];
+}
+
+async function patchPaperclipSecretMetadata(
+  session: PaperclipSession,
+  secretId: string,
+  metadata: Record<string, unknown>,
+): Promise<void> {
+  const patched = await session.call("PATCH", `/api/secrets/${encodeURIComponent(secretId)}`, {
+    providerMetadata: metadata,
+  });
+  if (patched.status < 200 || patched.status >= 300) {
+    throw new ApiError(502, "PAPERCLIP_SECRET_METADATA_FAILED", "paperclip secret metadata update failed", {
+      detail: bodyDetail(patched.body),
+    });
+  }
+}
+
+async function upsertPaperclipSecret(
+  session: PaperclipSession,
+  companyId: string,
+  existingSecrets: PaperclipSecretRecord[],
+  key: string,
+  value: string,
+  source: VaultSecretSource,
+): Promise<"created" | "rotated" | "unchanged"> {
+  const existing = existingSecrets.find((s) => s.key === key || s.name === key);
+  const metadata = existing?.providerMetadata && typeof existing.providerMetadata === "object"
+    ? existing.providerMetadata
+    : {};
+  const metadataMatches =
+    metadata.source === "vaultwarden" &&
+    metadata.vaultwardenItemId === source.itemId &&
+    metadata.vaultwardenRevisionDate === source.revisionDate &&
+    metadata.paperclipLatestVersion === existing?.latestVersion;
+  if (existing?.id && metadataMatches) {
+    return "unchanged";
+  }
+
+  if (!existing) {
+    const created = await session.call("POST", `/api/companies/${encodeURIComponent(companyId)}/secrets`, {
+      name: key,
+      key,
+      provider: "local_encrypted",
+      managedMode: "paperclip_managed",
+      value,
+      description: `Replicated from Vaultwarden folder ${PAPERCLIP_SECRET_FOLDER}. Vaultwarden is authoritative.`,
+      providerMetadata: paperclipSecretSyncMetadata(source, null),
+    });
+    if (created.status < 200 || created.status >= 300) {
+      throw new ApiError(502, "PAPERCLIP_SECRET_UPSERT_FAILED", "paperclip secret create failed", {
+        key,
+        detail: bodyDetail(created.body),
+      });
+    }
+    const createdBody = created.body as Record<string, unknown>;
+    const secretId = typeof createdBody.id === "string" ? createdBody.id : null;
+    const latestVersion = typeof createdBody.latestVersion === "number" ? createdBody.latestVersion : 1;
+    if (secretId) {
+      await patchPaperclipSecretMetadata(session, secretId, paperclipSecretSyncMetadata(source, latestVersion));
+    }
+    return "created";
+  }
+
+  if (typeof existing.id !== "string") {
+    throw new ApiError(502, "PAPERCLIP_BAD_RESPONSE", "paperclip secret list returned a secret without id", { key });
+  }
+  const rotated = await session.call("POST", `/api/secrets/${encodeURIComponent(existing.id)}/rotate`, { value });
+  if (rotated.status < 200 || rotated.status >= 300) {
+    throw new ApiError(502, "PAPERCLIP_SECRET_UPSERT_FAILED", "paperclip secret rotate failed", {
+      key,
+      detail: bodyDetail(rotated.body),
+    });
+  }
+  const rotatedBody = rotated.body as Record<string, unknown>;
+  const latestVersion = typeof rotatedBody.latestVersion === "number"
+    ? rotatedBody.latestVersion
+    : (typeof existing.latestVersion === "number" ? existing.latestVersion + 1 : null);
+  await patchPaperclipSecretMetadata(session, existing.id, paperclipSecretSyncMetadata(source, latestVersion));
+  return "rotated";
+}
+
 // ── routes ────────────────────────────────────────────────────────────────────
 
 /** Wrap a handler so a PaperclipNotSeededError surfaces the exact C1 503
@@ -658,6 +852,108 @@ export function registerPaperclipAdminRoutes(): void {
       sendJson(res, 200, { agents });
     }),
   );
+
+  // 6. POST /companies/:companyId/secrets/sync — one-way Vaultwarden → Paperclip.
+  addRoute(
+    "POST",
+    "/api/v1/paperclip/admin/companies/:companyId/secrets/sync",
+    withPaperclipErrors(async ({ res, params, body }) => {
+      const companyId = requireString(params.companyId, "companyId");
+      const b = (body ?? {}) as Record<string, unknown>;
+      const dryRun = b.dry_run === true;
+      if (b.prune === true) {
+        throw new ValidationError("prune=true is intentionally not supported by this additive sync route");
+      }
+
+      const foldersResp = await vaultFetch("/list/object/folders");
+      if (foldersResp.status >= 500) {
+        throw new ApiError(502, "VAULTWARDEN_UNREACHABLE", "vault-cli unreachable");
+      }
+      const folders = listFromVault(foldersResp.body);
+      const folder = folders.find((f) => f.name === PAPERCLIP_SECRET_FOLDER);
+      const folderId = typeof folder?.id === "string" ? folder.id : null;
+      if (!folderId) {
+        sendJson(res, 200, {
+          ok: true,
+          companyId,
+          folder: PAPERCLIP_SECRET_FOLDER,
+          dry_run: dryRun,
+          synced: 0,
+          skipped: [{ reason: "folder_not_found", folder: PAPERCLIP_SECRET_FOLDER }],
+          keys: [],
+        });
+        return;
+      }
+
+      const itemsResp = await vaultFetch(`/list/object/items?folderid=${encodeURIComponent(folderId)}`);
+      if (itemsResp.status >= 500) {
+        throw new ApiError(502, "VAULTWARDEN_UNREACHABLE", "vault-cli unreachable");
+      }
+      const items = listFromVault(itemsResp.body);
+      const session = dryRun ? null : await establishSession();
+      const existingSecrets = session ? await listPaperclipSecrets(session, companyId) : [];
+      const keys: string[] = [];
+      const skipped: Record<string, unknown>[] = [];
+      const actions: Record<string, unknown>[] = [];
+      const seenKeys = new Set<string>();
+      let synced = 0;
+
+      for (const it of items) {
+        const id = typeof it.id === "string" ? it.id : "";
+        const name = typeof it.name === "string" ? it.name : "";
+        const key = paperclipSecretKeyForItem(name, companyId);
+        if (!id || !key) {
+          skipped.push({ name, reason: "not_for_company" });
+          continue;
+        }
+        validatePaperclipSecretKey(key);
+        if (seenKeys.has(key)) {
+          skipped.push({ name, key, reason: "duplicate_selected_key" });
+          continue;
+        }
+        seenKeys.add(key);
+        const fullResp = await vaultFetch(`/object/item/${encodeURIComponent(id)}`);
+        if (fullResp.status >= 500) {
+          throw new ApiError(502, "VAULTWARDEN_UNREACHABLE", "vault-cli unreachable");
+        }
+        const full = unwrapVault(fullResp.body);
+        if (typeof full !== "object" || full === null) {
+          skipped.push({ name, key, reason: "bad_vault_item" });
+          continue;
+        }
+        const fullItem = full as Record<string, unknown>;
+        const value = vaultItemPassword(fullItem);
+        if (!value) {
+          skipped.push({ name, key, reason: "missing_login_password" });
+          continue;
+        }
+        const revisionDate = typeof fullItem.revisionDate === "string" ? fullItem.revisionDate : null;
+        keys.push(key);
+        let action: "dry_run" | "created" | "rotated" | "unchanged" = "dry_run";
+        if (!dryRun && session) {
+          action = await upsertPaperclipSecret(session, companyId, existingSecrets, key, value, {
+            itemId: id,
+            itemName: name,
+            revisionDate,
+          });
+        }
+        actions.push({ key, action, vaultwarden_item_id: id, vaultwarden_revision_date: revisionDate });
+        synced += action === "unchanged" ? 0 : 1;
+      }
+
+      sendJson(res, 200, {
+        ok: true,
+        companyId,
+        folder: PAPERCLIP_SECRET_FOLDER,
+        dry_run: dryRun,
+        synced,
+        skipped,
+        keys,
+        actions,
+      });
+    }),
+  );
+
 }
 
 /** Pull a user id out of a Better-Auth sign-up response. Tolerates both the

--- a/packages/ctrl/src/api/routes/paperclip_admin.ts
+++ b/packages/ctrl/src/api/routes/paperclip_admin.ts
@@ -487,7 +487,7 @@ async function upsertPaperclipSecret(
     if (created.status < 200 || created.status >= 300) {
       throw new ApiError(502, "PAPERCLIP_SECRET_UPSERT_FAILED", "paperclip secret create failed", {
         key,
-        detail: bodyDetail(created.body),
+        status: created.status,
       });
     }
     const createdBody = created.body as Record<string, unknown>;
@@ -506,7 +506,7 @@ async function upsertPaperclipSecret(
   if (rotated.status < 200 || rotated.status >= 300) {
     throw new ApiError(502, "PAPERCLIP_SECRET_UPSERT_FAILED", "paperclip secret rotate failed", {
       key,
-      detail: bodyDetail(rotated.body),
+      status: rotated.status,
     });
   }
   const rotatedBody = rotated.body as Record<string, unknown>;

--- a/packages/ctrl/tests/paperclip_admin.test.ts
+++ b/packages/ctrl/tests/paperclip_admin.test.ts
@@ -709,7 +709,6 @@ describe("paperclip admin — Vaultwarden secret sync", () => {
       {},
     );
 
-    if (r.status !== 200) console.error(JSON.stringify(r.payload));
     assert.equal(r.status, 200);
     assert.equal(r.payload.synced, 2);
     assert.deepEqual(r.payload.keys, ["OPENAI_API_KEY", "PAPERCLIP_ONLY"]);

--- a/packages/ctrl/tests/paperclip_admin.test.ts
+++ b/packages/ctrl/tests/paperclip_admin.test.ts
@@ -33,6 +33,7 @@ process.env.STATE_DB_PATH = path.join(tmp, "alfred-state.db");
 process.env.SQLITE_VEC_PATH = "";
 process.env.DOMAIN = "admintest.alfred.black";
 process.env.PAPERCLIP_INTERNAL_URL = "http://paperclip:3100";
+process.env.VAULT_CLI_URL = "http://vault-cli.test";
 
 const seedCredentialsFile = path.join(tmp, "paperclip-seed-credentials.json");
 process.env.PAPERCLIP_SEED_CREDENTIALS_FILE = seedCredentialsFile;
@@ -76,6 +77,33 @@ type Responder = (c: MockCall) => {
   setCookies?: string[];
 };
 let responder: Responder = () => ({ status: 200, body: {} });
+
+const originalFetch = globalThis.fetch;
+const vaultItems: Record<string, any> = {};
+let vaultFolders: Record<string, any>[] = [];
+let vaultListItems: Record<string, any>[] = [];
+const vaultFetches: { url: string; method: string }[] = [];
+
+globalThis.fetch = (async (input: any, init?: any) => {
+  const url = typeof input === "string" ? input : (input?.url ?? String(input));
+  const method = (init?.method ?? "GET").toUpperCase();
+  if (url.startsWith("http://vault-cli.test")) {
+    vaultFetches.push({ url, method });
+    const u = new URL(url);
+    if (u.pathname === "/list/object/folders") {
+      return new Response(JSON.stringify({ success: true, data: vaultFolders }), { status: 200 });
+    }
+    if (u.pathname === "/list/object/items") {
+      return new Response(JSON.stringify({ success: true, data: vaultListItems }), { status: 200 });
+    }
+    const itemMatch = u.pathname.match(/^\/object\/item\/(.+)$/);
+    if (itemMatch) {
+      const item = vaultItems[decodeURIComponent(itemMatch[1])];
+      return new Response(JSON.stringify({ success: true, data: item ?? null }), { status: item ? 200 : 404 });
+    }
+  }
+  return originalFetch(input, init);
+}) as typeof fetch;
 
 function installMock(r: Responder): void {
   responder = r;
@@ -127,10 +155,15 @@ async function invokeRoute(
 
 beforeEach(() => {
   calls = [];
+  vaultFolders = [];
+  vaultListItems = [];
+  for (const k of Object.keys(vaultItems)) delete vaultItems[k];
+  vaultFetches.length = 0;
   writeSeed();
 });
 after(() => {
   _setPaperclipTransportForTests(null);
+  globalThis.fetch = originalFetch;
 });
 
 describe("paperclip admin — seeding gate", () => {
@@ -640,5 +673,91 @@ describe("paperclip admin — company access grant (#246)", () => {
     );
     assert.equal(r.status, 503);
     assert.deepEqual(r.payload, { error: "paperclip_not_seeded" });
+  });
+
+
+describe("paperclip admin — Vaultwarden secret sync", () => {
+  it("syncs selected Vaultwarden folder items to Paperclip without returning values", async () => {
+    vaultFolders = [{ id: "folder-paperclip", name: "paperclip" }];
+    vaultListItems = [
+      { id: "item1", name: "OPENAI_API_KEY" },
+      { id: "item2", name: "other-company/IGNORED" },
+      { id: "item3", name: "cmp_secret/PAPERCLIP_ONLY" },
+      { id: "item4", name: "NO_PASSWORD" },
+    ];
+    vaultItems.item1 = { id: "item1", name: "OPENAI_API_KEY", revisionDate: "2026-06-04T10:00:00Z", login: { password: "secret-value-one" } };
+    vaultItems.item3 = { id: "item3", name: "cmp_secret/PAPERCLIP_ONLY", revisionDate: "2026-06-04T10:01:00Z", login: { password: "secret-value-two" } };
+    vaultItems.item4 = { id: "item4", name: "NO_PASSWORD", login: { username: "x" } };
+    installMock((c) => {
+      if (c.path === "/api/auth/sign-in/email") return { status: 200, body: {}, setCookies: ["s=1"] };
+      if (c.method === "GET" && c.path === "/api/companies/cmp_secret/secrets") {
+        return { status: 200, body: [] };
+      }
+      if (c.method === "POST" && c.path === "/api/companies/cmp_secret/secrets") {
+        const key = (c.body as Record<string, unknown>).key as string;
+        return { status: 201, body: { id: `sec_${key}`, key, name: key, latestVersion: 1 } };
+      }
+      if (c.method === "PATCH" && c.path.startsWith("/api/secrets/sec_")) {
+        return { status: 200, body: { ok: true } };
+      }
+      return { status: 500, body: { unexpected: c.path } };
+    });
+
+    const r = await invokeRoute(
+      "POST",
+      "/api/v1/paperclip/admin/companies/cmp_secret/secrets/sync",
+      {},
+    );
+
+    if (r.status !== 200) console.error(JSON.stringify(r.payload));
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.synced, 2);
+    assert.deepEqual(r.payload.keys, ["OPENAI_API_KEY", "PAPERCLIP_ONLY"]);
+    const wire = JSON.stringify(r.payload);
+    assert.equal(wire.includes("secret-value-one"), false);
+    assert.equal(wire.includes("secret-value-two"), false);
+
+    const creates = calls.filter((c) => c.method === "POST" && c.path === "/api/companies/cmp_secret/secrets");
+    assert.equal(creates.length, 2);
+    assert.equal((creates[0].body as Record<string, unknown>).key, "OPENAI_API_KEY");
+    assert.equal((creates[0].body as Record<string, unknown>).provider, "local_encrypted");
+    assert.equal((creates[0].body as Record<string, unknown>).managedMode, "paperclip_managed");
+    assert.equal((creates[0].body as Record<string, unknown>).value, "secret-value-one");
+    assert.equal((creates[1].body as Record<string, unknown>).key, "PAPERCLIP_ONLY");
+    assert.equal((creates[1].body as Record<string, unknown>).value, "secret-value-two");
+    const metadataPatches = calls.filter((c) => c.method === "PATCH" && c.path.startsWith("/api/secrets/sec_"));
+    assert.equal(metadataPatches.length, 2);
+    assert.equal(
+      ((metadataPatches[0].body as Record<string, any>).providerMetadata as Record<string, unknown>).source,
+      "vaultwarden",
+    );
+  });
+
+  it("supports dry_run without signing into or writing Paperclip", async () => {
+    vaultFolders = [{ id: "folder-paperclip", name: "paperclip" }];
+    vaultListItems = [{ id: "item1", name: "OPENAI_API_KEY" }];
+    vaultItems.item1 = { id: "item1", login: { password: "secret-value-one" } };
+    installMock(() => ({ status: 500, body: { should_not_call: true } }));
+
+    const r = await invokeRoute(
+      "POST",
+      "/api/v1/paperclip/admin/companies/cmp_secret/secrets/sync",
+      { dry_run: true },
+    );
+
+    assert.equal(r.status, 200);
+    assert.equal(r.payload.synced, 1);
+    assert.equal(r.payload.dry_run, true);
+    assert.equal(calls.length, 0);
+  });
+
+  it("is additive-only and rejects prune=true", async () => {
+    installMock(() => ({ status: 200, body: {} }));
+    const r = await invokeRoute(
+      "POST",
+      "/api/v1/paperclip/admin/companies/cmp_secret/secrets/sync",
+      { prune: true },
+    );
+    assert.equal(r.status, 400);
   });
 });

--- a/packages/ctrl/tests/paperclip_admin.test.ts
+++ b/packages/ctrl/tests/paperclip_admin.test.ts
@@ -676,6 +676,8 @@ describe("paperclip admin — company access grant (#246)", () => {
   });
 
 
+});
+
 describe("paperclip admin — Vaultwarden secret sync", () => {
   it("syncs selected Vaultwarden folder items to Paperclip without returning values", async () => {
     vaultFolders = [{ id: "folder-paperclip", name: "paperclip" }];


### PR DESCRIPTION
## Summary

Implements one-way Vaultwarden → Paperclip secret sync for GH #253.

- Vaultwarden remains authoritative; Paperclip `local_encrypted` secrets are read-replica copies.
- Adds a company-scoped ctrl route for selected Vaultwarden folder items.
- Supports dry-run, create/rotate/no-op actions, and explicitly rejects `prune=true` so deletion is separately gated.
- Avoids returning secret values in API responses.
- Adds operator documentation and manual sync script.

## Smoke evidence

- `npm ci`
- `node --experimental-sqlite --experimental-test-module-mocks --import tsx --experimental-loader ./tests/text-loader.mjs --test tests/paperclip_admin.test.ts` — 18/18 passing
- `npm run build` — `Build complete — dist/api.mjs`

Paperclip: ALFA-57