### PR TITLE
Bug: vault maintenance workers fail synchronously while status remains stale or falsely healthy (lane phase0)

### DIFF
--- a/docs/FIX-CONTRACTS.md
+++ b/docs/FIX-CONTRACTS.md
@@ -19,6 +19,10 @@ Provider → consumer notation: *(Lane X provides → Lane Y consumes)*.
 > goal was met another way), **INCOMPLETE** (partially enforced; gaps cited).
 > Statuses annotate, they do not amend. A lane that finds a status wrong
 > STOPs and reports — this file is orchestrator/phase0-only.
+>
+> **Issue #316 target (added 2026-07-21).** C20 is a new target freeze on top
+> of that audited state. It is not a claim that the pinned head implements the
+> interface; its current gaps and owning lanes are recorded below.
 
 ---
 
@@ -181,6 +185,171 @@ clears the card **only on 2xx** (F50).
 `LINK_FIELDS` extended with `key_people, related_persons, related_orgs, org` (F10) so person/matter
 edges resolve; `MatterDetailPage` consumes `backlinks` (F55).
 
+### C20 · Durable asynchronous worker runs *(I ↔ IV; II consumes distiller)*
+
+**Target for issue #316 — not implemented at this phase-0 head.** The two
+agent-backed manual trigger routes become durable enqueue operations:
+
+- `POST /api/v1/workers/process` → worker `curator`;
+- `POST /api/v1/workers/distiller/run` → worker `distiller`.
+
+Their run ledger is internal bookkeeping on the existing `alfred_data` named
+volume, not vault knowledge and not a sixth principal store. The same directory
+is visible as **`/alfred-data/state/worker-runs`** in ctrl-api and
+**`/app/data/state/worker-runs`** in the vault-worker container. One file named
+`<run_id>.json` holds one run. Both sides write by same-directory temporary
+file, file `fsync`, atomic rename, then directory `fsync`; readers ignore temp
+files and therefore see either the previous complete JSON document or the new
+one, never a partial write.
+
+The canonical record has this shape (nullable timestamps are present as
+`null`, not omitted):
+
+```json
+{
+  "schema_version": 1,
+  "run_id": "01K...",
+  "worker": "curator",
+  "state": "queued",
+  "trigger": {
+    "kind": "manual_api",
+    "route": "/api/v1/workers/process",
+    "requested_at": "2026-07-21T12:00:00.000Z"
+  },
+  "input": {"limit": null, "dry_run": false, "jobs": 4},
+  "timeout_policy": {
+    "claim_timeout_seconds": 60,
+    "heartbeat_timeout_seconds": 120,
+    "no_progress_timeout_seconds": 900,
+    "run_timeout_seconds": 21600
+  },
+  "timestamps": {
+    "created_at": "2026-07-21T12:00:00.000Z",
+    "queued_at": "2026-07-21T12:00:00.000Z",
+    "claimed_at": null,
+    "started_at": null,
+    "heartbeat_at": null,
+    "last_progress_at": null,
+    "last_successful_output_at": null,
+    "finished_at": null,
+    "updated_at": "2026-07-21T12:00:00.000Z"
+  },
+  "progress": {
+    "total": null,
+    "started": 0,
+    "succeeded": 0,
+    "failed": 0,
+    "skipped": 0,
+    "outputs_created": 0,
+    "outputs_modified": 0
+  },
+  "terminal_error": null,
+  "reliability": {
+    "attempt": 0,
+    "claim_id": null,
+    "worker_instance_id": null,
+    "pid": null,
+    "effective_jobs": null,
+    "heartbeat_sequence": 0,
+    "write_sequence": 0,
+    "exit_code": null,
+    "termination_signal": null,
+    "recovered_at": null,
+    "recovery_reason": null
+  }
+}
+```
+
+`schema_version`, `run_id` (ULID), `worker`, `trigger`, validated canonical
+`input`, `timeout_policy`, `timestamps.created_at`, and
+`timestamps.queued_at` are immutable. `state` is exactly
+`queued | running | succeeded | failed | timed_out`. Progress values are
+non-negative integers; `total` is `null` until discovery and thereafter never
+decreases. `last_progress_at` advances only when a counter advances, while the
+worker refreshes `heartbeat_at` at least every 30 seconds during a run.
+`last_successful_output_at` advances only when `outputs_created` or
+`outputs_modified` advances. `terminal_error` is non-null only for `failed` or
+`timed_out` and is the sanitized shape
+`{code, message, retryable, at}` — no stack, bearer, provider output, or secret.
+For these two producers `trigger.kind` is exactly `manual_api`, and
+`trigger.route` must match the route-to-worker table above; arbitrary caller
+provenance is not copied into the record. The worker serializes updates per run,
+verifies the current `claim_id` before every replacement, and increments
+`write_sequence` monotonically; heartbeat-only writes also increment
+`heartbeat_sequence`.
+
+Input validation happens before enqueue and unknown keys are rejected:
+
+- curator: `limit` is `null` or an integer `1..10000`; `dry_run` is boolean;
+  `jobs` is an integer `1..32` (defaults: `null`, `false`, `4`). The Hermes
+  backend may force serial execution; the actual value is reported as
+  `reliability.effective_jobs` without mutating the requested input.
+- distiller: `project` is `null` or a trimmed, control-character-free string
+  of 1–200 characters (default `null`).
+
+**Writer ownership is phase-separated.** ctrl-api owns validation, same-worker
+deduplication, ULID generation, and the one initial durable `queued` write. It
+does no inbox bridge, vault scan, agent call, or blocking `docker exec` before
+responding. The vault worker claims a queued run by atomically changing it to
+`running`, assigning a boot-unique `worker_instance_id`, `claim_id`, PID, and
+`attempt=1`; after that claim it is the only writer of heartbeats, progress,
+output timestamps, recovery metadata, and the terminal transition. GET/status
+handlers are read-only.
+
+At worker boot and on every queue poll, the vault worker performs stranded-run
+recovery before claiming new work. A `running` record owned by another boot
+instance, or whose recorded process is absent, becomes `failed` with a
+`stranded_running` terminal error. A same-instance run past its heartbeat,
+no-progress, or hard-run deadline has its owned process group terminated and
+becomes `timed_out` with the corresponding reason. Recovery never replays a
+run automatically because curator/distiller side effects are not generally
+idempotent; a later trigger creates a new run id. Old queued work is claimed
+oldest-first. Active records are never pruned; terminal records are retained
+for at least 30 days and at least the newest 100 records per worker.
+
+Both POST routes return promptly with HTTP **202** after the durable enqueue:
+`{run_id, worker, state, reused, input, status_url}` plus
+`Location: /api/v1/workers/runs/<run_id>`. Under one ctrl-api worker-scoped
+enqueue lock, a request finding any `queued` or `running` record for the same
+worker returns that record with `reused:true` — even when the new request body
+differs — rather than starting duplicate side effects. A derived `stalled`
+record remains active and is reused until vault-worker recovery terminalizes
+it. `GET /api/v1/workers/runs/:run_id` returns `{run, derived}` or 404
+`WORKER_RUN_NOT_FOUND`; `derived` includes status, health reasons, queue age,
+and deadline ages without mutating the file.
+
+`GET /api/v1/workers/status` keeps its existing `raw` compatibility field and
+adds structured `workers.curator` / `workers.distiller` summaries. Per-worker
+run status is derived as follows:
+
+- `idle`: no run record exists;
+- `queued`: the active queued run is still inside its claim timeout;
+- `running`: the active running run has fresh heartbeat/progress and is inside
+  its hard timeout;
+- `stalled`: active queued age exceeds the claim timeout, or an active running
+  run has `queue_age_exceeded`, `heartbeat_stale`, `no_progress`, or
+  `hard_timeout_exceeded` in `health_reasons`;
+- `failed`: there is no active run and the latest terminal run is `failed` or
+  `timed_out`;
+- `complete`: there is no active run and the latest terminal run succeeded.
+
+Each summary exposes `active_run_id`, `latest_run_id`, `health_reasons`, and
+`metrics` with `queue_age_seconds`, `last_successful_output_at`,
+`failure_streak`, `throughput_window_seconds: 86400`, and
+`trailing_effective_throughput_per_minute`. Queue age is live while queued and
+frozen to `claimed_at - queued_at` afterward. Failure streak counts consecutive
+failed/timed-out terminal runs since the newest success (active runs ignored).
+Trailing effective throughput is successful units divided by active running
+minutes across portions of runs overlapping the trailing 24-hour window; it is
+`null` when that window contains zero running seconds. Queue and idle time are
+excluded, but failed/no-progress running time remains in the denominator.
+
+Lane II's `run_distiller_batch` is an existing non-interactive consumer of the
+distiller POST. It must treat 202 as acceptance, retain the returned `run_id`,
+and poll the inspection route to a terminal state with Temporal heartbeats; it
+must not report zero learnings as a completed run merely because enqueue
+succeeded.
+
 ---
 
 ## Per-clause status table (2026-07-15 audit)
