### PR TITLE
feat(learn): report ingest extraction failures so poison events dead-letter (#311, consumer half)

### DIFF
--- a/packages/learn/src/activities/signals.py
+++ b/packages/learn/src/activities/signals.py
@@ -3438,3 +3438,81 @@ async def mark_stream_event_processed(
         "signals.mark_stream_event_processed: marked path=%s signal_path=%s",
         stream_event_path, signal_path or "(none)",
     )
+
+
+@activity.defn
+async def report_ingest_event_failure(
+    stream_event_path: str,
+    error: str,
+    error_class: str = "retryable",
+) -> dict[str, Any]:
+    """Report one consumer-side extraction failure to ctrl-api (#311).
+
+    Without this, a malformed or unsupported event is simply never marked
+    processed, so it comes back on the pending feed every tick — forever.
+    Three event IDs were cycling ~20 times each, burning capacity and
+    burying genuinely new failures.
+
+    ctrl-api owns the policy: ``non_retryable`` dead-letters immediately,
+    ``retryable`` dead-letters once the fixed budget is exhausted. Once
+    dead-lettered the event drops off ``/events/pending``, so the workflow
+    stops seeing it without ever marking it processed (it was never
+    consumed — marking it would be a lie).
+
+    Only ``ingest:<id>`` refs are reportable; legacy vault-path events have
+    no ingest row. Never raises: a failed report must not convert a handled
+    extraction failure into a workflow error.
+
+    Returns ``{"reported": bool, "dead_lettered": bool, "failure_count": int}``.
+    """
+    out: dict[str, Any] = {"reported": False, "dead_lettered": False, "failure_count": 0}
+    if not stream_event_path or not isinstance(stream_event_path, str):
+        return out
+    if not stream_event_path.startswith(_INGEST_REF_PREFIX):
+        return out
+
+    event_id = stream_event_path[len(_INGEST_REF_PREFIX):]
+    cfg = load_config()
+    api_key = __import__("os").environ.get("AAS_API_KEY", "")
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    cls = "non_retryable" if error_class == "non_retryable" else "retryable"
+    try:
+        async with httpx.AsyncClient(
+            base_url=cfg.alfred_ctrl_url, timeout=30.0, headers=headers
+        ) as client:
+            resp = await client.post(
+                f"/api/v1/ingest/events/{event_id}/failure",
+                json={
+                    "error": str(error)[:1000],
+                    "error_class": cls,
+                    "source": "signal_extract",
+                },
+            )
+            resp.raise_for_status()
+            body = resp.json() if resp.content else {}
+    except Exception as exc:  # noqa: BLE001
+        # An older ctrl-api has no /failure route (404). That is the
+        # pre-#311 behaviour — retry-forever — not a new failure mode, so
+        # log once and move on rather than escalating.
+        logger.warning(
+            "signals.report_ingest_event_failure: report failed id=%s err=%s",
+            event_id, exc,
+        )
+        return out
+
+    out["reported"] = True
+    out["dead_lettered"] = bool(body.get("dead_lettered"))
+    out["failure_count"] = int(body.get("failure_count") or 0)
+    if out["dead_lettered"]:
+        logger.warning(
+            "signals.report_ingest_event_failure: DEAD-LETTERED id=%s after "
+            "%s failures (%s) — off the pending feed, requeue via "
+            "POST /api/v1/ingest/events/%s/requeue",
+            event_id, out["failure_count"], cls, event_id,
+        )
+    else:
+        logger.info(
+            "signals.report_ingest_event_failure: id=%s failure %s (%s)",
+            event_id, out["failure_count"], cls,
+        )
+    return out

--- a/packages/learn/src/worker.py
+++ b/packages/learn/src/worker.py
@@ -536,6 +536,7 @@ from src.activities.signals import (
     extract_signals_from_event,
     list_unprocessed_stream_events,
     mark_stream_event_processed,
+    report_ingest_event_failure,
     write_signal_record,
 )
 
@@ -1150,6 +1151,7 @@ ALL_ACTIVITIES = [
     extract_signals_from_event,
     write_signal_record,
     mark_stream_event_processed,
+    report_ingest_event_failure,
     # Steward Phase 6 (T6.5.1) — auto-create tasks for no-target
     # signals. Invoked from inside extract_signal_from_event; the env
     # gate (STEWARD_SIGNAL_AUTOCREATE_TASKS) is read at activity

--- a/packages/learn/src/workflows/signals.py
+++ b/packages/learn/src/workflows/signals.py
@@ -70,6 +70,7 @@ with workflow.unsafe.imports_passed_through():
         # single-signal extractor (one signal or None) while new runs
         # use the multi-signal extractor (list[dict]).
         extract_signals_from_event,
+        report_ingest_event_failure,
         list_unprocessed_stream_events,
         mark_stream_event_processed,
         write_signal_record,
@@ -120,6 +121,17 @@ class SignalExtractResult:
     multi_signal_branch: bool = False
     multi_signal_max: int = 0
     multi_signal_events_with_multiple: int = 0
+
+
+# #311 — extraction failures that can never succeed on a retry, no matter how
+# many parser fixes land. Everything NOT listed here is treated as retryable
+# and bounded by ctrl-api's fixed failure budget, so an unknown source_type
+# still gets a fair number of chances before it is parked.
+_NON_RETRYABLE_EXTRACT_ERRORS: frozenset[str] = frozenset({
+    "SchemaInvalid",
+    "ValidationError",
+    "MalformedPayload",
+})
 
 
 @workflow.defn(name="SignalExtractWorkflow")
@@ -265,7 +277,49 @@ class SignalExtractWorkflow:
                         "signal_extract.extract_failed path=%s err=%s",
                         path, extracted,
                     )
-                    # Don't mark on extractor failure — next tick retries.
+                    # #311 — report the failure so ctrl-api can BOUND the
+                    # retries. Without this the event is simply never marked
+                    # processed and returns on the pending feed every tick,
+                    # forever (three IDs cycled ~20× each). Once ctrl
+                    # dead-letters it, it drops off the feed — and we still
+                    # never mark it processed, because it genuinely was not
+                    # consumed; marking it would be a lie.
+                    #
+                    # DETERMINISM: a new activity call inside a deployed
+                    # workflow is non-additive for history replay, so it is
+                    # gated per packages/learn/CLAUDE.md.
+                    if workflow.patched("signal_extract_dead_letter_v1"):
+                        err_type = (
+                            getattr(extracted, "type", "")
+                            or type(extracted).__name__
+                        )
+                        # An unknown source_type may become extractable once a
+                        # parser is fixed, so it stays retryable (bounded by
+                        # the budget). A structurally invalid payload never
+                        # will be.
+                        failure_class = (
+                            "non_retryable"
+                            if err_type in _NON_RETRYABLE_EXTRACT_ERRORS
+                            else "retryable"
+                        )
+                        try:
+                            await workflow.execute_activity(
+                                report_ingest_event_failure,
+                                args=[path, str(extracted)[:500], failure_class],
+                                start_to_close_timeout=timedelta(seconds=20),
+                                retry_policy=retry,
+                            )
+                        except Exception as exc:  # noqa: BLE001
+                            # Reporting is best-effort: a failed report must
+                            # not turn a handled extraction failure into a
+                            # workflow error.
+                            workflow.logger.warning(
+                                "signal_extract.failure_report_failed "
+                                "path=%s err=%s",
+                                path, exc,
+                            )
+                    # Don't mark on extractor failure — next tick retries,
+                    # now bounded: ctrl dead-letters at the budget.
                     continue
 
                 # Normalise both branches to a list[dict] of signals

--- a/packages/learn/tests/test_signal_extract_dead_letter.py
+++ b/packages/learn/tests/test_signal_extract_dead_letter.py
@@ -1,0 +1,135 @@
+"""Consumer half of the ingest dead-letter loop (#311).
+
+ctrl-api owns the retry budget, but nothing bounds anything unless the
+consumer actually *reports* its failures. Before this, a failed extraction
+just skipped `mark_stream_event_processed`, so the event returned on the
+pending feed every tick — forever. Three IDs cycled ~20 times each.
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from src.activities import signals as sig
+
+
+class _Resp:
+    def __init__(self, payload: dict, status: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status
+        self.content = b"x"
+
+    def json(self) -> dict:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            req = httpx.Request("POST", "http://ctrl/x")
+            raise httpx.HTTPStatusError(
+                str(self.status_code), request=req,
+                response=httpx.Response(self.status_code, request=req),
+            )
+
+
+class _Client:
+    """Captures the outbound report instead of making it."""
+
+    def __init__(self, payload: dict | None = None, status: int = 200) -> None:
+        self._payload = payload or {"failure_count": 1, "dead_lettered": False}
+        self._status = status
+        self.calls: list[tuple[str, dict]] = []
+
+    async def __aenter__(self) -> "_Client":
+        return self
+
+    async def __aexit__(self, *_exc) -> bool:
+        return False
+
+    async def post(self, url: str, json: dict | None = None):
+        self.calls.append((url, json or {}))
+        return _Resp(self._payload, self._status)
+
+
+@pytest.fixture
+def patch_client(monkeypatch):
+    holder: dict[str, _Client] = {}
+
+    def install(payload=None, status=200):
+        client = _Client(payload, status)
+        holder["c"] = client
+        monkeypatch.setattr(
+            sig.httpx, "AsyncClient", lambda *a, **k: client
+        )
+        return client
+
+    return install
+
+
+async def test_reports_retryable_failure_with_event_id(patch_client):
+    client = patch_client({"failure_count": 2, "dead_lettered": False})
+
+    out = await sig.report_ingest_event_failure(
+        "ingest:01ABCDEF", "Unknown source_type='unknown'", "retryable"
+    )
+
+    assert out["reported"] is True
+    assert out["dead_lettered"] is False
+    assert out["failure_count"] == 2
+
+    url, body = client.calls[0]
+    assert url == "/api/v1/ingest/events/01ABCDEF/failure"
+    assert body["error_class"] == "retryable"
+    assert body["source"] == "signal_extract"
+    assert "Unknown source_type" in body["error"]
+
+
+async def test_surfaces_dead_letter_verdict(patch_client):
+    patch_client({"failure_count": 5, "dead_lettered": True})
+    out = await sig.report_ingest_event_failure("ingest:01XYZ", "boom", "retryable")
+    assert out["dead_lettered"] is True
+    assert out["failure_count"] == 5
+
+
+async def test_non_retryable_is_passed_through(patch_client):
+    client = patch_client({"failure_count": 1, "dead_lettered": True})
+    await sig.report_ingest_event_failure("ingest:01Q", "bad schema", "non_retryable")
+    assert client.calls[0][1]["error_class"] == "non_retryable"
+
+
+async def test_unknown_error_class_defaults_to_retryable(patch_client):
+    """A typo must not silently dead-letter an event on its first failure."""
+    client = patch_client()
+    await sig.report_ingest_event_failure("ingest:01Q", "x", "banana")
+    assert client.calls[0][1]["error_class"] == "retryable"
+
+
+@pytest.mark.parametrize("path", ["", None, "signal/foo.md", "vault/stream_event/x.md"])
+async def test_non_ingest_refs_are_a_noop(patch_client, path):
+    """Legacy vault-path events have no ingest row to report against."""
+    client = patch_client()
+    out = await sig.report_ingest_event_failure(path, "x", "retryable")
+    assert out == {"reported": False, "dead_lettered": False, "failure_count": 0}
+    assert client.calls == []
+
+
+async def test_report_failure_never_raises(patch_client):
+    """An older ctrl-api has no /failure route. That is the pre-#311
+    behaviour, not a new failure mode — it must not escalate a handled
+    extraction failure into a workflow error."""
+    patch_client({}, status=404)
+    out = await sig.report_ingest_event_failure("ingest:01Q", "x", "retryable")
+    assert out["reported"] is False
+
+
+def test_workflow_gates_the_new_activity_call():
+    """Adding an activity call to a deployed workflow is non-additive for
+    history replay — packages/learn/CLAUDE.md requires workflow.patched()."""
+    import inspect
+
+    from src.workflows import signals as wf
+
+    src = inspect.getsource(wf)
+    assert "report_ingest_event_failure" in src
+    assert 'workflow.patched("signal_extract_dead_letter_v1")' in src
+    # and the classification must default to retryable
+    assert "_NON_RETRYABLE_EXTRACT_ERRORS" in src


### PR DESCRIPTION
Completes #311. Provider half was #352 (+ crash fix #353).

## Why this half matters
#352 gave ctrl-api a budget, a poison queue and a requeue path — but **nothing called them**. On an extraction failure the workflow skipped `mark_stream_event_processed` and `continue`d, so the event returned on the pending feed every tick. The dead-letter machinery existed and was unreachable.

## What landed
- **`report_ingest_event_failure`** activity → `POST /ingest/events/:id/failure`. Only `ingest:<id>` refs are reportable; legacy vault-path events have no ingest row. **Never raises** — an older ctrl-api without the route is the pre-#311 behaviour, not a new failure mode.
- **SignalExtractWorkflow** calls it on the extractor-failure branch.
- The event is **still never marked processed** — it genuinely wasn't consumed. Once ctrl dead-letters it, it drops off the feed on its own.

## Classification, deliberately conservative
`UnknownSourceTypeRetry` stays **retryable**: a parser fix can still make that event extractable, so it deserves the full budget rather than immediate parking. Only structurally-invalid payloads are `non_retryable`. An unrecognised error type **defaults to retryable**, so a typo in the allowlist can never dead-letter an event on its first failure.

## Determinism
Adding an activity call inside a deployed workflow is non-additive for history replay, so it is gated behind `workflow.patched("signal_extract_dead_letter_v1")` per `packages/learn/CLAUDE.md`. A test asserts the gate is present so it can't be dropped silently later.

## Smoke evidence

```
tests/test_signal_extract_dead_letter.py     10/10 passed
  - event id extracted from the ingest: ref, correct URL + source
  - dead-letter verdict surfaced to the caller
  - non_retryable passed through; unknown class DEFAULTS to retryable
  - non-ingest refs ("", None, signal/*.md, vault path) are a no-op
  - a 404 from an older ctrl-api does not raise
  - workflow.patched gate + retryable-default constant are present

full learn suite                              2355 passed, 0 failed
  (excludes 3 files needing optional local deps: fastapi, openpyxl — unrelated)
```

The provider half is already verified live on home (#352): dead-letters exactly at budget 5, `non_retryable` immediate, poison excluded from the pending feed, requeue restores. Post-deploy I'll confirm the two halves close the loop end-to-end on real traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)