### PR TITLE
Bug: admin activity feed is empty despite active workflows and failures (lane I)

### DIFF
--- a/packages/ctrl/src/api/activity.ts
+++ b/packages/ctrl/src/api/activity.ts
@@ -20,9 +20,22 @@ export interface DurableActivityFeed {
 export function readDurableActivity(limit: number): DurableActivityFeed {
   const generated_at = new Date().toISOString();
   try {
-    const items = getStateDb()
+    const rows = getStateDb()
       .prepare("SELECT * FROM audit ORDER BY ts DESC LIMIT ?")
       .all(limit) as Array<Record<string, unknown>>;
+    const items = rows.map((row) => {
+      const event = String(row.action_type ?? "activity");
+      const sourceTool = inferTool(String(row.source ?? ""));
+      const actorTool = inferTool(String(row.actor ?? ""));
+      return {
+        ...row,
+        timestamp: String(row.ts ?? ""),
+        tool: sourceTool !== "system" ? sourceTool : actorTool !== "system" ? actorTool : inferTool(event),
+        level: "info" as const,
+        event,
+        message: String(row.summary ?? humanizeEventName(event)),
+      };
+    });
     return {
       items,
       generated_at,

--- a/packages/ctrl/src/api/activity.ts
+++ b/packages/ctrl/src/api/activity.ts
@@ -6,6 +6,42 @@
  * activity items for the SaaS dashboard.
  */
 
+import { getStateDb } from "../db/state.js";
+
+export interface DurableActivityFeed {
+  items: Array<Record<string, unknown>>;
+  generated_at: string;
+  newest_event_ts: string | null;
+  sources: Array<{ name: string; ok: boolean; count: number }>;
+  partial: boolean;
+}
+
+/** Read the durable activity ledger. Store failures are represented in-band. */
+export function readDurableActivity(limit: number): DurableActivityFeed {
+  const generated_at = new Date().toISOString();
+  try {
+    const items = getStateDb()
+      .prepare("SELECT * FROM audit ORDER BY ts DESC LIMIT ?")
+      .all(limit) as Array<Record<string, unknown>>;
+    return {
+      items,
+      generated_at,
+      newest_event_ts: items.length ? String(items[0].ts) : null,
+      sources: [{ name: "audit", ok: true, count: items.length }],
+      partial: false,
+    };
+  } catch (err) {
+    console.error(`[activity] audit read failed: ${err}`);
+    return {
+      items: [],
+      generated_at,
+      newest_event_ts: null,
+      sources: [{ name: "audit", ok: false, count: 0 }],
+      partial: true,
+    };
+  }
+}
+
 export interface ActivityItem {
   timestamp: string;
   tool: "curator" | "janitor" | "distiller" | "surveyor" | "system";

--- a/packages/ctrl/src/api/routes/admin.ts
+++ b/packages/ctrl/src/api/routes/admin.ts
@@ -3,15 +3,8 @@ import { addRoute } from "../server.js";
 import { sendJson, ValidationError } from "../errors.js";
 import { dockerComposeCmd, dockerExec, execAsync, sudoExec, parseJsonLines, validateServiceName, COMPOSE_DIR, HERMES_CMD, HERMES_CONTAINER } from "../helpers.js";
 import { getVaultContextData, getInboxFiles, VAULT_PATH } from "./vault.js";
-import { parseActivityFeed } from "../activity.js";
-import { ttlCache } from "../cache.js";
+import { readDurableActivity } from "../activity.js";
 import { queryAuditCrossTier } from "../../db/coldRead.js";
-
-// Activity feed is the most expensive read on the Desk page — it spawns
-// `docker compose logs --tail=N alfred` which forks a process per call.
-// Coalesce repeat reads (every Desk page-load fires this once, and
-// every click invalidates+refetches) onto a single subprocess invocation.
-const activityFeedCache = ttlCache<{ items: any[] }>({ ttlMs: 3_000 });
 
 // alfred-black mounts the alfred daemon's data dir as a named Docker volume
 // (PLAN.md Part E), bind-mounted into ctrl-api at /alfred-data by default.
@@ -658,15 +651,9 @@ export function registerAdminRoutes(): void {
   // --- Activity Feed ---
 
   addRoute("GET", "/api/v1/admin/activity", async ({ res, query }) => {
-    const limit = parseInt(query.get("limit") ?? "50", 10);
+    const limit = Math.min(parseInt(query.get("limit") ?? "50", 10), 200);
     if (isNaN(limit) || limit < 1) throw new ValidationError("limit must be a positive number");
-    const payload = await activityFeedCache.get(`activity:${limit}`, async () => {
-      // Fetch 3x more raw lines to account for noise filtering
-      const rawTail = Math.min(limit * 3, 1000).toString();
-      const stdout = await dockerComposeCmd(["logs", "--no-color", "--tail", rawTail, "alfred"]);
-      return { items: parseActivityFeed(stdout, limit) };
-    });
-    sendJson(res, 200, payload);
+    sendJson(res, 200, readDurableActivity(limit));
   });
 
   // GET /api/v1/admin/audit?limit&include_automated=0&cursor=<ts> — the durable
@@ -837,6 +824,13 @@ export function registerAdminRoutes(): void {
     // Fast synchronous reads
     const vaultRaw = getVaultContextData();
     const inboxFiles = getInboxFiles();
+    const activityHealth = readDurableActivity(1);
+    const rawHealth = healthResult.status === "fulfilled" && healthResult.value &&
+      typeof healthResult.value === "object" ? healthResult.value : {};
+    const health = {
+      ...rawHealth,
+      status: healthResult.status === "fulfilled" && !activityHealth.partial ? "ok" : "degraded",
+    };
 
     // NOTE (issue #59): the legacy `openclawCfg` field is gone. It read
     // `/hermes-data/main/config.yaml` — a nonexistent path — so it was
@@ -847,7 +841,7 @@ export function registerAdminRoutes(): void {
     // match.
 
     sendJson(res, 200, {
-      health: healthResult.status === "fulfilled" ? healthResult.value : null,
+      health,
       containers: containersResult.status === "fulfilled" ? containersResult.value : null,
       pairing: pairingResult.status === "fulfilled" ? pairingResult.value : null,
       vault: vaultRaw,

--- a/packages/ctrl/tests/admin-activity-durable.test.ts
+++ b/packages/ctrl/tests/admin-activity-durable.test.ts
@@ -1,0 +1,119 @@
+import { before, describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ServerResponse } from "node:http";
+
+mock.module("node:child_process", {
+  namedExports: {
+    execFile: mock.fn((...args: any[]) => {
+      const callback = args.at(-1) as Function;
+      const stdout = args[0] === "/opt/alfred/healthcheck.sh" ? '{"containers":[]}' : "";
+      callback(null, stdout, "");
+    }),
+    execFileSync: mock.fn(() => ""),
+    spawn: mock.fn(),
+  },
+});
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "admin-activity-durable-"));
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.STATE_DB_PATH = path.join(tmp, "alfred-state.db");
+process.env.VAULT_PATH = path.join(tmp, "vault");
+process.env.SQLITE_VEC_PATH = "";
+
+const { getStateDb } = await import("../src/db/state.js");
+const { appendAudit } = await import("../src/api/routes/state.js");
+const { registerAdminRoutes } = await import("../src/api/routes/admin.js");
+const { matchRoute } = await import("../src/api/server.js");
+
+registerAdminRoutes();
+
+async function getActivity(limit = 200): Promise<{ status: number; data: any }> {
+  const match = matchRoute("GET", "/api/v1/admin/activity");
+  assert.ok(match, "activity route must be registered");
+  let status = 0;
+  let data: any;
+  const res = {
+    writeHead(code: number) { status = code; return res; },
+    end(json?: string) { data = json ? JSON.parse(json) : undefined; },
+  } as unknown as ServerResponse;
+  await match.handler({
+    req: { url: `/api/v1/admin/activity?limit=${limit}` } as any,
+    res, params: {}, body: undefined,
+    query: new URLSearchParams(`limit=${limit}`),
+  });
+  return { status, data };
+}
+
+describe("GET /api/v1/admin/activity — durable audit ledger", () => {
+  const workflowTs = "2026-07-17T09:00:00.000Z";
+  const workflowPayload = {
+    workflow_id: "wf-317", run_id: "run-abc", correlation_id: "corr-xyz",
+  };
+
+  before(() => {
+    getStateDb();
+    appendAudit({
+      ts: "2026-07-17T08:00:00.000Z", action_type: "decision",
+      actor: "principal", source: "desk", subject_ref: "decision:d-1",
+      summary: "Approved durable activity",
+    });
+    appendAudit({
+      ts: workflowTs, action_type: "workflow_run", actor: "alfred",
+      source: "temporal", subject_ref: "workflow:wf-317",
+      summary: "Workflow run completed", payload: workflowPayload,
+    });
+  });
+
+  it("returns newest-first audit rows and preserves workflow correlation data", async () => {
+    const { status, data } = await getActivity();
+    assert.equal(status, 200);
+    assert.equal(data.partial, false);
+    assert.deepEqual(data.items.map((row: any) => row.action_type), ["workflow_run", "decision"]);
+    assert.equal(data.newest_event_ts, workflowTs);
+    assert.ok(!Number.isNaN(Date.parse(data.generated_at)));
+    assert.deepEqual(data.sources, [{ name: "audit", ok: true, count: 2 }]);
+    const workflow = data.items[0];
+    for (const key of ["id", "ts", "action_type", "actor", "source", "summary", "subject_ref"])
+      assert.ok(key in workflow, `missing ${key}`);
+    assert.equal(workflow.subject_ref, "workflow:wf-317");
+    assert.deepEqual(JSON.parse(workflow.payload_json), workflowPayload);
+    assert.equal((await getActivity(1)).data.items.length, 1, "limit must be honored");
+  });
+
+  it("returns a complete empty freshness envelope for an empty audit table", async () => {
+    getStateDb().exec("DELETE FROM audit");
+    const { status, data } = await getActivity();
+    assert.equal(status, 200);
+    assert.deepEqual(data.items, []);
+    assert.equal(data.newest_event_ts, null);
+    assert.equal(data.partial, false);
+    assert.deepEqual(data.sources, [{ name: "audit", ok: true, count: 0 }]);
+  });
+
+  it("returns 200 with partial:true when the audit store read throws", async () => {
+    getStateDb().close();
+    const { status, data } = await getActivity();
+    assert.equal(status, 200);
+    assert.deepEqual(data.items, []);
+    assert.equal(data.partial, true);
+    assert.deepEqual(data.sources, [{ name: "audit", ok: false, count: 0 }]);
+
+    const dashboard = matchRoute("GET", "/api/v1/admin/dashboard");
+    assert.ok(dashboard, "dashboard route must be registered");
+    let dashboardStatus = 0;
+    let dashboardData: any;
+    const res = {
+      writeHead(code: number) { dashboardStatus = code; return res; },
+      end(json?: string) { dashboardData = json ? JSON.parse(json) : undefined; },
+    } as unknown as ServerResponse;
+    await dashboard.handler({
+      req: { url: "/api/v1/admin/dashboard" } as any,
+      res, params: {}, body: undefined, query: new URLSearchParams(),
+    });
+    assert.equal(dashboardStatus, 200);
+    assert.equal(dashboardData.health.status, "degraded");
+  });
+});

--- a/packages/ctrl/tests/admin-activity-durable.test.ts
+++ b/packages/ctrl/tests/admin-activity-durable.test.ts
@@ -57,7 +57,7 @@ describe("GET /api/v1/admin/activity — durable audit ledger", () => {
     getStateDb();
     appendAudit({
       ts: "2026-07-17T08:00:00.000Z", action_type: "decision",
-      actor: "principal", source: "desk", subject_ref: "decision:d-1",
+      actor: "principal", source: "curator", subject_ref: "decision:d-1",
       summary: "Approved durable activity",
     });
     appendAudit({
@@ -80,6 +80,10 @@ describe("GET /api/v1/admin/activity — durable audit ledger", () => {
       assert.ok(key in workflow, `missing ${key}`);
     assert.equal(workflow.subject_ref, "workflow:wf-317");
     assert.deepEqual(JSON.parse(workflow.payload_json), workflowPayload);
+    assert.deepEqual(
+      data.items.map(({ timestamp, tool, level, event, message }: any) => ({ timestamp, tool, level, event, message })),
+      [{ timestamp: workflowTs, tool: "system", level: "info", event: "workflow_run", message: "Workflow run completed" }, { timestamp: "2026-07-17T08:00:00.000Z", tool: "curator", level: "info", event: "decision", message: "Approved durable activity" }],
+    );
     assert.equal((await getActivity(1)).data.items.length, 1, "limit must be honored");
   });
 


### PR DESCRIPTION
Part of #317

Controller job: `ctrl-317` · lane `I`

## Smoke evidence

`cd packages/ctrl && npm run build`

```text
> alfred-ctrl-api@0.1.0 build
> node build.mjs

Build complete — dist/api.mjs
```

The trusted controller independently reran this command after validating every changed path against the approved plan.