@@ -206,6 +375,7 @@ edges resolve; `MatterDetailPage` consumes `backlinks` (F55).
 | **C17** · Model-config matrix API | **LIVE** | `GET /api/v1/admin/models[?refresh=true]` (`packages/ctrl/src/api/routes/models.ts:385-386`; cache bust wired via `credentials.ts:245`); `GET /api/v1/admin/profiles` including `heavy` :18791 (`agents.ts:326-329`, profile table `agents.ts:59`, comment cites C17); `PATCH /api/v1/admin/agents/:agentId/model` (`agents.ts:371-372`). |
 | **C18** · Decision record = single source of truth | **LIVE** (amended by C-B4/C-B5 + the 2026-05-24 `state=open` fix) | `POST /api/v1/decisions`: writes `decision/<ts>.md` + `indexVaultWrite()` same-request (`decisions.ts:626, 636` — F1); mirrors to state.db audit (`decisions.ts:651` area); synchronous source flip per intent with `side_effects.synchronous_flip` (`decisions.ts:290-534`); delegate flips NA→dispatched only after dispatch succeeds (`decisions.ts:361-363`, F2/C18 comment). Amendment beyond the frozen text: **every** intent now mints `state: "open"` (`decisions.ts:568` `initialState = "open"`, rationale block :550-567) so DecisionRouter always runs `extract_observation_from_decision`; the router flips to `completed` itself. Root `CLAUDE.md` §6.3 documents the amended shape. |
 | **C19** · Vault graph focus/backlinks | **LIVE** | `GET /api/v1/vault/graph?focus=` (`packages/ctrl/src/api/routes/vault.ts:1310`); `LINK_FIELDS` includes `key_people, related_persons, related_orgs, org` (F10) plus later `related_places, place` (B9) (`vault.ts:1316-1327`); `backlinks:[{path,name,rel}]` computed for the focused record (`vault.ts:1452-1462`). |
