### PR TITLE
fix(ctrl): don't index a column the schema hasn't retrofitted yet (#311 follow-up)

### DIFF
--- a/packages/ctrl/src/db/ingest-schema.sql
+++ b/packages/ctrl/src/db/ingest-schema.sql
@@ -42,9 +42,13 @@ CREATE TABLE IF NOT EXISTS stream_event (
   dead_letter_reason TEXT
 );
 
--- Operator surface: list the poison queue newest-first.
-CREATE INDEX IF NOT EXISTS idx_stream_event_dead_letter
-  ON stream_event(dead_lettered_at) WHERE dead_lettered_at IS NOT NULL;
+-- NOTE: the poison-queue index (idx_stream_event_dead_letter) is deliberately
+-- NOT declared here. On a tenant provisioned before #311 the CREATE TABLE
+-- above is a no-op, so an index over `dead_lettered_at` in this same file
+-- would run BEFORE the retrofit adds that column and abort the whole schema
+-- exec with "no such column: dead_lettered_at" — crash-looping ctrl-api on
+-- every existing tenant. It is created in src/db/ingest.ts instead, straight
+-- after ensureColumns(), which is correct for both fresh and legacy tenants.
 
 -- Sequential consume: EventProcessor walks pending events oldest-first.
 CREATE INDEX IF NOT EXISTS idx_stream_event_pending


### PR DESCRIPTION
Follow-up to #352. **This fixes a crash I shipped**, caught on home during post-deploy verification.

## What broke
I put the poison-queue index in `ingest-schema.sql`. On a tenant provisioned before #311, `CREATE TABLE IF NOT EXISTS stream_event` is a no-op, so the next statement indexed `dead_lettered_at` — which doesn't exist until `ensureColumns()` runs *after* the schema exec:

```
Error: no such column: dead_lettered_at
    at getIngestDb (file:///app/api.mjs:3712:6)
code: 'ERR_SQLITE_ERROR'
```

ctrl-api crash-looped on home for ~3 minutes. **Every already-provisioned tenant would have done the same** — the exact failure mode the retrofit existed to prevent.

## Fix
One statement moved. The index is created in `src/db/ingest.ts` right after `ensureColumns()`, correct for fresh tenants (columns from CREATE TABLE) and legacy ones (columns from the retrofit). The schema file keeps a comment explaining why it must not live there.

## Why CI didn't catch it — the part that matters
`packages/ctrl/tests/*` **never runs anywhere**. `build-ctrl` only bundles with esbuild; there is no `test-ctrl` job. `tsx` isn't installed locally either. So `tests/ingest-dead-letter.test.ts` — which *does* exec the real schema against a legacy table and would have failed loudly — executed in neither place. That is **#290**, and this outage is its concrete cost. I'd treat #290 as higher priority than its current labelling suggests.

## Smoke evidence

Against the **real** `ingest-schema.sql`, replicating `getIngestDb()` exactly (exec schema → retrofit → index):

```
A. PRE-FIX schema on a legacy tenant -> reproduces 'no such column: dead_lettered_at' ✓
B. FIXED schema on a legacy tenant -> boots, retrofits, indexes, idempotent on reopen ✓
C. FRESH tenant -> columns come from CREATE TABLE, index created ✓
ALL SCHEMA-ORDER CHECKS PASSED
```

Recovery on home (already applied, before this PR):
```
failure_count: ADDED   last_error: ADDED
dead_lettered_at: ADDED   dead_letter_reason: ADDED
stream_event rows intact: 458
ctrl-api: Up 9 seconds (healthy)
```
ingest.db was backed up first (`ingest.db.bak-pre311-*`). With this PR the manual step is unnecessary — a fresh deploy retrofits itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)