### PR TITLE
fix(voice): #226 Lane VI — inject per-call timezone anchor into voice instructions

### DIFF
--- a/packages/voice-bridge/src/instructions.test.ts
+++ b/packages/voice-bridge/src/instructions.test.ts
@@ -1,0 +1,192 @@
+// instructions.test.ts — #226 Lane V: per-call timezone anchor in voice instructions.
+//
+// Covers the 6 smoke sections from the contracts doc:
+//   1. Setup — InstructionContext with voiceContext.timeZone = "Europe/Budapest"
+//      and a fixed June now (2026-06-02T17:40:00Z).
+//   2. Trigger — call buildInstructions(ctx, fixedNow).
+//   3. Assert positive — output contains anchor line, "Europe/Budapest",
+//      "+02:00" (DST sanity), and today/tomorrow date pair.
+//   4. Assert non-UTC != UTC — Budapest offset is NOT "+00:00" / "Z".
+//   5. Assert fallback — absent timeZone renders UTC anchor without crash.
+//   6. Cleanup — pure function; assert no globals mutated.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+// A fixed June instant: 2026-06-02T17:40:00Z
+// Europe/Budapest in June = CEST = UTC+02:00, so local time is 19:40:00+02:00.
+const FIXED_NOW = new Date("2026-06-02T17:40:00Z");
+
+test("buildTimeAnchor: Europe/Budapest June instant → +02:00 (DST sanity)", async () => {
+  const { buildTimeAnchor } = await import("./instructions.js");
+  const anchor = buildTimeAnchor("Europe/Budapest", FIXED_NOW);
+
+  // Must contain the IANA zone name
+  assert.match(anchor, /Europe\/Budapest/, "must contain IANA zone name");
+
+  // Must contain UTC+02:00 (CEST — June DST offset)
+  assert.match(anchor, /\+02:00/, "must show +02:00 offset for June Budapest");
+
+  // Must NOT be UTC (prove zone is applied, not ignored)
+  assert.doesNotMatch(
+    anchor,
+    /\+00:00/,
+    "Budapest in June must not render as +00:00",
+  );
+  assert.doesNotMatch(anchor, /UTC\+00/, "must not render as UTC+00");
+
+  // Must contain today/tomorrow date info
+  assert.match(anchor, /Today is/, "must include today label");
+  assert.match(anchor, /tomorrow is/, "must include tomorrow label");
+
+  // Must contain June 2026 dates
+  assert.match(anchor, /2026/, "must include the year");
+  assert.match(anchor, /June/, "must include the month");
+
+  // Must contain the calendar/timezone instruction sentence
+  assert.match(
+    anchor,
+    /When calling calendar\/email tools/,
+    "must include the tool-use instruction",
+  );
+  assert.match(
+    anchor,
+    /report times in it/,
+    "must include the reporting instruction",
+  );
+});
+
+test("buildInstructions: anchor prepended with Budapest timezone", async () => {
+  const { buildInstructions } = await import("./instructions.js");
+
+  const ctx = {
+    tenantPhoneNumber: "+36201234567",
+    voiceContext: {
+      memoryMd: "Sir prefers brevity.",
+      voiceSkill: "",
+      openMatters: [],
+      openTasks: [],
+      recentSessions: [],
+      generatedAt: "2026-06-02T17:00:00Z",
+      timeZone: "Europe/Budapest",
+    },
+  };
+
+  const result = buildInstructions(ctx, FIXED_NOW);
+
+  // Section 3: Assert positive — anchor present
+  assert.match(result, /Europe\/Budapest/, "output must contain IANA zone");
+  assert.match(result, /\+02:00/, "output must contain +02:00 DST offset");
+  assert.match(result, /Today is/, "output must contain today label");
+  assert.match(result, /tomorrow is/, "output must contain tomorrow label");
+  assert.match(
+    result,
+    /When calling calendar\/email tools/,
+    "output must contain tool-use instruction",
+  );
+
+  // Section 4: Assert non-UTC != UTC — Budapest offset is NOT +00:00 / Z
+  assert.doesNotMatch(
+    result,
+    /Current time:.*\+00:00/,
+    "Budapest anchor must not show +00:00",
+  );
+
+  // The rest of the instructions must still be present (no regression)
+  assert.match(result, /Yes, sir\?/, "persona greeting must still be present");
+  assert.match(
+    result,
+    /Voice guardrails/,
+    "guardrails block must still be present",
+  );
+});
+
+test("buildInstructions: timeZone absent → UTC anchor without crash", async () => {
+  const { buildInstructions } = await import("./instructions.js");
+
+  // Section 5: fallback — no timeZone field
+  const ctx = {
+    tenantPhoneNumber: null,
+    voiceContext: {
+      memoryMd: "",
+      voiceSkill: "",
+      openMatters: [],
+      openTasks: [],
+      recentSessions: [],
+      generatedAt: "2026-06-02T17:00:00Z",
+      // timeZone intentionally absent
+    },
+  };
+
+  let result: string;
+  assert.doesNotThrow(() => {
+    result = buildInstructions(ctx, FIXED_NOW);
+  }, "must not throw when timeZone is absent");
+
+  // Should still render an anchor (in UTC)
+  assert.match(result!, /Today is/, "UTC fallback must still render today");
+  assert.match(result!, /UTC/, "UTC fallback must mention UTC");
+});
+
+test("buildInstructions: null voiceContext → UTC anchor without crash", async () => {
+  const { buildInstructions } = await import("./instructions.js");
+
+  const ctx = {
+    tenantPhoneNumber: null,
+    voiceContext: null,
+  };
+
+  let result: string;
+  assert.doesNotThrow(() => {
+    result = buildInstructions(ctx, FIXED_NOW);
+  }, "must not throw when voiceContext is null");
+
+  // Should still render something (anchor in UTC)
+  assert.match(result!, /Today is/, "UTC anchor must render even with null context");
+});
+
+test("buildTimeAnchor: UTC fallback renders correctly", async () => {
+  const { buildTimeAnchor } = await import("./instructions.js");
+
+  const anchor = buildTimeAnchor("UTC", FIXED_NOW);
+
+  assert.match(anchor, /UTC/, "UTC anchor must mention UTC");
+  assert.match(anchor, /\+00:00/, "UTC must show +00:00 offset");
+  assert.match(anchor, /Today is/, "UTC anchor must include today");
+  assert.match(anchor, /tomorrow is/, "UTC anchor must include tomorrow");
+});
+
+test("buildInstructions: no globals mutated (pure function)", async () => {
+  const { buildInstructions } = await import("./instructions.js");
+
+  const ctx = {
+    tenantPhoneNumber: null,
+    voiceContext: {
+      memoryMd: "",
+      voiceSkill: "",
+      openMatters: [],
+      openTasks: [],
+      recentSessions: [],
+      generatedAt: "2026-06-02T17:00:00Z",
+      timeZone: "Europe/Budapest",
+    },
+  };
+
+  // Capture global state before
+  const dateNowBefore = Date.now();
+
+  buildInstructions(ctx, FIXED_NOW);
+  buildInstructions(ctx, FIXED_NOW);
+
+  // Date.now() still advances normally (no freeze applied globally)
+  const dateNowAfter = Date.now();
+  assert.ok(
+    dateNowAfter >= dateNowBefore,
+    "Date.now() must not be frozen globally after buildInstructions",
+  );
+
+  // Two calls with same input produce same output (pure / deterministic)
+  const r1 = buildInstructions(ctx, FIXED_NOW);
+  const r2 = buildInstructions(ctx, FIXED_NOW);
+  assert.equal(r1, r2, "buildInstructions must be deterministic with fixed now");
+});

