### PR TITLE
Bug: finance surfaces can present cached fallback balances without freshness provenance (lane phase0)

### DIFF
--- a/packages/ctrl/CONTRACT.md
+++ b/packages/ctrl/CONTRACT.md
@@ -89,7 +89,7 @@ One row per module in `src/api/routes/` (complete index = the `register*` import
 | `mcpTokens.ts` | `/api/v1/mcp/tokens*` | Per-app MCP scoped-token proxy (PR #278). See call-out §MCP tokens. |
 | `claudeSetup.ts` | `/api/v1/claude-setup*` | /claude page payload + `MCP_APPROVAL_SECRET` rotation |
 | `vaultwarden.ts` | `/api/v1/vaultwarden/*` | Vaultwarden proxy via the vault-cli sidecar (`VAULT_CLI_URL`, default `http://vault-cli:8087`) |
-| `sure.ts` | `/api/v1/sure/*` | Sure personal-finance REST proxy (96 endpoints; auth via `SURE_API_KEY`, missing key → `NOT_CONFIGURED`) |
+| `sure.ts` | `/api/v1/sure/*` | Sure personal-finance REST proxy (97 endpoints). Account-bearing responses add per-account `balance_provenance` (`source`: `provider`/`cached_fallback`; `observed_at`: ISO8601; `freshness`: `fresh`/`stale`/`unknown`; `fallback_reason`: string/null). Aggregate balance-sheet/net-worth responses also add `data_quality` (`fresh_accounts`, `stale_accounts`, `unknown_accounts`, `partial`: boolean). `GET /api/v1/sure/sync-health` returns each account's anchor/staleness status plus a remediation hint. All routes authenticate via `SURE_API_KEY`; a missing key returns `NOT_CONFIGURED`, including for sync-health. |
 | `sureAssistant.ts` | `/api/v1/sure/assistant` | Sure AI-assistant endpoint |
 | `plane.ts` | `/api/v1/plane/*` | **DORMANT, not deployed** — Plane proxy + webhook. Plane was removed from the compose stack fleet-wide (PR #279); no `plane` service exists in `docker-compose.yaml`. Routes remain registered but have no upstream. Do not build against; deletion is an open follow-up. |
 | `webhooks/plane.ts` | `/api/v1/webhooks/plane/steward` | **DORMANT** — same status as `plane.ts` |

--- a/packages/mcp-server/CONTRACT.md
+++ b/packages/mcp-server/CONTRACT.md
@@ -22,7 +22,7 @@ lookup surface; a token or stdio arg outside this set is rejected.
 | AppId | Source file | Tools | Naming | Backing |
 |---|---|---|---|---|
 | `alfred` | `src/tools/alfred.ts` | 29 | `list_vault_by_type`, `search_vault`, `spawn_alfred_task`, `start_workflow`, `act_on_decision`, `delegate_to_focused_agent`, `notify_principal`, … | ctrl-api vault/workflow/decision routes |
-| `sure` | `src/tools/sure.ts` | 95 | `list_transactions`, `get_balance_sheet`, `bulk_update_transactions`, … | ctrl-api Sure REST proxy |
+| `sure` | `src/tools/sure.ts` | 96 | `list_transactions`, `get_balance_sheet`, `get_sync_health`, `bulk_update_transactions`, …; `get_balance_sheet` passes through each account's additive `balance_provenance` and the aggregate `data_quality` unchanged | ctrl-api Sure REST proxy (`get_sync_health` → `GET /api/v1/sure/sync-health`) |
 | `vaultwarden` | `src/tools/vaultwarden.ts` | 14 | `list_vault_items`, `create_vault_item`, `generate_password`, `vault_refresh`, … | ctrl-api Vaultwarden proxy |
 | `execute` | `src/tools/execute.ts` | 6 | `list_composio_tools`, `composio_execute`, `list_connections`, `create_connection`, `reconnect_connection`, `delete_connection` | ctrl-api `/api/v1/integrations/*` (Composio; execute = `/api/v1/integrations/execute`) |
 | `hermes` | `src/tools/hermes.ts` | 7 | `run`, `stop_run`, `health`, `list_models`, `schedule_prompt`, `list_scheduled`, `cancel_scheduled` (all take optional `profile: main\|workers`) | ctrl-api `/api/v1/hermes/*` (schedule tools hit `/api/v1/hermes/cron`; ctrl-api bridges those to the in-container `hermes cron` CLI) |


### PR DESCRIPTION
Part of #318

Controller job: `contracts-318` · lane `phase0`

## Smoke evidence

`true`

```text
(command exited 0 with no output)
```

The trusted controller independently reran this command after validating every changed path against the approved plan.