### PR TITLE
fix(ctrl): canonical state beats stale status mirror in decisions list (#369 completion)

### DIFF
--- a/packages/ctrl/src/api/routes/decisions.ts
+++ b/packages/ctrl/src/api/routes/decisions.ts
@@ -733,10 +733,19 @@ export function registerDecisionRoutes(): void {
       } catch {
         continue;
       }
-      // Defensive state match: the effective state is the index status column,
-      // or frontmatter `state`, or frontmatter `status` — whichever is set.
+      // Defensive state match. `state` is a decision's CANONICAL lifecycle
+      // field, so it wins — the index `status` column and frontmatter
+      // `status` are fallbacks for legacy rows that carry only those.
+      //
+      // #369: this used to read `row.status ?? fm.state ?? …`, i.e. the
+      // mirror BEFORE the canonical field. Externally-written decisions
+      // (the alfred-code build-gate records) carry a frozen `status: open`
+      // alongside `state`, so once the router retired them to
+      // state=completed they STILL came back on `?state=open` — the router
+      // re-fetched and re-skipped the same 12 records every 60s, exactly
+      // the churn the retire was meant to end.
       if (stateFilter) {
-        const effective = row.status ?? fm.state ?? fm.status ?? null;
+        const effective = fm.state ?? row.status ?? fm.status ?? null;
         if (String(effective ?? "") !== stateFilter) continue;
       }
       if (sourceFilter && String(fm.source ?? "") !== sourceFilter) continue;

--- a/packages/ctrl/tests/decisions-list-state-vs-status.test.ts
+++ b/packages/ctrl/tests/decisions-list-state-vs-status.test.ts
@@ -44,6 +44,17 @@ before(() => {
   indexDecision("decision/legacy.md", { source: "judgment", state: "open" }, null);
   // A non-matching row so the filter is doing real work.
   indexDecision("decision/done.md", { source: "judgment", status: "completed", state: "completed" }, "completed");
+  // #369 — DIVERGENT row: an externally-written decision (the alfred-code
+  // build-gate records on home) carries a frozen `status: open` that its
+  // writer never updates, while the router retires the canonical `state`
+  // to completed. `state` must win, or the retired record keeps coming
+  // back on ?state=open and the router re-skips it every 60s forever.
+  indexDecision(
+    "decision/retired-external.md",
+    { source: "alfred-code-foreman", status: "open", state: "completed",
+      side_effects: { decision_router: "missing_source_record" } },
+    "open",
+  );
 });
 
 async function listDecisions(qs: string): Promise<any> {
@@ -75,12 +86,25 @@ describe("GET /api/v1/decisions — state filter (status-vs-state)", () => {
 
   it("an unfiltered list returns every decision", async () => {
     const out = await listDecisions("");
-    assert.equal(out.decisions.length, 3);
+    assert.equal(out.decisions.length, 4);
   });
 
   it("state=completed still filters correctly", async () => {
     const out = await listDecisions("?state=completed");
     const ids = out.decisions.map((d: any) => d.id);
-    assert.deepEqual(ids.sort(), ["done"]);
+    assert.deepEqual(ids.sort(), ["done", "retired-external"]);
+  });
+
+  it("#369: canonical `state` beats a stale `status` mirror", async () => {
+    // The retired external record must NOT come back as open — that churn
+    // is what kept 12 records cycling through the router on home for
+    // 3-14 days.
+    const open = await listDecisions("?state=open");
+    const openIds = open.decisions.map((d: any) => d.id);
+    assert.ok(
+      !openIds.includes("retired-external"),
+      "a decision retired to state=completed must not list as open just " +
+        "because its writer left status=open behind",
+    );
   });
 });


### PR DESCRIPTION
Completes #369 (the learn-side retire shipped in #389).

## Why a second PR
Live smoke on home proved the retire writes correctly — the record now carries `state: "completed"` and `side_effects.decision_router: "missing_source_record"` — but `GET /api/v1/decisions?state=open` still returned all 12 orphans, so DecisionRouter kept re-fetching and re-skipping them every 60s. The retire was invisible to the only reader that matters.

**Cause:** the list's defensive match read `row.status ?? fm.state ?? fm.status` — the index *mirror* ahead of the *canonical* field, directly contradicting the comment two lines above it ("a decision's canonical lifecycle field is `state`"). The externally-written alfred-code build-gate records carry a frozen `status: open` their writer never updates, which pinned them open regardless of `state`.

**Fix:** `fm.state ?? row.status ?? fm.status`. ctrl-native decisions don't set a divergent `status`, so their behavior is identical; only records whose mirror has gone stale change — exactly the broken case.

## Smoke evidence
- `tsc --noEmit` clean.
- Extended `decisions-list-state-vs-status.test.ts` with the divergent row (status=open + state=completed) asserting it does NOT list as open; the two shared count assertions updated in the same commit (§11.3 — no "fix the test later").
- Post-deploy on home (to be commented on #369): `?state=open` drops from 12 → 0 orphans, and `decision_router: opens=N` stops reporting the same 12 records every tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)