### PR TITLE
fix(learn): repair the instinct-learning loop (reflection wedge + click→instinct link + noise suppression)

### DIFF
--- a/packages/learn/src/activities/decision_observations.py
+++ b/packages/learn/src/activities/decision_observations.py
@@ -108,17 +108,18 @@ async def _resolve_sender_for_needs_attention(
     stream_event and run the same sender extractor the signal-side
     observations use.
 
-    The signal record's frontmatter is LLM-extracted and does NOT
-    carry a structured ``raw.from`` — it stores the rendered email
-    headers inside ``raw_quote`` (a string) plus a
-    ``source_event_path`` pointing at the upstream stream_event. The
-    stream_event frontmatter is where the structured sender info
-    actually lives, and where we already have a battle-tested
-    extractor (signal_observations._extract_sender_from_event).
-    Reuse it here so OBS-1 + OBS-2 stay in lockstep.
+    Post-4-store-cutover (PLAN.md Part I): a needs_attention card's
+    ``source_signal_path`` is a **state.db** signal ULID (not a
+    ``signal/*.md`` vault path) and its ``source_event_path`` is an
+    ``ingest:<id>`` ref into **ingest.db** (Store 4). Reading either over
+    the vault route (``/api/v1/vault/records/…``) 404s — which is exactly
+    why this returned "" for ~80% of clicks and left ``instinct_ref``
+    NULL, severing the click→observation→instinct loop. Read the signal
+    from state.db (``read_signal_record``) and the event from ingest.db
+    (``_fetch_ingest_event_as_record``); fall back to the vault route
+    only for a genuine ``signal/…md`` path (pre-cutover history).
 
-    Cheap and cached by the in-process mtime cache. Returns "" if any
-    step fails — sender is optional on the observation.
+    Returns "" if any step fails — sender is optional on the observation.
     """
     if not source_record.startswith("needs_attention/"):
         return ""
@@ -129,19 +130,30 @@ async def _resolve_sender_for_needs_attention(
         na_fm = (resp.json().get("frontmatter") or {})
     except Exception:  # noqa: BLE001
         return ""
-    sig_path = str(na_fm.get("source_signal_path") or "").strip()
-    if not sig_path:
-        return ""
-    try:
-        sig_resp = await client.get(f"/api/v1/vault/records/{sig_path}")
-        if sig_resp.status_code >= 400:
-            return ""
-        sig_fm = (sig_resp.json().get("frontmatter") or {})
-    except Exception:  # noqa: BLE001
-        return ""
 
-    # First try the (rare) structured fields on the signal itself, in
-    # case a future signal writer emits them — cheap and harmless.
+    # Resolve the signal. Post-cutover the ref is a bare state.db ULID;
+    # a ``signal/…md`` path only appears in legacy pre-cutover history.
+    sig_ref = str(na_fm.get("source_signal_path") or "").strip()
+    sig_fm: dict = {}
+    if sig_ref and not sig_ref.startswith("signal/"):
+        try:
+            from src.utils.signal_state import read_signal_record
+            sig_rec = await read_signal_record(sig_ref)
+        except Exception:  # noqa: BLE001
+            sig_rec = None
+        if sig_rec:
+            sig_fm = sig_rec.get("frontmatter") or {}
+    elif sig_ref:
+        try:
+            sig_resp = await client.get(f"/api/v1/vault/records/{sig_ref}")
+            if sig_resp.status_code < 400:
+                sig_fm = (sig_resp.json().get("frontmatter") or {})
+        except Exception:  # noqa: BLE001
+            sig_fm = {}
+    if not isinstance(sig_fm, dict):
+        sig_fm = {}
+
+    # (rare) structured sender directly on the signal — cheap first try.
     raw = sig_fm.get("raw") or {}
     if isinstance(raw, dict):
         for k in ("from", "From", "sender", "from_email", "organizer", "organiser"):
@@ -153,31 +165,43 @@ async def _resolve_sender_for_needs_attention(
         if isinstance(v, str) and v.strip():
             return v.strip()
 
-    # Preferred source of truth: the upstream stream_event the signal
-    # was extracted from. Read its frontmatter and apply the canonical
-    # sender extractor.
-    event_path = str(sig_fm.get("source_event_path") or "").strip()
-    if event_path:
+    # Preferred source of truth: the stream_event the signal was
+    # extracted from. Post-cutover it is an ``ingest:<id>`` ref — read it
+    # via the ingest route, not the vault. The NA card also carries the
+    # ref directly, so fall back to it if the signal row was evicted
+    # (state.db retention) but the ingest event survives.
+    event_ref = (
+        str(sig_fm.get("source_event_path") or "").strip()
+        or str(na_fm.get("source_event_path") or "").strip()
+    )
+    from src.activities.signal_observations import _extract_sender_from_event
+    if event_ref.startswith("ingest:"):
         try:
-            evt_resp = await client.get(f"/api/v1/vault/records/{event_path}")
+            from src.activities.signals import _fetch_ingest_event_as_record
+            evt_rec = await _fetch_ingest_event_as_record(event_ref[len("ingest:"):])
+        except Exception:  # noqa: BLE001
+            evt_rec = None
+        if evt_rec:
+            evt_fm = evt_rec.get("frontmatter") or {}
+            if isinstance(evt_fm, dict):
+                sender = _extract_sender_from_event(evt_fm)
+                if sender:
+                    return sender
+    elif event_ref:
+        # Legacy vault stream_event path (pre-cutover history only).
+        try:
+            evt_resp = await client.get(f"/api/v1/vault/records/{event_ref}")
             if evt_resp.status_code < 400:
                 evt_fm = (evt_resp.json().get("frontmatter") or {})
                 if isinstance(evt_fm, dict):
-                    from src.activities.signal_observations import (
-                        _extract_sender_from_event,
-                    )
                     sender = _extract_sender_from_event(evt_fm)
                     if sender:
                         return sender
         except Exception:  # noqa: BLE001
-            pass  # fall through to raw_quote fallback
+            pass
 
-    # Fallback: parse the signal's own ``raw_quote`` string. The
-    # signal-extract activity stores the rendered email/event preview
-    # there (e.g. `**From**: "Acme" <a@example.com> **To**: ...`). Stream
-    # events get purged after extraction (StreamEventPurgeWorkflow), so
-    # for older decisions the stream_event lookup above 404s and this
-    # fallback is the only way to recover the sender.
+    # Last resort: parse the signal's own ``raw_quote`` (works only when
+    # it embeds ``**From**:`` headers — most post-cutover signals do NOT).
     return _sender_from_raw_quote(str(sig_fm.get("raw_quote") or ""))
 
 

--- a/packages/learn/src/activities/noise_patterns.py
+++ b/packages/learn/src/activities/noise_patterns.py
@@ -408,14 +408,18 @@ _NOISE_INSTINCT_CACHE: dict[str, Any] = {"loaded_at": 0.0, "instincts": []}
 
 
 async def load_noise_instincts() -> list[dict[str, Any]]:
-    """Return active instincts whose ``intent_key`` is ``noise``.
+    """Return active instincts that mean "keep this off the Desk".
+
+    Includes BOTH ``intent_key: noise`` (OBS-5 machine-generated) and
+    ``routing_rule.destination_type: hold`` (reflection/hand-authored).
 
     Result entries:
-      ``{"path": <vault path>, "sender_domains": [<glob>...]}``
+      ``{"path": <vault path>, "sender_domains": [<glob>...],
+         "subject_keywords": [<kw>...]}``
 
     Empty list when none are present, when ctrl-api list fails, or
-    when an instinct has no sender_domains (a noise instinct with no
-    domain anchors can't filter anything).
+    when an instinct has no anchors (neither sender_domains nor
+    subject_keywords — can't filter anything).
     """
     import time
     now = time.time()
@@ -447,27 +451,46 @@ async def load_noise_instincts() -> list[dict[str, Any]]:
             continue
         if str(fm.get("status") or "").strip().lower() != "active":
             continue
-        if str(fm.get("intent_key") or "").strip().lower() != "noise":
+        # A noise/suppress instinct is one whose intent is to keep the
+        # signal off the Desk. Two encodings exist in the wild:
+        #   * OBS-5 machine-generated: top-level ``intent_key: noise``
+        #   * reflection / hand-authored: ``routing_rule.destination_type: hold``
+        # Honour BOTH — a maxed-confidence "hold" rule (e.g.
+        # suppress-ci-github-workflow-noise) carried only the routing_rule
+        # and was invisible to the intent_key-only gate, so it never
+        # suppressed despite matching (BUG 3).
+        intent_key = str(fm.get("intent_key") or "").strip().lower()
+        rr = fm.get("routing_rule") or {}
+        dest_type = ""
+        if isinstance(rr, dict):
+            dest_type = str(rr.get("destination_type") or "").strip().lower()
+        if intent_key != "noise" and dest_type != "hold":
             continue
-        # Pull sender_domains from input_patterns (preferred) or
-        # legacy signals.domain_patterns mirror.
+        # Pull sender_domains from input_patterns (preferred) or legacy
+        # signals.domain_patterns mirror; also collect subject_keywords —
+        # a CI/PR instinct anchors on the subject, not just the domain.
         ip = fm.get("input_patterns") or {}
         sender_domains: list[str] = []
+        subject_keywords: list[str] = []
         if isinstance(ip, dict):
             v = ip.get("sender_domains") or []
             if isinstance(v, list):
                 sender_domains.extend(str(x) for x in v if isinstance(x, str))
+            k = ip.get("subject_keywords") or []
+            if isinstance(k, list):
+                subject_keywords.extend(str(x) for x in k if isinstance(x, str))
         if not sender_domains:
             sigs = fm.get("signals") or {}
             if isinstance(sigs, dict):
                 v = sigs.get("domain_patterns") or []
                 if isinstance(v, list):
                     sender_domains.extend(str(x) for x in v if isinstance(x, str))
-        if not sender_domains:
+        if not sender_domains and not subject_keywords:
             continue  # Noise instinct without anchors — can't filter
         out.append({
             "path": str(r.get("path") or ""),
             "sender_domains": sender_domains,
+            "subject_keywords": subject_keywords,
         })
 
     _NOISE_INSTINCT_CACHE["loaded_at"] = now
@@ -479,35 +502,59 @@ async def load_noise_instincts() -> list[dict[str, Any]]:
 def event_matches_noise_instinct(
     event_fm: dict[str, Any],
     noise_instincts: list[dict[str, Any]],
+    event_body: str | None = None,
 ) -> dict[str, Any] | None:
     """Return the first matching noise instinct (or None).
 
-    We use the event's derived signature (gmail sender, gcal organiser,
-    etc.) as the comparison key and match each instinct's
-    ``sender_domains`` glob list against it. Same fnmatch semantics
-    the deterministic scorer uses, so a noise instinct adopted from a
-    cluster (OBS-5) fires here identically to how it would fire on a
-    full signal-routing pass — except cheaper, since we short-circuit
-    the LLM call.
+    Matches on TWO anchors:
+      * sender-domain globs vs the event's derived signature (gmail
+        sender / gcal organiser / slack user);
+      * subject_keywords substrings vs the event subject/title.
+
+    ``event_body`` is forwarded to ``derive_signature`` so the sender is
+    recoverable from a ``**From**:`` header in the rendered body (the
+    composio-gmail curator often does not stamp a top-level ``from``).
+    Bare (wildcard-free) sender globs are also tried as ``*glob*`` so a
+    hand-authored ``github.com`` anchor matches ``x@notifications.github.com``.
     """
     if not noise_instincts:
         return None
-    sig = derive_signature(event_fm)
+    sig = derive_signature(event_fm, event_body=event_body)
     sig_value = (sig.get("value") or "").strip().lower()
-    if not sig_value:
-        return None
-    # Only sender-anchored signatures are matchable today. Once OBS-5
-    # writes instincts with subject_keywords / attachment patterns,
-    # extend the match here.
-    if sig.get("kind") not in ("gmail_sender", "gcal_organiser", "slack_user"):
-        return None
+    # Subject text for keyword matching — a CI/PR instinct anchors here.
+    subject_text = " ".join(
+        str(event_fm.get(k) or "")
+        for k in ("subject", "title", "name", "display_headline")
+    ).strip().lower()
+    # ``gcal_organiser_title`` is what derive_signature actually emits;
+    # the old allowlist listed ``gcal_organiser`` and was dead.
+    sender_kinds = ("gmail_sender", "gcal_organiser_title", "slack_user")
     for inst in noise_instincts:
-        for glob in inst["sender_domains"]:
-            if fnmatch.fnmatch(sig_value, glob.strip().lower()):
-                return {
-                    "kind": f"instinct_{sig['kind']}",
-                    "value": sig_value,
-                    "path": inst["path"],
-                    "matched_glob": glob,
-                }
+        # 1. sender-domain globs (tolerate a bare domain via *glob*)
+        if sig.get("kind") in sender_kinds and sig_value:
+            for glob in inst.get("sender_domains", []):
+                g = glob.strip().lower()
+                if not g:
+                    continue
+                if fnmatch.fnmatch(sig_value, g) or (
+                    "*" not in g and "?" not in g
+                    and fnmatch.fnmatch(sig_value, f"*{g}*")
+                ):
+                    return {
+                        "kind": f"instinct_{sig['kind']}",
+                        "value": sig_value,
+                        "path": inst["path"],
+                        "matched_glob": glob,
+                    }
+        # 2. subject-keyword substrings (the anchor CI instincts carry)
+        if subject_text:
+            for kw in inst.get("subject_keywords", []):
+                k = kw.strip().lower()
+                if k and k in subject_text:
+                    return {
+                        "kind": "instinct_subject_keyword",
+                        "value": subject_text[:120],
+                        "path": inst["path"],
+                        "matched_keyword": kw,
+                    }
     return None

--- a/packages/learn/src/activities/reflect.py
+++ b/packages/learn/src/activities/reflect.py
@@ -14,50 +14,86 @@ async def validate_proposals(proposals: dict[str, Any]) -> list[dict[str, Any]]:
     """Validate instinct change proposals from the Clerk.
 
     Returns only valid proposals with their action type tagged.
+
+    Tolerant of malformed clerk output: a non-dict envelope, a non-list
+    bucket, a bare-string entry (treated as an instinct path/id), or one
+    bad entry must NEVER crash the activity. A crash here retried forever
+    and wedged ReflectionWorkflow (the third wedge found on the home
+    canary: the clerk returned a bare-string ``deprecate`` entry and
+    ``dep.get(...)`` raised AttributeError).
     """
     valid: list[dict[str, Any]] = []
+    if not isinstance(proposals, dict):
+        return valid
+
+    def _bucket(key: str) -> list:
+        v = proposals.get(key)
+        return v if isinstance(v, list) else []
 
     # Process creates
-    for instinct in proposals.get("create", []):
-        proposal = {"action": "create", "instinct": instinct}
-        result = validate_instinct_proposal(proposal)
-        if result.valid:
-            valid.append(proposal)
+    for instinct in _bucket("create"):
+        if not isinstance(instinct, dict):
+            continue
+        try:
+            proposal = {"action": "create", "instinct": instinct}
+            if validate_instinct_proposal(proposal).valid:
+                valid.append(proposal)
+        except Exception:  # noqa: BLE001 — one bad proposal must not wedge the run
+            continue
 
-    # Process updates
-    for update in proposals.get("update", []):
-        proposal = {
-            "action": "update",
-            "path": update.get("instinct_id", update.get("path", "")),
-            "changes": update.get("changes", {}),
-            "name": update.get("name", ""),
-        }
-        result = validate_instinct_proposal(proposal)
-        if result.valid:
-            valid.append(proposal)
+    # Process updates (a bare string == the instinct path/id)
+    for update in _bucket("update"):
+        if isinstance(update, str):
+            update = {"path": update}
+        if not isinstance(update, dict):
+            continue
+        try:
+            proposal = {
+                "action": "update",
+                "path": update.get("instinct_id", update.get("path", "")),
+                "changes": update.get("changes", {}),
+                "name": update.get("name", ""),
+            }
+            if validate_instinct_proposal(proposal).valid:
+                valid.append(proposal)
+        except Exception:  # noqa: BLE001
+            continue
 
     # Process merges
-    for merge in proposals.get("merge", []):
-        proposal = {
-            "action": "merge",
-            "source_paths": merge.get("source_ids", merge.get("source_paths", [])),
-            "merged_instinct": merge.get("merged_instinct", {}),
-            "name": merge.get("merged_instinct", {}).get("name", "merged"),
-        }
-        result = validate_instinct_proposal(proposal)
-        if result.valid:
-            valid.append(proposal)
+    for merge in _bucket("merge"):
+        if not isinstance(merge, dict):
+            continue
+        try:
+            merged = merge.get("merged_instinct", {})
+            if not isinstance(merged, dict):
+                merged = {}
+            proposal = {
+                "action": "merge",
+                "source_paths": merge.get("source_ids", merge.get("source_paths", [])),
+                "merged_instinct": merged,
+                "name": merged.get("name", "merged"),
+            }
+            if validate_instinct_proposal(proposal).valid:
+                valid.append(proposal)
+        except Exception:  # noqa: BLE001
+            continue
 
-    # Process deprecations
-    for dep in proposals.get("deprecate", []):
-        proposal = {
-            "action": "deprecate",
-            "path": dep.get("instinct_id", dep.get("path", "")),
-            "reason": dep.get("reason", ""),
-            "name": dep.get("name", ""),
-        }
-        result = validate_instinct_proposal(proposal)
-        if result.valid:
-            valid.append(proposal)
+    # Process deprecations (a bare string == the instinct path/id)
+    for dep in _bucket("deprecate"):
+        if isinstance(dep, str):
+            dep = {"path": dep}
+        if not isinstance(dep, dict):
+            continue
+        try:
+            proposal = {
+                "action": "deprecate",
+                "path": dep.get("instinct_id", dep.get("path", "")),
+                "reason": dep.get("reason", ""),
+                "name": dep.get("name", ""),
+            }
+            if validate_instinct_proposal(proposal).valid:
+                valid.append(proposal)
+        except Exception:  # noqa: BLE001
+            continue
 
     return valid

--- a/packages/learn/src/activities/signals.py
+++ b/packages/learn/src/activities/signals.py
@@ -1558,6 +1558,7 @@ async def extract_signal_from_event(
             if noise_instincts and event_fm_for_match:
                 matched = event_matches_noise_instinct(
                     event_fm_for_match, noise_instincts,
+                    event_body=_event_body(event),
                 )
                 if matched is not None:
                     logger.info(
@@ -2202,6 +2203,7 @@ async def extract_signals_from_event(
             if noise_instincts and event_fm_for_match:
                 matched = event_matches_noise_instinct(
                     event_fm_for_match, noise_instincts,
+                    event_body=_event_body(event),
                 )
                 if matched is not None:
                     logger.info(

--- a/packages/learn/src/activities/vault.py
+++ b/packages/learn/src/activities/vault.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 from datetime import datetime
 from typing import Any, Optional
@@ -766,14 +767,18 @@ async def fetch_unprocessed_observations() -> list[dict[str, Any]]:
         # list_observation_records doesn't expose it, so query directly.
         from src.utils.signal_state import StateClient, observation_row_to_record
 
-        # Batch capped at 75: clerk_reflect sends every fetched observation to
-        # the LLM in one prompt. At 200 the call blew past clerk_reflect's
-        # StartToClose timeout (the whole ReflectionWorkflow then failed and
-        # marked nothing processed — so a backlog could never drain). 75 keeps a
-        # single reflection comfortably inside the timeout; the backlog drains
-        # across successive runs instead of choking on one oversized batch.
+        # Batch size (env-tunable via REFLECTION_BATCH_SIZE, default 250).
+        # clerk_reflect sends EVERY fetched observation to the LLM in ONE
+        # prompt, so batch size == the number of clerk/Codex calls needed to
+        # drain the backlog. A bigger batch means far fewer LLM calls (gentler
+        # on Codex quota) at the cost of one longer call — paired with the 900s
+        # clerk_reflect StartToClose timeout in ReflectionWorkflow. History: 75
+        # paired with a 300s timeout; 200@300s once overflowed and drained
+        # nothing, so keep the batch and the timeout moving together. Set
+        # REFLECTION_BATCH_SIZE higher for a one-off catch-up drain.
+        batch = int(os.environ.get("REFLECTION_BATCH_SIZE", "250") or "250")
         async with StateClient(config) as sc:
-            rows = await sc.list_observations(status="unprocessed", limit=75)
+            rows = await sc.list_observations(status="unprocessed", limit=batch)
         return [observation_row_to_record(r) for r in rows]
     except Exception:  # noqa: BLE001
         return []
@@ -892,7 +897,18 @@ name: Intuition Index
             obs_count = inst.get("observation_count", 0)
             content += f"- [[{path}]] — {name} ({obs_count} observations)\n"
 
-        await client.write_record("index", "intuition-index", content)
+        # Best-effort: "index" is NOT a canonical vault type — ctrl-api's
+        # promotion contract 422s it — and NOTHING in the learning loop reads
+        # this file (it is a cosmetic convenience index). A failure here must
+        # NEVER wedge ReflectionWorkflow: an uncapped 422 on this write left the
+        # workflow retrying for a month, so the observation backlog never drained
+        # and no instinct was ever promoted. Log and move on.
+        try:
+            await client.write_record("index", "intuition-index", content)
+        except Exception as exc:  # noqa: BLE001 — cosmetic; must not fail the run
+            activity.logger.warning(
+                "rebuild_intuition_index: index write skipped (%s)", exc
+            )
     finally:
         await client.close()
 
@@ -941,8 +957,23 @@ Reviewed {len(observations)} observations. Applied {changes} instinct changes.
             detail = p.get("name", p.get("path", ""))
             content += f"- **{action}**: {detail}\n"
 
-        path = await client.write_record("reflection", f"reflection-{date_str}", content)
-        return path
+        # Best-effort: "reflection" is NOT a canonical vault type — ctrl-api's
+        # promotion contract 422s it since the storage cutover — and NOTHING in
+        # the learning loop READS this report (it is a human-facing nightly
+        # summary). A failure here must NEVER wedge ReflectionWorkflow: this is
+        # the SECOND wedge point after rebuild_intuition_index — once step 7 was
+        # made non-fatal, replayed runs stalled HERE instead (found on the home
+        # canary). Log and move on so observations still drain and instincts
+        # still promote.
+        try:
+            return await client.write_record(
+                "reflection", f"reflection-{date_str}", content
+            )
+        except Exception as exc:  # noqa: BLE001 — cosmetic; must not fail the run
+            activity.logger.warning(
+                "write_reflection_report: report write skipped (%s)", exc
+            )
+            return ""
     finally:
         await client.close()
 

--- a/packages/learn/src/workflows/reflection.py
+++ b/packages/learn/src/workflows/reflection.py
@@ -71,11 +71,14 @@ class ReflectionWorkflow:
         proposals = await workflow.execute_activity(
             clerk_reflect,
             args=[observations, instincts, distiller_learnings, janitor_flags],
-            # 300s (was 120s): one LLM pass over the observation batch + the full
-            # instinct set is slow; 120s timed out, failed the whole workflow, and
-            # left every observation unprocessed (a backlog could never drain).
-            # Paired with the batch cap of 75 in fetch_unprocessed_observations.
-            start_to_close_timeout=timedelta(seconds=300),
+            # 900s: one LLM pass over the whole observation batch + the full
+            # instinct set is slow, and the batch is now larger + env-tunable
+            # (REFLECTION_BATCH_SIZE, default 250) to keep Codex/clerk CALL COUNT
+            # low when draining a backlog. Timeout must move WITH the batch size:
+            # 120s@small and 300s@75 both timed out and marked nothing processed.
+            # retry cap 2 so a genuine overflow fails fast (doesn't burn quota
+            # retrying forever).
+            start_to_close_timeout=timedelta(seconds=900),
             retry_policy=RetryPolicy(maximum_attempts=2),
         )
 
@@ -103,17 +106,28 @@ class ReflectionWorkflow:
             start_to_close_timeout=timedelta(seconds=30),
         )
 
-        # 7. Rebuild intuition index
+        # 7. Rebuild intuition index (cosmetic — nothing in the loop reads it).
+        # Cap retries so a failure fails fast instead of wedging the whole
+        # workflow. An uncapped promotion-contract 422 here retried ~26k times
+        # over a month and blocked the schedule from ever draining the
+        # observation backlog. The activity now also swallows the 422
+        # (belt-and-suspenders); this cap bounds any other failure mode.
+        # (Adding retry_policy to an existing activity call is replay-safe.)
         await workflow.execute_activity(
             rebuild_intuition_index,
             start_to_close_timeout=timedelta(seconds=30),
+            retry_policy=RetryPolicy(maximum_attempts=1),
         )
 
-        # 8. Write reflection report
+        # 8. Write reflection report (human-facing summary; nothing in the loop
+        # reads it). Bounded retries so no failure mode can wedge the workflow —
+        # the "reflection" type is non-canonical and 422s (the activity now
+        # swallows that), and a transient error must not retry forever.
         report_path: str = await workflow.execute_activity(
             write_reflection_report,
             args=[observations, valid_proposals, changes],
             start_to_close_timeout=timedelta(seconds=30),
+            retry_policy=RetryPolicy(maximum_attempts=3),
         )
 
         return ReflectionResult(changes=changes, report=report_path)

--- a/packages/learn/tests/test_bug3_suppress_ci_github_noise.py
+++ b/packages/learn/tests/test_bug3_suppress_ci_github_noise.py
@@ -1,0 +1,103 @@
+"""BUG 3 — a matched suppression instinct must actually suppress.
+
+`suppress-ci-github-workflow-noise` was matched for display but never
+enforced: the extract-time noise filter (`load_noise_instincts` +
+`event_matches_noise_instinct`) skipped it (it carries
+`routing_rule.destination_type: hold`, not `intent_key: noise`), the
+`gcal_organiser` kind check was dead, its bare `github.com` glob never
+matched `notifications@github.com`, and its `subject_keywords` were
+never consulted. These pin the fix.
+"""
+from __future__ import annotations
+
+from src.activities.noise_patterns import (
+    event_matches_noise_instinct,
+    load_noise_instincts,
+)
+
+
+def _ci_instinct() -> dict:
+    return {
+        "path": "instinct/suppress-ci-github-workflow-noise.md",
+        "sender_domains": ["github.com"],  # bare, no wildcard (hand-authored)
+        "subject_keywords": ["CI failed", "workflow failed"],
+    }
+
+
+def test_bare_domain_glob_matches_real_sender() -> None:
+    # notifications@github.com must match a bare "github.com" anchor.
+    event = {"source_type": "gmail", "from": "GitHub <notifications@github.com>"}
+    m = event_matches_noise_instinct(event, [_ci_instinct()])
+    assert m is not None
+    assert m["path"] == "instinct/suppress-ci-github-workflow-noise.md"
+
+
+def test_sender_recovered_from_body() -> None:
+    # No top-level `from`; the sender lives only in the rendered body.
+    event = {"source_type": "gmail"}
+    body = "**From**: GitHub <notifications@github.com>\n**Subject**: run failed"
+    m = event_matches_noise_instinct(event, [_ci_instinct()], event_body=body)
+    assert m is not None
+
+
+def test_subject_keyword_match_without_sender() -> None:
+    event = {"source_type": "gmail", "subject": "CI failed on main"}
+    inst = {
+        "path": "instinct/x.md",
+        "sender_domains": [],
+        "subject_keywords": ["CI failed"],
+    }
+    m = event_matches_noise_instinct(event, [inst])
+    assert m is not None
+    assert m["matched_keyword"] == "CI failed"
+    assert m["kind"] == "instinct_subject_keyword"
+
+
+def test_non_github_stays_narrow() -> None:
+    event = {"source_type": "gmail", "from": "hello@example.com", "subject": "Lunch?"}
+    assert event_matches_noise_instinct(event, [_ci_instinct()]) is None
+
+
+async def test_load_honours_destination_type_hold(monkeypatch) -> None:
+    """An instinct with routing_rule.destination_type=hold and NO
+    intent_key must still load (it was invisible to the old gate)."""
+    import src.activities.noise_patterns as np
+
+    class _Resp:
+        status_code = 200
+
+        def json(self) -> dict:
+            return {
+                "results": [
+                    {
+                        "path": "instinct/suppress-ci-github-workflow-noise.md",
+                        "frontmatter": {
+                            "status": "active",
+                            "routing_rule": {"destination_type": "hold"},
+                            "input_patterns": {
+                                "sender_domains": ["github.com"],
+                                "subject_keywords": ["CI failed"],
+                            },
+                        },
+                    }
+                ]
+            }
+
+    class _Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get(self, *a, **k):
+            return _Resp()
+
+    monkeypatch.setattr(np, "_http", lambda: _Client())
+    np._NOISE_INSTINCT_CACHE["loaded_at"] = 0.0  # bust the 60s cache
+    out = await load_noise_instincts()
+    np._NOISE_INSTINCT_CACHE["loaded_at"] = 0.0  # don't poison other tests
+    assert len(out) == 1
+    assert out[0]["path"] == "instinct/suppress-ci-github-workflow-noise.md"
+    assert out[0]["sender_domains"] == ["github.com"]
+    assert out[0]["subject_keywords"] == ["CI failed"]

--- a/packages/learn/tests/test_decision_observation_sender_from_state.py
+++ b/packages/learn/tests/test_decision_observation_sender_from_state.py
@@ -1,0 +1,93 @@
+"""BUG 2 — Desk clicks must link to instincts (sender resolved post-cutover).
+
+`_resolve_sender_for_needs_attention` chased the signal/event over the
+VAULT route, but post-4-store-cutover the NA card's `source_signal_path`
+is a state.db ULID and its `source_event_path` is an `ingest:<id>` ref —
+both 404 on the vault route, so sender="" and `instinct_ref` stayed NULL
+for ~81% of clicks. The resolver must read the signal from state.db and
+the event from ingest.db.
+"""
+from __future__ import annotations
+
+from src.activities import decision_observations as dobs
+
+
+class _Resp:
+    def __init__(self, status: int, payload: dict) -> None:
+        self.status_code = status
+        self._p = payload
+
+    def json(self) -> dict:
+        return self._p
+
+
+class _NAClient:
+    """Stands in for the httpx client: only the NA-card vault read is
+    served here; the signal/event reads go through the state.db / ingest
+    helpers (monkeypatched below), NOT this client."""
+
+    async def get(self, url: str, *a, **k):
+        if url.startswith("/api/v1/vault/records/needs_attention/"):
+            return _Resp(200, {"frontmatter": {
+                "source_signal_path": "01ULIDSIGNAL0000000000000",
+                "source_event_path": "ingest:01ULIDEVENT0000000000000",
+            }})
+        # Any attempt to read the ULID/ingest ref over the vault route
+        # 404s — exactly the pre-cutover breakage this fix routes around.
+        return _Resp(404, {})
+
+
+async def test_sender_resolved_from_state_and_ingest(monkeypatch) -> None:
+    import src.utils.signal_state as sstate
+    import src.activities.signals as sigmod
+
+    async def fake_read_signal(ref, **k):
+        assert ref == "01ULIDSIGNAL0000000000000"
+        return {"frontmatter": {
+            "source_event_path": "ingest:01ULIDEVENT0000000000000",
+            "raw_quote": "Your run failed — body only, no From header",
+        }}
+
+    async def fake_fetch_ingest(evid):
+        assert evid == "01ULIDEVENT0000000000000"
+        return {"frontmatter": {
+            "source_type": "gmail",
+            "from": "GitHub <notifications@github.com>",
+            "subject": "CI workflow failed",
+        }}
+
+    monkeypatch.setattr(sstate, "read_signal_record", fake_read_signal)
+    monkeypatch.setattr(sigmod, "_fetch_ingest_event_as_record", fake_fetch_ingest)
+
+    sender = await dobs._resolve_sender_for_needs_attention(
+        _NAClient(), "needs_attention/card.md",
+    )
+    # Pre-fix: "" (vault GET of the ULID 404s). Post-fix: recovered.
+    assert "notifications@github.com" in sender
+
+
+async def test_sender_falls_back_to_na_card_event_path_when_signal_evicted(
+    monkeypatch,
+) -> None:
+    """If the signal row aged out of state.db but the ingest event
+    survives, recover the sender from the NA card's own event ref."""
+    import src.utils.signal_state as sstate
+    import src.activities.signals as sigmod
+
+    async def fake_read_signal(ref, **k):
+        return None  # signal evicted
+
+    async def fake_fetch_ingest(evid):
+        assert evid == "01ULIDEVENT0000000000000"
+        return {"frontmatter": {
+            "source_type": "gmail",
+            "from": "GitHub <notifications@github.com>",
+        }}
+
+    monkeypatch.setattr(sstate, "read_signal_record", fake_read_signal)
+    monkeypatch.setattr(sigmod, "_fetch_ingest_event_as_record", fake_fetch_ingest)
+
+    sender = await dobs._resolve_sender_for_needs_attention(
+        _NAClient(), "needs_attention/card.md",
+    )
+    assert "notifications@github.com" in sender

--- a/packages/learn/tests/test_reflection_index_write_nonfatal.py
+++ b/packages/learn/tests/test_reflection_index_write_nonfatal.py
@@ -1,0 +1,48 @@
+"""BUG 1 — rebuild_intuition_index must never wedge ReflectionWorkflow.
+
+The "index" vault type is rejected by ctrl-api's promotion contract
+(HTTP 422). Before the fix, that write raised, the workflow step had no
+retry cap, and ReflectionWorkflow retried it ~26k times over a month —
+so the observation backlog never drained and no instinct was ever
+promoted. The activity must now swallow the write failure and return.
+"""
+from __future__ import annotations
+
+from src.activities import vault as vmod
+
+
+async def test_rebuild_intuition_index_swallows_write_failure(monkeypatch) -> None:
+    class _FakeClient:
+        async def list_records(self, _type):
+            return [{"name": "n", "path": "instinct/n.md", "observation_count": 1}]
+
+        async def write_record(self, *a, **k):
+            # Mirror the real ctrl-api rejection of a non-canonical type.
+            raise RuntimeError("422 PROMOTION_CONTRACT_VIOLATION: index")
+
+        async def close(self):
+            return None
+
+    monkeypatch.setattr(vmod, "VaultClient", lambda *a, **k: _FakeClient())
+    monkeypatch.setattr(vmod, "load_config", lambda: object())
+
+    # Must NOT raise. (Pre-fix this propagated the 422 and wedged the run.)
+    await vmod.rebuild_intuition_index()
+
+
+async def test_write_reflection_report_swallows_write_failure(monkeypatch) -> None:
+    # The SECOND wedge point (found on the home canary): "reflection" is also a
+    # non-canonical type → 422. Must swallow and return "" so the workflow
+    # completes and the observation backlog drains.
+    class _FakeClient:
+        async def write_record(self, *a, **k):
+            raise RuntimeError("422 PROMOTION_CONTRACT_VIOLATION: reflection")
+
+        async def close(self):
+            return None
+
+    monkeypatch.setattr(vmod, "VaultClient", lambda *a, **k: _FakeClient())
+    monkeypatch.setattr(vmod, "load_config", lambda: object())
+
+    out = await vmod.write_reflection_report([], [], 0)
+    assert out == ""

--- a/packages/learn/tests/test_relight_learning_loop.py
+++ b/packages/learn/tests/test_relight_learning_loop.py
@@ -39,12 +39,15 @@ def test_reflection_fetch_batch_is_bounded():
     from src.activities import vault
 
     src = inspect.getsource(vault.fetch_unprocessed_observations)
-    m = re.search(r"list_observations\([^)]*limit=(\d+)", src, re.DOTALL)
-    assert m, "fetch_unprocessed_observations must pass an explicit limit"
-    limit = int(m.group(1))
-    # 200 was the value that overflowed clerk_reflect's timeout. Keep the batch
-    # small enough that one reflection comfortably completes.
-    assert limit <= 100, f"reflection batch limit {limit} is too large (was 200)"
+    # Batch is env-tunable (REFLECTION_BATCH_SIZE) so a one-off backlog drain can
+    # use bigger batches — fewer clerk/Codex CALLS for the same work. The DEFAULT
+    # must stay bounded so a nightly run fits clerk_reflect's (900s) timeout; it
+    # must move together with that timeout, never unbounded.
+    assert "REFLECTION_BATCH_SIZE" in src, "reflection batch size should be env-tunable"
+    m = re.search(r'REFLECTION_BATCH_SIZE",\s*"(\d+)"', src)
+    assert m, "REFLECTION_BATCH_SIZE must carry a numeric default"
+    default = int(m.group(1))
+    assert 75 <= default <= 500, f"reflection default batch {default} out of range"
 
 
 def test_reflection_clerk_timeout_has_headroom():

--- a/packages/learn/tests/test_validate_proposals_robust.py
+++ b/packages/learn/tests/test_validate_proposals_robust.py
@@ -1,0 +1,42 @@
+"""BUG (3rd wedge, found on the home canary) — validate_proposals must
+tolerate ANY clerk output shape without crashing.
+
+A crash here (the clerk returned a bare-STRING `deprecate` entry, so
+`dep.get(...)` raised AttributeError) retried forever and wedged
+ReflectionWorkflow one step after the index/report writes.
+"""
+from __future__ import annotations
+
+from src.activities.reflect import validate_proposals
+
+
+async def test_bare_string_entries_do_not_crash() -> None:
+    # The exact shape that wedged home: bare-string deprecate/update entries.
+    proposals = {
+        "deprecate": ["instinct/foo.md"],
+        "update": ["instinct/bar.md"],
+        "create": ["not-a-dict"],
+        "merge": ["also-not-a-dict"],
+    }
+    out = await validate_proposals(proposals)  # must NOT raise
+    assert isinstance(out, list)
+
+
+async def test_non_dict_envelope_returns_empty() -> None:
+    assert await validate_proposals(None) == []  # type: ignore[arg-type]
+    assert await validate_proposals([]) == []  # type: ignore[arg-type]
+
+
+async def test_non_list_buckets_ignored() -> None:
+    out = await validate_proposals({"create": "oops", "deprecate": None})
+    assert out == []
+
+
+async def test_well_formed_update_still_processed() -> None:
+    # Regression: a normal dict update must still flow through.
+    out = await validate_proposals(
+        {"update": [{"instinct_id": "instinct/x.md", "changes": {"observation_count": 5}}]}
+    )
+    assert isinstance(out, list)
+    # (validity depends on the instinct validator; we only assert no crash
+    # and that a dict entry is not dropped by the shape guards.)


### PR DESCRIPTION
## Summary
Instinct learning was silently dead on live tenants — proven on **home** via the GitHub-CI-noise case (588 "noise" clicks, 81% of decision-observations unlinked, the CI instinct never enforced). Root-caused to **five** independent breaks in the reflection/observation path, any one of which alone froze learning. All fixed surgically in `packages/learn` (Lane II), forbidden zone untouched.

## The five breaks
1. **Reflection wedged ~1 month** — `rebuild_intuition_index` writes a `type:index` vault record → ctrl-api 422 → uncapped retry → workflow never completed → backlog never drained, `apply_instinct_change` never ran. → best-effort write + retry cap.
2. **`write_reflection_report` (step 8)** — same `type:reflection` 422 one step down (surfaced on the home canary once step 7 was unblocked). → best-effort + retry cap.
3. **`validate_proposals` crash (step 4)** — crashed on a bare-string clerk `deprecate` entry (`dep.get` → AttributeError), infinite retry (also canary-found). → tolerant of any clerk output shape.
4. **Clicks never linked to instincts** — `_resolve_sender_for_needs_attention` read the signal/event over the vault route, but post-4-store-cutover those are state.db ULIDs / `ingest:` refs → 404 → `sender=""` → `instinct_ref` NULL on 81% of decision-observations. → read signal from state.db, event from ingest.db.
5. **Matched suppression instinct never enforced** — extract-time noise filter only honored `intent_key:noise` (missed `destination_type:hold`), dead `gcal_organiser` kind, no body-sender recovery, bare-glob miss, ignored `subject_keywords`. → all fixed.

Plus: reflection batch made env-tunable (`REFLECTION_BATCH_SIZE`, default 250) paired with a 300→900s clerk timeout — one clerk/Codex call drains 250 observations instead of 75 (~3.7× fewer calls to drain a backlog; gentler on Codex quota).

## Smoke evidence
Canary-deployed live to **home** (hot-patch: `docker cp` + `docker restart`) and verified end-to-end:
- All **7 wedged ReflectionWorkflow runs self-healed to Completed** (no manual termination — the step-8 best-effort let them finish).
- Fresh triggered runs **Completed** and **drained the backlog**: `observation` status `processed` **679 → 754 → 1004** (a 250-batch run completed in ~2 min, well inside the 900s timeout; `index write skipped` + `report write skipped` logged and swallowed cleanly).
- `load_noise_instincts()` now returns the CI instinct (**0 → 1**: `suppress-ci-github-workflow-noise`, `github.com` + 8 subject-keywords) → future GitHub-CI is filtered pre-Desk.
- Local: 4 new failing-tests-first files (red→green); full `packages/learn` suite green (**2351 passed**; only pre-existing `fastapi`/`openpyxl` import errors, unrelated). CI `pytest-learn` green on this PR.

## Rollout
Deploy `alfred-learn:latest` to home (replaces the hot-patch with the durable image), then zsolt + miguel. No manual wedged-run termination needed — the step-8 best-effort lets stuck runs self-complete. Backlog drains 250/night via the al-reflection schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)