### PR TITLE
feat(mcp): per-app scoped bearer tokens + management UI

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -632,6 +632,13 @@ services:
       # point it at the profiles parent so paths resolve to
       # /hermes-state/profiles/{main,workers}/config.yaml
       - HERMES_CONFIG_DIR=/hermes-state/profiles
+      # MCP scoped-token management proxy (/api/v1/mcp/tokens/*). ctrl-api
+      # forwards the dashboard's mint/list/rotate/delete calls to mcp-server's
+      # /manage API, presenting MCP_APPROVAL_SECRET as the Bearer. env_file
+      # also injects MCP_APPROVAL_SECRET; pinned explicitly so it's obvious
+      # ctrl-api consumes it, matching the SURE_API_KEY/PAPERCLIP convention.
+      - MCP_SERVER_URL=http://mcp-server:8787
+      - MCP_APPROVAL_SECRET=${MCP_APPROVAL_SECRET:-}
       # Sure REST proxy auth. sure-bootstrap.rb seeds this same value into
       # Sure's DB; ctrl-api's sure.ts reads only process.env.SURE_API_KEY. Pin
       # it explicitly (env_file also injects it) so the bridge is unambiguous —

--- a/packages/ctrl/src/api/routes/mcpTokens.ts
+++ b/packages/ctrl/src/api/routes/mcpTokens.ts
@@ -1,0 +1,96 @@
+// Proxy surface for per-app MCP scoped bearer tokens — `/api/v1/mcp/tokens/*`.
+//
+// The mcp-server container OWNS these tokens: it mints/lists/rotates/deletes
+// them in its own SQLite and validates them locally on every `POST
+// /<app>/mcp` (see packages/mcp-server/src/scopedTokens.ts + index.ts). This
+// module is a THIN server-side proxy so the dashboard can drive that surface
+// without the browser ever holding the tenant-wide MCP_APPROVAL_SECRET:
+//
+//     browser → web (Wasp op) → ctrl-api (here) → mcp-server /manage/tokens
+//
+// It preserves the "web only ever talks to ctrl-api" invariant. Auth: the
+// inbound hop is gated by the global authenticate() middleware (AAS_API_KEY),
+// like every ctrl-api route; the onward hop to mcp-server presents
+// MCP_APPROVAL_SECRET (injected via env_file .env, explicit in compose).
+//
+// PRIVACY: the raw token is returned by mcp-server EXACTLY ONCE (mint +
+// rotate); list responses never carry it. This module relays verbatim, so
+// the same posture holds end-to-end.
+
+import type { ServerResponse } from "node:http";
+import { addRoute } from "../server.js";
+import { sendJson } from "../errors.js";
+
+const MCP_SERVER_URL = (process.env.MCP_SERVER_URL ?? "http://mcp-server:8787").replace(/\/+$/, "");
+
+/** Forward a management call to mcp-server and relay its status + JSON body. */
+async function forward(
+  res: ServerResponse,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<void> {
+  const secret = process.env.MCP_APPROVAL_SECRET ?? "";
+  if (!secret) {
+    sendJson(res, 500, {
+      error: {
+        code: "MCP_NOT_CONFIGURED",
+        message: "MCP_APPROVAL_SECRET is not set on ctrl-api; cannot manage MCP tokens",
+      },
+    });
+    return;
+  }
+  let upstream: Response;
+  try {
+    upstream = await fetch(`${MCP_SERVER_URL}${path}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${secret}`,
+        ...(body !== undefined ? { "Content-Type": "application/json" } : {}),
+      },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+  } catch (err) {
+    sendJson(res, 502, {
+      error: { code: "MCP_UNREACHABLE", message: `mcp-server unreachable: ${(err as Error).message}` },
+    });
+    return;
+  }
+  const text = await upstream.text();
+  let data: unknown;
+  try {
+    data = text ? JSON.parse(text) : {};
+  } catch {
+    data = { raw: text };
+  }
+  sendJson(res, upstream.status, data);
+}
+
+export function registerMcpTokensRoutes(): void {
+  // GET /api/v1/mcp/tokens[?app=<app>] — list token metadata (never the raw
+  // value) + the supported apps + public connector base for the UI.
+  addRoute("GET", "/api/v1/mcp/tokens", async ({ res, query }) => {
+    const app = query.get("app");
+    const qs = app ? `?app=${encodeURIComponent(app)}` : "";
+    await forward(res, "GET", `/manage/tokens${qs}`);
+  });
+
+  // POST /api/v1/mcp/tokens {app, label} — mint. Raw token returned ONCE.
+  addRoute("POST", "/api/v1/mcp/tokens", async ({ res, body }) => {
+    const b = (body ?? {}) as { app?: unknown; label?: unknown };
+    await forward(res, "POST", "/manage/tokens", {
+      app: typeof b.app === "string" ? b.app : "",
+      label: typeof b.label === "string" ? b.label : "",
+    });
+  });
+
+  // POST /api/v1/mcp/tokens/:id/rotate — rotate in place. Raw token ONCE.
+  addRoute("POST", "/api/v1/mcp/tokens/:id/rotate", async ({ res, params }) => {
+    await forward(res, "POST", `/manage/tokens/${encodeURIComponent(params.id)}/rotate`);
+  });
+
+  // DELETE /api/v1/mcp/tokens/:id — delete (hard).
+  addRoute("DELETE", "/api/v1/mcp/tokens/:id", async ({ res, params }) => {
+    await forward(res, "DELETE", `/manage/tokens/${encodeURIComponent(params.id)}`);
+  });
+}

--- a/packages/ctrl/src/api/server.ts
+++ b/packages/ctrl/src/api/server.ts
@@ -75,6 +75,7 @@ import { registerFilesRoutes } from "./routes/files.js";
 import { registerChannelsTailscaleRoutes } from "./routes/channels_tailscale.js";
 import { registerProfileRoutes } from "./routes/profiles.js";
 import { registerChannelIdentityRoutes } from "./routes/channel_identity.js";
+import { registerMcpTokensRoutes } from "./routes/mcpTokens.js";
 
 export interface RouteParams {
   [key: string]: string;
@@ -249,6 +250,10 @@ export function createApiServer(): http.Server {
   // Consumed by Lane IV adapters at send time via resolveChannelIdentity().
   // See packages/ctrl/src/db/migrations/0018_channel_identity.sql.
   registerChannelIdentityRoutes();
+  // /api/v1/mcp/tokens/* — thin proxy to mcp-server's /manage/tokens API so
+  // the dashboard can mint/list/rotate/delete per-app scoped bearer tokens
+  // without the browser holding MCP_APPROVAL_SECRET. web → ctrl-api → mcp-server.
+  registerMcpTokensRoutes();
 
   const server = http.createServer(async (req: IncomingMessage, res: ServerResponse) => {
     const start = Date.now();

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -18,8 +18,10 @@ import type { ZodObject, ZodRawShape } from "zod";
 
 import { loadEnv } from "./env.js";
 import { OAuthStorage } from "./oauth/storage.js";
+import type { ScopedTokenRow } from "./oauth/storage.js";
 import { SqliteOAuthProvider, issueAuthCode, timingSafeEqual } from "./oauth/provider.js";
 import type { MCPProps } from "./oauth/provider.js";
+import { mintScopedToken, verifyScopedToken } from "./scopedTokens.js";
 import { type AppId, getToolsForApp, isAppId, SUPPORTED_APPS } from "./tools/registry.js";
 import type { CtrlContext } from "./tools/types.js";
 import { runTool } from "./tools/types.js";
@@ -234,6 +236,21 @@ async function main() {
           };
           return next();
         }
+        // Per-app scoped bearer token (dashboard-minted, one per vendor).
+        // Bound to exactly this app, so a token for another app's URL
+        // falls through to the OAuth verifier and 401s.
+        if (token && verifyScopedToken(storage, appId, token, Date.now())) {
+          (req as Request & { auth?: unknown }).auth = {
+            token,
+            clientId: "scoped-token",
+            scopes: [],
+            extra: {
+              appId,
+              tenantLabel: env.TENANT_LABEL,
+            } satisfies MCPProps,
+          };
+          return next();
+        }
       }
       // Anything else (no header, malformed, mismatched secret) → defer to
       // the standard OAuth verifier.
@@ -332,6 +349,119 @@ async function main() {
       }
     });
   }
