### PR TITLE
fix(learn): kill the permanent-422 wedge class (#364) + un-wedge the task runner (#367)

### DIFF
--- a/packages/learn/scripts/register_schedules.py
+++ b/packages/learn/scripts/register_schedules.py
@@ -169,11 +169,6 @@ INTERVAL_SCHEDULES = [
         "interval": timedelta(minutes=15),
     },
     {
-        "id": "al-session-tracker",
-        "workflow": "SessionTrackerWorkflow",
-        "interval": timedelta(minutes=15),
-    },
-    {
         "id": "al-learning",
         "workflow": "LearningWorkflow",
         "interval": timedelta(minutes=15),

--- a/packages/learn/src/activities/tasks.py
+++ b/packages/learn/src/activities/tasks.py
@@ -17,6 +17,7 @@ from temporalio import activity
 
 from src.config import load_config
 from src.utils.retry_policy import raise_if_permanent
+from src.utils.state_client import StateClient
 from src.utils.vault_client import VaultClient
 
 
@@ -137,6 +138,7 @@ async def check_task_prerequisites(task: dict[str, Any]) -> bool:
         client = VaultClient(config)
         try:
             for dep_path in depends_on:
+                dep_path = _normalize_record_path(dep_path)
                 try:
                     dep = await client.read_record(dep_path)
                 except httpx.HTTPStatusError as exc:
@@ -450,6 +452,24 @@ async def complete_task(task: dict[str, Any], result: dict[str, Any]) -> None:
         await client.close()
 
 
+def _normalize_record_path(ref: str) -> str:
+    """Normalize a relationship reference to a bare vault record path.
+
+    Vault authors (and Obsidian itself) write relationships as wikilinks —
+    ``[[task/foo]]`` or ``[[task/foo|Alias]]`` — which is the vault's own
+    documented convention. Readers must strip that syntax before using the
+    value as an API path: on home a raw wikilink in ``depends_on`` produced
+    ``GET /vault/records/%5B%5Btask/...%5D%5D`` → 404 on every attempt and
+    wedged the al-task-runner schedule for 3 days (#367).
+    """
+    ref = str(ref).strip()
+    if ref.startswith("[[") and ref.endswith("]]"):
+        ref = ref[2:-2].split("|", 1)[0].strip()
+    if ref and "/" in ref and not ref.endswith(".md"):
+        ref += ".md"
+    return ref
+
+
 def _sanitize_yaml_scalar(value: str) -> str:
     """Escape a string for safe use inside a quoted YAML scalar.
 
@@ -472,40 +492,27 @@ async def write_ledger_entry(
     """Write a ledger entry to vault recording task completion.
 
     Ledger entries are the completion record — what was done, by whom,
-    and what it affected.
+    and what it affected. They are machine bookkeeping, not something the
+    principal reads in the vault: ``ledger_entry`` was never a canonical
+    vault type, so the old vault write was a guaranteed promotion-contract
+    422 on every attempt (#364, the same class that wedged session-tracker
+    for 9 days). Demoted to the audit table per CLAUDE.md §5.1.
 
-    Returns the created ledger entry path.
+    Returns the created audit row id.
     """
     config = load_config()
-    client = VaultClient(config)
+    client = StateClient(config)
     try:
-        from src.activities.vault import vault_record_path, slugify
-
-        now = datetime.now(timezone.utc)
-        title = _sanitize_yaml_scalar(
-            task.get("title", task.get("name", "Untitled Task"))
+        title = task.get("title", task.get("name", "Untitled Task"))
+        return await client.append_audit(
+            action_type="task-completed",
+            actor="alfred",
+            summary=f"Completed: {title} — {result.get('summary', 'No summary')}",
+            source="task_runner.write_ledger_entry",
+            target_path=task.get("path") or None,
+            target_kind="task",
+            subject_ref=task.get("matter", task.get("initiative", "")) or None,
         )
-        matter = task.get("matter", task.get("initiative", ""))
-        summary = _sanitize_yaml_scalar(result.get("summary", "No summary"))
-
-        content = f"""---
-type: ledger_entry
-title: "Completed: {title}"
-source_task: "{task.get('path', '')}"
-matter: "{matter}"
-summary: "{summary}"
-entities_affected: []
-created: "{now.isoformat()}"
-tags: [consequential]
----
-
-# Completed: {title}
-
-{summary}
-"""
-        name = vault_record_path("ledger_entry", slugify(f"completed-{title}"), now)
-        path = await client.write_record("ledger_entry", name, content)
-        return path
     finally:
         await client.close()
 
@@ -600,12 +607,15 @@ async def evaluate_consequentials(
 
             content = f"""---
 type: task
-status: queued
+status: todo
+state: pending
 title: "{fu_title}"
 owner: "{owner}"
 tier: 2
 source_task: "{task.get('path', '')}"
 matter: "{matter}"
+parent_matter: "{matter}"
+matter_ref: "{matter}"
 created: "{now.isoformat()}"
 created_by: consequential
 priority: medium

--- a/packages/learn/src/worker.py
+++ b/packages/learn/src/worker.py
@@ -13,7 +13,6 @@ from src.config import load_config
 
 # Workflows
 from src.workflows.event_processor import EventProcessorWorkflow
-from src.workflows.session_tracker import SessionTrackerWorkflow
 from src.workflows.learning import LearningWorkflow
 from src.workflows.reflection import ReflectionWorkflow
 from src.workflows.judgment import JudgmentWorkflow
@@ -216,16 +215,10 @@ from src.activities.classify import (
     extract_metadata,
 )
 
-# Activities — session
-from src.activities.session import (
-    append_to_session,
-    close_session,
-    create_session,
-    detect_session_boundaries,
-    fetch_recent_records,
-    read_session_state,
-    write_session_state,
-)
+# #364: the session activity module was deleted along with
+# SessionTrackerWorkflow — "session" was never a canonical vault type, so
+# create_session 422'd on every attempt since day one and nothing consumes
+# session records.
 
 # Activities — notify
 from src.activities.notify import notify_digest_ready, notify_eod_prompt, escalate_to_user
@@ -778,7 +771,6 @@ def _spawn_workflow_audit(event: dict[str, str]) -> None:
 
 _STATIC_WORKFLOWS = [
     EventProcessorWorkflow,
-    SessionTrackerWorkflow,
     LearningWorkflow,
     ReflectionWorkflow,
     JudgmentWorkflow,
@@ -906,14 +898,6 @@ ALL_ACTIVITIES = [
     # Classify
     classify_event,
     extract_metadata,
-    # Session
-    append_to_session,
-    close_session,
-    create_session,
-    detect_session_boundaries,
-    fetch_recent_records,
-    read_session_state,
-    write_session_state,
     # Notify
     notify_digest_ready,
     notify_eod_prompt,

--- a/packages/learn/src/workflows/task_runner.py
+++ b/packages/learn/src/workflows/task_runner.py
@@ -55,25 +55,32 @@ class TaskRunnerWorkflow:
         for task in tasks[:5]:
             task_path = task.get("path", "unknown")
 
-            # 2. Check prerequisites
-            ready: bool = await workflow.execute_activity(
-                check_task_prerequisites,
-                args=[task],
-                start_to_close_timeout=timedelta(seconds=15),
-            )
-
-            if not ready:
-                result.skipped += 1
-                continue
-
-            # 3. Mark active
-            await workflow.execute_activity(
-                update_task_status,
-                args=[task, "active"],
-                start_to_close_timeout=timedelta(seconds=15),
-            )
-
+            # Steps 2-8 all live inside one try so a single poisoned task
+            # (e.g. a depends_on reference that can never resolve) marks
+            # THAT task failed and the loop moves on. Before #367, steps
+            # 2-3 sat outside the try: one bad task failed the whole run,
+            # and with the schedule's SKIP overlap policy a permanently
+            # failing task wedged the entire runner for days (322 skipped
+            # ticks on home).
             try:
+                # 2. Check prerequisites
+                ready: bool = await workflow.execute_activity(
+                    check_task_prerequisites,
+                    args=[task],
+                    start_to_close_timeout=timedelta(seconds=15),
+                )
+
+                if not ready:
+                    result.skipped += 1
+                    continue
+
+                # 3. Mark active
+                await workflow.execute_activity(
+                    update_task_status,
+                    args=[task, "active"],
+                    start_to_close_timeout=timedelta(seconds=15),
+                )
+
                 # 4. Assemble context
                 context: str = await workflow.execute_activity(
                     assemble_task_context,
@@ -116,12 +123,20 @@ class TaskRunnerWorkflow:
                 result.executed += 1
 
             except Exception:
-                # Mark task as blocked on failure
-                await workflow.execute_activity(
-                    update_task_status,
-                    args=[task, "blocked"],
-                    start_to_close_timeout=timedelta(seconds=15),
-                )
+                # Mark task as blocked on failure. Best-effort with a
+                # bounded retry: if even this write fails, count the
+                # failure and move on rather than wedging the run.
+                try:
+                    await workflow.execute_activity(
+                        update_task_status,
+                        args=[task, "blocked"],
+                        start_to_close_timeout=timedelta(seconds=15),
+                        retry_policy=RetryPolicy(maximum_attempts=3),
+                    )
+                except Exception:
+                    workflow.logger.warning(
+                        "task_runner: could not mark %s blocked", task_path
+                    )
                 result.failed += 1
 
         return result

--- a/packages/learn/tests/test_task_pipeline_364_367.py
+++ b/packages/learn/tests/test_task_pipeline_364_367.py
@@ -1,0 +1,172 @@
+"""Regression tests for the task-pipeline P0 pair (#364 + #367).
+
+Live incident (home, 2026-07): a `depends_on` entry stored as the raw
+wikilink ``[[task/repair-alfred-code-delivery-control-plane]]`` was used as
+a literal API path — 404 on every attempt, and because the activity call
+sat outside any try/except with a SKIP-overlap schedule, one bad task
+wedged the whole al-task-runner schedule for 3 days (322 skipped ticks).
+
+Second half (#364): ``write_ledger_entry`` wrote vault type
+``ledger_entry`` — never a canonical type, so every write was a guaranteed
+promotion-contract 422 (the same class that wedged session-tracker for 9
+days at 7,731 attempts). It now lands in the audit table.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from src.activities import tasks as tasks_mod
+from src.activities.tasks import _normalize_record_path
+
+
+class TestNormalizeRecordPath:
+    def test_strips_wikilink(self):
+        assert (
+            _normalize_record_path("[[task/repair-alfred-code-delivery-control-plane]]")
+            == "task/repair-alfred-code-delivery-control-plane.md"
+        )
+
+    def test_strips_wikilink_alias(self):
+        assert _normalize_record_path("[[task/foo|The Foo Task]]") == "task/foo.md"
+
+    def test_plain_path_gains_md(self):
+        assert _normalize_record_path("task/foo") == "task/foo.md"
+
+    def test_md_path_untouched(self):
+        assert _normalize_record_path("task/foo.md") == "task/foo.md"
+
+    def test_non_path_string_untouched(self):
+        # A bare slug without a slash is left alone — we only know how to
+        # complete type-prefixed vault paths.
+        assert _normalize_record_path("just-a-slug") == "just-a-slug"
+
+    def test_whitespace_stripped(self):
+        assert _normalize_record_path("  [[task/foo]]  ") == "task/foo.md"
+
+
+class _FakeVaultClient:
+    """Captures reads/writes; serves canned records by path."""
+
+    def __init__(self, records: dict[str, dict] | None = None) -> None:
+        self.records = records or {}
+        self.read_paths: list[str] = []
+        self.writes: list[tuple[str, str, str]] = []
+
+    async def read_record(self, path: str) -> dict:
+        self.read_paths.append(path)
+        try:
+            return self.records[path]
+        except KeyError:
+            import httpx
+
+            req = httpx.Request("GET", f"http://ctrl-api/api/v1/vault/records/{path}")
+            resp = httpx.Response(404, request=req)
+            raise httpx.HTTPStatusError("404", request=req, response=resp)
+
+    async def list_records(self, *_a, **_k) -> list:
+        return []
+
+    async def write_record(self, rtype: str, name: str, content: str) -> str:
+        self.writes.append((rtype, name, content))
+        return name
+
+    async def close(self) -> None:
+        return None
+
+
+class _FakeStateClient:
+    def __init__(self, *_a, **_k) -> None:
+        self.audits: list[dict] = []
+
+    async def append_audit(self, **kwargs) -> str:
+        self.audits.append(kwargs)
+        return "01AUDIT"
+
+    async def close(self) -> None:
+        return None
+
+
+class TestCheckTaskPrerequisites:
+    def test_wikilink_dependency_resolves(self, monkeypatch):
+        """The exact live failure shape: wikilink dep, record exists at the
+        normalized path. Old code 404'd forever; new code resolves it."""
+        fake = _FakeVaultClient(
+            records={"task/repair-alfred-code-delivery-control-plane.md": {"status": "done"}}
+        )
+        monkeypatch.setattr(tasks_mod, "VaultClient", lambda _cfg: fake)
+        ready = asyncio.run(
+            tasks_mod.check_task_prerequisites(
+                {"depends_on": ["[[task/repair-alfred-code-delivery-control-plane]]"]}
+            )
+        )
+        assert ready is True
+        assert fake.read_paths == ["task/repair-alfred-code-delivery-control-plane.md"]
+
+    def test_unfinished_dependency_not_ready(self, monkeypatch):
+        fake = _FakeVaultClient(records={"task/dep.md": {"status": "todo"}})
+        monkeypatch.setattr(tasks_mod, "VaultClient", lambda _cfg: fake)
+        ready = asyncio.run(
+            tasks_mod.check_task_prerequisites({"depends_on": ["[[task/dep]]"]})
+        )
+        assert ready is False
+
+
+class TestWriteLedgerEntry:
+    def test_lands_in_audit_not_vault(self, monkeypatch):
+        """#364: ledger entries are machine bookkeeping → audit table.
+        The old vault write could never succeed (non-canonical type)."""
+        fake_state = _FakeStateClient()
+        fake_vault = _FakeVaultClient()
+        monkeypatch.setattr(tasks_mod, "StateClient", lambda _cfg: fake_state)
+        monkeypatch.setattr(tasks_mod, "VaultClient", lambda _cfg: fake_vault)
+
+        audit_id = asyncio.run(
+            tasks_mod.write_ledger_entry(
+                {"title": "Fix the gutters", "path": "task/fix-the-gutters.md",
+                 "matter": "matter/house.md"},
+                {"summary": "Gutters fixed."},
+            )
+        )
+
+        assert audit_id == "01AUDIT"
+        assert fake_vault.writes == [], "must not touch the vault"
+        (audit,) = fake_state.audits
+        assert audit["action_type"] == "task-completed"
+        assert audit["target_kind"] == "task"
+        assert audit["target_path"] == "task/fix-the-gutters.md"
+        assert "Fix the gutters" in audit["summary"]
+        assert "Gutters fixed." in audit["summary"]
+
+
+class TestConsequentialFollowUpShape:
+    def test_follow_up_task_has_validator_safe_shape(self, monkeypatch):
+        """§15.2: status 'queued' is validator-rejected; writers must set
+        BOTH status and state, plus parent_matter/matter_ref linkage."""
+        fake_state = _FakeStateClient()
+        fake_vault = _FakeVaultClient()
+        monkeypatch.setattr(tasks_mod, "StateClient", lambda _cfg: fake_state)
+        monkeypatch.setattr(tasks_mod, "VaultClient", lambda _cfg: fake_vault)
+
+        created = asyncio.run(
+            tasks_mod.evaluate_consequentials(
+                {"title": "Parent", "path": "task/parent.md", "matter": ""},
+                {
+                    "summary": "done",
+                    "follow_up_tasks": [
+                        {"title": "Call the plumber", "owner": "human", "reason": "leak"}
+                    ],
+                },
+            )
+        )
+
+        assert len(created) == 1
+        task_writes = [w for w in fake_vault.writes if w[0] == "task"]
+        assert len(task_writes) == 1
+        content = task_writes[0][2]
+        assert "status: todo" in content
+        assert "state: pending" in content
+        assert "status: queued" not in content
+        assert "parent_matter:" in content
+        assert "matter_ref:" in content


### PR DESCRIPTION
Closes #364. Closes #367.

## What
Two interlocked P0s from the 2026-07-31 learn deep-inspect, one deploy cycle (per the interlock note on both issues — fixing #367 alone would un-dam the pipeline straight into #364's latent ledger_entry 422).

**#364 — non-canonical vault writes:**
- `SessionTrackerWorkflow` deleted entirely (workflow, `activities/session.py`, worker registration, `al-session-tracker` schedule seed). `session` was never a canonical type → `create_session` 422'd on every attempt since day one (attempt 7,731 / 9-day wedge on home); nothing consumes session records.
- `write_ledger_entry` → `StateClient.append_audit(action_type="task-completed", …)`. Activity name/signature preserved; ledger entries are machine bookkeeping per §5.1.

**#367 — task-runner wedge:**
- `_normalize_record_path()`: strips `[[…|alias]]` wikilink syntax + completes `.md` before `depends_on` refs hit the API (the live 404-forever shape).
- Per-task isolation: steps 2–8 in one try/except; poisoned task → marked `blocked` (bounded, best-effort) → loop continues. No more 322-skipped-tick wedges.
- Consequential follow-ups: `status: queued`→`todo` + `state: pending` + `parent_matter`/`matter_ref` (the #366 spec-addition, same file).

## Temporal determinism
No renames, no signature changes, no new activity types in existing replay paths. Try-scope change leaves the happy-path command sequence identical; the only histories that would diverge are already-closed failed runs. Zero in-flight `al-task-runner`/`al-session-tracker` runs (both wedged runs failed terminal under #296 on 2026-07-31; schedules currently produce short-lived runs only).

## Post-deploy steps on home (manual, documented here)
1. `docker compose pull alfred-learn && docker compose up -d alfred-learn`
2. `temporal schedule delete --schedule-id al-session-tracker` (seed no longer creates it; existing tenants carry it until deleted)

## Smoke evidence
- Local: `pytest tests/` → **2426 passed**, 0 regressions (4 pre-existing local-env failures: missing `pypdf`/`fastapi` modules, reproduce with this diff stashed; pass in the CI image).
- New regression tests (10): wikilink normalization incl. the exact live failure string; write_ledger_entry lands in audit and *must not touch the vault*; follow-up shape validator-safe.
- Live smoke on home after deploy (will comment results on #364/#367): al-task-runner completes a tick with the malformed task present; no 422s in learn logs; audit row visible via `GET /api/v1/state/audit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)