### PR TITLE
Bug: admin activity feed is empty despite active workflows and failures (lane III)

### DIFF
--- a/packages/web/src/dashboard/activityFeedCore.test.ts
+++ b/packages/web/src/dashboard/activityFeedCore.test.ts
@@ -1,0 +1,65 @@
+/** Run: cd packages/web && npx tsx --test src/dashboard/activityFeedCore.test.ts */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  formatActivityFreshness,
+  parseActivityEnvelope,
+  selectActivityFeedState,
+} from "./activityFeedCore";
+
+test("parses the freshness envelope and workflow correlation metadata", () => {
+  const envelope = parseActivityEnvelope({
+    generated_at: "2026-07-17T09:05:00.000Z",
+    partial: false,
+    sources: [{ name: "audit", ok: true, count: 1 }],
+    items: [{
+      ts: "2026-07-17T09:00:00.000Z",
+      action_type: "workflow_run",
+      summary: "Workflow run completed",
+      payload_json: JSON.stringify({ correlation_id: "corr-xyz" }),
+    }],
+  });
+  assert.equal(
+    formatActivityFreshness(envelope.generatedAt),
+    "as of 2026-07-17T09:05:00.000Z",
+  );
+  assert.equal(selectActivityFeedState(envelope), "ready");
+  assert.deepEqual(envelope.items[0], {
+    timestamp: "2026-07-17T09:00:00.000Z",
+    tool: "system",
+    level: "info",
+    event: "workflow_run",
+    message: "Workflow run completed",
+    actionType: "workflow_run",
+    correlationRef: "corr-xyz",
+  });
+});
+
+test("keeps complete-empty and partial-empty states distinct", () => {
+  const empty = parseActivityEnvelope({
+    items: [], partial: false, sources: [{ name: "audit", ok: true, count: 0 }],
+  });
+  const degraded = parseActivityEnvelope({
+    items: [], partial: true,
+    sources: [{ name: "audit", ok: false }, { name: "workflows", ok: false }],
+  });
+  assert.equal(selectActivityFeedState(empty), "empty");
+  assert.equal(selectActivityFeedState(degraded), "degraded");
+  assert.deepEqual(degraded.failedSources, ["audit", "workflows"]);
+});
+
+test("malformed optional payloads do not break envelope parsing", () => {
+  const envelope = parseActivityEnvelope({
+    items: [
+      {
+        action_type: "workflow_run",
+        subject_ref: "workflow:wf-317",
+        payload_json: "{",
+      },
+    ],
+    partial: true,
+  });
+  assert.equal(envelope.items[0].correlationRef, "workflow:wf-317");
+  assert.deepEqual(envelope.failedSources, ["unknown source"]);
+  assert.equal(formatActivityFreshness(envelope.generatedAt), "freshness unavailable");
+});

