### PR TITLE
fix(learn): blocked_by as list — stop poisoning task records (#394)

### DIFF
--- a/packages/learn/src/activities/tasks.py
+++ b/packages/learn/src/activities/tasks.py
@@ -352,7 +352,10 @@ async def complete_task(task: dict[str, Any], result: dict[str, Any]) -> None:
             "completed_at": now,
         }
         if result.get("blocked_reason"):
-            updates["blocked_by"] = result["blocked_reason"]
+            # #394: blocked_by is a LIST field — writing a bare string
+            # poisoned 3 live records against every subsequent PATCH
+            # (the daemon revalidates the whole frontmatter on any edit).
+            updates["blocked_by"] = [str(result["blocked_reason"])]
 
         updated = _apply_frontmatter_updates(raw, updates)
 

--- a/packages/learn/tests/test_blocked_by_list_394.py
+++ b/packages/learn/tests/test_blocked_by_list_394.py
@@ -1,0 +1,47 @@
+"""#394 — blocked_by must be written as a list, never a bare string.
+
+Live: 3 task records carried string blocked_by; the vault daemon
+revalidates full frontmatter on ANY edit, so every subsequent PATCH
+against those records failed (16 failures/6h) until repaired.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from src.activities import tasks as tasks_mod
+
+
+class _FakeVaultClient:
+    def __init__(self):
+        self.writes = []
+
+    async def read_record(self, path):
+        return {"frontmatter": {"status": "active"}, "body": "b",
+                "content": "---\nstatus: active\n---\nb"}
+
+    async def write_record(self, rtype, name, content):
+        self.writes.append((rtype, name, content))
+        return name
+
+    async def close(self):
+        return None
+
+
+def test_blocked_reason_lands_as_list(monkeypatch):
+    fake = _FakeVaultClient()
+    monkeypatch.setattr(tasks_mod, "VaultClient", lambda _cfg: fake)
+    asyncio.run(
+        tasks_mod.complete_task(
+            {"path": "task/t.md", "title": "T"},
+            {"status": "blocked", "blocked_reason": "waiting on approval",
+             "summary": "s"},
+        )
+    )
+    content = fake.writes[0][2]
+    # list form: a "blocked_by:" line followed by a "- " item — never
+    # "blocked_by: <bare string>"
+    assert "blocked_by:" in content
+    import re
+    assert not re.search(r"^blocked_by: (?!\[)\S.*$", content, flags=re.M) or \
+           "blocked_by: [" in content, content
+    assert "waiting on approval" in content


### PR DESCRIPTION
Closes #394.

One-line writer fix (`complete_task`: `blocked_by = [str(reason)]`) + regression test. Data half already executed on home: the 3 poisoned records (`close-mcp-trust-proxy-rate-limit-bypass`, `correct-lunchflow-non-usd-account-balances`, `repair-alfred-code-delivery-control-plane`) converted to list form with host backups, then **proven PATCH-healthy via live API probes** (probe fields removed after).

No learn reader of `blocked_by` exists, so no read-tolerance needed; the failure was daemon-side revalidation on unrelated edits.

## Smoke evidence
- Local: new regression test green; writer path pinned.
- Live: the 3 records accept PATCHes again (probe evidence in the run log); watch ctrl logs for zero blocked_by failures over 24h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)