### PR TITLE
feat(ctrl): probe the workers gateway before spending a delegation budget (#297)

### DIFF
--- a/packages/ctrl/src/api/routes/agents.ts
+++ b/packages/ctrl/src/api/routes/agents.ts
@@ -268,6 +268,43 @@ const DELEGATE_TIMEOUT_MS = (() => {
   return Number.isFinite(raw) && raw >= 10_000 ? raw : 300_000;
 })();
 
+/** Readiness-probe budget before a delegation commits the full timeout (#297).
+ *
+ *  Set to 0 to disable probing entirely — an escape hatch, so a flaky probe
+ *  can never become a new way to refuse work that would have succeeded.
+ */
+const DELEGATE_PROBE_TIMEOUT_MS = (() => {
+  const raw = Number(process.env.HERMES_DELEGATE_PROBE_TIMEOUT_MS ?? 3_000);
+  if (!Number.isFinite(raw) || raw < 0) return 3_000;
+  return raw === 0 ? 0 : Math.max(250, raw);
+})();
+
+/** Probe the workers gateway before spending a delegation budget on it.
+ *
+ *  An unhealthy gateway used to consume the ENTIRE request timeout per
+ *  attempt, and callers that fall back to a second delegation compounded
+ *  that minute by minute (#297). A sub-second probe converts "hang for the
+ *  full budget, then report a misleading error" into "refuse immediately and
+ *  say why".
+ *
+ *  Returns null when the gateway is ready, else a short human reason.
+ */
+async function probeWorkersGateway(): Promise<string | null> {
+  if (DELEGATE_PROBE_TIMEOUT_MS === 0) return null; // probing disabled
+  try {
+    const resp = await fetch(`${HERMES_WORKERS_GATEWAY_URL}/health`, {
+      signal: AbortSignal.timeout(DELEGATE_PROBE_TIMEOUT_MS),
+    });
+    if (!resp.ok) return `workers gateway /health returned ${resp.status}`;
+    return null;
+  } catch (err: any) {
+    const timedOut = err?.name === "TimeoutError" || err?.name === "AbortError";
+    return timedOut
+      ? `workers gateway /health did not answer within ${DELEGATE_PROBE_TIMEOUT_MS}ms`
+      : `workers gateway unreachable: ${String(err?.message ?? err).slice(0, 160)}`;
+  }
+}
+
 /** Read API_SERVER_KEY for the workers profile out of its rendered .env.
  *
  *  Same key-resolution pattern as channels_paperclip.ts /
@@ -747,6 +784,23 @@ export function registerAgentRoutes(): void {
         ok: false,
         error: "HERMES_WORKERS_KEY_MISSING",
         detail: `Hermes workers API key not found at ${HERMES_CONFIG_DIR}/workers/.env — has hermes-init run?`,
+      });
+      return;
+    }
+
+    // #297 — fail fast instead of burning the whole budget on a gateway that
+    // is not answering. Costs ~3ms on the happy path (measured on home);
+    // saves up to DELEGATE_TIMEOUT_MS per attempt when workers are down, and
+    // stops chained fallbacks compounding a minute each.
+    const unready = await probeWorkersGateway();
+    if (unready) {
+      sendJson(res, 503, {
+        ok: false,
+        error: "HERMES_WORKERS_UNAVAILABLE",
+        detail: `${unready}. Refused before dispatch — no delegation budget was spent and nothing was started on the gateway.`,
+        session_key: sessionKey,
+        probe_timeout_ms: DELEGATE_PROBE_TIMEOUT_MS,
+        retryable: true,
       });
       return;
     }

--- a/packages/ctrl/tests/agents_focused_subagent.test.ts
+++ b/packages/ctrl/tests/agents_focused_subagent.test.ts
@@ -48,8 +48,21 @@ let nextFetchResponse: { status: number; body: string } = {
   }),
 };
 
+// #297 added a readiness probe (GET <gateway>/health) before dispatch. Stub
+// it separately, so `nextFetchResponse` keeps meaning "what the DISPATCH
+// returns" — otherwise a test simulating a failed dispatch is intercepted by
+// the probe and never reaches the code under test. `lastFetchCall` also stays
+// the dispatch, so every existing assertion below is unaffected.
+let nextProbeStatus = 200;
 globalThis.fetch = (async (url: any, init?: any) => {
-  lastFetchCall = { url: String(url), init };
+  const target = String(url);
+  if (target.endsWith("/health")) {
+    return new Response("{}", {
+      status: nextProbeStatus,
+      headers: { "content-type": "application/json" },
+    });
+  }
+  lastFetchCall = { url: target, init };
   return new Response(nextFetchResponse.body, {
     status: nextFetchResponse.status,
     headers: { "content-type": "application/json" },
@@ -233,6 +246,67 @@ describe("POST /api/v1/agents/focused-subagent — happy path", () => {
     assert.equal(r.payload.ok, false);
     assert.equal(r.payload.error, "HERMES_WORKERS_ERROR");
     // Reset for the next test (mutable shared state).
+    nextFetchResponse = {
+      status: 200,
+      body: JSON.stringify({ output: [{ content: [{ text: "ok" }] }] }),
+    };
+  });
+  // ── #297 — health-aware fail-fast ────────────────────────────────────────
+  //
+  // An unhealthy gateway used to consume the ENTIRE delegation budget per
+  // attempt (300s after #325, 60s before it), and callers that fell back to a
+  // second delegation compounded that minute by minute. A sub-second probe
+  // turns that into an immediate, honest refusal.
+
+  it("refuses fast when the workers gateway is unhealthy, without dispatching", async () => {
+    nextProbeStatus = 503;
+    lastFetchCall = null;
+
+    const r = await invokeRoute("POST", "/api/v1/agents/focused-subagent", {
+      body: { task: "task", domain: "sure" },
+    });
+
+    assert.equal(r.status, 503);
+    assert.equal(r.payload.ok, false);
+    assert.equal(r.payload.error, "HERMES_WORKERS_UNAVAILABLE");
+    assert.equal(r.payload.retryable, true);
+    // The whole point: no budget spent, nothing started on the gateway.
+    assert.equal(lastFetchCall, null, "must not dispatch when the probe fails");
+    assert.match(String(r.payload.detail), /Refused before dispatch/);
+
+    nextProbeStatus = 200;
+  });
+
+  it("dispatches normally when the probe is healthy", async () => {
+    nextProbeStatus = 200;
+    lastFetchCall = null;
+
+    const r = await invokeRoute("POST", "/api/v1/agents/focused-subagent", {
+      body: { task: "task", domain: "sure" },
+    });
+
+    assert.equal(r.status, 200);
+    assert.ok(lastFetchCall, "a healthy probe must not block the dispatch");
+    assert.match(lastFetchCall!.url, /\/v1\/responses$/);
+  });
+
+  it("distinguishes an unhealthy gateway from a failed dispatch", async () => {
+    // Both are 5xx to the caller, but they mean different things and need
+    // different error codes — conflating them is what made #325 undiagnosable.
+    nextProbeStatus = 200;
+    nextFetchResponse = { status: 500, body: "internal explosion" };
+    const failed = await invokeRoute("POST", "/api/v1/agents/focused-subagent", {
+      body: { task: "task", domain: "sure" },
+    });
+    assert.equal(failed.payload.error, "HERMES_WORKERS_ERROR");
+
+    nextProbeStatus = 500;
+    const unavailable = await invokeRoute("POST", "/api/v1/agents/focused-subagent", {
+      body: { task: "task", domain: "sure" },
+    });
+    assert.equal(unavailable.payload.error, "HERMES_WORKERS_UNAVAILABLE");
+
+    nextProbeStatus = 200;
     nextFetchResponse = {
       status: 200,
       body: JSON.stringify({ output: [{ content: [{ text: "ok" }] }] }),


### PR DESCRIPTION
The fail-fast + readiness half of #297. Builds directly on #325 (already verified on home).

## Problem
An unhealthy gateway consumed the **entire** request timeout per attempt — 300s after #325, 60s before it — and a caller falling back to a second delegation compounded that minute by minute. The failure was also indistinct: "gateway is down" and "gateway ran your task and it failed" both looked like a 5xx after a long wait.

## Fix
A sub-second readiness probe before dispatch. On failure: **503 `HERMES_WORKERS_UNAVAILABLE`** immediately, stating no budget was spent and nothing was started.

Three now-distinct outcomes:
| Error | Means |
|---|---|
| `HERMES_WORKERS_UNAVAILABLE` (503) | probe failed — nothing dispatched, nothing started |
| `HERMES_WORKERS_ERROR` (5xx) | dispatch ran, gateway returned non-2xx |
| `HERMES_WORKERS_TIMEOUT` (504) | we ran out of budget; the run may still be executing |

Costs **~3ms** on the happy path — measured on home, where `/health` answered in 3ms while a delegation was burning 60s. `HERMES_DELEGATE_PROBE_TIMEOUT_MS` tunes it, and **`0` disables probing entirely** so a flaky probe can never become a new way to refuse work that would have succeeded.

## Harness change worth flagging
The existing stub returned `nextFetchResponse` for *every* fetch, so the new probe would have intercepted `"surfaces 502 when the workers gateway returns non-2xx"` — that test would have silently asserted against the probe instead of the dispatch. The stub now answers `/health` separately, which keeps `nextFetchResponse` meaning "what the dispatch returns" and leaves every existing assertion untouched.

## Scope — what this does NOT do
- **No queue-depth/saturation telemetry.** hermes `/health` returns only `{status, platform, version}`; there is no queue signal to surface. Claiming otherwise would be inventing data.
- **No durable delegation IDs, checkpointing or resume.** That is a larger design; the issue stays open for it.

## Smoke evidence

```
+3 tests in agents_focused_subagent.test.ts
  probe fails      -> 503 HERMES_WORKERS_UNAVAILABLE, retryable:true,
                      and lastFetchCall stays null (NEVER dispatched — the
                      actual point of the change)
  probe healthy    -> dispatch proceeds to /v1/responses unchanged
  unhealthy gateway vs failed dispatch -> different error codes
```

**Honest limitation:** I could not execute these locally — `esbuild` and `tsx` are both absent here, and there is still no `test-ctrl` job in CI (#290), so `packages/ctrl/tests/*` runs nowhere. CI's `build-ctrl` bundles the change; **live verification on home follows the deploy** and I'll post the output here — that is the same path that caught my #311 crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)