### PR TITLE
fix: background workers can no longer reach the principal's channels (#288 L1+L2)

### DIFF
--- a/packages/ctrl/src/api/routes/agents.ts
+++ b/packages/ctrl/src/api/routes/agents.ts
@@ -486,9 +486,21 @@ export function registerAgentRoutes(): void {
   //                         etc. to force a specific one.
   //   at_seconds?: number   default 1 — seconds from now before fire.
   //   name?:       string   default "agent-task-<ts>-<rand>".
-  //   announce?:   boolean  default true. false = run silently (no
-  //                         delivery; used when the agent's job is
-  //                         background work that shouldn't DM Sir).
+  //   announce?:   boolean  default FALSE — channel delivery is opt-in
+  //                         (#288). It used to default true, which is the
+  //                         right default for a principal-facing caller
+  //                         ("tell Alfred to post X") and the wrong one for
+  //                         every background worker — and nothing here can
+  //                         tell the two apart. The vault-janitor's repair
+  //                         pipeline spawned one-shots through this route
+  //                         and dumped raw failure text into the
+  //                         principal's Slack (13 deliveries, 0 silent),
+  //                         re-spawning each sweep because the repairs
+  //                         could never succeed. Silence-by-convention
+  //                         ([SILENT] in the prompt) cannot hold: a failure
+  //                         always looks report-worthy, so failures always
+  //                         delivered. Callers that genuinely want the
+  //                         principal notified now say so explicitly.
   addRoute("POST", "/api/v1/agents/main/task", async ({ res, body }) => {
     const b = body as Record<string, unknown> | undefined;
     if (!b || typeof b.task !== "string" || !(b.task as string).trim()) {
@@ -501,7 +513,10 @@ export function registerAgentRoutes(): void {
     const atSeconds = typeof b.at_seconds === "number" && (b.at_seconds as number) > 0
       ? Math.floor(b.at_seconds as number)
       : 1;
-    const announce = b.announce !== false;
+    // Opt-in, not opt-out (#288). Every shipped caller that wants delivery
+    // already passes this explicitly (weekly_money_day.py, the
+    // alfred-chore-authoring template); background callers never did.
+    const announce = b.announce === true;
     const jobName = typeof b.name === "string" && (b.name as string).length > 0
       ? (b.name as string)
       : `agent-task-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;

--- a/packages/hermes/hermes-config.yaml.njk
+++ b/packages/hermes/hermes-config.yaml.njk
@@ -491,6 +491,35 @@ mcp_servers:
       AAS_API_KEY: "${AAS_API_KEY}"
     timeout: 120
     connect_timeout: 60
+{%- if not is_main %}
+    # BACKGROUND PROFILES HAVE NO CHANNEL AUTHORITY — issue #288.
+    #
+    # workers/heavy run autonomous, unattended agents (clerk, curator,
+    # janitor, distiller, Reflection). They need the vault read/write
+    # surface; they have no business messaging the principal directly.
+    #
+    # The vault-janitor's repair pipeline reached for `spawn_alfred_task`
+    # to delegate a fix to main. That tool schedules a one-shot cron whose
+    # reply is delivered to the principal's most-recent channel, so 13 raw
+    # failure dumps landed in Sir's Slack in a single day — and because the
+    # repairs could never succeed, the next sweep re-detected the same
+    # issue and spawned again. Prompt-level "[SILENT] if nothing to report"
+    # cannot prevent this: a failure always looks report-worthy.
+    #
+    # Delivery being opt-in (#288 L1, ctrl-api /agents/main/task) already
+    # makes the storm silent. Removing the capability outright makes it
+    # impossible — a background agent cannot reach a channel even if it
+    # decides to. Defence in depth, because the L1 default is one edit away
+    # from being flipped back.
+    #
+    # Anything a background agent genuinely needs surfaced goes through the
+    # audit ledger / needs-attention records, which the principal reads on
+    # /desk — a pull surface, not a push one.
+    tools:
+      exclude:
+        - spawn_alfred_task
+        - notify_principal
+{%- endif %}
 
   sure:
     command: "node"

--- a/packages/hermes/tests/test_background_channel_authority.py
+++ b/packages/hermes/tests/test_background_channel_authority.py
@@ -1,0 +1,97 @@
+"""Background profiles must have no channel authority (#288).
+
+The vault-janitor's repair pipeline reached for `spawn_alfred_task` — a tool
+that schedules a one-shot cron whose reply is delivered to the principal's
+most-recent channel. 13 raw failure dumps landed in Sir's Slack in one day,
+and because the repairs could never succeed the next sweep re-spawned them.
+
+Prompt-level "[SILENT] if nothing to report" cannot prevent that: a failure
+always looks report-worthy, so failures always delivered. The guarantee has to
+be structural — the capability is removed from the profiles that run
+unattended agents, so a background agent cannot reach a channel even if it
+decides to.
+
+These tests render the real template, so they fail if the guard is ever
+dropped or the tool list drifts.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+HERMES = Path(__file__).resolve().parent.parent
+SCRIPT = HERMES / "init" / "render_hermes.py"
+
+# Tools that can put text in front of the principal without them asking.
+CHANNEL_TOOLS = ("spawn_alfred_task", "notify_principal")
+
+# Profiles that run unattended agents. main is the principal's own chat.
+BACKGROUND_PROFILES = ("workers", "heavy")
+
+
+def _render(profile: str, out_dir: Path, port: str | None = None) -> dict:
+    env = dict(os.environ)
+    env.setdefault("OPENROUTER_API_KEY", "test-or-key")
+    env.setdefault("AAS_API_KEY", "test-aas")
+    if port:
+        env["HERMES_RENDER_PORT"] = port
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), profile, str(out_dir), str(HERMES), "test-token"],
+        env=env, capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    return yaml.safe_load((out_dir / "config.yaml").read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize("profile", BACKGROUND_PROFILES)
+def test_background_profiles_exclude_channel_tools(profile: str, tmp_path: Path):
+    cfg = _render(profile, tmp_path)
+    alfred = (cfg.get("mcp_servers") or {}).get("alfred")
+    assert alfred, f"{profile} should still register the alfred MCP server"
+    excluded = ((alfred.get("tools") or {}).get("exclude")) or []
+    for tool in CHANNEL_TOOLS:
+        assert tool in excluded, (
+            f"{profile} can still call {tool} — a background agent must not be "
+            f"able to reach the principal's channel (#288)"
+        )
+
+
+@pytest.mark.parametrize("profile", BACKGROUND_PROFILES)
+def test_background_profiles_keep_the_vault_surface(profile: str, tmp_path: Path):
+    """Removing channel authority must not remove the ability to do the work."""
+    cfg = _render(profile, tmp_path)
+    alfred = (cfg.get("mcp_servers") or {})["alfred"]
+    excluded = ((alfred.get("tools") or {}).get("exclude")) or []
+    for tool in (
+        "get_vault_record",
+        "update_vault_record",
+        "create_vault_record",
+        "search_vault",
+    ):
+        assert tool not in excluded, f"{profile} lost {tool} — it cannot do its job"
+
+
+def test_main_keeps_channel_tools(tmp_path: Path):
+    """main IS the principal-facing chat. "Tell Alfred to post X to Slack" has
+    to keep working — this fix must not silence the surface Sir talks to."""
+    cfg = _render("main", tmp_path)
+    alfred = (cfg.get("mcp_servers") or {})["alfred"]
+    excluded = ((alfred.get("tools") or {}).get("exclude")) or []
+    for tool in CHANNEL_TOOLS:
+        assert tool not in excluded, f"main must retain {tool}"
+
+
+def test_user_facing_profiles_are_main_like(tmp_path: Path):
+    """A user-facing profile (cratchit et al.) is a conversational Alfred, so
+    it keeps channel tools — the exclusion targets unattended agents only."""
+    cfg = _render("cratchit", tmp_path, port="18794")
+    alfred = (cfg.get("mcp_servers") or {})["alfred"]
+    excluded = ((alfred.get("tools") or {}).get("exclude")) or []
+    for tool in CHANNEL_TOOLS:
+        assert tool not in excluded, f"user-facing profile must retain {tool}"

--- a/packages/mcp-server/src/tools/alfred.ts
+++ b/packages/mcp-server/src/tools/alfred.ts
@@ -184,7 +184,7 @@ const agentTools: ToolDef[] = [
   {
     name: "spawn_alfred_task",
     description:
-      "Hand a one-shot task to Sir's main Alfred agent and (by default) deliver his reply to his most-recent active channel (Slack/Telegram/etc). Use this when Sir asks claude.ai to 'tell Alfred to …' or when you want Alfred to DO something (run a skill, post a briefing, perform a workflow) rather than just compute it here. Under the hood: creates an openclaw cron job with `--at 1s --delete-after-run`, the job fires immediately, runs in an isolated main-agent session with Sir's full skill set + memory, then self-destroys. Returns 202 `{status: 'scheduled', name, channel, at_seconds, job}`. Set `announce: false` for silent background work that should NOT DM Sir. Set `channel` to a specific channel name to override 'last'. NOT idempotent — calling twice schedules two runs. Backing: docker exec openclaw cron add (the same path the in-CLI scheduler uses).",
+      "Hand a one-shot task to Sir's main Alfred agent. Use this when Sir asks claude.ai to 'tell Alfred to …' or when you want Alfred to DO something (run a skill, post a briefing, perform a workflow) rather than just compute it here. Under the hood: creates an openclaw cron job with `--at 1s --delete-after-run`, the job fires immediately, runs in an isolated main-agent session with Sir's full skill set + memory, then self-destroys. Returns 202 `{status: 'scheduled', name, channel, at_seconds, job}`. DELIVERY IS OPT-IN: by default the run is silent and Sir is NOT messaged — pass `announce: true` only when Sir asked for the result on a channel (#288: background callers relying on the old announce-by-default filled his Slack with worker failure dumps). Set `channel` to override 'last'. NOT idempotent — calling twice schedules two runs. Backing: docker exec openclaw cron add (the same path the in-CLI scheduler uses).",
     inputSchema: z.object({
       task: z.string().min(1).describe(
         "The prompt Alfred sees. Be explicit — Alfred won't see context from claude.ai. Include any skill names, vault paths, or recipients he needs.",
@@ -202,7 +202,7 @@ const agentTools: ToolDef[] = [
         "Cron job name; default `agent-task-<ts>-<rand>`. Override only when Sir wants the run identifiable in `openclaw cron list` output.",
       ),
       announce: z.boolean().optional().describe(
-        "Default true (Alfred posts his reply to `channel`). Set false for background work where Sir shouldn't be DMed.",
+        "Channel delivery. Default FALSE — the run happens but Sir is NOT messaged. Pass true ONLY when Sir has asked for the result to reach him on a channel (e.g. 'tell Alfred to post the briefing to Slack'). Never pass true from background/maintenance work: that is how vault-worker failure dumps ended up in Sir's Slack (#288).",
       ),
     }),
     buildRequest: (args) => ({

--- a/packages/web/public/mcp-skills/alfred-mcp.md
+++ b/packages/web/public/mcp-skills/alfred-mcp.md
@@ -27,7 +27,7 @@ The catalogue is intentionally narrow. Container restarts, credential rotation, 
 
 ### Agents (2) — delegate to Alfred
 
-- `spawn_alfred_task` — hand a one-shot prompt to Alfred main; he runs it and posts the reply to Sir's last channel
+- `spawn_alfred_task` — hand a one-shot prompt to Alfred main; he runs it silently unless you pass `announce: true`, which posts the reply to Sir's last channel
 - `list_agents` — show which OpenClaw agents are configured (main, learn-clerk, vault-curator, vault-janitor, vault-distiller)
 
 ### Workflows (4) — Temporal orchestration
@@ -160,9 +160,11 @@ Do NOT paste the raw search JSON to Sir. Summarise: "Three matters mention Acme 
 
 ### "Tell Alfred to deliver the briefing / run a skill / DM me the result"
 
-`spawn_alfred_task({task: "<explicit prompt for Alfred — name the skill, vault path, recipient>"})`.
+`spawn_alfred_task({task: "<explicit prompt for Alfred — name the skill, vault path, recipient>", announce: true})`.
 
-Alfred sees ONLY the prompt — claude.ai conversation context does NOT carry over. If you want Alfred to use a particular skill, name it explicitly: "deliver the morning briefing per the alfred-daily-briefing skill". If Sir wants a silent run (no DM back), pass `announce: false`.
+Alfred sees ONLY the prompt — claude.ai conversation context does NOT carry over. If you want Alfred to use a particular skill, name it explicitly: "deliver the morning briefing per the alfred-daily-briefing skill".
+
+**Delivery is opt-in.** Without `announce: true` the task runs silently and Sir is never messaged. Pass it only when Sir actually asked for the result to reach him on a channel — which is exactly the case in this section's heading. Leave it off for anything investigative or background: that default is what kept vault-worker failure dumps out of Sir's Slack (#288).
 
 ### "Kick off / check on a workflow"
 


### PR DESCRIPTION
Closes the leak in #288. Two independent layers, because one of them is a default — and defaults get flipped back.

## L1 — delivery is opt-in
`POST /api/v1/agents/main/task` defaulted `announce: true`. Right default for "tell Alfred to post the briefing", wrong for every background worker, and **nothing at that boundary can tell them apart**. The janitor's repair pipeline spawned one-shots through this route and dumped raw failure text into Sir's Slack — **13 deliveries in a day, 0 silent** — re-spawning each sweep because the repairs could never succeed.

`[SILENT] if nothing to report` cannot fix this. A failure always looks report-worthy, so **failures always deliver**. Silence-by-convention isn't silence.

**Why flipping the default is safe — I checked before changing it:**
| Caller | Passes `announce` explicitly? |
|---|---|
| `weekly_money_day.py` | ✅ `"announce": not preview_only` |
| `alfred-chore-authoring` template | ✅ same pattern |
| user-chores on home | n/a — none call this route |
| background one-shots | ❌ relied on the default — *this is the bug* |

Nothing legitimate goes silent.

## L2 — capability removal
`workers`/`heavy` run unattended agents. They keep the full vault read/write surface and lose `spawn_alfred_task` + `notify_principal` via Hermes' native `tools.exclude`. A background agent now **cannot** reach a channel even if it decides to.

`main` and user-facing profiles are untouched — "tell Alfred to post X to Slack" still works, which is the thing this fix must not break.

Belt *and* braces on purpose: L1 alone is one edit away from regressing; L2 alone wouldn't stop a main-profile agent improvising background work (which is exactly what the HA-polling and Tapo-research storms were).

## Not in this diff
L3 (janitor should PATCH via ctrl-api instead of delegating to main at all, plus the ~696k-char stage-3 prompt bug) and L4 (exempt `_templates`/`_docs` from enrichment). Those are alfred-vault-lane correctness/waste fixes. **The leak itself is closed by L1+L2**; the issue stays open for them.

## Smoke evidence

Tests render the **real** template per profile, so they fail if the guard is dropped or the tool list drifts:

```
tests/test_background_channel_authority.py                6/6 passed
  workers  excludes spawn_alfred_task + notify_principal
  heavy    excludes spawn_alfred_task + notify_principal
  workers/heavy still keep get/update/create_vault_record + search_vault
      (removing authority must not remove the ability to do the work)
  main            retains both  (the principal's own chat)
  cratchit        retains both  (user-facing profiles are main-like)

packages/hermes  150 passed, 5 failed
packages/mcp-server  tsc clean, tests 0 fail
```

**Honest note:** the 5 hermes failures are in `test_patch_upstream_hermes_auth.py` and are **pre-existing** — verified byte-identical with this change stashed. Not introduced here, not fixed here.

Post-deploy on home I'll confirm the rendered `workers`/`heavy` configs carry the exclusion and that main can still deliver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)