### PR TITLE
Bug: vault maintenance workers fail synchronously while status remains stale or falsely healthy (lane I)

### DIFF
--- a/packages/ctrl/src/api/workerRuns/ledger.ts
+++ b/packages/ctrl/src/api/workerRuns/ledger.ts
@@ -1,0 +1,98 @@
+import * as fs from "node:fs";
+import path from "node:path";
+import { randomBytes } from "node:crypto";
+import { decodeWorkerRun, type WorkerName, type WorkerRunRecord } from "./model.js";
+import { createQueuedWorkerRun } from "./request.js";
+
+const RUN_ID = /^[0-7][0-9A-HJKMNP-TV-Z]{25}$/;
+type LedgerFs = Pick<typeof fs, "mkdirSync" | "existsSync" | "openSync" | "writeFileSync" | "fsyncSync" | "closeSync" | "renameSync" | "unlinkSync" | "readFileSync" | "readdirSync">;
+
+export function workerRunsDirectory(dataDir: string | undefined = process.env.ALFRED_DATA_DIR): string {
+  return path.join(dataDir || "/alfred-data", "state", "worker-runs");
+}
+
+export class WorkerRunLedgerEntryError extends Error {
+  constructor(readonly entry: string, message: string, options?: ErrorOptions) {
+    super(`worker-run ledger entry ${entry}: ${message}`, options);
+    this.name = "WorkerRunLedgerEntryError";
+  }
+}
+
+function isNotFound(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
+}
+
+export function readWorkerRun(
+  runId: string,
+  directory = workerRunsDirectory(),
+  io: LedgerFs = fs,
+): WorkerRunRecord | null {
+  if (!RUN_ID.test(runId)) throw new WorkerRunLedgerEntryError(runId, "invalid run id");
+  const file = path.join(directory, `${runId}.json`);
+  try {
+    const run = decodeWorkerRun(JSON.parse(io.readFileSync(file, "utf8")));
+    if (run.run_id !== runId) throw new Error("run_id does not match filename");
+    return run;
+  } catch (error) {
+    if (isNotFound(error)) return null;
+    if (error instanceof WorkerRunLedgerEntryError) throw error;
+    throw new WorkerRunLedgerEntryError(path.basename(file), "malformed or unreadable", { cause: error });
+  }
+}
+
+export function listWorkerRuns(
+  directory = workerRunsDirectory(),
+  io: LedgerFs = fs,
+): WorkerRunRecord[] {
+  let entries: fs.Dirent[];
+  try { entries = io.readdirSync(directory, { withFileTypes: true }); }
+  catch (error) { if (isNotFound(error)) return []; throw error; }
+  const runs: WorkerRunRecord[] = [];
+  for (const entry of entries.sort((a, b) => a.name < b.name ? -1 : a.name > b.name ? 1 : 0)) {
+    if (entry.name.startsWith(".") || entry.name.includes(".tmp") || !entry.name.endsWith(".json")) continue;
+    const runId = entry.name.slice(0, -5);
+    if (!entry.isFile() || !RUN_ID.test(runId)) throw new WorkerRunLedgerEntryError(entry.name, "invalid final filename");
+    const run = readWorkerRun(runId, directory, io);
+    if (run) runs.push(run); // A concurrent retention pass may remove a terminal entry.
+  }
+  return runs;
+}
+
+export function writeInitialWorkerRun(
+  value: WorkerRunRecord,
+  directory = workerRunsDirectory(),
+  io: LedgerFs = fs,
+): void {
+  const run = decodeWorkerRun(value);
+  if (run.state !== "queued") throw new WorkerRunLedgerEntryError(run.run_id, "initial record must be queued");
+  io.mkdirSync(directory, { recursive: true });
+  const finalPath = path.join(directory, `${run.run_id}.json`);
+  if (io.existsSync(finalPath)) throw new WorkerRunLedgerEntryError(run.run_id, "record already exists");
+  const temporaryPath = path.join(directory, `.${run.run_id}.${process.pid}.${randomBytes(6).toString("hex")}.tmp`);
+  let fd: number | null = null;
+  try {
+    fd = io.openSync(temporaryPath, "wx", 0o600);
+    io.writeFileSync(fd, `${JSON.stringify(run)}\n`, "utf8");
+    io.fsyncSync(fd); io.closeSync(fd); fd = null;
+    io.renameSync(temporaryPath, finalPath);
+    const directoryFd = io.openSync(directory, "r");
+    try { io.fsyncSync(directoryFd); } finally { io.closeSync(directoryFd); }
+  } catch (error) {
+    if (fd !== null) try { io.closeSync(fd); } catch { /* preserve the write error */ }
+    try { io.unlinkSync(temporaryPath); } catch { /* absent after rename or failed before create */ }
+    throw error;
+  }
+}
+
+export function enqueueWorkerRun<W extends WorkerName>(
+  worker: W,
+  body: unknown,
+  now = new Date(),
+  directory = workerRunsDirectory(),
+): { run: WorkerRunRecord<W>; reused: boolean } {
+  const candidate = createQueuedWorkerRun(worker, body, now); // Validate every trigger, including reuse.
+  const active = listWorkerRuns(directory).find((run) => run.worker === worker && (run.state === "queued" || run.state === "running"));
+  if (active) return { run: active as WorkerRunRecord<W>, reused: true };
+  writeInitialWorkerRun(candidate, directory);
+  return { run: candidate, reused: false };
+}

