### PR TITLE
docs(operators): alfred-code intake note (#292)

### DIFF
--- a/docs/operators/alfred-code-intake.md
+++ b/docs/operators/alfred-code-intake.md
@@ -8,8 +8,9 @@ in the loop.
 In label-gated mode, an issue enters the controller when it is labeled
 `alfred-code`. When automatic intake is enabled, every open issue enters
 without requiring that label. Label removal is not a cancellation mechanism
-after a plan or job exists; reject the current plan in GitHub or use the
-documented incident procedure instead.
+after a plan or job exists. Before approval, reject the exact current plan in
+GitHub. Once a job has launched, the current controller has no cancellation
+command; do not treat label removal or a late plan rejection as a stop signal.
 
 ## Planning before building
 
@@ -46,17 +47,19 @@ hash.
 
 ## Where to look: Projects vs Superset
 
-GitHub Projects is the control center and Superset is the execution
-viewer.
+GitHub Projects is the control center and Superset is the execution runtime.
 
 - **GitHub Projects** is where operators act: issue status, published
   plans, approval comments, and PR linkage all live on the board and the
-  issues themselves. Decisions happen here.
-- **Superset** is where operators watch: it renders the running lane
-  agents, their worktrees, and live job output. It is read-only from a
-  control standpoint — nothing you do in Superset approves, dispatches,
-  or halts work.
+  issues themselves. Supported approval and rejection decisions happen here.
+- **Superset** renders running lane agents, their worktrees, and live job
+  output. It also exposes manual agent and workspace controls, but those are
+  outside the controller protocol: they do not count as plan approval,
+  rejection, or cancellation, and using them can leave the job blocked or
+  out of sync with GitHub.
 
-If a run looks wrong in Superset, act on it from GitHub (comment on the
-issue or PR); the controller only responds to signals in the control
-center.
+For normal controller-managed work, record decisions and feedback on the
+GitHub issue or PR. The controller also observes Superset execution state and
+can block a job when an agent fails or terminates. If manual intervention is
+required after launch, first compare the GitHub state, controller state, and
+Superset logs; after intervening, reconcile all three before resuming work.

--- a/docs/operators/alfred-code-intake.md
+++ b/docs/operators/alfred-code-intake.md
@@ -3,12 +3,13 @@
 How a GitHub issue becomes controller-managed work, and where a human sits
 in the loop.
 
-## Intake: the `alfred-code` label
+## Intake
 
-An issue enters the controller when it is labeled `alfred-code`. Nothing
-else triggers intake — an unlabeled issue is invisible to the controller,
-and removing the label withdraws it. Apply the label only when the issue
-is ready to be planned.
+In label-gated mode, an issue enters the controller when it is labeled
+`alfred-code`. When automatic intake is enabled, every open issue enters
+without requiring that label. Label removal is not a cancellation mechanism
+after a plan or job exists; reject the current plan in GitHub or use the
+documented incident procedure instead.
 
 ## Planning before building
 
@@ -30,6 +31,11 @@ the complete hex string, copied verbatim:
 ```
 /approve-plan <full-plan-hash>
 ```
+
+To reject the plan without starting a build, use the corresponding exact
+full-hash command shown by the controller. Any other operator comment made
+while the plan awaits approval is specification feedback and produces a new
+plan with a new hash.
 
 Truncated, paraphrased, or retyped-from-memory hashes are not accepted.
 The hash binds the approval to the full plan content and the pinned base

--- a/docs/operators/alfred-code-intake.md
+++ b/docs/operators/alfred-code-intake.md
@@ -34,9 +34,10 @@ the complete hex string, copied verbatim:
 ```
 
 To reject the plan without starting a build, use the corresponding exact
-full-hash command shown by the controller. Any other operator comment made
-while the plan awaits approval is specification feedback and produces a new
-plan with a new hash.
+full-hash command shown by the controller. Any other non-command operator
+comment made while the plan awaits approval is specification feedback and
+produces a new plan with a new hash. Malformed approval or rejection commands
+are ignored rather than interpreted as feedback.
 
 Truncated, paraphrased, or retyped-from-memory hashes are not accepted.
 The hash binds the approval to the full plan content and the pinned base

--- a/docs/operators/alfred-code-intake.md
+++ b/docs/operators/alfred-code-intake.md
@@ -1,0 +1,56 @@
+# Alfred Code intake
+
+How a GitHub issue becomes controller-managed work, and where a human sits
+in the loop.
+
+## Intake: the `alfred-code` label
+
+An issue enters the controller when it is labeled `alfred-code`. Nothing
+else triggers intake — an unlabeled issue is invisible to the controller,
+and removing the label withdraws it. Apply the label only when the issue
+is ready to be planned.
+
+## Planning before building
+
+Planning discovers lanes and contracts before any build begins. On intake
+the controller reads the live lane policy (`scripts/hooks/lanes.json`),
+maps every path the change touches to its owning lane, and lists the
+contracts each lane job must read (and any a phase0 job would change).
+The result is an execution plan published as an issue comment: pinned base
+SHA, ordered lane jobs with paths and per-job verification commands, and
+the contract set. No branch is cut and no implementation job starts during
+planning.
+
+## Approval: the exact full plan hash
+
+The controller halts after publishing the plan and waits for a human.
+Approval must use the exact full plan hash displayed by the controller —
+the complete hex string, copied verbatim:
+
+```
+/approve-plan <full-plan-hash>
+```
+
+Truncated, paraphrased, or retyped-from-memory hashes are not accepted.
+The hash binds the approval to the full plan content and the pinned base
+SHA; if the plan is regenerated for any reason, it gets a new hash and any
+approval of the old hash is invalid. No approval is recorded and no
+build/implementation job starts until a human supplies the exact full
+hash.
+
+## Where to look: Projects vs Superset
+
+GitHub Projects is the control center and Superset is the execution
+viewer.
+
+- **GitHub Projects** is where operators act: issue status, published
+  plans, approval comments, and PR linkage all live on the board and the
+  issues themselves. Decisions happen here.
+- **Superset** is where operators watch: it renders the running lane
+  agents, their worktrees, and live job output. It is read-only from a
+  control standpoint — nothing you do in Superset approves, dispatches,
+  or halts work.
+
+If a run looks wrong in Superset, act on it from GitHub (comment on the
+issue or PR); the controller only responds to signals in the control
+center.


### PR DESCRIPTION
Adds the operator note requested by #292: `docs/operators/alfred-code-intake.md`, documenting the Alfred Code control-plane intake flow.

The note covers both label-gated and automatic intake, lane and contract discovery before building, exact full-hash approval and rejection before launch, the lack of a post-launch cancellation command, and the authority boundary between GitHub Projects and the Superset execution runtime.

Lane V (`edges-infra`), controller job `docs-292`, pinned base `eaf0802a`, approved plan `0b0c823a01293dc5979185259da0616ce08131b8a8063ce134a02e724544902e`. Documentation-only; `docs/operators/` matches the lane V `docs/**` allowed glob and no forbidden-zone glob.

Refs #292

## Smoke evidence

Exact current head: `318d1559ac82275a4e2b64f9280914139037d223`.

Diff versus the pinned base is exactly one added file and 66 inserted lines:

```
$ git diff --name-status eaf0802aab77a9bb127790ec7837b3544183a95d..HEAD
A	docs/operators/alfred-code-intake.md

$ git diff --numstat eaf0802aab77a9bb127790ec7837b3544183a95d..HEAD
66	0	docs/operators/alfred-code-intake.md

$ git diff --check eaf0802aab77a9bb127790ec7837b3544183a95d..HEAD
# exit 0
```

Lane V verification at the current branch head, with the local ignored `.env` already present:

```
$ docker compose config -q
# exit 0

$ python3 scripts/hooks/check_lane.py --ci --lane V --base eaf0802aab77a9bb127790ec7837b3544183a95d
✓ lane V (edges-infra) CI gate passed — 66 LOC, 1 files
# exit 0

$ PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v scripts.hooks.test_check_lane
Ran 17 tests
OK
```

Focused controller behavior was verified against `ssdavidai/alfred-code@4cba6bc5c5aeae62e8552068804ae632c1de4b1b`:

```
$ PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python3 -m unittest discover -s tests -v
Ran 44 tests
OK
```

The issue thread records plan publication before the owner supplied the exact full-hash approval. Focused tests verify that no job or workspace is materialized before approval, exact rejection blocks a pre-build plan, automatic intake projects an issue to Specifying before planning, and a late rejection does not cancel a launched job.