### PR TITLE
fix(rate-guard): honor full provider reset horizon + recent-429 grace

### DIFF
--- a/packages/alfred-vault/src/alfred/curator/rate_backoff.py
+++ b/packages/alfred-vault/src/alfred/curator/rate_backoff.py
@@ -29,10 +29,20 @@ DEFAULT_BACKOFF_PATH = "/alfred-data/state/steward/rate-guard.json"
 _BACKOFF_KEY = "rate_429_until"  # gitleaks:allow — JSON key name, not a secret
 
 # Clamp window for armed backoffs: never shorter than 30s (avoid tight retry
-# loops), never longer than 24h (avoid a parse glitch stalling the daemon for
-# days).
+# loops), never longer than 7d. 7d (was 24h) so a weekly provider cap
+# (ChatGPT Pro usage_limit_reached reports a multi-day resets_in_seconds) is
+# waited out in full instead of re-probed every 24h; the ceiling still bounds
+# a bad parse.
 _MIN_BACKOFF = 30
-_MAX_BACKOFF = 24 * 60 * 60
+_MAX_BACKOFF = 7 * 24 * 60 * 60
+
+# Recent-429 grace (mirrors learn's rate_guard): after any 429, keep deferring
+# this long even past rate_429_until, so a herd can't re-probe a still-closed
+# cap at the boundary. Shared via the rate_429_last_event_ts key.
+_GRACE_SECONDS = 120
+# Timestamp of the most recent 429, written alongside rate_429_until so the
+# learn pipeline's grace accounts for curator-side 429s too.
+_LAST_EVENT_KEY = "rate_429_last_event_ts"
 
 
 class RateBackoffDeferred(Exception):
@@ -85,9 +95,19 @@ def read_backoff_until(path: str | Path | None = None) -> float:
     except (FileNotFoundError, json.JSONDecodeError, OSError):
         return 0.0
     try:
-        return float(data.get(_BACKOFF_KEY) or 0.0)
+        until = float(data.get(_BACKOFF_KEY) or 0.0)
     except (TypeError, ValueError):
-        return 0.0
+        until = 0.0
+    # Honor the recent-429 grace: a 429 within the grace window holds the
+    # backoff even past rate_429_until (boundary herd protection). Shared with
+    # the learn rate_guard via rate_429_last_event_ts.
+    try:
+        last_429 = float(data.get(_LAST_EVENT_KEY) or 0.0)
+    except (TypeError, ValueError):
+        last_429 = 0.0
+    if last_429:
+        until = max(until, last_429 + _GRACE_SECONDS)
+    return until
 
 
 def arm_backoff(seconds: float, path: str | Path | None = None) -> float:
