### PR TITLE
fix(ctrl): spawn_alfred_task returns 500 fleet-wide — migrate to current hermes cron create CLI

### DIFF
--- a/packages/ctrl/src/api/routes/agents.ts
+++ b/packages/ctrl/src/api/routes/agents.ts
@@ -527,24 +527,33 @@ export function registerAgentRoutes(): void {
       }
     }
 
+    // Hermes `cron create` CLI. The retired OpenClaw interface
+    // (`cron add --agent/--at/--delete-after-run/--message/--best-effort-deliver
+    // /--announce/--channel/--to/--no-deliver/--json`) no longer exists — the
+    // current Hermes CLI rejects every one of those flags, so this endpoint
+    // (and thus spawn_alfred_task) returned HTTP 500 on every tenant until this
+    // fix. Real grammar (identical on 0.14 + 0.17):
+    //   hermes -p main cron create <schedule> <prompt> --name <n> --deliver <t>
+    // - `schedule` is a POSITIONAL duration string. Sub-minute is unsupported
+    //   (`'5s'` → "Invalid schedule"), so the floor is 1m; the old `--at 1s`
+    //   "≈immediate" becomes "≈1m" (the smallest one-shot the scheduler takes).
+    // - One-shot DURATION jobs auto-remove after firing (no --delete-after-run).
+    // - Delivery is a single `--deliver` target: `<platform>:<chat_id>` when
+    //   announcing to a resolved channel, `origin` as a fallback, `local` for a
+    //   silent background run (no external DM).
+    const scheduleMinutes = Math.max(1, Math.ceil(atSeconds / 60));
     const args = [
       ...HERMES_CMD,
-      "cron", "add",
+      "-p", "main",
+      "cron", "create",
+      `${scheduleMinutes}m`,
+      task,
       "--name", jobName,
-      "--agent", "main",
-      "--at", `${atSeconds}s`,
-      "--delete-after-run",
-      "--message", task,
-      "--best-effort-deliver",
-      "--json",
     ];
     if (announce) {
-      args.push("--announce", "--channel", effectiveChannel);
-      if (toTarget) {
-        args.push("--to", toTarget);
-      }
+      args.push("--deliver", toTarget ? `${effectiveChannel}:${toTarget}` : "origin");
     } else {
-      args.push("--no-deliver");
+      args.push("--deliver", "local");
     }
 
     try {

--- a/packages/ctrl/tests/agents.test.ts
+++ b/packages/ctrl/tests/agents.test.ts
@@ -222,3 +222,54 @@ describe("PATCH /api/v1/admin/agents/:agentId/model", () => {
     assert.ok(data.agent?.id === "main");
   });
 });
+
+describe("POST /api/v1/agents/main/task (spawn_alfred_task)", () => {
+  // Regression: the handler shelled out to the retired OpenClaw cron interface
+  // (`cron add --agent/--at/--delete-after-run/--message/--announce/--channel/
+  // --to/--best-effort-deliver/--no-deliver/--json`). The current Hermes CLI
+  // rejects every one of those flags, so spawn_alfred_task returned HTTP 500 on
+  // every tenant. These lock in the current `cron create` grammar.
+  const cronArgv = () =>
+    execFileFn.mock.calls
+      .map((c: any) => c.arguments)
+      .find((a: any) => Array.isArray(a?.[1]) && a[1].includes("cron"))?.[1] as string[] | undefined;
+
+  it("uses `hermes -p main cron create <schedule> <prompt> --deliver`, not the retired `cron add` flags", async () => {
+    execFileStdout = "Created job: abc123\n  Name: unit-test-job\n  Schedule: once in 1m";
+    execFileFn.mock.resetCalls();
+    const { status } = await req("POST", "/api/v1/agents/main/task", {
+      task: "do the thing", announce: false, name: "unit-test-job",
+    });
+    assert.strictEqual(status, 202);
+    const argv = cronArgv();
+    assert.ok(argv, "expected an execFile call invoking the hermes cron CLI");
+    assert.ok(argv!.includes("create"), "must use `cron create`");
+    assert.ok(!argv!.includes("add"), "must NOT use the retired `cron add`");
+    assert.ok(argv!.includes("-p") && argv![argv!.indexOf("-p") + 1] === "main", "targets `-p main`");
+    assert.ok(argv!.some((x) => /^\d+m$/.test(x)), "positional duration schedule (e.g. `1m`)");
+    assert.ok(argv!.includes("do the thing"), "prompt passed as a positional, not `--message`");
+    // announce:false → silent local delivery
+    const di = argv!.indexOf("--deliver");
+    assert.ok(di >= 0 && argv![di + 1] === "local", "announce:false → `--deliver local`");
+    // every retired flag must be gone
+    for (const dead of [
+      "--agent", "--at", "--delete-after-run", "--message",
+      "--best-effort-deliver", "--announce", "--channel", "--to",
+      "--no-deliver", "--json",
+    ]) {
+      assert.ok(!argv!.includes(dead), `retired flag ${dead} must not be passed`);
+    }
+  });
+
+  it("maps an announced delivery to `--deliver <channel>:<to>`", async () => {
+    execFileStdout = "Created job: x";
+    execFileFn.mock.resetCalls();
+    const { status } = await req("POST", "/api/v1/agents/main/task", {
+      task: "hi", announce: true, channel: "telegram", to: "12345",
+    });
+    assert.strictEqual(status, 202);
+    const argv = cronArgv();
+    const di = argv!.indexOf("--deliver");
+    assert.ok(di >= 0 && argv![di + 1] === "telegram:12345", "announce + to → `--deliver telegram:12345`");
+  });
+});


