### PR TITLE
fix(hermes): prune workers/heavy sessions + VACUUM state.db on a nightly cron

### DIFF
--- a/packages/hermes/hermes-config.yaml.njk
+++ b/packages/hermes/hermes-config.yaml.njk
@@ -174,7 +174,41 @@ cron:
       schedule: "13 3 * * *"
       command: "find /work/runs -maxdepth 1 -mindepth 1 -type d -mtime +7 -exec rm -rf {} +"
 {%- else %}
-# Workers profile: no cron consumers — cron is left at Hermes defaults.
+# Background profiles (workers / heavy) — disk-bloat GC.
+#
+# These profiles run high-volume autonomous agents (clerk / curator / janitor
+# / distiller on workers; onboarding / chore reasoning on heavy). Every run
+# writes a `sessions/session_*.json` transcript (and, when a tool errors with
+# debug dumps on, a `sessions/request_dump_*.json`), and appends to the
+# profile's `state.db`. Nothing prunes either, so they grow without bound.
+#
+# Live evidence (2026-06-19): zsolt.alfred.black workers state.db = 111 G and
+# sessions/ = 140 G across 312,875 files filled the disk to 100% and took the
+# whole tenant down. joe state.db 52 G, rj 59 G, rami sessions 37 G/92 k files,
+# home sessions 19 G/54 k files — the bloat is fleet-wide.
+#
+# Two jobs, both nightly, both off-peak:
+#   * prune-old-sessions — delete session_* and request_dump_* files older than
+#     7 days. Worker sessions are one-shot (session_reset idle 30m) so a file
+#     older than a day is already dead; 7 days keeps a forensic window.
+#   * vacuum-state-db — reclaim free pages the prune leaves behind. SQLite does
+#     not shrink the file on DELETE; VACUUM rewrites it compactly. Uses python3
+#     (always present in the image) rather than the sqlite3 CLI (not installed).
+#
+# wrap_response: false — no channel consumer; these run silently.
+#
+# NOTE: this block is also backfilled onto already-seeded tenants by the
+# idempotent converger init/render_workers_pruning.py (config.yaml is
+# operator-owned and only seeded once — see render_mcp_servers.py docstring).
+cron:
+  wrap_response: false
+  jobs:
+    - name: prune-old-sessions
+      schedule: "23 3 * * *"
+      command: "find {{ runtime_profile_dir }}/sessions -maxdepth 1 -type f \\( -name 'session_*.json' -o -name 'request_dump_*.json' \\) -mtime +7 -delete"
+    - name: vacuum-state-db
+      schedule: "43 3 * * *"
+      command: "python3 -c \"import sqlite3,os; p='{{ runtime_profile_dir }}/state.db'; (sqlite3.connect(p).execute('VACUUM').connection.close()) if os.path.exists(p) else None\""
 {%- endif %}
 
 # =============================================================================

--- a/packages/hermes/init/Dockerfile
+++ b/packages/hermes/init/Dockerfile
@@ -95,6 +95,13 @@ COPY packages/hermes/init/render_mcp_servers.py ./render_mcp_servers.py
 # inlining 321 MCP tool schemas (~67k input tokens per turn). Workers/
 # heavy/codex-builder are unaffected (no-op). Sibling of render_mcp_servers.
 COPY packages/hermes/init/migrate_main_profile_tool_trim.py ./migrate_main_profile_tool_trim.py
+# render_workers_pruning.py — idempotent ADD-only mutator that backfills the
+# disk-bloat GC cron (prune-old-sessions + vacuum-state-db) onto the
+# background profiles' (workers/heavy) operator-owned config.yaml. Motivated
+# by the 2026-06-19 zsolt disk exhaustion (workers state.db 111G + sessions/
+# 140G across 312,875 files). No-op on main/codex-builder. Sibling of
+# render_mcp_servers.
+COPY packages/hermes/init/render_workers_pruning.py ./render_workers_pruning.py
 # Paperclip auto-bootstrap. Invoked as the entrypoint of the sibling
 # `paperclip-init` compose service (see docker-compose.yaml). Not run by
 # this image's default entrypoint.sh — keeps the main init container

--- a/packages/hermes/init/entrypoint.sh
+++ b/packages/hermes/init/entrypoint.sh
@@ -605,6 +605,19 @@ for profile in "${PROFILES_RENDERED[@]}"; do
         PROFILE_DIR="$INIT_PROFILE_DIR" \
             python3 /setup/migrate_main_profile_tool_trim.py "$profile" \
             || echo "[init] WARN: migrate_main_profile_tool_trim.py failed for $profile (non-fatal)"