@@ -98,8 +118,9 @@ def arm_backoff(seconds: float, path: str | Path | None = None) -> float:
     cap outage). Returns the resulting ``rate_429_until``.
     """
     p = resolve_backoff_path(path)
+    now = time.time()
     secs = max(_MIN_BACKOFF, min(_MAX_BACKOFF, int(seconds)))
-    new_until = time.time() + secs
+    new_until = now + secs
 
     data: dict = {}
     try:
@@ -117,6 +138,9 @@ def arm_backoff(seconds: float, path: str | Path | None = None) -> float:
         new_until = current
 
     data[_BACKOFF_KEY] = new_until
+    # Record the 429 time so the recent-429 grace (here + learn's rate_guard)
+    # holds the boundary herd.
+    data[_LAST_EVENT_KEY] = now
 
     try:
         Path(p).parent.mkdir(parents=True, exist_ok=True)

--- a/packages/alfred-vault/tests/test_curator_hardening.py
+++ b/packages/alfred-vault/tests/test_curator_hardening.py
@@ -28,6 +28,8 @@ from alfred.curator.config import (
     load_from_unified,
 )
 from alfred.curator.rate_backoff import (
+    _GRACE_SECONDS,
+    _MAX_BACKOFF,
     RateBackoffDeferred,
     arm_backoff,
     parse_backoff_seconds_from_output,
@@ -99,6 +101,53 @@ def test_arm_backoff_only_extends(tmp_path):
     # Arming a shorter backoff must not shorten an existing longer one.
     until = arm_backoff(60, path=p)
     assert abs(until - far) < 0.01
+
+
+def test_arm_backoff_honors_multiday_horizon(tmp_path):
+    """A 4-day horizon is honored, not clamped to 24h."""
+    p = tmp_path / "rate-guard.json"
+    until = arm_backoff(4 * 24 * 60 * 60, path=p)
+    assert until - time.time() > 3.5 * 24 * 60 * 60
+
+
+def test_arm_backoff_clamps_at_7d(tmp_path):
+    """An absurd horizon is bounded by the 7d ceiling."""
+    p = tmp_path / "rate-guard.json"
+    until = arm_backoff(30 * 24 * 60 * 60, path=p)  # 30 days
+    assert until - time.time() <= _MAX_BACKOFF + 5
+    assert until - time.time() > _MAX_BACKOFF - 60
+
+
+def test_read_backoff_honors_recent_429_grace(tmp_path):
+    """Past rate_429_until but a 429 within grace -> read returns a future deadline."""
+    p = tmp_path / "rate-guard.json"
+    now = time.time()
+    p.write_text(
+        json.dumps({"rate_429_until": now - 10, "rate_429_last_event_ts": now - 10}),
+        encoding="utf-8",
+    )
+    assert read_backoff_until(p) > now  # grace holds it open
+
+
+def test_read_backoff_grace_clears_when_stale(tmp_path):
+    """Past rate_429_until and a stale 429 -> read returns the (past) deadline."""
+    p = tmp_path / "rate-guard.json"
+    now = time.time()
+    stale = now - (_GRACE_SECONDS + 60)
+    p.write_text(
+        json.dumps({"rate_429_until": stale, "rate_429_last_event_ts": stale}),
+        encoding="utf-8",
+    )
+    assert read_backoff_until(p) <= now  # grace cleared, calls may resume
+
+
+def test_arm_backoff_writes_last_event_ts(tmp_path):
+    """arm_backoff records rate_429_last_event_ts so learn's grace sees it."""
+    p = tmp_path / "rate-guard.json"
+    arm_backoff(60, path=p)
+    data = json.loads(p.read_text(encoding="utf-8"))
+    assert "rate_429_last_event_ts" in data
+    assert abs(data["rate_429_last_event_ts"] - time.time()) < 5
 
 
 @pytest.mark.parametrize("text,expected", [

--- a/packages/learn/src/activities/rate_guard.py
+++ b/packages/learn/src/activities/rate_guard.py
@@ -94,6 +94,18 @@ MAX_WINDOW_SECONDS = max(WINDOW_SECONDS.values())
 # trims a real rolling-window query but bounds memory.
 MAX_RETAINED_EVENTS = 20_000
 
+# Longest provider-429 backoff we'll honor. 7d so a weekly cap
+# (ChatGPT Pro usage_limit_reached) is waited out in full instead of
+# re-probed every 24h; still a ceiling against a bad parse.
+RATE_429_MAX_BACKOFF_SECONDS = 7 * 24 * 60 * 60
+
+# Recent-429 grace: after ANY provider 429, keep deferring for this long even
+# once rate_429_until passes. Closes the concurrency race at the backoff
+# boundary — a herd of waiters can't all re-probe a still-closed cap the
+# instant the deadline expires. Self-clears: when the cap truly opens, 429s
+# stop, the last-event timestamp ages past the grace, and calls resume.
+RATE_429_GRACE_SECONDS = 120
+
 
 # ---------------------------------------------------------------------------
 # State path + I/O
@@ -265,6 +277,27 @@ class RateGuard:
                 counts=counts,
             )
 
+        # 1b) Recent-429 grace. Even past the deadline, if a 429 was recorded
+        #     within the grace window the cap is almost certainly still closed
+        #     (the deadline was an estimate, or a concurrent burst is mid-flight
+        #     right at the boundary). Hold the herd so it doesn't all re-probe a
+        #     closed cap at once. Self-clears once 429s stop arriving.
+        last_429 = float(state.get("rate_429_last_event_ts") or 0.0)
+        if last_429 and (now - last_429) < RATE_429_GRACE_SECONDS:
+            counts = self._snapshot_counts(state["events"], now, task_path, matter_path)
+            grace_until = last_429 + RATE_429_GRACE_SECONDS
+            logger.warning(
+                "rate_guard: blocked task=%s matter=%s reason=429_grace last_429=%.0fs_ago",
+                task_path, matter_path, now - last_429,
+            )
+            return RateDecision(
+                allowed=False,
+                reason=f"provider 429 {int(now - last_429)}s ago — grace backoff",
+                cap="rate_429",
+                backoff_until=grace_until,
+                counts=counts,
+            )
+
         events = _prune_events(state.get("events") or [], now)
 
         # 2) Walk the caps in order of decreasing window so a per-day cap
@@ -347,8 +380,12 @@ class RateGuard:
             secs = 60
         if secs <= 0:
             secs = 60
-        if secs > 60 * 60 * 24:
-            secs = 60 * 60 * 24  # cap at 24h — no provider back-off should be longer
+        if secs > RATE_429_MAX_BACKOFF_SECONDS:
+            # Cap at 7d so we HONOR a weekly provider cap (ChatGPT Pro's
+            # usage_limit_reached can report a multi-day resets_in_seconds);
+            # the ceiling still bounds a bad parse. Previously clamped at 24h,
+            # which made a multi-day cap re-probe every 24h and 429 each time.
+            secs = RATE_429_MAX_BACKOFF_SECONDS
 
         now = self._now()
         state = _read_state(self.cfg)

--- a/packages/learn/tests/test_rate_guard_honor_reset.py
+++ b/packages/learn/tests/test_rate_guard_honor_reset.py
@@ -1,0 +1,89 @@
+"""rate-guard honors the real reset horizon + recent-429 grace
+(fix/rate-guard-honor-reset).
+
+Before this fix ``record_429`` clamped any backoff to 24h, so a multi-day
+ChatGPT Pro *weekly* cap (``usage_limit_reached`` reports a multi-day
+``resets_in_seconds``) re-probed every 24h and 429'd each time. And the
+instant ``rate_429_until`` passed, a concurrent herd could all re-probe a
+still-closed cap.
+
+These tests lock in:
+  (1) the backoff honors a multi-day horizon, up to a 7d ceiling;
+  (2) a 429 within the grace window keeps deferring even past
+      ``rate_429_until`` (boundary-herd protection), and self-clears once the
+      429 ages past the grace.
+"""
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import src.activities.rate_guard as rate_guard_mod  # noqa: E402
+from src.config import Config  # noqa: E402
+from src.activities.rate_guard import (  # noqa: E402
+    RATE_429_GRACE_SECONDS,
+    RATE_429_MAX_BACKOFF_SECONDS,
+    RateGuard,
+)
+
+
+def _cfg(tmp_path: Path) -> Config:
+    return Config(alfred_data_dir=str(tmp_path))
+
+
+@pytest.mark.asyncio
+async def test_record_429_honors_multiday_horizon(tmp_path: Path) -> None:
+    """A 4-day horizon is honored, not clamped down to 24h."""
+    cfg = _cfg(tmp_path)
+    guard = RateGuard(cfg)
+    await guard.record_429(4 * 24 * 60 * 60)
+    state = rate_guard_mod._read_state(cfg)
+    remaining = float(state["rate_429_until"]) - time.time()
+    assert remaining > 3.5 * 24 * 60 * 60  # ~4 days, well past the old 24h cap
+
+
+@pytest.mark.asyncio
+async def test_record_429_clamps_at_7d(tmp_path: Path) -> None:
+    """An absurd horizon is still bounded by the 7d ceiling."""
+    cfg = _cfg(tmp_path)
+    guard = RateGuard(cfg)
+    await guard.record_429(30 * 24 * 60 * 60)  # 30 days
+    state = rate_guard_mod._read_state(cfg)
+    remaining = float(state["rate_429_until"]) - time.time()
+    assert RATE_429_MAX_BACKOFF_SECONDS - 60 < remaining <= RATE_429_MAX_BACKOFF_SECONDS + 5
+
+
+@pytest.mark.asyncio
+async def test_grace_blocks_after_deadline(tmp_path: Path) -> None:
+    """Past rate_429_until but a 429 within grace -> still deferred."""
+    cfg = _cfg(tmp_path)
+    guard = RateGuard(cfg)
+    now = time.time()
+    state = rate_guard_mod._empty_state()
+    state["rate_429_until"] = now - 10            # deadline already passed
+    state["rate_429_last_event_ts"] = now - 10    # but a 429 fired 10s ago
+    rate_guard_mod._write_state(cfg, state)
+    dec = await guard.check_and_reserve(task_path="t", matter_path="m")
+    assert not dec.allowed
+    assert dec.cap == "rate_429"
+
+
+@pytest.mark.asyncio
+async def test_grace_clears_when_stale(tmp_path: Path) -> None:
+    """Past rate_429_until and the last 429 older than grace -> calls resume."""
+    cfg = _cfg(tmp_path)
+    guard = RateGuard(cfg)
+    now = time.time()
+    stale = now - (RATE_429_GRACE_SECONDS + 60)
+    state = rate_guard_mod._empty_state()
+    state["rate_429_until"] = stale
+    state["rate_429_last_event_ts"] = stale
+    rate_guard_mod._write_state(cfg, state)
+    dec = await guard.check_and_reserve(task_path="t", matter_path="m")
+    assert dec.allowed


### PR DESCRIPTION
## Problem

After #268/#269/#270 the storm is gone, but zsolt (currently at its ChatGPT Pro **weekly** cap, ~4-day reset) was still leaking ~48 codex 429s / 10min despite ~1,110 calls/10min correctly deferred. Two causes:

1. **24h clamp vs multi-day cap.** `record_429` clamped any backoff to 24h. The weekly cap reports a multi-day `resets_in_seconds`, so the backoff expired every 24h, calls resumed, hit the still-closed cap, 429'd, and re-armed — a daily re-probe burst.
2. **Boundary herd.** The instant `rate_429_until` passed, concurrent workflows all passed the "is it armed?" check before the first 429 re-armed the guard, so a burst slipped through each time.

## Fix (both guards — learn `rate_guard.py` + curator `rate_backoff.py`, shared JSON)

1. **Honor the real horizon:** raise the clamp **24h → 7d** so a weekly cap is waited out in full (ceiling still bounds a bad parse). No more daily re-probe.
2. **Recent-429 grace:** after *any* 429, keep deferring for **120s** even past `rate_429_until`. Closes the boundary race — the herd can't re-probe a closed cap. Shared across both pipelines via the `rate_429_last_event_ts` key. **Self-clears:** once the cap truly opens, 429s stop, the last-event ages past the grace, and calls resume.

Net: guarded paths (signal-extract, decision-router, steward, curator) go silent until the cap *actually* resets, instead of re-testing every 24h.

## Smoke evidence

Tested on zsolt.alfred.black (live) + unit.

```
§1 baseline (live, zsolt): weekly cap, resets_in_seconds ~358,011 (~4d);
   rate_429_until clamped to 24h -> expired & re-probed; ~1,110 deferred /10m
   but ~48 leaked 429s /10m (Steward + signal-extract).
§2 mutation (unit):
   learn:   cd packages/learn && python3 -m pytest tests/test_rate_guard_honor_reset.py -q   -> 4 passed
            broader sweep (rate/guard/steward/signal/decision/codex) -> 291 passed
   curator: cd packages/alfred-vault && PYTHONPATH=src pytest tests/test_curator_hardening.py -q -> 24 passed
   Covers: 4-day horizon honored (not clamped to 24h); 30-day clamped to 7d;
   grace blocks past-deadline when a 429 is within 120s; grace self-clears when stale.
§3 isolation: only rate_guard.py / rate_backoff.py + their tests touched; grace
   keys shared by path, no cross-package import. Plain-429 / non-429 behavior unchanged.
§4 expected post-deploy on zsolt: guarded-path 429s -> ~0 until the real cap
   reset (~4d); will verify live after rollout.
```

Note: touches `packages/learn` (→ build-learn) and `packages/alfred-vault` (→ build-alfred-worker), both auto-deploy via deploy-fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)