### PR TITLE
Bug: vault maintenance workers fail synchronously while status remains stale or falsely healthy (lane I)

### DIFF
--- a/packages/ctrl/src/api/workerRuns/health.ts
+++ b/packages/ctrl/src/api/workerRuns/health.ts
@@ -1,0 +1,70 @@
+import type { WorkerRunRecord } from "./model.js";
+
+export const WORKER_RUN_HEALTH_REASONS = [
+  "queue_age_exceeded",
+  "heartbeat_stale",
+  "no_progress",
+  "hard_timeout_exceeded",
+] as const;
+
+export type WorkerRunHealthReason = typeof WORKER_RUN_HEALTH_REASONS[number];
+export type WorkerRunHealthStatus = "idle" | "queued" | "running" | "stalled" | "failed" | "complete";
+
+export interface WorkerRunHealth {
+  status: WorkerRunHealthStatus;
+  health_reasons: WorkerRunHealthReason[];
+  queue_age_seconds: number | null;
+  heartbeat_age_seconds: number | null;
+  no_progress_age_seconds: number | null;
+  run_age_seconds: number | null;
+}
+
+const ageSeconds = (from: string, until: number): number =>
+  Math.max(0, (until - Date.parse(from)) / 1_000);
+
+/** Derive inspection health without writing to, or otherwise owning, the run. */
+export function deriveWorkerRunHealth(
+  run: WorkerRunRecord | null,
+  now = new Date(),
+): WorkerRunHealth {
+  if (run === null) return {
+    status: "idle", health_reasons: [], queue_age_seconds: null,
+    heartbeat_age_seconds: null, no_progress_age_seconds: null, run_age_seconds: null,
+  };
+
+  const observedAt = run.timestamps.finished_at === null
+    ? now.getTime()
+    : Date.parse(run.timestamps.finished_at);
+  const queueUntil = run.timestamps.claimed_at === null
+    ? observedAt
+    : Date.parse(run.timestamps.claimed_at);
+  const queueAge = ageSeconds(run.timestamps.queued_at, queueUntil);
+  if (run.state === "queued") {
+    const reasons: WorkerRunHealthReason[] = queueAge > run.timeout_policy.claim_timeout_seconds
+      ? ["queue_age_exceeded"] : [];
+    return {
+      status: reasons.length === 0 ? "queued" : "stalled", health_reasons: reasons,
+      queue_age_seconds: queueAge, heartbeat_age_seconds: null,
+      no_progress_age_seconds: null, run_age_seconds: null,
+    };
+  }
+
+  const heartbeatAge = ageSeconds(run.timestamps.heartbeat_at!, observedAt);
+  const noProgressAge = ageSeconds(run.timestamps.last_progress_at ?? run.timestamps.started_at!, observedAt);
+  const runAge = ageSeconds(run.timestamps.started_at!, observedAt);
+  const reasons: WorkerRunHealthReason[] = [];
+  if (run.state === "running") {
+    if (queueAge > run.timeout_policy.claim_timeout_seconds) reasons.push("queue_age_exceeded");
+    if (heartbeatAge > run.timeout_policy.heartbeat_timeout_seconds) reasons.push("heartbeat_stale");
+    if (noProgressAge > run.timeout_policy.no_progress_timeout_seconds) reasons.push("no_progress");
+    if (runAge > run.timeout_policy.run_timeout_seconds) reasons.push("hard_timeout_exceeded");
+  }
+  const status: WorkerRunHealthStatus = run.state === "running"
+    ? (reasons.length === 0 ? "running" : "stalled")
+    : run.state === "succeeded" ? "complete" : "failed";
+  return {
+    status, health_reasons: reasons, queue_age_seconds: queueAge,
+    heartbeat_age_seconds: heartbeatAge, no_progress_age_seconds: noProgressAge,
+    run_age_seconds: runAge,
+  };
+}