### PR DESCRIPTION
## Problem
`spawn_alfred_task` (POST `/api/v1/agents/main/task`) shelled out to the **retired
OpenClaw cron interface** — `hermes cron add --agent main --at 1s
--delete-after-run --message <t> --best-effort-deliver --json [--announce
--channel --to | --no-deliver]`. The current Hermes CLI rejects all of those
flags, so **every call returned HTTP 500, on every tenant**. "Tell Alfred to do
X" (run a skill, post a briefing, delegate a one-shot) was dead fleet-wide.

Confirmed live on joe:
```
{"status":"error","error":"docker failed (2): ... hermes: error: unrecognized
arguments: --agent --at --delete-after-run --message ... --no-deliver"}  HTTP 500
```

## Root cause
CLI drift. The real grammar (identical on Hermes **0.14 and 0.17**) is:
```
hermes -p main cron create <schedule> [prompt] --name <n> --deliver <target>
```
positional `schedule` (duration/interval/cron/timestamp) + positional `prompt`;
delivery via a single `--deliver`. The ctrl-api code was never migrated off the
OpenClaw `cron add` flags.

## Fix
Rewrite the one handler to `cron create`:
- schedule → positional duration; sub-minute unsupported (`'5s'` → "Invalid
  schedule"), so floor to `1m` (old `--at 1s` ≈immediate → ≈1m, the smallest
  one-shot the scheduler accepts),
- prompt → positional (not `--message`),
- delivery → `--deliver <channel>:<to>` (announce, resolved), `origin`
  (fallback), `local` (silent),
- drop all 10 retired flags; one-shot duration jobs auto-remove (no
  `--delete-after-run`).

## Smoke evidence
- **Broken path** (live joe): `cron add --agent …` → HTTP 500 (above).
- **Fixed path** (live joe): the exact emitted command
  `hermes -p main cron create "1m" "<prompt>" --name X --deliver local` →
  `Created job: 19450df9c0a5 … Schedule: once in 1m` ✓. One-shot confirmed.
- **Build**: esbuild bundle clean on the edited `agents.ts`.
- **Logic check** (standalone): handler emits
  `hermes -p main cron create 1m … --deliver local` (silent) and
  `… --deliver telegram:12345` (announce+to) — all assertions pass.
- **Regression test** added (`agents.test.ts`): asserts `cron create` (not
  `add`), `-p main`, positional duration + prompt, correct `--deliver`, and the
  **absence of all 10 retired flags** — red against the old handler.
  (node:test needs `tsx`, run in CI `ci-check`.)

## Deploy
ctrl-api `:latest` is identical on every tenant, so this was broken everywhere.
Merge → `build-ctrl-api` → `deploy-fleet` rolls `ctrl-api` fleet-wide. I'll then
POST a live spawn to a tenant to confirm 202 end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
