### PR TITLE
fix(ctrl): serve the worker-run status_url the trigger already advertises (#316)

### DIFF
--- a/packages/ctrl/src/api/routes/workers.ts
+++ b/packages/ctrl/src/api/routes/workers.ts
@@ -1,8 +1,9 @@
 import http from "node:http";
 import { addRoute } from "../server.js";
-import { sendJson, ValidationError } from "../errors.js";
+import { sendJson, ValidationError, NotFoundError } from "../errors.js";
 import { dockerExec, dockerComposeCmd, ALFRED_CMD } from "../helpers.js";
 import { enqueueWorkerRun } from "../workerRuns/enqueue.js";
+import { readWorkerRun, listWorkerRuns } from "../workerRuns/ledger.js";
 import type { WorkerName } from "../workerRuns/model.js";
 
 /** Legacy inbox bridge retained for non-trigger callers; durable triggers never invoke it. */
@@ -44,6 +45,47 @@ export function registerWorkerRoutes(): void {
   addRoute("GET", "/api/v1/workers/status", async ({ res }) => {
     const stdout = await dockerExec("alfred", [...ALFRED_CMD, "status"]);
     sendJson(res, 200, { raw: stdout.trim() });
+  });
+
+  // --- Durable manual-run handles (#316) ---
+  //
+  // enqueueManualRun answers 202 with `status_url:
+  // /api/v1/workers/runs/<id>`, but nothing ever served that path — the
+  // advertised run handle 404'd, so an operator had a run id and no way to
+  // ask what happened to it. The ledger read helpers already existed; they
+  // were simply never exposed. Registered BEFORE `/runs/:id` so the literal
+  // collection path is not captured as a run id.
+
+  addRoute("GET", "/api/v1/workers/runs", async ({ res, query }) => {
+    const limit = Math.max(1, Math.min(200, parseInt(query.get("limit") ?? "50", 10) || 50));
+    const worker = query.get("worker");
+    const state = query.get("state");
+    let runs = listWorkerRuns();
+    if (worker) runs = runs.filter((r) => r.worker === worker);
+    if (state) runs = runs.filter((r) => r.state === state);
+    // Run ids are ULIDs, so descending id is newest-first.
+    runs.sort((a, b) => (a.run_id < b.run_id ? 1 : a.run_id > b.run_id ? -1 : 0));
+    const counts: Record<string, number> = {};
+    for (const r of runs) counts[r.state] = (counts[r.state] ?? 0) + 1;
+    sendJson(res, 200, {
+      runs: runs.slice(0, limit),
+      count: Math.min(runs.length, limit),
+      total: runs.length,
+      states: counts,
+    });
+  });
+
+  addRoute("GET", "/api/v1/workers/runs/:id", async ({ res, params }) => {
+    let run;
+    try {
+      run = readWorkerRun(params.id);
+    } catch (err: any) {
+      // An invalid or corrupt id is a client/ledger problem, not a 500 —
+      // the whole point of this endpoint is inspectable failure.
+      throw new ValidationError(String(err?.message ?? err).slice(0, 200));
+    }
+    if (!run) throw new NotFoundError(`worker run ${params.id} not found`);
+    sendJson(res, 200, run);
   });
 
   // Start workers

--- a/packages/ctrl/tests/worker-runs-read-routes.test.ts
+++ b/packages/ctrl/tests/worker-runs-read-routes.test.ts
@@ -1,0 +1,136 @@
+// #316 — `POST /api/v1/workers/janitor/fix` answers 202 with
+// `status_url: /api/v1/workers/runs/<id>`, but nothing ever served that path:
+//
+//   GET /api/v1/workers/runs/01KY6ENE704FFBV3ZPPQP8YBNG
+//   {"error":{"code":"NOT_FOUND","message":"No route: ..."}}
+//
+// So an operator got a durable run id and no way to ask what happened to it —
+// the opposite of "durable jobs with run IDs, progress and inspectable failure
+// reasons". The ledger read helpers already existed; they were never exposed.
+import { after, before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), "worker-read-routes-"));
+process.env.ALFRED_DATA_DIR = root;
+
+const { writeInitialWorkerRun } = await import("../src/api/workerRuns/ledger.js");
+const { createQueuedWorkerRun } = await import("../src/api/workerRuns/request.js");
+const { handleError } = await import("../src/api/errors.js");
+const { registerWorkerRoutes } = await import("../src/api/routes/workers.js");
+const { matchRoute } = await import("../src/api/server.js");
+
+registerWorkerRoutes();
+
+type Response = { status: number; body: any };
+
+async function get(route: string): Promise<Response> {
+  const [pathname, search = ""] = route.split("?");
+  const match = matchRoute("GET", pathname);
+  assert.ok(match, `${pathname} must be registered`);
+  let status = 0;
+  let payload: unknown;
+  const res: any = {
+    setHeader() {},
+    writeHead(code: number) { status = code; return res; },
+    end(chunk?: string) { if (chunk) payload = JSON.parse(chunk); return res; },
+  };
+  const ctx = {
+    req: {} as any,
+    res,
+    params: match.params,
+    query: new URLSearchParams(search),
+    body: undefined,
+  };
+  try {
+    await match.handler(ctx as any);
+  } catch (error) {
+    handleError(res, error);
+  }
+  return { status, body: payload };
+}
+
+function seed(worker: "curator" | "distiller" | "janitor", state: string, at: string) {
+  const run = createQueuedWorkerRun(
+    worker,
+    worker === "curator" ? { jobs: 8 } : worker === "distiller" ? { project: null } : {},
+    new Date(at),
+  );
+  (run as any).state = state;
+  writeInitialWorkerRun(run as any);
+  return run;
+}
+
+before(() => {
+  seed("janitor", "queued", "2026-07-31T01:00:00.000Z");
+  seed("distiller", "running", "2026-07-31T02:00:00.000Z");
+  seed("curator", "succeeded", "2026-07-31T03:00:00.000Z");
+});
+
+after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+describe("GET /api/v1/workers/runs/:id (#316)", () => {
+  it("serves the status_url the 202 advertises", async () => {
+    const list = await get("/api/v1/workers/runs");
+    const id = list.body.runs[0].run_id;
+
+    const res = await get(`/api/v1/workers/runs/${id}`);
+    assert.equal(res.status, 200);
+    assert.equal(res.body.run_id, id);
+    // The fields the contract asks to be inspectable.
+    assert.ok(res.body.state);
+    assert.ok(res.body.timestamps);
+    assert.ok("terminal_error" in res.body);
+    assert.ok(res.body.reliability);
+  });
+
+  it("404s a well-formed but unknown run id", async () => {
+    const res = await get("/api/v1/workers/runs/01KY6ENE704FFBV3ZPPQP8YBNZ");
+    assert.equal(res.status, 404);
+  });
+
+  it("rejects a malformed run id as 400, not 500", async () => {
+    // Inspectability is the point — a bad id must not look like a server bug.
+    const res = await get("/api/v1/workers/runs/not-a-ulid");
+    assert.equal(res.status, 400);
+  });
+});
+
+describe("GET /api/v1/workers/runs (#316)", () => {
+  it("lists newest-first with state counts", async () => {
+    const res = await get("/api/v1/workers/runs");
+    assert.equal(res.status, 200);
+    assert.equal(res.body.total, 3);
+    // ULIDs sort lexicographically by time; newest seeded run is first.
+    const ids = res.body.runs.map((r: any) => r.run_id);
+    assert.deepEqual([...ids].sort().reverse(), ids, "must be newest-first");
+    assert.deepEqual(res.body.states, { queued: 1, running: 1, succeeded: 1 });
+  });
+
+  it("filters by worker", async () => {
+    const res = await get("/api/v1/workers/runs?worker=distiller");
+    assert.equal(res.body.count, 1);
+    assert.equal(res.body.runs[0].worker, "distiller");
+  });
+
+  it("filters by state", async () => {
+    const res = await get("/api/v1/workers/runs?state=queued");
+    assert.equal(res.body.count, 1);
+    assert.equal(res.body.runs[0].state, "queued");
+  });
+
+  it("honours limit while still reporting the true total", async () => {
+    const res = await get("/api/v1/workers/runs?limit=1");
+    assert.equal(res.body.count, 1);
+    assert.equal(res.body.total, 3, "total must not be truncated by limit");
+  });
+
+  it("does not capture the collection path as a run id", async () => {
+    // If /runs/:id were registered first, "runs" would 400 as a bad ULID.
+    const res = await get("/api/v1/workers/runs");
+    assert.equal(res.status, 200);
+    assert.ok(Array.isArray(res.body.runs));
+  });
+});


