### PR TITLE
feat(gate): harden the lane gate — CI replay, full package coverage, audit fixes

### DIFF
--- a/.github/workflows/lane-gate.yml
+++ b/.github/workflows/lane-gate.yml
@@ -53,16 +53,21 @@ jobs:
 
       - name: Reject unmapped lane-* branch names
         if: steps.lane.outputs.lane == 'INVALID'
+        env:
+          BRANCH: ${{ github.head_ref }}
         run: |
-          echo "::error::branch '${{ github.head_ref }}' uses lane-* naming but maps to no lane (valid: lane-1 … lane-7). Rename the branch or use a non-lane branch for operator work."
+          echo "::error::branch '$BRANCH' uses lane-* naming but maps to no lane (valid: lane-1 … lane-7). Rename the branch or use a non-lane branch for operator work."
           exit 1
 
       - name: Replay the lane gate on the PR diff
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          LANE: ${{ steps.lane.outputs.lane }}
         run: |
-          git fetch origin "${{ github.base_ref }}" --depth=200 || git fetch origin "${{ github.base_ref }}"
+          git fetch origin "$BASE_REF" --depth=200 || git fetch origin "$BASE_REF"
           python3 scripts/hooks/check_lane.py --ci \
-            --lane "${{ steps.lane.outputs.lane }}" \
-            --base "origin/${{ github.base_ref }}"
+            --lane "$LANE" \
+            --base "origin/$BASE_REF"
 
       - name: Gate unit tests
         run: python3 scripts/hooks/test_check_lane.py