--- a/packages/ctrl/tests/worker-runs-ledger.test.ts
+++ b/packages/ctrl/tests/worker-runs-ledger.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createQueuedWorkerRun } from "../src/api/workerRuns/request.js";
+import { enqueueWorkerRun, listWorkerRuns, readWorkerRun, WorkerRunLedgerEntryError, workerRunsDirectory, writeInitialWorkerRun } from "../src/api/workerRuns/ledger.js";
+
+const roots: string[] = [];
+const ledger = () => { const root = fs.mkdtempSync(path.join(os.tmpdir(), "worker-runs-")); roots.push(root); return path.join(root, "state", "worker-runs"); };
+afterEach(() => { for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true }); });
+
+describe("worker-run ledger", () => {
+  it("resolves the shared production location and ALFRED_DATA_DIR override", () => {
+    assert.equal(workerRunsDirectory(""), "/alfred-data/state/worker-runs");
+    assert.equal(workerRunsDirectory("/tenant-data"), "/tenant-data/state/worker-runs");
+  });
+
+  it("creates a durable record with temp, file fsync, rename, then directory fsync", () => {
+    const dir = "/data/state/worker-runs", run = createQueuedWorkerRun("curator", {}, new Date("2026-07-21T12:00:00Z"));
+    const calls: string[] = []; let written = ""; let temporary = "";
+    const io = {
+      mkdirSync: (p: string) => { calls.push(`mkdir:${p}`); }, existsSync: () => false,
+      openSync: (p: string, flag: string) => { calls.push(`open:${flag}:${p}`); if (flag === "wx") temporary = p; return flag === "wx" ? 1 : 2; },
+      writeFileSync: (_fd: number, data: string) => { written = data; calls.push("write:1"); },
+      fsyncSync: (fd: number) => { calls.push(`fsync:${fd}`); }, closeSync: (fd: number) => { calls.push(`close:${fd}`); },
+      renameSync: (from: string, to: string) => { calls.push(`rename:${from}:${to}`); }, unlinkSync: () => {},
+    } as unknown as typeof fs;
+    writeInitialWorkerRun(run, dir, io);
+    assert.equal(path.dirname(temporary), dir); assert.match(temporary, /\.tmp$/);
+    assert.equal(JSON.parse(written).run_id, run.run_id);
+    assert.deepEqual(calls.slice(-6), ["fsync:1", "close:1", `rename:${temporary}:${path.join(dir, `${run.run_id}.json`)}`, `open:r:${dir}`, "fsync:2", "close:2"]);
+  });
+
+  it("publishes only the complete final JSON and ignores temporary files", () => {
+    const dir = ledger(), run = createQueuedWorkerRun("janitor", {}, new Date("2026-07-21T12:00:00Z"));
+    writeInitialWorkerRun(run, dir);
+    fs.writeFileSync(path.join(dir, `.${run.run_id}.crashed.tmp`), "{");
+    fs.writeFileSync(path.join(dir, `${run.run_id}.json.inflight`), "{");
+    assert.deepEqual(fs.readdirSync(dir).filter((name) => !name.includes("tmp") && name.endsWith(".json")), [`${run.run_id}.json`]);
+    assert.deepEqual(readWorkerRun(run.run_id, dir), run);
+    assert.deepEqual(listWorkerRuns(dir), [run]);
+  });
+
+  it("distinguishes an empty ledger from malformed or mismatched final entries", () => {
+    const dir = ledger();
+    assert.deepEqual(listWorkerRuns(dir), []);
+    const run = createQueuedWorkerRun("distiller", {}, new Date("2026-07-21T12:00:00Z"));
+    fs.mkdirSync(dir, { recursive: true }); fs.writeFileSync(path.join(dir, `${run.run_id}.json`), "{");
+    assert.throws(() => listWorkerRuns(dir), WorkerRunLedgerEntryError);
+    fs.writeFileSync(path.join(dir, `${run.run_id}.json`), JSON.stringify({ ...run, run_id: "01K0ABCDEF1234567890GHJKMN" }));
+    assert.throws(() => readWorkerRun(run.run_id, dir), WorkerRunLedgerEntryError);
+    assert.equal(readWorkerRun("01K0ABCDEF1234567890GHJKMP", dir), null);
+  });
+
+  it("deduplicates concurrent same-worker enqueues without replacing immutable input", async () => {
+    const dir = ledger();
+    const [first, second] = await Promise.all([8, 1].map((jobs, minute) => Promise.resolve().then(
+      () => enqueueWorkerRun("curator", { jobs }, new Date(`2026-07-21T12:0${minute}:00Z`), dir),
+    )));
+    const other = enqueueWorkerRun("janitor", {}, new Date("2026-07-21T12:01:00Z"), dir);
+    assert.equal(first.reused, false); assert.equal(second.reused, true); assert.equal(other.reused, false);
+    assert.equal(second.run.run_id, first.run.run_id); assert.deepEqual(second.run.input, { limit: null, dry_run: false, jobs: 8 });
+    assert.throws(() => enqueueWorkerRun("curator", { jobs: 0 }, new Date(), dir));
+    assert.equal(listWorkerRuns(dir).length, 2);
+  });
+});


### PR DESCRIPTION
Part of #316

Controller job: `ctrl-run-ledger-316-r3-r3` · lane `I`

## Smoke evidence

`cd packages/ctrl && npm run build`

```text
> alfred-ctrl-api@0.1.0 build
> node build.mjs

Build complete — dist/api.mjs
```

The trusted controller independently reran this command after validating every changed path against the approved plan.