### PR TITLE
feat(alfred-vault): worker-run ledger claimant — dashboard triggers become real (#407)

### DIFF
--- a/packages/alfred-vault/src/alfred/cli.py
+++ b/packages/alfred-vault/src/alfred/cli.py
@@ -91,7 +91,7 @@ def cmd_up(args: argparse.Namespace) -> None:
             _setup_logging_from_config(raw)
         from alfred.orchestrator import run_all
         from alfred._data import get_skills_dir
-        run_all(raw, only=args.only, skills_dir=get_skills_dir(), pid_path=pid_path, live_mode=live_mode)
+        run_all(raw, only=args.only, skills_dir=get_skills_dir(), pid_path=pid_path, live_mode=live_mode, config_path=getattr(args, 'config', None))
     else:
         # Daemon mode: re-exec as detached background process
         from alfred.daemon import spawn_daemon

--- a/packages/alfred-vault/src/alfred/orchestrator.py
+++ b/packages/alfred-vault/src/alfred/orchestrator.py
@@ -170,6 +170,7 @@ def run_all(
     skills_dir: Path | None = None,
     pid_path: Path | None = None,
     live_mode: bool = False,
+    config_path: str | None = None,
 ) -> None:
     """Start selected daemons as child processes with auto-restart."""
     if skills_dir is None:
@@ -221,6 +222,15 @@ def run_all(
         if not live_mode:
             print(f"  [{tool}] started (pid {p.pid})")
         return p
+
+    # #407: the durable worker-run claimant — executes the manual runs
+    # ctrl-api enqueues (janitor fix / distiller run). Without it every
+    # dashboard trigger 202'd into a ledger nothing ever read.
+    try:
+        from alfred.worker_runs import start_claimant
+        start_claimant(config_path)
+    except Exception as exc:  # noqa: BLE001
+        print(f"  [run-claimant] failed to start: {exc}")
 
     # Start all — stagger by 10s to avoid thundering herd on shared infra
     for i, tool in enumerate(tools):

--- a/packages/alfred-vault/src/alfred/worker_runs.py
+++ b/packages/alfred-vault/src/alfred/worker_runs.py
@@ -1,0 +1,193 @@
+"""Durable worker-run claimant (#407).
+
+ctrl-api enqueues manual runs (janitor fix / curator process / distiller
+run) as JSON records under ``$ALFRED_DATA_DIR/state/worker-runs/`` and
+answers 202 with a status URL — but until this module, NOTHING claimed
+them: runs sat ``queued`` forever (two on home since 2026-07-23) and every
+dashboard trigger was a silent no-op.
+
+This is the executor half of that ledger. A single thread inside the
+``alfred up`` supervisor polls the directory, claims queued runs by
+atomically rewriting the record (same dot-prefixed ``.tmp`` + rename
+discipline ctrl's ledger.ts uses — its directory listing skips those
+names), executes the mapped CLI, heartbeats while the child runs, and
+finishes the record with ``succeeded``/``failed`` + exit code.
+
+Single-claimant by design: ctrl-api never claims, and only one vault
+daemon runs per tenant, so claiming needs no cross-process locking —
+the atomic rename is belt enough.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import threading
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+log = structlog.get_logger("alfred.worker_runs")
+
+POLL_INTERVAL_SECONDS = 15
+HEARTBEAT_INTERVAL_SECONDS = 45
+RUN_TIMEOUT_SECONDS = 6 * 3600  # mirrors the ledger's run_timeout_seconds
+
+
+def runs_directory() -> Path:
+    return Path(os.environ.get("ALFRED_DATA_DIR", "/alfred-data")) / "state" / "worker-runs"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _atomic_write(path: Path, record: dict[str, Any]) -> None:
+    tmp = path.parent / f".{path.stem}.{os.getpid()}.{uuid.uuid4().hex[:8]}.tmp"
+    tmp.write_text(json.dumps(record) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def _touch(record: dict[str, Any]) -> None:
+    record["reliability"]["write_sequence"] = int(record["reliability"].get("write_sequence") or 0) + 1
+    record["timestamps"]["updated_at"] = _now()
+
+
+def _command_for(record: dict[str, Any], config_path: str | None) -> list[str] | None:
+    """Map a run record to its CLI invocation; None = unsupported worker."""
+    base = ["alfred"]
+    if config_path:
+        base += ["--config", config_path]
+    worker = record.get("worker")
+    inp = record.get("input") or {}
+    if worker == "janitor":
+        return base + ["janitor", "fix"]
+    if worker == "distiller":
+        cmd = base + ["distiller", "run"]
+        if inp.get("project"):
+            cmd += ["--project", str(inp["project"])]
+        return cmd
+    # curator: the daemon processes the inbox continuously; there is no
+    # one-shot CLI yet. Fail the run VISIBLY rather than leaving it queued.
+    return None
+
+
+def _claim(path: Path, record: dict[str, Any]) -> dict[str, Any]:
+    now = _now()
+    record["state"] = "running"
+    ts = record["timestamps"]
+    ts["claimed_at"] = now
+    ts["started_at"] = now
+    ts["heartbeat_at"] = now
+    ts["last_progress_at"] = now
+    rel = record["reliability"]
+    rel["attempt"] = int(rel.get("attempt") or 0) + 1
+    rel["claim_id"] = uuid.uuid4().hex
+    rel["worker_instance_id"] = f"vault-daemon-{os.getpid()}"
+    rel["pid"] = os.getpid()
+    _touch(record)
+    _atomic_write(path, record)
+    return record
+
+
+def _finish(path: Path, record: dict[str, Any], *, exit_code: int | None, error: str | None = None) -> None:
+    now = _now()
+    record["state"] = "succeeded" if exit_code == 0 else "failed"
+    record["timestamps"]["finished_at"] = now
+    record["timestamps"]["last_progress_at"] = now
+    if exit_code == 0:
+        record["timestamps"]["last_successful_output_at"] = now
+    record["reliability"]["exit_code"] = exit_code
+    if error:
+        record["last_error"] = str(error)[:500]
+    _touch(record)
+    _atomic_write(path, record)
+
+
+def _execute(path: Path, record: dict[str, Any], config_path: str | None) -> None:
+    cmd = _command_for(record, config_path)
+    if cmd is None:
+        log.warning("worker_runs.unsupported", run_id=record.get("run_id"), worker=record.get("worker"))
+        _finish(path, record, exit_code=1,
+                error=f"no one-shot executor for worker={record.get('worker')} (v1: janitor, distiller)")
+        return
+
+    log.info("worker_runs.exec", run_id=record.get("run_id"), cmd=" ".join(cmd))
+    proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+    deadline = time.monotonic() + RUN_TIMEOUT_SECONDS
+    last_beat = time.monotonic()
+    while True:
+        rc = proc.poll()
+        if rc is not None:
+            err = (proc.stderr.read() or b"").decode("utf-8", "replace")[:500] if proc.stderr else None
+            _finish(path, record, exit_code=rc, error=err if rc != 0 else None)
+            log.info("worker_runs.done", run_id=record.get("run_id"), exit_code=rc)
+            return
+        if time.monotonic() > deadline:
+            proc.kill()
+            record["reliability"]["termination_signal"] = "SIGKILL"
+            record["state"] = "timed_out"
+            record["timestamps"]["finished_at"] = _now()
+            _touch(record)
+            _atomic_write(path, record)
+            log.warning("worker_runs.timeout", run_id=record.get("run_id"))
+            return
+        if time.monotonic() - last_beat >= HEARTBEAT_INTERVAL_SECONDS:
+            record["timestamps"]["heartbeat_at"] = _now()
+            record["reliability"]["heartbeat_sequence"] = (
+                int(record["reliability"].get("heartbeat_sequence") or 0) + 1
+            )
+            _touch(record)
+            _atomic_write(path, record)
+            last_beat = time.monotonic()
+        time.sleep(2)
+
+
+def _scan_once(config_path: str | None) -> int:
+    directory = runs_directory()
+    if not directory.is_dir():
+        return 0
+    claimed = 0
+    for entry in sorted(directory.iterdir()):
+        if entry.name.startswith(".") or not entry.name.endswith(".json"):
+            continue
+        try:
+            record = json.loads(entry.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            log.warning("worker_runs.unreadable", file=entry.name, err=str(exc)[:120])
+            continue
+        if not isinstance(record, dict) or record.get("state") != "queued":
+            continue
+        try:
+            record = _claim(entry, record)
+            claimed += 1
+            _execute(entry, record, config_path)
+        except Exception as exc:  # noqa: BLE001 — one bad run must not kill the loop
+            log.warning("worker_runs.run_failed", file=entry.name, err=str(exc)[:200])
+            try:
+                _finish(entry, record, exit_code=1, error=str(exc))
+            except Exception:  # noqa: BLE001
+                pass
+    return claimed
+
+
+def start_claimant(config_path: str | None) -> threading.Thread:
+    """Start the background claim loop; returns the (daemon) thread."""
+
+    def _loop() -> None:
+        log.info("worker_runs.claimant_started", dir=str(runs_directory()))
+        while True:
+            try:
+                _scan_once(config_path)
+            except Exception as exc:  # noqa: BLE001
+                log.warning("worker_runs.scan_error", err=str(exc)[:200])
+            time.sleep(POLL_INTERVAL_SECONDS)
+
+    t = threading.Thread(target=_loop, name="alfred-run-claimant", daemon=True)
+    t.start()
+    return t

--- a/packages/alfred-vault/tests/test_worker_runs_claimant_407.py
+++ b/packages/alfred-vault/tests/test_worker_runs_claimant_407.py
@@ -1,0 +1,112 @@
+"""#407 — the durable worker-run claimant."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from alfred import worker_runs as wr
+
+
+def _record(run_id="01KYXXXXXXXXXXXXXXXXXXXXXX", worker="janitor", state="queued", inp=None):
+    now = "2026-07-23T00:00:00.000Z"
+    return {
+        "schema_version": 1, "run_id": run_id, "worker": worker, "state": state,
+        "input": inp or {},
+        "timestamps": {"created_at": now, "queued_at": now, "claimed_at": None,
+                       "started_at": None, "heartbeat_at": None, "last_progress_at": None,
+                       "last_successful_output_at": None, "finished_at": None, "updated_at": now},
+        "reliability": {"attempt": 0, "claim_id": None, "worker_instance_id": None,
+                        "pid": None, "effective_jobs": None, "heartbeat_sequence": 0,
+                        "write_sequence": 0, "exit_code": None, "termination_signal": None,
+                        "recovered_at": None, "recovery_reason": None},
+    }
+
+
+@pytest.fixture
+def ledger(tmp_path, monkeypatch):
+    d = tmp_path / "state" / "worker-runs"
+    d.mkdir(parents=True)
+    monkeypatch.setenv("ALFRED_DATA_DIR", str(tmp_path))
+    return d
+
+
+def _write(d: Path, rec: dict) -> Path:
+    p = d / f"{rec['run_id']}.json"
+    p.write_text(json.dumps(rec))
+    return p
+
+
+class TestCommandMapping:
+    def test_janitor(self):
+        cmd = wr._command_for(_record(), "/cfg.yaml")
+        assert cmd == ["alfred", "--config", "/cfg.yaml", "janitor", "fix"]
+
+    def test_distiller_with_project(self):
+        cmd = wr._command_for(_record(worker="distiller", inp={"project": "x"}), None)
+        assert cmd == ["alfred", "distiller", "run", "--project", "x"]
+
+    def test_curator_unsupported(self):
+        assert wr._command_for(_record(worker="curator"), None) is None
+
+
+class TestClaimAndFinish:
+    def test_queued_run_executes_and_succeeds(self, ledger, monkeypatch):
+        rec = _record()
+        p = _write(ledger, rec)
+        calls = []
+
+        class _P:
+            stderr = None
+            def __init__(self, cmd, **kw): calls.append(cmd)
+            def poll(self): return 0
+            def kill(self): pass
+
+        monkeypatch.setattr(wr.subprocess, "Popen", _P)
+        claimed = wr._scan_once("/cfg.yaml")
+        assert claimed == 1
+        out = json.loads(p.read_text())
+        assert out["state"] == "succeeded"
+        assert out["reliability"]["exit_code"] == 0
+        assert out["reliability"]["claim_id"]
+        assert out["timestamps"]["claimed_at"] and out["timestamps"]["finished_at"]
+        assert out["reliability"]["write_sequence"] >= 2
+        assert calls and calls[0][-2:] == ["janitor", "fix"]
+
+    def test_failed_child_marks_failed_with_error(self, ledger, monkeypatch):
+        import io
+        rec = _record(run_id="01KYYYYYYYYYYYYYYYYYYYYYYY")
+        p = _write(ledger, rec)
+
+        class _P:
+            stderr = io.BytesIO(b"boom: no gate")
+            def __init__(self, cmd, **kw): pass
+            def poll(self): return 3
+            def kill(self): pass
+
+        monkeypatch.setattr(wr.subprocess, "Popen", _P)
+        wr._scan_once(None)
+        out = json.loads(p.read_text())
+        assert out["state"] == "failed"
+        assert out["reliability"]["exit_code"] == 3
+        assert "boom" in out["last_error"]
+
+    def test_curator_run_fails_visibly_not_stuck(self, ledger):
+        rec = _record(run_id="01KYZZZZZZZZZZZZZZZZZZZZZZ", worker="curator")
+        p = _write(ledger, rec)
+        wr._scan_once(None)
+        out = json.loads(p.read_text())
+        assert out["state"] == "failed"
+        assert "no one-shot executor" in out["last_error"]
+
+    def test_non_queued_untouched(self, ledger):
+        rec = _record(run_id="01KYWWWWWWWWWWWWWWWWWWWWWW", state="running")
+        p = _write(ledger, rec)
+        assert wr._scan_once(None) == 0
+        assert json.loads(p.read_text())["state"] == "running"
+
+    def test_tmp_files_skipped(self, ledger):
+        (ledger / ".01KYVVVV.123.abc.tmp").write_text("{}")
+        assert wr._scan_once(None) == 0


### PR DESCRIPTION
Closes #407.

The executor half the #316 ledger always needed: a claimant thread in `alfred up` that polls `/alfred-data/state/worker-runs/`, claims queued runs (atomic rename, ctrl-compatible), runs the mapped CLI with heartbeats, and finishes the record. Curator runs fail visibly with "no one-shot executor" rather than queueing forever (v1 scope note in the code).

## Smoke evidence
- 8 new tests green (isolated venv); the package's 15 pre-existing surveyor failures unchanged.
- Post-deploy on home: the two stale runs from 2026-07-23 (incl. `01KY6ENE704FFBV3ZPPQP8YBNG`) get claimed on the first poll — the janitor one executes the NEW #288 JSON pipeline end-to-end, which also completes #288's live verification. Evidence to both issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)