--- a/packages/ctrl/tests/worker-runs-health.test.ts
+++ b/packages/ctrl/tests/worker-runs-health.test.ts
@@ -1,0 +1,81 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { deriveWorkerRunHealth } from "../src/api/workerRuns/health.js";
+import type { WorkerRunRecord, WorkerRunState } from "../src/api/workerRuns/model.js";
+import { createQueuedWorkerRun } from "../src/api/workerRuns/request.js";
+
+const at = (value: string) => new Date(value);
+
+function claimedRun(state: Exclude<WorkerRunState, "queued">): WorkerRunRecord<"curator"> {
+  const run = createQueuedWorkerRun("curator", {}, at("2026-07-21T12:00:00Z"));
+  run.state = state;
+  Object.assign(run.timestamps, {
+    claimed_at: "2026-07-21T12:00:30Z", started_at: "2026-07-21T12:00:30Z",
+    heartbeat_at: "2026-07-21T12:00:30Z", updated_at: "2026-07-21T12:00:30Z",
+    finished_at: state === "running" ? null : "2026-07-21T13:00:30Z",
+  });
+  Object.assign(run.reliability, {
+    attempt: 1, claim_id: "claim", worker_instance_id: "boot", pid: 42,
+    effective_jobs: 1, write_sequence: 1, exit_code: state === "running" ? null : 0,
+  });
+  if (state === "failed" || state === "timed_out") run.terminal_error = {
+    code: "worker_failed", message: "failed", retryable: false,
+    at: run.timestamps.finished_at!,
+  };
+  return run;
+}
+
+describe("worker-run health", () => {
+  it("derives idle and live queued health at the exact claim boundary", () => {
+    assert.deepEqual(deriveWorkerRunHealth(null, at("2026-07-21T12:00:00Z")), {
+      status: "idle", health_reasons: [], queue_age_seconds: null,
+      heartbeat_age_seconds: null, no_progress_age_seconds: null, run_age_seconds: null,
+    });
+    const run = createQueuedWorkerRun("curator", {}, at("2026-07-21T12:00:00Z"));
+    assert.equal(deriveWorkerRunHealth(run, at("2026-07-21T12:01:00Z")).status, "queued");
+    assert.deepEqual(deriveWorkerRunHealth(run, at("2026-07-21T12:01:00.001Z")), {
+      status: "stalled", health_reasons: ["queue_age_exceeded"], queue_age_seconds: 60.001,
+      heartbeat_age_seconds: null, no_progress_age_seconds: null, run_age_seconds: null,
+    });
+  });
+
+  it("freezes queue age at claim while running timeout ages remain live", () => {
+    const run = claimedRun("running");
+    const first = deriveWorkerRunHealth(run, at("2026-07-21T12:01:00Z"));
+    const later = deriveWorkerRunHealth(run, at("2026-07-21T12:02:00Z"));
+    assert.equal(first.status, "running");
+    assert.equal(first.queue_age_seconds, 30);
+    assert.equal(later.queue_age_seconds, 30);
+    assert.equal(later.heartbeat_age_seconds, 90);
+    assert.equal(later.no_progress_age_seconds, 90);
+    assert.equal(later.run_age_seconds, 90);
+  });
+
+  it("emits simultaneous running reasons in the contracted order", () => {
+    const run = claimedRun("running");
+    Object.assign(run.timeout_policy, {
+      claim_timeout_seconds: 1, heartbeat_timeout_seconds: 1,
+      no_progress_timeout_seconds: 1, run_timeout_seconds: 1,
+    });
+    assert.deepEqual(deriveWorkerRunHealth(run, at("2026-07-21T12:01:01Z")).health_reasons, [
+      "queue_age_exceeded", "heartbeat_stale", "no_progress", "hard_timeout_exceeded",
+    ]);
+    assert.equal(deriveWorkerRunHealth(run, at("2026-07-21T12:01:01Z")).status, "stalled");
+  });
+
+  it("maps terminal states and freezes every age without mutating the record", () => {
+    for (const state of ["succeeded", "failed", "timed_out"] as const) {
+      const run = claimedRun(state), before = structuredClone(run);
+      const first = deriveWorkerRunHealth(run, at("2026-07-22T00:00:00Z"));
+      const later = deriveWorkerRunHealth(run, at("2026-07-23T00:00:00Z"));
+      assert.equal(first.status, state === "succeeded" ? "complete" : "failed");
+      assert.deepEqual(first, later);
+      assert.deepEqual(first.health_reasons, []);
+      assert.deepEqual(first, {
+        ...first, queue_age_seconds: 30, heartbeat_age_seconds: 3_600,
+        no_progress_age_seconds: 3_600, run_age_seconds: 3_600,
+      });
+      assert.deepEqual(run, before);
+    }
+  });
+});


### PR DESCRIPTION
Part of #316

Controller job: `ctrl-run-health-316-r3-r3` · lane `I`

## Smoke evidence

`cd packages/ctrl && npm run build`

```text
> alfred-ctrl-api@0.1.0 build
> node build.mjs

Build complete — dist/api.mjs
```

The trusted controller independently reran this command after validating every changed path against the approved plan.