+
+        # --- 6a-ter. Background-profile disk-bloat GC cron (workers/heavy) ---
+        # config.yaml is operator-owned and only seeded once, so the GC cron
+        # block added to hermes-config.yaml.njk for the background profiles
+        # never reaches an already-seeded tenant. render_workers_pruning.py is
+        # an idempotent ADD-only mutator that backfills the prune-old-sessions
+        # + vacuum-state-db jobs (preserving any operator-tuned job). No-op on
+        # main / codex-builder. Motivated by the 2026-06-19 zsolt disk
+        # exhaustion (workers state.db 111G + sessions 140G).
+        PROFILE_DIR="$INIT_PROFILE_DIR" \
+        HERMES_RUNTIME_PROFILE_DIR="$RUNTIME_PROFILE_DIR" \
+            python3 /setup/render_workers_pruning.py "$profile" \
+            || echo "[init] WARN: render_workers_pruning.py failed for $profile (non-fatal)"
     fi
 done
 

--- a/packages/hermes/init/render_workers_pruning.py
+++ b/packages/hermes/init/render_workers_pruning.py
@@ -1,0 +1,184 @@
+"""render_workers_pruning.py — backfill disk-bloat GC cron onto background profiles.
+
+`render_hermes.py` seeds the per-profile config.yaml ONCE; on subsequent boots
+the file is operator-owned and never re-rendered (see render_mcp_servers.py
+docstring for the full rationale). That means the `cron:` GC block added to
+hermes-config.yaml.njk for the background profiles (workers / heavy) is
+invisible to any tenant whose config.yaml predates the change — exactly the
+fleet that is already bloated.
+
+This is an idempotent ADD-only mutator, the same shape as render_mcp_servers.py
+and render_sms_gateway.py. It ensures the two GC jobs exist in
+`cron.jobs` for the workers + heavy profiles:
+
+  * prune-old-sessions — delete sessions/session_*.json and
+    sessions/request_dump_*.json older than 7 days.
+  * vacuum-state-db    — VACUUM the profile's state.db (SQLite does not shrink
+                          the file on DELETE; VACUUM rewrites it compactly).
+
+It is ADD-only: if a job with the same `name` already exists (operator may have
+tuned the schedule or command), it is preserved verbatim. Any OTHER operator
+cron job is preserved. `cron.wrap_response` is set to false only if the key is
+absent (these profiles have no channel consumer).
+
+Motivating regression (2026-06-19): zsolt.alfred.black workers state.db = 111 G
+and sessions/ = 140 G across 312,875 files filled the host disk to 100% and
+took the whole tenant down. The bloat is fleet-wide (joe state.db 52 G, rj
+59 G, rami sessions 37 G/92 k files, home 19 G/54 k files); nothing prunes
+either store. See the GC block in hermes-config.yaml.njk.
+
+main / codex-builder are skipped:
+  * main already renders its own `cron:` block (wrap_response + reminders);
+    its sessions are the live chat surface and reset on a daily boundary.
+  * codex-builder is a sealed runtime with its own `cleanup-old-runs` GC of
+    /work/runs — its sessions live elsewhere.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# Profiles that get the GC cron. Mirrors the `{%- else %}` background branch in
+# hermes-config.yaml.njk (everything that is not main / codex-builder).
+_BACKGROUND_PROFILES = {"workers", "heavy"}
+
+# Retention window for session / request_dump files, in days. Worker sessions
+# are one-shot (session_reset idle 30m) so a file older than a day is already
+# dead; 7 keeps a forensic window. Keep in sync with the .njk template.
+_SESSION_RETENTION_DAYS = 7
+
+
+def _gc_jobs(runtime_profile_dir: str) -> list[dict]:
+    """The two GC jobs, rendered for a given runtime profile dir.
+
+    Schedules + commands MUST stay in sync with the `cron.jobs` block the
+    .njk template renders for the background profiles.
+    """
+    sessions = f"{runtime_profile_dir}/sessions"
+    state_db = f"{runtime_profile_dir}/state.db"
+    return [
+        {
+            "name": "prune-old-sessions",
+            "schedule": "23 3 * * *",
+            "command": (
+                f"find {sessions} -maxdepth 1 -type f "
+                f"\\( -name 'session_*.json' -o -name 'request_dump_*.json' \\) "
+                f"-mtime +{_SESSION_RETENTION_DAYS} -delete"
+            ),
+        },
+        {
+            "name": "vacuum-state-db",
+            "schedule": "43 3 * * *",
+            "command": (
+                "python3 -c \"import sqlite3,os; "
+                f"p='{state_db}'; "
+                "(sqlite3.connect(p).execute('VACUUM').connection.close()) "
+                "if os.path.exists(p) else None\""
+            ),
+        },
+    ]
+
+
+def ensure_workers_pruning(
+    config_path: Path,
+    *,
+    profile: str,
+    runtime_profile_dir: str,
+) -> str:
+    """Ensure the GC cron jobs exist on a background profile's config.yaml.
+
+    Returns one of: "skipped" (not a background profile / no config),
+    "present" (both jobs already there), "added" (one or both backfilled).
+    """
+    if profile not in _BACKGROUND_PROFILES:
+        return "skipped"
+    if not config_path.exists():
+        return "skipped"
+
+    # ruamel.yaml round-trip — preserves the operator's comments / quoting /
+    # ordering; only the grafted cron sub-block changes. Same editor the
+    # sibling ADD-only mutators (render_mcp_servers, render_sms_gateway) use.
+    from ruamel.yaml import YAML
+
+    yaml = YAML()
+    yaml.preserve_quotes = True
+
+    data = yaml.load(config_path.read_text(encoding="utf-8"))
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        return "skipped"
+
+    cron = data.get("cron")
+    if not isinstance(cron, dict):
+        cron = {}
+        data["cron"] = cron
+
+    # Silent background runs — only set if the operator hasn't.
+    if "wrap_response" not in cron:
+        cron["wrap_response"] = False
+
+    jobs = cron.get("jobs")
+    if not isinstance(jobs, list):
+        jobs = []
+        cron["jobs"] = jobs
+
+    existing_names = {
+        j.get("name") for j in jobs if isinstance(j, dict) and j.get("name")
+    }
+
+    added_any = False
+    for job in _gc_jobs(runtime_profile_dir):
+        if job["name"] in existing_names:
+            continue  # ADD-only — preserve an operator-tuned job verbatim.
+        jobs.append(job)
+        added_any = True
+
+    if not added_any:
+        return "present"
+
+    with config_path.open("w", encoding="utf-8") as f:
+        yaml.dump(data, f)
+    return "added"
+
+
+if __name__ == "__main__":
+    profile = (sys.argv[1] if len(sys.argv) > 1 else "").strip().lower()
+    if not profile:
+        print(
+            "usage: render_workers_pruning.py <profile>\n"
+            "  env: PROFILE_DIR, HERMES_RUNTIME_PROFILE_DIR",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    profile_dir = Path(
+        os.environ.get("PROFILE_DIR", f"/hermes-state/profiles/{profile}")
+    )
+    config = profile_dir / "config.yaml"
+
+    # The runtime view of the profile dir (what the gateway process sees) — the
+    # cron commands run inside the hermes runtime container, not the init
+    # container. Same resolution as render_mcp_servers.py.
+    runtime_override = os.environ.get("HERMES_RUNTIME_PROFILE_DIR", "").strip()
+    runtime_home = os.environ.get("HERMES_RUNTIME_HOME", "").strip()
+    if runtime_override:
+        runtime_profile_dir = runtime_override
+    elif runtime_home:
+        runtime_profile_dir = str(Path(runtime_home) / "profiles" / profile)
+    else:
+        runtime_profile_dir = str(profile_dir)
+
+    try:
+        outcome = ensure_workers_pruning(
+            config,
+            profile=profile,
+            runtime_profile_dir=runtime_profile_dir,
+        )
+    except Exception as exc:
+        # Best-effort step; never abort init on a render hiccup.
+        print(f"[render-workers-pruning] WARN {config}: {exc}", file=sys.stderr)
+        sys.exit(0)
+    print(f"[render-workers-pruning] {config} ({profile}): {outcome}")

--- a/packages/hermes/tests/test_init_workers_pruning_mutator.py
+++ b/packages/hermes/tests/test_init_workers_pruning_mutator.py
@@ -1,0 +1,244 @@
+"""Tests for render_workers_pruning.py — the idempotent ADD-only mutator that
+backfills the disk-bloat GC cron (prune-old-sessions + vacuum-state-db) onto
+the background profiles' (workers / heavy) config.yaml.
+
+Why this script exists: `render_hermes.py` is seed-only — once config.yaml
+exists on disk, init never re-renders it. So the GC `cron:` block added to
+hermes-config.yaml.njk for the background profiles is invisible to any tenant
+whose config.yaml was seeded before the change — exactly the bloated fleet
+(2026-06-19: zsolt workers state.db 111G + sessions/ 140G filled the disk).
+
+This mutator runs after render_hermes.py on every init boot. It is:
+  - ADD-only: an operator-tuned job with the same name survives verbatim
+  - Per-profile: workers + heavy only (no-op on main / codex-builder)
+  - Idempotent: returns "present" with no rewrite when both jobs exist
+  - Best-effort: missing config returns a sentinel, never raises
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+HERMES = Path(__file__).resolve().parent.parent
+RENDER_SCRIPT = HERMES / "init" / "render_workers_pruning.py"
+
+
+def _load_render_module():
+    spec = importlib.util.spec_from_file_location(
+        "render_workers_pruning", RENDER_SCRIPT
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def render_module():
+    pytest.importorskip(
+        "ruamel.yaml",
+        reason="ruamel.yaml is the round-trip YAML mutator the init image installs.",
+    )
+    return _load_render_module()
+
+
+RUNTIME_DIR = "/hermes-state/profiles/workers"
+
+
+def _call(mod, config: Path, profile: str = "workers", runtime: str = RUNTIME_DIR):
+    return mod.ensure_workers_pruning(
+        config, profile=profile, runtime_profile_dir=runtime
+    )
+
+
+# --- core behaviour ---------------------------------------------------------
+def test_added_when_no_cron_block(tmp_path: Path, render_module):
+    """A workers config.yaml with no `cron:` block at all gets both GC jobs
+    injected (the pre-change seed shape — the template renders no cron for
+    the background profiles before this fix)."""
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        "model:\n  default: x-ai/grok-4.1-fast\n", encoding="utf-8"
+    )
+
+    assert _call(render_module, config) == "added"
+
+    from ruamel.yaml import YAML
+    data = YAML().load(config.read_text())
+    jobs = {j["name"]: j for j in data["cron"]["jobs"]}
+    assert set(jobs) == {"prune-old-sessions", "vacuum-state-db"}
+    assert data["cron"]["wrap_response"] is False
+    # The prune job targets the runtime sessions dir + the 7-day window.
+    assert f"{RUNTIME_DIR}/sessions" in jobs["prune-old-sessions"]["command"]
+    assert "-mtime +7" in jobs["prune-old-sessions"]["command"]
+    assert "request_dump_*.json" in jobs["prune-old-sessions"]["command"]
+    # The vacuum job targets state.db.
+    assert f"{RUNTIME_DIR}/state.db" in jobs["vacuum-state-db"]["command"]
+    assert "VACUUM" in jobs["vacuum-state-db"]["command"]
+    # Existing keys preserved.
+    assert data["model"]["default"] == "x-ai/grok-4.1-fast"
+
+
+def test_added_when_cron_exists_without_gc_jobs(tmp_path: Path, render_module):
+    """A config that already has `cron:` for some other reason gets the GC
+    jobs grafted into `cron.jobs` WITHOUT dropping the operator's job."""
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        "cron:\n"
+        "  wrap_response: true\n"
+        "  jobs:\n"
+        "    - name: operator-job\n"
+        "      schedule: '0 9 * * *'\n"
+        "      command: echo hi\n",
+        encoding="utf-8",
+    )
+
+    assert _call(render_module, config) == "added"
+
+    from ruamel.yaml import YAML
+    data = YAML().load(config.read_text())
+    names = {j["name"] for j in data["cron"]["jobs"]}
+    assert "operator-job" in names  # preserved
+    assert {"prune-old-sessions", "vacuum-state-db"} <= names
+    # An operator wrap_response is NOT overwritten.
+    assert data["cron"]["wrap_response"] is True
+
+
+def test_noop_when_both_jobs_present(tmp_path: Path, render_module):
+    """If both GC jobs already exist (previously injected / operator-set),
+    the mutator is a no-op and does not rewrite the file."""
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        "cron:\n"
+        "  wrap_response: false\n"
+        "  jobs:\n"
+        "    - name: prune-old-sessions\n"
+        "      schedule: '23 3 * * *'\n"
+        "      command: custom-prune\n"
+        "    - name: vacuum-state-db\n"
+        "      schedule: '43 3 * * *'\n"
+        "      command: custom-vacuum\n",
+        encoding="utf-8",
+    )
+    original = config.read_text()
+
+    assert _call(render_module, config) == "present"
+    assert config.read_text() == original  # byte-equal, no rewrite
+
+
+def test_operator_tuned_job_preserved(tmp_path: Path, render_module):
+    """An operator-tuned prune job (different schedule/command, same name)
+    survives verbatim — the mutator is ADD-only, keyed by job name. Only the
+    missing vacuum job is grafted."""
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        "cron:\n"
+        "  jobs:\n"
+        "    - name: prune-old-sessions\n"
+        "      schedule: '0 2 * * *'\n"
+        "      command: find /custom -mtime +30 -delete\n",
+        encoding="utf-8",
+    )
+
+    assert _call(render_module, config) == "added"
+
+    from ruamel.yaml import YAML
+    data = YAML().load(config.read_text())
+    jobs = {j["name"]: j for j in data["cron"]["jobs"]}
+    # Operator's prune job untouched.
+    assert jobs["prune-old-sessions"]["schedule"] == "0 2 * * *"
+    assert jobs["prune-old-sessions"]["command"] == "find /custom -mtime +30 -delete"
+    # Vacuum job backfilled.
+    assert "vacuum-state-db" in jobs
+
+
+def test_heavy_profile_also_gets_gc(tmp_path: Path, render_module):
+    """The heavy profile is a background profile too — it gets the GC cron."""
+    config = tmp_path / "config.yaml"
+    config.write_text("model:\n  default: anthropic/claude-opus\n", encoding="utf-8")
+    runtime = "/hermes-state/profiles/heavy"
+
+    assert _call(render_module, config, profile="heavy", runtime=runtime) == "added"
+
+    from ruamel.yaml import YAML
+    data = YAML().load(config.read_text())
+    names = {j["name"] for j in data["cron"]["jobs"]}
+    assert {"prune-old-sessions", "vacuum-state-db"} <= names
+    assert f"{runtime}/sessions" in {
+        seg
+        for j in data["cron"]["jobs"]
+        for seg in [j["command"]]
+        if runtime in j["command"]
+    } or any(runtime in j["command"] for j in data["cron"]["jobs"])
+
+
+def test_main_profile_skipped(tmp_path: Path, render_module):
+    """main renders its own cron block (wrap_response + reminders) and its
+    sessions are the live chat surface — never touched by this mutator."""
+    config = tmp_path / "config.yaml"
+    config.write_text("cron:\n  wrap_response: false\n", encoding="utf-8")
+    original = config.read_text()
+
+    assert _call(render_module, config, profile="main") == "skipped"
+    assert config.read_text() == original
+
+
+def test_codex_builder_skipped(tmp_path: Path, render_module):
+    """codex-builder has its own cleanup-old-runs GC and is a sealed runtime
+    — this mutator must not touch it."""
+    config = tmp_path / "config.yaml"
+    config.write_text("cron:\n  jobs: []\n", encoding="utf-8")
+
+    assert _call(render_module, config, profile="codex-builder") == "skipped"
+
+
+def test_no_config_returns_cleanly(tmp_path: Path, render_module):
+    """A missing config.yaml is recoverable — return a sentinel, never raise,
+    so init never aborts on a fresh boot before render_hermes seeds the file."""
+    assert _call(render_module, tmp_path / "missing.yaml") == "skipped"
+
+
+# --- entrypoint.sh + Dockerfile wire pins -----------------------------------
+def test_entrypoint_invokes_pruning_step():
+    """The init entrypoint must call render_workers_pruning.py, guarded for
+    the case where the profile's config.yaml does not yet exist."""
+    src = (HERMES / "init" / "entrypoint.sh").read_text()
+    assert "render_workers_pruning.py" in src
+
+
+def test_entrypoint_pruning_runs_after_render_hermes():
+    """Order matters: render_hermes seeds the file; render_workers_pruning
+    backfills the GC cron onto it."""
+    src = (HERMES / "init" / "entrypoint.sh").read_text()
+    render_idx = src.find("python3 /setup/render_hermes.py")
+    prune_idx = src.find("python3 /setup/render_workers_pruning.py")
+    assert 0 < render_idx < prune_idx
+
+
+def test_dockerfile_copies_render_workers_pruning():
+    """The init image must bundle the mutator alongside the other mutators."""
+    dockerfile = (HERMES / "init" / "Dockerfile").read_text()
+    assert "COPY packages/hermes/init/render_workers_pruning.py" in dockerfile
+
+
+# --- template wire pin ------------------------------------------------------
+def test_template_renders_gc_cron_for_workers():
+    """The .njk template must render the two GC jobs for the workers profile
+    (new-tenant first-seed path). Mirrors what the mutator backfills."""
+    jinja2 = pytest.importorskip("jinja2")
+    import yaml as pyyaml
+
+    src = (HERMES / "hermes-config.yaml.njk").read_text()
+    out = jinja2.Environment().from_string(src).render(
+        profile="workers",
+        is_main=False,
+        workers_model="x-ai/grok-4.1-fast",
+        runtime_profile_dir="/hermes-state/profiles/workers",
+    )
+    data = pyyaml.safe_load(out)
+    names = {j["name"] for j in data["cron"]["jobs"]}
+    assert {"prune-old-sessions", "vacuum-state-db"} == names


