### PR TITLE
fix(alfred-vault): janitor L3+L4 — JSON-propose/Python-apply repairs, template exemption, prompt caps (#288)

### DIFF
--- a/packages/alfred-vault/src/alfred/_bundled/skills/vault-janitor/prompts/stage2_link_repair.md
+++ b/packages/alfred-vault/src/alfred/_bundled/skills/vault-janitor/prompts/stage2_link_repair.md
@@ -26,23 +26,28 @@ The following vault records were found as possible matches for `[[{broken_target
 1. Read the file using `alfred vault read "{file_path}"`
 2. Examine the candidates above
 3. If ONE candidate is clearly the correct match, fix the link
-4. If you are NOT SURE, do NOTHING. Reply with "SKIP" and nothing else.
+4. If you are NOT SURE, choose null.
 
-## How to fix
+## How to answer — JSON ONLY, no tools
 
-- To fix a wikilink in the body: `alfred vault edit "{file_path}" --body-replace "[[{broken_target}]]" "[[correct/Target Name]]"`
-- To fix a wikilink in a frontmatter field: `alfred vault edit "{file_path}" --set field="[[correct/Target Name]]"`
+You do NOT edit anything. You only CHOOSE. The janitor applies your
+choice deterministically in Python (#288 L3 — the old contract asked you
+to run a CLI that does not exist in your environment, so no repair ever
+landed).
+
+Reply with ONLY this JSON object and nothing else:
+
+```json
+{{"chosen": "<the correct candidate name exactly as listed>"}}
+```
+
+or, when no candidate is clearly correct:
+
+```json
+{{"chosen": null}}
+```
 
 ## Rules — READ CAREFULLY
 
-- Fix ONLY the one broken link described above. Touch NOTHING else in the file.
-- Do NOT add any fields (no janitor_note, no tags, no metadata).
-- Do NOT modify the body text except for the exact wikilink replacement.
-- Do NOT rewrite, reformat, or "improve" any content.
-- Do NOT delete, move, or create any files.
-- Do NOT modify files other than `{file_path}`.
-- If unsure, do NOTHING. It is better to skip than to make a wrong fix.
-
----
-
-{vault_cli_reference}
+- "chosen" MUST be one of the candidate names listed above, verbatim, or null.
+- If unsure, null. It is better to skip than to pick a wrong link.

--- a/packages/alfred-vault/src/alfred/_bundled/skills/vault-janitor/prompts/stage3_enrich.md
+++ b/packages/alfred-vault/src/alfred/_bundled/skills/vault-janitor/prompts/stage3_enrich.md
@@ -79,16 +79,24 @@ Current record content:
 - `status`: Only if clearly determinable from context
 - Do NOT overwrite fields that already have values
 
+## How to answer — JSON ONLY, no tools
+
+You do NOT edit anything. You only PROPOSE. The janitor applies your
+proposal deterministically in Python (#288 L3 — the old contract asked
+you to run a CLI that does not exist in your environment, so no
+enrichment ever landed).
+
+Reply with ONLY this JSON object and nothing else:
+
+```json
+{{"frontmatter_updates": {{"<field>": "<value>"}}, "body_append": "<markdown to append, or empty string>"}}
+```
+
+If you cannot enrich meaningfully, reply: `{{"frontmatter_updates": {{}}, "body_append": ""}}`
+
 ## Rules
 
-- Modify ONLY the file `{file_path}`. Do not touch any other file.
-- Do NOT create or delete any files.
-- Do NOT remove base view embeds (`![[*.base#Section]]`)
-- APPEND to the body, never replace existing content
+- frontmatter_updates may ONLY contain fields that are currently empty — never overwrite existing values.
+- body_append is APPENDED — never a replacement. Do NOT include base view embeds.
 - Write in English. Keep proper nouns in original form.
-- Every fact you write MUST be traceable to either the vault context above or verifiable public information.
-- If you cannot enrich meaningfully, output "SKIP: insufficient context" and do nothing.
-
----
-
-{vault_cli_reference}
+- Every fact MUST be traceable to the vault context above or verifiable public information.

--- a/packages/alfred-vault/src/alfred/janitor/pipeline.py
+++ b/packages/alfred-vault/src/alfred/janitor/pipeline.py
@@ -147,6 +147,25 @@ async def _call_llm(
 # ---------------------------------------------------------------------------
 
 
+
+def _parse_llm_json(raw: str) -> dict:
+    """Best-effort JSON object extraction from an agent reply (#288 L3).
+
+    The agent is instructed to reply with pure JSON, but wrappers add
+    fences/prose. Slice first '{' .. last '}' and parse; {} on failure.
+    """
+    if not raw:
+        return {}
+    start, end = raw.find("{"), raw.rfind("}")
+    if start < 0 or end <= start:
+        return {}
+    try:
+        obj = json.loads(raw[start:end + 1])
+        return obj if isinstance(obj, dict) else {}
+    except (json.JSONDecodeError, ValueError):
+        return {}
+
+
 def _find_link_candidates(
     broken_target: str,
     vault_path: Path,
@@ -327,20 +346,28 @@ async def _stage2_link_repair(
         safe_name = re.sub(r'[^a-zA-Z0-9_-]', '', broken_target.replace(' ', '-').replace('/', '-'))[:30]
         stage_label = f"s2-link-{safe_name}"
 
-        # Snapshot file mtime before LLM call to detect actual changes.
-        # The mutation log doesn't work cross-container (openclaw-wrapper
-        # sends prompts via HTTP to the openclaw container which doesn't
-        # have ALFRED_VAULT_SESSION), so we check the filesystem directly.
-        target_path = config.vault.vault_path / issue.file
-        before_mtime = target_path.stat().st_mtime if target_path.exists() else 0
-
-        await _call_llm(prompt, config, session_path, stage_label)
-
-        after_mtime = target_path.stat().st_mtime if target_path.exists() else 0
-        if after_mtime > before_mtime:
-            repaired += 1
-
-        log.info("pipeline.s2_llm_repair", file=issue.file, target=broken_target)
+        # #288 L3: the agent CHOOSES, Python APPLIES. The old contract told
+        # the agent to run `alfred vault edit` — a CLI that does not exist
+        # in its container — so every ambiguous repair failed, re-queued
+        # next sweep, and (pre-L1/L2) spammed the principal with the
+        # failure dumps. Same write path as the unambiguous branch above.
+        raw = await _call_llm(prompt, config, session_path, stage_label)
+        choice = _parse_llm_json(raw).get("chosen")
+        valid_names = {c.get("name", c["path"]) for c in candidates}
+        if isinstance(choice, str) and choice in valid_names:
+            if _fix_link_in_python(
+                issue.file, broken_target, choice, vault_path, session_path
+            ):
+                repaired += 1
+                log.info(
+                    "pipeline.s2_fixed_llm_choice",
+                    file=issue.file, old=broken_target, new=choice,
+                )
+        else:
+            log.info(
+                "pipeline.s2_llm_skip",
+                file=issue.file, target=broken_target, choice=str(choice)[:60],
+            )
 
     log.info("pipeline.s2_complete", repaired=repaired)
     return repaired
@@ -459,6 +486,15 @@ async def _stage3_enrich(
         log.warning("pipeline.s3_no_template")
         return 0
 
+    # #288 L4: never "enrich" scaffolding. Template/docs files are not
+    # thin records — they are deliberately skeletal, and LLM-enriching
+    # them (observed live on zsolt: person-Your-Name, project-My-Project,
+    # _docs/*) is pure token waste that also corrupts the templates.
+    stub_issues = [
+        i for i in stub_issues
+        if not str(i.file).startswith(("_templates/", "_docs/", "_template"))
+    ]
+
     # Issue #15: filter out stale stubs (enrichment exhausted, content unchanged)
     if state is not None:
         filtered: list[Issue] = []
@@ -527,10 +563,11 @@ async def _stage3_enrich(
         type_schema = _load_type_schema(record_type) if record_type else "(unknown type)"
 
         # Collect linked records for context
-        linked_records = _collect_linked_records(file_path, vault_path, ignore_dirs)
+        linked_records = _collect_linked_records(file_path, vault_path, ignore_dirs)[:24_000]
 
-        # Format current record content
-        record_content = json.dumps(record, indent=2, default=str)
+        # Format current record content. #288: cap the interpolations —
+        # a 696k-char prompt (TSMC record on zsolt) crashed the stage.
+        record_content = json.dumps(record, indent=2, default=str)[:16_000]
 
         prompt = template.format(
             file_path=file_path,
@@ -545,8 +582,33 @@ async def _stage3_enrich(
         safe_name = re.sub(r'[^a-zA-Z0-9_-]', '', record_name.replace(' ', '-'))[:30]
         stage_label = f"s3-enrich-{safe_name}"
 
-        await _call_llm(prompt, config, session_path, stage_label)
-        enriched += 1
+        # #288 L3: the agent PROPOSES, Python APPLIES (same rationale as
+        # stage 2 — the old CLI contract could never land a write).
+        raw = await _call_llm(prompt, config, session_path, stage_label)
+        proposal = _parse_llm_json(raw)
+        fm_updates = proposal.get("frontmatter_updates") or {}
+        body_append = str(proposal.get("body_append") or "").strip()
+        # Only fill EMPTY fields — never overwrite.
+        safe_updates = {
+            k: v for k, v in fm_updates.items()
+            if isinstance(k, str) and not fm.get(k)
+        }
+        if not safe_updates and not body_append:
+            log.info("pipeline.s3_llm_skip", file=file_path)
+            if state is not None:
+                state.record_enrichment_attempt(file_path, max_attempts)
+            continue
+        try:
+            from ..vault.ops import vault_edit
+            vault_edit(
+                vault_path,
+                file_path,
+                set_fields=safe_updates or None,
+                body_append=("\n\n" + body_append) if body_append else None,
+            )
+            enriched += 1
+        except Exception as exc:  # noqa: BLE001
+            log.warning("pipeline.s3_apply_failed", file=file_path, err=str(exc)[:200])
 
         # Issue #15: track enrichment attempt in state
         if state is not None:

--- a/packages/alfred-vault/tests/test_janitor_pipeline_288.py
+++ b/packages/alfred-vault/tests/test_janitor_pipeline_288.py
@@ -1,0 +1,108 @@
+"""#288 L3/L4 — janitor repairs apply in Python, never via agent CLI.
+
+The agentic stages previously instructed the LLM to run `alfred vault
+edit` — a CLI that does not exist in the agent's container — so no
+ambiguous link repair or enrichment EVER landed (zsolt incident
+2026-07-15: failed repairs re-queued every sweep and spammed Slack).
+The agent now returns JSON; the janitor applies it deterministically.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from alfred.janitor import pipeline as pl
+from alfred.janitor.issues import Issue
+
+
+class TestParseLlmJson:
+    def test_pure_json(self):
+        assert pl._parse_llm_json('{"chosen": "person/Jane Doe"}') == {
+            "chosen": "person/Jane Doe"
+        }
+
+    def test_fenced_and_prosed(self):
+        raw = 'Sure!\n```json\n{"chosen": null}\n```\nDone.'
+        assert pl._parse_llm_json(raw) == {"chosen": None}
+
+    def test_garbage_is_empty(self):
+        assert pl._parse_llm_json("I edited the file for you") == {}
+        assert pl._parse_llm_json("") == {}
+
+
+class TestStage2ChoiceApplication:
+    def _run(self, monkeypatch, tmp_path, llm_reply):
+        vault = tmp_path
+        (vault / "note").mkdir()
+        (vault / "person").mkdir()
+        f = vault / "note" / "n.md"
+        f.write_text("---\ntype: note\n---\nsee [[Jane Do]]\n")
+        (vault / "person" / "Jane Doe.md").write_text("---\ntype: person\n---\nx")
+        (vault / "person" / "Janet Doeman.md").write_text("---\ntype: person\n---\ny")
+
+        class _Cfg:
+            class vault:  # noqa: N801
+                vault_path = vault
+                ignore_dirs = []
+
+        applied = []
+        monkeypatch.setattr(
+            pl, "_load_stage_prompt", lambda name: "prompt {file_path} {broken_target} {candidates} {candidate_names}"
+        )
+        monkeypatch.setattr(
+            pl, "_find_link_candidates",
+            lambda *a, **k: [
+                {"name": "person/Jane Doe", "path": "person/Jane Doe.md"},
+                {"name": "person/Janet Doeman", "path": "person/Janet Doeman.md"},
+            ],
+        )
+        monkeypatch.setattr(pl, "_is_unambiguous_match", lambda *a: None)
+
+        async def fake_llm(prompt, config, session_path, label):
+            return llm_reply
+
+        monkeypatch.setattr(pl, "_call_llm", fake_llm)
+        monkeypatch.setattr(
+            pl, "_fix_link_in_python",
+            lambda file, old, new, vp, sp: applied.append((file, old, new)) or True,
+        )
+        issue = Issue(file="note/n.md", code="LINK001",
+                      message="Broken wikilink: [[Jane Do]]", severity="warn")
+        n = asyncio.run(pl._stage2_link_repair([issue], _Cfg(), "/tmp/s"))
+        return n, applied
+
+    def test_valid_choice_is_applied_in_python(self, monkeypatch, tmp_path):
+        n, applied = self._run(monkeypatch, tmp_path, '{"chosen": "person/Jane Doe"}')
+        assert n == 1
+        assert applied == [("note/n.md", "Jane Do", "person/Jane Doe")]
+
+    def test_null_choice_applies_nothing(self, monkeypatch, tmp_path):
+        n, applied = self._run(monkeypatch, tmp_path, '{"chosen": null}')
+        assert n == 0 and applied == []
+
+    def test_hallucinated_choice_rejected(self, monkeypatch, tmp_path):
+        """A choice outside the candidate list must never be applied."""
+        n, applied = self._run(monkeypatch, tmp_path, '{"chosen": "person/Mallory"}')
+        assert n == 0 and applied == []
+
+
+class TestStage3Guardrails:
+    def test_templates_and_docs_exempt(self):
+        """#288 L4 — scaffolding is never enrichment fodder."""
+        issues = [
+            Issue(file="_templates/person.md", code="STUB001", message="stub", severity="info"),
+            Issue(file="_docs/README.md", code="STUB001", message="stub", severity="info"),
+        ]
+
+        class _Cfg:
+            class vault:  # noqa: N801
+                vault_path = None
+                ignore_dirs = []
+
+            class sweep:  # noqa: N801
+                max_stubs_per_sweep = 10
+                max_enrichment_attempts = 3
+
+        n = asyncio.run(pl._stage3_enrich(issues, _Cfg(), "/tmp/s", state=None))
+        assert n == 0


### PR DESCRIPTION
Addresses the L3 + L4 remainders of #288 (leaves it open for the final fleet verification + zsolt's structural_only lift).

## What
- **L3**: both agentic stages now return JSON and the janitor applies deterministically — the agent's environment can no longer make repairs impossible (the old contract required a CLI the agent never had; zero repairs ever landed). s2 reuses `_fix_link_in_python`; s3 applies via `vault_edit` (quoting-safe, fill-empty-only, append-only); out-of-candidate hallucinations rejected.
- **L4**: `_templates/` + `_docs/` exempt from enrichment.
- Prompt caps (16k record / 24k linked context) — the 696k-char TSMC prompt class.

## Smoke evidence
- 7 new tests green in an isolated venv; the package's 15 pre-existing surveyor failures reproduce identically with this diff stashed (local py3.14 env artifact — CI's image is authoritative).
- Post-deploy plan (will comment on #288): pull alfred-worker on home, run `janitor scan` + a bounded `fix` with the new pipeline, confirm an ambiguous-link repair lands via the JSON path and `_templates` stubs are skipped. zsolt's `structural_only: true` can lift after that evidence.

## Rollout
`build-alfred-worker.yml` builds the image. Fleet note: this changes janitor behavior only — no schedules, no Temporal surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)