### PR DESCRIPTION
Partial fix for #316 — the durable-run-handle half.

## What I found
Two of the three complaints in #316 turned out to be **already fixed**; one real bug was hiding behind them.

| #316 complaint | Status on home today |
|---|---|
| `janitor/fix` 500s after 49–59s | **Already fixed** — returns `202` in **0.007s** with a run id |
| `distiller/run` 500s after ~54s | **Already fixed** — returns `202` in **0.003s**, `reused: true` on repeat (idempotent) |
| Status stale / falsely healthy | **Still open** — see "Not in this diff" |
| *(unreported)* | **The advertised run handle 404s** — fixed here |

## The real bug
Both triggers answer 202 with `status_url: /api/v1/workers/runs/<id>`, but **no route was ever registered for that path**:

```
GET /api/v1/workers/runs/01KY6ENE704FFBV3ZPPQP8YBNG
{"error":{"code":"NOT_FOUND","message":"No route: GET /api/v1/workers/runs/..."}}
```

An operator got a durable run id and no way to ask what happened to it — the exact opposite of the issue's "durable jobs with run IDs, progress, timeout policy, and inspectable failure reasons".

## Fix — wiring, not new machinery
The ledger already records everything the contract asks for: `state`, `progress`, `terminal_error`, `timestamps` (incl. `heartbeat_at`, `last_progress_at`, `last_successful_output_at`), and `reliability` (`attempt`, `exit_code`, `recovery_reason`). `readWorkerRun` / `listWorkerRuns` already existed. They were simply never exposed.

