### PR TITLE
fix: surface silently-dropped records — chore failures, unparseable frontmatter, uncovered closure predicates

### DIFF
--- a/packages/ctrl/src/db/vaultIndex.ts
+++ b/packages/ctrl/src/db/vaultIndex.ts
@@ -65,8 +65,24 @@ function parseRecord(relPath: string, raw: string): ParsedRecord {
       if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
         fm = parsed as Record<string, unknown>;
       }
-    } catch {
-      /* malformed frontmatter — index with empty fm */
+    } catch (err) {
+      // A malformed-YAML record is indexed with EMPTY frontmatter, which
+      // makes it invisible to every index-backed reader — it does not 404,
+      // it simply never appears. Live on home: 42 decision records written
+      // by an external tool carry an unquoted `name:` containing ": "
+      // (e.g. `name: Build approval needed: GH #298`), so js-yaml throws
+      // "mapping values are not allowed here" and they vanish from
+      // GET /api/v1/decisions entirely — DecisionRouter has never seen
+      // them, and #369's retire cannot reach what it cannot list.
+      //
+      // Still non-fatal (one bad record must not fail the whole index
+      // rebuild), but NEVER silent again: this is the only signal that a
+      // record has fallen out of the system.
+      console.warn(
+        `[vault-index] frontmatter parse failed for ${relPath} — indexing ` +
+          `with EMPTY frontmatter, record will be invisible to filtered ` +
+          `reads: ${String((err as Error)?.message ?? err).slice(0, 200)}`,
+      );
     }
     body = m[2] ?? "";
   }

--- a/packages/learn/src/activities/stream_log.py
+++ b/packages/learn/src/activities/stream_log.py
@@ -15,6 +15,43 @@ from src.utils.vault_client import VaultClient
 logger = logging.getLogger("alfred-learn")
 
 