+| **C20** · Durable asynchronous worker runs | **TARGET — NOT IMPLEMENTED** | At the pinned head, `workers.ts:82-97,180-190` awaits the full `dockerExec`; `helpers.ts:32-53,100-115` imposes a 30 s exec timeout; `GET /workers/status` wraps human CLI output as `{raw}`; curator progress is in-memory only (`curator/process.py:49-58,88-99`); and no `worker-runs` path exists. The prerequisite shared mount is live: `alfred_data:/alfred-data` on ctrl-api and `alfred_data:/app/data` on alfred (`docker-compose.yaml:554,504`). Lane I owns enqueue/read/status; Lane IV owns claim/progress/terminal/recovery; Lane II updates the scheduled distiller consumer. |
 
 ---
 

--- a/packages/ctrl/CONTRACT.md
+++ b/packages/ctrl/CONTRACT.md
@@ -2,6 +2,9 @@
 
 **Frozen cross-lane interface.** Lane agents code against this document, not against ctrl's source. Regenerated 2026-07-15 from `main`; every current-runtime claim below is verified in code at the cited path. Clauses explicitly labelled `#261 target` instead freeze Lane I's required future behavior and are not code-verified claims about this phase-0 head.
 
+**Issue #316 phase-0 target (added 2026-07-21).** The C20 call-out below is
+also a required future interface, not a claim about this pinned head.
+
 ctrl-api is the tenant API server: a zero-dependency-at-runtime Node 22 HTTP service on **:3100** that is the **sole writer** of all four stores (vault markdown, `alfred-state.db`, `ingest.db`, cold archive) plus Store 5 (files). It is HTTP-only — the pre-cutover CLI/TUI was deleted; `build.mjs` produces exactly one artefact, `dist/api.mjs`, from entry `src/api/standalone.ts`. Every other service (web, alfred-learn, the alfred vault daemon, Hermes profiles via the `alfred-ctrl` MCP server, voice-bridge) persists state by calling ctrl-api over HTTP. ctrl-api in turn reaches siblings via `docker exec` (helpers `dockerExec`, `src/api/helpers.ts:100`) and HTTP (Hermes gateway, vault-cli, mcp-server, Sure, Paperclip).
 
 ---
@@ -158,6 +161,131 @@ Resolution precedence: env var > `${ALFRED_DATA_DIR}/settings.json` > default. R
 
 `/api/v1/mcp/tokens` (GET list, POST mint), `/:id/rotate`, DELETE `/:id` (`routes/mcpTokens.ts`) — a **thin proxy** to mcp-server's `/manage/tokens` API. mcp-server owns the tokens (its own SQLite; local validation on every `POST /<app>/mcp`). Chain: browser → web (Wasp op) → ctrl-api → mcp-server, so the browser never holds `MCP_APPROVAL_SECRET`; ctrl-api presents it as the onward Bearer. The raw token appears exactly once (mint + rotate responses); list never carries it; ctrl-api relays verbatim. Missing secret → 500 `MCP_NOT_CONFIGURED`; mcp-server down → 502 `MCP_UNREACHABLE`.
 
