### PR TITLE
Bug: retired Plane MCP remains registered and delays every Hermes startup (lane phase0)

### DIFF
--- a/packages/hermes/CONTRACT.md
+++ b/packages/hermes/CONTRACT.md
@@ -197,11 +197,20 @@ auto-namespaces tools as `mcp_<server>_<tool>`.
 | `hass` | stdio (bundle) | ✓ (trimmed) | — | — | — | main-only (#110); proxies ctrl-api `/api/v1/channels/ha/*`; the HA token never reaches the MCP server |
 | `paperclip` | stdio (upstream npm) | ✓ (trimmed) | ✓ | ✓ | — | needs `PAPERCLIP_API_KEY` = **board key** (`pcp_board_…`, minted by `init/bootstrap-paperclip.sh` step 12 into the profile `.env`) + `PAPERCLIP_COMPANY_ID`/`PAPERCLIP_AGENT_ID` |
 | `files` | stdio (bundle) | ✓ | ✓ | — | — | Store-5 blob surface onto ctrl-api `/api/v1/files/*` (#114) |
-| `plane` | — | — | — | — | — | **DORMANT, not deployed**: the stdio app still ships in the bundle but no profile registers it on `main`; a stale in-template comment (line ~440) still lists it in the "base 7" |
 
 Counts on `main` branch: main 8, workers 7, heavy 6, codex-builder 0
 (`mcp_servers: {}` — the hard fence). User-facing dynamic profiles render
 main-like and get the main set.
+
+On every init boot, `render_mcp_servers.py` runs against every profile's
+operator-owned `config.yaml`. Its reconciliation is idempotent: the ADD pass
+backfills missing required registrations, then the REMOVE pass deletes retired
+server keys (currently `plane`) from `mcp_servers`; unrelated operator-owned
+blocks are preserved.
+
+A deployment-conformance test pins the resulting graph: configured MCP server
+keys must not include any retired key, and every HTTP-based server URL's host
+must map to a service declared in the root `docker-compose.yaml`.
 
 ### 7. Init container responsibilities (`init/entrypoint.sh`)
 

--- a/packages/hermes/CONTRACT.md
+++ b/packages/hermes/CONTRACT.md
@@ -160,9 +160,10 @@ Jinja2-compatible subset) into `<profile_dir>/config.yaml` + `.env`.
 Ownership split — **the load-bearing rule**:
 
 - `config.yaml` is **operator-owned**: seeded once, never overwritten by a
-  re-render. New template features reach existing tenants only via the
-  idempotent ADD-only mutators run by init on every boot:
-  `render_mcp_servers.py` (backfill missing required MCP servers),
+  re-render. New template features and retired-key cleanup reach existing
+  tenants only via the idempotent mutators run by init on every boot:
+  `render_mcp_servers.py` (backfill missing required MCP servers and remove
+  retired server keys),
   `migrate_main_profile_tool_trim.py` (issue #175 `tools.include`
   whitelists + `kanban.dispatch_in_gateway: false` add-if-unset — an
   explicit operator setting is preserved),
@@ -225,7 +226,7 @@ One-shot, idempotent; every other service gates on
 | 3 | Seed `/alfred-data/config.yaml` for the alfred vault daemon (from `config.yaml.tpl`; preserved once present) |
 | 4 | Gateway token: honour `OPENCLAW_GATEWAY_TOKEN` if set, else generate `token_urlsafe(32)` → `/alfred-data/.gateway-token`, chmod **644** |
 | 5 | Seed `/vault/intuition/index.md` + `matter/inbox.md` (the orphan-task fallback target) |
-| 6 | Render each profile's `config.yaml` + `.env` (`render_hermes.py`) and run the ADD-only mutators (§5). Writes via `/hermes-state`, bakes runtime paths from `HERMES_RUNTIME_HOME` |
+| 6 | Render each profile's `config.yaml` + `.env` (`render_hermes.py`) and run the idempotent mutators (§5). Writes via `/hermes-state`, bakes runtime paths from `HERMES_RUNTIME_HOME` |
 | 7 | `chown -R 10000:10000` on the hermes volume + `/vault`; codex-builder subtree re-owned 10001 mode 0711 + deploy-key write + negative-assert spot-checks (uid 10001 must NOT read `/vault`, `/alfred-data/.gateway-token`, other profiles' `.env` — NOT the rest of `/alfred-data`, which is deliberately 777) |
 | 8–9 | Mirror `COMPOSIO_USER_ID` → `/alfred-data/.composio-user-id`; seed `/vault/.auth/authorized_senders.json` from `OWNER_EMAIL` |
 | 10 | Stage Sure bootstrap inputs (email/password files + `bootstrap.rb` + the 16 `sure-*-mutate.rb` scripts) for the separate `sure-init` service |
@@ -316,11 +317,13 @@ deliberately blanked in this container — Hermes is the sole key holder.
 3. **Boot ordering**: init completes before hermes starts (compose gate);
    the supervisor additionally waits for `_registry.json` then each
    profile's `config.yaml` + `.env` (FATAL after 300 s/profile).
-4. **`config.yaml` is operator-owned** — never overwrite; extend only via
-   ADD-only mutators. **`.env` is deployment-owned** — re-rendered every
-   init with `_RUNTIME_KEY_PREFIXES` merge-preservation. The mcp-stdio
-   bundle is **image-owned** — rsync `--delete` on every init; never
-   hand-edit it on the volume.
+4. **`config.yaml` is operator-owned** — never overwrite; reconcile only via
+   idempotent mutators. `render_mcp_servers.py` performs required-key ADD and
+   retired-key REMOVE passes; the remaining config mutators are ADD-only.
+   **`.env` is deployment-owned** — re-rendered every init with
+   `_RUNTIME_KEY_PREFIXES` merge-preservation. The mcp-stdio bundle is
+   **image-owned** — rsync `--delete` on every init; never hand-edit it on the
+   volume.
 5. **codex-builder is sealed**: uid 10001, `mcp_servers: {}`,
    positive-allowlist `.env` (no `AAS_API_KEY`, no provider keys, no
    `PAPERCLIP_API_KEY`), iptables egress allowlist installed before launch,

--- a/packages/mcp-server/CONTRACT.md
+++ b/packages/mcp-server/CONTRACT.md
@@ -177,7 +177,7 @@ other than its own `oauth.sqlite`; everything else is HTTP to ctrl-api.
 | Hermes `heavy` profile | stdio | `alfred`, `sure`, `vaultwarden`, `execute` | same (no `hass`/`files`/`paperclip-admin`) |
 | Hermes `codex-builder` profile | — | none | `mcp_servers: {}` by design (sealed runtime) |
 | claude.ai Custom Connectors | HTTP + OAuth | any app, one connector per app | `https://mcp.<DOMAIN>/<app>/mcp` |
-| voice-bridge | HTTP + master secret | `alfred`, `sure`, `vaultwarden`, `execute`, `hermes` (its `APPS` list at `packages/voice-bridge/src/mcp-clients.ts:36` still names `plane` — stale; that URL now 404s) | `MCP_SERVER_URL=http://mcp-server:8787` in compose |
+| voice-bridge | HTTP + master secret | `alfred`, `sure`, `vaultwarden`, `execute`, `hermes` | `MCP_SERVER_URL=http://mcp-server:8787` in compose |
 | Third-party voice vendors (ElevenLabs, LiveKit) | HTTP + scoped token | one app per token | connector URL from `/manage/tokens` responses |
 | ctrl-api + web dashboard | HTTP `/manage/*` | token management only | see P5 chain |
 

--- a/packages/mcp-server/CONTRACT.md
+++ b/packages/mcp-server/CONTRACT.md
@@ -172,7 +172,7 @@ other than its own `oauth.sqlite`; everything else is HTTP to ctrl-api.
 
 | Consumer | Transport | Apps consumed | Wiring |
 |---|---|---|---|
-| Hermes `main` profile | stdio | `alfred`, `sure` (trimmed), `vaultwarden`, `execute`, `hass` (trimmed), `files`, `paperclip-admin` | `packages/hermes/hermes-config.yaml.njk` `mcp_servers:` blocks spawn `{{mcp_stdio_dir}}/dist/bin/stdio-app.js <app>`; `paperclip-admin` is backfilled by `packages/hermes/init/render_mcp_servers.py` (ADD-only mutator, every init boot) |
+| Hermes `main` profile | stdio | `alfred`, `sure` (trimmed), `vaultwarden`, `execute`, `hass` (trimmed), `files`, `paperclip-admin` | `packages/hermes/hermes-config.yaml.njk` `mcp_servers:` blocks spawn `{{mcp_stdio_dir}}/dist/bin/stdio-app.js <app>`; `paperclip-admin` is backfilled by `packages/hermes/init/render_mcp_servers.py` (idempotent mutator, every init boot) |
 | Hermes `workers` profile | stdio | `alfred`, `sure` (full), `vaultwarden`, `execute`, `files`, `paperclip-admin` | same |
 | Hermes `heavy` profile | stdio | `alfred`, `sure`, `vaultwarden`, `execute` | same (no `hass`/`files`/`paperclip-admin`) |
 | Hermes `codex-builder` profile | — | none | `mcp_servers: {}` by design (sealed runtime) |
@@ -229,11 +229,10 @@ Hermes auto-namespaces every tool as `mcp_<server>_<tool>` (e.g.
    Bearer is equivalent to what `/approve` could already mint; keep the
    bypass and the form gated by the SAME secret.
 8. **`plane` stays out** unless Plane returns to the deployed stack (removal:
-   PR #279). Surfaces that still reference it (voice-bridge `APPS`,
-   `skills/plane-mcp-skill.md`, stale header comments in `stdio-app.ts` /
-   `hermes.ts` / `files.ts` naming plane in the app list, and the
-   user-visible "one of: sure, plane" bad-resource error string in
-   `src/oauth/provider.ts` `authorize()`)
+   PR #279). Surfaces that still reference it (`skills/plane-mcp-skill.md`,
+   stale header comments in `stdio-app.ts` / `hermes.ts` / `files.ts` naming
+   plane in the app list, and the user-visible "one of: sure, plane"
+   bad-resource error string in `src/oauth/provider.ts` `authorize()`)
    are dormant, not load-bearing.
 9. **Session transports are in-memory, single-replica.** Scaling to multiple
    replicas requires a shared session store (noted in `index.ts`); do not


### PR DESCRIPTION
Part of #314

Controller job: `contracts-314` · lane `phase0`

## Smoke evidence

`true`

```text
(command exited 0 with no output)
```

The trusted controller independently reran this command after validating every changed path against the approved plan.