### PR DESCRIPTION
## Problem

The Hermes **workers** (and **heavy**) profiles run high-volume autonomous
background agents (clerk / vault-curator / vault-janitor / vault-distiller).
Every run writes a `sessions/session_*.json` transcript (plus a
`sessions/request_dump_*.json` when a tool errors with the upstream debug-dump
path active) and appends to the profile's `state.db`. **Nothing prunes either
store**, so they grow without bound — the realization of the long-documented
`[S1] "Session store growth / leak — must be verified under load"`
(docs/FAILURE-MODES.md).

### Evidence (live fleet, 2026-06-19)

`/var/lib/docker/volumes/alfred-black_hermes_data/_data/profiles/workers`

| tenant | workers state.db | sessions/ | session files |
|--------|------------------|-----------|---------------|
| zsolt  | 111G → 57M (cleaned) | 140G → 211M | 312,875 → 340 |
| rj     | **59G** | 50M | 0 |
| joe    | **52G** | 1.6G | 3,965 |
| home   | 6.0G | **19G** | 54,537 |
| rami   | 5.8G | **37G** | 92,712 |
| miguel | 1.8G | 1.4M | 0 |

`zsolt.alfred.black` hit 100% disk and took the whole tenant down (docker exec
failed → all healthchecks unhealthy → sure-web 500). The bloat is fleet-wide;
zsolt just also caught an active curator failure-loop that accelerated it.