+### Call-out: C20 durable asynchronous worker runs
+
+**#316 target (Lanes I + IV; not implemented at this phase-0 head).** Current
+`routes/workers.ts` still blocks on the full curator/distiller CLI invocation,
+and `dockerExec()` has a 30-second helper timeout. Lane I must replace only the
+two agent-backed manual trigger routes with durable enqueue semantics:
+
+| Route | Canonical worker | Validated input |
+|---|---|---|
+| `POST /api/v1/workers/process` | `curator` | `{limit: null|integer 1..10000, dry_run: boolean, jobs: integer 1..32}`; defaults `null,false,4`; unknown keys rejected |
+| `POST /api/v1/workers/distiller/run` | `distiller` | `{project: null|string}`; string is trimmed, control-character-free, 1–200 chars; default `null`; unknown keys rejected |
+
+The ledger is internal execution bookkeeping on the already-shared
+`alfred_data` volume: ctrl-api uses
+**`/alfred-data/state/worker-runs`**, while the alfred vault-worker uses
+**`/app/data/state/worker-runs`**. It is not vault knowledge, SQLite state, or a
+new principal store. A run is one `<run_id>.json` file. Every replacement is a
+same-directory temp write followed by file `fsync`, atomic rename, and directory
+`fsync`; readers ignore temp files and never accept malformed JSON as `idle`.
+
+The required record fields are:
+
+```text
+schema_version: 1
+run_id: ULID                         # immutable
+worker: curator | distiller          # immutable
+state: queued | running | succeeded | failed | timed_out
+trigger: {kind, route, requested_at} # immutable, allowlisted provenance
+input: <canonical validated object>  # immutable
+timeout_policy: {                    # immutable snapshot; defaults below
+  claim_timeout_seconds: 60,
+  heartbeat_timeout_seconds: 120,
+  no_progress_timeout_seconds: 900,
+  run_timeout_seconds: 21600
+}
+timestamps: {
+  created_at, queued_at, claimed_at, started_at, heartbeat_at,
+  last_progress_at, last_successful_output_at, finished_at, updated_at
+}
+progress: {
+  total, started, succeeded, failed, skipped,
+  outputs_created, outputs_modified
+}
+terminal_error: null | {code, message, retryable, at}
+reliability: {
+  attempt, claim_id, worker_instance_id, pid, effective_jobs,
+  heartbeat_sequence, write_sequence, exit_code, termination_signal,
+  recovered_at, recovery_reason
+}
+```
+
+All nullable timestamp/reliability keys are present as `null`. Progress counters
+are non-negative integers; `total` is `null` until discovery and never decreases
+afterward. `last_progress_at` changes only with a counter. The worker updates
+`heartbeat_at` at least every 30 seconds, and updates
+`last_successful_output_at` only when `outputs_created` or `outputs_modified`
+increases. A terminal error exists only for `failed`/`timed_out`, is sanitized,
+and never includes a stack, bearer, provider output, or secret. When Hermes
+forces serial curator execution, the request's immutable `input.jobs` remains
+unchanged and `reliability.effective_jobs` reports `1`.
+For these routes `trigger.kind` is exactly `manual_api`, and `trigger.route`
+must match the route-to-worker table; arbitrary caller provenance is not copied
+into the record. The worker serializes replacements per run, verifies the
+current `claim_id`, and monotonically increments `write_sequence` on every
+write plus `heartbeat_sequence` on heartbeat-only writes.
+
+**Writer boundary:** ctrl-api owns validation, same-worker enqueue locking,
+ULID generation, and exactly the initial atomic `queued` record. It must return
+without running the inbox bridge, scan, agent, or a blocking `docker exec`.
+The vault worker atomically claims the record (`state=running`, boot-unique
+`worker_instance_id`, `claim_id`, PID, `attempt=1`) and is then the sole writer
+of progress, heartbeats, output timestamps, recovery fields, and terminal
+state. Inspection and status routes never mutate records.
+
+Both POSTs return HTTP **202** after durable enqueue with
+`{run_id, worker, state, reused, input, status_url}` and a `Location` header.
+While any record for that worker remains `queued` or `running`, another trigger
+returns the same record and `reused:true`, even if the second request supplied
+different valid input. It never returns 409 and never starts duplicate side
+effects. A read-derived `stalled` run is still active until worker recovery
+terminalizes it, so it is also reused.
+
+`GET /api/v1/workers/runs/:run_id` validates the ULID and returns
+`200 {run, derived}`; unknown records return 404
+`WORKER_RUN_NOT_FOUND`. `derived` contains the status, health reasons, live or
+frozen queue age, and timeout ages. No response may expose an ignored temp file
+or a partially decoded record.
+
+The vault worker recovers stranded runs before new claims at boot and every
+queue poll. A running record from another boot instance or a missing recorded
+process becomes `failed` / `stranded_running`. A same-instance process beyond
+its heartbeat, no-progress, or hard deadline is terminated as an owned process
+group and becomes `timed_out` with the matching reason. There is no automatic
+replay: curator/distiller effects are not generally idempotent, so a later
+trigger receives a new run id. Queued records are claimed oldest-first. Active
+records are never pruned; keep terminal records for at least 30 days and at
+least the latest 100 per worker.
+
+`GET /api/v1/workers/status` retains the current `raw` field for compatibility
+and adds `workers.curator` and `workers.distiller`. Each structured entry has
+`status`, `active_run_id`, `latest_run_id`, `health_reasons`, and `metrics`:
+
+- `idle`: no record; `queued`: inside claim timeout; `running`: active and
+  healthy; `stalled`: queue age, heartbeat age, no-progress age, or hard runtime
+  exceeded; `failed`: no active record and latest terminal failed/timed out;
+  `complete`: no active record and latest terminal succeeded.
+- Stalled reason codes are exactly `queue_age_exceeded`, `heartbeat_stale`,
+  `no_progress`, and `hard_timeout_exceeded`; more than one may apply.
+- Metrics are `queue_age_seconds`, `last_successful_output_at`,
+  `failure_streak`, `throughput_window_seconds` (86400), and
+  `trailing_effective_throughput_per_minute`. Failure streak ignores active
+  runs and counts consecutive failed/timed-out terminals since the newest
+  success. Throughput is successful units divided by active running minutes in
+  portions of runs overlapping the trailing 24 hours; failed/no-progress
+  running time remains in the denominator, while queued/idle time does not.
+  With zero running seconds it is `null`.
+
+Implementation tests are mandatory in the owning lanes: they must prove
+validation/defaults, 202-before-work, same-worker reuse under concurrent
+requests, atomic-reader behavior, GET/404, phase-separated writer ownership,
+boot/PID/timeout recovery, terminal error redaction, every derived status and
+stalled reason, and the four metric calculations. Lane II must also update the
+scheduled `run_distiller_batch` consumer to poll the returned inspection URL to
+a terminal state with Temporal heartbeats; enqueue acceptance is not completion.
+
 ### Call-out: disk-usage watcher and system-info
 
 **#261 target (Lane I; not implemented at this phase-0 head).** ctrl-api