--- a/packages/voice-bridge/src/instructions.ts
+++ b/packages/voice-bridge/src/instructions.ts
@@ -154,7 +154,75 @@ const VOICE_GUARDRAILS = [
   "7. **Files: respect `too_large`.** If `files__read_text` returns `{too_large: true, ...}`, the file's contents are NOT in your context. Tell Sir the file is too large to read aloud (or that it's binary) and offer the dashboard — never recite contents you didn't actually receive.",
 ].join("\n");
 
-export function buildInstructions(ctx: InstructionContext): string {
+/**
+ * Build a per-call current-time anchor string that tells the Realtime model
+ * the exact local time in the principal's IANA timezone. Called on every
+ * `buildInstructions` invocation so the time is never stale from a cached
+ * bundle (the bundle's 60s TTL would make a baked timestamp wrong).
+ *
+ * `now` is injectable for deterministic testing — pass a fixed Date in tests,
+ * omit in production to get `new Date()`.
+ *
+ * DST is handled automatically by `Intl.DateTimeFormat`. Do NOT hardcode
+ * offsets — Europe/Budapest is UTC+01:00 in winter (CET) and UTC+02:00 in
+ * summer (CEST). Intl picks the correct one for the given instant.
+ *
+ * Exported so tests can call it directly without building a full context.
+ */
+export function buildTimeAnchor(timeZone: string, now: Date = new Date()): string {
+  // Resolve DST-correct offset via Intl. We use "longOffset" (e.g.
+  // "GMT+02:00") and strip the "GMT" prefix to get "+02:00".
+  const offsetFmt = new Intl.DateTimeFormat("en-GB", {
+    timeZone,
+    timeZoneName: "longOffset",
+  });
+  const offsetParts = offsetFmt.formatToParts(now);
+  const rawOffset =
+    offsetParts.find((p) => p.type === "timeZoneName")?.value ?? "GMT+00:00";
+  // "GMT+02:00" → "+02:00"; "GMT" alone (UTC) → "+00:00"
+  const utcOffset = rawOffset === "GMT" ? "+00:00" : rawOffset.replace("GMT", "");
+
+  // Current local time formatted as ISO-ish with the offset
+  const localTimeFmt = new Intl.DateTimeFormat("en-GB", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+  const timeParts = Object.fromEntries(
+    localTimeFmt.formatToParts(now).map((p) => [p.type, p.value]),
+  ) as Record<string, string>;
+  const localIso =
+    `${timeParts.year}-${timeParts.month}-${timeParts.day}` +
+    `T${timeParts.hour}:${timeParts.minute}:${timeParts.second}${utcOffset}`;
+
+  // Today's and tomorrow's weekday+date in the principal's zone
+  const dayFmt = new Intl.DateTimeFormat("en-GB", {
+    timeZone,
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+  const todayStr = dayFmt.format(now);
+  const tomorrowStr = dayFmt.format(new Date(now.getTime() + 86_400_000));
+
+  // Display name for UTC zones: keep "UTC" when offset is +00:00, otherwise
+  // show the IANA name.
+  const zoneDisplay = timeZone === "UTC" ? "UTC" : timeZone;
+
+  return [
+    `Current time: ${localIso} (${zoneDisplay}, UTC${utcOffset}).`,
+    `Today is ${todayStr}; tomorrow is ${tomorrowStr}.`,
+    "When calling calendar/email tools, build time ranges in this timezone and report times in it.",
+  ].join("\n");
+}
+
+export function buildInstructions(ctx: InstructionContext, now: Date = new Date()): string {
   const persona =
     ctx.initiator === "alfred"
       ? outboundIntent(ctx.intent)
@@ -170,7 +238,15 @@ export function buildInstructions(ctx: InstructionContext): string {
     ? `\n\nCaller: ${ctx.callerNumber} (use this number for any SMS the caller asks you to send).`
     : "";
 
+  // #226 — per-call timezone anchor. Computed fresh every call (not cached
+  // with the bundle) so it's always accurate. Falls back to UTC when the
+  // bundle doesn't carry a timeZone (pre-Lane-I deploys, or cache miss).
+  const timeZone = ctx.voiceContext?.timeZone || "UTC";
+  const timeAnchor = buildTimeAnchor(timeZone, now);
+
   // Order matters — guardrails LAST so recency-weighted attention favours
   // them over the (also-load-bearing-but-not-as-load-bearing) primer.
-  return `${persona}${callerLine}${primer}\n${VOICE_GUARDRAILS}`;
+  // Time anchor goes right after persona / caller line so the model always
+  // sees the current time before the context primer and guardrails.
+  return `${persona}${callerLine}\n\n## Current time\n\n${timeAnchor}${primer}\n${VOICE_GUARDRAILS}`;
 }

--- a/packages/voice-bridge/src/tenant.ts
+++ b/packages/voice-bridge/src/tenant.ts
@@ -87,6 +87,12 @@ export interface VoiceContextBundle {
   // `execute__list_composio_tools` on demand if it ever needs to enumerate.
   skills?: Array<{ name: string; description: string; body: string }>;
   generatedAt: string;
+  // #226 — IANA timezone name for the principal's calendar (e.g.
+  // "Europe/Budapest"). Populated by Lane I (ctrl-api) from the cached
+  // Google Calendar primary-calendar timeZone. Falls back to "UTC" when
+  // absent. Used by the voice-bridge to inject a per-call current-time
+  // anchor so the Realtime model stops guessing UTC for +02:00 events.
+  timeZone?: string;
 }
 
 /**


### PR DESCRIPTION
Reopens #228 (auto-closed by the lane-5 → lane-6 head-branch rename; voice-bridge is lane VI under lanes.json v2). Same two commits, same SHIP review (autonomous-loop lane review, head be40970). Closes #226.

## Summary

- Add `timeZone?: string` to `VoiceContextBundle` in `tenant.ts` per the frozen C226 contract (IANA name, e.g. `"Europe/Budapest"`, falls back to `"UTC"`).
- Export `buildTimeAnchor(timeZone, now)` in `instructions.ts` — uses `Intl.DateTimeFormat` to compute a DST-correct offset, today/tomorrow weekday+date, and the tool-use instruction. No hardcoded offsets; `now` is injectable for deterministic tests.
- Update `buildInstructions(ctx, now?)` to prepend the anchor on every call (computed fresh, not cached in the bundle) so the Realtime model always sees the current local time before the context primer.
- Add `instructions.test.ts` — 6 smoke sections per contract spec.

References #226 (Lane I, the provider, merges first).
Closes #226

## Smoke evidence

All 98 voice-bridge tests pass (`tsc && node --test dist/*.test.js`), including all 6 new anchor tests:

```
✔ buildTimeAnchor: Europe/Budapest June instant → +02:00 (DST sanity) (32.732125ms)
✔ buildInstructions: anchor prepended with Budapest timezone (0.451917ms)
✔ buildInstructions: timeZone absent → UTC anchor without crash (0.328292ms)
✔ buildInstructions: null voiceContext → UTC anchor without crash (0.619458ms)
✔ buildTimeAnchor: UTC fallback renders correctly (0.250958ms)
✔ buildInstructions: no globals mutated (pure function) (0.635666ms)
```

Full run summary:
```
ℹ tests 98
ℹ suites 0
ℹ pass 98
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 5344.024084
```

### Section-by-section

1. **Setup** — `InstructionContext` with `voiceContext.timeZone = "Europe/Budapest"` and `FIXED_NOW = new Date("2026-06-02T17:40:00Z")` (a June instant where Budapest is CEST = UTC+02:00).
2. **Trigger** — `buildInstructions(ctx, FIXED_NOW)` and `buildTimeAnchor("Europe/Budapest", FIXED_NOW)`.
3. **Assert positive** — output contains `Europe/Budapest`, `+02:00`, `Today is`, `tomorrow is`, `When calling calendar/email tools`. All pass.
4. **Assert non-UTC ≠ UTC** — verified that Budapest in June renders `+02:00`, NOT `+00:00` / `GMT`. The `doesNotMatch` assertion passes.
5. **Assert fallback** — absent `timeZone` and `null` voiceContext both render UTC anchor without throwing. Both pass.
6. **Cleanup** — pure function: two calls with the same `(ctx, fixedNow)` produce identical output. `Date.now()` advances normally after calls (no global freeze). Both assertions pass.

## Files touched

- `packages/voice-bridge/src/tenant.ts` — `VoiceContextBundle.timeZone?: string`
- `packages/voice-bridge/src/instructions.ts` — `buildTimeAnchor` export + `buildInstructions` updated
- `packages/voice-bridge/src/instructions.test.ts` — NEW, 6 smoke tests

## Architecture choice

`buildTimeAnchor` is exported as a standalone helper (rather than inlined in `buildInstructions`) so tests can call it directly with a fixed instant — no need to build a full `InstructionContext`. `buildInstructions` gains an optional `now: Date = new Date()` param that defaults to real wall-clock time for all existing callers.

The time anchor is prepended right after the persona/caller line, under a `## Current time` heading, so the Realtime model sees it before the cross-channel context primer and before the guardrails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
