### PR TITLE
fix(learn): cap recover_stuck_dispatching resurrection, dead-letter to failed (#282 Lane II)

### DIFF
--- a/packages/learn/src/activities/decision_router.py
+++ b/packages/learn/src/activities/decision_router.py
@@ -129,6 +129,37 @@ async def list_decisions_by_state(state: str) -> list[dict[str, Any]]:
 DISPATCHING_STALE_MINUTES = 10
 
 
+# A dispatch that can never succeed loops forever under the recovery
+# pass: ``open → route_decision (dispatch fails) → dispatching →
+# recover → open → …`` every ~60s, re-firing the action and
+# re-notifying the principal each cycle (live incident 2026-07-15,
+# ``office-ac-quiet-mode``). Cap the resurrections: after
+# ``MAX_DISPATCH_ATTEMPTS`` reset-to-open cycles, move the decision to
+# the terminal ``failed`` dead-letter state (surfaced exactly once,
+# because a ``failed`` decision no longer appears in the
+# ``?state=dispatching`` sweep) instead of resurrecting it again.
+def _resolve_max_dispatch_attempts() -> int:
+    """Resolve ``MAX_DISPATCH_ATTEMPTS`` defensively from the env
+    override ``DECISION_MAX_DISPATCH_ATTEMPTS`` — falls back to 3 on
+    unset/garbage, floored at a minimum of 1 (so the cap can never
+    disable itself)."""
+    raw = os.environ.get("DECISION_MAX_DISPATCH_ATTEMPTS", "")
+    try:
+        val = int(str(raw).strip())
+    except (TypeError, ValueError):
+        return 3
+    return max(1, val)
+
+
+MAX_DISPATCH_ATTEMPTS = _resolve_max_dispatch_attempts()
+
+
+def _now_iso() -> str:
+    """Current UTC instant as an ISO8601 string with a trailing ``Z``
+    (parity with the ``created`` timestamp ctrl-api writes)."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
 def _parse_iso(ts: str) -> datetime | None:
     """Parse the ISO timestamp ctrl-api writes for ``created`` (always
     UTC, trailing ``Z``). Returns None on any parse failure so the
@@ -154,24 +185,32 @@ async def recover_stuck_dispatching() -> dict[str, Any]:
       * ``True`` → the Hermes call landed but the final ``executing``
         PATCH was dropped (route_decision's activity timed out
         between the dispatch and the state-write). PATCH to
-        ``executing`` so check_decision_outcomes picks it up.
-      * ``False`` / missing → presume the dispatch crashed. PATCH back
-        to ``open`` so the next tick's route_decision pass re-routes
-        cleanly (the #55 idempotency guard relies on ``dispatching``
-        being a recent thing; an old ``dispatching`` is treated as
-        crashed).
+        ``executing`` so check_decision_outcomes picks it up. This is
+        a legitimate promotion and is **not** capped.
+      * ``False`` / missing → presume the dispatch crashed. This branch
+        is **capped** (issue #282): each reset increments
+        ``side_effects.dispatch_attempts``. While ``attempts <
+        MAX_DISPATCH_ATTEMPTS`` we PATCH back to ``open`` (as before) so
+        the next tick's route_decision pass re-routes cleanly. Once
+        ``attempts >= MAX_DISPATCH_ATTEMPTS`` the dispatch is presumed
+        never able to succeed, so instead of resurrecting again we move
+        the decision to the terminal ``failed`` dead-letter state and
+        surface it exactly once — never re-firing the action forever.
 
     Every PATCH is audit-logged via ``POST /api/v1/state/audit`` with
-    ``action_type=state-change`` and ``source=decision_router.recovery``
-    so production can count occurrences.
+    ``action_type=state-change``. The reset/promote path uses
+    ``source=decision_router.recovery``; the dead-letter crossover uses
+    ``source=decision_router.dead_letter`` so production can count
+    dead-letters separately.
 
     Returns ``{scanned, recovered, reset_to_open,
-    promoted_to_executing}`` for observability.
+    promoted_to_executing, dead_lettered}`` for observability.
     """
     scanned = 0
     recovered = 0
     reset_to_open = 0
     promoted_to_executing = 0
+    dead_lettered = 0
     cutoff = datetime.now(timezone.utc) - timedelta(
         minutes=DISPATCHING_STALE_MINUTES,
     )
@@ -204,19 +243,130 @@ async def recover_stuck_dispatching() -> dict[str, Any]:
                 side_effects = {}
             agent_dispatched = bool(side_effects.get("agent_dispatched"))
 
-            new_state = "executing" if agent_dispatched else "open"
-            reason = (
-                "agent_dispatched=true; final state-write dropped — "
-                "promoting to executing"
-                if agent_dispatched
-                else "agent_dispatched=false/missing; presumed crash — "
-                "resetting to open for re-routing"
-            )
+            # ---- Branch A: legitimate promotion (NOT capped) ----
+            # agent_dispatched=true means the Hermes call landed but the
+            # final executing PATCH was dropped. Promote to executing so
+            # check_decision_outcomes picks it up. Uncapped by design.
+            if agent_dispatched:
+                new_state = "executing"
+                reason = (
+                    "agent_dispatched=true; final state-write dropped — "
+                    "promoting to executing"
+                )
+                try:
+                    patch_resp = await client.patch(
+                        f"/api/v1/decisions/{decision_id}",
+                        json={"state": new_state},
+                    )
+                    patch_resp.raise_for_status()
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "decision_router.recover_stuck_dispatching: PATCH "
+                        "failed decision=%s new_state=%s err=%s",
+                        decision_id, new_state, exc,
+                    )
+                    continue
 
+                recovered += 1
+                promoted_to_executing += 1
+                await _emit_recovery_audit(
+                    client,
+                    decision_id=decision_id,
+                    source="decision_router.recovery",
+                    new_state=new_state,
+                    reason=reason,
+                    created=created,
+                    agent_dispatched=True,
+                    extra_changes=None,
+                )
+                logger.warning(
+                    "decision_router.recover_stuck_dispatching: "
+                    "unstuck decision=%s dispatching → %s (%s)",
+                    decision_id, new_state, reason,
+                )
+                continue
+
+            # ---- Branch B: presumed crash — CAPPED (issue #282) ----
+            # Each reset increments dispatch_attempts. PATCH replaces the
+            # whole side_effects object, so we merge client-side: read the
+            # current object, add our bookkeeping keys, PATCH it back.
+            prior = side_effects.get("dispatch_attempts", 0)
+            try:
+                prior = int(prior)
+            except (TypeError, ValueError):
+                prior = 0
+            attempts = prior + 1
+            now_iso = _now_iso()
+
+            merged = dict(side_effects)
+            merged["dispatch_attempts"] = attempts
+
+            if attempts >= MAX_DISPATCH_ATTEMPTS:
+                # Dead-letter: dispatch never succeeded across the cap.
+                # Move to the terminal ``failed`` state (NOT open) so the
+                # decision drops out of the ?state=dispatching sweep and
+                # the surfacing audit below fires exactly once.
+                new_state = "failed"
+                dead_letter_reason = (
+                    f"exceeded MAX_DISPATCH_ATTEMPTS ({MAX_DISPATCH_ATTEMPTS}) "
+                    f"resurrections; dispatch never succeeded"
+                )
+                merged["dead_lettered_at"] = now_iso
+                merged["dead_letter_reason"] = dead_letter_reason
+                try:
+                    patch_resp = await client.patch(
+                        f"/api/v1/decisions/{decision_id}",
+                        json={"state": new_state, "side_effects": merged},
+                    )
+                    patch_resp.raise_for_status()
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "decision_router.recover_stuck_dispatching: PATCH "
+                        "failed decision=%s new_state=%s err=%s",
+                        decision_id, new_state, exc,
+                    )
+                    continue
+
+                recovered += 1
+                dead_lettered += 1
+                # Best-effort: an audit failure must NOT roll back the
+                # ``failed`` PATCH (which already landed above). Fires
+                # exactly once — a ``failed`` decision is no longer in
+                # the ?state=dispatching sweep.
+                await _emit_recovery_audit(
+                    client,
+                    decision_id=decision_id,
+                    source="decision_router.dead_letter",
+                    new_state=new_state,
+                    reason=dead_letter_reason,
+                    created=created,
+                    agent_dispatched=False,
+                    extra_changes={
+                        "dispatch_attempts": attempts,
+                        "dead_letter_reason": dead_letter_reason,
+                    },
+                )
+                logger.error(
+                    "decision_router.recover_stuck_dispatching: "
+                    "DEAD-LETTER decision=%s dispatching → failed "
+                    "after %d attempts (%s)",
+                    decision_id, attempts, dead_letter_reason,
+                )
+                continue
+
+            # Under the cap — reset to open as before, but stamp the
+            # attempt counter + last_dispatch_at into side_effects.
+            new_state = "open"
+            reason = (
+                "agent_dispatched=false/missing; presumed crash — "
+                f"resetting to open for re-routing (attempt {attempts}/"
+                f"{MAX_DISPATCH_ATTEMPTS})"
+            )
+            merged["last_dispatch_at"] = now_iso
             try:
                 patch_resp = await client.patch(
                     f"/api/v1/decisions/{decision_id}",
-                    json={"state": new_state},
+                    json={"state": new_state, "side_effects": merged},
                 )
                 patch_resp.raise_for_status()
             except Exception as exc:  # noqa: BLE001
@@ -228,62 +378,17 @@ async def recover_stuck_dispatching() -> dict[str, Any]:
                 continue
 
             recovered += 1
-            if new_state == "executing":
-                promoted_to_executing += 1
-            else:
-                reset_to_open += 1
-
-            # Audit-emit so production can count. We post directly to
-            # /api/v1/state/audit (the StateClient envelope) rather
-            # than going through StateClient here — the existing _http
-            # client already holds the same bearer token and base URL,
-            # so this keeps the activity dependency-light and parity
-            # with the rest of decision_router's HTTP calls.
-            try:
-                audit_resp = await client.post(
-                    "/api/v1/state/audit",
-                    json={
-                        "action_type": "state-change",
-                        "actor": "decision_router",
-                        "source": "decision_router.recovery",
-                        "target_path": f"decision/{decision_id}.md",
-                        "target_kind": "decision",
-                        "summary": (
-                            f"recovery: decision/{decision_id} "
-                            f"dispatching → {new_state} "
-                            f"({reason})"
-                        ),
-                        "changes": {
-                            "state": {
-                                "from": "dispatching",
-                                "to": new_state,
-                            },
-                            "age_minutes": (
-                                (
-                                    datetime.now(timezone.utc) - created
-                                ).total_seconds()
-                                / 60.0
-                            ),
-                            "agent_dispatched": agent_dispatched,
-                        },
-                        "mode": "live",
-                    },
-                )
-                # Best-effort: an audit-write failure doesn't roll
-                # back the recovery PATCH that already landed.
-                if audit_resp.status_code >= 400:
-                    logger.warning(
-                        "decision_router.recover_stuck_dispatching: "
-                        "audit POST returned %s for decision=%s",
-                        audit_resp.status_code, decision_id,
-                    )
-            except Exception as exc:  # noqa: BLE001
-                logger.warning(
-                    "decision_router.recover_stuck_dispatching: "
-                    "audit POST failed decision=%s err=%s",
-                    decision_id, exc,
-                )
-
+            reset_to_open += 1
+            await _emit_recovery_audit(
+                client,
+                decision_id=decision_id,
+                source="decision_router.recovery",
+                new_state=new_state,
+                reason=reason,
+                created=created,
+                agent_dispatched=False,
+                extra_changes={"dispatch_attempts": attempts},
+            )
             logger.warning(
                 "decision_router.recover_stuck_dispatching: "
                 "unstuck decision=%s dispatching → %s (%s)",
@@ -295,7 +400,69 @@ async def recover_stuck_dispatching() -> dict[str, Any]:
         "recovered": recovered,
         "reset_to_open": reset_to_open,
         "promoted_to_executing": promoted_to_executing,
+        "dead_lettered": dead_lettered,
     }
+
+
+async def _emit_recovery_audit(
+    client: Any,
+    *,
+    decision_id: str,
+    source: str,
+    new_state: str,
+    reason: str,
+    created: datetime,
+    agent_dispatched: bool,
+    extra_changes: dict[str, Any] | None,
+) -> None:
+    """Best-effort audit emit for the recovery pass. We post directly to
+    ``/api/v1/state/audit`` (the StateClient envelope) rather than going
+    through StateClient here — the existing ``_http`` client already
+    holds the same bearer token and base URL, so this keeps the activity
+    dependency-light and parity with decision_router's other HTTP calls.
+
+    An audit-write failure MUST NOT roll back the state PATCH that
+    already landed — all failure modes here are swallowed with a warning.
+    """
+    changes: dict[str, Any] = {
+        "state": {"from": "dispatching", "to": new_state},
+        "age_minutes": (
+            (datetime.now(timezone.utc) - created).total_seconds() / 60.0
+        ),
+        "agent_dispatched": agent_dispatched,
+    }
+    if extra_changes:
+        changes.update(extra_changes)
+    verb = "dead-letter" if new_state == "failed" else "recovery"
+    try:
+        audit_resp = await client.post(
+            "/api/v1/state/audit",
+            json={
+                "action_type": "state-change",
+                "actor": "decision_router",
+                "source": source,
+                "target_path": f"decision/{decision_id}.md",
+                "target_kind": "decision",
+                "summary": (
+                    f"{verb}: decision/{decision_id} "
+                    f"dispatching → {new_state} ({reason})"
+                ),
+                "changes": changes,
+                "mode": "live",
+            },
+        )
+        if audit_resp.status_code >= 400:
+            logger.warning(
+                "decision_router.recover_stuck_dispatching: "
+                "audit POST returned %s for decision=%s",
+                audit_resp.status_code, decision_id,
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "decision_router.recover_stuck_dispatching: "
+            "audit POST failed decision=%s err=%s",
+            decision_id, exc,
+        )
 
 
 # ---------------------------------------------------------------------

--- a/packages/learn/tests/test_decision_router_dispatch_cap.py
+++ b/packages/learn/tests/test_decision_router_dispatch_cap.py
@@ -1,0 +1,280 @@
+"""Dead-letter cap on ``recover_stuck_dispatching`` (issue #282).
+
+Live incident 2026-07-15 (``office-ac-quiet-mode``): a delegate decision
+whose dispatch could never succeed looped forever. Every ~60s
+``DecisionRouterWorkflow`` ran the recovery pass, which reset the
+``state=dispatching`` / ``agent_dispatched=false`` decision back to
+``open``; the next tick re-dispatched, failed, marked ``dispatching``
+again — re-firing the action and re-notifying the principal each cycle,
+with no cap.
+
+Fix (this file exercises it): the ``agent_dispatched=false`` branch of
+``recover_stuck_dispatching`` now counts resurrections in
+``side_effects.dispatch_attempts``. While ``attempts <
+MAX_DISPATCH_ATTEMPTS`` it resets to ``open`` as before (stamping the
+counter). Once ``attempts >= MAX_DISPATCH_ATTEMPTS`` it PATCHes the
+decision to the terminal ``failed`` dead-letter state (NOT open),
+stamps ``dead_lettered_at`` + ``dead_letter_reason``, and emits exactly
+one surfacing audit with ``source=decision_router.dead_letter``. Because
+a ``failed`` decision no longer appears in the ``?state=dispatching``
+sweep, that surfacing fires exactly once by construction.
+
+The ``agent_dispatched=true`` → ``executing`` branch is a legitimate
+promotion and is NOT capped.
+
+Test doubles mirror ``test_decision_router_dispatching_recovery.py`` so
+this lane does not depend on Lane I (ctrl-api ``failed`` state) being
+merged — the fake ctrl endpoint accepts any PATCH.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import httpx
+
+import src.activities.decision_router as dr
+
+
+# ---------------------------------------------------------------------------
+# Test doubles (parity with test_decision_router_dispatching_recovery.py)
+# ---------------------------------------------------------------------------
+
+
+class _Resp:
+    def __init__(self, payload: Any = None, status_code: int = 200) -> None:
+        self._payload = payload or {}
+        self.status_code = status_code
+
+    def json(self) -> Any:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class _FakeClient:
+    """One client per logical unit of work; records every call."""
+
+    def __init__(self, decisions: list[dict[str, Any]]) -> None:
+        self.decisions = decisions
+        self.calls: list[tuple[str, str, dict]] = []
+
+    async def __aenter__(self) -> "_FakeClient":
+        return self
+
+    async def __aexit__(self, *a: Any) -> None:
+        return None
+
+    async def get(self, url: str, **k: Any) -> _Resp:
+        self.calls.append(("GET", url, {}))
+        if "/api/v1/decisions?state=" in url:
+            state = url.split("state=", 1)[1].split("&", 1)[0]
+            rows = [d for d in self.decisions if d.get("state") == state]
+            return _Resp({"decisions": rows, "count": len(rows)})
+        return _Resp({})
+
+    async def patch(self, url: str, **k: Any) -> _Resp:
+        self.calls.append(("PATCH", url, k.get("json") or {}))
+        return _Resp({"ok": True})
+
+    async def post(self, url: str, **k: Any) -> _Resp:
+        self.calls.append(("POST", url, k.get("json") or {}))
+        return _Resp({"id": "audit-1"})
+
+
+class _Cfg:
+    alfred_ctrl_url = "http://ctrl-test:3100"
+
+
+def _install(monkeypatch, fake: _FakeClient) -> None:
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **k: fake)
+    import src.config as cfg_mod
+    monkeypatch.setattr(cfg_mod, "load_config", lambda: _Cfg())
+    monkeypatch.setenv("AAS_API_KEY", "test-key")
+
+
+def _iso(dt: datetime) -> str:
+    return dt.replace(tzinfo=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def _dispatching(
+    decision_id: str,
+    *,
+    age_minutes: float,
+    agent_dispatched: bool | None = None,
+    dispatch_attempts: int | None = None,
+) -> dict[str, Any]:
+    created = datetime.now(timezone.utc) - timedelta(minutes=age_minutes)
+    side_effects: dict[str, Any] = {}
+    if agent_dispatched is True:
+        side_effects["agent_dispatched"] = True
+    elif agent_dispatched is False:
+        side_effects["agent_dispatched"] = False
+    if dispatch_attempts is not None:
+        side_effects["dispatch_attempts"] = dispatch_attempts
+    return {
+        "id": decision_id,
+        "intent": "delegate",
+        "source": "needs_attention",
+        "source_record": f"needs_attention/{decision_id}.md",
+        "source_headline": "office AC quiet mode",
+        "note": "",
+        "state": "dispatching",
+        "side_effects": side_effects,
+        "created": _iso(created.replace(tzinfo=None)),
+    }
+
+
+def _state_patches(fake: _FakeClient, decision_id: str) -> list[dict]:
+    return [
+        c[2]
+        for c in fake.calls
+        if c[0] == "PATCH"
+        and f"/api/v1/decisions/{decision_id}" in c[1]
+    ]
+
+
+def _dead_letter_audits(fake: _FakeClient) -> list[dict]:
+    return [
+        c[2]
+        for c in fake.calls
+        if c[0] == "POST"
+        and "/api/v1/state/audit" in c[1]
+        and (c[2] or {}).get("source") == "decision_router.dead_letter"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_first_reset_stamps_dispatch_attempts_1(monkeypatch):
+    """A crashed dispatching decision with no prior counter → reset to
+    ``open`` with ``side_effects.dispatch_attempts=1`` and a
+    ``last_dispatch_at`` timestamp. Not dead-lettered yet."""
+    monkeypatch.setattr(dr, "MAX_DISPATCH_ATTEMPTS", 3)
+    dec = _dispatching("ac-quiet", age_minutes=15, agent_dispatched=False)
+    fake = _FakeClient([dec])
+    _install(monkeypatch, fake)
+
+    result = asyncio.run(dr.recover_stuck_dispatching())
+
+    patches = _state_patches(fake, "ac-quiet")
+    assert len(patches) == 1, f"expected one PATCH, got {patches}"
+    body = patches[0]
+    assert body.get("state") == "open", body
+    se = body.get("side_effects") or {}
+    assert se.get("dispatch_attempts") == 1, se
+    assert isinstance(se.get("last_dispatch_at"), str) and se["last_dispatch_at"], se
+    # Not dead-lettered.
+    assert "dead_lettered_at" not in se, se
+    assert result["reset_to_open"] == 1
+    assert result["dead_lettered"] == 0
+    assert _dead_letter_audits(fake) == []
+
+
+def test_crossover_to_failed_at_max_minus_one(monkeypatch):
+    """A crashed dispatching decision already at
+    ``dispatch_attempts=MAX-1`` → the next recover crosses the cap and
+    PATCHes to ``state=failed`` (NOT open), stamps ``dead_lettered_at`` +
+    ``dead_letter_reason``, and emits exactly ONE dead_letter audit."""
+    monkeypatch.setattr(dr, "MAX_DISPATCH_ATTEMPTS", 3)
+    dec = _dispatching(
+        "ac-quiet",
+        age_minutes=15,
+        agent_dispatched=False,
+        dispatch_attempts=2,  # MAX - 1
+    )
+    fake = _FakeClient([dec])
+    _install(monkeypatch, fake)
+
+    result = asyncio.run(dr.recover_stuck_dispatching())
+
+    patches = _state_patches(fake, "ac-quiet")
+    assert len(patches) == 1, f"expected one PATCH, got {patches}"
+    body = patches[0]
+    assert body.get("state") == "failed", (
+        f"MAX-th resurrection must dead-letter to failed, not open: {body}"
+    )
+    se = body.get("side_effects") or {}
+    assert se.get("dispatch_attempts") == 3, se
+    assert isinstance(se.get("dead_lettered_at"), str) and se["dead_lettered_at"], se
+    assert "MAX_DISPATCH_ATTEMPTS" in (se.get("dead_letter_reason") or ""), se
+
+    # Exactly one dead_letter audit, naming the decision + reason.
+    dl = _dead_letter_audits(fake)
+    assert len(dl) == 1, f"expected exactly ONE dead_letter audit, got {dl}"
+    summary = dl[0].get("summary") or ""
+    assert "ac-quiet" in summary, summary
+    assert dl[0].get("action_type") == "state-change", dl[0]
+
+    assert result["dead_lettered"] == 1
+    assert result["reset_to_open"] == 0
+
+
+def test_agent_dispatched_true_still_promotes_uncapped(monkeypatch):
+    """The ``agent_dispatched=true`` branch is a legitimate promotion:
+    it still PATCHes to ``executing`` and is NEVER capped or
+    dead-lettered — even with a high dispatch_attempts count present."""
+    monkeypatch.setattr(dr, "MAX_DISPATCH_ATTEMPTS", 3)
+    dec = _dispatching(
+        "dispatched-stuck",
+        age_minutes=15,
+        agent_dispatched=True,
+        dispatch_attempts=99,  # irrelevant — this branch is uncapped
+    )
+    fake = _FakeClient([dec])
+    _install(monkeypatch, fake)
+
+    result = asyncio.run(dr.recover_stuck_dispatching())
+
+    patches = _state_patches(fake, "dispatched-stuck")
+    assert len(patches) == 1, f"expected one PATCH, got {patches}"
+    assert patches[0].get("state") == "executing", patches[0]
+    assert result["promoted_to_executing"] == 1
+    assert result["dead_lettered"] == 0
+    assert _dead_letter_audits(fake) == []
+
+
+def test_return_dict_includes_dead_lettered_count(monkeypatch):
+    """The return dict carries the ``dead_lettered`` counter alongside
+    the existing observability fields."""
+    monkeypatch.setattr(dr, "MAX_DISPATCH_ATTEMPTS", 3)
+    dec = _dispatching(
+        "ac-quiet",
+        age_minutes=15,
+        agent_dispatched=False,
+        dispatch_attempts=2,
+    )
+    fake = _FakeClient([dec])
+    _install(monkeypatch, fake)
+
+    result = asyncio.run(dr.recover_stuck_dispatching())
+
+    for key in (
+        "scanned",
+        "recovered",
+        "reset_to_open",
+        "promoted_to_executing",
+        "dead_lettered",
+    ):
+        assert key in result, f"return dict missing {key}: {result}"
+    assert result["dead_lettered"] == 1
+
+
+def test_resolve_max_dispatch_attempts_defensive(monkeypatch):
+    """The env resolver falls back to 3 on unset/garbage and floors at 1."""
+    monkeypatch.delenv("DECISION_MAX_DISPATCH_ATTEMPTS", raising=False)
+    assert dr._resolve_max_dispatch_attempts() == 3
+
+    monkeypatch.setenv("DECISION_MAX_DISPATCH_ATTEMPTS", "not-a-number")
+    assert dr._resolve_max_dispatch_attempts() == 3
+
+    monkeypatch.setenv("DECISION_MAX_DISPATCH_ATTEMPTS", "0")
+    assert dr._resolve_max_dispatch_attempts() == 1  # floored
+
+    monkeypatch.setenv("DECISION_MAX_DISPATCH_ATTEMPTS", "5")
+    assert dr._resolve_max_dispatch_attempts() == 5


### PR DESCRIPTION
Closes #282

## What & why
`recover_stuck_dispatching`'s `agent_dispatched=false` branch reset any stale
`state=dispatching` decision back to `open` every ~60s DecisionRouter cycle with
**no cap**. A dispatch that can never succeed looped forever — `open →
route_decision(dispatch fails) → dispatching → recover → open → …` — re-firing the
action and re-notifying the principal each cycle (live incident 2026-07-15,
`office-ac-quiet-mode`).

## Fix (contracts C2/C3/C4)
- Module constant `MAX_DISPATCH_ATTEMPTS` (3), env-overridable via
  `DECISION_MAX_DISPATCH_ATTEMPTS`, parsed defensively (fallback 3, floored at 1).
- `agent_dispatched=false` branch now counts resurrections in
  `side_effects.dispatch_attempts` (merged **client-side** — PATCH replaces
  side_effects wholesale). While `attempts < MAX`: reset to `open` as before, plus
  stamp `dispatch_attempts` + `last_dispatch_at`. At `attempts >= MAX`: PATCH to
  terminal `state=failed` (dead-letter) with `dead_lettered_at` +
  `dead_letter_reason`, and emit **exactly one** surfacing audit
  (`source=decision_router.dead_letter`, distinct from `decision_router.recovery`).
  A `failed` decision drops out of the `?state=dispatching` sweep, so surfacing
  fires exactly once by construction. Audit is best-effort — a failure never rolls
  back the `failed` PATCH.
- The `agent_dispatched=true → executing` promotion is a legitimate path and is left
  **uncapped and unchanged**.
- Return dict gains a `dead_lettered` counter.

## Merge ordering
**Merge/deploy Lane I (ctrl-api `failed` state) FIRST, then this PR.** Lane II PATCHes
decisions to `state=failed`; ctrl must accept it or returns 422. Unit tests mock the
ctrl HTTP endpoint (fake httpx server) so this lane builds/tests without Lane I.

## Temporal replay safety
Edits the **activity** `recover_stuck_dispatching` body only — no new
`execute_activity` call, activity name and signature unchanged, `@workflow.run`
untouched. Replay-safe **without** a `workflow.patched()` gate (per
`packages/learn/CLAUDE.md`).

## Smoke evidence

### 1. Setup
Fake ctrl-api httpx server (records every GET/PATCH/POST), aged (`created` 15 min ago,
past `DISPATCHING_STALE_MINUTES=10`) `state=dispatching` delegate decision
`ac-quiet`, `MAX_DISPATCH_ATTEMPTS=3`. Mirrors
`tests/test_decision_router_dispatching_recovery.py` doubles. No real stores.

### 2. Action — the recover pass at attempts=0 and attempts=MAX-1 (captured PATCH/POST bodies)

**attempts=0 (first crash, no prior counter):**
```
PATCH /api/v1/decisions/ac-quiet
  {"state": "open", "side_effects": {"agent_dispatched": false, "dispatch_attempts": 1, "last_dispatch_at": "2026-07-15T10:50:21.703445Z"}}
POST /api/v1/state/audit  source=decision_router.recovery
RETURN: {"scanned": 1, "recovered": 1, "reset_to_open": 1, "promoted_to_executing": 0, "dead_lettered": 0}
```

**attempts=MAX-1 (=2) → crossover:**
```
PATCH /api/v1/decisions/ac-quiet
  {"state": "failed", "side_effects": {"agent_dispatched": false, "dispatch_attempts": 3, "dead_lettered_at": "2026-07-15T10:50:21.703748Z", "dead_letter_reason": "exceeded MAX_DISPATCH_ATTEMPTS (3) resurrections; dispatch never succeeded"}}
POST /api/v1/state/audit  source=decision_router.dead_letter  summary="dead-letter: decision/ac-quiet dispatching → failed (…)"
RETURN: {"scanned": 1, "recovered": 1, "reset_to_open": 0, "promoted_to_executing": 0, "dead_lettered": 1}
```

### 3. Assertion
- attempts increments 0→1 (reset stays `open`), then crosses to `state=failed` at the cap — NOT `open`.
- `dead_lettered_at` + `dead_letter_reason` stamped on crossover.
- Exactly ONE `decision_router.dead_letter` audit, naming the decision id + reason.
- `agent_dispatched=true` branch still promotes to `executing`, uncapped (test `test_agent_dispatched_true_still_promotes_uncapped`, even with `dispatch_attempts=99`).
- Return dict carries `dead_lettered`.

### 4. Isolation
```
 packages/learn/src/activities/decision_router.py   | 313 ++++++++++++++++-----
 packages/learn/tests/test_decision_router_dispatch_cap.py | 280 ++++++++++++++++++
 2 files changed
```
Only the two ALLOWED files touched.

### 5. Regression
```
$ python3 -m pytest tests/test_decision_router_dispatching_recovery.py tests/test_decision_router_dispatch_cap.py -q
...........
11 passed in 0.10s
```
Existing recovery suite (9 tests incl. the `<MAX` reset-to-open behavior) unbroken; 5 new cap tests pass.

### 6. Cleanup
No real vault / state.db / ctrl-api touched — fake httpx server only. No processes spawned.