+
+  // ── Management API — per-app scoped bearer tokens ─────────────────────────
+  //
+  // Gated by the tenant-wide MCP_APPROVAL_SECRET. The dashboard calls these
+  // SERVER-SIDE (the web Wasp server holds the secret; the browser never
+  // does), letting Sir mint / list / rotate / delete multiple long-lived
+  // per-app bearer tokens — e.g. one per voice vendor — so third-party
+  // clients (ElevenLabs, LiveKit) authenticate with a scoped credential
+  // instead of the master secret. The raw token is returned ONLY on
+  // create/rotate; list never exposes it.
+  const requireMaster = (req: Request, res: Response, next: NextFunction) => {
+    const header = req.headers.authorization;
+    const token =
+      typeof header === "string" && header.startsWith("Bearer ")
+        ? header.slice("Bearer ".length).trim()
+        : "";
+    if (token && timingSafeEqual(token, env.MCP_APPROVAL_SECRET)) return next();
+    res.status(401).json({ error: "unauthorized" });
+  };
+
+  const publicBase = env.PUBLIC_URL.replace(/\/+$/, "");
+  const connectorUrl = (appId: string) => `${publicBase}/${appId}/mcp`;
+  const publicToken = (t: ScopedTokenRow) => ({
+    id: t.id,
+    app: t.app_id,
+    label: t.label,
+    prefix: t.prefix,
+    url: connectorUrl(t.app_id),
+    created_at: t.created_at,
+    last_used_at: t.last_used_at,
+    revoked: t.revoked_at != null,
+  });
+
+  // List tokens (metadata only), optionally ?app=<app>. Also returns the
+  // supported apps + public base so the UI can render the connector URLs.
+  app.get("/manage/tokens", requireMaster, (req, res) => {
+    const appQ = typeof req.query.app === "string" ? req.query.app : undefined;
+    const filter = appQ && isAppId(appQ) ? appQ : undefined;
+    res.json({
+      tenant: env.TENANT_LABEL,
+      public_url: publicBase,
+      apps: [...SUPPORTED_APPS],
+      transport: "streamable-http",
+      tokens: storage.listScopedTokens(filter).map(publicToken),
+    });
+  });
+
+  // Mint a new token for an app. Returns the raw token ONCE.
+  app.post("/manage/tokens", requireMaster, express.json(), (req, res) => {
+    const body = (req.body ?? {}) as { app?: string; label?: string };
+    const appId = body.app;
+    const label = (body.label ?? "").trim();
+    if (!appId || !isAppId(appId)) {
+      res.status(400).json({ error: `invalid app; must be one of ${[...SUPPORTED_APPS].join(", ")}` });
+      return;
+    }
+    if (!label) {
+      res.status(400).json({ error: "label required" });
+      return;
+    }
+    const minted = mintScopedToken(appId);
+    storage.insertScopedToken({
+      id: minted.id,
+      app_id: appId,
+      token_hash: minted.token_hash,
+      prefix: minted.prefix,
+      label,
+      created_at: Date.now(),
+      last_used_at: null,
+      revoked_at: null,
+    });
+    res.status(201).json({
+      id: minted.id,
+      app: appId,
+      label,
+      prefix: minted.prefix,
+      url: connectorUrl(appId),
+      token: minted.token, // shown once
+    });
+  });
+
+  // Rotate an existing token in place (same id + label, new secret).
+  app.post("/manage/tokens/:id/rotate", requireMaster, (req, res) => {
+    const existing = storage.getScopedTokenById(req.params.id);
+    if (!existing) {
+      res.status(404).json({ error: "not found" });
+      return;
+    }
+    const minted = mintScopedToken(existing.app_id);
+    const ok = storage.rotateScopedToken(existing.id, minted.token_hash, minted.prefix, Date.now());
+    if (!ok) {
+      res.status(404).json({ error: "not found" });
+      return;
+    }
+    res.json({
+      id: existing.id,
+      app: existing.app_id,
+      label: existing.label,
+      prefix: minted.prefix,
+      url: connectorUrl(existing.app_id),
+      token: minted.token, // shown once
+    });
+  });
+
+  // Delete (hard) a token.
+  app.delete("/manage/tokens/:id", requireMaster, (req, res) => {
+    const ok = storage.deleteScopedToken(req.params.id);
+    if (!ok) {
+      res.status(404).json({ error: "not found" });
+      return;
+    }
+    res.json({ ok: true });
+  });
 
   // Catch-all 404 for anything else (the cloudflared ingress should route
   // only `/<app>/mcp` + OAuth paths to us; ctrl-api handles everything else

