### PR TITLE
Bug: admin activity feed is empty despite active workflows and failures (lane II)

### DIFF
--- a/packages/learn/src/activities/stream_log.py
+++ b/packages/learn/src/activities/stream_log.py
@@ -9,6 +9,7 @@ import httpx
 from temporalio import activity
 
 from src.config import load_config
+from src.utils.state_client import StateClient
 from src.utils.vault_client import VaultClient
 
 logger = logging.getLogger("alfred-learn")
@@ -25,6 +26,53 @@ tags: [stream-log, daily]
 # Stream Log — {date}
 
 """
+
+
+async def emit_workflow_audit_event(
+    *,
+    workflow_id: str,
+    run_id: str,
+    workflow_type: str,
+    outcome: str,
+    error: str | None = None,
+    client: StateClient | None = None,
+) -> None:
+    """Best-effort ctrl-api audit emission for a Temporal workflow run."""
+    summary = f"{workflow_type} {outcome}"
+    if outcome == "failed" and error:
+        summary = f"{summary}: {error}"
+    state_client = client
+    try:
+        if state_client is None:
+            state_client = StateClient(load_config())
+        await state_client.append_audit(
+            action_type="workflow_run",
+            actor="alfred-learn",
+            source="temporal",
+            target_kind="workflow",
+            subject_ref=workflow_id,
+            summary=summary,
+            payload={
+                "workflow_id": workflow_id,
+                "run_id": run_id,
+                "workflow_type": workflow_type,
+                "outcome": outcome,
+            },
+        )
+    except Exception as exc:  # noqa: BLE001 — audit must never affect a run
+        logger.warning(
+            "workflow audit POST failed for %s/%s (%s): %s",
+            workflow_id,
+            run_id,
+            outcome,
+            str(exc)[:200],
+        )
+    finally:
+        if client is None and state_client is not None:
+            try:
+                await state_client.close()
+            except Exception as exc:  # noqa: BLE001 — best-effort cleanup
+                logger.warning("workflow audit client close failed: %s", str(exc)[:200])
 
 
 @activity.defn

--- a/packages/learn/src/utils/state_client.py
+++ b/packages/learn/src/utils/state_client.py
@@ -46,12 +46,14 @@ class StateClient:
     surprises.
     """
 
-    def __init__(self, config: Config) -> None:
+    def __init__(
+        self, config: Config, *, transport: httpx.AsyncBaseTransport | None = None
+    ) -> None:
         self._base = config.alfred_ctrl_url
         api_key = os.environ.get("AAS_API_KEY", "")
         headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
         self._client = httpx.AsyncClient(
-            base_url=self._base, timeout=30.0, headers=headers
+            base_url=self._base, timeout=30.0, headers=headers, transport=transport
         )
 
     async def close(self) -> None:

--- a/packages/learn/src/worker.py
+++ b/packages/learn/src/worker.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import asyncio
 import logging
 
+from temporalio import workflow
 from temporalio.client import Client
-from temporalio.worker import Worker
+from temporalio.worker import Interceptor, WorkflowInboundInterceptor, Worker
 
 from src.config import load_config
 
@@ -276,7 +277,7 @@ from src.activities.omi_audio import (
 )
 
 # Activities — stream log
