### PR TITLE
Hermes workers sessions/request-dumps have no retention — filled zsolt's 300GB disk in 6 days (full-stack outage) (lane I)

### DIFF
--- a/packages/ctrl/src/api/cron.ts
+++ b/packages/ctrl/src/api/cron.ts
@@ -22,6 +22,13 @@
 // higher up — Temporal handles it; this computer only mirrors the
 // raw cron semantics.
 
+import { runDiskWatch } from "./diskWatch.js";
+
+const diskWatchTimer = setInterval(() => {
+  void runDiskWatch().catch((err) => console.error(`[disk-watch] ${err}`));
+}, 15 * 60_000);
+diskWatchTimer.unref();
+
 type FieldRange = { min: number; max: number };
 
 const RANGES: Record<"min" | "hour" | "dom" | "month" | "dow", FieldRange> = {

--- a/packages/ctrl/src/api/diskWatch.ts
+++ b/packages/ctrl/src/api/diskWatch.ts
@@ -2,12 +2,13 @@ import fs from "node:fs";
 import path from "node:path";
 import { statfs } from "node:fs/promises";
 import { getStateDb } from "../db/state.js";
+import { indexVaultWrite } from "../db/vaultIndex.js";
 import { invalidateVaultCachesForType } from "./vaultCache.js";
 
 export type DiskAlertLevel = "ok" | "warn" | "page" | "unknown";
 export interface DiskInfo { disk_total_bytes: number | null; disk_free_bytes: number | null; disk_used_pct: number | null; disk_alert_level: DiskAlertLevel; disk_alert_warn_pct: number; disk_alert_page_pct: number }
 type StatFs = { blocks: number | bigint; bfree: number | bigint; bsize: number | bigint };
-type Deps = { sample?: () => Promise<DiskInfo>; recentWarn?: (since: string) => boolean; card?: (d: DiskInfo, now: Date) => string; audit?: (d: DiskInfo, card: string, now: Date) => void | Promise<void>; notify?: (d: DiskInfo) => Promise<void>; now?: () => Date };
+type Deps = { sample?: () => Promise<DiskInfo>; recentWarn?: (since: string) => boolean; card?: (d: DiskInfo, now: Date) => string | Promise<string>; audit?: (d: DiskInfo, card: string, now: Date) => void | Promise<void>; pageActive?: () => boolean; auditPage?: (d: DiskInfo, active: boolean, now: Date) => void | Promise<void>; notify?: (d: DiskInfo) => Promise<void>; now?: () => Date };
 
 function envPct(name: string, fallback: number): number {
   const raw = process.env[name];
@@ -37,14 +38,20 @@ export async function getDiskInfo(): Promise<DiskInfo> {
 }
 
 const VAULT = process.env.VAULT_PATH ?? "/vault";
-function mintCard(d: DiskInfo, now: Date): string {
+async function mintCard(d: DiskInfo, now: Date): Promise<string> {
   const id = `disk-pressure-${now.toISOString().replace(/[:.]/g, "-")}`;
   const rel = `needs_attention/${id}.md`, dir = path.join(VAULT, "needs_attention");
   fs.mkdirSync(dir, { recursive: true });
   const pct = d.disk_used_pct!.toFixed(1);
   fs.writeFileSync(path.join(VAULT, rel), `---\ntype: needs_attention\nstatus: pending\ncreated: ${JSON.stringify(now.toISOString())}\naction_what: ${JSON.stringify(`Free disk space; usage is ${pct}%`)}\nsuggested_actor: principal\ntarget_kind: system\ndecision_reason: disk_pressure\ndisplay_headline: ${JSON.stringify(`Disk usage is ${pct}%`)}\nreasoning: ${JSON.stringify(`Disk usage crossed the ${d.disk_alert_warn_pct}% warning threshold. Remove unneeded data before services fail.`)}\n---\n\nDisk pressure was detected on the filesystem containing alfred-state.db.\n`, { flag: "wx" });
+  indexVaultWrite(rel);
   invalidateVaultCachesForType("needs_attention");
-  return rel;
+  // Validate through the canonical attention reader. Once the principal acts
+  // on this record, those routes also mint the normal decision mirror.
+  const { readNeedsAttention } = await import("./routes/attention.js");
+  const rec = readNeedsAttention(id);
+  if (!rec) throw new Error(`failed to mint readable needs-attention card ${rel}`);
+  return rec.path;
 }
 
 async function auditWarning(d: DiskInfo, card: string, now: Date): Promise<void> {
@@ -54,6 +61,28 @@ async function auditWarning(d: DiskInfo, card: string, now: Date): Promise<void>
 
 function recentAudit(since: string): boolean {
   return Boolean(getStateDb().prepare("SELECT 1 FROM audit WHERE action_type = 'disk_pressure_warning' AND ts >= ? LIMIT 1").get(since));
+}
+
+function pageAlertActive(): boolean {
+  const row = getStateDb().prepare(
+    "SELECT action_type FROM audit WHERE action_type IN ('disk_pressure_page', 'disk_pressure_page_cleared') ORDER BY ts DESC, rowid DESC LIMIT 1",
+  ).get() as { action_type: string } | undefined;
+  return row?.action_type === "disk_pressure_page";
+}
+
+async function auditPageTransition(d: DiskInfo, active: boolean, now: Date): Promise<void> {
+  const { appendAudit } = await import("./routes/state.js");
+  appendAudit({
+    ts: now.toISOString(),
+    action_type: active ? "disk_pressure_page" : "disk_pressure_page_cleared",
+    actor: "alfred",
+    source: "disk_watch",
+    target_kind: "system",
+    summary: active
+      ? `Critical disk notification sent at ${d.disk_used_pct!.toFixed(1)}% usage`
+      : `Disk usage fell below the page threshold at ${d.disk_used_pct!.toFixed(1)}%`,
+    payload: d,
+  }, { strict: true });
 }
 
 function recentCard(since: string): string | null {
@@ -70,8 +99,9 @@ async function notifyPage(d: DiskInfo): Promise<void> {
   if (!resp.ok) throw new Error(`notification returned ${resp.status}`);
 }
 
-let previousLevel: DiskAlertLevel = "unknown";
-export function _resetDiskWatchForTests(): void { previousLevel = "unknown"; }
+// Kept for the existing test API. Crossing state is intentionally durable in
+// state.db, so a process reset must not re-arm a page notification.
+export function _resetDiskWatchForTests(): void {}
 
 export async function runDiskWatch(deps: Deps = {}): Promise<DiskInfo> {
   const d = await (deps.sample ?? getDiskInfo)();
@@ -82,13 +112,20 @@ export async function runDiskWatch(deps: Deps = {}): Promise<DiskInfo> {
     if (d.disk_alert_level !== "ok") {
       const since = new Date(now.getTime() - 86_400_000).toISOString();
       if (!(deps.recentWarn ?? recentAudit)(since)) {
-        const card = deps.card ? deps.card(d, now) : recentCard(since) ?? mintCard(d, now);
+        const card = deps.card
+          ? await deps.card(d, now)
+          : recentCard(since) ?? await mintCard(d, now);
         await (deps.audit ?? auditWarning)(d, card, now);
       }
     }
   } catch (err) { warningError = err; }
-  if (d.disk_alert_level === "page" && previousLevel !== "page") await (deps.notify ?? notifyPage)(d);
-  previousLevel = d.disk_alert_level;
+  const pageWasActive = (deps.pageActive ?? pageAlertActive)();
+  if (d.disk_alert_level === "page" && !pageWasActive) {
+    await (deps.notify ?? notifyPage)(d);
+    await (deps.auditPage ?? auditPageTransition)(d, true, now);
+  } else if (d.disk_alert_level !== "page" && pageWasActive) {
+    await (deps.auditPage ?? auditPageTransition)(d, false, now);
+  }
   if (warningError) throw warningError;
   return d;
 }

--- a/packages/ctrl/src/api/diskWatch.ts
+++ b/packages/ctrl/src/api/diskWatch.ts
@@ -1,0 +1,94 @@
+import fs from "node:fs";
+import path from "node:path";
+import { statfs } from "node:fs/promises";
+import { getStateDb } from "../db/state.js";
+import { invalidateVaultCachesForType } from "./vaultCache.js";
+
+export type DiskAlertLevel = "ok" | "warn" | "page" | "unknown";
+export interface DiskInfo { disk_total_bytes: number | null; disk_free_bytes: number | null; disk_used_pct: number | null; disk_alert_level: DiskAlertLevel; disk_alert_warn_pct: number; disk_alert_page_pct: number }
+type StatFs = { blocks: number | bigint; bfree: number | bigint; bsize: number | bigint };
+type Deps = { sample?: () => Promise<DiskInfo>; recentWarn?: (since: string) => boolean; card?: (d: DiskInfo, now: Date) => string; audit?: (d: DiskInfo, card: string, now: Date) => void | Promise<void>; notify?: (d: DiskInfo) => Promise<void>; now?: () => Date };
+
+function envPct(name: string, fallback: number): number {
+  const raw = process.env[name];
+  const n = raw?.trim() ? Number(raw) : NaN;
+  return Number.isFinite(n) && n >= 0 && n <= 100 ? n : fallback;
+}
+
+export function diskThresholds(): { warn: number; page: number } {
+  return { warn: envPct("DISK_ALERT_WARN_PCT", 80), page: envPct("DISK_ALERT_PAGE_PCT", 90) };
+}
+
+export async function sampleDiskUsage(
+  statfsFn: (p: string, options: { bigint: true }) => Promise<StatFs> = statfs as any,
+): Promise<DiskInfo> {
+  const dbPath = process.env.STATE_DB_PATH ?? path.join(process.cwd(), "data", "alfred-state.db");
+  const s = await statfsFn(path.dirname(dbPath), { bigint: true });
+  const blocks = Number(s.blocks), free = Number(s.bfree), size = Number(s.bsize);
+  if (!(blocks > 0) || !(free >= 0) || !(size > 0)) throw new Error("invalid statfs result");
+  const used = ((blocks - free) / blocks) * 100;
+  const { warn, page } = diskThresholds();
+  return { disk_total_bytes: blocks * size, disk_free_bytes: free * size, disk_used_pct: used, disk_alert_level: used >= page ? "page" : used >= warn ? "warn" : "ok", disk_alert_warn_pct: warn, disk_alert_page_pct: page };
+}
+
+export async function getDiskInfo(): Promise<DiskInfo> {
+  try { return await sampleDiskUsage(); }
+  catch { const { warn, page } = diskThresholds(); return { disk_total_bytes: null, disk_free_bytes: null, disk_used_pct: null, disk_alert_level: "unknown", disk_alert_warn_pct: warn, disk_alert_page_pct: page }; }
+}
+
+const VAULT = process.env.VAULT_PATH ?? "/vault";
+function mintCard(d: DiskInfo, now: Date): string {
+  const id = `disk-pressure-${now.toISOString().replace(/[:.]/g, "-")}`;
+  const rel = `needs_attention/${id}.md`, dir = path.join(VAULT, "needs_attention");
+  fs.mkdirSync(dir, { recursive: true });
+  const pct = d.disk_used_pct!.toFixed(1);
+  fs.writeFileSync(path.join(VAULT, rel), `---\ntype: needs_attention\nstatus: pending\ncreated: ${JSON.stringify(now.toISOString())}\naction_what: ${JSON.stringify(`Free disk space; usage is ${pct}%`)}\nsuggested_actor: principal\ntarget_kind: system\ndecision_reason: disk_pressure\ndisplay_headline: ${JSON.stringify(`Disk usage is ${pct}%`)}\nreasoning: ${JSON.stringify(`Disk usage crossed the ${d.disk_alert_warn_pct}% warning threshold. Remove unneeded data before services fail.`)}\n---\n\nDisk pressure was detected on the filesystem containing alfred-state.db.\n`, { flag: "wx" });
+  invalidateVaultCachesForType("needs_attention");
+  return rel;
+}
+
+async function auditWarning(d: DiskInfo, card: string, now: Date): Promise<void> {
+  const { appendAudit } = await import("./routes/state.js");
+  appendAudit({ ts: now.toISOString(), action_type: "disk_pressure_warning", actor: "alfred", source: "disk_watch", target_path: card, target_kind: "needs_attention", summary: `Disk usage reached ${d.disk_used_pct!.toFixed(1)}%`, payload: d }, { strict: true });
+}
+
+function recentAudit(since: string): boolean {
+  return Boolean(getStateDb().prepare("SELECT 1 FROM audit WHERE action_type = 'disk_pressure_warning' AND ts >= ? LIMIT 1").get(since));
+}
+
+function recentCard(since: string): string | null {
+  const dir = path.join(VAULT, "needs_attention"), cutoff = Date.parse(since);
+  try {
+    const file = fs.readdirSync(dir).find((f) => f.startsWith("disk-pressure-") && f.endsWith(".md") && fs.statSync(path.join(dir, f)).mtimeMs >= cutoff);
+    return file ? `needs_attention/${file}` : null;
+  } catch { return null; }
+}
+
+async function notifyPage(d: DiskInfo): Promise<void> {
+  const port = process.env.AAS_PORT ?? "3100";
+  const resp = await fetch(`http://127.0.0.1:${port}/api/v1/notifications`, { method: "POST", headers: { Authorization: `Bearer ${process.env.AAS_API_KEY ?? ""}`, "Content-Type": "application/json" }, body: JSON.stringify({ message: `Critical disk pressure: ${d.disk_used_pct!.toFixed(1)}% used (page threshold ${d.disk_alert_page_pct}%). Free disk space now to prevent an outage.`, urgency: "high", source_kind: "system", source_ref: "disk-pressure", source_headline: "Critical disk pressure" }), signal: AbortSignal.timeout(75_000) });
+  if (!resp.ok) throw new Error(`notification returned ${resp.status}`);
+}
+
+let previousLevel: DiskAlertLevel = "unknown";
+export function _resetDiskWatchForTests(): void { previousLevel = "unknown"; }
+
+export async function runDiskWatch(deps: Deps = {}): Promise<DiskInfo> {
+  const d = await (deps.sample ?? getDiskInfo)();
+  if (d.disk_alert_level === "unknown") return d;
+  const now = (deps.now ?? (() => new Date()))();
+  let warningError: unknown;
+  try {
+    if (d.disk_alert_level !== "ok") {
+      const since = new Date(now.getTime() - 86_400_000).toISOString();
+      if (!(deps.recentWarn ?? recentAudit)(since)) {
+        const card = deps.card ? deps.card(d, now) : recentCard(since) ?? mintCard(d, now);
+        await (deps.audit ?? auditWarning)(d, card, now);
+      }
+    }
+  } catch (err) { warningError = err; }
+  if (d.disk_alert_level === "page" && previousLevel !== "page") await (deps.notify ?? notifyPage)(d);
+  previousLevel = d.disk_alert_level;
+  if (warningError) throw warningError;
+  return d;
+}

--- a/packages/ctrl/src/api/routes/admin.ts
+++ b/packages/ctrl/src/api/routes/admin.ts
@@ -5,6 +5,7 @@ import { dockerComposeCmd, dockerExec, execAsync, sudoExec, parseJsonLines, vali
 import { getVaultContextData, getInboxFiles, VAULT_PATH } from "./vault.js";
 import { readDurableActivity } from "../activity.js";
 import { queryAuditCrossTier } from "../../db/coldRead.js";
+import { getDiskInfo } from "../diskWatch.js";
 
 // alfred-black mounts the alfred daemon's data dir as a named Docker volume
 // (PLAN.md Part E), bind-mounted into ctrl-api at /alfred-data by default.
@@ -875,6 +876,10 @@ export function registerAdminRoutes(): void {
   });
 
   // --- System info ---
+
+  addRoute("GET", "/api/v1/admin/system-info", async ({ res }) => {
+    sendJson(res, 200, await getDiskInfo());
+  });
 
   addRoute("GET", "/api/v1/admin/system/info", async ({ res }) => {
     const [uptimeResult, diskResult, memResult] = await Promise.all([

--- a/packages/ctrl/src/api/routes/admin.ts
+++ b/packages/ctrl/src/api/routes/admin.ts
@@ -5,6 +5,7 @@ import { dockerComposeCmd, dockerExec, execAsync, sudoExec, parseJsonLines, vali
 import { getVaultContextData, getInboxFiles, VAULT_PATH } from "./vault.js";
 import { readDurableActivity } from "../activity.js";
 import { queryAuditCrossTier } from "../../db/coldRead.js";
+import { getStateDb } from "../../db/state.js";
 import { getDiskInfo } from "../diskWatch.js";
 
 // alfred-black mounts the alfred daemon's data dir as a named Docker volume
@@ -676,8 +677,25 @@ export function registerAdminRoutes(): void {
         until: cursor || null, limit: includeAutomated ? limit : limit * 4, offset: 0,
       } as any);
     } catch {
-      sendJson(res, 200, { items: [], total: 0, next_cursor: null });
-      return;
+      // The cold archive is optional for serving current data. If it is
+      // temporarily unavailable, preserve the hot audit ledger instead of
+      // turning a healthy state.db into an empty activity feed.
+      try {
+        const where = cursor ? "WHERE ts <= ?" : "";
+        const args = cursor ? [cursor] : [];
+        const fetchLimit = includeAutomated ? limit : limit * 4;
+        const db = getStateDb();
+        const entries = db.prepare(
+          `SELECT * FROM audit ${where} ORDER BY ts DESC LIMIT ?`,
+        ).all(...args, fetchLimit) as Array<Record<string, unknown>>;
+        const total = (db.prepare(
+          `SELECT COUNT(*) AS n FROM audit ${where}`,
+        ).get(...args) as { n: number }).n;
+        result = { entries, total };
+      } catch {
+        sendJson(res, 200, { items: [], total: 0, next_cursor: null });
+        return;
+      }
     }
     const visible = (result.entries as Array<Record<string, any>>).filter(
       (row) => includeAutomated || !isAutomatedAuditType(String(row.action_type ?? "")),

--- a/packages/ctrl/tests/disk-watch.test.ts
+++ b/packages/ctrl/tests/disk-watch.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "disk-watch-"));
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.STATE_DB_PATH = path.join(tmp, "state.db");
+process.env.VAULT_PATH = path.join(tmp, "vault");
+process.env.SQLITE_VEC_PATH = "";
+delete process.env.DISK_ALERT_WARN_PCT;
+delete process.env.DISK_ALERT_PAGE_PCT;
+const { _resetDiskWatchForTests, runDiskWatch, sampleDiskUsage } = await import("../src/api/diskWatch.js");
+type DiskInfo = Awaited<ReturnType<typeof sampleDiskUsage>>;
+
+const info = (level: "ok" | "warn" | "page", pct: number): DiskInfo => ({ disk_total_bytes: 1000, disk_free_bytes: 1000 - pct * 10, disk_used_pct: pct, disk_alert_level: level, disk_alert_warn_pct: 80, disk_alert_page_pct: 90 });
+
+describe("disk watcher", () => {
+  beforeEach(() => _resetDiskWatchForTests());
+
+  it("computes used percent and bytes from statfs on the state-db directory", async () => {
+    process.env.STATE_DB_PATH = "/state/alfred-state.db";
+    let sampled = "";
+    const d = await sampleDiskUsage(async (p) => { sampled = p; return { blocks: 100n, bfree: 20n, bsize: 4096n }; });
+    assert.equal(sampled, "/state");
+    assert.equal(d.disk_used_pct, 80);
+    assert.equal(d.disk_total_bytes, 409600);
+    assert.equal(d.disk_free_bytes, 81920);
+    process.env.STATE_DB_PATH = path.join(tmp, "state.db");
+  });
+
+  it("exposes structured disk pressure through admin/system-info", async () => {
+    const { registerAdminRoutes } = await import("../src/api/routes/admin.js");
+    const { matchRoute } = await import("../src/api/server.js");
+    registerAdminRoutes();
+    const route = matchRoute("GET", "/api/v1/admin/system-info");
+    assert.ok(route);
+    let payload: DiskInfo | undefined;
+    const res = { writeHead() { return res; }, end(body: string) { payload = JSON.parse(body); } } as any;
+    await route.handler({ req: {} as any, res, params: {}, body: undefined, query: new URLSearchParams() });
+    assert.equal(payload?.disk_alert_warn_pct, 80);
+    assert.equal(payload?.disk_alert_page_pct, 90);
+    assert.equal(typeof payload?.disk_used_pct, "number");
+  });
+
+  it("deduplicates the warn audit/card for 24 hours", async () => {
+    await runDiskWatch({ sample: async () => info("warn", 82) });
+    await runDiskWatch({ sample: async () => info("warn", 82) });
+    const [file] = fs.readdirSync(path.join(tmp, "vault", "needs_attention"));
+    assert.ok(file);
+    const { readNeedsAttention } = await import("../src/api/routes/attention.js");
+    assert.equal(readNeedsAttention(file.replace(/\.md$/, ""))?.frontmatter.status, "pending");
+    const { getStateDb } = await import("../src/db/state.js");
+    const row = getStateDb().prepare("SELECT count(*) AS n FROM audit WHERE action_type = 'disk_pressure_warning'").get() as { n: number };
+    assert.equal(row.n, 1);
+  });
+
+  it("notifies once per page crossing", async () => {
+    let current = info("page", 92), calls = 0;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (url) => { calls++; assert.match(String(url), /\/api\/v1\/notifications$/); return new Response("{}", { status: 200 }); }) as typeof fetch;
+    try {
+      const deps = { sample: async () => current, recentWarn: () => true };
+      await runDiskWatch(deps); await runDiskWatch(deps);
+      current = info("warn", 85); await runDiskWatch(deps);
+      current = info("page", 93); await runDiskWatch(deps);
+      assert.equal(calls, 2);
+    } finally { globalThis.fetch = originalFetch; }
+  });
+
+  it("does nothing below threshold", async () => {
+    let effects = 0;
+    await runDiskWatch({ sample: async () => info("ok", 40), recentWarn: () => { effects++; return false; }, card: () => { effects++; return "x"; }, audit: () => { effects++; }, notify: async () => { effects++; } });
+    assert.equal(effects, 0);
+  });
+});

--- a/packages/ctrl/tests/disk-watch.test.ts
+++ b/packages/ctrl/tests/disk-watch.test.ts
@@ -54,24 +54,31 @@ describe("disk watcher", () => {
     const { getStateDb } = await import("../src/db/state.js");
     const row = getStateDb().prepare("SELECT count(*) AS n FROM audit WHERE action_type = 'disk_pressure_warning'").get() as { n: number };
     assert.equal(row.n, 1);
+    const indexed = getStateDb().prepare("SELECT status FROM vault_index WHERE path = ?").get(`needs_attention/${file}`) as { status: string } | undefined;
+    assert.equal(indexed?.status, "pending");
   });
 
-  it("notifies once per page crossing", async () => {
+  it("persists page crossings so a restart does not notify again", async () => {
     let current = info("page", 92), calls = 0;
     const originalFetch = globalThis.fetch;
     globalThis.fetch = (async (url) => { calls++; assert.match(String(url), /\/api\/v1\/notifications$/); return new Response("{}", { status: 200 }); }) as typeof fetch;
     try {
       const deps = { sample: async () => current, recentWarn: () => true };
-      await runDiskWatch(deps); await runDiskWatch(deps);
+      await runDiskWatch(deps);
+      _resetDiskWatchForTests();
+      await runDiskWatch(deps);
       current = info("warn", 85); await runDiskWatch(deps);
       current = info("page", 93); await runDiskWatch(deps);
       assert.equal(calls, 2);
+      const { getStateDb } = await import("../src/db/state.js");
+      const row = getStateDb().prepare("SELECT count(*) AS n FROM audit WHERE action_type = 'disk_pressure_page'").get() as { n: number };
+      assert.equal(row.n, 2);
     } finally { globalThis.fetch = originalFetch; }
   });
 
   it("does nothing below threshold", async () => {
     let effects = 0;
-    await runDiskWatch({ sample: async () => info("ok", 40), recentWarn: () => { effects++; return false; }, card: () => { effects++; return "x"; }, audit: () => { effects++; }, notify: async () => { effects++; } });
+    await runDiskWatch({ sample: async () => info("ok", 40), recentWarn: () => { effects++; return false; }, card: () => { effects++; return "x"; }, audit: () => { effects++; }, pageActive: () => false, auditPage: () => { effects++; }, notify: async () => { effects++; } });
     assert.equal(effects, 0);
   });
 });


### PR DESCRIPTION
Part of #261

Controller job: `ctrl-261` · lane `I`

## Smoke evidence

`cd packages/ctrl && npm run build`

```text
> alfred-ctrl-api@0.1.0 build
> node build.mjs

Build complete — dist/api.mjs
```

The trusted controller independently reran this command after validating every changed path against the approved plan.