### PR TITLE
Bug: vault maintenance workers fail synchronously while status remains stale or falsely healthy (lane I)

### DIFF
--- a/packages/ctrl/src/api/routes/workers.ts
+++ b/packages/ctrl/src/api/routes/workers.ts
@@ -2,38 +2,40 @@ import http from "node:http";
 import { addRoute } from "../server.js";
 import { sendJson, ValidationError } from "../errors.js";
 import { dockerExec, dockerComposeCmd, ALFRED_CMD } from "../helpers.js";
+import { enqueueWorkerRun } from "../workerRuns/enqueue.js";
+import type { WorkerName } from "../workerRuns/model.js";
 
-/**
- * Trigger inbox → stream scan before Curator processing.
- * This ensures inbox files are ingested as stream events so alfred-learn
- * can classify, route, and learn from them.
- */
+/** Legacy inbox bridge retained for non-trigger callers; durable triggers never invoke it. */
 async function bridgeInboxToStreams(): Promise<void> {
   const hostname = process.env.AAS_HOST ?? "localhost";
   const portEnv = process.env.AAS_PORT;
   const port = portEnv !== undefined ? Number.parseInt(portEnv, 10) : 3100;
   const effectivePort = Number.isNaN(port) ? 3100 : port;
-
   const headers: Record<string, string> = { "Content-Type": "application/json" };
-  if (process.env.AAS_API_KEY) {
-    headers.Authorization = `Bearer ${process.env.AAS_API_KEY}`;
-  }
-
+  if (process.env.AAS_API_KEY) headers.Authorization = `Bearer ${process.env.AAS_API_KEY}`;
   return new Promise((resolve) => {
-    const req = http.request(
-      {
-        hostname,
-        port: effectivePort,
-        path: "/api/v1/streams/inbox/scan",
-        method: "POST",
-        headers,
-        timeout: 10000,
-      },
-      () => resolve(),
-    );
-    req.on("error", () => resolve()); // best-effort, don't block processing
+    const req = http.request({ hostname, port: effectivePort, path: "/api/v1/streams/inbox/scan", method: "POST", headers, timeout: 10000 }, () => resolve());
+    req.on("error", () => resolve());
     req.on("timeout", () => { req.destroy(); resolve(); });
     req.end();
+  });
+}
+
+async function enqueueManualRun(
+  worker: WorkerName,
+  body: unknown,
+  res: Parameters<typeof sendJson>[0],
+): Promise<void> {
+  const { run, reused } = await enqueueWorkerRun(worker, body);
+  const statusUrl = `/api/v1/workers/runs/${run.run_id}`;
+  res.setHeader("Location", statusUrl);
+  sendJson(res, 202, {
+    run_id: run.run_id,
+    worker: run.worker,
+    state: run.state,
+    reused,
+    input: run.input,
+    status_url: statusUrl,
   });
 }
 
@@ -78,22 +80,9 @@ export function registerWorkerRoutes(): void {
     }
   });
 
-  // Process inbox — bridge to streams first so alfred-learn sees the files
+  // Durably queue Curator processing; the vault worker owns execution.
   addRoute("POST", "/api/v1/workers/process", async ({ res, body }) => {
-    // Bridge inbox files to the system-inbox stream (best-effort)
-    await bridgeInboxToStreams();
-
-    const b = body as Record<string, unknown> | undefined;
-    const args = [...ALFRED_CMD, "process"];
-    if (b?.limit) args.push("--limit", String(b.limit));
-    if (b?.dry_run) args.push("--dry-run");
-    if (b?.jobs) args.push("--jobs", String(b.jobs));
-    const stdout = await dockerExec("alfred", args);
-    try {
-      sendJson(res, 200, JSON.parse(stdout));
-    } catch {
-      sendJson(res, 200, { raw: stdout.trim() });
-    }
+    await enqueueManualRun("curator", body, res);
   });
 
   // --- Janitor ---
@@ -118,14 +107,9 @@ export function registerWorkerRoutes(): void {
     }
   });
 