- `GET /api/v1/workers/runs` — newest-first, `?worker=` `?state=` `?limit=`, per-state counts, and a **true total** that isn't truncated by `limit`.
- `GET /api/v1/workers/runs/:id` — the advertised handle.

Registered collection-before-`:id` so the literal `runs` path isn't captured as a run id, and a malformed id answers **400, not 500** — inspectability is the whole point.

## Not in this diff
Structured `/workers/status`. It currently returns a raw CLI text blob (`{"raw":"=====\nALFRED STATUS\n..."}`) carrying real data — curator last run 2026-07-28, janitor 9027/9333 files with issues, distiller 0 learn records — but with no idle/stalled/failed/complete classification and no stale detection. That's the remaining half of #316 and I've left the issue open for it.

## Smoke evidence

Live on home.alfred.black, 2026-07-31 — the baseline this PR targets:
```
POST /api/v1/workers/janitor/fix   -> 202 in 0.007196s
  {"run_id":"01KY6ENE704FFBV3ZPPQP8YBNG","worker":"janitor","state":"queued",
   "reused":true,"status_url":"/api/v1/workers/runs/01KY6ENE704FFBV3ZPPQP8YBNG"}

POST /api/v1/workers/distiller/run -> 202 in 0.003303s
  {"run_id":"01KY6ENE92E94SCH8K2QTYA1FG","state":"queued","reused":true, ...}

GET  /api/v1/workers/runs/01KY6ENE704FFBV3ZPPQP8YBNG
  {"error":{"code":"NOT_FOUND","message":"No route: ..."}}      <-- the bug
```

Tests: `tests/worker-runs-read-routes.test.ts` — serves the advertised handle and exposes state/timestamps/terminal_error/reliability; 404 for an unknown-but-valid ULID; **400 not 500** for a malformed id; newest-first ordering; `?worker=` / `?state=` filters; `limit` truncates the page but not `total`; and the collection path isn't captured as a run id.

**Honest caveat:** `packages/ctrl/tests/*` still does not execute in CI (no `test-ctrl` job — see #290), so these tests are written but unrun. I will verify both routes live on home after deploy and post the output here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)