--- a/packages/web/src/dashboard/activityFeedCore.ts
+++ b/packages/web/src/dashboard/activityFeedCore.ts
@@ -1,0 +1,83 @@
+// Pure response-shaping helpers for the dashboard activity feed.
+
+export type ActivityTool = "curator" | "janitor" | "distiller" | "surveyor" | "system";
+export type ActivityLevel = "info" | "warning" | "error";
+
+export interface ActivityItem {
+  timestamp: string;
+  tool: ActivityTool;
+  level: ActivityLevel;
+  event: string;
+  message: string;
+  actionType: string;
+  correlationRef: string | null;
+}
+
+export interface ActivityEnvelope {
+  items: ActivityItem[];
+  generatedAt: string | null;
+  partial: boolean;
+  failedSources: string[];
+}
+
+const TOOLS = new Set<ActivityTool>(["curator", "janitor", "distiller", "surveyor", "system"]);
+const LEVELS = new Set<ActivityLevel>(["info", "warning", "error"]);
+
+function record(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function text(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function correlationRef(item: Record<string, unknown>): string | null {
+  let payload = record(item.payload);
+  try {
+    if (!Object.keys(payload).length && text(item.payload_json)) {
+      payload = record(JSON.parse(text(item.payload_json)));
+    }
+  } catch { /* Fall through to the row-level correlation reference. */ }
+  return text(payload.correlation_id) || text(item.correlation_id) || text(item.subject_ref) || null;
+}
+
+export function parseActivityEnvelope(value: unknown): ActivityEnvelope {
+  const envelope = record(value);
+  const partial = envelope.partial === true;
+  const failedSources = (Array.isArray(envelope.sources) ? envelope.sources : [])
+    .map(record)
+    .filter((source) => source.ok === false)
+    .map((source) => text(source.name))
+    .filter(Boolean);
+  const items = (Array.isArray(envelope.items) ? envelope.items : []).map((value) => {
+    const item = record(value);
+    const tool = text(item.tool) as ActivityTool;
+    const level = text(item.level) as ActivityLevel;
+    const event = text(item.event) || text(item.action_type) || "activity";
+    return {
+      timestamp: text(item.timestamp) || text(item.ts),
+      tool: TOOLS.has(tool) ? tool : "system",
+      level: LEVELS.has(level) ? level : "info",
+      event,
+      message: text(item.message) || text(item.summary) || event,
+      actionType: text(item.action_type) || event,
+      correlationRef: correlationRef(item),
+    };
+  });
+  return {
+    items,
+    generatedAt: text(envelope.generated_at) || null,
+    partial,
+    failedSources: failedSources.length || !partial ? failedSources : ["unknown source"],
+  };
+}
+
+export function formatActivityFreshness(generatedAt: string | null): string {
+  return generatedAt ? `as of ${generatedAt}` : "freshness unavailable";
+}
+
+export function selectActivityFeedState(envelope: ActivityEnvelope): "ready" | "empty" | "degraded" {
+  return envelope.partial ? "degraded" : envelope.items.length ? "ready" : "empty";
+}

--- a/packages/web/src/dashboard/components/ActivityFeed.tsx
+++ b/packages/web/src/dashboard/components/ActivityFeed.tsx
@@ -2,14 +2,12 @@ import { useEffect, useRef } from "react";
 import { useQuery, getActivityFeed } from "wasp/client/operations";
 import { Card, CardContent, CardTitle } from "../../client/components/ui/card";
 import { Activity, AlertTriangle, CheckCircle2 } from "lucide-react";
-
-interface ActivityItem {
-  timestamp: string;
-  tool: "curator" | "janitor" | "distiller" | "surveyor" | "system";
-  level: "info" | "warning" | "error";
-  event: string;
-  message: string;
-}
+import {
+  formatActivityFreshness,
+  parseActivityEnvelope,
+  selectActivityFeedState,
+  type ActivityItem,
+} from "../activityFeedCore";
 
 const TOOL_COLORS: Record<string, string> = {
   curator: "text-blue-400",
@@ -54,7 +52,9 @@ export default function ActivityFeed() {
 
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  const items: ActivityItem[] = Array.isArray(data?.items) ? data.items : [];
+  const envelope = parseActivityEnvelope(data);
+  const { items } = envelope;
+  const feedState = selectActivityFeedState(envelope);
 
   useEffect(() => {
     if (scrollRef.current) {
@@ -72,6 +72,24 @@ export default function ActivityFeed() {
           </CardTitle>
         </div>
 
+        {data && (
+          <p className="mb-3 font-mono text-[0.6rem] text-muted-foreground/60">
+            {formatActivityFreshness(envelope.generatedAt)}
+          </p>
+        )}
+
+        {feedState === "degraded" && (
+          <div
+            role="alert"
+            className="mb-3 flex items-start gap-2 rounded-sm border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-amber-400"
+          >
+            <AlertTriangle className="mt-0.5 h-3 w-3 flex-shrink-0" />
+            <p className="font-mono text-[0.65rem]">
+              Partial data — failed sources: {envelope.failedSources.join(", ")}
+            </p>
+          </div>
+        )}
+
         {isLoading && items.length === 0 && (
           <p className="font-mono text-xs text-muted-foreground">Loading...</p>
         )}
@@ -82,7 +100,7 @@ export default function ActivityFeed() {
           </p>
         )}
 
-        {items.length === 0 && !isLoading && !error && (
+        {feedState === "empty" && !isLoading && !error && (
           <p className="font-mono text-xs text-muted-foreground/60">
             No recent activity
           </p>
@@ -104,9 +122,15 @@ export default function ActivityFeed() {
                 >
                   {item.tool}
                 </span>
-                <span className="min-w-0 flex-1 font-mono text-[0.65rem] leading-relaxed text-foreground/80">
-                  {item.message}
-                </span>
+                <div className="min-w-0 flex-1 font-mono leading-relaxed">
+                  <p className="text-[0.65rem] text-foreground/80">
+                    {item.message}
+                  </p>
+                  <p className="text-[0.55rem] text-muted-foreground/50">
+                    {item.actionType}
+                    {item.correlationRef && ` · correlation ${item.correlationRef}`}
+                  </p>
+                </div>
                 <span className="flex-shrink-0 font-mono text-[0.6rem] text-muted-foreground/50">
                   {formatTime(item.timestamp)}
                 </span>

--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -1534,7 +1534,7 @@ export const getActivityFeed: GetActivityFeed<void, any> = async (
 // GET /api/v1/admin/audit (one row per user action, not the legacy
 // needs_attention_action + desk-action event-file twin). `includeAutomated`
 // maps to ?include_automated=1 so the UI can surface steward/auto noise.
-// Distinct from getActivityFeed, which scrapes the alfred container's logs.
+// Distinct from getActivityFeed, which returns ctrl's freshness envelope.
 export const getAuditFeed: GetAuditFeed<
   { includeAutomated?: boolean } | void,
   any


### PR DESCRIPTION
Part of #317

Controller job: `web-317` · lane `III`

## Smoke evidence

`cd packages/web && npx tsc --noEmit`

```text
(command exited 0 with no output)
```

The trusted controller independently reran this command after validating every changed path against the approved plan.