### PR TITLE
fix(learn): live instinct scorer — pattern coverage replaces body-diluted Jaccard (#365)

### DIFF
--- a/packages/learn/src/activities/signal_actions.py
+++ b/packages/learn/src/activities/signal_actions.py
@@ -275,55 +275,62 @@ def _score_signal_against_instinct(
     signal_text: str,
     instinct: dict[str, Any],
 ) -> float:
-    """Return a 0.0–1.0 similarity score between a signal and an instinct.
+    """Return a 0.0–1.0 pattern-coverage score between a signal and an instinct.
 
-    Algorithm: token-set Jaccard between
-    ``tokens(signal_text)`` and
-    ``tokens(instinct.description + flatten(input_patterns))``.
+    #365: the original implementation was token-set Jaccard between the
+    FULL signal text and the instinct corpus. A real signal carries a
+    whole email body, so the union denominator dwarfed any overlap — the
+    max score ever recorded live was 0.1951 against MATCH_FLOOR=0.30,
+    and ``matched_instinct`` was NULL on 1002/1002 signals all-time.
+    (Gap 5b fixed this exact failure class in matching/scorer.py, but
+    that scorer only feeds the dead JudgmentWorkflow — this inline one
+    is what SignalRouter actually runs.) The "2x weighting by repeating
+    tokens" was also a no-op: tokens land in a set.
 
-    We weight ``input_patterns`` 2x by repeating its tokens — the
-    pattern fields (``sender_domains``, ``subject_keywords``,
-    ``input_types``) are the operationally significant signal. The
-    description gets 1x weight to fold in semantic context that
-    patterns can't express.
+    Now: the score is the fraction of the instinct's ``input_patterns``
+    entries (sender_domains, subject_keywords, input_types, …) that the
+    signal satisfies — mirroring matching/scorer.py's fixed
+    ``_score_keyword_overlap``. A pattern matches if EITHER
+      (a) it appears verbatim as a substring of the signal text
+          (multi-word phrases, sender domains), OR
+      (b) every token of the pattern appears in the signal's token set
+          (paraphrase tolerance).
+    An instinct with no usable patterns scores 0.0 — description prose
+    is not an anchoring signal, and the HUMAN path remains the catch-all.
 
-    Pure Python; deterministic; no LLM. Good enough as a first-pass
-    filter — the discretion threshold then gates whether we autonomously
-    dispatch. If the rough score plus the high-confidence threshold
-    isn't enough to safely auto-dispatch, the human path catches it.
+    Pure Python; deterministic; no LLM. The discretion threshold still
+    gates autonomous dispatch above this floor.
     """
     fm = instinct.get("frontmatter")
     if not isinstance(fm, dict):
         fm = instinct
-    description = str(fm.get("description") or "").strip()
     input_patterns = _parse_input_patterns(fm.get("input_patterns"))
 
-    instinct_text_parts: list[str] = []
-    if description:
-        instinct_text_parts.append(description)
-    # Flatten input_patterns values — sender_domains, subject_keywords,
-    # input_types, attachment_types — into one token corpus, then add
-    # them again to weight 2x.
-    pattern_tokens: list[str] = []
+    patterns: list[str] = []
     for v in input_patterns.values():
         if isinstance(v, list):
-            pattern_tokens.extend(str(x) for x in v if x is not None)
-        elif isinstance(v, str):
-            pattern_tokens.append(v)
-    if pattern_tokens:
-        instinct_text_parts.append(" ".join(pattern_tokens))
-        instinct_text_parts.append(" ".join(pattern_tokens))
+            patterns.extend(str(x) for x in v if x is not None)
+        elif isinstance(v, str) and v.strip():
+            patterns.append(v)
+    patterns = [p.lower().strip() for p in patterns if str(p).strip()]
+    if not patterns:
+        return 0.0
 
-    instinct_tokens = _tokenize(" ".join(instinct_text_parts))
+    text_lc = (signal_text or "").lower()
     signal_tokens = _tokenize(signal_text)
-    if not instinct_tokens or not signal_tokens:
+    if not text_lc:
         return 0.0
 
-    overlap = signal_tokens & instinct_tokens
-    union = signal_tokens | instinct_tokens
-    if not union:
-        return 0.0
-    return len(overlap) / len(union)
+    matched = 0
+    for pattern in patterns:
+        if pattern in text_lc:
+            matched += 1
+            continue
+        pattern_tokens = _tokenize(pattern)
+        if pattern_tokens and pattern_tokens <= signal_tokens:
+            matched += 1
+
+    return matched / len(patterns)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/learn/tests/test_live_scorer_365.py
+++ b/packages/learn/tests/test_live_scorer_365.py
@@ -1,0 +1,118 @@
+"""Regression tests for #365 — the live instinct scorer.
+
+The old scorer was token-set Jaccard between the FULL signal text and the
+instinct corpus. Real signals carry whole email bodies, so the union
+denominator dwarfed the overlap: live evidence on home showed
+``matched_instinct`` NULL on 1002/1002 signals all-time with a maximum
+recorded score of 0.1951 against MATCH_FLOOR=0.30. The investigator
+reproduced 0.074 as the best achievable score against all 36 live
+instincts. These tests use a realistic long-body signal — under the old
+Jaccard they scored ~0.05 and FAILED (verified red before the fix).
+"""
+from __future__ import annotations
+
+import json
+
+from src.activities.signal_actions import (
+    MATCH_FLOOR,
+    _score_signal_against_instinct,
+)
+
+# A live-shaped signal: subject + a real-length email body, the shape the
+# router actually feeds the scorer. Under Jaccard, this body is what
+# drove every score to ~zero.
+CI_SIGNAL_TEXT = """
+Subject: [ssdavidai/alfred] Run failed: build-learn - main (b3bc00de)
+From: GitHub <notifications@github.com>
+
+The build-learn workflow run failed for commit b3bc00de pushed by
+ssdavidai. Annotations: 1 failure. Job build-learn failed after 22
+minutes of execution on ubuntu-latest. View workflow run at
+https://github.com/ssdavidai/alfred/actions/runs/12345678901.
+You are receiving this because you are subscribed to this repository.
+To unsubscribe from these emails, adjust your notification settings at
+https://github.com/settings/notifications. GitHub, Inc. is located at
+88 Colin P Kelly Jr St, San Francisco, CA 94107.
+"""
+
+SUPPRESS_CI_INSTINCT = {
+    "frontmatter": {
+        "description": "Suppress routine CI notification noise from the Desk",
+        # Production shape: JSON string inside frontmatter (see
+        # _parse_input_patterns docstring).
+        "input_patterns": json.dumps(
+            {
+                "sender_domains": ["github.com"],
+                "subject_keywords": ["run failed", "build"],
+            }
+        ),
+    }
+}
+
+BILLING_INSTINCT = {
+    "frontmatter": {
+        "description": "Routine billing receipts get filed, not surfaced",
+        "input_patterns": {
+            "sender_domains": ["stripe.com"],
+            "subject_keywords": ["receipt", "payment succeeded"],
+        },
+    }
+}
+
+
+class TestRealisticSignalClearsFloor:
+    def test_ci_signal_matches_suppress_ci(self):
+        """THE live failure case: long-body CI email vs the suppress-ci
+        instinct. Old Jaccard: ~0.05 (red). Pattern coverage: 3/3."""
+        score = _score_signal_against_instinct(CI_SIGNAL_TEXT, SUPPRESS_CI_INSTINCT)
+        assert score >= MATCH_FLOOR, f"score={score} below floor {MATCH_FLOOR}"
+        assert score == 1.0  # github.com + "run failed" + "build" all present
+
+    def test_long_body_does_not_dilute(self):
+        """Padding the body 10x must not change the score — the exact
+        Jaccard failure mode (denominator growth)."""
+        padded = CI_SIGNAL_TEXT + ("lorem ipsum filler words " * 400)
+        assert _score_signal_against_instinct(
+            padded, SUPPRESS_CI_INSTINCT
+        ) == _score_signal_against_instinct(CI_SIGNAL_TEXT, SUPPRESS_CI_INSTINCT)
+
+
+class TestNoOverMatch:
+    def test_unrelated_instinct_scores_below_floor(self):
+        score = _score_signal_against_instinct(CI_SIGNAL_TEXT, BILLING_INSTINCT)
+        assert score < MATCH_FLOOR, f"unrelated instinct scored {score}"
+
+    def test_partial_coverage_is_fractional(self):
+        """One of two patterns present → 0.5, not all-or-nothing."""
+        inst = {
+            "frontmatter": {
+                "input_patterns": {
+                    "sender_domains": ["github.com"],
+                    "subject_keywords": ["deployment protection rule"],
+                }
+            }
+        }
+        score = _score_signal_against_instinct(CI_SIGNAL_TEXT, inst)
+        assert score == 0.5
+
+
+class TestConservativeEdges:
+    def test_no_patterns_scores_zero(self):
+        """Description-only instincts never anchor a match — prose is not
+        an anchoring signal; the HUMAN path stays the catch-all."""
+        inst = {"frontmatter": {"description": "GitHub build run failed notification"}}
+        assert _score_signal_against_instinct(CI_SIGNAL_TEXT, inst) == 0.0
+
+    def test_empty_signal_scores_zero(self):
+        assert _score_signal_against_instinct("", SUPPRESS_CI_INSTINCT) == 0.0
+
+    def test_paraphrase_matches_via_token_subset(self):
+        """'build failed' tokens both appear even when the phrase isn't
+        verbatim — branch (b)."""
+        inst = {"frontmatter": {"input_patterns": {"subject_keywords": ["failed build"]}}}
+        assert _score_signal_against_instinct(CI_SIGNAL_TEXT, inst) == 1.0
+
+    def test_flat_dict_instinct_without_frontmatter_key(self):
+        """Some callers pass the frontmatter dict directly."""
+        inst = {"input_patterns": {"sender_domains": ["github.com"]}}
+        assert _score_signal_against_instinct(CI_SIGNAL_TEXT, inst) == 1.0


### PR DESCRIPTION
Closes #365.

## What
`_score_signal_against_instinct` (signal_actions.py) — the scorer the LIVE SignalRouter runs — was full-text Jaccard: real email bodies blew up the union denominator, making MATCH_FLOOR=0.30 structurally unreachable (`matched_instinct` NULL on **1002/1002 signals all-time**, max score 0.1951). Replaced the body with pattern-coverage scoring mirroring the Gap 5b-fixed `matching/scorer.py`: fraction of `input_patterns` satisfied via substring or all-tokens-present. Same name, same signature, same floor; the discretion gate remains the autonomy safety belt.

## Failing-test-first
6/8 new tests red under the old scorer (verified via stash-swap in this branch's test run), including the exact live failure shape: a long-body GitHub CI email vs the suppress-ci instinct — old ~0.05, new 1.0 — plus a dilution test (10× body padding must not move the score) and anti-over-match tests (unrelated instinct < floor; partial coverage fractional; description-only instincts 0.0).

## Interlocks
- #330 (33/34 instincts missing tier): independent — this makes matching fire; tiers gate discretion. Autonomy needs both, no ordering constraint.
- #374 (retire JudgmentWorkflow/dead scorer): lands after; this PR copies nothing from `matching/scorer.py`, so no sequencing hazard.

## Temporal determinism
Helper-function change inside an activity module. No workflow code, no renames, no signature changes.

## Smoke evidence
- Local: full learn suite **2416 passed**; existing `test_signal_router_instinct_match.py` untouched and green.
- Live smoke on home after deploy (results to be commented on #365): watch `signal` table for first non-NULL `matched_instinct` on a fresh CI/billing signal; confirm NO autonomous dispatch storm in the first hours (discretion gate holds — suppress instincts have low observation_count → high threshold → HUMAN/SUPPRESSED routing only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)