-  // Janitor fix (scan + agent fix)
-  addRoute("POST", "/api/v1/workers/janitor/fix", async ({ res }) => {
-    const stdout = await dockerExec("alfred", [...ALFRED_CMD, "janitor", "fix"]);
-    try {
-      sendJson(res, 200, JSON.parse(stdout));
-    } catch {
-      sendJson(res, 200, { raw: stdout.trim() });
-    }
+  // Durably queue Janitor repair; the vault worker owns scan and agent work.
+  addRoute("POST", "/api/v1/workers/janitor/fix", async ({ res, body }) => {
+    await enqueueManualRun("janitor", body, res);
   });
 
   // Janitor history
@@ -176,17 +160,9 @@ export function registerWorkerRoutes(): void {
     }
   });
 
-  // Distiller run (scan + extract)
+  // Durably queue Distiller extraction; the vault worker owns execution.
   addRoute("POST", "/api/v1/workers/distiller/run", async ({ res, body }) => {
-    const b = body as Record<string, unknown> | undefined;
-    const args = [...ALFRED_CMD, "distiller", "run"];
-    if (b?.project) args.push("--project", b.project as string);
-    const stdout = await dockerExec("alfred", args);
-    try {
-      sendJson(res, 200, JSON.parse(stdout));
-    } catch {
-      sendJson(res, 200, { raw: stdout.trim() });
-    }
+    await enqueueManualRun("distiller", body, res);
   });
 
   // Distiller history

