### PR TITLE
fix(ctrl-api): route sibling-container profiles to hermes-<slug> host

### DIFF
--- a/packages/ctrl/src/api/routes/channelsEmail.ts
+++ b/packages/ctrl/src/api/routes/channelsEmail.ts
@@ -152,7 +152,14 @@ function gatewayTokenFor(ctx: ProfileChannelContext): string {
 }
 
 function hermesBaseUrlFor(ctx: ProfileChannelContext): string {
-  return `${HERMES_PROTOCOL}//${HERMES_HOST}:${ctx.api_server_port}`;
+  // 'sibling' profiles run in their OWN container (e.g. cratchit at the
+  // `hermes-cratchit` network alias), NOT inside the main `hermes` container.
+  // Addressing them at HERMES_HOST would only vary the port and POST to the
+  // wrong container (connection refused — the run is silently dropped by the
+  // fire-and-forget .catch). Supervised/core profiles stay on HERMES_HOST.
+  const host =
+    ctx.deployment_shape === "sibling" ? `hermes-${ctx.slug}` : HERMES_HOST;
+  return `${HERMES_PROTOCOL}//${host}:${ctx.api_server_port}`;
 }
 
 /**

--- a/packages/ctrl/src/api/routes/channels_paperclip.ts
+++ b/packages/ctrl/src/api/routes/channels_paperclip.ts
@@ -340,9 +340,16 @@ function resolvePaperclipContext(
   );
 }
 
-/** Build the Hermes /v1 base URL for a resolved profile. */
+/** Build the Hermes /v1 base URL for a resolved profile.
+ *
+ * 'sibling' profiles run in their OWN container (e.g. cratchit at the
+ * `hermes-cratchit` network alias), NOT inside the main `hermes` container,
+ * so addressing them at HERMES_HOST would POST to the wrong container.
+ * Supervised/core profiles keep HERMES_HOST (port-varied). */
 function hermesBaseUrlFor(ctx: ProfileChannelContext): string {
-  return `${HERMES_PROTOCOL}//${HERMES_HOST}:${ctx.api_server_port}`;
+  const host =
+    ctx.deployment_shape === "sibling" ? `hermes-${ctx.slug}` : HERMES_HOST;
+  return `${HERMES_PROTOCOL}//${host}:${ctx.api_server_port}`;
 }
 
 async function callHermes(

--- a/packages/ctrl/src/db/agentProfiles.ts
+++ b/packages/ctrl/src/db/agentProfiles.ts
@@ -598,6 +598,12 @@ export function bindChannel(
 export interface ProfileChannelContext {
   /** Final resolved profile slug (after archived-target cascade). */
   slug: string;
+  /** Deployment shape of the resolved profile. 'supervised' profiles run as
+   *  gateway processes inside the ONE main `hermes` container (addressed via
+   *  HERMES_HOST, port-varied); 'sibling' profiles run in their own container
+   *  reachable at the `hermes-<slug>` network alias. The channel-route URL
+   *  builders branch on this — see hermesBaseUrlFor in the channel routes. */
+  deployment_shape: DeploymentShape;
   /** The profile slug the binding pointed at BEFORE the archived cascade.
    *  Equal to `slug` on the happy path. Useful for diagnostics. */
   bound_slug: string;
@@ -674,12 +680,16 @@ export function resolveProfileContextForChannel(
   // really "should never happen"), surface a synthetic 18789-on-main shape
   // so the caller can fail honestly downstream rather than crashing here.
   const port = row?.api_server_port ?? 18789;
+  // 'main' (and the other 18789..18793 infra rows) are always supervised; if
+  // the row is missing we synthesize a supervised/main shape downstream.
+  const shape: DeploymentShape = row?.deployment_shape ?? "supervised";
   const baseDir = HERMES_PROFILE_BASE_DIR();
   const profileDir = `${baseDir}/${slug}`;
   const apiKey = readHermesProfileApiKey(profileDir);
 
   return {
     slug,
+    deployment_shape: shape,
     bound_slug: boundSlug,
     cascaded,
     api_server_port: port,

--- a/packages/ctrl/tests/agent-profiles-channel-context.test.ts
+++ b/packages/ctrl/tests/agent-profiles-channel-context.test.ts
@@ -63,6 +63,7 @@ describe("resolveProfileContextForChannel — Lane IV", () => {
     const db = freshDb();
     const ctx = resolveProfileContextForChannel(db, "telegram", null);
     assert.equal(ctx.slug, "main");
+    assert.equal(ctx.deployment_shape, "supervised");
     assert.equal(ctx.bound_slug, "main");
     assert.equal(ctx.cascaded, false);
     assert.equal(ctx.api_server_port, 18789);
@@ -96,6 +97,41 @@ describe("resolveProfileContextForChannel — Lane IV", () => {
     assert.equal(ctx.api_server_port, 18794); // first user-facing port
     assert.equal(ctx.api_server_key, "sentinel-secret");
     assert.equal(ctx.journal_scope_key, "sentinel");
+    db.close();
+  });
+
+  it("sibling-container profile carries deployment_shape='sibling'", () => {
+    const db = freshDb();
+    // Sibling-container profiles (e.g. cratchit) are registered out-of-band
+    // by Lane VI's tooling, not via createProfile (which rejects 'sibling').
+    // Insert the registry row directly the way that tooling does.
+    const now = Date.now();
+    db.prepare(
+      `INSERT INTO agent_profile
+         (slug, label, description, model, deployment_shape,
+          api_server_port, persona_template, status,
+          is_user_facing, is_reserved, created_at, updated_at)
+       VALUES (?, ?, NULL, ?, 'sibling', 18792, NULL, 'running', 1, 0, ?, ?)`,
+    ).run("cratchit", "Cratchit", "x-ai/grok-4.3", now, now);
+    bindChannel(db, {
+      channel_kind: "email",
+      channel_identity: "cratchit@example.com",
+      profile_slug: "cratchit",
+    });
+    writeProfileEnv("cratchit", "API_SERVER_KEY=cratchit-secret\n");
+
+    const ctx = resolveProfileContextForChannel(
+      db,
+      "email",
+      "cratchit@example.com",
+    );
+    assert.equal(ctx.slug, "cratchit");
+    // The bug: this MUST be 'sibling' so the channel-route URL builder
+    // targets hermes-cratchit:18792 (its own container) instead of
+    // hermes:18792 (the main container — connection refused).
+    assert.equal(ctx.deployment_shape, "sibling");
+    assert.equal(ctx.api_server_port, 18792);
+    assert.equal(ctx.api_server_key, "cratchit-secret");
     db.close();
   });
 

--- a/packages/ctrl/tests/voice-routes-lane-vb.test.ts
+++ b/packages/ctrl/tests/voice-routes-lane-vb.test.ts
@@ -140,6 +140,7 @@ mock.module("../src/db/agentProfiles.js", {
       identity: any,
     ) => ({
       slug: "main",
+      deployment_shape: "supervised",
       bound_slug: "main",
       cascaded: false,
       api_server_port: 18789,


### PR DESCRIPTION
## Bug

ctrl-api dispatches inbound channel events (email, SMS, paperclip, ...) to a Hermes profile by POSTing `/v1/runs` (or `/v1/responses`) to `${HERMES_HOST}:${api_server_port}`. `HERMES_HOST` is a SINGLE host derived from `HERMES_GATEWAY_URL` (`hermes`), and only the **port** was varied per profile.

That is correct for **supervised** profiles — all their gateway processes live inside the ONE main `hermes` container (main=18789, workers=18790, heavy=18791, codex-builder=18793). It is **wrong** for **sibling-container** profiles (`deployment_shape='sibling'`), which run in their OWN container reachable only at the `hermes-<slug>` Docker network alias.

`resolveProfileContextForChannel` resolves the correct sibling profile (right slug, right port), but `hermesBaseUrlFor` then builds the URL with the wrong host. The dispatch `fetch` is fire-and-forget with a `.catch`, so the failed POST is **silently dropped** — email/SMS/any ctrl-api-dispatched channel routed to a sibling profile never reaches the agent.

## Smoke evidence

_(retitled 2026-07-15 for the now-required pr-review-gate; content below is the original live before/after evidence recorded at PR time)_

### Live evidence (tenant joe.alfred.black, 2026-06-15)

`cratchit` is a sibling profile (`deployment_shape='sibling'`, api_server on 18792, network alias `hermes-cratchit`):

- `hermes-cratchit:18792/health` → **200**
- `hermes:18792` → **unreachable** (connection refused — cratchit is not in the main `hermes` container)

So ctrl-api resolved cratchit, then POSTed the run to `hermes:18792` and the `.catch` swallowed the connection-refused error.

## Fix

Thread `deployment_shape` through the channel context and branch on it in the URL builders:

- `packages/ctrl/src/db/agentProfiles.ts` — add `deployment_shape: DeploymentShape` to `ProfileChannelContext`; populate it in `resolveProfileContextForChannel` from the resolved profile row (defaults to `supervised` when the row is missing, matching the existing synthetic-main fallback).
- `packages/ctrl/src/api/routes/channelsEmail.ts` — `hermesBaseUrlFor` now uses host `hermes-${ctx.slug}` when `deployment_shape === 'sibling'`, else `HERMES_HOST`.
- `packages/ctrl/src/api/routes/channels_paperclip.ts` — same change to its `hermesBaseUrlFor`.

(These two are the `hermesBaseUrlFor` / `hermesBaseUrlFor2` pair the esbuild bundler emits in the deployed `dist/api.mjs`.)

### Tests
- `packages/ctrl/tests/agent-profiles-channel-context.test.ts` — new "sibling-container profile carries deployment_shape='sibling'" case (inserts a cratchit sibling row at 18792 the way Lane VI tooling does, asserts `ctx.deployment_shape === 'sibling'`), plus a `deployment_shape === 'supervised'` assertion on the main happy-path.
- `packages/ctrl/tests/voice-routes-lane-vb.test.ts` — added `deployment_shape` to the mocked context literal so it still satisfies `ProfileChannelContext`.

### Build / typecheck
- `node build.mjs` (esbuild, the canonical build) → **Build complete — dist/api.mjs**.
- The relevant test file passes 7/8; the single failing case (`archived bound profile cascades to main`) fails identically on clean `main` in this environment (pre-existing, unrelated to this change).
- `tsc --noEmit` surfaces only pre-existing repo-wide errors (`node:sqlite` type resolution, etc.) — none in the changed code. This project ships via esbuild, not tsc.

## Deferred follow-up: sibling email reply/send creds

The `/api/v1/email/{reply,send,forward}` routes call `getCreds(query.get("profile"))`. A sibling agent's `self()` call omits `?profile=`, so creds fall through to the empty tenant-level config and the send fails.

This was investigated but **not fixed here**: `self()` reaches ctrl-api with the shared master `AAS_API_KEY` bearer (auth Path 1 grants everything — see `packages/ctrl/src/api/auth.ts`), so there is no per-profile identity on the request to derive creds from. A correct fix requires Hermes to pass an explicit profile identity (header or query) on `self()` calls — a cross-component contract change beyond this PR's blast radius. Filing as a separate follow-up.

## DO NOT MERGE — opened for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