+async def _stamp_chore_failure(workflow_type: str, error: str | None) -> None:
+    """Mark the owning chore's vault record when its workflow run failed.
+
+    Maps ``workflow_type`` back to a chore via the ``workflow_class_name``
+    frontmatter field (the same binding the dynamic loader uses), then
+    patches ``last_run`` / ``last_result`` so /chores shows the failure
+    instead of the last successful run. No-ops for non-chore workflows.
+    """
+    if not workflow_type:
+        return
+    config = load_config()
+    client = VaultClient(config)
+    try:
+        chores = await client.list_records("chore", limit=500)
+        target: str | None = None
+        for rec in chores:
+            fm = rec.get("frontmatter") if isinstance(rec, dict) else None
+            if not isinstance(fm, dict):
+                continue
+            if str(fm.get("workflow_class_name") or "").strip() == workflow_type:
+                target = str(rec.get("path") or "")
+                break
+        if not target:
+            return  # not a chore workflow — nothing to stamp
+        detail = (error or "unknown error").replace("\n", " ")[:180]
+        await client.patch_frontmatter(
+            target,
+            {
+                "last_run": datetime.now(timezone.utc).isoformat(),
+                "last_result": f"FAILED: {detail}",
+            },
+        )
+        logger.info("chore failure stamped on %s (%s)", target, workflow_type)
+    finally:
+        await client.close()
+
+
 _STREAM_LOG_HEADER = """\
 ---
 type: note
@@ -67,12 +104,30 @@ async def emit_workflow_audit_event(
             outcome,
             str(exc)[:200],
         )
+
     finally:
         if client is None and state_client is not None:
             try:
                 await state_client.close()
             except Exception as exc:  # noqa: BLE001 — best-effort cleanup
                 logger.warning("workflow audit client close failed: %s", str(exc)[:200])
+
+    # #366 follow-up — chore failures must be visible WITHOUT SSH.
+    # `record_chore_run` only fires on success paths, so a chore whose run
+    # throws leaves its vault record showing the last SUCCESSFUL run and
+    # the dashboard reads it as healthy. Live example: trkblint showed a
+    # green last_run while Temporal had two Failed scheduled ticks.
+    #
+    # Done here rather than in each of the 13 chore templates: this is the
+    # one place every workflow failure already passes through.
+    if outcome == "failed":
+        try:
+            await _stamp_chore_failure(workflow_type, error)
+        except Exception as exc:  # noqa: BLE001 — never affect a run
+            logger.warning(
+                "chore failure stamp skipped for %s: %s",
+                workflow_type, str(exc)[:200],
+            )
 
 
 @activity.defn

--- a/packages/learn/src/activities/task_creation.py
+++ b/packages/learn/src/activities/task_creation.py
@@ -1097,6 +1097,8 @@ def _structured_predicate_from_strings(
     gmail_from = ""
     gmail_subject = ""
     sure_term = ""
+    thread_id = ""
+    event_id = ""
     for raw in predicates:
         s = str(raw or "").strip()
         if s.startswith("sure:transaction:match:") and not sure_term:
@@ -1105,12 +1107,25 @@ def _structured_predicate_from_strings(
             gmail_from = s[len("gmail:from:"):].strip()
         elif s.startswith("gmail:subject_contains:") and not gmail_subject:
             gmail_subject = s[len("gmail:subject_contains:"):].strip()
+        elif s.startswith("gmail:thread:") and not thread_id:
+            thread_id = s[len("gmail:thread:"):].strip()
+        elif s.startswith("calendar:event_accepted:") and not event_id:
+            event_id = s[len("calendar:event_accepted:"):].strip()
     if sure_term:
         return {"kind": "payment_to_merchant", "fields": {"merchant": sure_term}}
+    # A thread id is a stronger, cheaper match than from+subject heuristics,
+    # so it outranks them when both are present.
+    if thread_id:
+        return {"kind": "gmail_thread_reply", "fields": {"thread_id": thread_id}}
     if gmail_from and gmail_subject:
         return {
             "kind": "gmail_from_subject",
             "fields": {"from": gmail_from, "subject_contains": gmail_subject},
+        }
+    if event_id:
+        return {
+            "kind": "calendar_event_accepted",
+            "fields": {"event_id": event_id},
         }
     return None
 

--- a/packages/learn/tests/test_batch_373_379.py
+++ b/packages/learn/tests/test_batch_373_379.py
@@ -120,3 +120,56 @@ class TestStructuredPredicateMapping379:
 
     def test_evaluate_predicate_garbage_string_is_none(self):
         assert evaluate_predicate("not json", {}) is None
+
+
+class TestAllFourPredicateKindsCovered:
+    """#379 follow-up (post-fix rescan): the mapper only covered 2 of the
+    4 documented closure-predicate kinds, so thread-reply and
+    calendar-accept auto-tasks still had an inert fast path."""
+
+    def test_gmail_thread_reply(self):
+        from src.activities.task_creation import _structured_predicate_from_strings
+
+        out = _structured_predicate_from_strings(["gmail:thread:18f0abc"])
+        assert out == {"kind": "gmail_thread_reply", "fields": {"thread_id": "18f0abc"}}
+
+    def test_calendar_event_accepted(self):
+        from src.activities.task_creation import _structured_predicate_from_strings
+
+        out = _structured_predicate_from_strings(["calendar:event_accepted:evt_99"])
+        assert out == {"kind": "calendar_event_accepted", "fields": {"event_id": "evt_99"}}
+
+    def test_thread_id_outranks_from_subject(self):
+        """A thread id is an exact match; from+subject is a heuristic."""
+        from src.activities.task_creation import _structured_predicate_from_strings
+
+        out = _structured_predicate_from_strings([
+            "gmail:from:a@b.com", "gmail:subject_contains:invoice",
+            "gmail:thread:18f0abc",
+        ])
+        assert out["kind"] == "gmail_thread_reply"
+
+    def test_payment_still_wins_overall(self):
+        from src.activities.task_creation import _structured_predicate_from_strings
+
+        out = _structured_predicate_from_strings([
+            "gmail:thread:18f0abc", "sure:transaction:match:ACME",
+        ])
+        assert out["kind"] == "payment_to_merchant"
+
+    def test_every_mapped_kind_is_one_the_watcher_consumes(self):
+        """Guard: the mapper must never invent a kind evaluate_predicate
+        doesn't implement — that would look wired and silently no-op."""
+        from src.activities import task_closure
+        from src.activities.task_creation import _structured_predicate_from_strings
+
+        cases = [
+            ["sure:transaction:match:X"],
+            ["gmail:thread:t1"],
+            ["gmail:from:a@b.com", "gmail:subject_contains:s"],
+            ["calendar:event_accepted:e1"],
+        ]
+        known = set(task_closure._PREDICATE_KINDS)
+        for c in cases:
+            out = _structured_predicate_from_strings(c)
+            assert out is not None and out["kind"] in known, (c, out)

