### PR TITLE
fix(ci): escape Markdown in titles before the Telegram notify [skip smoke gate]

### DIFF
--- a/.github/workflows/notify-telegram.yml
+++ b/.github/workflows/notify-telegram.yml
@@ -56,11 +56,18 @@ jobs:
             echo "::warning::ALFRED_CODE_BOT_TOKEN or ALFRED_CODE_CHAT_ID missing; skipping notify."
             exit 0
           fi
+          # Telegram's legacy Markdown parse mode treats _ * ` [ as formatting.
+          # A PR title like "serve the worker-run status_url ..." opens an
+          # italic run that never closes and the whole send 400s:
+          #   can't parse entities: Can't find end of the entity at byte 73
+          # The notification then fails on a perfectly good PR. Escape any
+          # user-authored text before it reaches the message body.
+          md_escape() { printf '%s' "$1" | sed 's/[][_*`]/\\&/g'; }
           case "$EVENT_NAME" in
             pull_request)
               action=$(echo "$EVENT" | jq -r '.action')
               num=$(echo "$EVENT" | jq -r '.pull_request.number')
-              title=$(echo "$EVENT" | jq -r '.pull_request.title')
+              title=$(md_escape "$(echo "$EVENT" | jq -r '.pull_request.title')")
               url=$(echo "$EVENT" | jq -r '.pull_request.html_url')
               merged=$(echo "$EVENT" | jq -r '.pull_request.merged // false')
               actor=$(echo "$EVENT" | jq -r '.sender.login')
@@ -78,7 +85,7 @@ jobs:
             issues)
               action=$(echo "$EVENT" | jq -r '.action')
               num=$(echo "$EVENT" | jq -r '.issue.number')
-              title=$(echo "$EVENT" | jq -r '.issue.title')
+              title=$(md_escape "$(echo "$EVENT" | jq -r '.issue.title')")
               url=$(echo "$EVENT" | jq -r '.issue.html_url')
               actor=$(echo "$EVENT" | jq -r '.sender.login')
               icon="📋"


### PR DESCRIPTION
Found while merging #355 — its own title broke the notifier.

## Problem
`notify-telegram` sends with `parse_mode=Markdown` and interpolates the raw GitHub title. Telegram's legacy Markdown treats `_ * ` [` as formatting, so any title containing one opens a run that never closes:

```
Telegram sendMessage failed: {"ok":false,"error_code":400,
 "description":"Bad Request: can't parse entities:
  Can't find end of the entity starting at byte offset 73"}
```

Byte 73 of PR #355's title is inside `status_url`. The result is a **red check on a perfectly healthy PR** — the kind of false signal that trains people to ignore CI.

## Fix
Escape the four special characters in user-authored titles only. The surrounding `*PR #N*` bold is ours and stays intentional.

## Smoke evidence

Against the title that actually broke it, and one using all four characters:
```
before: fix(ctrl): serve the worker-run status_url the trigger already advertises (#316)
after : fix(ctrl): serve the worker-run status\_url the trigger already advertises (#316)

before: feat: add [beta] *bold* and `code` and under_score
after : feat: add \[beta\] \*bold\* and \`code\` and under\_score
```

Lint, against the same file on `main`:
```
baseline SC2016 count: 2
mine     SC2016 count: 2
new finding kinds: none
YAML: parses
```

`[skip smoke gate]` — CI workflow change with no tenant surface; the evidence above is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)