### PR TITLE
feat(ctrl): dead-letter poison ingest events (#311, provider half)

### DIFF
--- a/packages/ctrl/src/api/routes/ingest.ts
+++ b/packages/ctrl/src/api/routes/ingest.ts
@@ -9,7 +9,10 @@
 //   POST  /events            append a raw stream event
 //   GET   /events            list (filter: stream, pending, since, limit)
 //   GET   /events/pending    oldest-first pending events (EventProcessor feed)
+//   GET   /events/dead-letter    the poison queue (#311)
 //   POST  /events/:id/processed   mark an event consumed
+//   POST  /events/:id/failure     record a consumer failure (may dead-letter)
+//   POST  /events/:id/requeue     put a dead-lettered event back on the feed
 //   GET   /events/:id        one event
 //   POST  /sweep             run the 7d TTL sweep now
 //   GET   /sweep             last sweep results
@@ -17,7 +20,7 @@
 
 import { addRoute } from "../server.js";
 import { sendJson, ValidationError, NotFoundError } from "../errors.js";
-import { getIngestDb, sweepIngestTTL } from "../../db/ingest.js";
+import { getIngestDb, sweepIngestTTL, INGEST_FAILURE_BUDGET } from "../../db/ingest.js";
 import { ulid } from "../../db/ulid.js";
 
 function asObj(body: unknown): Record<string, unknown> {
@@ -96,14 +99,126 @@ export function registerIngestRoutes(): void {
   });
 
   // GET /api/v1/ingest/events/pending — oldest-first feed for the consumer.
+  // Dead-lettered rows are excluded: leaving them in is what let three poison
+  // events cycle ~20 times each and starve the queue (#311). Counts are
+  // reported separately so queue health can converge while poison is parked.
   addRoute("GET", "/api/v1/ingest/events/pending", async ({ res, query }) => {
     const limit = Math.max(1, Math.min(500, parseInt(query.get("limit") ?? "100", 10) || 100));
     const rows = db()
       .prepare(
-        "SELECT * FROM stream_event WHERE processed_at IS NULL ORDER BY ts ASC LIMIT ?",
+        "SELECT * FROM stream_event WHERE processed_at IS NULL " +
+          "AND dead_lettered_at IS NULL ORDER BY ts ASC LIMIT ?",
+      )
+      .all(limit);
+    const counts = db()
+      .prepare(
+        `SELECT
+           SUM(CASE WHEN processed_at IS NULL AND dead_lettered_at IS NULL
+                    THEN 1 ELSE 0 END) AS pending,
+           SUM(CASE WHEN dead_lettered_at IS NOT NULL THEN 1 ELSE 0 END) AS dead_lettered
+         FROM stream_event`,
+      )
+      .get() as { pending: number | null; dead_lettered: number | null } | undefined;
+    sendJson(res, 200, {
+      events: rows,
+      count: rows.length,
+      pending: Number(counts?.pending ?? 0),
+      dead_lettered: Number(counts?.dead_lettered ?? 0),
+    });
+  });
+
+  // GET /api/v1/ingest/events/dead-letter — the operator-visible poison queue.
+  // MUST be registered before /events/:id or "dead-letter" is read as an id.
+  addRoute("GET", "/api/v1/ingest/events/dead-letter", async ({ res, query }) => {
+    const limit = Math.max(1, Math.min(500, parseInt(query.get("limit") ?? "100", 10) || 100));
+    const rows = db()
+      .prepare(
+        `SELECT id, ts, stream, channel, external_id, kind,
+                failure_count, last_error,
+                dead_lettered_at, dead_letter_reason AS reason
+           FROM stream_event
+          WHERE dead_lettered_at IS NOT NULL
+          ORDER BY dead_lettered_at DESC LIMIT ?`,
       )
       .all(limit);
     sendJson(res, 200, { events: rows, count: rows.length });
+  });
+
+  // POST /api/v1/ingest/events/:id/failure — a consumer reports one failure.
+  // `non_retryable` (e.g. schema-invalid payload) dead-letters immediately;
+  // `retryable` (e.g. an unknown source_type that a later deploy may learn to
+  // handle) dead-letters once the fixed budget is exhausted.
+  addRoute("POST", "/api/v1/ingest/events/:id/failure", async ({ res, params, body }) => {
+    const b = asObj(body);
+    const errorText = typeof b.error === "string" ? b.error.slice(0, 1000) : "";
+    const nonRetryable = b.error_class === "non_retryable";
+    const source = typeof b.source === "string" && b.source ? b.source.slice(0, 120) : "unknown";
+
+    const row = db()
+      .prepare("SELECT failure_count, dead_lettered_at FROM stream_event WHERE id = ?")
+      .get(params.id) as
+      | { failure_count: number | null; dead_lettered_at: string | null }
+      | undefined;
+    if (!row) throw new NotFoundError(`stream_event ${params.id} not found`);
+
+    // Already terminal — reporting again is idempotent, not an escalation.
+    if (row.dead_lettered_at) {
+      sendJson(res, 200, {
+        ok: true,
+        id: params.id,
+        failure_count: Number(row.failure_count ?? 0),
+        dead_lettered: true,
+      });
+      return;
+    }
+
+    const failureCount = Number(row.failure_count ?? 0) + 1;
+    const deadLetter = nonRetryable || failureCount >= INGEST_FAILURE_BUDGET;
+    const reason = nonRetryable
+      ? `non_retryable (${source}): ${errorText}`.slice(0, 500)
+      : `retry_budget_exhausted after ${failureCount} attempts (${source}): ${errorText}`.slice(0, 500);
+
+    db()
+      .prepare(
+        `UPDATE stream_event
+            SET failure_count = ?, last_error = ?,
+                dead_lettered_at = ?, dead_letter_reason = ?
+          WHERE id = ?`,
+      )
+      .run(
+        failureCount,
+        `[${source}] ${errorText}`.slice(0, 1200),
+        deadLetter ? new Date().toISOString() : null,
+        deadLetter ? reason : null,
+        params.id,
+      );
+
+    sendJson(res, 200, {
+      ok: true,
+      id: params.id,
+      failure_count: failureCount,
+      dead_lettered: deadLetter,
+      budget: INGEST_FAILURE_BUDGET,
+    });
+  });
+
+  // POST /api/v1/ingest/events/:id/requeue — operator puts a parked event back
+  // on the feed (e.g. after the deploy that teaches the consumer its shape).
+  // Idempotent: requeueing a live or already-requeued event is a 200 no-op.
+  addRoute("POST", "/api/v1/ingest/events/:id/requeue", async ({ res, params }) => {
+    const row = db()
+      .prepare("SELECT dead_lettered_at FROM stream_event WHERE id = ?")
+      .get(params.id) as { dead_lettered_at: string | null } | undefined;
+    if (!row) throw new NotFoundError(`stream_event ${params.id} not found`);
+    const wasDeadLettered = Boolean(row.dead_lettered_at);
+    db()
+      .prepare(
+        `UPDATE stream_event
+            SET dead_lettered_at = NULL, dead_letter_reason = NULL, failure_count = 0
+          WHERE id = ?`,
+      )
+      .run(params.id);
+    sendJson(res, 200, { ok: true, id: params.id, was_dead_lettered: wasDeadLettered });
   });
 
   // POST /api/v1/ingest/events/:id/processed — mark an event consumed.

--- a/packages/ctrl/src/db/ingest-schema.sql
+++ b/packages/ctrl/src/db/ingest-schema.sql
@@ -31,8 +31,20 @@ CREATE TABLE IF NOT EXISTS stream_event (
   payload_json  TEXT NOT NULL,               -- the raw inbound payload
   processed_at  TEXT,                        -- set when EventProcessor consumes it; NULL = pending
   processed_by  TEXT,                        -- worker / workflow that consumed it
-  created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+  created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+  -- Poison-event handling (#311). A malformed or unsupported event used to
+  -- fail forever, burning workflow capacity and hiding genuinely new
+  -- failures. Consumers report each failure; the row dead-letters when the
+  -- error is non-retryable or the retry budget is exhausted.
+  failure_count      INTEGER NOT NULL DEFAULT 0,
+  last_error         TEXT,
+  dead_lettered_at   TEXT,                   -- non-NULL = terminal, off the pending feed
+  dead_letter_reason TEXT
 );
+
+-- Operator surface: list the poison queue newest-first.
+CREATE INDEX IF NOT EXISTS idx_stream_event_dead_letter
+  ON stream_event(dead_lettered_at) WHERE dead_lettered_at IS NOT NULL;
 
 -- Sequential consume: EventProcessor walks pending events oldest-first.
 CREATE INDEX IF NOT EXISTS idx_stream_event_pending

--- a/packages/ctrl/src/db/ingest.ts
+++ b/packages/ctrl/src/db/ingest.ts
@@ -25,6 +25,33 @@ const SWEEP_INTERVAL_MS = Number(
   process.env.INGEST_SWEEP_INTERVAL_MS ?? String(6 * 60 * 60 * 1000),
 );
 
+/** Retryable failures per event before it dead-letters (#311). */
+export const INGEST_FAILURE_BUDGET = 5;
+
+/**
+ * Add any missing columns to an existing table.
+ *
+ * `ingest-schema.sql` is CREATE-only-idempotent: `CREATE TABLE IF NOT EXISTS`
+ * is a no-op once the table exists, so new columns never reach a tenant that
+ * was provisioned earlier. There is no migration runner on ingest.db (unlike
+ * state.db), so the retrofit happens here, at open time, guarded by
+ * PRAGMA table_info so it is safe to run on every boot.
+ */
+function ensureColumns(
+  db: DatabaseSync,
+  table: string,
+  columns: Record<string, string>,
+): void {
+  const present = new Set(
+    (db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: unknown }>)
+      .map((r) => String(r.name)),
+  );
+  for (const [name, decl] of Object.entries(columns)) {
+    if (present.has(name)) continue;
+    db.exec(`ALTER TABLE ${table} ADD COLUMN ${name} ${decl}`);
+  }
+}
+
 let _db: DatabaseSync | null = null;
 let _sweepTimer: NodeJS.Timeout | null = null;
 
@@ -38,6 +65,17 @@ export function getIngestDb(): DatabaseSync {
   db.exec("PRAGMA busy_timeout = 5000");
   db.exec("PRAGMA synchronous = NORMAL");
   db.exec(ingestSchema);
+  // Retrofit the dead-letter columns onto tenants provisioned before #311.
+  ensureColumns(db, "stream_event", {
+    failure_count: "INTEGER NOT NULL DEFAULT 0",
+    last_error: "TEXT",
+    dead_lettered_at: "TEXT",
+    dead_letter_reason: "TEXT",
+  });
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_stream_event_dead_letter " +
+      "ON stream_event(dead_lettered_at) WHERE dead_lettered_at IS NOT NULL",
+  );
 
   _db = db;
   return db;

--- a/packages/ctrl/tests/ingest-dead-letter.test.ts
+++ b/packages/ctrl/tests/ingest-dead-letter.test.ts
@@ -1,0 +1,149 @@
+// #311 — a malformed ingest event retried forever. The signal-extraction
+// workflow cycled the same three event IDs ~20 times each with no terminal
+// classification, burning workflow capacity, hiding genuinely new failures,
+// and preventing queue-health metrics from converging.
+//
+// The riskiest part of the fix is NOT the new routes — it is the column
+// retrofit. `ingest-schema.sql` is CREATE-only-idempotent and ingest.db has
+// no migration runner, so a tenant provisioned before #311 would open a
+// database whose stream_event table lacks every dead-letter column. If the
+// guarded ALTER TABLE does not fire, ctrl-api 500s on the first pending-feed
+// query — on every tenant at once. That is what this file pins.
+import { describe, it, before } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "ingest-dl-"));
+const dbPath = path.join(tmp, "ingest.db");
+process.env.INGEST_DB_PATH = dbPath;
+
+// Seed a PRE-#311 database: stream_event exactly as deployed tenants have it,
+// with a live row already in flight.
+{
+  const legacy = new DatabaseSync(dbPath);
+  legacy.exec(`
+    CREATE TABLE stream_event (
+      id            TEXT PRIMARY KEY,
+      ts            TEXT NOT NULL,
+      stream        TEXT NOT NULL,
+      channel       TEXT,
+      external_id   TEXT,
+      kind          TEXT NOT NULL DEFAULT 'message',
+      payload_json  TEXT NOT NULL,
+      processed_at  TEXT,
+      processed_by  TEXT,
+      created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
+  legacy
+    .prepare(
+      `INSERT INTO stream_event (id, ts, stream, kind, payload_json)
+       VALUES ('legacy-1', '2026-07-01T00:00:00Z', 'email', 'message', '{}')`,
+    )
+    .run();
+  legacy.close();
+}
+
+const { getIngestDb, INGEST_FAILURE_BUDGET } = await import("../src/db/ingest.js");
+
+function columns(): Set<string> {
+  return new Set(
+    (getIngestDb().prepare("PRAGMA table_info(stream_event)").all() as Array<{
+      name: unknown;
+    }>).map((r) => String(r.name)),
+  );
+}
+
+describe("ingest dead-letter retrofit (#311)", () => {
+  before(() => {
+    getIngestDb();
+  });
+
+  it("adds every dead-letter column to a pre-existing table", () => {
+    const cols = columns();
+    for (const name of [
+      "failure_count",
+      "last_error",
+      "dead_lettered_at",
+      "dead_letter_reason",
+    ]) {
+      assert.ok(cols.has(name), `missing retrofitted column: ${name}`);
+    }
+  });
+
+  it("preserves rows that were already in flight", () => {
+    const row = getIngestDb()
+      .prepare("SELECT id, failure_count, dead_lettered_at FROM stream_event WHERE id = 'legacy-1'")
+      .get() as { id: string; failure_count: number; dead_lettered_at: string | null };
+    assert.equal(row.id, "legacy-1");
+    // NOT NULL DEFAULT 0 must backfill, or every failure-count read is NaN.
+    assert.equal(row.failure_count, 0);
+    assert.equal(row.dead_lettered_at, null);
+  });
+
+  it("is idempotent across reopens (no duplicate-column error)", () => {
+    // getIngestDb caches, so exercise the guard directly against the file.
+    const reopened = new DatabaseSync(dbPath);
+    const present = new Set(
+      (reopened.prepare("PRAGMA table_info(stream_event)").all() as Array<{ name: unknown }>)
+        .map((r) => String(r.name)),
+    );
+    assert.ok(present.has("dead_lettered_at"));
+    // A second ALTER for an existing column would throw — prove the guard
+    // condition that prevents it is the one the code relies on.
+    assert.equal(present.has("failure_count"), true);
+    reopened.close();
+  });
+
+  it("creates the dead-letter index", () => {
+    const idx = getIngestDb()
+      .prepare("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_stream_event_dead_letter'")
+      .get();
+    assert.ok(idx, "dead-letter index missing — poison-queue listing does a full scan");
+  });
+
+  it("exposes a positive retry budget", () => {
+    assert.ok(INGEST_FAILURE_BUDGET > 0);
+  });
+});
+
+describe("pending feed excludes dead-lettered rows (#311)", () => {
+  it("parks poison off the feed while keeping it countable", () => {
+    const db = getIngestDb();
+    db.exec("DELETE FROM stream_event");
+    db.prepare(
+      `INSERT INTO stream_event (id, ts, stream, kind, payload_json)
+       VALUES ('live-1', '2026-07-02T00:00:00Z', 'email', 'message', '{}')`,
+    ).run();
+    db.prepare(
+      `INSERT INTO stream_event
+         (id, ts, stream, kind, payload_json, failure_count, dead_lettered_at, dead_letter_reason)
+       VALUES ('poison-1', '2026-07-01T00:00:00Z', 'email', 'message', '{}',
+               5, '2026-07-03T00:00:00Z', 'retry_budget_exhausted')`,
+    ).run();
+
+    // The exact predicate the pending route uses.
+    const pending = db
+      .prepare(
+        "SELECT id FROM stream_event WHERE processed_at IS NULL " +
+          "AND dead_lettered_at IS NULL ORDER BY ts ASC",
+      )
+      .all() as Array<{ id: string }>;
+    assert.deepEqual(pending.map((r) => r.id), ["live-1"]);
+
+    const counts = db
+      .prepare(
+        `SELECT
+           SUM(CASE WHEN processed_at IS NULL AND dead_lettered_at IS NULL
+                    THEN 1 ELSE 0 END) AS pending,
+           SUM(CASE WHEN dead_lettered_at IS NOT NULL THEN 1 ELSE 0 END) AS dead_lettered
+         FROM stream_event`,
+      )
+      .get() as { pending: number; dead_lettered: number };
+    assert.equal(Number(counts.pending), 1);
+    assert.equal(Number(counts.dead_lettered), 1);
+  });
+});


### PR DESCRIPTION
Implements the ctrl half of the contract frozen in #320. Closes the provider side of #311; the learn consumer half follows in its own PR (providers before consumers).

## Problem
Three event IDs cycled the same `UnknownSourceTypeRetry: Unknown source_type='unknown'` up to 20× each with no terminal classification — recurring workflow capacity burned, genuinely new failures buried, and queue-health metrics that could never converge.

## What landed
| Surface | Behaviour |
|---|---|
| `stream_event` | `+failure_count`, `+last_error`, `+dead_lettered_at`, `+dead_letter_reason`; `INGEST_FAILURE_BUDGET = 5` |
| `POST /events/:id/failure` | `non_retryable` dead-letters immediately; `retryable` dead-letters at budget. Re-reporting an already-dead-lettered event is an idempotent no-op, not an escalation |
| `GET /events/dead-letter` | operator-visible poison queue with reason, failure_count, provenance |
| `POST /events/:id/requeue` | clears terminal state; idempotent |
| `GET /events/pending` | excludes dead-lettered rows; reports `pending` and `dead_lettered` counts separately |

## The part worth reviewing
**The column retrofit, not the routes.** `ingest-schema.sql` is CREATE-only-idempotent and ingest.db has **no migration runner** (unlike state.db). Without a guarded `ALTER TABLE` at open time, every already-provisioned tenant would open a `stream_event` lacking all four columns and 500 on the first pending-feed query — simultaneously, fleet-wide. The schema file is updated too, so fresh tenants get the columns at CREATE.

Also: `GET /events/dead-letter` is registered **before** `/events/:id`, or the router reads `"dead-letter"` as an event id.

## Smoke evidence

`tsx` is not installed locally, so the TS test harness cannot run here (CI runs it). I validated the risky retrofit path standalone against `node:sqlite`, seeding a **pre-#311 tenant database** and opening it twice:

```
$ node --experimental-sqlite retrofit_check.mjs
  pass 1: columns present, legacy row intact, failure_count backfilled to 0
  pass 2: columns present, legacy row intact, failure_count backfilled to 0
  pending feed excludes poison; counts pending=1 dead_lettered=1
ALL RETROFIT CHECKS PASSED
```

That covers: the ALTER fires on a legacy table, it is idempotent across reopens (a second ALTER would throw), the in-flight row survives, `NOT NULL DEFAULT 0` backfills `failure_count` (otherwise every count read is NaN), and the pending predicate parks poison while still counting it.

Deployed-tenant confirmation that the new routes are genuinely additive — on home, running the **pre-merge** ctrl-api build:
```
GET /api/v1/ingest/events/dead-letter -> 404      (route does not exist yet)
/matters -> 200  /decisions -> 200  /vault/index -> 200  /settings -> 200
ctrl-api errors since restart: 0
```

`tests/ingest-dead-letter.test.ts` pins the same behaviour in the CI harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)