--- a/packages/ctrl/tests/worker-runs-trigger-routes.test.ts
+++ b/packages/ctrl/tests/worker-runs-trigger-routes.test.ts
@@ -1,0 +1,114 @@
+import { after, beforeEach, describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+const root = fs.mkdtempSync(path.join(os.tmpdir(), "worker-trigger-routes-"));
+process.env.ALFRED_DATA_DIR = root;
+const realEnqueue = await import("../src/api/workerRuns/enqueue.js");
+let enqueueFailure: Error | null = null;
+mock.module("../src/api/workerRuns/enqueue.js", {
+  namedExports: {
+    enqueueWorkerRun: (...args: Parameters<typeof realEnqueue.enqueueWorkerRun>) => {
+      if (enqueueFailure) throw enqueueFailure;
+      return realEnqueue.enqueueWorkerRun(...args);
+    },
+  },
+});
+const realHelpers = await import("../src/api/helpers.js");
+const executionCalls: unknown[][] = [];
+mock.module("../src/api/helpers.js", {
+  namedExports: {
+    ...realHelpers,
+    dockerExec: async (...args: unknown[]) => {
+      executionCalls.push(args);
+      throw new Error("manual trigger must not execute a worker");
+    },
+  },
+});
+const { handleError } = await import("../src/api/errors.js");
+const { registerWorkerRoutes } = await import("../src/api/routes/workers.js");
+const { matchRoute } = await import("../src/api/server.js");
+registerWorkerRoutes();
+type Response = { status: number; body: any; headers: Record<string, string> };
+async function call(route: string, body?: unknown): Promise<Response> {
+  const match = matchRoute("POST", route);
+  assert.ok(match, `${route} must be registered`);
+  let status = 0, payload: unknown;
+  const headers: Record<string, string> = {};
+  const res: any = {
+    setHeader(name: string, value: string | number) {
+      headers[name.toLowerCase()] = String(value);
+    },
+    writeHead(code: number, values?: Record<string, string | number>) {
+      status = code;
+      for (const [name, value] of Object.entries(values ?? {})) {
+        headers[name.toLowerCase()] = String(value);
+      }
+    },
+    end(value?: string) { payload = value ? JSON.parse(value) : undefined; },
+  };
+  try { await match.handler({ req: {} as any, res, params: {}, body, query: new URLSearchParams() }); }
+  catch (error) { handleError(res, error); }
+  return { status, body: payload, headers };
+}
+beforeEach(() => {
+  enqueueFailure = null; executionCalls.length = 0;
+  fs.rmSync(path.join(root, "state"), { recursive: true, force: true });
+});
+after(() => fs.rmSync(root, { recursive: true, force: true }));
+describe("durable manual worker trigger routes", () => {
+  it("returns canonical defaults, a precise 202 shape, and identical Location", async () => {
+    const cases = [
+      ["/api/v1/workers/process", "curator", { limit: null, dry_run: false, jobs: 4 }],
+      ["/api/v1/workers/distiller/run", "distiller", { project: null }],
+      ["/api/v1/workers/janitor/fix", "janitor", {}],
+    ] as const;
+    for (const [route, worker, input] of cases) {
+      const response = await call(route);
+      assert.equal(response.status, 202); assert.equal(response.body.worker, worker);
+      assert.deepEqual(Object.keys(response.body).sort(), ["input", "reused", "run_id", "state", "status_url", "worker"]);
+      assert.equal(response.body.state, "queued"); assert.equal(response.body.reused, false); assert.deepEqual(response.body.input, input);
+      assert.equal(response.body.status_url, `/api/v1/workers/runs/${response.body.run_id}`);
+      assert.equal(response.headers.location, response.body.status_url);
+    }
+    assert.deepEqual(executionCalls, []);
+  });
+  it("canonicalizes valid input and rejects invalid bodies and unknown fields", async () => {
+    const curator = await call("/api/v1/workers/process", { limit: 10_000, dry_run: true, jobs: 32 }); const distiller = await call("/api/v1/workers/distiller/run", { project: "  Project Ω  " });
+    assert.deepEqual(curator.body.input, { limit: 10_000, dry_run: true, jobs: 32 });
+    assert.deepEqual(distiller.body.input, { project: "Project Ω" });
+    fs.rmSync(path.join(root, "state"), { recursive: true, force: true });
+    for (const [route, body] of [
+      ["/api/v1/workers/process", { jobs: 0 }],
+      ["/api/v1/workers/process", { extra: true }],
+      ["/api/v1/workers/distiller/run", { project: "line\nbreak" }],
+      ["/api/v1/workers/distiller/run", []],
+      ["/api/v1/workers/janitor/fix", { scan: true }],
+      ["/api/v1/workers/janitor/fix", null],
+    ] as const) {
+      const response = await call(route, body);
+      assert.equal(response.status, 400, `${route}: ${JSON.stringify(body)}`); assert.equal(response.body.error.code, "VALIDATION_ERROR");
+    }
+    assert.deepEqual(executionCalls, []);
+  });
+  it("surfaces durable enqueue failure without a false acceptance", async () => {
+    enqueueFailure = new Error("disk fsync failed"); const response = await call("/api/v1/workers/process", {});
+    assert.equal(response.status, 500); assert.equal(response.body.error.code, "INTERNAL_ERROR"); assert.equal(response.headers.location, undefined);
+    assert.deepEqual(executionCalls, []);
+  });
+  it("atomically reuses concurrent same-worker triggers while workers remain independent", async () => {
+    const curatorResponses = await Promise.all(Array.from({ length: 20 }, (_, jobs) =>
+      call("/api/v1/workers/process", { jobs: (jobs % 16) + 1 }),
+    ));
+    assert.equal(curatorResponses.filter((response) => response.body.reused === false).length, 1); assert.equal(new Set(curatorResponses.map((response) => response.body.run_id)).size, 1);
+    assert.ok(curatorResponses.every((response) => response.status === 202 && response.body.state === "queued"));
+    const [distiller, janitor] = await Promise.all([
+      call("/api/v1/workers/distiller/run", { project: "independent" }),
+      call("/api/v1/workers/janitor/fix", {}),
+    ]);
+    assert.equal(distiller.body.reused, false); assert.equal(janitor.body.reused, false);
+    assert.equal(new Set([curatorResponses[0].body.run_id, distiller.body.run_id, janitor.body.run_id]).size, 3);
+    assert.deepEqual(executionCalls, []);
+  });
+});


### PR DESCRIPTION
Part of #316

Controller job: `ctrl-run-triggers-316-r4-r4` · lane `I`

## Smoke evidence

`cd packages/ctrl && npm run build`

```text
> alfred-ctrl-api@0.1.0 build
> node build.mjs

Build complete — dist/api.mjs
```

The trusted controller independently reran this command after validating every changed path against the approved plan.