### PR TITLE
feat(learn): classify permanent HTTP failures so activities stop retrying forever (#296)

### DIFF
--- a/packages/learn/src/activities/session.py
+++ b/packages/learn/src/activities/session.py
@@ -8,7 +8,10 @@ from typing import Any
 
 from temporalio import activity
 
+import httpx
+
 from src.config import load_config
+from src.utils.retry_policy import raise_if_permanent
 from src.utils.vault_client import VaultClient
 
 
@@ -102,7 +105,16 @@ idle_minutes: 0
         for p in record_paths:
             content += f"- [[{p}]]\n"
 
-        path = await client.write_record("session", name, content)
+        try:
+            path = await client.write_record("session", name, content)
+        except httpx.HTTPStatusError as exc:
+            # A 4xx here means the session payload itself is rejected — most
+            # often 422 from the promotion contract. Retrying an invalid
+            # payload cannot make it valid: on home this activity reached
+            # attempt 7208 against the same 422, burning worker capacity and
+            # burying every other failure in the log (#296).
+            raise_if_permanent(exc, context="create_session write_record")
+            raise
         session["id"] = path
 
         # Assign records to session

--- a/packages/learn/src/activities/tasks.py
+++ b/packages/learn/src/activities/tasks.py
@@ -16,6 +16,7 @@ import httpx
 from temporalio import activity
 
 from src.config import load_config
+from src.utils.retry_policy import raise_if_permanent
 from src.utils.vault_client import VaultClient
 
 
@@ -136,7 +137,21 @@ async def check_task_prerequisites(task: dict[str, Any]) -> bool:
         client = VaultClient(config)
         try:
             for dep_path in depends_on:
-                dep = await client.read_record(dep_path)
+                try:
+                    dep = await client.read_record(dep_path)
+                except httpx.HTTPStatusError as exc:
+                    # A 404 here means the depends_on reference itself is
+                    # wrong — on home this was a raw "[[task/...]]" wikilink
+                    # that was never normalised into a path, and the activity
+                    # reached attempt 2387 against the same 404. The reference
+                    # can never resolve, so surface it as terminal instead of
+                    # retrying forever; a silent `return False` would hide the
+                    # data bug indefinitely (#296).
+                    raise_if_permanent(
+                        exc,
+                        context=f"check_task_prerequisites depends_on={dep_path!r}",
+                    )
+                    raise
                 if dep.get("status") != "done":
                     return False
         finally:

--- a/packages/learn/src/utils/retry_policy.py
+++ b/packages/learn/src/utils/retry_policy.py
@@ -1,0 +1,112 @@
+"""Shared transient-vs-permanent failure classification for activities (#296).
+
+Temporal retries an activity until its policy is exhausted. That is right for a
+transient failure and actively harmful for a permanent one: the same doomed
+call is re-made forever, burning worker capacity and burying genuinely new
+failures in the noise.
+
+Two live examples on home (2026-07-31), both still climbing when found:
+
+    create_session            attempt 7208   HTTP 422 on POST /vault/records
+    check_task_prerequisites  attempt 2387   HTTP 404 on a malformed
+                                             `[[task/...]]` wikilink path
+
+Neither can ever succeed. A 422 means the payload is invalid; a 404 on a
+malformed path means the path is wrong. Retrying either 7000 times changes
+nothing — it just makes the logs useless.
+
+This module centralises the judgement so activities don't each invent it, and
+so the rule can be corrected in one place. It deliberately does NOT wrap the
+HTTP client: several callers catch `httpx.HTTPStatusError` to handle a 404 as
+"record absent", and hijacking that globally would break them. Adoption is at
+the activity boundary, where the caller knows whether a status is meaningful.
+
+Mirrors the precedent set for clerk calls in #240 (`ApplicationError(...,
+non_retryable=True)`).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+from temporalio.exceptions import ApplicationError
+
+# Statuses that will never succeed on replay of the SAME request.
+# 404 is included deliberately: for these activities the path is derived from
+# stored data, so a miss means the data is wrong, not that the record is late.
+PERMANENT_STATUSES: frozenset[int] = frozenset(
+    {400, 401, 402, 403, 404, 405, 409, 410, 413, 422}
+)
+
+# Statuses that plausibly succeed later without the caller changing anything.
+TRANSIENT_STATUSES: frozenset[int] = frozenset({408, 425, 429, 500, 502, 503, 504})
+
+
+def classify_status(status: int | None) -> str:
+    """Return ``"permanent"``, ``"transient"`` or ``"unknown"``.
+
+    Unknown is the safe default: an unrecognised status keeps the existing
+    retry behaviour rather than inventing a terminal verdict.
+    """
+    if status is None:
+        return "unknown"
+    if status in PERMANENT_STATUSES:
+        return "permanent"
+    if status in TRANSIENT_STATUSES:
+        return "transient"
+    if 500 <= status <= 599:
+        return "transient"
+    if 400 <= status <= 499:
+        return "permanent"
+    return "unknown"
+
+
+def retry_after_ms(response: Any) -> int | None:
+    """Parse a ``Retry-After`` header (delta-seconds form) into milliseconds."""
+    try:
+        raw = response.headers.get("Retry-After")
+    except Exception:  # noqa: BLE001 — header access on a non-response
+        return None
+    if not raw:
+        return None
+    try:
+        seconds = float(str(raw).strip())
+    except (TypeError, ValueError):
+        return None  # HTTP-date form: not worth parsing for a retry hint
+    if seconds < 0:
+        return None
+    return int(seconds * 1000)
+
+
+def raise_if_permanent(exc: BaseException, *, context: str) -> None:
+    """Re-raise a permanent HTTP failure as a non-retryable ApplicationError.
+
+    Returns normally when the failure is transient or unclassifiable, so the
+    caller can let Temporal's existing policy handle it.
+
+    ``context`` names the operation in the surfaced error, because the whole
+    point is that an operator reading the log can tell WHAT stopped and why.
+    """
+    response = getattr(exc, "response", None)
+    status = getattr(response, "status_code", None)
+    if classify_status(status) != "permanent":
+        return
+
+    detail = str(exc)[:300]
+    raise ApplicationError(
+        f"{context}: HTTP {status} is permanent — not retrying. {detail}",
+        type="PermanentHttpError",
+        non_retryable=True,
+    ) from exc
+
+
+def is_transient(exc: BaseException) -> bool:
+    """True when ``exc`` is worth retrying.
+
+    Transport-level errors (connect/read/timeout) are transient by nature —
+    they say nothing about whether the request itself is valid.
+    """
+    if isinstance(exc, (httpx.TimeoutException, httpx.TransportError)):
+        return True
+    status = getattr(getattr(exc, "response", None), "status_code", None)
+    return classify_status(status) == "transient"

--- a/packages/learn/tests/test_retry_policy.py
+++ b/packages/learn/tests/test_retry_policy.py
@@ -1,0 +1,107 @@
+"""Transient-vs-permanent classification (#296).
+
+Temporal retries until the policy is exhausted, which is right for a transient
+failure and harmful for a permanent one. Two activities on home were still
+climbing when found:
+
+    create_session            attempt 7208   HTTP 422 on POST /vault/records
+    check_task_prerequisites  attempt 2387   HTTP 404 on a malformed
+                                             `[[task/...]]` wikilink path
+
+Neither could ever succeed.
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+from temporalio.exceptions import ApplicationError
+
+from src.utils.retry_policy import (
+    classify_status,
+    is_transient,
+    raise_if_permanent,
+    retry_after_ms,
+)
+
+
+def _http_error(status: int, headers: dict | None = None) -> httpx.HTTPStatusError:
+    req = httpx.Request("POST", "http://ctrl-api/api/v1/vault/records")
+    resp = httpx.Response(status, request=req, headers=headers or {})
+    return httpx.HTTPStatusError(f"{status}", request=req, response=resp)
+
+
+class TestClassifyStatus:
+    @pytest.mark.parametrize("status", [400, 401, 403, 404, 409, 413, 422])
+    def test_client_errors_are_permanent(self, status):
+        assert classify_status(status) == "permanent"
+
+    @pytest.mark.parametrize("status", [408, 429, 500, 502, 503, 504])
+    def test_retryable_statuses_are_transient(self, status):
+        assert classify_status(status) == "transient"
+
+    def test_429_is_transient_not_permanent(self):
+        """Rate limiting is the classic 4xx that IS worth retrying."""
+        assert classify_status(429) == "transient"
+
+    def test_408_is_transient_not_permanent(self):
+        assert classify_status(408) == "transient"
+
+    @pytest.mark.parametrize("status", [None, 200, 201, 304])
+    def test_non_failures_are_not_permanent(self, status):
+        assert classify_status(status) != "permanent"
+
+    def test_unknown_status_defaults_to_unknown(self):
+        """An unrecognised status must not invent a terminal verdict —
+        unknown keeps the caller's existing retry behaviour."""
+        assert classify_status(None) == "unknown"
+        assert classify_status(600) == "unknown"
+
+
+class TestRaiseIfPermanent:
+    def test_permanent_becomes_non_retryable(self):
+        with pytest.raises(ApplicationError) as caught:
+            raise_if_permanent(_http_error(422), context="create_session")
+        err = caught.value
+        assert err.non_retryable is True
+        assert err.type == "PermanentHttpError"
+        assert "422" in str(err)
+        assert "create_session" in str(err), "the operation must be named in the error"
+
+    def test_404_is_permanent(self):
+        """The check_task_prerequisites case: a malformed dependency path."""
+        with pytest.raises(ApplicationError):
+            raise_if_permanent(_http_error(404), context="check_task_prerequisites")
+
+    @pytest.mark.parametrize("status", [429, 500, 502, 503, 504])
+    def test_transient_is_left_alone(self, status):
+        """Returns normally so Temporal's existing policy still retries."""
+        raise_if_permanent(_http_error(status), context="x")
+
+    def test_non_http_error_is_left_alone(self):
+        raise_if_permanent(RuntimeError("something else"), context="x")
+
+
+class TestIsTransient:
+    def test_timeouts_are_transient(self):
+        assert is_transient(httpx.ReadTimeout("timed out")) is True
+
+    def test_transport_errors_are_transient(self):
+        assert is_transient(httpx.ConnectError("refused")) is True
+
+    def test_422_is_not_transient(self):
+        assert is_transient(_http_error(422)) is False
+
+
+class TestRetryAfter:
+    def test_parses_delta_seconds(self):
+        assert retry_after_ms(_http_error(429, {"Retry-After": "30"}).response) == 30_000
+
+    def test_missing_header_is_none(self):
+        assert retry_after_ms(_http_error(429).response) is None
+
+    def test_http_date_form_is_ignored_not_crashed(self):
+        resp = _http_error(429, {"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"}).response
+        assert retry_after_ms(resp) is None
+
+    def test_negative_is_ignored(self):
+        assert retry_after_ms(_http_error(429, {"Retry-After": "-5"}).response) is None


### PR DESCRIPTION
The classification core of #296, grounded in two loops running live on home rather than in an abstraction.

## Evidence
Found while verifying an unrelated deploy — both still climbing:
```
create_session            attempt 7208   HTTP 422 on POST /vault/records   (since 2026-07-22)
check_task_prerequisites  attempt 2387   HTTP 404 on "[[task/...]]" path   (since 2026-07-28)
```
Neither can ever succeed. A 422 means the payload is invalid; a 404 on a malformed wikilink means the reference is wrong. **7208 attempts changed nothing except making the log useless** — which is precisely how the second one survived 2387 attempts unnoticed.

## Fix
`src/utils/retry_policy.py` centralises the judgement: permanent vs transient status sets, `Retry-After` parsing, and `raise_if_permanent()` re-raising as `ApplicationError(non_retryable=True)` — mirroring the clerk precedent from #240.

Design choices worth reviewing:
- **Unknown statuses stay "unknown"** and keep existing retry behaviour. The helper never invents a terminal verdict.
- **429 and 408 are transient**, not permanent — the 4xx that genuinely are worth retrying.
- **`check_task_prerequisites` surfaces rather than swallows.** Returning `False` for a missing dependency would have been easier and would have hidden the malformed reference forever.
- **Deliberately NOT wrapped around `VaultClient`.** Several callers catch `httpx.HTTPStatusError` to treat 404 as "record absent"; a global hook would break them. Adoption is at the activity boundary, where the caller knows whether a status is meaningful.

## Not in this diff — issue stays open
Automatic pagination/narrowing for oversized reads, partial fan-out preservation, and structured circuit-breaker / `continuation` / `partial_results` metadata. Those are real work, not a minimum-diff fix, and pretending otherwise would misrepresent the issue's state.

## Smoke evidence

```
tests/test_retry_policy.py                     35/35 passed
  400/401/403/404/409/413/422 -> permanent
  408/429/500/502/503/504     -> transient   (the 4xx that ARE retryable)
  unknown/None                -> "unknown", retry behaviour unchanged
  permanent -> ApplicationError(non_retryable=True, type=PermanentHttpError)
               with the operation named in the message
  transient -> returns normally, Temporal still retries
  non-HTTP errors             -> untouched
  transport errors/timeouts   -> transient
  Retry-After: "30" -> 30000ms; HTTP-date and negative -> ignored, not crashed

full learn suite                               2390 passed
```

**On one flaky result:** an earlier full-suite run showed a single failure in `test_files_cold_archive.py` with a GraalVM resource trace. It passes in isolation and on a clean re-run of the full suite, both with and without this change — flaky, not caused here. Flagging rather than quietly re-running until green.

Post-merge I'll confirm on home that the `create_session` and `check_task_prerequisites` attempt counters stop climbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)