--- a/packages/learn/tests/test_chore_failure_visibility.py
+++ b/packages/learn/tests/test_chore_failure_visibility.py
@@ -1,0 +1,95 @@
+"""A failed chore run must be visible on /chores (#366 follow-up).
+
+`record_chore_run` only fires on success paths, so a chore whose run
+throws leaves its vault record showing the last SUCCESSFUL run — the
+dashboard reads it as healthy. Confirmed live on home: trkblint's record
+showed a green manual-trigger run while Temporal had two Failed
+*scheduled* ticks on the pre-#366 transport bug. You had to SSH to the
+box and read Temporal to know a chore was dead.
+
+The stamp lives in the workflow-audit emitter rather than in each of the
+13 chore templates: that is the one place every workflow failure already
+passes through.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from src.activities import stream_log as sl
+
+
+class _FakeVaultClient:
+    def __init__(self, chores):
+        self._chores = chores
+        self.patches: list[tuple[str, dict]] = []
+
+    async def list_records(self, *_a, **_k):
+        return self._chores
+
+    async def patch_frontmatter(self, path, updates):
+        self.patches.append((path, updates))
+
+    async def close(self):
+        return None
+
+
+CHORES = [
+    {"path": "chore/other.md",
+     "frontmatter": {"workflow_class_name": "SomeOtherWorkflow"}},
+    {"path": "chore/trkblint-household-works-ledger.md",
+     "frontmatter": {"workflow_class_name": "TorokbalintHouseholdWorksLedgerWorkflow"}},
+]
+
+
+@pytest.fixture
+def stamp(monkeypatch):
+    def _run(workflow_type, error, chores=CHORES):
+        fake = _FakeVaultClient(chores)
+        monkeypatch.setattr(sl, "VaultClient", lambda _cfg: fake)
+        asyncio.run(sl._stamp_chore_failure(workflow_type, error))
+        return fake
+
+    return _run
+
+
+class TestStampsTheOwningChore:
+    def test_failure_marks_the_matching_chore_record(self, stamp):
+        fake = stamp("TorokbalintHouseholdWorksLedgerWorkflow", "boom: gateway 404")
+        assert len(fake.patches) == 1
+        path, updates = fake.patches[0]
+        assert path == "chore/trkblint-household-works-ledger.md"
+        assert updates["last_result"].startswith("FAILED: ")
+        assert "gateway 404" in updates["last_result"]
+        assert updates["last_run"]
+
+    def test_error_detail_is_single_line_and_bounded(self, stamp):
+        fake = stamp("TorokbalintHouseholdWorksLedgerWorkflow", "line1\nline2 " + "x" * 400)
+        _, updates = fake.patches[0]
+        assert "\n" not in updates["last_result"]
+        assert len(updates["last_result"]) < 220
+
+    def test_missing_error_still_stamps(self, stamp):
+        fake = stamp("TorokbalintHouseholdWorksLedgerWorkflow", None)
+        _, updates = fake.patches[0]
+        assert "unknown error" in updates["last_result"]
+
+
+class TestLeavesEverythingElseAlone:
+    def test_non_chore_workflow_is_a_no_op(self, stamp):
+        """DecisionRouter/SignalRouter failures must not touch any chore."""
+        fake = stamp("DecisionRouterWorkflow", "some error")
+        assert fake.patches == []
+
+    def test_empty_workflow_type_is_a_no_op(self, stamp):
+        fake = stamp("", "err")
+        assert fake.patches == []
+
+    def test_no_chores_configured_is_a_no_op(self, stamp):
+        fake = stamp("AnyWorkflow", "err", chores=[])
+        assert fake.patches == []
+
+    def test_malformed_chore_records_are_skipped(self, stamp):
+        fake = stamp("X", "err", chores=[{"path": "chore/a.md"}, "not-a-dict", {}])
+        assert fake.patches == []


### PR DESCRIPTION
From the post-fix deep re-scan. Three findings, one theme: **work that fails invisibly.**

## 1. Chore failures were invisible (#366 follow-up)
`record_chore_run` only fires on success paths, so a chore whose run throws leaves its vault record showing the last *successful* run — /chores reads it as healthy. Live proof: `trkblint` displayed a green manual-trigger run while Temporal held two **Failed** scheduled ticks. You had to SSH and read Temporal to know a chore was dead.

Fixed in the workflow-audit emitter (the one place every failure already passes through) rather than in each of the 13 chore templates. Maps `workflow_type` → chore via `workflow_class_name`; no-ops for non-chore workflows.

## 2. `vaultIndex` swallowed YAML parse errors (ctrl) — the significant one
`parseRecord` had a bare `catch {}` that indexed malformed-frontmatter records with **empty** frontmatter. Such a record doesn't 404 — it silently never appears in any filtered read.

Live on home: **42 decision records** written by an external tool carry an unquoted `name:` containing `": "` (e.g. `name: Build approval needed: GH #298`) → js-yaml throws `mapping values are not allowed here` → invisible to `GET /api/v1/decisions`. DecisionRouter has never seen them.

**This corrects something I reported earlier today.** I said #369 took open orphans 12 → 0. That was true *for the visible set* (16 records carry a genuine `retired_at` stamp), but 42 more were never visible at all — #369's retire cannot reach what the index won't list. Still non-fatal (one bad record mustn't fail an index rebuild), but never silent again.

## 3. Closure-predicate mapper covered 2 of 4 kinds (#379 follow-up)
`gmail_thread_reply` and `calendar_event_accepted` auto-tasks kept an inert deterministic fast path. Both added, thread-id outranking the from+subject heuristic. Includes a guard test asserting every kind the mapper can emit is one `evaluate_predicate` actually implements — that test caught a wrong registry name in its own first draft.

## Not in this PR (deliberate)
- **The 42 records' data repair** — quoting their `name:` would make them parse and let #369 retire them. It's a write to the principal's vault, so I'm asking rather than doing.
- **The writer** that emits unquoted YAML is out-of-repo (alfred-code / Paperclip side). Filing separately.

## Smoke evidence
- Learn suite **2455 passed**; `tsc --noEmit` clean. 7 new chore-failure cases + 5 predicate-coverage cases.
- Post-deploy: the vaultIndex warning should immediately name all 42 offending files in the ctrl-api log — that's the verification, and it also gives the exact repair list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)