--- a/.github/workflows/lane-gate.yml
+++ b/.github/workflows/lane-gate.yml
@@ -1,0 +1,68 @@
+# Server-side replay of the lane commit gate (scripts/hooks/check_lane.py).
+#
+# WHY THIS EXISTS: the local pre-commit gate depends on client git config,
+# and the Claude Code worktree harness rewrites core.hooksPath at worktree
+# creation — which silently disarmed the local gate for ~6 weeks (2026-06 →
+# 2026-07 audit). This workflow is the authoritative, un-clobberable copy of
+# the same rules: it derives the lane from the PR's branch name and replays
+# boundary + forbidden-zone + scope checks against the full PR diff.
+#
+# Branch → lane mapping (docs/lane-protocol.md):
+#   lane-1/* → I (ctrl)          lane-5/* → V  (edges/infra)
+#   lane-2/* → II (learn)        lane-6/* → VI (voice-bridge)
+#   lane-3/* → III (web)         lane-7/* → VII (paperclip)
+#   lane-4/* → IV (alfred-vault)
+#   anything else → phase0 (operator branch; allow-all by design — the lane
+#   protocol constrains AGENT branches, and agents must use lane-N/ naming).
+#
+# VERIFY (builds/tests) is NOT run here — ci-check.yml owns that.
+name: lane-gate
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  lane-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve lane from branch name
+        id: lane
+        env:
+          BRANCH: ${{ github.head_ref }}
+        run: |
+          case "$BRANCH" in
+            lane-1/*) LANE=I ;;
+            lane-2/*) LANE=II ;;
+            lane-3/*) LANE=III ;;
+            lane-4/*) LANE=IV ;;
+            lane-5/*) LANE=V ;;
+            lane-6/*) LANE=VI ;;
+            lane-7/*) LANE=VII ;;
+            lane-*)   LANE=INVALID ;;
+            *)        LANE=phase0 ;;
+          esac
+          echo "lane=$LANE" >> "$GITHUB_OUTPUT"
+          echo "branch '$BRANCH' → lane $LANE"
+
+      - name: Reject unmapped lane-* branch names
+        if: steps.lane.outputs.lane == 'INVALID'
+        run: |
+          echo "::error::branch '${{ github.head_ref }}' uses lane-* naming but maps to no lane (valid: lane-1 … lane-7). Rename the branch or use a non-lane branch for operator work."
+          exit 1
+
+      - name: Replay the lane gate on the PR diff
+        run: |
+          git fetch origin "${{ github.base_ref }}" --depth=200 || git fetch origin "${{ github.base_ref }}"
+          python3 scripts/hooks/check_lane.py --ci \
+            --lane "${{ steps.lane.outputs.lane }}" \
+            --base "origin/${{ github.base_ref }}"
+
+      - name: Gate unit tests
+        run: python3 scripts/hooks/test_check_lane.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,8 +33,9 @@ Alfred at `https://<their-domain>` with TLS, the dashboard, all 5 sidecars
 (Plane, Sure, Vaultwarden, Hermes, the chat surface), and the full
 intelligence layer.
 
-The full design rationale is in `docs/PLAN.md` (Parts A–I). Read it before
-making structural changes.
+Design rationale lives under `docs/design/` + `docs/specs/`; the
+architecture contracts are §5–§10 here. Read them before making
+structural changes.
 
 ---
 
@@ -53,15 +54,21 @@ alfred-black/
 │   ├── web/                 Wasp dashboard (auth + UI; proxies to ctrl-api)
 │   ├── ctrl/                ctrl-api: tenant API server (:3100) + 4-store layer
 │   ├── learn/               alfred-learn: Temporal intelligence layer (Python)
-│   ├── mcp-server/          5-app MCP bundle (alfred/sure/plane/vaultwarden/execute)
+│   ├── alfred-vault/        the Python vault daemon (validator; separate package)
+│   ├── mcp-server/          MCP app bundle (alfred/sure/vaultwarden/execute/…)
 │   ├── vault-init/          Vaultwarden bootstrap
-│   └── hermes/              Hermes runtime image (Dockerfile + supervisor.sh + init/)
+│   ├── hermes/              Hermes runtime image (Dockerfile + supervisor.sh + init/)
+│   ├── voice-bridge/        Twilio/telephony bridge (own image + CI)
+│   ├── paperclip/           Paperclip adapter (own image + CI; see docs/PAPERCLIP-BOOTSTRAP-CONTRACT.md)
+│   └── setup/               first-run setup wizard (own image + CI)
 ├── docs/
-│   ├── PLAN.md              the complete plan
-│   ├── FAILURE-MODES.md     ranked bug catalogue
-│   ├── FIX-PLAN.md          lane fan-out plan
-│   └── FIX-CONTRACTS.md     frozen cross-lane interfaces (Cn…)
-├── deploy/                  CUTOVER.md and ops runbooks
+│   ├── lane-protocol.md     CANONICAL lane protocol (mirrored in the operator harness)
+│   ├── FAILURE-MODES.md     ranked bug catalogue (historical; stamped)
+│   ├── FIX-PLAN.md          lane fan-out plan (historical — protocol now lives here + §11)
+│   ├── FIX-CONTRACTS.md     frozen cross-lane interfaces (Cn…)
+│   ├── design/ specs/       design rationale + per-issue specs
+│   └── operators/           ops runbooks
+├── deploy/                  ops runbooks
 ├── debug/                   ignored — investigation outputs land here
 └── CLAUDE.md                this file
 ```
@@ -134,7 +141,7 @@ to `/desk`. `/triage` → `/desk`. `/back-office` → `/study`.
 
 ---
 
-## 5. The four-store architecture (PLAN.md Part I)
+## 5. The four-store architecture
 
 > **The vault is the principal's published output, not the system's database.**
 
@@ -506,8 +513,8 @@ npm test               # node:test suite (~440 tests)
 
 Numbered SQL files in `packages/ctrl/src/db/migrations/`, applied
 transactionally on ctrl-api boot. **Never edit a migration after it has
-merged — append a new one.** See `packages/ctrl/CLAUDE.md` §state.db
-migrations for the rules.
+merged — append a new one.** Migrations are forbidden-zone: only the
+orchestrator (phase0) lands them.
 
 ---
 
@@ -551,36 +558,50 @@ For mapping unknown breakage (e.g. a sweep over the live product):
    never improvises across the boundary.**
 
 4. **Package-scoped lanes**, non-overlapping glob territory (→ conflict-free
-   merges by construction):
+   merges by construction). Canonical source: `docs/lane-protocol.md` +
+   `scripts/hooks/lanes.json` (v2 2026-07-15 — every package has exactly
+   one owning lane):
 
-   | Lane | Glob | Owns |
-   |------|------|------|
-   | **I**·ctrl | `packages/ctrl/**` | ctrl-api routes, the 4-store layer, settings |
-   | **II**·learn | `packages/learn/**` | Temporal activities, the intelligence layer, scoring |
-   | **III**·web | `packages/web/**` | Wasp app, dashboard pages, operations.ts |
-   | **IV**·alfred-vault | `packages/alfred-vault/**` | The Python vault daemon (separate package `alfred-vault` 1.0+) |
-   | **V**·edges/infra | `packages/{hermes,mcp-server,vault-init}/**`, `scripts/**`, `caddy/**`, `docker-compose.yaml`, `.env.example`, `Makefile`, `docs/**` | All non-package config |
+   | Lane | Branch | Glob | Owns |
+   |------|--------|------|------|
+   | **I**·ctrl | `lane-1/` | `packages/ctrl/**` | ctrl-api routes (incl. channels), the 4-store layer, settings |
+   | **II**·learn | `lane-2/` | `packages/learn/**` | Temporal activities, the intelligence layer, scoring |
+   | **III**·web | `lane-3/` | `packages/web/**` | Wasp app, dashboard pages, operations.ts |
+   | **IV**·alfred-vault | `lane-4/` | `packages/alfred-vault/**` | The Python vault daemon (separate package `alfred-vault` 1.0+) |
+   | **V**·edges/infra | `lane-5/` | `packages/{hermes,mcp-server,vault-init,setup}/**`, `scripts/**`, `caddy/**`, `docker-compose.yaml`, `.env.example`, `Makefile`, `docs/**` | All non-package config |
+   | **VI**·voice-bridge | `lane-6/` | `packages/voice-bridge/**` | Twilio/telephony bridge |
+   | **VII**·paperclip | `lane-7/` | `packages/paperclip/**` | Paperclip adapter |
 
-   **At most one agent per lane at a time** — lanes parallel, tasks within
-   a lane serial.
+   These are the ONLY valid lane IDs — never invent one ("CTRL"/"HERMES"
+   inventions are how the 2026-06 ungated commits happened). `.github/**`
+   is phase0-only. **At most one agent per lane at a time** — lanes
+   parallel, tasks within a lane serial.
 
-5. **The commit gate makes violations impossible to land**
-   (`scripts/hooks/`, `bash scripts/hooks/install.sh` sets `core.hooksPath`,
-   inherited by every worktree). On `git commit`, `check_lane.py` rejects
-   the diff if it:
-   - (a) leaves the lane's `allowed` globs (lane-jumping)
-   - (b) touches the **forbidden zone** (`schema.sql`, `db/migrations/**`,
-     `migrate.ts`, `api/server.ts`, `**/CONTRACT.md`, the `FIX-*` /
-     `FAILURE-MODES` docs, `scripts/hooks/**`, `CLAUDE.md`)
-   - (c) exceeds **~200 net LOC**, or
-   - (d) fails the lane **VERIFY** (build / `tsc` / pytest / `compose
-     config` — the regression gate)
+5. **The gate makes violations impossible to land — twice.**
+   - **Local pre-commit** (`scripts/hooks/`, `bash scripts/hooks/install.sh`):
+     on `git commit`, `check_lane.py` rejects the diff if it
+     - (a) leaves the lane's `allowed` globs (lane-jumping) — deletions
+       and rename-sources count too,
+     - (b) touches the **forbidden zone** (`schema.sql`, `db/migrations/**`,
+       `migrate.ts`, `api/server.ts`, `**/CONTRACT.md`, the `FIX-*` /
+       `FAILURE-MODES` docs, `docs/lane-protocol.md`, `scripts/hooks/**`,
+       `.github/**`, `CLAUDE.md`),
+     - (c) exceeds **~200 net LOC**, or
+     - (d) fails the lane **VERIFY** (build / `tsc` / pytest / `compose
+       config` — the regression gate).
+   - **Server-side CI replay** (`.github/workflows/lane-gate.yml`): every
+     PR from a `lane-N/*` branch re-runs rules (a)–(c) against the full PR
+     diff. This copy is authoritative — local hook removal or the harness
+     clobbering `core.hooksPath` (see §11.3) does not bypass it.
 
    The lane is declared by a `.lane` manifest at the worktree root:
-   `{"lane":"II","verify":"…","scope_limit":300}`.
+   `{"lane":"II","verify":"…","scope_limit":300}`, and by the branch name
+   in CI (`lane-2/… → II`; non-lane branches are phase0/operator).
    The **main checkout (no `.lane`) is `phase0`** — orchestrator, allow-all.
-   A linked worktree with **no `.lane` is rejected** (fail-safe).
+   A linked worktree with **no `.lane` is rejected**, and **`phase0` is not
+   self-declarable from a linked worktree** (fail-safe).
    **Never use `ALFRED_SKIP_VERIFY`.**
+   Gate unit tests: `python3 scripts/hooks/test_check_lane.py`.
 
 6. **Agent brief** = LANE / GOAL (one sentence) / ALLOWED + FORBIDDEN globs
    / VERIFY / CONTRACT (the package `CONTRACT.md` + the relevant
@@ -604,6 +625,14 @@ For mapping unknown breakage (e.g. a sweep over the live product):
 
 ### 11.3 Hard-won rules (these bit me — do not relearn them)
 
+- **The Claude Code worktree harness disarms local hooks.** At every
+  worktree creation it rewrites `core.hooksPath` back to `.git/hooks`
+  (shared config AND per-worktree `config.worktree`) — this silently
+  killed the lane gate for ~6 weeks (2026-06 → 2026-07-15 audit).
+  `install.sh` now also symlinks `.git/hooks/pre-commit → scripts/hooks/
+  pre-commit` so the gate fires under either config value, and strips
+  stale per-worktree overrides — re-run it whenever in doubt. The CI
+  `lane-gate` workflow is the authoritative backstop either way.
 - **`isolation: worktree` does NOT guarantee isolation.** Agents have
   shared the working tree and overwritten each other's `.lane`. Either
   confirm each agent got a real separate worktree, **or** run coordinated
@@ -643,7 +672,12 @@ Path-filtered, push-to-main:
 | `build-hermes.yml` | `packages/hermes/**` (Dockerfile, supervisor.sh, configs) | `ssdavidai00/alfred-black-hermes:latest` |
 | `build-init.yml` | `packages/hermes/init/**`, `packages/ctrl/src/templates/**`, hermes-config templates | `ssdavidai00/alfred-init:latest` |
 | `build-mcp-server.yml` | `packages/mcp-server/**` | `ssdavidai00/alfred-mcp-server:latest` |
+| `build-voice-bridge.yml` | `packages/voice-bridge/**` | voice-bridge image |
+| `build-paperclip.yml` | `packages/paperclip/**` | paperclip image |
+| `build-setup.yml` | `packages/setup/**` | setup image |
 | `ci-check.yml` | * (all) | `tsc --noEmit` + `pytest` + `docker compose config` |
+| `lane-gate.yml` | PRs | server-side replay of the lane gate on the PR diff (see §11.2.5) |
+| `pr-review-gate.yml` | PRs | `smoke-evidence-check` — PR body must carry `## Smoke evidence` |
 | `gitleaks.yml` | * (all) | Secret scanning |
 
 `docker compose up` **never builds** — it pulls `:latest` for every
@@ -881,10 +915,11 @@ containers.
 
 ## 17. References — read these when you touch the relevant area
 
-- `docs/PLAN.md` — the complete plan (Parts A–I)
+- `docs/lane-protocol.md` — the canonical lane protocol (lanes, gate, contracts file)
 - `docs/FAILURE-MODES.md` — ranked bug catalogue
 - `docs/FIX-PLAN.md` — lane fan-out plan
 - `docs/FIX-CONTRACTS.md` — frozen cross-lane interfaces
+- `docs/PAPERCLIP-BOOTSTRAP-CONTRACT.md` — paperclip cross-lane contract
 - `packages/ctrl/docs/STORAGE-ARCHITECTURE.md` — the 4-store model
 - `packages/ctrl/CONTRACT.md` — what ctrl-api provides + requires
 - `packages/learn/CONTRACT.md` — what alfred-learn provides + requires
@@ -896,7 +931,8 @@ containers.
 - `packages/hermes/docker/supervisor.sh` — the 3-process supervisor
 - `packages/hermes/init/entrypoint.sh` — vault scaffold, Hermes profile rendering, password generation
 - `caddy/Caddyfile` — Caddy ingress with `{$DOMAIN}` substitution
-- `scripts/hooks/check_lane.py` — the commit gate (read this before opening a PR)
+- `scripts/hooks/check_lane.py` — the commit gate (read this before opening a PR); tests in `scripts/hooks/test_check_lane.py`
+- `.github/workflows/lane-gate.yml` — the server-side gate replay
 - `CHANGELOG.md` — bare-date release tags
 
 ---

--- a/docs/lane-protocol.md
+++ b/docs/lane-protocol.md
@@ -1,0 +1,207 @@
+# The lane protocol
+
+> This is the CANONICAL copy. A mirror lives in the operator harness at
+> `~/.claude/alfred-code/docs/lane-protocol.md` and must stay identical.
+> Unified 2026-07-15: the lane IDs below ARE the enforcement lanes in
+> `scripts/hooks/lanes.json`. There is no separate "harness lane scheme"
+> anymore — that divergence is what let agents invent lanes ("CTRL",
+> "HERMES") and commit voice-bridge work as "lane V".
+
+Decompose a multi-PR issue into independent lanes with explicit contracts.
+Each lane is one PR's worth of work; lanes don't share files; the
+user-visible flow is the close gate.
+
+## The lanes (enforcement territory — matches `scripts/hooks/lanes.json`)
+
+| Lane | Branch prefix | Owns (allowed globs) | VERIFY |
+|---|---|---|---|
+| **I** — ctrl-api | `lane-1/` | `packages/ctrl/**` (routes, 4-store layer, settings, channels, templates — NOT migrations/schema/server.ts) | `cd packages/ctrl && npm run build` |
+| **II** — learn | `lane-2/` | `packages/learn/**` (Temporal workflows, activities, scoring) | `cd packages/learn && python3 -m pytest -q` |
+| **III** — web | `lane-3/` | `packages/web/**` (Wasp pages, ops, dashboard) | `cd packages/web && npx tsc --noEmit` |
+| **IV** — alfred-vault | `lane-4/` | `packages/alfred-vault/**` (the Python vault daemon) | `cd packages/alfred-vault && python3 -m pytest -q` |
+| **V** — edges/infra | `lane-5/` | `packages/{hermes,mcp-server,vault-init,setup}/**`, `scripts/**`, `caddy/**`, `docker-compose.yaml`, `.env.example`, `Makefile`, `docs/**` | `docker compose config -q` |
+| **VI** — voice-bridge | `lane-6/` | `packages/voice-bridge/**` | `cd packages/voice-bridge && npm test` |
+| **VII** — paperclip | `lane-7/` | `packages/paperclip/**` | `cd packages/paperclip/adapter && npm run typecheck && npm test` |
+| phase0 — orchestrator | n/a (main checkout) | `**` (allow-all) | `true` |
+
+Branch naming: `lane-<arabic>/<issue>-<slug>` — the arabic digit maps to
+the roman lane ID (lane-1 = Lane I … lane-7 = Lane VII). These are the
+ONLY valid lane IDs. If your work doesn't fit a lane, it's orchestrator
+(phase0) work — STOP and report; do not invent a lane name.
+
+Channel-routing work inside `packages/ctrl` (channels_*.ts, alfredDeliver)
+is Lane I territory — it is not a separate lane. Voice/telephony work is
+Lane VI. One-shot tenant-migration scripts under `scripts/` are Lane V or
+orchestrator work.
+
+Three lanes is common. Six is rare.
+
+## The forbidden zone (no lane may touch — orchestrator/phase0 only)
+
+- `packages/ctrl/src/db/schema.sql`
+- `packages/ctrl/src/db/migrations/**`
+- `packages/ctrl/src/db/migrate.ts`
+- `packages/ctrl/src/api/server.ts`
+- `**/CONTRACT.md`
+- `docs/FIX-CONTRACTS.md`, `docs/FIX-PLAN.md`, `docs/FAILURE-MODES.md`
+- `scripts/hooks/**`
+- `CLAUDE.md`
+
+**Migrations are orchestrator-owned.** If an issue needs a state.db
+migration, the orchestrator lands it (phase0, main checkout) BEFORE
+dispatching the lanes that depend on it — the contracts file records the
+allocated migration number and resulting `user_version` so lanes code
+against it. A lane that finds itself needing a forbidden-zone edit STOPs
+and reports; it never improvises across the boundary.
+
+`.github/**` is likewise phase0-only (CI changes are orchestrator work).
+
+## The `.lane` manifest (first action of every lane agent)
+
+Before writing any code, drop a manifest at the worktree root:
+
+```sh
+echo '{"lane":"II"}' > .lane
+# optional per-task narrowing of the VERIFY:
+echo '{"lane":"II","verify":"cd packages/learn && python -m pytest tests/test_x.py -q"}' > .lane
+```
+
+The pre-commit gate (`scripts/hooks/check_lane.py`) reads it and rejects
+any commit that (a) leaves the lane's allowed globs, (b) touches the
+forbidden zone, (c) exceeds ~200 net LOC, or (d) fails the lane VERIFY.
+The same check runs server-side in CI (the `lane-gate` workflow) against
+the PR diff — removing the local hook does not bypass it. A blocked
+commit means **re-scope, not override**: never set `ALFRED_SKIP_VERIFY`,
+never widen `lanes.json`, never relabel yourself phase0.
+
+## Hard rules (each has bitten us)
+
+- **~200 net LOC per commit.** Bigger → STOP and report to the
+  orchestrator; don't salami-slice.
+- **Never run `npm install` / `npm ci` / `npm prune`** in a worktree — it
+  corrupts the shared symlinked `node_modules`. VERIFY uses existing
+  deps. Orchestrator-only: `npm ci` for a fresh worktree.
+- **Stage only your own files** (`git add <paths>`, never `git add -A`).
+- **One agent per lane at a time** — lanes parallel, tasks within a lane
+  serial.
+- **`isolation: "worktree"` does not guarantee isolation** — the
+  orchestrator must `git show --stat` each agent's commit to confirm it
+  touched only its own files before trusting it.
+
+## The contracts file
+
+For every multi-lane issue, write `/tmp/orchestrator-<issue>-contracts.md`
+before dispatching:
+
+```markdown
+# Contracts for #<n>
+
+## Migration (orchestrator-owned)
+- Allocated: 0NNN (landed by orchestrator on main before lane dispatch)
+- user_version after: NN → NN+1
+
+## Env-var convention
+- Per-profile writes: resolveProfileEnvPath(slug)
+- Per-channel keys: <UPPERCASE_KIND>_<FIELD>
+
+## File-ownership matrix
+| Lane | Exclusive files |
+|---|---|
+| I   | packages/ctrl/src/api/routes/X.ts, src/db/X.ts (NOT migrations) |
+| II  | packages/learn/src/workflows/Y.py, src/activities/Y.py |
+| III | packages/web/src/dashboard/ZPage.tsx, operations.ts (append-only) |
+
+## Inter-lane deps
+- Lane III's UI smoke gated on Lane I's route being live (Lane I lands first)
+
+## Cascade rules
+- When Lane II archives a row, what happens to bound rows elsewhere:
+  pick ONE shape, name the owning lane, document it here.
+  Lanes never negotiate this at PR time.
+```
+
+Each lane reads this verbatim. If a lane needs a contract changed, it
+comes back to the orchestrator — contracts don't move mid-dispatch.
+
+Cross-lane interfaces that outlive the issue get frozen in the package
+`CONTRACT.md` (orchestrator lands that edit — CONTRACT.md is forbidden
+zone) or registered as a clause in `docs/FIX-CONTRACTS.md`.
+
+## The Y/N gate (mandatory)
+
+Before any `Agent` dispatch:
+
+```
+AskUserQuestion({
+  question: "Lane decomposition for #<n>: proceed?",
+  options: ["Yes — dispatch", "Wait — refine", "Skip — leave open"],
+  header: "#<n> dispatch",
+})
+```
+
+(In the autonomous loop, the Telegram Y/N gate plays this role.)
+
+Each lane's bullet in the question body:
+
+```
+Lane I — agent_profile registry + CRUD routes
+  Files: src/db/agentProfiles.ts, src/api/routes/profiles.ts
+  Smoke: insert 1 profile + list + bind channel + archive + assert main unaffected
+```
+
+## Dispatch shape
+
+```python
+Agent({
+  subagent_type: "general-purpose",
+  isolation: "worktree",                # MANDATORY — hook blocks otherwise
+  run_in_background: true,              # for parallel lanes
+  description: "Lane <N> — <one-liner>",
+  prompt: f"""
+Inherit lane-worker.md. Your lane scope:
+  {lane_scope}
+
+FIRST ACTION: write the .lane manifest — echo '{{"lane":"<ID>"}}' > .lane
+(valid IDs: I II III IV V VI VII — see docs/lane-protocol.md).
+
+Contracts at /tmp/orchestrator-{n}-contracts.md (read verbatim, don't drift).
+
+Standard smoke template:
+  {get_smoke_template_for(kind)}
+
+Branch: lane-<arabic>/{n}-<slug>. Stay inside your lane's allowed globs;
+~200 net LOC; never npm install; git add only your own paths.
+
+Open PR titled `feat(...): #{n} Lane <N> — <one-liner>`. PR body:
+  - References `#{n}` (not Closes — only the lane that completes the flow uses Closes)
+  - Includes `## Smoke evidence` section (mandatory; the hook + CI gate block merge otherwise)
+"""
+})
+```
+
+## Verification per lane
+
+After completion:
+
+1. Read the PR diff (`git show --stat`). Did it stay in its lane's globs?
+2. Read the `## Smoke evidence`. Real, not theater? (Isolation assertion present?)
+3. If anything's wrong: re-dispatch with the gap named in the new prompt.
+   Don't try to fix it in cargo-cult iterations.
+
+## Closing the issue
+
+Only when:
+
+- ✓ All lanes' PRs are merged (providers before consumers)
+- ✓ Real-tenant smoke exercises the principal-visible end-to-end flow on `home.alfred.black`
+- ✓ Two-paragraph CHANGELOG.md entry under a new `[YYYY-MM-DD]` heading
+
+Merge itself is Sir's manual gate — lanes and orchestrators only open PRs.
+Until then: leave open, post a comment with the queue.
+
+## Lineage
+
+Descended from Sir-8 Lanes I/II/III/V (2026-05 multi-lane runs) and the
+Wave A–E staged-deploy protocol (#109–#114), generalized into one shape:
+decompose, contract, gate, dispatch, verify, close — and unified with the
+repo enforcement gate on 2026-07-15.

--- a/scripts/hooks/check_lane.py
+++ b/scripts/hooks/check_lane.py
@@ -1,23 +1,43 @@
 #!/usr/bin/env python3
-"""Lane-enforcement pre-commit gate for the Alfred fix fan-out.
+"""Lane-enforcement gate for the Alfred fix fan-out.
 
-Rejects a commit BEFORE it reaches the orchestrator if it:
-  1. touches a file outside the current lane's ALLOWED globs (lane-jumping),
-  2. touches anything in the global FORBIDDEN_ZONE (Phase-0-owned shared surface),
-  3. exceeds the lane SCOPE_LIMIT (net changed LOC — the ~200-LOC discipline),
-  4. fails the lane VERIFY command (the regression gate).
+Two modes:
 
-The lane is read from `.lane` (JSON, repo top-level, git-ignored) or $ALFRED_LANE.
-A *linked worktree* with no `.lane` is rejected (fail-safe — a lane agent must
-declare its lane). The *main* checkout with no `.lane` is the `phase0`
-orchestrator lane (allow-all), so this never blocks normal work on main.
+  pre-commit (default, no args)
+      Runs against the STAGED diff. Rejects a commit BEFORE it reaches the
+      orchestrator if it:
+        1. touches a file outside the current lane's ALLOWED globs (lane-jumping),
+        2. touches anything in the global FORBIDDEN_ZONE (Phase-0-owned),
+        3. exceeds the lane SCOPE_LIMIT (net changed LOC — the ~200-LOC discipline),
+        4. fails the lane VERIFY command (the regression gate).
+      The lane is read from `.lane` (JSON, worktree top-level, git-ignored)
+      or $ALFRED_LANE.
 
-`.lane` format:  {"lane": "II"}            # required: I|II|III|IV|V
+  --ci --lane <ID> --base <ref>   (server-side replay; .github/workflows/lane-gate.yml)
+      Runs rules 1-3 against the merge-base diff `<ref>...HEAD` of a PR.
+      VERIFY is skipped in CI (ci-check.yml runs the builds/tests). Scope is
+      soft up to 3x the cap (warn), hard-fail above — a PR may bundle a few
+      <=200-LOC commits. Local hook removal does NOT bypass this mode.
+
+Hardening (2026-07-15, post-audit):
+  * Deletions and rename-sources now count — `--name-status` parsing includes
+    D entries and both sides of R/C entries (the old `--diff-filter=ACMR
+    --name-only` was blind to a lane deleting forbidden-zone files).
+  * `phase0` is NOT self-declarable from a linked worktree — the main
+    checkout is the only phase0 context. A `.lane` (or $ALFRED_LANE) that
+    claims phase0 inside a linked worktree is rejected.
+  * lanes.json is loaded from HEAD (`git show HEAD:scripts/hooks/lanes.json`)
+    when available, so an uncommitted local edit to lanes.json cannot widen
+    the rules for the same commit. Falls back to the on-disk copy only when
+    HEAD has no copy (fresh repo).
+
+`.lane` format:  {"lane": "II"}            # required: I|II|III|IV|V|VI|VII
                  {"lane": "II", "verify": "cd packages/learn && python -m pytest tests/test_signals.py -q"}
                  {"lane": "II", "scope_limit": 350}   # only for a justified larger task
 
 Escape hatch:    ALFRED_SKIP_VERIFY=1 git commit ...   # skips ONLY the regression gate (boundary + scope still enforced)
 """
+import argparse
 import fnmatch
 import json
 import os
@@ -26,13 +46,15 @@ import sys
 
 RED, GREEN, YELLOW, RESET = "\033[31m", "\033[32m", "\033[33m", "\033[0m"
 
+ROMAN_LANES = ("I", "II", "III", "IV", "V", "VI", "VII")
+
 
 def run(*args):
     return subprocess.run(args, capture_output=True, text=True).stdout.strip()
 
 
 def die(msg):
-    sys.stderr.write(f"\n{RED}✗ commit blocked by the lane gate{RESET}\n\n{msg}\n\n")
+    sys.stderr.write(f"\n{RED}✗ blocked by the lane gate{RESET}\n\n{msg}\n\n")
     sys.exit(1)
 
 
@@ -49,82 +71,168 @@ def match(pattern, path):
     return fnmatch.fnmatch(path, pattern)
 
 
-HERE = os.path.dirname(os.path.abspath(__file__))
-with open(os.path.join(HERE, "lanes.json")) as fh:
-    CFG = json.load(fh)
+def load_config():
+    """lanes.json from HEAD (tamper-resistant); fall back to the local file."""
+    head_copy = run("git", "show", "HEAD:scripts/hooks/lanes.json")
+    if head_copy:
+        try:
+            return json.loads(head_copy)
+        except json.JSONDecodeError:
+            pass  # corrupted HEAD copy — fall through to on-disk
+    here = os.path.dirname(os.path.abspath(os.path.realpath(__file__)))
+    with open(os.path.join(here, "lanes.json")) as fh:
+        return json.load(fh)
 
-top = run("git", "rev-parse", "--show-toplevel")
 
-# ---- resolve the lane ------------------------------------------------------
-lane_id = None
-verify_override = None
-scope_override = None
-lane_file = os.path.join(top, ".lane")
-if os.path.exists(lane_file):
-    try:
-        data = json.load(open(lane_file))
-    except (json.JSONDecodeError, OSError) as exc:
-        die(f"`.lane` is present but unreadable: {exc}")
-    lane_id = data.get("lane")
-    verify_override = data.get("verify")
-    scope_override = data.get("scope_limit")
-lane_id = lane_id or os.environ.get("ALFRED_LANE")
+def changed_paths(diff_args):
+    """All paths touched by the diff, including deletions and BOTH sides of
+    renames/copies. Returns (paths, net_loc)."""
+    paths = set()
+    for line in run("git", "diff", *diff_args, "--name-status", "-M", "-C").splitlines():
+        parts = line.split("\t")
+        if not parts or not parts[0]:
+            continue
+        status = parts[0][0]
+        if status in ("A", "M", "D", "T") and len(parts) >= 2:
+            paths.add(parts[1])
+        elif status in ("R", "C") and len(parts) >= 3:
+            paths.add(parts[1])  # source — moving a file OUT of a zone counts
+            paths.add(parts[2])  # destination
+    loc = 0
+    for line in run("git", "diff", *diff_args, "--numstat").splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 2 and parts[0].isdigit() and parts[1].isdigit():
+            loc += int(parts[0]) + int(parts[1])
+    return sorted(paths), loc
 
-git_dir = os.path.abspath(run("git", "rev-parse", "--git-dir"))
-common_dir = os.path.abspath(run("git", "rev-parse", "--git-common-dir"))
-is_linked_worktree = git_dir != common_dir
 
-if lane_id is None:
-    if is_linked_worktree:
-        die("This is a linked worktree but has no `.lane` manifest.\n"
-            "A lane agent must declare its lane before committing, e.g.:\n"
-            "    echo '{\"lane\": \"II\"}' > .lane")
-    lane_id = "phase0"  # main checkout, orchestrator — allow-all
+def boundary_violations(paths, lane_id, lane, forbidden):
+    violations = []
+    for p in paths:
+        if any(match(g, p) for g in forbidden):
+            violations.append(
+                f"  FORBIDDEN ZONE   {p}\n"
+                f"                   → Phase-0-owned shared surface. Coordinate centrally; do not edit in a lane.")
+        elif not any(match(g, p) for g in lane["allowed"]):
+            violations.append(
+                f"  OUT OF LANE      {p}\n"
+                f"                   → lane {lane_id} ({lane['name']}) owns only: {', '.join(lane['allowed'])}")
+    return violations
 
-if lane_id not in CFG["lanes"]:
-    die(f"Unknown lane '{lane_id}'. Valid lanes: {', '.join(CFG['lanes'])}")
 
-lane = CFG["lanes"][lane_id]
-allowed = lane["allowed"]
-forbidden = CFG["forbidden_zone"]
-scope_limit = scope_override if scope_override is not None else lane.get("scope_limit", 200)
-verify = verify_override or lane.get("verify", "true")
+def main():
+    ap = argparse.ArgumentParser(description="Alfred lane gate")
+    ap.add_argument("--ci", action="store_true", help="CI replay mode (diff vs --base, no VERIFY)")
+    ap.add_argument("--lane", help="lane id (CI mode; hook mode reads .lane/$ALFRED_LANE)")
+    ap.add_argument("--base", help="base ref for the PR diff (CI mode)")
+    args = ap.parse_args()
 
-staged = [p for p in run("git", "diff", "--cached", "--name-only", "--diff-filter=ACMR").splitlines() if p]
-if not staged:
+    cfg = load_config()
+    forbidden = cfg["forbidden_zone"]
+
+    if args.ci:
+        lane_id = args.lane or "phase0"
+        if lane_id not in cfg["lanes"]:
+            die(f"Unknown lane '{lane_id}'. Valid lanes: {', '.join(cfg['lanes'])}")
+        if lane_id == "phase0":
+            sys.stderr.write(f"{YELLOW}◦ phase0 (operator) branch — lane gate allows all; "
+                             f"forbidden-zone and scope rules do not apply.{RESET}\n")
+            sys.exit(0)
+        if not args.base:
+            die("--ci requires --base <ref>")
+        merge_base = run("git", "merge-base", args.base, "HEAD")
+        if not merge_base:
+            die(f"cannot resolve merge-base of {args.base} and HEAD")
+        paths, loc = changed_paths([merge_base, "HEAD"])
+        lane = cfg["lanes"][lane_id]
+        violations = boundary_violations(paths, lane_id, lane, forbidden)
+        if violations:
+            die(f"PR violates lane {lane_id} boundaries:\n\n" + "\n".join(violations))
+        cap = lane.get("scope_limit", 200)
+        if loc > cap * 3:
+            die(f"PR scope {loc} LOC exceeds 3x the lane {lane_id} cap ({cap}). "
+                f"Split the work — the protocol is ~{cap} net LOC per task.")
+        if loc > cap:
+            sys.stderr.write(f"{YELLOW}⚠ PR scope {loc} LOC exceeds the lane {lane_id} cap ({cap}) "
+                             f"— acceptable only if the PR bundles several <=cap commits; "
+                             f"reviewer should check.{RESET}\n")
+        sys.stderr.write(f"{GREEN}✓ lane {lane_id} ({lane['name']}) CI gate passed — "
+                         f"{loc} LOC, {len(paths)} files{RESET}\n")
+        sys.exit(0)
+
+    # ---- pre-commit mode -----------------------------------------------------
+    top = run("git", "rev-parse", "--show-toplevel")
+
+    lane_id = None
+    verify_override = None
+    scope_override = None
+    lane_file = os.path.join(top, ".lane")
+    if os.path.exists(lane_file):
+        try:
+            data = json.load(open(lane_file))
+        except (json.JSONDecodeError, OSError) as exc:
+            die(f"`.lane` is present but unreadable: {exc}")
+        lane_id = data.get("lane")
+        verify_override = data.get("verify")
+        scope_override = data.get("scope_limit")
+    lane_id = lane_id or os.environ.get("ALFRED_LANE")
+
+    git_dir = os.path.abspath(run("git", "rev-parse", "--git-dir"))
+    common_dir = os.path.abspath(run("git", "rev-parse", "--git-common-dir"))
+    is_linked_worktree = git_dir != common_dir
+
+    if lane_id is None:
+        if is_linked_worktree:
+            die("This is a linked worktree but has no `.lane` manifest.\n"
+                "A lane agent must declare its lane before committing, e.g.:\n"
+                "    echo '{\"lane\": \"II\"}' > .lane\n"
+                f"Valid lanes: {', '.join(ROMAN_LANES)}")
+        lane_id = "phase0"  # main checkout, orchestrator — allow-all
+
+    if lane_id == "phase0" and is_linked_worktree:
+        die("phase0 (orchestrator, allow-all) is not self-declarable from a linked worktree.\n"
+            "Orchestrator work happens in the MAIN checkout. Declare a real lane here:\n"
+            f"    valid lanes: {', '.join(ROMAN_LANES)}")
+
+    if lane_id not in cfg["lanes"]:
+        die(f"Unknown lane '{lane_id}'. Valid lanes: {', '.join(cfg['lanes'])}")
+
+    lane = cfg["lanes"][lane_id]
+    scope_limit = scope_override if scope_override is not None else lane.get("scope_limit", 200)
+    verify = verify_override or lane.get("verify", "true")
+
+    paths, loc = changed_paths(["--cached"])
+    if not paths:
+        sys.exit(0)
+
+    # ---- 1 + 2: lane boundary + forbidden zone (deletions + renames included)
+    if lane_id != "phase0":
+        violations = boundary_violations(paths, lane_id, lane, forbidden)
+        if violations:
+            die("Lane-jumping detected — these staged files are not in your lane:\n\n"
+                + "\n".join(violations))
+
+    # ---- 3: scope limit (net changed LOC) ------------------------------------
+    if loc > scope_limit:
+        die(f"Scope limit exceeded: {loc} LOC changed > {scope_limit} cap for lane {lane_id}.\n"
+            f"A task this big should be split. Per your brief: STOP and report.\n"
+            f"(If this single task legitimately needs more, set \"scope_limit\" in .lane and say so in the PR.)")
+
+    # ---- 4: verify (regression gate) ------------------------------------------
+    if os.environ.get("ALFRED_SKIP_VERIFY") == "1":
+        sys.stderr.write(f"{YELLOW}⚠ ALFRED_SKIP_VERIFY=1 — regression gate skipped "
+                         f"(boundary + scope still enforced).{RESET}\n")
+    else:
+        sys.stderr.write(f"▶ lane {lane_id} verify: {verify}\n")
+        if subprocess.run(verify, shell=True, cwd=top).returncode != 0:
+            die(f"VERIFY failed: {verify}\n"
+                f"A test/typecheck regressed. Fix it before committing, or scope the change down.\n"
+                f"(Emergency-only override: ALFRED_SKIP_VERIFY=1 git commit …)")
+
+    sys.stderr.write(f"{GREEN}✓ lane {lane_id} ({lane['name']}) gate passed — "
+                     f"{loc} LOC, {len(paths)} files, verify ok{RESET}\n")
     sys.exit(0)
 
-# ---- 1 + 2: lane boundary + forbidden zone ---------------------------------
-if lane_id != "phase0":
-    violations = []
-    for p in staged:
-        if any(match(g, p) for g in forbidden):
-            violations.append(f"  FORBIDDEN ZONE   {p}\n                   → Phase-0-owned shared surface. Coordinate centrally; do not edit in a lane.")
-        elif not any(match(g, p) for g in allowed):
-            violations.append(f"  OUT OF LANE      {p}\n                   → lane {lane_id} ({lane['name']}) owns only: {', '.join(allowed)}")
-    if violations:
-        die("Lane-jumping detected — these staged files are not in your lane:\n\n" + "\n".join(violations))
 
-# ---- 3: scope limit (net changed LOC) --------------------------------------
-loc = 0
-for line in run("git", "diff", "--cached", "--numstat").splitlines():
-    parts = line.split("\t")
-    if len(parts) >= 2 and parts[0].isdigit() and parts[1].isdigit():
-        loc += int(parts[0]) + int(parts[1])
-if loc > scope_limit:
-    die(f"Scope limit exceeded: {loc} LOC changed > {scope_limit} cap for lane {lane_id}.\n"
-        f"A task this big should be split. Per your brief: STOP and report.\n"
-        f"(If this single task legitimately needs more, set \"scope_limit\" in .lane and say so in the PR.)")
-
-# ---- 4: verify (regression gate) -------------------------------------------
-if os.environ.get("ALFRED_SKIP_VERIFY") == "1":
-    sys.stderr.write(f"{YELLOW}⚠ ALFRED_SKIP_VERIFY=1 — regression gate skipped (boundary + scope still enforced).{RESET}\n")
-else:
-    sys.stderr.write(f"▶ lane {lane_id} verify: {verify}\n")
-    if subprocess.run(verify, shell=True, cwd=top).returncode != 0:
-        die(f"VERIFY failed: {verify}\n"
-            f"A test/typecheck regressed. Fix it before committing, or scope the change down.\n"
-            f"(Emergency-only override: ALFRED_SKIP_VERIFY=1 git commit …)")
-
-sys.stderr.write(f"{GREEN}✓ lane {lane_id} ({lane['name']}) gate passed — {loc} LOC, {len(staged)} files, verify ok{RESET}\n")
-sys.exit(0)
+if __name__ == "__main__":
+    main()

--- a/scripts/hooks/install.sh
+++ b/scripts/hooks/install.sh
@@ -1,11 +1,39 @@
 #!/usr/bin/env bash
-# Install the Alfred lane-enforcement gate. Run once from the repo root:
+# Install the Alfred lane-enforcement gate. Run once from the repo root
+# (idempotent — safe to re-run any time):
 #     bash scripts/hooks/install.sh
 set -euo pipefail
 ROOT="$(git rev-parse --show-toplevel)"
+GIT_COMMON="$(git -C "${ROOT}" rev-parse --git-common-dir)"
+case "${GIT_COMMON}" in /*) : ;; *) GIT_COMMON="${ROOT}/${GIT_COMMON}" ;; esac
 
+# 1. The intended wiring.
 git -C "${ROOT}" config core.hooksPath scripts/hooks
 chmod +x "${ROOT}/scripts/hooks/pre-commit" "${ROOT}/scripts/hooks/check_lane.py"
+
+# 2. Harness-proofing: the Claude Code worktree harness rewrites
+#    core.hooksPath to the default .git/hooks (shared AND per-worktree
+#    config.worktree) at every worktree creation — this silently disarmed the
+#    gate for ~6 weeks (2026-06 → 2026-07 audit). Symlink the hook INTO
+#    .git/hooks so the gate fires whichever value core.hooksPath holds.
+#    pre-commit resolves check_lane.py via `git rev-parse --show-toplevel`,
+#    so running via this symlink is safe in the main checkout and in every
+#    linked worktree.
+mkdir -p "${GIT_COMMON}/hooks"
+ln -sf "${ROOT}/scripts/hooks/pre-commit" "${GIT_COMMON}/hooks/pre-commit"
+
+# 3. Strip any stale per-worktree hooksPath overrides the harness left behind
+#    (worktree config takes precedence over shared config).
+if [ -d "${GIT_COMMON}/worktrees" ]; then
+  for wt_cfg in "${GIT_COMMON}"/worktrees/*/config.worktree; do
+    [ -f "${wt_cfg}" ] || continue
+    if grep -q 'hooksPath' "${wt_cfg}" 2>/dev/null; then
+      # keep the file, drop only the hooksPath line (portable sed -i)
+      sed -i.bak '/hooksPath/d' "${wt_cfg}" && rm -f "${wt_cfg}.bak"
+      echo "  · stripped stale hooksPath override: ${wt_cfg}"
+    fi
+  done
+fi
 
 # `.lane` is per-worktree metadata — never commit it.
 if ! grep -qxF '.lane' "${ROOT}/.gitignore" 2>/dev/null; then