-from src.activities.stream_log import append_to_stream_log
+from src.activities.stream_log import append_to_stream_log, emit_workflow_audit_event
 from src.activities.maintenance import (
     purge_old_stream_events,
     run_distiller_batch,
@@ -720,6 +721,51 @@ from src.validators.frontmatter import validate_classification
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("alfred-learn")
+
+_WORKFLOW_AUDIT_EXTERN = "__alfred_workflow_audit"
+_AUDIT_TASKS: set[asyncio.Task[None]] = set()
+
+
+class _WorkflowAuditInboundInterceptor(WorkflowInboundInterceptor):
+    """Observe run transitions without adding commands to workflow history."""
+
+    def __init__(self, next: WorkflowInboundInterceptor) -> None:
+        super().__init__(next)
+        self._emit = workflow.extern_functions()[_WORKFLOW_AUDIT_EXTERN]
+
+    async def execute_workflow(self, input: object) -> object:
+        info = workflow.info()
+        event = {
+            "workflow_id": info.workflow_id,
+            "run_id": info.run_id,
+            "workflow_type": info.workflow_type,
+        }
+        if not workflow.unsafe.is_replaying():
+            self._emit({**event, "outcome": "started"})
+        try:
+            result = await self.next.execute_workflow(input)
+        except Exception as exc:
+            if not workflow.unsafe.is_replaying():
+                self._emit({**event, "outcome": "failed", "error": str(exc)})
+            raise
+        if not workflow.unsafe.is_replaying():
+            self._emit({**event, "outcome": "completed"})
+        return result
+
+
+class WorkflowAuditInterceptor(Interceptor):
+    def __init__(self, emit: object) -> None:
+        self._emit = emit
+
+    def workflow_interceptor_class(self, input: object) -> type[WorkflowInboundInterceptor]:
+        input.unsafe_extern_functions[_WORKFLOW_AUDIT_EXTERN] = self._emit
+        return _WorkflowAuditInboundInterceptor
+
+
+def _spawn_workflow_audit(event: dict[str, str]) -> None:
+    task = asyncio.create_task(emit_workflow_audit_event(**event))
+    _AUDIT_TASKS.add(task)
+    task.add_done_callback(_AUDIT_TASKS.discard)
 
 
 _STATIC_WORKFLOWS = [
@@ -1253,11 +1299,16 @@ async def run_worker() -> None:
     client = await Client.connect(config.temporal_host)
 
     logger.info("Starting worker on task queue: %s", config.task_queue)
+    loop = asyncio.get_running_loop()
+    audit_interceptor = WorkflowAuditInterceptor(
+        lambda event: loop.call_soon_threadsafe(_spawn_workflow_audit, event)
+    )
     worker = Worker(
         client,
         task_queue=config.task_queue,
         workflows=ALL_WORKFLOWS,
         activities=ALL_ACTIVITIES,
+        interceptors=[audit_interceptor],
     )
 
     logger.info("Alfred Learn worker running.")

--- a/packages/learn/src/worker.py
+++ b/packages/learn/src/worker.py
@@ -733,6 +733,12 @@ class _WorkflowAuditInboundInterceptor(WorkflowInboundInterceptor):
         super().__init__(next)
         self._emit = workflow.extern_functions()[_WORKFLOW_AUDIT_EXTERN]
 
+    def _emit_best_effort(self, event: dict[str, str]) -> None:
+        try:
+            self._emit(event)
+        except Exception as exc:  # noqa: BLE001 — audit must never affect a run
+            logger.warning("workflow audit scheduling failed: %s", str(exc)[:200])
+
     async def execute_workflow(self, input: object) -> object:
         info = workflow.info()
         event = {
@@ -741,15 +747,15 @@ class _WorkflowAuditInboundInterceptor(WorkflowInboundInterceptor):
             "workflow_type": info.workflow_type,
         }
         if not workflow.unsafe.is_replaying():
-            self._emit({**event, "outcome": "started"})
+            self._emit_best_effort({**event, "outcome": "started"})
         try:
             result = await self.next.execute_workflow(input)
         except Exception as exc:
             if not workflow.unsafe.is_replaying():
-                self._emit({**event, "outcome": "failed", "error": str(exc)})
+                self._emit_best_effort({**event, "outcome": "failed", "error": str(exc)})
             raise
         if not workflow.unsafe.is_replaying():
-            self._emit({**event, "outcome": "completed"})
+            self._emit_best_effort({**event, "outcome": "completed"})
         return result
 
 

--- a/packages/learn/tests/test_workflow_audit_events.py
+++ b/packages/learn/tests/test_workflow_audit_events.py
@@ -7,10 +7,7 @@ from src.config import Config
 from src.utils.state_client import StateClient
 
 def _client(handler) -> StateClient:
-    return StateClient(
-        Config(alfred_ctrl_url="http://ctrl-api:3100"),
-        transport=httpx.MockTransport(handler),
-    )
+    return StateClient(Config(alfred_ctrl_url="http://ctrl-api:3100"), transport=httpx.MockTransport(handler))
 
 async def test_emitter_posts_completed_and_failed_correlations():
     requests = []
@@ -19,12 +16,10 @@ async def test_emitter_posts_completed_and_failed_correlations():
         return httpx.Response(201, json={"id": "audit-1"})
     client = _client(handler)
     try:
-        await emit_workflow_audit_event(
-            workflow_id="wf-1", run_id="run-1",
+        await emit_workflow_audit_event(workflow_id="wf-1", run_id="run-1",
             workflow_type="SignalExtractWorkflow", outcome="completed", client=client,
         )
-        await emit_workflow_audit_event(
-            workflow_id="wf-2", run_id="run-2",
+        await emit_workflow_audit_event(workflow_id="wf-2", run_id="run-2",
             workflow_type="SignalExtractWorkflow", outcome="failed",
             error="extractor unavailable", client=client,
         )
@@ -35,10 +30,13 @@ async def test_emitter_posts_completed_and_failed_correlations():
     assert all(body["action_type"] == "workflow_run" for body in bodies)
     assert all(body["actor"] == "alfred-learn" for body in bodies)
     assert bodies[0]["payload"] == {
-        "workflow_id": "wf-1", "run_id": "run-1",
-        "workflow_type": "SignalExtractWorkflow", "outcome": "completed",
+        "workflow_id": "wf-1", "run_id": "run-1", "workflow_type": "SignalExtractWorkflow",
+        "outcome": "completed",
     }
-    assert bodies[1]["payload"]["outcome"] == "failed"
+    assert bodies[1]["payload"] == {
+        "workflow_id": "wf-2", "run_id": "run-2", "workflow_type": "SignalExtractWorkflow",
+        "outcome": "failed",
+    }
     assert "failed: extractor unavailable" in bodies[1]["summary"]
 
 async def test_emitter_swallows_ctrl_api_http_error(caplog):
@@ -82,10 +80,14 @@ async def test_worker_interceptor_emits_all_transitions(monkeypatch):
     interceptor = learn_worker._WorkflowAuditInboundInterceptor(Next())
     assert await interceptor.execute_workflow(None) == "ok"
     with pytest.raises(RuntimeError, match="boom"):
-        await learn_worker._WorkflowAuditInboundInterceptor(
-            Next(RuntimeError("boom"))
-        ).execute_workflow(None)
-    assert [event["outcome"] for event in emitted] == [
-        "started", "completed", "started", "failed",
-    ]
+        await learn_worker._WorkflowAuditInboundInterceptor(Next(
+            RuntimeError("boom"))).execute_workflow(None)
+    assert [event["outcome"] for event in emitted] == ["started", "completed", "started", "failed"]
     assert all(event["workflow_id"] == "wf-scheduled" for event in emitted)
+    def fail_audit(_event):
+        raise RuntimeError("audit scheduler failed")
+    interceptor._emit = fail_audit
+    assert await interceptor.execute_workflow(None) == "ok"
+    interceptor.next = Next(ValueError("original workflow failure"))
+    with pytest.raises(ValueError, match="original workflow failure"):
+        await interceptor.execute_workflow(None)

--- a/packages/learn/tests/test_workflow_audit_events.py
+++ b/packages/learn/tests/test_workflow_audit_events.py
@@ -1,0 +1,91 @@
+import json
+from types import SimpleNamespace
+import httpx
+import pytest
+from src.activities.stream_log import emit_workflow_audit_event
+from src.config import Config
+from src.utils.state_client import StateClient
+
+def _client(handler) -> StateClient:
+    return StateClient(
+        Config(alfred_ctrl_url="http://ctrl-api:3100"),
+        transport=httpx.MockTransport(handler),
+    )
+
+async def test_emitter_posts_completed_and_failed_correlations():
+    requests = []
+    def handler(request):
+        requests.append(request)
+        return httpx.Response(201, json={"id": "audit-1"})
+    client = _client(handler)
+    try:
+        await emit_workflow_audit_event(
+            workflow_id="wf-1", run_id="run-1",
+            workflow_type="SignalExtractWorkflow", outcome="completed", client=client,
+        )
+        await emit_workflow_audit_event(
+            workflow_id="wf-2", run_id="run-2",
+            workflow_type="SignalExtractWorkflow", outcome="failed",
+            error="extractor unavailable", client=client,
+        )
+    finally:
+        await client.close()
+    bodies = [json.loads(request.content) for request in requests]
+    assert {request.url.path for request in requests} == {"/api/v1/state/audit"}
+    assert all(body["action_type"] == "workflow_run" for body in bodies)
+    assert all(body["actor"] == "alfred-learn" for body in bodies)
+    assert bodies[0]["payload"] == {
+        "workflow_id": "wf-1", "run_id": "run-1",
+        "workflow_type": "SignalExtractWorkflow", "outcome": "completed",
+    }
+    assert bodies[1]["payload"]["outcome"] == "failed"
+    assert "failed: extractor unavailable" in bodies[1]["summary"]
+
+async def test_emitter_swallows_ctrl_api_http_error(caplog):
+    seen_paths = []
+    def handler(request):
+        seen_paths.append(request.url.path)
+        return httpx.Response(503, text="unavailable")
+    client = _client(handler)
+    try:
+        await emit_workflow_audit_event(
+            workflow_id="wf-3", run_id="run-3",
+            workflow_type="SignalExtractWorkflow", outcome="started", client=client,
+        )
+    finally:
+        await client.close()
+    assert seen_paths == ["/api/v1/state/audit"]
+    assert "workflow audit POST failed" in caplog.text
+
+async def test_worker_interceptor_emits_all_transitions(monkeypatch):
+    from src import worker as learn_worker
+    emitted = []
+    monkeypatch.setattr(
+        learn_worker.workflow, "extern_functions",
+        lambda: {learn_worker._WORKFLOW_AUDIT_EXTERN: emitted.append},
+    )
+    monkeypatch.setattr(
+        learn_worker.workflow, "info",
+        lambda: SimpleNamespace(
+            workflow_id="wf-scheduled", run_id="run-scheduled",
+            workflow_type="SignalExtractWorkflow",
+        ),
+    )
+    monkeypatch.setattr(learn_worker.workflow.unsafe, "is_replaying", lambda: False)
+    class Next:
+        def __init__(self, error=None):
+            self.error = error
+        async def execute_workflow(self, _input):
+            if self.error:
+                raise self.error
+            return "ok"
+    interceptor = learn_worker._WorkflowAuditInboundInterceptor(Next())
+    assert await interceptor.execute_workflow(None) == "ok"
+    with pytest.raises(RuntimeError, match="boom"):
+        await learn_worker._WorkflowAuditInboundInterceptor(
+            Next(RuntimeError("boom"))
+        ).execute_workflow(None)
+    assert [event["outcome"] for event in emitted] == [
+        "started", "completed", "started", "failed",
+    ]
+    assert all(event["workflow_id"] == "wf-scheduled" for event in emitted)


### PR DESCRIPTION
Part of #317

Controller job: `learn-317` · lane `II`

## Smoke evidence

`cd packages/learn && python3 -m pytest -q`

```text
........................................................................ [  2%]
........................................................................ [  5%]
........................................................................ [  8%]
........................................................................ [ 11%]
........................................................................ [ 14%]
........................................................................ [ 17%]
........................................................................ [ 20%]
........................................................................ [ 23%]
........................................................................ [ 26%]
........................................................................ [ 29%]
........................................................................ [ 31%]
........................................................................ [ 34%]
........................................................................ [ 37%]
........................................................................ [ 40%]
........................................................................ [ 43%]
........................................................................ [ 46%]
........................................................................ [ 49%]
........................................................................ [ 52%]
........................................................................ [ 55%]
........................................................................ [ 58%]
........................................................................ [ 60%]
........................................................................ [ 63%]
........................................................................ [ 66%]
........................................................................ [ 69%]
........................................................................ [ 72%]
........................................................................ [ 75%]
........................................................................ [ 78%]
........................................................................ [ 81%]
.....................................sssssssssssssssssssssssssssssssssss [ 84%]
ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss...... [ 87%]
........................................................................ [ 89%]
........................................................................ [ 92%]
........................................................................ [ 95%]
........................................................................ [ 98%]
..................................                                       [100%]
2381 passed, 101 skipped in 46.89s
```

The trusted controller independently reran this command after validating every changed path against the approved plan.