### PR TITLE
fix(learn): migrate chore/task LLM calls to Hermes-native /v1/responses (#366)

### DIFF
--- a/packages/learn/src/activities/chore_actions.py
+++ b/packages/learn/src/activities/chore_actions.py
@@ -551,109 +551,33 @@ async def _workers_spawn_subagent(
     run_timeout_s: int = 240,
     poll_timeout_s: int = 300,
 ) -> str:
-    """Spawn an openclaw-workers subagent and return the assistant's final text.
+    """Run a workers-gateway subagent and return the assistant's final text.
 
-    Hits config.execution_gateway_url (workers, :18790) — NOT the main openclaw
-    gateway — because chore LLM calls are pinned to workers per project
-    policy. Uses the existing sessions_spawn → sessions_history polling
-    pattern from _call_clerk, adapted for the workers endpoint.
+    #366: previously sessions_spawn + sessions_history against the retired
+    OpenClaw ``/tools/invoke`` envelope — a 404 on Hermes, which silently
+    killed the LLM-judgement step in 10 of 13 live user-chores. Now a
+    single Hermes-native call via ``_call_clerk`` (workers gateway,
+    heartbeats while in flight, billing/auth failures classified
+    non-retryable).
 
-    Returns the assistant's most recent text message, empty string on
-    timeout or failure. Caller is responsible for JSON-parsing if needed.
+    ``run_timeout_s`` / ``poll_timeout_s`` are retained for caller
+    signature compatibility; the completion budget is _call_clerk's.
+
+    Returns the assistant's final text, empty string on failure —
+    the contract every chore caller already handles. Failures are logged
+    at warning so a dead gateway is visible in the worker log.
     """
-    import asyncio
+    from src.activities.clerk import _call_clerk
 
-    config = load_config()
-    token = config.gateway_token()
-    base = config.execution_gateway_url.rstrip("/")
-    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
-
-    session_key: str | None = None
-    async with httpx.AsyncClient(timeout=60.0) as client:
-        spawn_resp = await client.post(
-            f"{base}/tools/invoke",
-            headers=headers,
-            json={
-                "tool": "sessions_spawn",
-                "args": {
-                    "task": prompt,
-                    "agentId": agent_id,
-                    "mode": "run",
-                    "cleanup": "auto",
-                    "sandbox": "inherit",
-                    "runTimeoutSeconds": run_timeout_s,
-                    "expectsCompletionMessage": False,
-                },
-            },
-        )
-        spawn_resp.raise_for_status()
-        spawn_data = spawn_resp.json()
-
-        for item in spawn_data.get("result", {}).get("content", []):
-            if isinstance(item, dict) and item.get("type") == "text":
-                try:
-                    session_key = json.loads(item["text"]).get("childSessionKey")
-                except (json.JSONDecodeError, KeyError):
-                    pass
-
-    if not session_key:
+    _ = (run_timeout_s, poll_timeout_s)  # legacy knobs, budget lives in clerk
+    try:
+        text = await _call_clerk(prompt, raw=True, agent_id=agent_id)
+    except Exception as exc:
         activity.logger.warning(
-            "_workers_spawn_subagent: no childSessionKey from spawn (agent=%s)", agent_id
+            "_workers_spawn_subagent: clerk call failed (agent=%s): %s", agent_id, exc
         )
         return ""
-
-    # Poll sessions_history for the assistant reply.
-    deadline = asyncio.get_event_loop().time() + poll_timeout_s
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        while asyncio.get_event_loop().time() < deadline:
-            activity.heartbeat(f"polling {agent_id} session {session_key[:8]}")
-            await asyncio.sleep(8)
-            try:
-                hist_resp = await client.post(
-                    f"{base}/tools/invoke",
-                    headers=headers,
-                    json={
-                        "tool": "sessions_history",
-                        "args": {"sessionKey": session_key, "limit": 6},
-                    },
-                )
-                if hist_resp.status_code != 200:
-                    continue
-                hist = hist_resp.json()
-            except Exception:
-                continue
-
-            messages: list[dict[str, Any]] = []
-            for item in hist.get("result", {}).get("content", []):
-                if isinstance(item, dict) and item.get("type") == "text":
-                    try:
-                        parsed = json.loads(item["text"])
-                        messages = parsed.get("messages", [])
-                    except (json.JSONDecodeError, TypeError):
-                        pass
-
-            # Latest assistant message wins. Skip user/system turns.
-            for msg in reversed(messages):
-                if msg.get("role") != "assistant":
-                    continue
-                content = msg.get("content", "")
-                if isinstance(content, str) and content.strip():
-                    return content
-                if isinstance(content, list):
-                    parts = [
-                        p.get("text", "")
-                        for p in content
-                        if isinstance(p, dict) and p.get("type") == "text"
-                    ]
-                    joined = "\n".join(t for t in parts if t).strip()
-                    if joined:
-                        return joined
-                break  # only look at the most recent assistant msg
-
-    activity.logger.warning(
-        "_workers_spawn_subagent: timed out after %ds (agent=%s)", poll_timeout_s, agent_id
-    )
-    return ""
+    return text if isinstance(text, str) else ""
 
 
 def _strip_code_fence(text: str) -> str:

--- a/packages/learn/src/activities/tasks.py
+++ b/packages/learn/src/activities/tasks.py
@@ -245,23 +245,14 @@ async def assemble_task_context(task: dict[str, Any]) -> str:
 
 @activity.defn
 async def execute_task(task: dict[str, Any], context: str) -> dict[str, Any]:
-    """Execute a task via OpenClaw sessions_spawn.
+    """Execute a task via a Hermes workers-gateway run (#366).
 
-    Spawns a subagent with the assembled context + task instructions.
-    Polls sessions_history for the result.
+    Runs the assembled context + task instructions through _call_clerk
+    (POST /v1/responses on :18790) and parses the final JSON message.
     Returns the execution result including any artifacts.
     """
     config = load_config()
-    token = config.gateway_token()
-    # execute_task spawns ephemeral / clerk-like subagents — routed to the
-    # WORKERS gateway (:18790). The main gateway is reserved for
-    # agentId=main (user-facing Alfred chat).
-    base = config.openclaw_workers_gateway_url
-    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
-
     agent_id = task.get("agent_id", config.clerk_agent_id)
-    tier = task.get("tier", 2)
-    budget = task.get("budget_turns", 25)
     title = task.get("title", task.get("name", "Untitled"))
 
     prompt = f"""You are executing a task. Follow the skill methodology provided.
@@ -287,95 +278,18 @@ Your FINAL message must be a JSON object:
 
 CRITICAL: Your final message must contain ONLY the JSON object above."""
 
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        spawn_resp = await client.post(
-            f"{base}/tools/invoke",
-            headers=headers,
-            json={
-                "tool": "sessions_spawn",
-                "args": {
-                    "task": prompt,
-                    "agentId": agent_id,
-                    "mode": "run",
-                    "cleanup": "auto",
-                    "sandbox": "inherit",
-                    "runTimeoutSeconds": 240,
-                    "expectsCompletionMessage": False,
-                },
-            },
-        )
-        spawn_resp.raise_for_status()
-        spawn_data = spawn_resp.json()
+    # #366: this used to sessions_spawn + poll the retired OpenClaw
+    # ``/tools/invoke`` envelope, which 404s on Hermes — every AI-task
+    # execution silently died here. _call_clerk is the Hermes-native
+    # POST /v1/responses path (workers gateway, heartbeats, retry-classified).
+    from src.activities.clerk import _call_clerk
 
-        # Extract session key
-        result = spawn_data.get("result", {})
-        content_list = result.get("content", [])
-        session_key = None
-        for item in content_list:
-            if isinstance(item, dict) and item.get("type") == "text":
-                try:
-                    inner = json.loads(item["text"])
-                    session_key = inner.get("childSessionKey")
-                except (json.JSONDecodeError, KeyError):
-                    pass
-
-        if not session_key:
-            return {
-                "status": "error",
-                "summary": f"Failed to spawn subagent: {spawn_data}",
-                "output": "",
-                "follow_up_tasks": [],
-            }
-
-    # Poll for result
-    async with httpx.AsyncClient(timeout=15.0) as client:
-        for attempt in range(28):
-            await asyncio.sleep(10)
-            try:
-                hist_resp = await client.post(
-                    f"{base}/tools/invoke",
-                    headers=headers,
-                    json={
-                        "tool": "sessions_history",
-                        "args": {"sessionKey": session_key, "limit": 5},
-                    },
-                )
-                if hist_resp.status_code != 200:
-                    continue
-                hist_data = hist_resp.json()
-            except Exception:
-                continue
-
-            # Parse messages
-            hist_result = hist_data.get("result", {})
-            hist_content = hist_result.get("content", [])
-            messages = []
-            for item in hist_content:
-                if isinstance(item, dict) and item.get("type") == "text":
-                    try:
-                        parsed = json.loads(item["text"])
-                        messages = parsed.get("messages", [])
-                    except (json.JSONDecodeError, TypeError):
-                        pass
-
-            for msg in messages:
-                if msg.get("role") == "assistant":
-                    msg_content = msg.get("content", "")
-                    text = ""
-                    if isinstance(msg_content, list):
-                        for part in msg_content:
-                            if isinstance(part, dict) and part.get("type") == "text":
-                                text = part["text"]
-                                break
-                    elif isinstance(msg_content, str):
-                        text = msg_content
-
-                    if text:
-                        return _extract_task_result(text, title)
-
+    text = await _call_clerk(prompt, raw=True, agent_id=agent_id)
+    if isinstance(text, str) and text.strip():
+        return _extract_task_result(text, title)
     return {
-        "status": "timeout",
-        "summary": f"Task execution timed out after 280s: {title}",
+        "status": "error",
+        "summary": f"Empty clerk output for task: {title}",
         "output": "",
         "follow_up_tasks": [],
     }
@@ -644,14 +558,9 @@ async def _llm_evaluate_consequentials(
 ) -> list[dict[str, Any]]:
     """Ask the LLM whether follow-up errands are needed after task completion.
 
-    Uses OpenClaw sessions_spawn in run mode with a short timeout.
+    Hermes-native clerk call on the workers gateway (#366).
     Returns a list of follow-up task dicts or empty list.
     """
-    token = config.gateway_token()
-    # Evaluates follow-ups via a clerk subagent on the WORKERS gateway.
-    base = config.openclaw_workers_gateway_url
-    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
-
     title = task.get("title", task.get("name", "Untitled"))
     summary = result.get("summary", "")
     output = result.get("output", "")
@@ -677,86 +586,14 @@ Return ONLY a JSON object:
 
 If no follow-ups are needed, return: {{"follow_up_tasks": []}}"""
 
-    async with httpx.AsyncClient(timeout=30.0) as http_client:
-        spawn_resp = await http_client.post(
-            f"{base}/tools/invoke",
-            headers=headers,
-            json={
-                "tool": "sessions_spawn",
-                "args": {
-                    "task": prompt,
-                    "agentId": config.clerk_agent_id,
-                    "mode": "run",
-                    "cleanup": "auto",
-                    "sandbox": "inherit",
-                    "runTimeoutSeconds": 60,
-                    "expectsCompletionMessage": False,
-                },
-            },
-        )
-        spawn_resp.raise_for_status()
-        spawn_data = spawn_resp.json()
+    # #366: Hermes-native call replaces the retired /tools/invoke poll loop.
+    from src.activities.clerk import _call_clerk
 
-        # Extract session key
-        content_list = spawn_data.get("result", {}).get("content", [])
-        session_key = None
-        for item in content_list:
-            if isinstance(item, dict) and item.get("type") == "text":
-                try:
-                    inner = json.loads(item["text"])
-                    session_key = inner.get("childSessionKey")
-                except (json.JSONDecodeError, KeyError):
-                    pass
-
-        if not session_key:
-            return []
-
-    # Poll for result (shorter timeout for consequentials evaluation)
-    async with httpx.AsyncClient(timeout=15.0) as http_client:
-        for _ in range(12):
-            await asyncio.sleep(5)
-            try:
-                hist_resp = await http_client.post(
-                    f"{base}/tools/invoke",
-                    headers=headers,
-                    json={
-                        "tool": "sessions_history",
-                        "args": {"sessionKey": session_key, "limit": 5},
-                    },
-                )
-                if hist_resp.status_code != 200:
-                    continue
-                hist_data = hist_resp.json()
-            except Exception:
-                continue
-
-            hist_content = hist_data.get("result", {}).get("content", [])
-            for item in hist_content:
-                if isinstance(item, dict) and item.get("type") == "text":
-                    try:
-                        parsed = json.loads(item["text"])
-                        messages = parsed.get("messages", [])
-                    except (json.JSONDecodeError, TypeError):
-                        continue
-
-                    for msg in messages:
-                        if msg.get("role") != "assistant":
-                            continue
-                        msg_content = msg.get("content", "")
-                        text = ""
-                        if isinstance(msg_content, list):
-                            for part in msg_content:
-                                if isinstance(part, dict) and part.get("type") == "text":
-                                    text = part["text"]
-                                    break
-                        elif isinstance(msg_content, str):
-                            text = msg_content
-
-                        if text:
-                            extracted = _extract_follow_ups(text)
-                            if extracted is not None:
-                                return extracted
-
+    text = await _call_clerk(prompt, raw=True, agent_id=config.clerk_agent_id)
+    if isinstance(text, str):
+        extracted = _extract_follow_ups(text)
+        if extracted is not None:
+            return extracted
     return []
 
 

--- a/packages/learn/tests/test_hermes_native_calls_366.py
+++ b/packages/learn/tests/test_hermes_native_calls_366.py
@@ -1,0 +1,121 @@
+"""Regression tests for #366 — the retired OpenClaw envelope.
+
+`chore_actions._workers_spawn_subagent`, `tasks.execute_task` and
+`tasks._llm_evaluate_consequentials` never got the Hermes-native
+POST /v1/responses migration that `clerk._call_clerk` received in #20/#46.
+They still POSTed `sessions_spawn` / `sessions_history` to
+``http://hermes:18790/tools/invoke`` — a 404 on every call — which
+silently killed the LLM step in 10 of 13 live user-chores and all
+TaskRunner AI-task execution on home.
+
+These tests pin the new transport: everything routes through
+``clerk._call_clerk`` and the retired envelope is gone from the code.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import pathlib
+
+import pytest
+
+from src.activities import chore_actions as ca
+from src.activities import tasks as tasks_mod
+from src.activities import clerk as clerk_mod
+
+SRC = pathlib.Path(__file__).resolve().parents[1] / "src"
+
+
+def _patch_clerk(monkeypatch, reply: str | Exception):
+    calls: list[dict] = []
+
+    async def fake_call_clerk(prompt, raw=False, agent_id=None):
+        calls.append({"prompt": prompt, "raw": raw, "agent_id": agent_id})
+        if isinstance(reply, Exception):
+            raise reply
+        return reply
+
+    monkeypatch.setattr(clerk_mod, "_call_clerk", fake_call_clerk)
+    return calls
+
+
+class TestWorkersSpawnSubagent:
+    def test_returns_clerk_text(self, monkeypatch):
+        calls = _patch_clerk(monkeypatch, "final answer")
+        out = asyncio.run(
+            ca._workers_spawn_subagent(agent_id="chore-x", prompt="do the thing")
+        )
+        assert out == "final answer"
+        assert calls[0]["raw"] is True
+        assert calls[0]["agent_id"] == "chore-x"
+
+    def test_failure_returns_empty_string_contract(self, monkeypatch):
+        """Chore callers all handle '' — a dead gateway must not throw here,
+        but it must also no longer be SILENT (logged at warning)."""
+        _patch_clerk(monkeypatch, RuntimeError("gateway down"))
+        out = asyncio.run(
+            ca._workers_spawn_subagent(agent_id="chore-x", prompt="p")
+        )
+        assert out == ""
+
+    def test_legacy_timeout_kwargs_still_accepted(self, monkeypatch):
+        _patch_clerk(monkeypatch, "ok")
+        out = asyncio.run(
+            ca._workers_spawn_subagent(
+                agent_id="a", prompt="p", run_timeout_s=5, poll_timeout_s=5
+            )
+        )
+        assert out == "ok"
+
+
+class TestExecuteTask:
+    def test_parses_final_json(self, monkeypatch):
+        reply = json.dumps(
+            {"status": "completed", "output": "did it", "summary": "done",
+             "follow_up_tasks": []}
+        )
+        calls = _patch_clerk(monkeypatch, reply)
+        result = asyncio.run(
+            tasks_mod.execute_task({"title": "T", "agent_id": "exec-1"}, "ctx")
+        )
+        assert result["status"] == "completed"
+        assert result["summary"] == "done"
+        assert calls[0]["agent_id"] == "exec-1"
+        assert "ctx" in calls[0]["prompt"]
+
+    def test_empty_output_is_error_result(self, monkeypatch):
+        _patch_clerk(monkeypatch, "   ")
+        result = asyncio.run(tasks_mod.execute_task({"title": "T"}, "ctx"))
+        assert result["status"] == "error"
+
+    def test_clerk_exception_propagates(self, monkeypatch):
+        """Auth/billing failures must reach Temporal's retry classifier,
+        not be swallowed into a fake 'timeout' result."""
+        _patch_clerk(monkeypatch, RuntimeError("boom"))
+        with pytest.raises(RuntimeError):
+            asyncio.run(tasks_mod.execute_task({"title": "T"}, "ctx"))
+
+
+class TestLlmEvaluateConsequentials:
+    def test_extracts_follow_ups(self, monkeypatch):
+        reply = json.dumps({"follow_up_tasks": [{"title": "F", "owner": "human"}]})
+        _patch_clerk(monkeypatch, reply)
+
+        class _Cfg:
+            clerk_agent_id = "learn-clerk"
+
+        out = asyncio.run(
+            tasks_mod._llm_evaluate_consequentials(_Cfg(), {"title": "T"}, {"summary": "s"})
+        )
+        assert out == [{"title": "F", "owner": "human"}]
+
+
+def test_retired_envelope_is_gone_from_fixed_modules():
+    """#366 guard: the retired OpenClaw envelope must not reappear in the
+    two migrated modules. (plane_alfred_triggers still carries it — dormant
+    Plane code, tracked under #374's cleanup, deliberately not asserted.)"""
+    for mod in ("activities/tasks.py", "activities/chore_actions.py"):
+        source = (SRC / mod).read_text()
+        assert '"tool": "sessions_spawn"' not in source, mod
+        assert '"tool": "sessions_history"' not in source, mod
+        assert "/tools/invoke\"" not in source.replace("f\"{base}", "\""), mod


### PR DESCRIPTION
Closes #366.

## What
The 10-of-13-dead-chores P0 from the deep-inspect: `_workers_spawn_subagent` (chore_actions), `execute_task` and `_llm_evaluate_consequentials` (tasks) still POSTed the retired OpenClaw `sessions_spawn`/`sessions_history` envelope to `/tools/invoke` — 404 on every call since the Hermes cutover. All three now route through `clerk._call_clerk` (the #20/#46 Hermes-native path: POST /v1/responses on :18790, heartbeats, #296 retry classification). **Net −230 LOC.**

Behavior contracts:
- `_workers_spawn_subagent` keeps its documented "empty string on failure" contract (all chore callers handle it) but failures now log at warning — no more total silence.
- `execute_task` now **propagates** clerk errors (billing/auth become non-retryable ApplicationErrors) instead of returning a fake timeout dict; TaskRunner's per-task isolation (#367, merged) marks the task blocked and moves on.
- Guard test pins the envelope out of both migrated modules. `plane_alfred_triggers.py` retains its copy deliberately — dormant Plane code, tracked under #374.

Deliberately NOT here: the `record_chore_run` failure-branch (P1 half of #366's spec) — will follow separately if post-deploy smoke shows chores still failing invisibly; the transport fix is what un-breaks them.

## Temporal determinism
Activity-internal transport change only. No renames, no signature changes, no workflow code touched.

## Smoke evidence
- Local: full learn suite **2408 passed** (env-gapped files excluded locally; run in CI image), 8 new regression tests green.
- Live smoke on home after deploy (results to be commented on #366): manually trigger `chore-trkblint-household-works-ledger` → completes without 404; TaskRunner executes an alfred-owned task end-to-end; workers-gateway log shows /v1/responses traffic from learn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)