### PR TITLE
fix(learn): exempt signal-extract funnel from per_matter_per_day cap (unblocks signal extraction fleet-wide)

### DIFF
--- a/packages/learn/src/activities/rate_guard.py
+++ b/packages/learn/src/activities/rate_guard.py
@@ -86,6 +86,17 @@ WINDOW_SECONDS: dict[str, int] = {
     "per_matter_per_day": 24 * 60 * 60,
 }
 
+# Infra "matters" that are pipeline FUNNELS, not real business matters. Signal
+# extraction routes the ENTIRE inbound stream through one synthetic
+# ``matter_path`` ("signal-extract"), so the per_matter_per_day noise-control
+# cap — meant to stop a single *business* matter being spammed — would instead
+# throttle all extraction, fleet-wide, to 50 LLM calls/day (and then pin at
+# 50/50, because deferred events never mark processed and re-list every tick).
+# Exempt these funnels: they stay gated by per_task_per_day (per event — stops
+# one event looping), the tenant-wide per_minute/hour/day windows, and the
+# provider-429 backoff (the real constraint, per the module note above).
+INFRA_MATTERS: frozenset[str] = frozenset({"signal-extract"})
+
 # Longest window — anything older than this can be pruned every read.
 MAX_WINDOW_SECONDS = max(WINDOW_SECONDS.values())
 
