### PR TITLE
fix(learn): instinct tier ladder — template default + reflection promotion rules (#330)

### DIFF
--- a/packages/learn/src/activities/clerk.py
+++ b/packages/learn/src/activities/clerk.py
@@ -433,6 +433,19 @@ Rules:
 - If distiller_learnings are provided, use them to strengthen or refine instincts
 - If janitor_flags are present, reduce confidence for affected records
 
+Tier promotion ladder (the trust gradient — you are its only writer):
+- Every instinct has "tier": "Asking" | "Confirming" | "Acting".
+- New instincts ALWAYS start at "Asking" (surface to the human, never act).
+- Promote Asking → Confirming only when an instinct has 10+ CONSISTENT
+  observations (human agreed with the routing) and no contradicting
+  observation in the window.
+- Promote Confirming → Acting only at 20+ consistent observations AND
+  zero reversals — Acting means autonomous execution; treat it like
+  handing over keys.
+- DEMOTE one step immediately on any reversal/contradiction observation.
+- Propose a tier change via update: {{"changes": {{"tier": "Confirming"}}}}.
+  Never skip a rung in either direction.
+
 When creating or updating instincts, use the rich schema:
 - input_patterns: {{ sender_domains: [], subject_keywords: [], attachment_types: [], input_types: [] }}
 - routing_rule: {{ destination_type: "project|person|process|hold", destination: "[[wikilink]]", destination_resolver: null, process: "", default_assignee: "[[person/name]]" }}
@@ -465,6 +478,7 @@ Return JSON only:
         "requires_approval": true
       }},
       "confidence_score": 0.0,
+      "tier": "Asking",
       "observations": ["[[...]]"],
       "tags": []
     }}

--- a/packages/learn/src/activities/vault.py
+++ b/packages/learn/src/activities/vault.py
@@ -1094,10 +1094,19 @@ def _build_instinct_content(instinct: dict[str, Any]) -> str:
     resolver = routing_rule.get("destination_resolver")
     resolver_yaml = "null" if resolver is None else f'"{resolver}"'
 
+    # #330: every instinct carries a promotion-ladder tier. Reflection is
+    # the sole promoter; a fresh instinct always starts at Asking. Before
+    # this, the template omitted tier entirely — 33/34 live instincts had
+    # no tier and the ladder had nothing valid to promote.
+    tier = str(instinct.get("tier") or "Asking").strip()
+    if tier not in ("Asking", "Confirming", "Acting"):
+        tier = "Asking"
+
     return f"""---
 type: instinct
 name: {name}
 status: active
+tier: {tier}
 description: "{description}"
 input_patterns:
   sender_domains: {input_patterns.get("sender_domains", [])}

--- a/packages/learn/tests/test_instinct_tier_330.py
+++ b/packages/learn/tests/test_instinct_tier_330.py
@@ -1,0 +1,37 @@
+"""#330 — every instinct carries a promotion-ladder tier.
+
+Live finding (home, 2026-07-20): 33/34 instinct records had NO tier and
+the 34th carried "Approved" (not in the Asking/Confirming/Acting vocab),
+so ReflectionWorkflow's promotion ladder had nothing valid to promote.
+The template simply never emitted the field.
+"""
+from __future__ import annotations
+
+from src.activities.vault import _build_instinct_content
+
+
+class TestInstinctTier:
+    def test_new_instinct_defaults_to_asking(self):
+        content = _build_instinct_content({"name": "test-instinct"})
+        assert "tier: Asking" in content
+
+    def test_explicit_valid_tier_respected(self):
+        content = _build_instinct_content(
+            {"name": "t", "tier": "Confirming"}
+        )
+        assert "tier: Confirming" in content
+
+    def test_invalid_tier_coerced_to_asking(self):
+        """'Approved' was the live wrong value — never write vocab the
+        ladder can't read."""
+        content = _build_instinct_content({"name": "t", "tier": "Approved"})
+        assert "tier: Asking" in content
+
+    def test_reflection_prompt_teaches_the_ladder(self):
+        import inspect
+
+        from src.activities import clerk
+
+        src = inspect.getsource(clerk.clerk_reflect)
+        for token in ("Asking", "Confirming", "Acting", "DEMOTE"):
+            assert token in src, f"ladder guidance missing: {token}"


### PR DESCRIPTION
Closes #330.

## What
- `_build_instinct_content` emits `tier: Asking` by default (non-vocab coerced) — the template previously never wrote the field, which is why 33/34 live instincts had no tier.
- `clerk_reflect` now teaches the Asking→Confirming→Acting ladder: promote at 10+/20+ consistent observations, never skip rungs, demote immediately on reversal; `tier` added to the create schema.
- No hard validator: none exists for instinct fields to extend; the sole creator now always emits tier and a test pins it (adding a required-field validator would risk 500ing legacy update paths for no marginal gain — noted on the issue).

## Data run (already executed on home)
35/35 instinct records now `tier: Asking`. Two required YAML surgery first — unquoted colons in `description`/`janitor_note` made them unreadable by the vault daemon (so NO api path could fix them); quoted, then re-patched via the API to prove health; host-side backups kept. One misfiled `type: assumption` record (janitor had flagged DIR001) moved to `_rescue/`. Notable: the second poisoned record was poisoned BY the janitor's own unquoted `janitor_note` annotation — that writer-quoting bug is being folded into the #288 L3/L4 janitor rework (next in queue).

## Smoke evidence
- Local: 4 new tests green (default/explicit/coerce + prompt-ladder guard); full learn suite pending in CI image.
- Live: tier census 35/35 Asking (evidence above); ReflectionWorkflow's next 02:00 run gets valid ladder data for the first time. Post-deploy check: next reflection report proposes tier changes only via `changes.tier` with vocab values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)