--- a/packages/mcp-server/src/oauth/storage.ts
+++ b/packages/mcp-server/src/oauth/storage.ts
@@ -59,6 +59,30 @@ export interface RefreshTokenRow {
   rotated_to: string | null;
 }
 
+/**
+ * A long-lived, per-app static bearer token — the headless alternative to
+ * the OAuth flow for non-interactive clients (ElevenLabs / LiveKit voice
+ * agents, scripts). Unlike the tenant-wide `MCP_APPROVAL_SECRET`, each row
+ * is scoped to exactly ONE app and can be listed / rotated / deleted
+ * independently, so a leaked or retired vendor credential is contained.
+ * Only the SHA-256 hash is persisted; the raw token is shown once at mint.
+ */
+export interface ScopedTokenRow {
+  /** Public id used for management (rotate/delete). Never secret. */
+  id: string;
+  /** The single app this token authorizes (`AppId`). */
+  app_id: string;
+  token_hash: string;
+  /** First chars of the raw token, for display in the UI. Not secret. */
+  prefix: string;
+  /** Human label, e.g. "ElevenLabs prod". */
+  label: string;
+  created_at: number;
+  last_used_at: number | null;
+  /** Soft-disable timestamp; a revoked token fails validation. */
+  revoked_at: number | null;
+}
+
 export class OAuthStorage {
   private db: DatabaseSync;
 
@@ -121,6 +145,18 @@ export class OAuthStorage {
       CREATE INDEX IF NOT EXISTS idx_access_expires ON access_tokens(expires_at);
       CREATE INDEX IF NOT EXISTS idx_refresh_expires ON refresh_tokens(expires_at);
       CREATE INDEX IF NOT EXISTS idx_authcodes_expires ON auth_codes(expires_at);
+      CREATE TABLE IF NOT EXISTS scoped_tokens (
+        id TEXT PRIMARY KEY,
+        app_id TEXT NOT NULL,
+        token_hash TEXT NOT NULL UNIQUE,
+        prefix TEXT NOT NULL,
+        label TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        last_used_at INTEGER,
+        revoked_at INTEGER
+      );
+      CREATE INDEX IF NOT EXISTS idx_scoped_app ON scoped_tokens(app_id);
+      CREATE INDEX IF NOT EXISTS idx_scoped_hash ON scoped_tokens(token_hash);
     `);
   }
 
@@ -224,6 +260,73 @@ export class OAuthStorage {
 
   markRefreshRotated(old_hash: string, new_hash: string): void {
     this.db.prepare("UPDATE refresh_tokens SET rotated_to = ? WHERE token_hash = ?").run(new_hash, old_hash);
+  }
+
+  // ── scoped (per-app static) tokens ─────────────────────────────────────────
+
+  private rowToScoped(row: {
+    id: string; app_id: string; token_hash: string; prefix: string; label: string;
+    created_at: number; last_used_at: number | null; revoked_at: number | null;
+  }): ScopedTokenRow {
+    return {
+      id: row.id,
+      app_id: row.app_id,
+      token_hash: row.token_hash,
+      prefix: row.prefix,
+      label: row.label,
+      created_at: row.created_at,
+      last_used_at: row.last_used_at,
+      revoked_at: row.revoked_at,
+    };
+  }
+
+  insertScopedToken(t: ScopedTokenRow): void {
+    this.db.prepare(
+      "INSERT INTO scoped_tokens(id, app_id, token_hash, prefix, label, created_at, last_used_at, revoked_at) VALUES(?, ?, ?, ?, ?, ?, ?, ?)",
+    ).run(t.id, t.app_id, t.token_hash, t.prefix, t.label, t.created_at, t.last_used_at, t.revoked_at);
+  }
+
+  getScopedTokenByHash(token_hash: string): ScopedTokenRow | null {
+    const row = this.db.prepare("SELECT * FROM scoped_tokens WHERE token_hash = ?").get(token_hash) as
+      | Parameters<OAuthStorage["rowToScoped"]>[0] | undefined;
+    return row ? this.rowToScoped(row) : null;
+  }
+
+  getScopedTokenById(id: string): ScopedTokenRow | null {
+    const row = this.db.prepare("SELECT * FROM scoped_tokens WHERE id = ?").get(id) as
+      | Parameters<OAuthStorage["rowToScoped"]>[0] | undefined;
+    return row ? this.rowToScoped(row) : null;
+  }
+
+  /** List tokens (newest first), optionally filtered to one app. Never exposes the hash's preimage. */
+  listScopedTokens(app_id?: string): ScopedTokenRow[] {
+    const rows = (app_id
+      ? this.db.prepare("SELECT * FROM scoped_tokens WHERE app_id = ? ORDER BY created_at DESC").all(app_id)
+      : this.db.prepare("SELECT * FROM scoped_tokens ORDER BY created_at DESC").all()
+    ) as Array<Parameters<OAuthStorage["rowToScoped"]>[0]>;
+    return rows.map((r) => this.rowToScoped(r));
+  }
+
+  touchScopedToken(id: string, ts: number): void {
+    this.db.prepare("UPDATE scoped_tokens SET last_used_at = ? WHERE id = ?").run(ts, id);
+  }
+
+  /** Replace the secret on an existing token in-place (keeps id + label). */
+  rotateScopedToken(id: string, token_hash: string, prefix: string, ts: number): boolean {
+    const r = this.db.prepare(
+      "UPDATE scoped_tokens SET token_hash = ?, prefix = ?, created_at = ?, last_used_at = NULL, revoked_at = NULL WHERE id = ?",
+    ).run(token_hash, prefix, ts, id);
+    return Number(r.changes) > 0;
+  }
+
+  revokeScopedToken(id: string, ts: number): boolean {
+    const r = this.db.prepare("UPDATE scoped_tokens SET revoked_at = ? WHERE id = ?").run(ts, id);
+    return Number(r.changes) > 0;
+  }
+
+  deleteScopedToken(id: string): boolean {
+    const r = this.db.prepare("DELETE FROM scoped_tokens WHERE id = ?").run(id);
+    return Number(r.changes) > 0;
   }
 
   // ── janitor ──────────────────────────────────────────────────────────────

--- a/packages/mcp-server/src/scopedTokens.test.ts
+++ b/packages/mcp-server/src/scopedTokens.test.ts
@@ -1,0 +1,102 @@
+// Tests for per-app scoped bearer tokens (mint + verify logic).
+//
+// Storage SQL is exercised live against the running container; here we cover
+// the pure logic with a fake reader so the suite needs no sqlite flag.
+
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { createHash } from "node:crypto";
+
+import { mintScopedToken, verifyScopedToken, type ScopedTokenReader } from "./scopedTokens.js";
+import type { ScopedTokenRow } from "./oauth/storage.js";
+
+function sha256(s: string): string {
+  return createHash("sha256").update(s).digest("hex");
+}
+
+// A minimal in-memory ScopedTokenReader keyed by hash, tracking touches.
+function fakeReader(rows: ScopedTokenRow[]) {
+  const touched: Array<{ id: string; ts: number }> = [];
+  const reader: ScopedTokenReader = {
+    getScopedTokenByHash(hash) {
+      return rows.find((r) => r.token_hash === hash) ?? null;
+    },
+    touchScopedToken(id, ts) {
+      touched.push({ id, ts });
+    },
+  };
+  return { reader, touched };
+}
+
+function row(over: Partial<ScopedTokenRow> & { token_hash: string; app_id: string }): ScopedTokenRow {
+  return {
+    id: "tok_test",
+    prefix: "alf_x",
+    label: "test",
+    created_at: 1,
+    last_used_at: null,
+    revoked_at: null,
+    ...over,
+  };
+}
+
+// ─── mint ───────────────────────────────────────────────────────────────────
+
+test("mintScopedToken · shape: alf_<app>_<random>, tok_ id, correct hash", () => {
+  const m = mintScopedToken("execute");
+  assert.ok(m.token.startsWith("alf_execute_"), `token should carry app prefix: ${m.token}`);
+  assert.ok(m.id.startsWith("tok_"), "id should be a tok_ handle");
+  assert.equal(m.token_hash, sha256(m.token), "hash must be sha256 of the raw token");
+  assert.equal(m.prefix, m.token.slice(0, 16), "prefix is the first 16 chars");
+  assert.ok(m.token.length > 30, "token should carry real entropy");
+});
+
+test("mintScopedToken · handles hyphenated app ids (paperclip-admin)", () => {
+  const m = mintScopedToken("paperclip-admin");
+  assert.ok(m.token.startsWith("alf_paperclip-admin_"));
+});
+
+test("mintScopedToken · two mints are distinct (token + id + hash)", () => {
+  const a = mintScopedToken("sure");
+  const b = mintScopedToken("sure");
+  assert.notEqual(a.token, b.token);
+  assert.notEqual(a.id, b.id);
+  assert.notEqual(a.token_hash, b.token_hash);
+});
+
+// ─── verify ─────────────────────────────────────────────────────────────────
+
+test("verifyScopedToken · valid token for the right app → true, and touches last_used", () => {
+  const m = mintScopedToken("execute");
+  const { reader, touched } = fakeReader([row({ id: "tok_1", token_hash: m.token_hash, app_id: "execute" })]);
+  assert.equal(verifyScopedToken(reader, "execute", m.token, 1000), true);
+  assert.deepEqual(touched, [{ id: "tok_1", ts: 1000 }]);
+});
+
+test("verifyScopedToken · token bound to another app → false (no cross-app replay)", () => {
+  const m = mintScopedToken("execute");
+  const { reader, touched } = fakeReader([row({ token_hash: m.token_hash, app_id: "execute" })]);
+  assert.equal(verifyScopedToken(reader, "sure", m.token, 1000), false);
+  assert.equal(touched.length, 0, "a rejected token must not be touched");
+});
+
+test("verifyScopedToken · revoked token → false", () => {
+  const m = mintScopedToken("sure");
+  const { reader } = fakeReader([row({ token_hash: m.token_hash, app_id: "sure", revoked_at: 500 })]);
+  assert.equal(verifyScopedToken(reader, "sure", m.token, 1000), false);
+});
+
+test("verifyScopedToken · unknown token → false", () => {
+  const { reader } = fakeReader([]);
+  assert.equal(verifyScopedToken(reader, "sure", mintScopedToken("sure").token, 1000), false);
+});
+
+test("verifyScopedToken · empty bearer → false (no lookup)", () => {
+  let looked = false;
+  const reader: ScopedTokenReader = {
+    getScopedTokenByHash() { looked = true; return null; },
+    touchScopedToken() {},
+  };
+  assert.equal(verifyScopedToken(reader, "sure", "", 1000), false);
+  assert.equal(looked, false, "empty token should short-circuit before any lookup");
+});

--- a/packages/mcp-server/src/scopedTokens.ts
+++ b/packages/mcp-server/src/scopedTokens.ts
@@ -1,0 +1,73 @@
+// Per-app scoped static bearer tokens — the headless auth path for
+// non-interactive MCP clients (ElevenLabs / LiveKit voice agents, scripts).
+//
+// Three ways to authenticate a `POST /<app>/mcp` request now exist, checked
+// in this order (see index.ts `authOrApprovalSecret`):
+//   1. `MCP_APPROVAL_SECRET`  — tenant-wide master key (all apps). Kept so
+//      existing integrations (the in-tenant voice-bridge, claude.ai's
+//      /approve flow) keep working unchanged.
+//   2. a scoped token (this module) — bound to ONE app, mintable/rotatable/
+//      deletable per vendor from the dashboard. Preferred for third parties.
+//   3. full OAuth 2.1 bearer — what claude.ai uses.
+//
+// Only the SHA-256 hash of a scoped token is persisted; the raw value is
+// returned exactly once at mint/rotate time.
+
+import { sha256, randomToken, randomShort } from "./oauth/storage.js";
+import type { ScopedTokenRow } from "./oauth/storage.js";
+
+/** The raw token carries a readable prefix so it's identifiable in logs / vaults. */
+const TOKEN_LABEL = "alf";
+
+export interface MintedScopedToken {
+  /** Public management id (`tok_…`). */
+  id: string;
+  /** The raw bearer value — shown to the operator ONCE. */
+  token: string;
+  /** SHA-256 hash to persist. */
+  token_hash: string;
+  /** Display prefix (not secret). */
+  prefix: string;
+}
+
+/**
+ * Mint a fresh scoped token for `appId`. The raw token has the shape
+ * `alf_<app>_<random>` so it's recognizable; the caller must persist
+ * `token_hash` and hand `token` to the operator once.
+ */
+export function mintScopedToken(appId: string): MintedScopedToken {
+  const token = `${TOKEN_LABEL}_${appId}_${randomToken(24)}`;
+  return {
+    id: `tok_${randomShort(12)}`,
+    token,
+    token_hash: sha256(token),
+    prefix: token.slice(0, 16),
+  };
+}
+
+/** Minimal storage surface `verifyScopedToken` needs — lets tests use a fake. */
+export interface ScopedTokenReader {
+  getScopedTokenByHash(token_hash: string): ScopedTokenRow | null;
+  touchScopedToken(id: string, ts: number): void;
+}
+
+/**
+ * Validate a bearer against the scoped tokens for `appId`. Returns true and
+ * stamps `last_used_at` on success. A token bound to a different app, a
+ * revoked token, or an unknown token all fail — so a token minted for
+ * `/execute/mcp` cannot be replayed against `/sure/mcp`.
+ */
+export function verifyScopedToken(
+  storage: ScopedTokenReader,
+  appId: string,
+  token: string,
+  now: number,
+): boolean {
+  if (!token) return false;
+  const row = storage.getScopedTokenByHash(sha256(token));
+  if (!row) return false;
+  if (row.app_id !== appId) return false;
+  if (row.revoked_at) return false;
+  storage.touchScopedToken(row.id, now);
+  return true;
+}

--- a/packages/web/main.wasp
+++ b/packages/web/main.wasp
@@ -557,6 +557,11 @@ query getClaudeSetup {
   entities: []
 }
 
+query getMcpTokens {
+  fn: import { getMcpTokens } from "@src/dashboard/operations",
+  entities: []
+}
+
 query getInboxItems {
   fn: import { getInboxItems } from "@src/dashboard/operations",
   entities: []
@@ -804,6 +809,21 @@ action provisionPhone {
 
 action rotateApprovalSecret {
   fn: import { rotateApprovalSecret } from "@src/dashboard/operations",
+  entities: []
+}
+
+action mintMcpToken {
+  fn: import { mintMcpToken } from "@src/dashboard/operations",
+  entities: []
+}
+
+action rotateMcpToken {
+  fn: import { rotateMcpToken } from "@src/dashboard/operations",
+  entities: []
+}
+
+action deleteMcpToken {
+  fn: import { deleteMcpToken } from "@src/dashboard/operations",
   entities: []
 }
 

--- a/packages/web/src/dashboard/ClaudePage.tsx
+++ b/packages/web/src/dashboard/ClaudePage.tsx
@@ -17,11 +17,15 @@
 //                         tenants that were provisioned with BW
 //
 // F82 — "Developer / API keys" lives under Settings → API keys; not here.
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   useQuery,
   getClaudeSetup,
   rotateApprovalSecret,
+  getMcpTokens,
+  mintMcpToken,
+  rotateMcpToken,
+  deleteMcpToken,
 } from "wasp/client/operations";
 
 // F77/C16 — the rotate action returns the fresh secret exactly once.
@@ -313,6 +317,265 @@ function ApprovalSecretSection({
   );
 }
 
+// ── MCP access tokens ──────────────────────────────────────────────────────
+// Per-app scoped bearer tokens for third-party clients that can't do the
+// browser OAuth flow (ElevenLabs / LiveKit voice agents, scripts). Each token
+// is bound to a single app; mint one per client so it can be rotated/revoked
+// in isolation. The raw token is shown exactly once (mint + rotate); the list
+// only carries metadata. Backed by getMcpTokens / mintMcpToken /
+// rotateMcpToken / deleteMcpToken → ctrl-api → mcp-server /manage/tokens.
+interface McpTokenRow {
+  id: string;
+  app: string;
+  label: string;
+  prefix: string;
+  url: string;
+  created_at: number;
+  last_used_at: number | null;
+  revoked: boolean;
+}
+interface McpTokensResp {
+  tenant?: string;
+  public_url?: string;
+  transport?: string;
+  apps: string[];
+  tokens: McpTokenRow[];
+}
+interface MintTokenResp {
+  id: string;
+  app: string;
+  label: string;
+  prefix: string;
+  url: string;
+  token: string;
+}
+
+function fmtTs(ms: number | null): string {
+  if (!ms) return "never";
+  return new Date(ms).toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" });
+}
+
+function McpTokensSection() {
+  const { data, isLoading, refetch } = useQuery(getMcpTokens);
+  const resp = data as McpTokensResp | undefined;
+  const apps = resp?.apps ?? [];
+  const tokens = resp?.tokens ?? [];
+
+  const [app, setApp] = useState<string>("");
+  const [label, setLabel] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [rowBusy, setRowBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState<string | null>(null);
+  const [revealed, setRevealed] = useState<MintTokenResp | null>(null);
+
+  // Default the app picker to the first app once the list loads.
+  useEffect(() => {
+    if (!app && apps.length > 0) setApp(apps[0]);
+  }, [apps, app]);
+
+  function copy(key: string, value: string) {
+    navigator.clipboard?.writeText(value);
+    setCopied(key);
+    setTimeout(() => setCopied((c) => (c === key ? null : c)), 1500);
+  }
+
+  async function mint() {
+    if (!app || !label.trim()) {
+      setError("Pick an app and give the token a label.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const r = (await mintMcpToken({ app, label: label.trim() })) as MintTokenResp;
+      setRevealed(r);
+      setLabel("");
+      await refetch();
+    } catch (e: any) {
+      setError(e?.message ?? "Could not mint the token.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function rotate(id: string) {
+    setRowBusy(id);
+    setError(null);
+    try {
+      const r = (await rotateMcpToken({ id })) as MintTokenResp;
+      setRevealed(r);
+      await refetch();
+    } catch (e: any) {
+      setError(e?.message ?? "Rotation failed.");
+    } finally {
+      setRowBusy(null);
+    }
+  }
+
+  async function remove(id: string) {
+    setRowBusy(id);
+    setError(null);
+    try {
+      await deleteMcpToken({ id });
+      await refetch();
+    } catch (e: any) {
+      setError(e?.message ?? "Delete failed.");
+    } finally {
+      setRowBusy(null);
+    }
+  }
+
+  return (
+    <div>
+      <h3 className="font-display text-3xl mb-2">MCP access tokens</h3>
+      <p className="font-body italic mb-8" style={{ color: "var(--marginalia)" }}>
+        Long-lived bearer tokens for connecting one app to a client that can't do the
+        browser OAuth flow — a voice agent (ElevenLabs, LiveKit), a script, anything else.
+        Each token is scoped to a single app; mint one per client so you can rotate or
+        delete it on its own.
+      </p>
+
+      {/* Reveal-once panel — the raw token is never shown again. */}
+      {revealed && (
+        <div className="border border-rule p-4 mb-8">
+          <div
+            className="font-mono text-[10px] uppercase tracking-[0.22em] mb-3"
+            style={{ color: "var(--brass)" }}
+          >
+            New token for {revealed.app} — “{revealed.label}” · copy it now, it won't be shown again
+          </div>
+          <div
+            className="font-mono text-[10px] uppercase tracking-[0.18em] mb-1"
+            style={{ color: "var(--marginalia)" }}
+          >
+            Token (send as Authorization: Bearer …)
+          </div>
+          <div className="flex items-center gap-2 mb-3">
+            <code className="flex-1 font-mono text-[12px] border border-rule p-2 break-all">
+              {revealed.token}
+            </code>
+            <button onClick={() => copy("tok", revealed.token)} className="btn-ghost">
+              {copied === "tok" ? "Copied" : "Copy"}
+            </button>
+          </div>
+          <div
+            className="font-mono text-[10px] uppercase tracking-[0.18em] mb-1"
+            style={{ color: "var(--marginalia)" }}
+          >
+            Server URL (transport: Streamable HTTP)
+          </div>
+          <div className="flex items-center gap-2 mb-4">
+            <code className="flex-1 font-mono text-[12px] border border-rule p-2 break-all">
+              {revealed.url}
+            </code>
+            <button onClick={() => copy("url", revealed.url)} className="btn-ghost">
+              {copied === "url" ? "Copied" : "Copy"}
+            </button>
+          </div>
+          <button onClick={() => setRevealed(null)} className="btn-ghost">
+            Done — I've saved it
+          </button>
+        </div>
+      )}
+
+      {/* Generate control */}
+      <div className="border border-rule p-4 mb-8">
+        <div
+          className="font-mono text-[10px] uppercase tracking-[0.22em] mb-3"
+          style={{ color: "var(--marginalia)" }}
+        >
+          Generate a token
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <select
+            value={app}
+            onChange={(e) => setApp(e.target.value)}
+            className="bg-transparent border border-rule px-2 py-1 font-mono text-[12px]"
+            aria-label="app"
+          >
+            {apps.length === 0 && <option value="">(loading apps…)</option>}
+            {apps.map((a) => (
+              <option key={a} value={a}>
+                {a}
+              </option>
+            ))}
+          </select>
+          <input
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            placeholder="Label (e.g. 'ElevenLabs prod')"
+            className="flex-1 min-w-[180px] bg-transparent border border-rule px-2 py-1 font-mono text-[12px]"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void mint();
+            }}
+          />
+          <button onClick={() => void mint()} disabled={busy || !app} className="btn-brass">
+            {busy ? "Generating…" : "Generate"}
+          </button>
+        </div>
+      </div>
+
+      {/* Existing tokens */}
+      {isLoading ? (
+        <p className="font-body italic text-[15px]" style={{ color: "var(--marginalia)" }}>
+          Reading tokens…
+        </p>
+      ) : tokens.length === 0 ? (
+        <p className="font-body italic text-[15px]" style={{ color: "var(--marginalia)" }}>
+          No tokens yet. Generate one above to connect a voice agent or script.
+        </p>
+      ) : (
+        <ul className="border-t border-rule">
+          {tokens.map((t) => (
+            <li
+              key={t.id}
+              className="grid grid-cols-[100px_1fr_auto] gap-4 py-3 border-b border-rule items-center"
+            >
+              <span className="font-mono text-[11px] uppercase tracking-[0.14em]">{t.app}</span>
+              <div className="min-w-0">
+                <div className="font-display italic text-[16px] truncate">{t.label}</div>
+                <div
+                  className="font-mono text-[10px] uppercase tracking-[0.12em]"
+                  style={{ color: "var(--marginalia)" }}
+                >
+                  {t.prefix}… · added {fmtTs(t.created_at)} · last used {fmtTs(t.last_used_at)}
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <button onClick={() => copy(`url-${t.id}`, t.url)} className="btn-link">
+                  {copied === `url-${t.id}` ? "Copied URL" : "Copy URL"}
+                </button>
+                <button
+                  onClick={() => void rotate(t.id)}
+                  disabled={rowBusy === t.id}
+                  className="btn-link"
+                >
+                  {rowBusy === t.id ? "…" : "Rotate"}
+                </button>
+                <button
+                  onClick={() => void remove(t.id)}
+                  disabled={rowBusy === t.id}
+                  className="btn-link"
+                  style={{ color: "var(--brass)" }}
+                >
+                  Delete
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {error && (
+        <p className="font-body italic text-[13px] mt-3" style={{ color: "var(--brass)" }}>
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
 // F84 — the Claude Setup body, rendered inline within Settings → Agent
 // Configuration (StudyPage). No Frame, no sidebar nav: each section renders
 // only when its data is present, and the sections stack vertically.
@@ -398,6 +661,8 @@ export function ClaudeSetupSections() {
               </ul>
             </div>
           )}
+
+          <McpTokensSection />
 
           {hasApproval && (
             <ApprovalSecretSection

--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -126,6 +126,54 @@ export const rotateApprovalSecret = async (_args: unknown, context: any) => {
   });
 };
 
+// ─── Per-app MCP scoped bearer tokens ──────────────────────────────────────
+// Thin proxies to ctrl-api /api/v1/mcp/tokens/* → mcp-server /manage/tokens.
+// Let Sir mint / list / rotate / delete multiple long-lived per-app bearer
+// tokens (one per voice vendor — ElevenLabs, LiveKit, …) without the browser
+// ever holding MCP_APPROVAL_SECRET. The raw token is returned by mint + rotate
+// EXACTLY ONCE; the list only ever carries metadata (prefix, label, usage).
+
+/** List token metadata + the supported apps + public connector base. */
+export const getMcpTokens = async (args: { app?: string } | undefined, context: any) => {
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    path: "/api/v1/mcp/tokens",
+    query: args?.app ? { app: args.app } : undefined,
+  });
+};
+
+/** Mint a new per-app token. Returns { id, app, label, prefix, url, token } once. */
+export const mintMcpToken = async (args: { app: string; label: string }, context: any) => {
+  if (!args?.app) throw new HttpError(400, "app required");
+  if (!args?.label?.trim()) throw new HttpError(400, "label required");
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    method: "POST",
+    path: "/api/v1/mcp/tokens",
+    body: { app: args.app, label: args.label.trim() },
+  });
+};
+
+/** Rotate a token in place (same id + label, new secret). Returns the raw token once. */
+export const rotateMcpToken = async (args: { id: string }, context: any) => {
+  if (!args?.id) throw new HttpError(400, "id required");
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    method: "POST",
+    path: `/api/v1/mcp/tokens/${encodeURIComponent(args.id)}/rotate`,
+  });
+};
+
+/** Delete a token (hard). The credential stops working immediately. */
+export const deleteMcpToken = async (args: { id: string }, context: any) => {
+  if (!args?.id) throw new HttpError(400, "id required");
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    method: "DELETE",
+    path: `/api/v1/mcp/tokens/${encodeURIComponent(args.id)}`,
+  });
+};
+
 // Sir #8 — SSH info for the /channels Terminal card. Backed by ctrl-api
 // GET /api/v1/system/ssh-info (Lane I owns the endpoint). Returns
 // { hostname, port, user, pubkey, hermes_exec } — each may be null


### PR DESCRIPTION
## What

A headless auth path for MCP clients that can't do the browser OAuth flow — **ElevenLabs / LiveKit voice agents, scripts**. Long-lived, **per-app** scoped bearer tokens, **multiple per app**, mintable / rotatable / deletable from the dashboard. The tenant-wide `MCP_APPROVAL_SECRET` stays a **master key** so existing integrations (voice-bridge, claude.ai OAuth) keep working unchanged.

## How

- **mcp-server** — `scoped_tokens` table in `oauth.sqlite`; local validation in `authOrApprovalSecret` (checked *after* the master-secret bypass, *before* the OAuth verifier). A token is bound to ONE app; cross-app replay 401s. New master-gated `/manage/tokens` API (list/mint/rotate/delete) — raw token returned **once**. +9 unit tests (205 pass).
- **ctrl-api** — thin proxy `/api/v1/mcp/tokens/*` → mcp-server `/manage/tokens` (presents the master secret server-side; preserves "web → ctrl-api only").
- **web** — "MCP access tokens" section on `/study#agent`: pick app + label → generate, copy URL, rotate, delete; reveal-once panel.
- **compose** — pins `MCP_SERVER_URL` + `MCP_APPROVAL_SECRET` on ctrl-api (env_file already injects the secret; code defaults the URL).

## Verified live (hot-patched mcp-server on home)

Mint → use on `/execute/mcp` = `http=200 tools=6` · cross-app `/sure/mcp` = `401` · master secret `/alfred/mcp` = `200 tools=29` (regression) · rotate (old→401,new→200) · delete→401. Third-party usage: `POST https://mcp.<domain>/<app>/mcp`, Streamable HTTP, `Authorization: Bearer <token>`.

## Validation
mcp-server: 205 tests + typecheck. ctrl-api: typecheck + esbuild bundle. web: `wasp compile` + `tsc --noEmit` clean. (ctrl/learn node:test suites run in CI — `tsx` unresolvable locally.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)