### PR TITLE
feat(learn): blocked-task recovery sweep — the last unswept strand class (#399)

### DIFF
--- a/packages/learn/scripts/register_schedules.py
+++ b/packages/learn/scripts/register_schedules.py
@@ -169,6 +169,11 @@ INTERVAL_SCHEDULES = [
         "interval": timedelta(minutes=15),
     },
     {
+        "id": "al-blocked-task-recovery",
+        "workflow": "BlockedTaskRecoveryWorkflow",
+        "interval": timedelta(hours=6),
+    },
+    {
         "id": "al-learning",
         "workflow": "LearningWorkflow",
         "interval": timedelta(minutes=15),

--- a/packages/learn/src/activities/tasks.py
+++ b/packages/learn/src/activities/tasks.py
@@ -163,8 +163,19 @@ async def check_task_prerequisites(task: dict[str, Any]) -> bool:
 
 
 @activity.defn
-async def update_task_status(task: dict[str, Any], new_status: str) -> None:
-    """Update a task's status field in the vault."""
+async def update_task_status(
+    task: dict[str, Any],
+    new_status: str,
+    blocked_reason: str | None = None,
+) -> None:
+    """Update a task's status field in the vault.
+
+    #399: when the runner blocks a task on an EXCEPTION (vs a considered
+    LLM "blocked" verdict), it passes ``blocked_reason`` so the record
+    says WHY — before this, exception-blocked tasks were indistinguishable
+    from principal-blocked ones, and the recovery sweep needs the
+    transient-error signature to know what is safe to retry.
+    """
     config = load_config()
     client = VaultClient(config)
     try:
@@ -177,8 +188,15 @@ async def update_task_status(task: dict[str, Any], new_status: str) -> None:
         if not raw:
             return
 
+        updates: dict[str, Any] = {"status": new_status}
+        if blocked_reason:
+            updates["blocked_by"] = [str(blocked_reason)[:300]]
+            updates["blocked_at"] = datetime.now(timezone.utc).isoformat(
+                timespec="seconds"
+            )
+
         from src.activities.vault import _apply_frontmatter_updates
-        updated = _apply_frontmatter_updates(raw, {"status": new_status})
+        updated = _apply_frontmatter_updates(raw, updates)
         await client.write_record("task", path, updated)
     finally:
         await client.close()
@@ -681,3 +699,99 @@ def _extract_task_result(text: str, task_title: str) -> dict[str, Any]:
         "summary": f"Completed: {task_title}",
         "follow_up_tasks": [],
     }
+
+
+@activity.defn
+async def recover_stale_blocked_tasks(
+    min_age_hours: int = 6,
+    max_recoveries: int = 3,
+) -> dict[str, Any]:
+    """Un-block tasks stranded by TRANSIENT execution failures (#399).
+
+    The runner marks a task blocked when execute_task throws (correct —
+    billing/auth errors must not retry blindly), but nothing ever
+    revisited them: a systemic clerk outage would permanently strand
+    every task touched during the window. This sweep flips ONLY tasks
+    whose ``blocked_by`` carries the runner's transient-error signature
+    back to ``todo`` — bounded per task (``recovery_attempts``), so a
+    genuinely broken task parks after ``max_recoveries``. Tasks blocked
+    by the principal or by an LLM "blocked" verdict are never touched.
+    """
+    from src.activities.vault import _apply_frontmatter_updates
+    from src.utils.state_client import StateClient
+
+    now = datetime.now(timezone.utc)
+    recovered = 0
+    parked = 0
+    config = load_config()
+    client = VaultClient(config)
+    state = StateClient(config)
+    try:
+        stubs = await client.list_records("task", status="blocked")
+        for stub in stubs:
+            path = stub.get("path", "")
+            fm = stub.get("frontmatter") or {}
+            if not path or not isinstance(fm, dict):
+                continue
+            blocked_by = fm.get("blocked_by")
+            first = ""
+            if isinstance(blocked_by, list) and blocked_by:
+                first = str(blocked_by[0])
+            elif isinstance(blocked_by, str):
+                first = blocked_by
+            if not first.startswith("transient-execution-error"):
+                continue
+            blocked_at_raw = str(fm.get("blocked_at") or "")
+            try:
+                blocked_at = datetime.fromisoformat(
+                    blocked_at_raw.replace("Z", "+00:00")
+                )
+                if blocked_at.tzinfo is None:
+                    blocked_at = blocked_at.replace(tzinfo=timezone.utc)
+            except ValueError:
+                blocked_at = None
+            if blocked_at is not None and (
+                now - blocked_at
+            ).total_seconds() < min_age_hours * 3600:
+                continue
+            attempts = int(fm.get("recovery_attempts") or 0)
+            full = await client.read_record(path)
+            raw = _reconstruct_markdown(full)
+            if not raw:
+                continue
+            if attempts >= max_recoveries:
+                updated = _apply_frontmatter_updates(
+                    raw, {"blocked_by": [f"{first} (recovery exhausted)"]}
+                )
+                await client.write_record("task", path, updated)
+                await state.append_audit(
+                    action_type="task_recovery",
+                    actor="alfred-learn",
+                    summary=f"task {path} parked after {attempts} recoveries",
+                    source="task_runner.recover_stale_blocked_tasks",
+                    target_path=path,
+                    target_kind="task",
+                )
+                parked += 1
+                continue
+            updated = _apply_frontmatter_updates(
+                raw,
+                {"status": "todo", "recovery_attempts": attempts + 1},
+            )
+            await client.write_record("task", path, updated)
+            await state.append_audit(
+                action_type="task_recovery",
+                actor="alfred-learn",
+                summary=(
+                    f"task {path} recovered blocked->todo "
+                    f"(attempt {attempts + 1}/{max_recoveries})"
+                ),
+                source="task_runner.recover_stale_blocked_tasks",
+                target_path=path,
+                target_kind="task",
+            )
+            recovered += 1
+    finally:
+        await client.close()
+        await state.close()
+    return {"recovered": recovered, "parked": parked}

--- a/packages/learn/src/worker.py
+++ b/packages/learn/src/worker.py
@@ -16,7 +16,7 @@ from src.workflows.event_processor import EventProcessorWorkflow
 from src.workflows.learning import LearningWorkflow
 from src.workflows.reflection import ReflectionWorkflow
 from src.workflows.media_ingestion import MediaIngestionWorkflow
-from src.workflows.task_runner import TaskRunnerWorkflow
+from src.workflows.task_runner import BlockedTaskRecoveryWorkflow, TaskRunnerWorkflow
 from src.workflows.stream_puller import StreamPullerWorkflow, StreamSweepWorkflow
 from src.workflows.onboarding_pipeline import OnboardingPipelineWorkflow
 from src.workflows.omi_processor import OmiAudioProcessorWorkflow
@@ -299,6 +299,7 @@ from src.activities.tasks import (
     assemble_task_context,
     check_task_prerequisites,
     complete_task,
+    recover_stale_blocked_tasks,
     evaluate_consequentials,
     execute_task,
     fetch_queued_tasks,
@@ -772,6 +773,7 @@ _STATIC_WORKFLOWS = [
     ReflectionWorkflow,
     MediaIngestionWorkflow,
     TaskRunnerWorkflow,
+    BlockedTaskRecoveryWorkflow,
     # StreamPullerWorkflow kept registered as a tombstone (#53): no
     # longer scheduled per-stream, but callable ad-hoc and harmless to
     # register. StreamSweepWorkflow is the scheduled entity.
@@ -913,6 +915,7 @@ ALL_ACTIVITIES = [
     assemble_task_context,
     check_task_prerequisites,
     complete_task,
+    recover_stale_blocked_tasks,
     evaluate_consequentials,
     execute_task,
     fetch_queued_tasks,

--- a/packages/learn/src/workflows/task_runner.py
+++ b/packages/learn/src/workflows/task_runner.py
@@ -22,6 +22,7 @@ with workflow.unsafe.imports_passed_through():
         evaluate_consequentials,
         execute_task,
         fetch_queued_tasks,
+        recover_stale_blocked_tasks,
         update_task_status,
         write_task_artifacts,
     )
@@ -137,7 +138,14 @@ class TaskRunnerWorkflow:
                 try:
                     await workflow.execute_activity(
                         update_task_status,
-                        args=[task, "blocked"],
+                        # #399: stamp WHY, with the transient signature the
+                        # recovery sweep keys on — an exception block is
+                        # retryable state, a considered LLM block is not.
+                        args=[
+                            task,
+                            "blocked",
+                            "transient-execution-error: runner exception",
+                        ],
                         start_to_close_timeout=timedelta(seconds=15),
                         retry_policy=RetryPolicy(maximum_attempts=3),
                     )
@@ -148,3 +156,22 @@ class TaskRunnerWorkflow:
                 result.failed += 1
 
         return result
+
+
+@workflow.defn(name="BlockedTaskRecoveryWorkflow")
+class BlockedTaskRecoveryWorkflow:
+    """#399 — bounded recovery for transient-error-blocked tasks.
+
+    Own workflow (not a TaskRunner pre-pass) so the deployed
+    TaskRunnerWorkflow's replay history is untouched. Scheduled as
+    ``al-blocked-task-recovery`` every 6h; the sweep itself is a no-op
+    when nothing carries the transient signature.
+    """
+
+    @workflow.run
+    async def run(self) -> dict:
+        return await workflow.execute_activity(
+            recover_stale_blocked_tasks,
+            start_to_close_timeout=timedelta(seconds=120),
+            retry_policy=RetryPolicy(maximum_attempts=2),
+        )

--- a/packages/learn/tests/test_blocked_recovery_399.py
+++ b/packages/learn/tests/test_blocked_recovery_399.py
@@ -1,0 +1,114 @@
+"""#399 — bounded recovery for transient-error-blocked tasks."""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+from src.activities import tasks as tasks_mod
+
+
+def _fm(blocked_by, hours_ago=12, attempts=0):
+    return {
+        "status": "blocked",
+        "blocked_by": blocked_by,
+        "blocked_at": (
+            datetime.now(timezone.utc) - timedelta(hours=hours_ago)
+        ).isoformat(timespec="seconds"),
+        "recovery_attempts": attempts,
+    }
+
+
+class _FakeVault:
+    def __init__(self, stubs):
+        self.stubs = stubs
+        self.writes = []
+
+    async def list_records(self, *_a, **_k):
+        return self.stubs
+
+    async def read_record(self, path):
+        stub = next(s for s in self.stubs if s["path"] == path)
+        import yaml
+        fm_yaml = yaml.dump(stub["frontmatter"])
+        return {"content": f"---\n{fm_yaml}---\nbody"}
+
+    async def write_record(self, rtype, name, content):
+        self.writes.append((name, content))
+        return name
+
+    async def close(self):
+        return None
+
+
+class _FakeState:
+    def __init__(self):
+        self.audits = []
+
+    async def append_audit(self, **kw):
+        self.audits.append(kw)
+        return "01A"
+
+    async def close(self):
+        return None
+
+
+def _run(stubs, monkeypatch):
+    fake_v, fake_s = _FakeVault(stubs), _FakeState()
+    monkeypatch.setattr(tasks_mod, "VaultClient", lambda _c: fake_v)
+    monkeypatch.setattr("src.utils.state_client.StateClient", lambda _c: fake_s)
+    out = asyncio.run(tasks_mod.recover_stale_blocked_tasks())
+    return out, fake_v, fake_s
+
+
+def test_transient_block_recovers(monkeypatch):
+    stubs = [{"path": "task/a.md",
+              "frontmatter": _fm(["transient-execution-error: runner exception"])}]
+    out, v, s = _run(stubs, monkeypatch)
+    assert out == {"recovered": 1, "parked": 0}
+    name, content = v.writes[0]
+    assert "status: todo" in content
+    assert "recovery_attempts: 1" in content
+    assert s.audits[0]["action_type"] == "task_recovery"
+
+
+def test_human_block_never_touched(monkeypatch):
+    stubs = [{"path": "task/b.md",
+              "frontmatter": _fm(["waiting for Sir's approval"])}]
+    out, v, _ = _run(stubs, monkeypatch)
+    assert out == {"recovered": 0, "parked": 0}
+    assert v.writes == []
+
+
+def test_cap_parks(monkeypatch):
+    stubs = [{"path": "task/c.md",
+              "frontmatter": _fm(["transient-execution-error: x"], attempts=3)}]
+    out, v, _ = _run(stubs, monkeypatch)
+    assert out == {"recovered": 0, "parked": 1}
+    assert "recovery exhausted" in v.writes[0][1]
+
+
+def test_fresh_block_waits(monkeypatch):
+    stubs = [{"path": "task/d.md",
+              "frontmatter": _fm(["transient-execution-error: x"], hours_ago=1)}]
+    out, v, _ = _run(stubs, monkeypatch)
+    assert out == {"recovered": 0, "parked": 0}
+
+
+def test_update_task_status_stamps_reason(monkeypatch):
+    class _V:
+        writes = []
+        async def read_record(self, p):
+            return {"content": "---\nstatus: active\n---\nb"}
+        async def write_record(self, rtype, name, content):
+            self.writes.append(content)
+            return name
+        async def close(self):
+            return None
+    v = _V()
+    monkeypatch.setattr(tasks_mod, "VaultClient", lambda _c: v)
+    asyncio.run(tasks_mod.update_task_status(
+        {"path": "task/e.md"}, "blocked",
+        "transient-execution-error: runner exception"))
+    c = v.writes[0]
+    assert "status: blocked" in c and "transient-execution-error" in c
+    assert "blocked_at:" in c


### PR DESCRIPTION
Closes #399.

Signals got their sweep (#373), decisions have #282's — tasks now get theirs. Exception-blocked tasks are stamped with a transient signature + `blocked_at`; a 6h `BlockedTaskRecoveryWorkflow` flips only those back to `todo`, 3 attempts max, park + audit after. Principal/LLM blocks are structurally untouchable (signature check). Own workflow + own schedule → zero replay risk to TaskRunner; `register_schedules` self-creates `al-blocked-task-recovery` at next boot on every tenant.

## Smoke evidence
- Local: full learn suite **2469 passed**; 5 new tests (recover/park/never-touch-human/fresh-waits/reason-stamp).
- Post-deploy on home: schedule appears; sweep logs `{recovered: 0, parked: 0}` (no transient-signature blocks live — the 25 blocked tasks are legitimate); evidence to the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)