@@ -310,7 +321,15 @@ class RateGuard:
         #      c) per_minute, per_hour, per_day  (tenant-wide rolling windows)
         check_order = [
             ("per_task_per_day", task_path, None),
-            ("per_matter_per_day", None, matter_path),
+            # per_matter_per_day is noise-control for a single *business* matter.
+            # Infra funnel matters (signal-extract) route the whole pipeline
+            # through one matter_path, so applying it there throttles all
+            # extraction to 50/day — exempt them (see INFRA_MATTERS).
+            *(
+                []
+                if matter_path in INFRA_MATTERS
+                else [("per_matter_per_day", None, matter_path)]
+            ),
             ("per_minute", None, None),
             ("per_hour", None, None),
             ("per_day", None, None),

--- a/packages/learn/tests/test_rate_guard_infra_matter_exempt.py
+++ b/packages/learn/tests/test_rate_guard_infra_matter_exempt.py
@@ -1,0 +1,81 @@
+"""Infra funnel matters are exempt from the per_matter_per_day cap.
+
+Signal extraction routes the entire inbound stream through one synthetic
+``matter_path="signal-extract"``. Before this fix the per_matter_per_day
+noise-control cap (50) applied to it, throttling ALL extraction fleet-wide to
+50 LLM calls/day and then pinning at 50/50 (deferred events re-list every tick
+and re-burn the window) — observed live on miguel.alfred.black (2026-07-03):
+``signal_extract.done listed=200 extracted=100 written=0 errors=100`` with
+``cap per_matter_per_day hit (50/50)`` and ZERO real provider 429s.
+
+These tests lock in:
+  (1) a funnel matter in INFRA_MATTERS is NOT capped by per_matter_per_day
+      (it stays gated by per_task/tenant-wide windows + the 429 backoff);
+  (2) a real *business* matter is still capped at 50 (the exemption is scoped).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from src.config import Config  # noqa: E402
+from src.activities.rate_guard import LIMITS, RateGuard  # noqa: E402
+
+
+def _cfg(tmp_path: Path) -> Config:
+    return Config(alfred_data_dir=str(tmp_path))
+
+
+@pytest.mark.asyncio
+async def test_signal_extract_matter_exempt_from_per_matter_cap(tmp_path: Path) -> None:
+    """>50 signal-extract reservations in one window all stay allowed.
+
+    Distinct task_paths keep per_task_per_day (6) clear; N is kept under
+    per_minute (60) so this isolates the per_matter cap. Before the fix the
+    (per_matter_per_day+1)th call was blocked with cap=per_matter_per_day.
+    """
+    n = LIMITS["per_matter_per_day"] + 5  # 55 — above the matter cap...
+    assert n < LIMITS["per_minute"], "test must stay under the tenant-wide per_minute cap"
+
+    guard = RateGuard(_cfg(tmp_path))
+    for i in range(n):
+        dec = await guard.check_and_reserve(
+            task_path=f"ingest:event-{i}",   # unique per event → per_task stays 1
+            matter_path="signal-extract",    # infra funnel → exempt
+        )
+        assert dec.allowed, (
+            f"reservation {i + 1}/{n} blocked (cap={dec.cap}, reason={dec.reason}); "
+            "signal-extract must be exempt from per_matter_per_day"
+        )
+
+
+@pytest.mark.asyncio
+async def test_business_matter_still_capped_at_per_matter_limit(tmp_path: Path) -> None:
+    """A real (non-infra) matter is still throttled at per_matter_per_day.
+
+    Regression guard: the exemption is scoped to INFRA_MATTERS, so ordinary
+    business matters keep their noise-control cap.
+    """
+    cap = LIMITS["per_matter_per_day"]
+    assert cap + 1 < LIMITS["per_minute"], "keep the test under the per_minute cap"
+
+    guard = RateGuard(_cfg(tmp_path))
+    for i in range(cap):
+        dec = await guard.check_and_reserve(
+            task_path=f"task-{i}",           # unique → per_task stays clear
+            matter_path="matter/acme-deal",  # a real business matter
+        )
+        assert dec.allowed, f"reservation {i + 1}/{cap} should be allowed"
+
+    # The (cap+1)th on the same business matter is blocked by per_matter_per_day.
+    blocked = await guard.check_and_reserve(
+        task_path="task-final",
+        matter_path="matter/acme-deal",
+    )
+    assert not blocked.allowed
+    assert blocked.cap == "per_matter_per_day"


### PR DESCRIPTION
## Problem
Signal extraction routes the **entire inbound stream through one synthetic
`matter_path="signal-extract"`**, so the `per_matter_per_day` noise-control cap
(50) — meant to stop a single *business* matter being spammed — instead
throttles **all extraction, fleet-wide, to 50 LLM calls/day**, then pins at
50/50 forever (deferred events never mark processed and re-list every tick,
constantly re-burning the 24h window).

**Live evidence — miguel.alfred.black, 2026-07-03:**
- `signal_extract.done listed=200 extracted=100 written=0 errors=100`
- every event: `rate-guard blocked … cap per_matter_per_day hit (50/50)`
- rate-guard file: **53 `signal-extract` events in window**, **`rate_429_count=0`** — i.e. **zero real provider 429s**; the block is 100% this artificial cap, not codex.
- Result: ~240 Gmail events over 12 days → ~6 signals. The signal→decision→learning loop is starved fleet-wide (same 50/50 seen on home).

## Fix
Add `INFRA_MATTERS = {"signal-extract"}` and skip `per_matter_per_day` for those
funnels in `check_and_reserve`. They stay gated by:
- `per_task_per_day` (per event — still stops one event looping),
- the tenant-wide `per_minute`/`hour`/`day` windows (6000/day is the real ceiling),
- the **provider-429 backoff** — the actual constraint, per the module note: *"the constraint is provider rate-limits, not cost."*

Raising 50→N would be a band-aid; the cap is semantically wrong for a funnel matter.

## Smoke evidence
- **Failing-test-first:** without the exemption the **51st** `signal-extract`
  reservation blocks with `cap=per_matter_per_day count=50/50` (reproduces
  miguel exactly); with the fix, 55 pass.
- **Scoped:** a business matter (`matter/acme-deal`) is still capped at 50.
- **No regression:** `test_rate_guard_infra_matter_exempt` (2) +
  `test_rate_guard_honor_reset` (4) + `test_codex_cap_aware_backoff` (8) all
  green locally (14 passed). The 429-backoff skip for signal-extract is
  **unchanged** — a real provider 429 still defers.
- **No Temporal concern:** change is inside `check_and_reserve` (a helper called
  by activities), not a workflow `@run` or activity signature — no replay/determinism impact.

## Deploy note
Throttles every tenant (Jun-22 learn image). Merge → `build-learn` → `:latest` →
`deploy-fleet` rolls `alfred-learn` fleet-wide, unblocking extraction. miguel's
`rate_429_count=0` confirms codex has headroom, so this unblocks into real
extraction, not a provider wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
