### PR TITLE
Hermes workers sessions/request-dumps have no retention — filled zsolt's 300GB disk in 6 days (full-stack outage) (lane phase0)

### DIFF
--- a/docs/FAILURE-MODES.md
+++ b/docs/FAILURE-MODES.md
@@ -356,6 +356,25 @@ gateway; `notify_principal` bridges ephemeral agents → main message tool.
   background profiles (template + idempotent `render_workers_pruning.py`
   backfill) and an `x-default-logging` cap in compose; cleanup runbook +
   upstream loop follow-up at `debug/2026-06-19/workers-disk-bloat-runbook.md`.
+- **☣ [S1] Retention guard failure + cross-profile auth divergence. ⟵ ISSUE
+  #261, zsolt incident 2026-06-10.** The dated fleet capture/cleanup runbook
+  was written on 2026-06-19, but issue #261 records the triggering zsolt
+  incident on 2026-06-10. Unbounded `session_*.json`,
+  `request_dump_*.json`, and workers/heavy `state.db` growth can fill the
+  tenant disk before a nightly profile cron succeeds. Independently, the old
+  boot-only, main-as-source `auth.json` copy lets workers/heavy retain an OAuth
+  refresh token invalidated when another profile refreshes, turning an auth
+  divergence into a retry storm that accelerates the same disk growth.
+  **Layered guards added by #261:** Lane V (Hermes/infra) adds the
+  supervised `session-janitor`, separate session/request-dump TTLs + dump
+  count cap, workers/heavy state.db TTL+VACUUM, and 900 s newest-
+  `openai-codex.last_refresh` auth convergence; Lane II (learn) adds the
+  default-on clerk breaker that opens only after sustained >=95%
+  `max_retries_exhausted` and emits one
+  needs-attention card per incident; Lane I (ctrl) adds 80% warn audit/card
+  and 90% Hermes-main outbound page thresholds plus structured disk fields on
+  `GET /api/v1/admin/system-info`. Any one layer can fail without returning to
+  silent disk exhaustion.
 - **☣ [S2] Memory parity gap.** Recall depends on the surveyor embedding the
   vault into sqlite-vec; if the embedder lags or the vector store drifts, Alfred
   "forgets" recent context and answers thinly.

--- a/docs/FAILURE-MODES.md
+++ b/docs/FAILURE-MODES.md
@@ -365,7 +365,10 @@ gateway; `notify_principal` bridges ephemeral agents → main message tool.
   boot-only, main-as-source `auth.json` copy lets workers/heavy retain an OAuth
   refresh token invalidated when another profile refreshes, turning an auth
   divergence into a retry storm that accelerates the same disk growth.
-  **Layered guards added by #261:** Lane V (Hermes/infra) adds the
+  **Current status at this phase-0 contract head:** the existing runtime has
+  the nightly background-profile cron, but none of the following three #261
+  guard families is implemented yet. **Layered guards frozen by #261 for the
+  implementation lanes:** Lane V (Hermes/infra) adds the
   supervised `session-janitor`, separate session/request-dump TTLs + dump
   count cap, workers/heavy state.db TTL+VACUUM, and 900 s newest-
   `openai-codex.last_refresh` auth convergence; Lane II (learn) adds the
@@ -373,8 +376,8 @@ gateway; `notify_principal` bridges ephemeral agents → main message tool.
   `max_retries_exhausted` and emits one
   needs-attention card per incident; Lane I (ctrl) adds 80% warn audit/card
   and 90% Hermes-main outbound page thresholds plus structured disk fields on
-  `GET /api/v1/admin/system-info`. Any one layer can fail without returning to
-  silent disk exhaustion.
+  `GET /api/v1/admin/system-info`. Once those lanes merge, any one layer can
+  fail without returning to silent disk exhaustion.
 - **☣ [S2] Memory parity gap.** Recall depends on the surveyor embedding the
   vault into sqlite-vec; if the embedder lags or the vector store drifts, Alfred
   "forgets" recent context and answers thinly.

--- a/packages/ctrl/CONTRACT.md
+++ b/packages/ctrl/CONTRACT.md
@@ -1,6 +1,6 @@
 # CONTRACT.md — alfred-ctrl-api (`packages/ctrl`)
 
-**Frozen cross-lane interface.** Lane agents code against this document, not against ctrl's source. Regenerated 2026-07-15 from `main`; every claim below is verified in code at the cited path.
+**Frozen cross-lane interface.** Lane agents code against this document, not against ctrl's source. Regenerated 2026-07-15 from `main`; every current-runtime claim below is verified in code at the cited path. Clauses explicitly labelled `#261 target` instead freeze Lane I's required future behavior and are not code-verified claims about this phase-0 head.
 
 ctrl-api is the tenant API server: a zero-dependency-at-runtime Node 22 HTTP service on **:3100** that is the **sole writer** of all four stores (vault markdown, `alfred-state.db`, `ingest.db`, cold archive) plus Store 5 (files). It is HTTP-only — the pre-cutover CLI/TUI was deleted; `build.mjs` produces exactly one artefact, `dist/api.mjs`, from entry `src/api/standalone.ts`. Every other service (web, alfred-learn, the alfred vault daemon, Hermes profiles via the `alfred-ctrl` MCP server, voice-bridge) persists state by calling ctrl-api over HTTP. ctrl-api in turn reaches siblings via `docker exec` (helpers `dockerExec`, `src/api/helpers.ts:100`) and HTTP (Hermes gateway, vault-cli, mcp-server, Sure, Paperclip).
 
