### PR TITLE
fix(mcp): harden proxy trust for rate-limit identity

### DIFF
--- a/docs/operators/mcp-reverse-proxy.md
+++ b/docs/operators/mcp-reverse-proxy.md
@@ -1,9 +1,5 @@
-# MCP reverse-proxy trust and rate-limit identity
+# MCP reverse-proxy trust
 
-The MCP HTTP server is exposed through the single Caddy ingress hop: `mcp.<DOMAIN> -> reverse_proxy mcp-server:8787`. Express must not use `trust proxy=true`: that accepts arbitrary `X-Forwarded-For` values and lets an untrusted caller evade IP-keyed OAuth rate limits.
+The MCP server is reachable through one Caddy reverse-proxy hop. Configure `TRUST_PROXY_HOPS=1`; `0` is direct/local mode. The server accepts only a bounded integer hop count (0-5). It rejects `true`, `*`, `all`, and wildcard CIDRs in production because Express would then trust arbitrary `X-Forwarded-For` values and an attacker could spoof the IP-keyed rate-limit identity.
 
-Set `TRUST_PROXY_HOPS=1` for the supported Caddy deployment. The value is a bounded integer from 0 to 5 and is applied to Express's proxy trust. `0` is the safe direct-connection/local-development mode. Do not set `true`, `*`, `all`, or a wildcard CIDR. Production startup rejects those permissive values with an actionable error before the listener is created.
-
-The edge proxy must overwrite, not append to, the incoming forwarded headers when it is the trusted how. Do not expose port 8787 directly to the Internet. With one trusted hop, the client IP is the first address to the left of the Caddy hop; extra forwarded entries are not trusted.
-
-Regression coverage lives in `src/trustProxy.test.ts` and covers the default trusted hop, direct mode, bounded multi-hop configuration, permissive-value rejection, and the development fail-closed path.
+Caddy must overwrite forwarded headers and port 8787 must not be Internet-facing. With one trusted hop, only the address immediately to the left of Caddy is trusted; additional client-supplied entries are not. Regression coverage is in `src/trustProxy.test.ts`.

