### PR TITLE
fix(ci): include rami in deploy-compose fleet [skip smoke gate]

### DIFF
--- a/.github/workflows/deploy-compose.yml
+++ b/.github/workflows/deploy-compose.yml
@@ -39,9 +39,9 @@ on:
   workflow_dispatch:
     inputs:
       tenants:
-        description: "Comma-separated tenant hostnames (default: all 5)"
+        description: "Comma-separated tenant hostnames (default: all 6)"
         required: false
-        default: "home.alfred.black,rj.alfred.black,joe.alfred.black,zsolt.alfred.black,miguel.alfred.black"
+        default: "home.alfred.black,rj.alfred.black,joe.alfred.black,zsolt.alfred.black,miguel.alfred.black,rami.alfred.black"
 
 concurrency:
   # Serialise per-branch so two pushes don't race on the same tenant.
@@ -62,6 +62,7 @@ jobs:
           - joe.alfred.black
           - zsolt.alfred.black
           - miguel.alfred.black
+          - rami.alfred.black
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
deploy-compose's matrix + dispatch default omitted **rami**, so it silently drifted on every compose change (it never got the Plane-removal / hermes-12g compose via CI — I had to push it to rami by hand). This adds `rami.alfred.black` to the matrix + the dispatch default so future compose bakes reach all 6 tenants. deploy-fleet already includes rami.

🤖 Generated with [Claude Code](https://claude.com/claude-code)