@@ -160,7 +160,11 @@ Resolution precedence: env var > `${ALFRED_DATA_DIR}/settings.json` > default. R
 
 ### Call-out: disk-usage watcher and system-info
 
-ctrl-api owns the tenant disk-usage watcher. Its frozen thresholds are
+**#261 target (Lane I; not implemented at this phase-0 head).** ctrl-api
+currently has neither a disk-usage watcher nor the hyphenated system-info
+route below; it exposes only the legacy raw-diagnostics
+`GET /api/v1/admin/system/info`. Lane I must add the tenant disk-usage watcher.
+Its frozen thresholds are
 `DISK_ALERT_WARN_PCT=80` and `DISK_ALERT_PAGE_PCT=90` (percentage of the
 Alfred data filesystem used):
 
@@ -169,7 +173,7 @@ Alfred data filesystem used):
 | warn (`used_pct >= 80` and `< 90`) | Append a state.db audit row and create a `needs_attention` card. The warning incident is deduplicated across watcher polls/restarts to at most one audit/card pair per 24 hours. |
 | page (`used_pct >= 90`) | Preserve the warn audit/card behavior and escalate with an outbound notification through the existing Hermes **main** notify path used by `POST /api/v1/notifications`; never send through workers/heavy. |
 
-The machine-readable read surface is
+The required machine-readable read surface is
 `GET /api/v1/admin/system-info`. Its new disk fields are `disk_used_pct`
 (number or `null` when sampling fails), `disk_alert_level`
 (`ok | warn | page | unknown`),
@@ -207,7 +211,7 @@ compatibility surface; new consumers use the hyphenated route.
 | `STATE_DB_PATH` / `INGEST_DB_PATH` / `COLD_DB_PATH` | no | default `<cwd>/data/{alfred-state.db,ingest.db,cold.db}`; volumes mount at `/state`, `/ingest`, `/cold` |
 | `SQLITE_VEC_PATH`, `EMBEDDING_DIM` (768), `EMBED_MODEL`, `OLLAMA_BASE_URL` | no | vector search + embedding |
 | `INGEST_TTL_DAYS` (7), `INGEST_SWEEP_INTERVAL_MS`, `COLD_TTL_*`, `COLD_COMPACT_*` | no | store TTL/compaction knobs |
-| `DISK_ALERT_WARN_PCT` / `DISK_ALERT_PAGE_PCT` | no | `80` / `90`; ctrl-api watcher warning and outbound-page thresholds |
+| `DISK_ALERT_WARN_PCT` / `DISK_ALERT_PAGE_PCT` | no | **#261 target (not read at this head):** `80` / `90`; ctrl-api watcher warning and outbound-page thresholds |
 | `HERMES_GATEWAY_URL`, `HERMES_WORKERS_GATEWAY_URL`, `HERMES_API_KEY`, `OPENCLAW_GATEWAY_TOKEN`, `OPENCLAW_GATEWAY_TOKEN_FILE` | no | see sibling table (OPENCLAW_* names are legacy fallbacks still read by code) |
 | `HERMES_CONFIG_DIR` | compose-pinned | `/hermes-state/profiles` — ctrl-api reads/writes per-profile `config.yaml` |
 | `MCP_SERVER_URL`, `MCP_APPROVAL_SECRET` | for /mcp/tokens | see call-out |