--- a/packages/mcp-server/src/env.ts
+++ b/packages/mcp-server/src/env.ts
@@ -1,1 +1,42 @@
-Ly8gUGVyLXRlbmFudCBlbnZpcm9ubWVudCB2YXJpYWJsZXMgcmVhZCBmcm9tIHRoZSBjb250YWluZXIncyBlbnZpcm9ubWVudC4KLy8gU2V0IHZpYSB0aGUgdGVuYW50IGNvbXBvc2UgYC5lbnZgICh0aGUgcHJvdmlzaW9uZXIgd3JpdGVzIHRoZW0gYXQgc2hpcAovLyB0aW1lOyBleGlzdGluZyB0ZW5hbnRzIGdldCB0aGVtIHZpYSBhIG9uZS1vZmYgb3BzIGNvbW1hbmQpLiBBbGwgdmFsdWVzCi8vIHNjb3BlZCB0byBUSElTIHRlbmFudCDigJQgdGhlIGNvbnRhaW5lciBpcyBzaW5nbGUtdGVuYW50IGJ5IGRlcGxveW1lbnQuCgpleHBvcnQgaW50ZXJmYWNlIEVudiB7CiAgLyoqIGN0cmwtYXBpIGJhc2UgVVJMIGluc2lkZSB0aGUgY29tcG9zZSBuZXR3b3JrLiBBbHdheXMgaHR0cDovL2N0cmwtYXBpOjMxMDAgaW4gcHJvZC4gKi8KICBDVFJMX1VSTDogc3RyaW5nOwogIC8qKiBCZWFyZXIgZm9yIHRoZSBpbi10ZW5hbnQgY3RybC1hcGkuICovCiAgQUFTX0FQSV9LRVk6IHN0cmluZzsKICAvKiogUHJlLXNoYXJlZCBzZWNyZXQgU2lyIGVudGVycyBvbmNlIG9uIC9hdXRob3JpemUgd2hlbiBhZGRpbmcgdGhlIGNvbm5lY3Rvci4gKi8KICBNQ1BfQVBQUk9WQUxfU0VDUkVUOiBzdHJpbmc7CiAgLyoqIFdoZXJlIFNRTGl0ZSBsaXZlcy4gQmluZC1tb3VudGVkIGZyb20gL21udC9lbmNyeXB0ZWQvbWNwLXNlcnZlciBpbiBjb21wb3NlLiAqLwogIERBVEFfRElSOiBzdHJpbmc7CiAgLyoqIFB1YmxpYyBVUkwgdGhlIHRlbmFudCBzdWJkb21haW4gc2VydmVzICh1c2VkIGFzIE9BdXRoIGlzc3VlcikuICovCiAgUFVCTElDX1VSTDogc3RyaW5nOwogIC8qKiBEaXNwbGF5IGxhYmVsIHNob3duIG9uIHRoZSBhcHByb3ZhbCBwYWdlLiBlLmcuICJTaXIiLiAqLwogIFRFTkFOVF9MQUJFTDogc3RyaW5nOwogIC8qKiBIVFRQIGxpc3RlbiBwb3J0LiBEZWZhdWx0IDg3ODcuICovCiAgUE9SVD86IHN0cmluZzsKICAvKiogQm91bmRlZCBwcm94eSBob3AgY291bnQuIFNldCB0byAxIGZvciB0aGUgZG9jdW1lbnRlZCBDYWRkeSBpbmdyZXNzLiAqLwogIFRSVVNUX1BST1hZX0hPUFM/OiBzdHJpbmc7Cn0KCmZ1bmN0aW9uIHZhbGlkYXRlZFRydXN0UHJveHlIb3BzKHJhdzogc3RyaW5nIHwgdW5kZWZpbmVkKTogc3RyaW5nIHwgdW5kZWZpbmVkIHsKICBjb25zdCB2YWx1ZSA9IHJhdyA/PyAiMSI7CiAgY29uc3QgcHJvZHVjdGlvbiA9IHByb2Nlc3MuZW52Lk5PREVfRU5WID09PSAicHJvZHVjdGlvbiI7CiAgaWYgKFsidHJ1ZSIsICIqIiwgImFsbCIsICIwLjAuMC4wLzAiLCAiOjovMCJdLmluY2x1ZGVzKHZhbHVlLnRyaW0oKS50b0xvd2VyQ2FzZSgpKSkgewogICAgaWYgKHByb2R1Y3Rpb24pIHsKICAgICAgdGhyb3cgbmV3IEVycm9yKAogICAgICAgIGBVbnNhZmUgVFJVU1RfUFJPWFlfSE9QUz0ke3ZhbHVlfTsgcHJvZHVjdGlvbiByZXF1aXJlcyBhIGJvdW5kZWQgaW50ZWdlciBob3AgY291bnQgKDAtNSlgLAogICAgICApOwogICAgfQogICAgcmV0dXJuICIwIjsKICB9CiAgaWYgKCEvXlxkKyQvLnRlc3QodmFsdWUpIHx8IE51bWJlcih2YWx1ZSkgPiA1KSB7CiAgICB0aHJvdyBuZXcgRXJyb3IoCiAgICAgIGBJbnZhbGlkIFRSVVNUX1BST1hZX0hPUFM9JHt2YWx1ZX07IHVzZSBhIGJvdW5kZWQgaW50ZWdlciBob3AgY291bnQgZnJvbSAwIHRvIDVgLAogICAgKTsKICB9CiAgcmV0dXJuIHZhbHVlOwp9CgpleHBvcnQgZnVuY3Rpb24gbG9hZEVudigpOiBFbnYgewogIGNvbnN0IHJlcXVpcmVkID0gKG5hbWU6IGtleW9mIEVudikgPT4gewogICAgY29uc3QgdiA9IHByb2Nlc3MuZW52W25hbWVdOwogICAgaWYgKCF2KSB0aHJvdyBuZXcgRXJyb3IoYE1pc3NpbmcgcmVxdWlyZWQgZW52OiAke25hbWV9YCk7CiAgICByZXR1cm4gdjsKICB9OwogIHJldHVybiB7CiAgICBDVFJMX1VSTDogcmVxdWlyZWQoIkNUUkxfVVJMIiksCiAgICBBQVNfQVBJX0tFWTogcmVxdWlyZWQoIkFBU19BUElfS0VZIiksCiAgICBNQ1BfQVBQUk9WQUxfU0VDUkVUOiByZXF1aXJlZCgiTUNQX0FQUFJPVkFMX1NFQ1JFVCIpLAogICAgREFUQV9ESVI6IHByb2Nlc3MuZW52LkRBVEFfRElSID8/ICIvZGF0YSIsCiAgICBQVUJMSUNfVVJMOiByZXF1aXJlZCgiUFVCTElDX1VSTCIpLAogICAgVEVOQU5UX0xBเสJFTDogcmVxdWlyZWQoIlRFTkFOVF9MQUJFTCIpLAogICAgUE9SVDogcHJvY2Vzcy5lbnYuUE9SVCwKICAgIFRSVVNUX1BST1hZX0hPUFM6IHZhbGlkYXRlZFRydXN0UHJveHlIb3BzKHByb2Nlc3MuZW52LlRSVVNUX1BST1hZX0hPUFMpLAogIH07Cn0K
+export interface Env {
+  CTRL_URL: string;
+  AAS_API_KEY: string;
+  MCP_APPROVAL_SECRET: string;
+  DATA_DIR: string;
+  PUBLIC_URL: string;
+  TENANT_LABEL: string;
+  PORT?: string;
+  TRUST_PROXY_HOPS?: string;
+}
+
+function validatedTrustProxyHops(raw: string | undefined): string {
+  const value = raw ?? "1";
+  const production = process.env.NODE_ENV === "production";
+  const permissive = ["true", "*", "all", "0.0.0.0/0", "::/0"].includes(value.trim().toLowerCase());
+  if (permissive) {
+    if (production) throw new Error(`Unsafe TRUST_PROXY_HOPS=${value}; production requires a bounded integer hop count (0-5)`);
+    return "0";
+  }
+  if (!/^\d+$/.test(value) || Number(value) > 5) {
+    throw new Error(`Invalid TRUST_PROXY_HOPS=${value}; use a bounded integer hop count from 0 to 5`);
+  }
+  return value;
+}
+
+export function loadEnv(): Env {
+  const required = (name: keyof Env) => {
+    const value = process.env[name];
+    if (!value) throw new Error(`Missing required env: ${name}`);
+    return value;
+  };
+  return {
+    CTRL_URL: required("CTRL_URL"),
+    AAS_API_KEY: required("AAS_API_KEY"),
+    MCP_APPROVAL_SECRET: required("MCP_APPROVAL_SECRET"),
+    DATA_DIR: process.env.DATA_DIR ?? "/data",
+    PUBLIC_URL: required("PUBLIC_URL"),
+    TENANT_LABEL: required("TENANT_LABEL"),
+    PORT: process.env.PORT,
+    TRUST_PROXY_HOPS: validatedTrustProxyHops(process.env.TRUST_PROXY_HOPS),
+  };
+}

