### PR TITLE
fix: five minimum-diff bug fixes (#312 #313 #325 #310 #315)

### DIFF
--- a/packages/ctrl/src/api/routes/admin.ts
+++ b/packages/ctrl/src/api/routes/admin.ts
@@ -871,7 +871,25 @@ export function registerAdminRoutes(): void {
   // --- Health ---
 
   addRoute("GET", "/api/v1/admin/health", async ({ res }) => {
-    const stdout = await execAsync("/opt/alfred/healthcheck.sh", []).then(r => r.stdout);
+    // The packaged healthcheck script is provisioned by cloud-init and is
+    // simply absent on stacks deployed another way. Its absence must degrade
+    // the payload, not 500 the one aggregate-health surface operators have
+    // (#310) — fall back to live container state.
+    let stdout: string;
+    try {
+      stdout = await execAsync("/opt/alfred/healthcheck.sh", []).then(r => r.stdout);
+    } catch (err: any) {
+      const containers = await dockerComposeCmd(["ps", "--format", "json"])
+        .then(s => parseJsonLines(s))
+        .catch(() => null);
+      sendJson(res, 200, {
+        status: "degraded",
+        script: "unavailable",
+        detail: String(err?.message ?? err).slice(0, 200),
+        containers,
+      });
+      return;
+    }
     try {
       sendJson(res, 200, JSON.parse(stdout.trim()));
     } catch {

--- a/packages/ctrl/src/api/routes/agents.ts
+++ b/packages/ctrl/src/api/routes/agents.ts
@@ -256,6 +256,18 @@ export function _hermesRestartPendingForTests(): boolean {
 const HERMES_WORKERS_GATEWAY_URL =
   process.env.HERMES_WORKERS_GATEWAY_URL ?? "http://hermes:18790";
 
+/** Wall-clock budget for one focused-agent delegation.
+ *
+ *  Focused runs are multi-step by design and routinely need more than a
+ *  minute. The previous hard 60s cap aborted legitimate work — and reported
+ *  the client-side abort as an unreachable gateway, which sent #325 chasing a
+ *  gateway that was answering /health in 3ms. Tunable per deployment.
+ */
+const DELEGATE_TIMEOUT_MS = (() => {
+  const raw = Number(process.env.HERMES_DELEGATE_TIMEOUT_MS ?? 300_000);
+  return Number.isFinite(raw) && raw >= 10_000 ? raw : 300_000;
+})();
+
 /** Read API_SERVER_KEY for the workers profile out of its rendered .env.
  *
  *  Same key-resolution pattern as channels_paperclip.ts /
@@ -738,19 +750,22 @@ export function registerAgentRoutes(): void {
           { role: "user", content: userMessage },
         ],
       }),
-      // 60s timeout — the subagent should complete within that for most
-      // tool-heavy fanouts.
-      signal: AbortSignal.timeout(60_000),
+      signal: AbortSignal.timeout(DELEGATE_TIMEOUT_MS),
     };
 
     let resp: Response;
     try {
       resp = await fetch(url, init);
     } catch (err: any) {
+      // A client-side abort means we ran out of budget, NOT that the gateway
+      // is down. Reporting both as UNREACHABLE is what made #325 undiagnosable.
+      const timedOut = err?.name === "TimeoutError" || err?.name === "AbortError";
       sendJson(res, 504, {
         ok: false,
-        error: "HERMES_WORKERS_UNREACHABLE",
-        detail: String(err?.message ?? err).slice(0, 300),
+        error: timedOut ? "HERMES_WORKERS_TIMEOUT" : "HERMES_WORKERS_UNREACHABLE",
+        detail: timedOut
+          ? `Delegation exceeded its ${DELEGATE_TIMEOUT_MS}ms budget (raise HERMES_DELEGATE_TIMEOUT_MS); the run may still be executing on the workers gateway`
+          : String(err?.message ?? err).slice(0, 300),
         session_key: sessionKey,
       });
       return;

--- a/packages/learn/src/activities/chore_promotion.py
+++ b/packages/learn/src/activities/chore_promotion.py
@@ -689,3 +689,19 @@ async def create_github_promotion_pr(draft: dict[str, Any]) -> dict[str, Any]:
             "pr_number": pr_number,
             "branch": branch,
         }
+
+
+@activity.defn
+async def promotion_auto_pr_enabled() -> bool:
+    """Return whether auto-PR creation is enabled for this tenant.
+
+    Exists purely so the workflow never touches ``os.environ`` itself:
+    Temporal's deterministic sandbox rejects env access from inside workflow
+    code, which failed every activation of ChorePromotionReflectionWorkflow
+    (#312). Activities run outside the sandbox, so this is the legal place to
+    read the flag. Default OFF — ops inspect drafts on disk and opt in
+    per-tenant.
+    """
+    return (
+        os.environ.get("ALFRED_PROMOTION_AUTO_PR", "false").strip().lower() == "true"
+    )

--- a/packages/learn/src/activities/scheduled_dispatch.py
+++ b/packages/learn/src/activities/scheduled_dispatch.py
@@ -47,6 +47,7 @@ async def fire_due_scheduled_dispatches() -> dict[str, Any]:
     now = datetime.now(timezone.utc)
     fired = 0
     examined = 0
+    retired = 0
     async with _http() as client:
         resp = await client.get(
             "/api/v1/decisions?state=scheduled&limit=500",
@@ -93,6 +94,35 @@ async def fire_due_scheduled_dispatches() -> dict[str, Any]:
                 dispatch_resp.raise_for_status()
                 dispatch_json = dispatch_resp.json()
             except Exception as exc:  # noqa: BLE001
+                status_code = getattr(
+                    getattr(exc, "response", None), "status_code", None
+                )
+                if status_code == 404:
+                    # The source needs_attention card is gone, so this
+                    # decision can NEVER fire. Retire it instead of retrying
+                    # every cycle forever (#313) — an eternally-eligible
+                    # decision buries genuinely new dispatch failures.
+                    prior = d.get("side_effects")
+                    prior = dict(prior) if isinstance(prior, dict) else {}
+                    prior["scheduled_dispatch"] = "source_card_missing"
+                    prior["retired_at"] = now.isoformat()
+                    try:
+                        await client.patch(
+                            f"/api/v1/decisions/{decision_id}",
+                            json={"state": "completed", "side_effects": prior},
+                        )
+                        retired += 1
+                        logger.info(
+                            "scheduled_dispatch: retired decision=%s — "
+                            "needs_attention/%s no longer exists (404)",
+                            decision_id, na_id,
+                        )
+                    except Exception as patch_exc:  # noqa: BLE001
+                        logger.warning(
+                            "scheduled_dispatch: could not retire %s: %s",
+                            decision_id, patch_exc,
+                        )
+                    continue
                 logger.warning(
                     "scheduled_dispatch: dispatch failed for %s: %s",
                     decision_id, exc,
@@ -126,8 +156,9 @@ async def fire_due_scheduled_dispatches() -> dict[str, Any]:
                 decision_id, na_id, execute_at,
             )
 
-    if examined or fired:
+    if examined or fired or retired:
         logger.info(
-            "scheduled_dispatch: examined=%d fired=%d", examined, fired,
+            "scheduled_dispatch: examined=%d fired=%d retired=%d",
+            examined, fired, retired,
         )
-    return {"examined": examined, "fired": fired}
+    return {"examined": examined, "fired": fired, "retired": retired}

--- a/packages/learn/src/worker.py
+++ b/packages/learn/src/worker.py
@@ -91,6 +91,7 @@ from src.activities.chore_promotion import (
     create_github_promotion_pr,
     draft_promotion_proposal,
     identify_promotion_candidates,
+    promotion_auto_pr_enabled,
     save_promotion_draft,
     scan_user_chores_directory,
 )
@@ -1025,6 +1026,7 @@ ALL_ACTIVITIES = [
     identify_promotion_candidates,
     draft_promotion_proposal,
     save_promotion_draft,
+    promotion_auto_pr_enabled,
     create_github_promotion_pr,
     # Composio tool belt (#376) — third-party tool execution
     list_composio_tools,

--- a/packages/learn/src/workflows/chore_promotion.py
+++ b/packages/learn/src/workflows/chore_promotion.py
@@ -27,12 +27,11 @@ from temporalio import workflow
 from temporalio.common import RetryPolicy
 
 with workflow.unsafe.imports_passed_through():
-    import os as _os
-
     from src.activities.chore_promotion import (
         create_github_promotion_pr,
         draft_promotion_proposal,
         identify_promotion_candidates,
+        promotion_auto_pr_enabled,
         save_promotion_draft,
         scan_user_chores_directory,
     )
@@ -201,11 +200,16 @@ class ChorePromotionReflectionWorkflow:
                 )
                 continue
 
-            # Phase 4: auto-create the GitHub PR if the env flag is set.
-            # Default is OFF so ops can inspect drafts on disk and decide
-            # per-tenant when to start auto-creating PRs.
-            auto_pr_enabled = (
-                _os.environ.get("ALFRED_PROMOTION_AUTO_PR", "false").lower() == "true"
+            # Phase 4: auto-create the GitHub PR if the tenant opted in.
+            # The ALFRED_PROMOTION_AUTO_PR flag is read by a tiny activity,
+            # never here: env access from inside workflow code trips
+            # Temporal's deterministic sandbox and failed every activation of
+            # this workflow (#312). Default stays OFF so ops can inspect
+            # drafts on disk and opt in per-tenant.
+            auto_pr_enabled = await workflow.execute_activity(
+                promotion_auto_pr_enabled,
+                start_to_close_timeout=timedelta(seconds=10),
+                retry_policy=RetryPolicy(maximum_attempts=2),
             )
             if not auto_pr_enabled:
                 continue

--- a/packages/learn/tests/test_chore_promotion_sandbox.py
+++ b/packages/learn/tests/test_chore_promotion_sandbox.py
@@ -1,0 +1,50 @@
+"""Regression tests for the ChorePromotion Temporal sandbox fix (#312).
+
+`ChorePromotionReflectionWorkflow` read `os.environ` from inside workflow
+code, so Temporal rejected every activation with:
+
+    Cannot access os.environ.__getitem__ from inside a workflow
+
+The flag now lives in a dedicated activity (activities run outside the
+deterministic sandbox), matching the rule documented in
+`workflows/meeting_capture.py`.
+"""
+from __future__ import annotations
+
+import inspect
+
+from src.activities.chore_promotion import promotion_auto_pr_enabled
+from src.workflows import chore_promotion as workflow_module
+
+
+async def test_auto_pr_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("ALFRED_PROMOTION_AUTO_PR", raising=False)
+    assert await promotion_auto_pr_enabled() is False
+
+
+async def test_auto_pr_enabled_when_flag_true(monkeypatch):
+    monkeypatch.setenv("ALFRED_PROMOTION_AUTO_PR", "true")
+    assert await promotion_auto_pr_enabled() is True
+
+
+async def test_auto_pr_flag_is_case_and_space_insensitive(monkeypatch):
+    monkeypatch.setenv("ALFRED_PROMOTION_AUTO_PR", "  TRUE  ")
+    assert await promotion_auto_pr_enabled() is True
+
+
+async def test_auto_pr_other_values_are_off(monkeypatch):
+    for value in ("false", "1", "yes", "", "no"):
+        monkeypatch.setenv("ALFRED_PROMOTION_AUTO_PR", value)
+        assert await promotion_auto_pr_enabled() is False, value
+
+
+def test_workflow_module_never_touches_os_environ():
+    """The structural guard: workflow code must not read env at all.
+
+    Temporal re-imports and replays workflow modules inside its sandbox, so
+    any `os.environ` access here is a latent activation failure — exactly
+    what #312 was. Keep this assertion; it is cheaper than another incident.
+    """
+    source = inspect.getsource(workflow_module)
+    assert "os.environ" not in source
+    assert "getenv" not in source

--- a/packages/learn/tests/test_scheduled_dispatch_retire.py
+++ b/packages/learn/tests/test_scheduled_dispatch_retire.py
@@ -1,0 +1,104 @@
+"""Regression tests for scheduled-dispatch terminal handling (#313).
+
+A scheduled decision whose source `needs_attention` card has been deleted
+can never dispatch: `/api/v1/admin/needs-attention/:id/dispatch` answers 404
+forever. Before the fix the activity swallowed the error and `continue`d, so
+the decision stayed `state=scheduled` and was re-tried on every 15-minute
+tick — permanent retry noise that buried genuinely new dispatch failures.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import httpx
+
+from src.activities import scheduled_dispatch as sd
+
+
+class _Ok:
+    def __init__(self, payload: dict | None = None) -> None:
+        self._payload = payload or {}
+        self.status_code = 200
+
+    def json(self) -> dict:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class _FakeClient:
+    """Minimal stand-in for the httpx.AsyncClient built by ``_http()``."""
+
+    def __init__(self, scheduled: list[dict], dispatch_status: int) -> None:
+        self._scheduled = scheduled
+        self._dispatch_status = dispatch_status
+        self.patches: list[tuple[str, dict]] = []
+        self.dispatch_calls = 0
+
+    async def __aenter__(self) -> "_FakeClient":
+        return self
+
+    async def __aexit__(self, *_exc) -> bool:
+        return False
+
+    async def get(self, url: str):
+        return _Ok({"decisions": self._scheduled})
+
+    async def post(self, url: str, json: dict | None = None):
+        self.dispatch_calls += 1
+        req = httpx.Request("POST", f"http://ctrl{url}")
+        resp = httpx.Response(self._dispatch_status, request=req)
+        raise httpx.HTTPStatusError(
+            f"{self._dispatch_status}", request=req, response=resp
+        )
+
+    async def patch(self, url: str, json: dict | None = None):
+        self.patches.append((url, json or {}))
+        return _Ok({})
+
+
+def _due_decision() -> dict:
+    past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    return {
+        "id": "dec-1",
+        "execute_at": past,
+        "source": "needs_attention",
+        "source_record": "needs_attention/2026-05-12T07-26-31Z-37a9b2e6.md",
+        "note": "send Adam Wednesday morning",
+        "side_effects": {"prior": "kept"},
+    }
+
+
+async def test_missing_source_card_retires_decision(monkeypatch):
+    """404 from dispatch → decision is flipped terminal, not retried."""
+    fake = _FakeClient([_due_decision()], dispatch_status=404)
+    monkeypatch.setattr(sd, "_http", lambda: fake)
+
+    out = await sd.fire_due_scheduled_dispatches()
+
+    assert out["fired"] == 0
+    assert out["retired"] == 1
+
+    assert len(fake.patches) == 1, "expected exactly one terminal PATCH"
+    url, body = fake.patches[0]
+    assert url == "/api/v1/decisions/dec-1"
+    # `state=scheduled` is the scan filter, so any other state removes the
+    # decision from the eligible set permanently.
+    assert body["state"] == "completed"
+    assert body["side_effects"]["scheduled_dispatch"] == "source_card_missing"
+    assert "retired_at" in body["side_effects"]
+    # pre-existing side effects must be preserved, not clobbered
+    assert body["side_effects"]["prior"] == "kept"
+
+
+async def test_transient_dispatch_failure_is_not_retired(monkeypatch):
+    """A 503 is transient — the decision stays eligible for the next tick."""
+    fake = _FakeClient([_due_decision()], dispatch_status=503)
+    monkeypatch.setattr(sd, "_http", lambda: fake)
+
+    out = await sd.fire_due_scheduled_dispatches()
+
+    assert out["fired"] == 0
+    assert out["retired"] == 0
+    assert fake.patches == [], "transient failure must not retire the decision"

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -40,7 +40,12 @@ async function main() {
   const provider = new SqliteOAuthProvider({ storage, publicUrl: env.PUBLIC_URL });
 
   const app = express();
-  app.set("trust proxy", true); // behind cloudflared
+  // Trust exactly the reverse-proxy hops in front of us (Caddy, plus
+  // cloudflared where present). `true` trusts the entire X-Forwarded-For
+  // chain, so a client can spoof its own IP and bypass express-rate-limit
+  // (#315 — ERR_ERL_PERMISSIVE_TRUST_PROXY).
+  const hopsRaw = Number(process.env.TRUST_PROXY_HOPS ?? 1);
+  app.set("trust proxy", Number.isFinite(hopsRaw) && hopsRaw >= 0 ? hopsRaw : 1);
 
   // CORS — claude.ai's browser-side connector wiring sends a preflight
   // OPTIONS before the real POST /<app>/mcp. Our bearer middleware runs


### PR DESCRIPTION
Batch 1 of the outstanding-issue sweep. Five independent, minimum-diff fixes — each touches exactly one seam.

| Issue | Package | Fix | Net |
|---|---|---|---|
| #312 | learn | Workflow read `os.environ` inside Temporal's sandbox → every activation rejected. Flag moved to a `promotion_auto_pr_enabled` activity (the pattern `meeting_capture.py` already documents). | +16/-6 |
| #313 | learn | 404 from a deleted needs-attention card was swallowed → decision stayed `state=scheduled` and re-dispatched forever. 404 now retires the decision; transient errors still retry. | +37/-5 |
| #325 | ctrl | Hardcoded 60s abort reported as `HERMES_WORKERS_UNREACHABLE` against a gateway answering /health in 3ms. Now `HERMES_DELEGATE_TIMEOUT_MS` (default 300s) + distinct `HERMES_WORKERS_TIMEOUT`. | +25/-6 |
| #310 | ctrl | `/api/v1/admin/health` 500'd when the cloud-init healthcheck script is absent. Degrades to live container state instead. | +20/-3 |
| #315 | mcp-server | `trust proxy: true` trusts the whole XFF chain → client can spoof IP and bypass rate limiting. Now a fixed hop count (`TRUST_PROXY_HOPS`, default 1). | +7/-2 |

### Notes on approach
- **#312**: the gate was deliberately *not* put inside `create_github_promotion_pr` — that changes the activity's contract for every caller and broke 12 existing tests. A dedicated env-read activity keeps the PR activity's contract intact.
- **#325 / #310** are behaviour-preserving on the happy path; both only change the failure branch.
- No schema, migration, or contract changes. No cross-package coupling.

### Verification
- `pytest` (learn): **2364 passed**. The 4 failures are pre-existing missing local `openpyxl`/pdf deps in `test_file_extraction.py`, unrelated to this diff.
- `test_chore_promotion.py`: **41/41** (was 12-failing under a rejected earlier approach).
- New: `test_scheduled_dispatch_retire.py` (404-retires / 503-does-not-retire), `test_chore_promotion_sandbox.py` (flag behaviour + structural guard that no workflow module reads env again).
- `tsc --noEmit` clean on mcp-server. ctrl typecheck relies on CI (no local esbuild/tsc).
- Lane gate: phase0 passed, 279 LOC.

Live verification on home.alfred.black follows after image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Smoke evidence

**Pre-fix baseline captured live on home.alfred.black (178.105.164.118), 2026-07-28.** Each probe confirms the defect this PR targets. Post-deploy re-run of the same probes is appended below after the image build lands.

```
§1 #310  GET /api/v1/admin/health
  HTTP 500
  {"error":{"code":"EXEC_ERROR","message":"/opt/alfred/healthcheck.sh failed (ENOENT): spawn /opt/alfred/healthcheck.sh ENOENT"}}
  host check: ls: cannot access '/opt/alfred/healthcheck.sh': No such file or directory
  → script is genuinely absent on this deployment; the endpoint has no fallback.

§2 #313  scheduled decisions stuck
  scheduled decisions: 1
   - 2026-05-12T07-27-38Z-22e019fb  execute_at=2026-05-19T07:00:00+00:00
     source_record=needs_attention/2026-05-12T07-26-31Z-37a9b2e6.md
  scheduled_dispatch 404 warnings (7d): 672
  WARNING:scheduled-dispatch: dispatch failed for 2026-05-12T07-27-38Z-22e019fb:
    Client error '404 Not Found' for url
    'http://ctrl-api:3100/api/v1/admin/needs-attention/2026-05-12T07-26-31Z-37a9b2e6/dispatch'
  → the exact decision named in #313, still eligible 70 days past due, 672 retries in one week.

§3 #312  ChorePromotionReflectionWorkflow
  os.environ sandbox errors (7d): 1102
  temporalio.worker.workflow_sandbox._restrictions.RestrictedWorkflowAccessError:
    Cannot access os.environ.get from inside a workflow.
  → every activation rejected; chore promotion has never run on this tenant.

§4 #325  delegation
  hermes-side `delegate_to_focused_agent returned error` (24h): 67
  → the 60s-abort churn is live traffic, not a historical artefact.

§5 #315  mcp-server
  ERR_ERL_PERMISSIVE_TRUST_PROXY occurrences (7d): 0
  → HONEST NOTE: the validator warning is NOT currently firing in home's 7-day
    logs. The permissive `trust proxy: true` config is still present, so this is
    a latent bypass risk hardened defensively rather than an actively-firing bug.
```

**Unit/CI evidence (this diff):**
```
pytest (packages/learn)              2364 passed
  4 failures = pre-existing missing local openpyxl/pdf deps in
  test_file_extraction.py, unrelated to this diff (CI's pytest-learn: PASS)
tests/test_chore_promotion.py        41/41 passed
tests/test_scheduled_dispatch_retire.py   2/2 passed  (404 retires, 503 does not)
tests/test_chore_promotion_sandbox.py     5/5 passed  (flag + structural no-env guard)
tsc --noEmit (mcp-server)            clean
CI on this PR                        12/13 green — build-ctrl PASS, pytest-learn PASS
lane-gate                            phase0 pass, 279 LOC
```

**Post-deploy verification plan (home):** re-run §1–§4 after the ctrl-api / learn / mcp-server images build and deploy. Expected: §1 → HTTP 200 `status: degraded`; §2 → decision retired, `retired=1`, 404-warning count stops growing; §3 → sandbox error count stops growing and the workflow completes; §4 → any future abort labelled `HERMES_WORKERS_TIMEOUT` with a 300s budget.