### PR TITLE
fix(learn): briefing type key (#368) + orphaned-decision retire (#369) + dead-letter holes (#371)

### DIFF
--- a/packages/learn/src/activities/briefing.py
+++ b/packages/learn/src/activities/briefing.py
@@ -2233,9 +2233,15 @@ async def compose_and_write_briefing(
     # the safe shape the parser handles uniformly).
     fm_lines: list[str] = [
         "---",
-        "record_type: briefing",
+        # #368: MUST be `type:` — ctrl-api's vault list endpoint filters
+        # on fm.type, so the old `record_type:` key meant briefing records
+        # never appeared in list_records("briefing") and get_prior_briefing
+        # silently fell back to a naive 24h window on every single run
+        # since the BriefingWorkflow cutover.
+        "type: briefing",
         f"slot: {slot_norm}",
         f"composed_at: {composed_at_iso}",
+        f"created: {composed_at_iso}",
         f"prior_briefing: {prior_briefing_path or ''}",
         f"window_start: {window_start_iso_norm}",
         f"window_end: {window_end_iso_norm}",

--- a/packages/learn/src/activities/decision_router.py
+++ b/packages/learn/src/activities/decision_router.py
@@ -531,6 +531,42 @@ async def route_decision(decision: dict[str, Any]) -> dict[str, Any]:
         return {"id": decision_id, "skipped": True, "reason": f"state={state}"}
 
     if not decision_id or not intent or not source_record:
+        # #369: this used to be a SILENT skip — the decision stayed
+        # state=open and was re-fetched and re-skipped every 60s forever
+        # (12 live orphans on home, written directly into the vault by an
+        # out-of-repo tool without source_record, wedged 3-14 days).
+        # Terminal-complete with a reason instead, mirroring the #313
+        # source_card_missing retire pattern. Without source_record there
+        # is no card to flip and no observation source — routing is
+        # impossible, so completed-with-reason is the honest state.
+        logger.warning(
+            "decision_router.route_decision: decision=%s missing required "
+            "fields (intent=%r source_record=%r) — retiring as completed "
+            "with side_effects.decision_router=missing_source_record",
+            decision_id, intent, source_record,
+        )
+        if decision_id:
+            retired_side_effects = dict(existing_side_effects)
+            retired_side_effects["decision_router"] = "missing_source_record"
+            retired_side_effects["retired_at"] = (
+                datetime.now(timezone.utc).isoformat()
+            )
+            try:
+                async with _http() as client:
+                    patch_resp = await client.patch(
+                        f"/api/v1/decisions/{decision_id}",
+                        json={
+                            "state": "completed",
+                            "side_effects": retired_side_effects,
+                        },
+                    )
+                    patch_resp.raise_for_status()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "decision_router.route_decision: retire PATCH failed "
+                    "decision=%s err=%s — will retry next tick",
+                    decision_id, exc,
+                )
         return {
             "id": decision_id,
             "skipped": True,

--- a/packages/learn/src/activities/scheduled_dispatch.py
+++ b/packages/learn/src/activities/scheduled_dispatch.py
@@ -134,6 +134,11 @@ async def fire_due_scheduled_dispatches() -> dict[str, Any]:
             if not isinstance(existing_side_effects, dict):
                 existing_side_effects = {}
             next_side_effects = dict(existing_side_effects)
+            # The /dispatch endpoint above already ran dispatchSignalToAgent,
+            # so this decision's agent IS dispatched — stamp it so any
+            # executing-state recovery sweep keyed on agent_dispatched
+            # (#282-family) never mistakes a scheduled fire for a strand.
+            next_side_effects["agent_dispatched"] = True
             next_side_effects["fired_at"] = now.isoformat()
             next_side_effects["re_routed_signal"] = dispatch_json.get(
                 "re_routed_signal"

--- a/packages/learn/src/workflows/event_processor.py
+++ b/packages/learn/src/workflows/event_processor.py
@@ -72,76 +72,89 @@ class EventProcessorWorkflow:
                 )
                 continue
 
-            # Media streams still get routed to their dedicated workflow
-            if event.get("stream_type") == "media":
-                await workflow.execute_child_workflow(
-                    "MediaIngestionWorkflow",
-                    event,
-                    id=f"media-{event_id[:16]}",
-                )
-                result.media_triggered += 1
+            # #371: the whole per-event body sits in one try so a single
+            # poison event (media child-workflow crash, inbox drop failure)
+            # logs + skips instead of failing the run — the same one-bad-
+            # item-wedges-everything class that froze the task runner for
+            # 3 days (#367). The skipped event stays unprocessed and is
+            # re-served next tick, visibly, while every other event flows.
+            try:
+                # Media streams still get routed to their dedicated workflow
+                if event.get("stream_type") == "media":
+                    await workflow.execute_child_workflow(
+                        "MediaIngestionWorkflow",
+                        event,
+                        id=f"media-{event_id[:16]}",
+                    )
+                    result.media_triggered += 1
+                    await workflow.execute_activity(
+                        mark_event_processed,
+                        args=[event_id, "media-ingestion", "media"],
+                        start_to_close_timeout=timedelta(seconds=10),
+                        retry_policy=_MARK_RETRY,
+                    )
+                    continue
+
+                # Tier 3: discard (empty/meaningless)
+                if is_tier3(event):
+                    await workflow.execute_activity(
+                        mark_event_processed,
+                        args=[event_id, "noise-discarded", "tier3"],
+                        start_to_close_timeout=timedelta(seconds=10),
+                        retry_policy=_MARK_RETRY,
+                    )
+                    result.tier3_discarded += 1
+                    continue
+
+                # System-inbox (manual uploads) → existing curator path
+                if event.get("stream_type") in ("system", "inbox-upload"):
+                    inbox_path: str = await workflow.execute_activity(
+                        drop_raw_event_to_inbox,
+                        args=[event],
+                        start_to_close_timeout=timedelta(seconds=30),
+                    )
+                    await workflow.execute_activity(
+                        mark_event_processed,
+                        args=[event_id, inbox_path, "tier1"],
+                        start_to_close_timeout=timedelta(seconds=10),
+                        retry_policy=_MARK_RETRY,
+                    )
+                    result.inbox_routed += 1
+                    result.paths.append(inbox_path)
+                    continue
+
+                # --- Non-inbox stream events ---
+                #
+                # Design-B (#78): a non-inbox stream event is NOT written to
+                # the vault. The promotion contract demotes `stream_event` to
+                # ingest.db (Store 4) and `event`/`memory` audit lines to
+                # state.db — both vault writes the old zero-LLM path performed
+                # (`create_stream_vault_record` → `stream_event/`,
+                # `append_to_stream_log` → `memory/stream-log-*`) now 422 and
+                # used to wedge this workflow on infinite retries.
+                #
+                # The puller already lands every event in ingest.db (ctrl-api
+                # mirrors `POST /api/v1/streams/ingest` into Store 4), and
+                # SignalExtractWorkflow consumes from there via
+                # `GET /api/v1/ingest/events/pending`. So EventProcessor's job
+                # for non-inbox events is simply: mark the JSONL-side event
+                # processed so the streams sidecar doesn't re-serve it. No
+                # vault write, no LLM. The system-inbox → curator path above
+                # is unchanged.
                 await workflow.execute_activity(
                     mark_event_processed,
-                    args=[event_id, "media-ingestion", "media"],
+                    args=[event_id, f"ingest:{event_id}", "ingest-store4"],
                     start_to_close_timeout=timedelta(seconds=10),
                     retry_policy=_MARK_RETRY,
                 )
-                continue
-
-            # Tier 3: discard (empty/meaningless)
-            if is_tier3(event):
-                await workflow.execute_activity(
-                    mark_event_processed,
-                    args=[event_id, "noise-discarded", "tier3"],
-                    start_to_close_timeout=timedelta(seconds=10),
-                    retry_policy=_MARK_RETRY,
+                result.vault_records += 1
+                result.paths.append(f"ingest:{event_id}")
+            except Exception as exc:  # noqa: BLE001
+                workflow.logger.warning(
+                    "event_processor: event %s failed (%s) — skipped this "
+                    "tick, will re-serve",
+                    event_id, str(exc)[:200],
                 )
-                result.tier3_discarded += 1
-                continue
-
-            # System-inbox (manual uploads) → existing curator path
-            if event.get("stream_type") in ("system", "inbox-upload"):
-                inbox_path: str = await workflow.execute_activity(
-                    drop_raw_event_to_inbox,
-                    args=[event],
-                    start_to_close_timeout=timedelta(seconds=30),
-                )
-                await workflow.execute_activity(
-                    mark_event_processed,
-                    args=[event_id, inbox_path, "tier1"],
-                    start_to_close_timeout=timedelta(seconds=10),
-                    retry_policy=_MARK_RETRY,
-                )
-                result.inbox_routed += 1
-                result.paths.append(inbox_path)
-                continue
-
-            # --- Non-inbox stream events ---
-            #
-            # Design-B (#78): a non-inbox stream event is NOT written to the
-            # vault. The promotion contract demotes `stream_event` to
-            # ingest.db (Store 4) and `event`/`memory` audit lines to
-            # state.db — both vault writes the old zero-LLM path performed
-            # (`create_stream_vault_record` → `stream_event/`,
-            # `append_to_stream_log` → `memory/stream-log-*`) now 422 and
-            # used to wedge this workflow on infinite retries.
-            #
-            # The puller already lands every event in ingest.db (ctrl-api
-            # mirrors `POST /api/v1/streams/ingest` into Store 4), and
-            # SignalExtractWorkflow consumes from there via
-            # `GET /api/v1/ingest/events/pending`. So EventProcessor's job
-            # for non-inbox events is simply: mark the JSONL-side event
-            # processed so the streams sidecar doesn't re-serve it. No vault
-            # write, no LLM. The system-inbox → curator path above is
-            # unchanged.
-            await workflow.execute_activity(
-                mark_event_processed,
-                args=[event_id, f"ingest:{event_id}", "ingest-store4"],
-                start_to_close_timeout=timedelta(seconds=10),
-                retry_policy=_MARK_RETRY,
-            )
-            result.vault_records += 1
-            result.paths.append(f"ingest:{event_id}")
 
         result.processed = len(result.paths)
         return result

--- a/packages/learn/src/workflows/signals.py
+++ b/packages/learn/src/workflows/signals.py
@@ -134,6 +134,23 @@ _NON_RETRYABLE_EXTRACT_ERRORS: frozenset[str] = frozenset({
 })
 
 
+def _extract_error_type(err: BaseException) -> str:
+    """Best error-type label for a failed extraction.
+
+    #371: the exception the workflow sees is Temporal's ``ActivityError``
+    WRAPPER, which has no ``.type`` — the ``ApplicationError`` carrying
+    the classification lives at ``__cause__``. Reading ``.type`` off the
+    wrapper made the non-retryable fast path dead code (it always fell
+    through to the wrapper's class name).
+    """
+    cause = getattr(err, "__cause__", None)
+    return (
+        str(getattr(cause, "type", "") or "")
+        or str(getattr(err, "type", "") or "")
+        or type(err).__name__
+    )
+
+
 @workflow.defn(name="SignalExtractWorkflow")
 class SignalExtractWorkflow:
     """Stream events → signal records (Phase 6 T6.0.5).
@@ -289,10 +306,7 @@ class SignalExtractWorkflow:
                     # workflow is non-additive for history replay, so it is
                     # gated per packages/learn/CLAUDE.md.
                     if workflow.patched("signal_extract_dead_letter_v1"):
-                        err_type = (
-                            getattr(extracted, "type", "")
-                            or type(extracted).__name__
-                        )
+                        err_type = _extract_error_type(extracted)
                         # An unknown source_type may become extractable once a
                         # parser is fixed, so it stays retryable (bounded by
                         # the budget). A structurally invalid payload never

--- a/packages/learn/tests/test_batch_368_371.py
+++ b/packages/learn/tests/test_batch_368_371.py
@@ -1,0 +1,129 @@
+"""Regression tests for the #368/#369/#371 batch (2026-08-01 deep-inspect).
+
+#368 — briefings wrote ``record_type: briefing``; ctrl-api's vault list
+filters on ``fm.type``, so briefing records never listed and
+``get_prior_briefing`` silently used a naive 24h fallback on every run
+since the BriefingWorkflow cutover ("Since yesterday" never had content).
+
+#369 — ``route_decision`` silently no-op'd decisions missing
+``source_record``: 12 live orphans on home re-fetched + re-skipped every
+60s for 3-14 days. Now retired terminal with a stamped reason.
+
+#371 — the signal-extract dead-letter gate read ``.type`` off Temporal's
+``ActivityError`` wrapper (which has none) instead of ``__cause__``, so
+the non_retryable classification was dead code.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+
+import pytest
+
+
+class TestBriefingTypeKey368:
+    def test_writer_emits_type_not_record_type(self):
+        """The frontmatter builder must key on `type:` — the only key the
+        ctrl-api list endpoint filters on."""
+        from src.activities import briefing as briefing_mod
+
+        src = inspect.getsource(briefing_mod)
+        assert '"type: briefing"' in src
+        assert '"record_type: briefing"' not in src
+
+
+class _FakeResp:
+    def __init__(self, payload=None, status=200):
+        self._payload = payload or {}
+        self.status_code = status
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class _FakeHttp:
+    def __init__(self):
+        self.patches: list[tuple[str, dict]] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def patch(self, url, json=None):
+        self.patches.append((url, json))
+        return _FakeResp()
+
+    async def get(self, url, **kw):
+        return _FakeResp({"decisions": []})
+
+    async def post(self, url, json=None):
+        return _FakeResp()
+
+
+class TestRouteDecisionRetires369:
+    def test_missing_source_record_is_retired_not_silently_skipped(
+        self, monkeypatch
+    ):
+        from src.activities import decision_router as dr
+
+        fake = _FakeHttp()
+        monkeypatch.setattr(dr, "_http", lambda: fake)
+
+        out = asyncio.run(
+            dr.route_decision(
+                {
+                    "id": "alfred-code-2026-07-28-build-gate",
+                    "state": "open",
+                    "intent": "delegate",
+                    # source_record missing — the orphan shape
+                }
+            )
+        )
+        assert out["skipped"] is True
+        assert out["reason"] == "missing required fields"
+        # The decision must be PATCHed terminal with the stamped reason.
+        assert len(fake.patches) == 1
+        url, body = fake.patches[0]
+        assert "alfred-code-2026-07-28-build-gate" in url
+        assert body["state"] == "completed"
+        assert body["side_effects"]["decision_router"] == "missing_source_record"
+        assert "retired_at" in body["side_effects"]
+
+    def test_decision_without_id_is_not_patched(self, monkeypatch):
+        from src.activities import decision_router as dr
+
+        fake = _FakeHttp()
+        monkeypatch.setattr(dr, "_http", lambda: fake)
+        out = asyncio.run(dr.route_decision({"state": "open"}))
+        assert out["skipped"] is True
+        assert fake.patches == []
+
+
+class TestErrorTypeUnwrap371:
+    def test_reads_type_from_cause(self):
+        from temporalio.exceptions import ApplicationError
+
+        from src.workflows.signals import _extract_error_type
+
+        wrapper = RuntimeError("activity failed")  # stand-in wrapper, no .type
+        wrapper.__cause__ = ApplicationError("bad payload", type="SchemaInvalid")
+        assert _extract_error_type(wrapper) == "SchemaInvalid"
+
+    def test_falls_back_to_wrapper_class_name(self):
+        from src.workflows.signals import _extract_error_type
+
+        assert _extract_error_type(ValueError("x")) == "ValueError"
+
+    def test_direct_application_error_type_still_read(self):
+        from temporalio.exceptions import ApplicationError
+
+        from src.workflows.signals import _extract_error_type
+
+        err = ApplicationError("boom", type="MalformedPayload")
+        assert _extract_error_type(err) == "MalformedPayload"

--- a/packages/learn/tests/test_briefing.py
+++ b/packages/learn/tests/test_briefing.py
@@ -468,12 +468,15 @@ async def test_compose_reads_post_mutation_state(fake_vault):
     # The composer prompt must include the POST-MUTATION text — proves
     # it re-read the matter rather than reusing a pre-mutation snapshot.
     assert any("POST-MUTATION" in p for p in captured_prompts)
-    # The write went through ctrl-api with record_type=briefing.
+    # The write went through ctrl-api keyed `type: briefing` — the only
+    # frontmatter key the vault list endpoint filters on (#368; the old
+    # `record_type:` key made briefings invisible to get_prior_briefing).
     assert fake_vault.write_calls
     rtype, name, content = fake_vault.write_calls[0]
     assert rtype == "briefing"
     assert name.endswith("-morning")
-    assert "record_type: briefing" in content
+    assert "type: briefing" in content
+    assert "record_type: briefing" not in content
     assert "slot: morning" in content
     assert "composed_at: 2026-05-13T07:00:00Z" in content
     assert "prior_briefing: briefing/2026-05-12-evening.md" in content


### PR DESCRIPTION
Closes #368. Closes #369. Closes #371.

## What
Three deep-inspect fixes, one Lane II batch (same package, disjoint files):

- **#368**: briefings now write `type: briefing` (+ `created:`) — `record_type:` was invisible to the vault list filter, so prior-brief chaining silently never worked. Pre-existing test asserted the broken key; assertion updated in the same commit per §11.3.
- **#369**: decisions missing `source_record` retire terminal (`side_effects.decision_router=missing_source_record`) instead of silently re-skipping every 60s forever. The 12 live orphans on home should flip within a minute of deploy.
- **#371**: ActivityError `.type` unwrap via `__cause__` (extracted to testable `_extract_error_type`; change is INSIDE the shipped `workflow.patched` branch — condition logic only, no new marker). Plus per-event try/except in EventProcessor so a poison media/inbox event can't fail the whole run.
- Bonus one-liner: scheduled fires stamp `side_effects.agent_dispatched=true` (dispatch already happens server-side; prevents future recovery-sweep false positives).

**#370 is NOT fixed here because it is invalid**: `fire_due_scheduled_dispatches` POSTs `/admin/needs-attention/:id/dispatch`, whose handler runs `dispatchSignalToAgent` BEFORE flipping the card (`attention.ts:601-648`) — the agent dispatch the issue claims is missing has been there all along. Closing #370 separately with the trace.

## Temporal determinism
No new activity calls, no renames, no signatures. EventProcessor/task-flow try-scope changes leave happy-path command sequences identical; failed runs are closed histories. `_extract_error_type` change is within the existing patch-gated branch.

## Smoke evidence
- Local: full learn suite **2426 passed** (env-gapped composio/file-extraction files excluded locally; green in CI image); 6 new regression tests.
- Post-deploy live checks planned (results to issues): #369 — the 12 orphaned `decision/alfred-code*` records flip to completed with the stamp within ~60s; #368 — tomorrow's brief lists the prior brief (log/frontmatter `prior_briefing:` populated from a listed record); #371 — no behavior change expected live today (classification path currently dormant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)