@@ -233,7 +237,7 @@ compatibility surface; new consumers use the hyphenated route.
 7. **No route module registers itself** — registration is centralized in `createApiServer()` (`server.ts`, forbidden-zone). Adding a module = orchestrator edit of `server.ts`.
 8. **Deploys pull, never build.** The image is `ssdavidai00/alfred-ctrl-api:latest`, built only by CI (`.github/workflows/build-ctrl-api.yml`); `docker compose up` never builds.
 9. **Plane surfaces are dormant.** No Plane container exists in the stack (PR #279). `plane.ts` / `webhooks/plane.ts` / `PLANE_*` env are dead config awaiting deletion; do not wire new consumers.
-10. **Disk pressure is surfaced before outage.** At the effective warn
+10. **#261 target — disk pressure is surfaced before outage.** At the effective warn
     threshold ctrl-api records an audit row plus a 24 h-deduped
     needs-attention card; at the page threshold it additionally delivers via
     the Hermes main notification path. `/api/v1/admin/system-info` reports the
@@ -259,6 +263,6 @@ npm test        # node:test over tests/*.test.ts (148 test files)
 
 ## Change protocol
 
-This file is **forbidden-zone**: the commit gate (`scripts/hooks/check_lane.py`) rejects any lane diff touching `**/CONTRACT.md`. Changes land only via an orchestrator (phase0) commit in the main checkout, after the interface change itself has merged.
+This file is **forbidden-zone**: the commit gate (`scripts/hooks/check_lane.py`) rejects any lane diff touching `**/CONTRACT.md`. Changes land only via an orchestrator (phase0) commit in the main checkout, normally after the interface change itself has merged. A phase-0 target freeze may precede provider implementation only when it is explicitly labelled, states the current gap and owning lane, and is not presented as deployed behavior.
 
 A lane that finds this contract wrong — a route missing, a shape mismatched, an invariant contradicted by code — **STOPs and reports to the orchestrator. It never improvises across the boundary**, never codes to "what the provider probably meant", and never edits this file to match its patch. The orchestrator reconciles (fix the provider, or fix the contract) and re-freezes before the lane resumes.

--- a/packages/ctrl/CONTRACT.md
+++ b/packages/ctrl/CONTRACT.md
@@ -158,6 +158,26 @@ Resolution precedence: env var > `${ALFRED_DATA_DIR}/settings.json` > default. R
 
 `/api/v1/mcp/tokens` (GET list, POST mint), `/:id/rotate`, DELETE `/:id` (`routes/mcpTokens.ts`) — a **thin proxy** to mcp-server's `/manage/tokens` API. mcp-server owns the tokens (its own SQLite; local validation on every `POST /<app>/mcp`). Chain: browser → web (Wasp op) → ctrl-api → mcp-server, so the browser never holds `MCP_APPROVAL_SECRET`; ctrl-api presents it as the onward Bearer. The raw token appears exactly once (mint + rotate responses); list never carries it; ctrl-api relays verbatim. Missing secret → 500 `MCP_NOT_CONFIGURED`; mcp-server down → 502 `MCP_UNREACHABLE`.
 
+### Call-out: disk-usage watcher and system-info
+
+ctrl-api owns the tenant disk-usage watcher. Its frozen thresholds are
+`DISK_ALERT_WARN_PCT=80` and `DISK_ALERT_PAGE_PCT=90` (percentage of the
+Alfred data filesystem used):
+
+| Level | Required side effects |
+|---|---|
+| warn (`used_pct >= 80` and `< 90`) | Append a state.db audit row and create a `needs_attention` card. The warning incident is deduplicated across watcher polls/restarts to at most one audit/card pair per 24 hours. |
+| page (`used_pct >= 90`) | Preserve the warn audit/card behavior and escalate with an outbound notification through the existing Hermes **main** notify path used by `POST /api/v1/notifications`; never send through workers/heavy. |
+
+The machine-readable read surface is
+`GET /api/v1/admin/system-info`. Its new disk fields are `disk_used_pct`
+(number or `null` when sampling fails), `disk_alert_level`
+(`ok | warn | page | unknown`),
+`disk_alert_warn_pct`, and `disk_alert_page_pct`. The last two fields report
+the effective configured thresholds, not hard-coded display values. The
+legacy `GET /api/v1/admin/system/info` raw diagnostics route remains a
+compatibility surface; new consumers use the hyphenated route.
+
 ---
 
 ## Requires
@@ -187,6 +207,7 @@ Resolution precedence: env var > `${ALFRED_DATA_DIR}/settings.json` > default. R
 | `STATE_DB_PATH` / `INGEST_DB_PATH` / `COLD_DB_PATH` | no | default `<cwd>/data/{alfred-state.db,ingest.db,cold.db}`; volumes mount at `/state`, `/ingest`, `/cold` |
 | `SQLITE_VEC_PATH`, `EMBEDDING_DIM` (768), `EMBED_MODEL`, `OLLAMA_BASE_URL` | no | vector search + embedding |
 | `INGEST_TTL_DAYS` (7), `INGEST_SWEEP_INTERVAL_MS`, `COLD_TTL_*`, `COLD_COMPACT_*` | no | store TTL/compaction knobs |
+| `DISK_ALERT_WARN_PCT` / `DISK_ALERT_PAGE_PCT` | no | `80` / `90`; ctrl-api watcher warning and outbound-page thresholds |
 | `HERMES_GATEWAY_URL`, `HERMES_WORKERS_GATEWAY_URL`, `HERMES_API_KEY`, `OPENCLAW_GATEWAY_TOKEN`, `OPENCLAW_GATEWAY_TOKEN_FILE` | no | see sibling table (OPENCLAW_* names are legacy fallbacks still read by code) |
 | `HERMES_CONFIG_DIR` | compose-pinned | `/hermes-state/profiles` — ctrl-api reads/writes per-profile `config.yaml` |
 | `MCP_SERVER_URL`, `MCP_APPROVAL_SECRET` | for /mcp/tokens | see call-out |
@@ -212,6 +233,11 @@ Resolution precedence: env var > `${ALFRED_DATA_DIR}/settings.json` > default. R
 7. **No route module registers itself** — registration is centralized in `createApiServer()` (`server.ts`, forbidden-zone). Adding a module = orchestrator edit of `server.ts`.
 8. **Deploys pull, never build.** The image is `ssdavidai00/alfred-ctrl-api:latest`, built only by CI (`.github/workflows/build-ctrl-api.yml`); `docker compose up` never builds.
 9. **Plane surfaces are dormant.** No Plane container exists in the stack (PR #279). `plane.ts` / `webhooks/plane.ts` / `PLANE_*` env are dead config awaiting deletion; do not wire new consumers.
+10. **Disk pressure is surfaced before outage.** At the effective warn
+    threshold ctrl-api records an audit row plus a 24 h-deduped
+    needs-attention card; at the page threshold it additionally delivers via
+    the Hermes main notification path. `/api/v1/admin/system-info` reports the
+    sampled percentage, level, and both effective thresholds.
 
 ---
 

--- a/packages/hermes/CONTRACT.md
+++ b/packages/hermes/CONTRACT.md
@@ -5,6 +5,13 @@
 > code against this file; if reality diverges, STOP and report (see Change
 > protocol).
 
+> **Issue #261 phase-0 target:** Clauses explicitly labelled `#261 target`
+> freeze Lane V's required interface; they are not claims that this exact
+> phase-0 head already implements it. At this head the supervisor has no
+> supervised session janitor or retention knobs, and `auth.json` propagation
+> remains boot-only, main-as-source, and size-based. Lane V must close those
+> named gaps before consumers or operators treat the target clauses as live.
+
 `packages/hermes` is the AI runtime of alfred-black. It produces the
 **Hermes runtime image** (one container supervising one Hermes gateway per
 registered profile — `main` :18789 / `workers` :18790 / `heavy` :18791, plus
@@ -63,10 +70,10 @@ is PID 1; the supervisor is its single child.
 | `codex-builder` | **18793** | Sealed builder runtime, uid 10001, iptables egress jail, `mcp_servers: {}` | only when `ENABLE_CODEX_BUILDER=true` (boot-only — never spawned by reconcile) |
 | user-facing profiles | **18794–18799** | Created via ctrl-api `POST /api/v1/agent-profiles`; rendered main-like (`is_main_like` in `init/render_hermes.py`) | registry-driven |
 
-The supervisor also owns a mandatory, portless **`session-janitor`** process.
-It is restarted with the same supervision/backoff discipline as the gateways
-and periodically bounds profile runtime state that Hermes itself leaves
-unbounded:
+**#261 target (Lane V; not implemented at this phase-0 head).** The supervisor
+must gain a mandatory, portless **`session-janitor`** process, restarted with
+the same supervision/backoff discipline as the gateways. It must periodically
+bound profile runtime state that Hermes itself leaves unbounded:
 
 | Frozen knob | Default | Contract |
 |---|---:|---|
@@ -98,13 +105,14 @@ After each gateway's `/health` goes 200, the supervisor POSTs
 `http://ctrl-api:3100/api/v1/agent-profiles/<slug>/status` with
 `Authorization: Bearer <AAS_API_KEY>` read from `profiles/main/.env`.
 
-Supervisor convergence side effects (all idempotent; auth convergence also
-runs periodically):
+Supervisor side effects (all idempotent; the second auth row is the #261
+replacement target for the first):
 
 | Step | Behaviour |
 |---|---|
 | Sticky default | `hermes profile use main` — bare `hermes` in a `docker exec` opens the Alfred main profile |
-| auth.json convergence | On boot, and then every `HERMES_AUTH_RESYNC_SECONDS` (default 900), inspect `main`, `workers`, and `heavy`; the valid file with the newest `providers.openai-codex.last_refresh` wins and is atomically mirrored to the other two. When `ENABLE_CODEX_BUILDER=1`, the same winner is also mirrored to `codex-builder/auth.json` AND `codex-builder/.codex/auth.json` (codex-CLI auth), chowned 10001 mode 0600. Missing/malformed files never displace a valid newer file. |
+| auth.json propagation (current at this phase-0 head) | At boot only, use `main/auth.json` as the source and copy it to `workers` / `heavy` when a destination is missing or smaller. When `ENABLE_CODEX_BUILDER=1`, the same size heuristic covers both builder auth locations. |
+| auth.json convergence (**#261 target**) | Lane V must replace the current rule: on boot, and then every `HERMES_AUTH_RESYNC_SECONDS` (default 900), inspect `main`, `workers`, and `heavy`; the valid file with the newest `providers.openai-codex.last_refresh` wins and is atomically mirrored to the other two. When `ENABLE_CODEX_BUILDER=1`, the same winner is also mirrored to `codex-builder/auth.json` AND `codex-builder/.codex/auth.json` (codex-CLI auth), chowned 10001 mode 0600. Missing/malformed files never displace a valid newer file. |
 | SOUL.md consolidation | Copies `profiles/main/SOUL.md` → `$HERMES_HOME/SOUL.md` (the file Hermes actually loads as persona) only if the source is >200 bytes AND the destination is missing, smaller, or contains the stock marker `You are Hermes Agent`. A hand-edited global SOUL is preserved |
 | hermes-lcm install | Copies `/opt/hermes-lcm` → `profiles/main/plugins/hermes-lcm` once (guard: `! -e`). Main only |
 | one-alfred install | Copies `/opt/one-alfred` → `profiles/main/plugins/one-alfred`, refreshed whenever the baked source mtime is newer. Main only |
@@ -118,13 +126,13 @@ Each gateway is launched as
 `AGENTS.md`) and the profile `.env` is source-and-exported into the process
 env (auth key visible in `/proc/<pid>/environ`; the 2026-05-28 hardening).
 
-Auth propagation is therefore **not boot-only**. Any one of the three normal
-gateways may be the process that refreshes `openai-codex`; timestamp election
-converges that newest refresh token before another profile continues using an
-invalidated predecessor. Operationally this preserves one effective OAuth
-refresher/identity across main/workers/heavy, per the 2026-06-11 operator
-decision, without treating `main` as an authority when another profile has the
-newer refresh.
+**#261 target:** auth propagation must no longer be boot-only. Any one of the
+three normal gateways may be the process that refreshes `openai-codex`;
+timestamp election must converge that newest refresh token before another
+profile continues using an invalidated predecessor. This preserves one
+effective OAuth refresher/identity across main/workers/heavy, per the
+2026-06-11 operator decision, without treating `main` as an authority when
+another profile has the newer refresh.
 
 ### 3. hermes-relay (:8767) + main dashboard (:9119)
 
@@ -297,9 +305,9 @@ deliberately blanked in this container — Hermes is the sole key holder.
 | `HERMES_CODEX_BUILDER_MODEL` | default `gpt-5-codex` | |
 | `HERMES_RELAY_ENABLED` | not set by compose → **on** | relay :8767 + dashboard :9119 |
 | `HERMES_CRON_TIMEOUT` | `1800` | per-cron-job wall clock; must stay ≥ the largest Temporal execution_timeout being migrated (#56) |
-| `HERMES_SESSION_RETENTION_DAYS` / `HERMES_REQUEST_DUMP_RETENTION_DAYS` / `HERMES_REQUEST_DUMP_KEEP` | `7` / `3` / `50` | supervised `session-janitor` bounds session transcripts and request dumps |
-| `HERMES_STATE_DB_RETENTION_DAYS` | `7` | workers/heavy `state.db` row TTL + `VACUUM` |
-| `HERMES_AUTH_RESYNC_SECONDS` | `900` | periodic newest-refresh auth convergence |
+| `HERMES_SESSION_RETENTION_DAYS` / `HERMES_REQUEST_DUMP_RETENTION_DAYS` / `HERMES_REQUEST_DUMP_KEEP` | `7` / `3` / `50` | **#261 target (not read at this head):** supervised `session-janitor` bounds session transcripts and request dumps |
+| `HERMES_STATE_DB_RETENTION_DAYS` | `7` | **#261 target (not read at this head):** workers/heavy `state.db` row TTL + `VACUUM` |
+| `HERMES_AUTH_RESYNC_SECONDS` | `900` | **#261 target (not read at this head):** periodic newest-refresh auth convergence |
 | depends_on | `init` completed, `temporal` healthy | |
 | caps | `cap_drop: ALL` + `DAC_OVERRIDE`, `NET_ADMIN`, `SETUID`, `SETGID` | last three exist for the codex-builder jail/uid-drop |
 | ulimits / mem / pids | nofile 65536, `mem_limit: 12g`, `pids_limit: 2048 ` | #222 fd headroom; 12 g per PR #279 |
@@ -356,7 +364,7 @@ deliberately blanked in this container — Hermes is the sole key holder.
 7. **Kanban dispatcher is disabled fleet-wide** (`kanban.
    dispatch_in_gateway: false` on every profile) — do not re-enable; work
    coordination flows through Paperclip.
-8. **One effective OAuth refresher/identity**: `hermes auth login` on any of
+8. **#261 target — one effective OAuth refresher/identity**: `hermes auth login` on any of
    main/workers/heavy is sufficient. At boot and every
    `HERMES_AUTH_RESYNC_SECONDS`, the supervisor elects the valid `auth.json`
    with the newest `providers.openai-codex.last_refresh` and mirrors it to the
@@ -376,7 +384,7 @@ deliberately blanked in this container — Hermes is the sole key holder.
     staging, the `plane` stdio app, learn/ctrl plane_sync) must be treated
     as dead surface; deleting it is an open follow-up — do not wire new
     features to it.
-13. **Runtime state is bounded by supervision**: `session-janitor` is the
+13. **#261 target — runtime state is bounded by supervision**: `session-janitor` is the
    durable owner of session/request-dump retention for supervised profiles and
    workers/heavy `state.db` TTL + compaction. A rendered Hermes cron may remain
    as rollout compatibility, but callers and operators must not rely on it as
@@ -388,7 +396,10 @@ deliberately blanked in this container — Hermes is the sole key holder.
 
 `CONTRACT.md` is **forbidden-zone** (the commit gate rejects lane edits —
 `scripts/hooks/check_lane.py`). Changes land only via an orchestrator/phase0
-commit, together with the code that makes them true.
+commit. Normally the code that makes a clause true lands with it. A phase-0
+contract-freeze may precede provider implementation only when the clause is
+explicitly labelled as a target, names the current divergence and owning lane,
+and is not presented as deployed behavior.
 
 If you are a lane agent and this contract disagrees with the code you are
 reading: **STOP and report the divergence** — do not improvise across the

--- a/packages/hermes/CONTRACT.md
+++ b/packages/hermes/CONTRACT.md
@@ -63,6 +63,25 @@ is PID 1; the supervisor is its single child.
 | `codex-builder` | **18793** | Sealed builder runtime, uid 10001, iptables egress jail, `mcp_servers: {}` | only when `ENABLE_CODEX_BUILDER=true` (boot-only — never spawned by reconcile) |
 | user-facing profiles | **18794–18799** | Created via ctrl-api `POST /api/v1/agent-profiles`; rendered main-like (`is_main_like` in `init/render_hermes.py`) | registry-driven |
 
+The supervisor also owns a mandatory, portless **`session-janitor`** process.
+It is restarted with the same supervision/backoff discipline as the gateways
+and periodically bounds profile runtime state that Hermes itself leaves
+unbounded:
+
+| Frozen knob | Default | Contract |
+|---|---:|---|
+| `HERMES_SESSION_RETENTION_DAYS` | `7` | Remove expired `sessions/session_*.json` artifacts from the supervised profiles. |
+| `HERMES_REQUEST_DUMP_RETENTION_DAYS` | `3` | Remove expired `sessions/request_dump_*.json` debug artifacts. |
+| `HERMES_REQUEST_DUMP_KEEP` | `50` | Independently cap request dumps to the newest 50 per profile; the age and count bounds both apply. |
+| `HERMES_STATE_DB_RETENTION_DAYS` | `7` | Apply row TTL to the high-volume `workers` and `heavy` profile `state.db` files, then `VACUUM` them so deleted pages return disk space. Main/user-facing state DBs are outside this destructive TTL. |
+| `HERMES_AUTH_RESYNC_SECONDS` | `900` | Reconcile shared OAuth state every 900 seconds in addition to the initial boot convergence. |
+
+The janitor must tolerate a missing profile/session directory or state DB, and
+one profile's cleanup failure must not stop the other profiles or any gateway.
+This supervised guard supersedes the background-profile-only rendered cron as
+the durable retention owner; the old cron is migration compatibility, not the
+cross-lane guarantee.
+
 Profile enumeration is **registry-driven**: the supervisor reads
 `$HERMES_HOME/profiles/_registry.json` (written by init's
 `render_registry.py` from ctrl-api's `agent_profile` table, and re-written by
@@ -79,12 +98,13 @@ After each gateway's `/health` goes 200, the supervisor POSTs
 `http://ctrl-api:3100/api/v1/agent-profiles/<slug>/status` with
 `Authorization: Bearer <AAS_API_KEY>` read from `profiles/main/.env`.
 
-Supervisor boot-time side effects (all idempotent):
+Supervisor convergence side effects (all idempotent; auth convergence also
+runs periodically):
 
 | Step | Behaviour |
 |---|---|
 | Sticky default | `hermes profile use main` — bare `hermes` in a `docker exec` opens the Alfred main profile |
-| auth.json propagation | If `profiles/main/auth.json` exists, mirror to `workers` + `heavy` whenever theirs is missing or smaller (one OAuth identity for all profiles). With `ENABLE_CODEX_BUILDER=1` also mirrored to `codex-builder/auth.json` AND `codex-builder/.codex/auth.json` (codex-CLI auth), chowned 10001 mode 0600 |
+| auth.json convergence | On boot, and then every `HERMES_AUTH_RESYNC_SECONDS` (default 900), inspect `main`, `workers`, and `heavy`; the valid file with the newest `providers.openai-codex.last_refresh` wins and is atomically mirrored to the other two. When `ENABLE_CODEX_BUILDER=1`, the same winner is also mirrored to `codex-builder/auth.json` AND `codex-builder/.codex/auth.json` (codex-CLI auth), chowned 10001 mode 0600. Missing/malformed files never displace a valid newer file. |
 | SOUL.md consolidation | Copies `profiles/main/SOUL.md` → `$HERMES_HOME/SOUL.md` (the file Hermes actually loads as persona) only if the source is >200 bytes AND the destination is missing, smaller, or contains the stock marker `You are Hermes Agent`. A hand-edited global SOUL is preserved |
 | hermes-lcm install | Copies `/opt/hermes-lcm` → `profiles/main/plugins/hermes-lcm` once (guard: `! -e`). Main only |
 | one-alfred install | Copies `/opt/one-alfred` → `profiles/main/plugins/one-alfred`, refreshed whenever the baked source mtime is newer. Main only |
@@ -97,6 +117,14 @@ Each gateway is launched as
 — the process cwd is the profile dir (so Hermes auto-discovers the profile's
 `AGENTS.md`) and the profile `.env` is source-and-exported into the process
 env (auth key visible in `/proc/<pid>/environ`; the 2026-05-28 hardening).
+
+Auth propagation is therefore **not boot-only**. Any one of the three normal
+gateways may be the process that refreshes `openai-codex`; timestamp election
+converges that newest refresh token before another profile continues using an
+invalidated predecessor. Operationally this preserves one effective OAuth
+refresher/identity across main/workers/heavy, per the 2026-06-11 operator
+decision, without treating `main` as an authority when another profile has the
+newer refresh.
 
 ### 3. hermes-relay (:8767) + main dashboard (:9119)
 
@@ -269,6 +297,9 @@ deliberately blanked in this container — Hermes is the sole key holder.
 | `HERMES_CODEX_BUILDER_MODEL` | default `gpt-5-codex` | |
 | `HERMES_RELAY_ENABLED` | not set by compose → **on** | relay :8767 + dashboard :9119 |
 | `HERMES_CRON_TIMEOUT` | `1800` | per-cron-job wall clock; must stay ≥ the largest Temporal execution_timeout being migrated (#56) |
+| `HERMES_SESSION_RETENTION_DAYS` / `HERMES_REQUEST_DUMP_RETENTION_DAYS` / `HERMES_REQUEST_DUMP_KEEP` | `7` / `3` / `50` | supervised `session-janitor` bounds session transcripts and request dumps |
+| `HERMES_STATE_DB_RETENTION_DAYS` | `7` | workers/heavy `state.db` row TTL + `VACUUM` |
+| `HERMES_AUTH_RESYNC_SECONDS` | `900` | periodic newest-refresh auth convergence |
 | depends_on | `init` completed, `temporal` healthy | |
 | caps | `cap_drop: ALL` + `DAC_OVERRIDE`, `NET_ADMIN`, `SETUID`, `SETGID` | last three exist for the codex-builder jail/uid-drop |
 | ulimits / mem / pids | nofile 65536, `mem_limit: 12g`, `pids_limit: 2048 ` | #222 fd headroom; 12 g per PR #279 |
@@ -325,8 +356,12 @@ deliberately blanked in this container — Hermes is the sole key holder.
 7. **Kanban dispatcher is disabled fleet-wide** (`kanban.
    dispatch_in_gateway: false` on every profile) — do not re-enable; work
    coordination flows through Paperclip.
-8. **One OAuth identity**: `hermes auth login` on main is sufficient; the
-   supervisor mirrors `auth.json` to the other profiles at every boot.
+8. **One effective OAuth refresher/identity**: `hermes auth login` on any of
+   main/workers/heavy is sufficient. At boot and every
+   `HERMES_AUTH_RESYNC_SECONDS`, the supervisor elects the valid `auth.json`
+   with the newest `providers.openai-codex.last_refresh` and mirrors it to the
+   other normal profiles (plus both codex-builder auth locations when enabled).
+   File size and a hard-coded `main` source are not freshness signals.
 9. **Plugins are main-only** (hermes-lcm, one-alfred, hermes-relay) and
    installed by the supervisor from image-baked sources — never `pip
    install`ed, never installed on workers/heavy.
@@ -341,6 +376,11 @@ deliberately blanked in this container — Hermes is the sole key holder.
     staging, the `plane` stdio app, learn/ctrl plane_sync) must be treated
     as dead surface; deleting it is an open follow-up — do not wire new
     features to it.
+13. **Runtime state is bounded by supervision**: `session-janitor` is the
+   durable owner of session/request-dump retention for supervised profiles and
+   workers/heavy `state.db` TTL + compaction. A rendered Hermes cron may remain
+   as rollout compatibility, but callers and operators must not rely on it as
+   the only guard.
 
 ---
 

--- a/packages/learn/CONTRACT.md
+++ b/packages/learn/CONTRACT.md
@@ -161,6 +161,29 @@ One-shot operator scripts under `packages/learn/scripts/` (e.g.
 `python -m scripts.<name>` inside the container; not part of the
 steady-state surface.
 
+### 4. Clerk gateway circuit breaker
+
+Every call through the shared clerk gateway path is protected by a persistent,
+per-tenant circuit breaker. `CLERK_BREAKER_ENABLED` defaults **ON** (the normal
+`false`/`0`/`no`/`off` spellings disable it). Its rolling outcome window opens
+only when all three conditions hold: samples span at least one hour, a
+non-zero fixed/test-pinned minimum call floor has been reached, and at least
+**95%** of outcomes are `max_retries_exhausted`. This is a sustained
+gateway-failure guard, not a trigger on a single failed workflow.
+
+Opening the breaker short-circuits ordinary clerk dispatch and creates exactly
+one `needs_attention` card for that incident through ctrl-api (never a direct
+vault write). Retries/restarts use the persisted incident identity and must not
+create duplicate cards. The breaker is **close-on-first-success**: an admitted
+recovery probe's first successful clerk completion closes it immediately; a
+later open state is a new incident and may create one new card.
+
+Breaker state is internal bookkeeping under
+`/alfred-data/state/steward/clerk-breaker.json`, alongside
+`reversal-calibration.json`, and is written with the same atomic replacement
+pattern. It is not vault knowledge and must not be stored in SQLite or a new
+vault record type.
+
 ---
 
 ## Requires
@@ -219,6 +242,7 @@ deployed tenant actually sees.
 | `GROQ_API_KEY` | (from `.env`) | Whisper transcription; without it OMI audio is silently dead. |
 | `COMPOSIO_API_KEY` | (from `.env`) | Composio SDK (sidecar + composio_tools). |
 | `DISPATCH_USE_EPHEMERAL_EXECUTOR` | compose: `1` | Delegate dispatch uses per-task `exec-<hash>` Hermes sessions. |
+| `CLERK_BREAKER_ENABLED` | **ON** | Invocation-time gate for the persistent clerk gateway circuit breaker; `false`/`0`/`no`/`off` disables it. |
 | `OPENROUTER_API_KEY` / `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` | **blanked in compose** | Hermes is the sole provider-key holder; learn makes no direct provider calls. |
 
 **Feature gates (registration-time — changing them requires a container
@@ -245,7 +269,7 @@ precedence)**: `STEWARD_SIGNAL_ACTION_LIVE_MODE`, `STEWARD_LIVE_MODE`,
 | Path | Access | Purpose |
 |---|---|---|
 | `/vault` (`vault_data`) | read | Vault markdown (writes go through ctrl-api). |
-| `/alfred-data` (`alfred_data`) | read/write | `.gateway-token` (read), `settings.json` (read — ctrl-api is the writer), `user-chores/` (dynamic templates), `chore-run-history.jsonl`, `state/steward/*` caches. |
+| `/alfred-data` (`alfred_data`) | read/write | `.gateway-token` (read), `settings.json` (read — ctrl-api is the writer), `user-chores/` (dynamic templates), `chore-run-history.jsonl`, `state/steward/*` caches including `reversal-calibration.json` and `clerk-breaker.json`. |
 | `/hermes-state` (`hermes_data`) | read/write | Hermes profile configs; onboarding writes `memories/MEMORY.md` etc. |
 
 ### Runtime
@@ -337,6 +361,13 @@ limit in compose. No local Whisper model — Groq-hosted.
     reflection (not synthesis), judgment (not router), discretion (not
     confidence gate), clerk (not subken). Source:
     `packages/learn/CLAUDE.md` §Key Constraints.
+
+11. **Clerk outages are incident-deduped.** With
+    `CLERK_BREAKER_ENABLED` on, only a >=95% `max_retries_exhausted` rate over
+    a sample spanning >=1 h and clearing the fixed minimum-call floor opens the
+    breaker. One open incident produces at most one ctrl-api needs-attention
+    card, persisted state survives worker restarts, and the first successful
+    recovery completion closes it.
 
 ---
 

--- a/packages/learn/CONTRACT.md
+++ b/packages/learn/CONTRACT.md
@@ -2,9 +2,11 @@
 
 > Frozen cross-lane interface for `packages/learn/**` (Lane II). Read this
 > before coding against or inside alfred-learn. Regenerated 2026-07-15 from
-> `main`; every claim below was verified against code, with
+> `main`; every current-runtime claim below was verified against code, with
 > `src/worker.py` (workflow/activity registration) and
-> `scripts/register_schedules.py` (schedules) as the authorities.
+> `scripts/register_schedules.py` (schedules) as the authorities. Clauses
+> explicitly labelled `#261 target` instead freeze Lane II's required future
+> behavior and are not code-verified claims about this phase-0 head.
 
 alfred-learn is the Temporal intelligence layer: a single Python 3.12
 worker container (`ssdavidai00/alfred-learn:latest`) that runs every
@@ -163,22 +165,26 @@ steady-state surface.
 
 ### 4. Clerk gateway circuit breaker
 
-Every call through the shared clerk gateway path is protected by a persistent,
-per-tenant circuit breaker. `CLERK_BREAKER_ENABLED` defaults **ON** (the normal
-`false`/`0`/`no`/`off` spellings disable it). Its rolling outcome window opens
-only when all three conditions hold: samples span at least one hour, a
-non-zero fixed/test-pinned minimum call floor has been reached, and at least
-**95%** of outcomes are `max_retries_exhausted`. This is a sustained
-gateway-failure guard, not a trigger on a single failed workflow.
+**#261 target (Lane II; not implemented at this phase-0 head).** The current
+shared clerk path dispatches directly and has no breaker gate, persisted
+breaker state, or incident card. Lane II must protect every call through that
+path with a persistent, per-tenant circuit breaker. `CLERK_BREAKER_ENABLED`
+defaults **ON** (the normal `false`/`0`/`no`/`off` spellings disable it). Its
+rolling outcome window must open only when all three conditions hold: samples
+span at least one hour, a non-zero fixed/test-pinned minimum call floor has
+been reached, and at least **95%** of outcomes are `max_retries_exhausted`.
+This is a sustained gateway-failure guard, not a trigger on a single failed
+workflow.
 
-Opening the breaker short-circuits ordinary clerk dispatch and creates exactly
-one `needs_attention` card for that incident through ctrl-api (never a direct
-vault write). Retries/restarts use the persisted incident identity and must not
-create duplicate cards. The breaker is **close-on-first-success**: an admitted
-recovery probe's first successful clerk completion closes it immediately; a
-later open state is a new incident and may create one new card.
+Opening the breaker must short-circuit ordinary clerk dispatch and create
+exactly one `needs_attention` card for that incident through ctrl-api (never a
+direct vault write). Retries/restarts must use the persisted incident identity
+and must not create duplicate cards. The breaker is
+**close-on-first-success**: an admitted recovery probe's first successful clerk
+completion must close it immediately; a later open state is a new incident and
+may create one new card.
 
-Breaker state is internal bookkeeping under
+Breaker state must be internal bookkeeping under
 `/alfred-data/state/steward/clerk-breaker.json`, alongside
 `reversal-calibration.json`, and is written with the same atomic replacement
 pattern. It is not vault knowledge and must not be stored in SQLite or a new
@@ -242,7 +248,7 @@ deployed tenant actually sees.
 | `GROQ_API_KEY` | (from `.env`) | Whisper transcription; without it OMI audio is silently dead. |
 | `COMPOSIO_API_KEY` | (from `.env`) | Composio SDK (sidecar + composio_tools). |
 | `DISPATCH_USE_EPHEMERAL_EXECUTOR` | compose: `1` | Delegate dispatch uses per-task `exec-<hash>` Hermes sessions. |
-| `CLERK_BREAKER_ENABLED` | **ON** | Invocation-time gate for the persistent clerk gateway circuit breaker; `false`/`0`/`no`/`off` disables it. |
+| `CLERK_BREAKER_ENABLED` | **ON** | **#261 target (not read at this head):** invocation-time gate for the persistent clerk gateway circuit breaker; `false`/`0`/`no`/`off` disables it. |
 | `OPENROUTER_API_KEY` / `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` | **blanked in compose** | Hermes is the sole provider-key holder; learn makes no direct provider calls. |
 
 **Feature gates (registration-time — changing them requires a container
@@ -269,7 +275,7 @@ precedence)**: `STEWARD_SIGNAL_ACTION_LIVE_MODE`, `STEWARD_LIVE_MODE`,
 | Path | Access | Purpose |
 |---|---|---|
 | `/vault` (`vault_data`) | read | Vault markdown (writes go through ctrl-api). |
-| `/alfred-data` (`alfred_data`) | read/write | `.gateway-token` (read), `settings.json` (read — ctrl-api is the writer), `user-chores/` (dynamic templates), `chore-run-history.jsonl`, `state/steward/*` caches including `reversal-calibration.json` and `clerk-breaker.json`. |
+| `/alfred-data` (`alfred_data`) | read/write | `.gateway-token` (read), `settings.json` (read — ctrl-api is the writer), `user-chores/` (dynamic templates), `chore-run-history.jsonl`, `state/steward/*` caches including current `reversal-calibration.json`; **#261 target** adds `clerk-breaker.json`. |
 | `/hermes-state` (`hermes_data`) | read/write | Hermes profile configs; onboarding writes `memories/MEMORY.md` etc. |
 
 ### Runtime
@@ -362,7 +368,7 @@ limit in compose. No local Whisper model — Groq-hosted.
     confidence gate), clerk (not subken). Source:
     `packages/learn/CLAUDE.md` §Key Constraints.
 
-11. **Clerk outages are incident-deduped.** With
+11. **#261 target — clerk outages are incident-deduped.** With
     `CLERK_BREAKER_ENABLED` on, only a >=95% `max_retries_exhausted` rate over
     a sample spanning >=1 h and clearing the fixed minimum-call floor opens the
     breaker. One open incident produces at most one ctrl-api needs-attention
@@ -391,3 +397,6 @@ changes — never as part of a lane's feature commit. If a lane discovers
 this contract is wrong (an endpoint moved, a schedule changed, a default
 flipped), the lane **STOPs and reports** to the orchestrator; it never
 improvises across the boundary or edits this file to match its code.
+A phase-0 target freeze may precede its provider implementation only when it
+is explicitly labelled, states the current gap and owning lane, and is not
+presented as deployed behavior.


### PR DESCRIPTION
Part of #261

Controller job: `contracts-261` · lane `phase0`

## Smoke evidence

`true`

```text
(command exited 0 with no output)
```

The trusted controller independently reran this command after validating every changed path against the approved plan.