## The fix

Mirrors the existing `codex-builder` `cleanup-old-runs` GC pattern:

- **`hermes-config.yaml.njk`** — the background-profile branch now renders a
  `cron:` block with two nightly off-peak jobs:
  - `prune-old-sessions` (03:23): delete `session_*` / `request_dump_*` files
    older than **7 days** (worker sessions are one-shot, idle-reset at 30m, so a
    day-old file is already dead; 7d keeps a forensic window).
  - `vacuum-state-db` (03:43): `VACUUM` the profile's `state.db` (SQLite does
    not shrink the file on `DELETE`; uses `python3`, always present in the
    image, not the `sqlite3` CLI which is not installed).
- **`init/render_workers_pruning.py`** — an **idempotent ADD-only** converger
  (sibling of `render_mcp_servers.py` / `render_sms_gateway.py`). `config.yaml`
  is operator-owned and seeded ONCE, so a template-only change never reaches the
  already-bloated existing fleet. This backfills the same two jobs on every init
  boot, using `ruamel.yaml` so operator comments/quoting survive, preserving any
  operator-tuned job verbatim (keyed by name). No-op on main / codex-builder.
- **`init/entrypoint.sh`** — wires the converger after `render_hermes.py` per
  profile (guarded for missing config.yaml).
- **`init/Dockerfile`** — `COPY`s the new script into the init image.
- **`tests/test_init_workers_pruning_mutator.py`** — 12 tests (add /
  idempotent / operator-preserve / profile-gating / entrypoint+Dockerfile wire
  pins / template render). All pass; sibling mutator suites still green.

## Scope note

This bounds **future** growth on the natural schedule. Reclaiming the
**already-accumulated** bloat is a one-time manual cleanup per tenant — see the
runbook in `fix/workers-disk-bloat-docs-runbook`
(`debug/2026-06-19/workers-disk-bloat-runbook.md`).

The cross-session curator retry loop that accelerated zsolt is an **upstream**
defect (the per-run `tool_loop_guardrails.hard_stop_after` resets every fresh
session, so it never trips for a task that re-spawns) — documented as a
follow-up in the runbook, not faked here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