--- a/packages/mcp-server/src/trustProxy.test.ts
+++ b/packages/mcp-server/src/trustProxy.test.ts
@@ -1,20 +1,15 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-
 import { resolveTrustProxy } from "./trustProxy.js";
 
-test("defaults to the single Caddy hop", () => {
-  assert.equal(resolveTrustProxy(undefined, true), 1);
-});
-test("accepts bounded hop counts", () => {
+test("trusts exactly one documented Caddy hop by default", () => assert.equal(resolveTrustProxy(undefined, true), 1));
+test("accepts only bounded hop counts", () => {
   assert.equal(resolveTrustProxy("0", true), 0);
   assert.equal(resolveTrustProxy("2", true), 2);
   assert.throws(() => resolveTrustProxy("6", true), /bounded integer/);
 });
-test("production rejects permissive trust values", () => {
+test("rejects permisive trust in production", () => {
   assert.throws(() => resolveTrustProxy("true", true), /Unsafe TRUST_PROXY_HOPS/);
   assert.throws(() => resolveTrustProxy("0.0.0.0/0", true), /Unsafe TRUST_PROXY_HOPS/);
 });
-test("development fails closed instead of enabling permissive trust", () => {
-  assert.equal(resolveTrustProxy("true", false), 0);
-});
+test("fails closed in development", () => assert.equal(resolveTrustProxy("true", false), 0));

--- a/packages/mcp-server/src/trustProxy.ts
+++ b/packages/mcp-server/src/trustProxy.ts
@@ -1,1 +1,12 @@
-x
+export function resolveTrustProxy(raw: string | undefined, production = process.env.NODE_ENV === "production"): number {
+  const value = raw ?? "1";
+  const permissive = ["true", "*", "all", "0.0.0.0/0", "::/0"].includes(value.trim().toLowerCase());
+  if (permissive) {
+    if (production) throw new Error(`Unsafe TRUST_PROXY_HOPS=${value}; use a bounded integer hop count (0-5)`);
+    return 0;
+  }
+  if (!/^\d+$/.test(value) || Number(value) > 5) {
+    throw new Error(`Invalid TRUST_PROXY_HOPS=${value}; use a bounded integer hop count from 0 5`);
+  }
+  return Number(value);
+}


### PR DESCRIPTION
Closes #315

Implements bounded reverse-proxy trust for the MCP HTTP server so permissive trust cannot let callers spoof the IP-keyed rate-limit identity. Adds production fail-closed validation, regression tests, and operator documentation.