@@ -224,6 +352,10 @@ compatibility surface; new consumers use the hyphenated route.
 
 `vault_data:/vault` · `alfred_data:/alfred-data` · `hermes_data:/hermes-state` · `state_data:/state` · `ingest_data:/ingest` · `cold_data:/cold` · `files_data:/files` (**sole `:rw`** — hermes + alfred mount `:ro`) · `files_cold_data:/cold-files` (ZSTD-19 archive, only ctrl-api mounts) · `/var/run/docker.sock` · `${COMPOSE_DIR_HOST:-/opt/alfred}:/srv/alfred-black` (RW) · `/root/.ssh/authorized_keys` (RW, for the Terminal card).
 
+**#316 target:** the existing `alfred_data` mount makes ctrl-api's
+`/alfred-data/state/worker-runs` the same directory as the alfred service's
+`/app/data/state/worker-runs`; no new volume is needed.
+
 ---
 
 ## Invariants (other lanes rely on these)
@@ -242,6 +374,11 @@ compatibility surface; new consumers use the hyphenated route.
     needs-attention card; at the page threshold it additionally delivers via
     the Hermes main notification path. `/api/v1/admin/system-info` reports the
     sampled percentage, level, and both effective thresholds.
+11. **#316 target — worker run ownership is phase-separated.** ctrl-api creates
+    only the initial queued C20 record; after vault-worker claim, only that
+    worker writes progress or terminal state. A same-worker active record is
+    reused, trigger requests return 202 without waiting for agent work, and
+    stalled state is observable and recoverable rather than silently stranded.
 
 ---
 


### PR DESCRIPTION
Part of #316

Controller job: `contract-v2-316-r2` · lane `phase0`

## Smoke evidence

`true`

```text
(command exited 0 with no output)
```

The trusted controller independently reran this command after validating every changed path against the approved plan.