@@ -13,15 +41,28 @@ if ! grep -qxF '.lane' "${ROOT}/.gitignore" 2>/dev/null; then
 fi
 
 cat <<'EOF'
-✓ lane gate installed (core.hooksPath=scripts/hooks). All worktrees inherit it.
+✓ lane gate installed:
+    core.hooksPath = scripts/hooks
+    .git/hooks/pre-commit → scripts/hooks/pre-commit   (harness-proof fallback)
+
+NOTE: local hooks are best-effort — the Claude Code worktree harness may
+re-point core.hooksPath at .git/hooks (the symlink covers that case) and new
+worktrees may carry a config.worktree override (re-run this script to strip
+them). The AUTHORITATIVE gate is server-side: .github/workflows/lane-gate.yml
+replays check_lane.py on every PR from a lane-N/* branch.
 
 Per-lane worktree setup — drop a `.lane` manifest at the worktree root:
     echo '{"lane":"II"}' > .lane                                  # whole-lane VERIFY default
     echo '{"lane":"II","verify":"cd packages/learn && python -m pytest tests/test_signals.py -q"}' > .lane
 
+Valid lanes: I (ctrl) · II (learn) · III (web) · IV (alfred-vault)
+             V (edges/infra+setup) · VI (voice-bridge) · VII (paperclip)
+
 The main checkout (no `.lane`) is the phase0 orchestrator lane (allow-all), so
 this never blocks normal work on main. A *linked worktree* with no `.lane` is
-rejected on purpose — a lane agent must declare its lane.
+rejected on purpose — a lane agent must declare its lane (and may NOT declare
+phase0; orchestrator work happens in the main checkout only).
 
 Self-test:  ALFRED_LANE=II python3 scripts/hooks/check_lane.py   (with files staged)
+            python3 scripts/hooks/test_check_lane.py             (unit tests)
 EOF

--- a/scripts/hooks/lanes.json
+++ b/scripts/hooks/lanes.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Lane definitions for the Alfred fix fan-out. Enforced by check_lane.py at pre-commit. forbidden_zone is Phase-0-owned and off-limits to every lane (except phase0). A staged file must match >=1 of its lane's `allowed` globs and 0 forbidden_zone globs. Glob rules: `a/b/**` = prefix match; `**/x` = suffix match; otherwise fnmatch; exact path = equality. `verify` is the regression gate (overridable per-task via .lane). scope_limit is net changed LOC.",
+  "_comment": "Lane definitions for the Alfred fix fan-out. Enforced by check_lane.py at pre-commit AND replayed server-side by .github/workflows/lane-gate.yml on every PR from a lane-N/* branch. forbidden_zone is Phase-0-owned and off-limits to every lane (except phase0). A staged file must match >=1 of its lane's `allowed` globs and 0 forbidden_zone globs. Glob rules: `a/b/**` = prefix match; `**/x` = suffix match; otherwise fnmatch; exact path = equality. `verify` is the regression gate (overridable per-task via .lane). scope_limit is net changed LOC. Branch naming: lane-<arabic>/<issue>-<slug> maps to the roman lane id (lane-1=I .. lane-7=VII). v2 2026-07-15: added lanes VI (voice-bridge) + VII (paperclip), setup joined lane V — every package now has exactly one owning lane; .github/** and docs/lane-protocol.md joined the forbidden zone.",
   "forbidden_zone": [
     "packages/ctrl/src/db/schema.sql",
     "packages/ctrl/src/db/migrations/**",
@@ -9,7 +9,9 @@
     "docs/FIX-CONTRACTS.md",
     "docs/FIX-PLAN.md",
     "docs/FAILURE-MODES.md",
+    "docs/lane-protocol.md",
     "scripts/hooks/**",
+    ".github/**",
     "CLAUDE.md"
   ],
   "lanes": {
@@ -43,6 +45,7 @@
         "packages/hermes/**",
         "packages/mcp-server/**",
         "packages/vault-init/**",
+        "packages/setup/**",
         "scripts/**",
         "caddy/**",
         "docker-compose.yaml",
@@ -51,6 +54,18 @@
         "docs/**"
       ],
       "verify": "docker compose config -q",
+      "scope_limit": 200
+    },
+    "VI": {
+      "name": "voice-bridge",
+      "allowed": ["packages/voice-bridge/**"],
+      "verify": "cd packages/voice-bridge && npm test",
+      "scope_limit": 200
+    },
+    "VII": {
+      "name": "paperclip",
+      "allowed": ["packages/paperclip/**"],
+      "verify": "cd packages/paperclip/adapter && npm run typecheck && npm test",
       "scope_limit": 200
     },
     "phase0": {

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,19 +1,30 @@
 #!/usr/bin/env bash
 # Alfred lane-enforcement gate (pre-commit).
 #
-# Installed by scripts/hooks/install.sh, which sets:
-#     git config core.hooksPath scripts/hooks
-# core.hooksPath is repo config shared by every linked worktree, so each lane
-# agent's worktree inherits this gate automatically.
+# Installed by scripts/hooks/install.sh two ways (belt and suspenders):
+#   1. git config core.hooksPath scripts/hooks       (the intended path)
+#   2. a symlink .git/hooks/pre-commit -> this file  (survives the Claude Code
+#      worktree harness, which rewrites core.hooksPath back to .git/hooks at
+#      every worktree creation — the 2026-06 gate-off regression)
+#
+# Because (2) means this script may run VIA A SYMLINK from .git/hooks, we do
+# NOT locate check_lane.py relative to $BASH_SOURCE (dirname of the symlink is
+# the wrong dir). The working tree's checkout is authoritative: git hooks run
+# with CWD at the top of the working tree, and every worktree has
+# scripts/hooks/check_lane.py checked out.
 #
 # It rejects a commit BEFORE the orchestrator ever sees the diff if it jumps
 # lanes, touches the Phase-0 forbidden zone, blows the ~200-LOC scope limit, or
 # fails the lane's VERIFY (regression) command. All logic lives in check_lane.py.
 set -euo pipefail
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOP="$(git rev-parse --show-toplevel)"
 PY="$(command -v python3 || command -v python || true)"
 if [ -z "${PY}" ]; then
   echo "✗ lane gate: python3 not found on PATH" >&2
   exit 1
 fi
-exec "${PY}" "${DIR}/check_lane.py"
+if [ ! -f "${TOP}/scripts/hooks/check_lane.py" ]; then
+  echo "✗ lane gate: ${TOP}/scripts/hooks/check_lane.py missing from the working tree" >&2
+  exit 1
+fi
+exec "${PY}" "${TOP}/scripts/hooks/check_lane.py"

--- a/scripts/hooks/test_check_lane.py
+++ b/scripts/hooks/test_check_lane.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Unit tests for the lane gate (scripts/hooks/check_lane.py).
+
+Pure-logic tests (glob matching, boundary classification, config shape) plus
+end-to-end tests that build throwaway git repos in a tempdir and run the gate
+as a subprocess — covering the 2026-07-15 hardening:
+
+  * deletions + rename-sources are caught (the old ACMR blindness),
+  * phase0 is rejected from a linked worktree,
+  * lanes.json is read from HEAD, so a local widening edit doesn't apply,
+  * invented lane names die,
+  * CI mode enforces boundary + forbidden zone + 3x scope on a branch diff.
+
+Run:  python3 scripts/hooks/test_check_lane.py
+"""
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+GATE = os.path.join(HERE, "check_lane.py")
+sys.path.insert(0, HERE)
+
+check_lane = __import__("check_lane")
+
+
+class TestMatch(unittest.TestCase):
+    def test_prefix_glob(self):
+        self.assertTrue(check_lane.match("packages/ctrl/**", "packages/ctrl/src/api/routes/vault.ts"))
+        self.assertFalse(check_lane.match("packages/ctrl/**", "packages/ctrl-extra/x.ts"))
+
+    def test_suffix_glob(self):
+        self.assertTrue(check_lane.match("**/CONTRACT.md", "packages/learn/CONTRACT.md"))
+        self.assertFalse(check_lane.match("**/CONTRACT.md", "packages/learn/CONTRACT.md.bak"))
+
+    def test_exact(self):
+        self.assertTrue(check_lane.match("docker-compose.yaml", "docker-compose.yaml"))
+        self.assertFalse(check_lane.match("docker-compose.yaml", "deploy/docker-compose.yaml"))
+
+
+class TestConfigShape(unittest.TestCase):
+    def setUp(self):
+        with open(os.path.join(HERE, "lanes.json")) as fh:
+            self.cfg = json.load(fh)
+
+    def test_all_seven_lanes_plus_phase0(self):
+        self.assertEqual(
+            set(self.cfg["lanes"].keys()),
+            {"I", "II", "III", "IV", "V", "VI", "VII", "phase0"})
+
+    def test_every_package_has_exactly_one_owning_lane(self):
+        packages = ["alfred-vault", "ctrl", "hermes", "learn", "mcp-server",
+                    "paperclip", "setup", "vault-init", "voice-bridge", "web"]
+        for pkg in packages:
+            probe = f"packages/{pkg}/some/file.ts"
+            owners = [lid for lid, lane in self.cfg["lanes"].items()
+                      if lid != "phase0"
+                      and any(check_lane.match(g, probe) for g in lane["allowed"])]
+            self.assertEqual(len(owners), 1, f"packages/{pkg} owned by {owners}")
+
+    def test_forbidden_zone_covers_the_audit_set(self):
+        fz = self.cfg["forbidden_zone"]
+        for probe in [
+            "packages/ctrl/src/db/migrations/0042_x.sql",
+            "packages/ctrl/src/db/schema.sql",
+            "packages/ctrl/src/api/server.ts",
+            "packages/learn/CONTRACT.md",
+            "docs/FIX-CONTRACTS.md",
+            "docs/lane-protocol.md",
+            "scripts/hooks/lanes.json",
+            ".github/workflows/lane-gate.yml",
+            "CLAUDE.md",
+        ]:
+            self.assertTrue(any(check_lane.match(g, probe) for g in fz),
+                            f"{probe} not covered by forbidden zone")
+
+
+class TestBoundary(unittest.TestCase):
+    def setUp(self):
+        with open(os.path.join(HERE, "lanes.json")) as fh:
+            self.cfg = json.load(fh)
+
+    def check(self, lane_id, paths):
+        return check_lane.boundary_violations(
+            paths, lane_id, self.cfg["lanes"][lane_id], self.cfg["forbidden_zone"])
+
+    def test_in_lane_ok(self):
+        self.assertEqual(self.check("II", ["packages/learn/src/activities/x.py"]), [])
+
+    def test_out_of_lane(self):
+        v = self.check("II", ["packages/ctrl/src/api/routes/x.ts"])
+        self.assertEqual(len(v), 1)
+        self.assertIn("OUT OF LANE", v[0])
+
+    def test_forbidden_zone_beats_allowed(self):
+        # migrations are inside lane I's package glob but forbidden-zone wins
+        v = self.check("I", ["packages/ctrl/src/db/migrations/0099_x.sql"])
+        self.assertEqual(len(v), 1)
+        self.assertIn("FORBIDDEN ZONE", v[0])
+
+    def test_voice_bridge_now_owned(self):
+        self.assertEqual(self.check("VI", ["packages/voice-bridge/src/server.ts"]), [])
+        v = self.check("V", ["packages/voice-bridge/src/server.ts"])
+        self.assertEqual(len(v), 1)  # the historic "voice under lane V" is now out-of-lane
+
+
+def sh(cwd, *args, env=None):
+    e = dict(os.environ)
+    e.update(env or {})
+    return subprocess.run(args, cwd=cwd, env=e, capture_output=True, text=True)
+
+
+class TestEndToEnd(unittest.TestCase):
+    """Throwaway-repo tests exercising the gate binary itself."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="lane-gate-test-")
+        self.repo = os.path.join(self.tmp, "repo")
+        os.makedirs(os.path.join(self.repo, "scripts/hooks"))
+        for f in ("check_lane.py", "lanes.json"):
+            shutil.copy(os.path.join(HERE, f), os.path.join(self.repo, "scripts/hooks", f))
+        sh(self.repo, "git", "init", "-q", "-b", "main")
+        sh(self.repo, "git", "config", "user.email", "t@t")
+        sh(self.repo, "git", "config", "user.name", "t")
+        os.makedirs(os.path.join(self.repo, "packages/learn/src"))
+        os.makedirs(os.path.join(self.repo, "packages/ctrl/src/db/migrations"))
+        self.write("packages/learn/src/a.py", "x = 1\n")
+        self.write("packages/ctrl/src/db/migrations/0001_init.sql", "-- init\n")
+        sh(self.repo, "git", "add", "-A")
+        sh(self.repo, "git", "commit", "-qm", "seed")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def write(self, rel, content):
+        p = os.path.join(self.repo, rel)
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        with open(p, "w") as fh:
+            fh.write(content)
+
+    def gate(self, cwd=None, env=None, *extra):
+        return sh(cwd or self.repo, sys.executable, GATE, *extra,
+                  env={"ALFRED_SKIP_VERIFY": "1", **(env or {})})
+
+    def test_in_lane_commit_passes(self):
+        self.write("packages/learn/src/b.py", "y = 2\n")
+        sh(self.repo, "git", "add", "packages/learn/src/b.py")
+        r = self.gate(env={"ALFRED_LANE": "II"})
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+    def test_deletion_of_forbidden_file_is_caught(self):
+        sh(self.repo, "git", "rm", "-q", "packages/ctrl/src/db/migrations/0001_init.sql")
+        r = self.gate(env={"ALFRED_LANE": "I"})
+        self.assertEqual(r.returncode, 1, r.stderr)
+        self.assertIn("FORBIDDEN ZONE", r.stderr)
+
+    def test_invented_lane_dies(self):
+        self.write("packages/learn/src/b.py", "y = 2\n")
+        sh(self.repo, "git", "add", "packages/learn/src/b.py")
+        r = self.gate(env={"ALFRED_LANE": "CTRL"})
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("Unknown lane", r.stderr)
+
+    def test_phase0_rejected_in_linked_worktree(self):
+        wt = os.path.join(self.tmp, "wt")
+        sh(self.repo, "git", "worktree", "add", "-q", wt, "-b", "wt-branch")
+        with open(os.path.join(wt, ".lane"), "w") as fh:
+            fh.write('{"lane": "phase0"}')
+        self.write("packages/learn/src/b.py", "y = 2\n")  # noise in main repo
+        p = os.path.join(wt, "packages/learn/src/c.py")
+        with open(p, "w") as fh:
+            fh.write("z = 3\n")
+        sh(wt, "git", "add", "packages/learn/src/c.py")
+        r = self.gate(cwd=wt)
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("not self-declarable", r.stderr)
+
+    def test_local_lanes_json_widening_is_ignored(self):
+        # widen the on-disk lanes.json to allow lane II everywhere — the gate
+        # must still use the HEAD copy and reject the out-of-lane file
+        cfg_path = os.path.join(self.repo, "scripts/hooks/lanes.json")
+        with open(cfg_path) as fh:
+            cfg = json.load(fh)
+        cfg["lanes"]["II"]["allowed"] = ["**"]
+        with open(cfg_path, "w") as fh:
+            json.dump(cfg, fh)
+        self.write("packages/ctrl/src/api/routes/x.ts", "// out of lane\n")
+        sh(self.repo, "git", "add", "packages/ctrl/src/api/routes/x.ts")
+        r = self.gate(env={"ALFRED_LANE": "II"})
+        self.assertEqual(r.returncode, 1, r.stderr)
+        self.assertIn("OUT OF LANE", r.stderr)
+
+    def test_ci_mode_boundary_and_scope(self):
+        sh(self.repo, "git", "checkout", "-qb", "lane-2/99-x")
+        self.write("packages/learn/src/b.py", "y = 2\n")
+        sh(self.repo, "git", "add", "-A")
+        sh(self.repo, "git", "commit", "-qm", "lane II work")
+        r = self.gate(None, {}, "--ci", "--lane", "II", "--base", "main")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        # now cross the boundary
+        self.write("packages/ctrl/src/api/routes/x.ts", "// oops\n")
+        sh(self.repo, "git", "add", "-A")
+        sh(self.repo, "git", "commit", "-qm", "cross-lane")
+        r = self.gate(None, {}, "--ci", "--lane", "II", "--base", "main")
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("OUT OF LANE", r.stderr)
+
+    def test_ci_mode_phase0_allows_all(self):
+        sh(self.repo, "git", "checkout", "-qb", "fix/operator-branch")
+        self.write("CLAUDE.md", "# operator edit\n")
+        sh(self.repo, "git", "add", "-A")
+        sh(self.repo, "git", "commit", "-qm", "operator work")
+        r = self.gate(None, {}, "--ci", "--lane", "phase0", "--base", "main")
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Post-audit hardening of the lane-enforcement layer (P0 + P1-repo + P3 of the 2026-07-15 lane-contract audit). The audit found the local commit gate had been **silently disarmed since ~2026-06-02**: the Claude Code worktree harness rewrites `core.hooksPath` back to `.git/hooks` (shared config AND per-worktree `config.worktree`) at every worktree creation, and provably-rejectable commits landed ungated (invented lane names "CTRL"/"HERMES", a 1,077-LOC single commit, voice-bridge work under lane V).

### The fix, in layers

1. **Server-side authority — `.github/workflows/lane-gate.yml`** (new): every PR replays `check_lane.py --ci` against the full PR diff. Lane derived from `lane-N/*` branch naming (lane-1→I … lane-7→VII); non-lane branches are phase0/operator by design; malformed `lane-*` names hard-fail. Local hook removal or harness clobbering cannot bypass this.
2. **lanes.json v2**: lanes **VI (voice-bridge)** + **VII (paperclip)**; `setup` joins lane V — every package now has exactly one owning lane (audit: 3 of 10 packages were unowned, which is what drove agents to invent lanes). `.github/**` + `docs/lane-protocol.md` join the forbidden zone.
3. **check_lane.py hardening**: deletions + rename-sources now count (old `--diff-filter=ACMR` was blind to a lane deleting forbidden-zone files); `phase0` not self-declarable from a linked worktree; `lanes.json` loaded from HEAD so an uncommitted widening edit can't apply; new `--ci` mode.
4. **Harness-proof local install**: `install.sh` now ALSO symlinks `.git/hooks/pre-commit → scripts/hooks/pre-commit` (the gate fires under either `hooksPath` value) and strips stale per-worktree overrides; `pre-commit` resolves `check_lane.py` via `git rev-parse --show-toplevel` (symlink-safe).
5. **`docs/lane-protocol.md`** shipped into the repo (the autonomous loop referenced it; it never existed in-repo) — canonical unified protocol, mirrored in the operator harness. CLAUDE.md §2/§11/§12/§17 updated (lane table v2, dual-gate description, dead refs to docs/PLAN.md / packages/ctrl/CLAUDE.md fixed).

## Smoke evidence

1. **Baseline**: `python3 scripts/hooks/test_check_lane.py` on the pre-change tree — old gate has no tests; new suite written failing-test-first against the audit findings.
2. **Setup**: throwaway git repos built in tempdir per test (seed commit with lane-II file + a migration).
3. **Mutation**: 17 tests exercise the gate binary end-to-end — in-lane pass, out-of-lane die, forbidden-zone-beats-allowed, **deletion of a migration caught** (old gate: passed silently), **invented lane "CTRL" dies**, **phase0 in linked worktree dies**, **on-disk lanes.json widening ignored (HEAD copy wins)**, CI mode boundary + phase0 allow-all.
4. **Isolation assertion**: every-package-exactly-one-lane property test over all 10 packages; voice-bridge under lane V (the historic misfile) now OUT OF LANE.
5. **Audit-row/verification**: 17/17 OK locally; `yaml.safe_load` + `json.tool` + `bash -n` all pass.
6. **Cleanup**: tempdir repos removed per-test (tearDown); no state left outside the worktree.

## Notes for merge

- This PR intentionally comes from an operator (`hardening/*`) branch → lane-gate treats it as phase0 (it edits the forbidden zone itself).
- After merge: run `bash scripts/hooks/install.sh` on any live checkout, and branch protection will make `lane-gate` a required check (done as a follow-up API call).
- Follow-up PR regenerates the stale package CONTRACT.md files (audit P2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)