### PR TITLE
feat(learn): flywheel telemetry — daily rollup + weekly FLAT-ARMS digest (#332)

### DIFF
--- a/packages/learn/scripts/register_schedules.py
+++ b/packages/learn/scripts/register_schedules.py
@@ -315,6 +315,14 @@ INTERVAL_SCHEDULES = [
 
 CALENDAR_SCHEDULES = [
     {
+        "id": "al-flywheel-telemetry",
+        "workflow": "FlywheelTelemetryWorkflow",
+        "calendar": ScheduleCalendarSpec(
+            hour=[ScheduleRange(start=3)],
+            minute=[ScheduleRange(start=30)],
+        ),
+    },
+    {
         "id": "al-reflection",
         "workflow": "ReflectionWorkflow",
         "calendar": ScheduleCalendarSpec(

--- a/packages/learn/src/activities/flywheel_telemetry.py
+++ b/packages/learn/src/activities/flywheel_telemetry.py
@@ -1,0 +1,218 @@
+"""Flywheel loop-health telemetry (#332).
+
+Daily rollup of the learning loop's vital signs, stored as an audit row
+(`action_type="flywheel_rollup"`, metrics in `changes`) — machine data
+per the four-store contract, queryable via the existing
+`GET /api/v1/state/audit?action_type=flywheel_rollup` with zero new
+storage. Sundays additionally compose a weekly digest and deliver it via
+the SANCTIONED notify path (VaultClient.notify — never cron announce,
+per #288).
+
+The point (from the issue): "it works" must be observed, not declared.
+Every silent-loop failure class found in the 07/08 campaigns — dead
+scorer, unprocessed observations, inert suppress arm — shows up here as
+a flat zero within a day.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from temporalio import activity
+
+from src.config import load_config
+from src.utils.state_client import StateClient
+from src.utils.vault_client import VaultClient
+
+logger = logging.getLogger("alfred-learn")
+
+
+def _day_bounds(day_iso: str | None) -> tuple[str, str, str]:
+    if day_iso:
+        day = datetime.fromisoformat(day_iso).date()
+    else:
+        day = (datetime.now(timezone.utc) - timedelta(days=1)).date()
+    start = datetime(day.year, day.month, day.day, tzinfo=timezone.utc)
+    end = start + timedelta(days=1)
+    return day.isoformat(), start.isoformat(), end.isoformat()
+
+
+def _in_window(ts: Any, start: str, end: str) -> bool:
+    s = str(ts or "")
+    return bool(s) and start <= s.replace(" ", "T")[: len(start)] < end
+
+
+@activity.defn
+async def compute_flywheel_rollup(day_iso: str | None = None) -> dict[str, Any]:
+    """Compute + persist yesterday's (or ``day_iso``'s) loop-health rollup."""
+    day, start, end = _day_bounds(day_iso)
+    config = load_config()
+    metrics: dict[str, Any] = {"day": day}
+
+    async with StateClient(config) as sc:
+        obs = await sc.list_observations(since=start, limit=2000)
+        by_kind: dict[str, int] = {}
+        unprocessed = 0
+        for o in obs:
+            if not _in_window(o.get("ts") or o.get("created_at"), start, end):
+                continue
+            kind = str(o.get("kind") or "unknown")
+            by_kind[kind] = by_kind.get(kind, 0) + 1
+            if str(o.get("status") or "") != "processed":
+                unprocessed += 1
+        metrics["observations_by_kind"] = by_kind
+        metrics["observations_total"] = sum(by_kind.values())
+        metrics["observations_unprocessed_eod"] = unprocessed
+
+        sigs = await sc.list_signals(since=start, limit=2000)
+        routing: dict[str, int] = {}
+        matched = 0
+        for s in sigs:
+            if not _in_window(s.get("ts") or s.get("created_at"), start, end):
+                continue
+            routing[str(s.get("status") or "unknown")] = (
+                routing.get(str(s.get("status") or "unknown"), 0) + 1
+            )
+            payload = s.get("payload_json") or s.get("payload") or "{}"
+            if isinstance(payload, str):
+                try:
+                    payload = json.loads(payload)
+                except json.JSONDecodeError:
+                    payload = {}
+            if isinstance(payload, dict) and payload.get("matched_instinct"):
+                matched += 1
+        metrics["signals_routing"] = routing
+        metrics["signals_total"] = sum(routing.values())
+        metrics["signals_matched_instinct"] = matched
+
+        tier_resp = await sc.list_audit(
+            action_type="instinct_tier_event", since=start, limit=200
+        )
+        tier_events = tier_resp.get("entries", []) if isinstance(tier_resp, dict) else tier_resp
+        metrics["tier_events"] = len(
+            [e for e in tier_events if _in_window(e.get("ts"), start, end)]
+        )
+
+    client = VaultClient(config)
+    try:
+        decisions = await client.list_decisions(since=start, limit=500)
+        intents: dict[str, int] = {}
+        reversals = 0
+        for d in decisions:
+            if not _in_window(d.get("created"), start, end):
+                continue
+            intents[str(d.get("intent") or "unknown")] = (
+                intents.get(str(d.get("intent") or "unknown"), 0) + 1
+            )
+            if str(d.get("state") or "") == "reversed":
+                reversals += 1
+        metrics["decisions_by_intent"] = intents
+        metrics["decisions_total"] = sum(intents.values())
+        metrics["reversals"] = reversals
+
+        # Surface hygiene: active-matter narrative freshness + orphan tasks.
+        matters = await client.list_records("matter", status="active")
+        fresh = stale = 0
+        cutoff = (datetime.now(timezone.utc) - timedelta(hours=24)).isoformat()
+        for m in matters:
+            fm = m.get("frontmatter") or {}
+            as_of = str(fm.get("as_of") or "")
+            if as_of and as_of >= cutoff:
+                fresh += 1
+            else:
+                stale += 1
+        metrics["matters_active"] = fresh + stale
+        metrics["matters_narrative_fresh_24h"] = fresh
+
+        tasks = await client.list_records("task", status="todo")
+        orphans = 0
+        for t in tasks:
+            fm = t.get("frontmatter") or {}
+            if not (fm.get("parent_matter") or fm.get("matter_ref") or fm.get("matter")):
+                orphans += 1
+        metrics["open_tasks_unlinked"] = orphans
+    finally:
+        await client.close()
+
+    summary = (
+        f"flywheel {day}: obs={metrics['observations_total']} "
+        f"sig={metrics['signals_total']} (matched={matched}) "
+        f"dec={metrics['decisions_total']} rev={reversals} "
+        f"tier_events={metrics['tier_events']} "
+        f"fresh_matters={metrics['matters_narrative_fresh_24h']}/{metrics['matters_active']} "
+        f"orphan_tasks={orphans}"
+    )
+    async with StateClient(config) as sc:
+        await sc.append_audit(
+            action_type="flywheel_rollup",
+            actor="alfred-learn",
+            source="flywheel_telemetry",
+            summary=summary,
+            subject_ref=day,
+            changes=metrics,
+        )
+    logger.info("flywheel_telemetry.rollup %s", summary)
+    return metrics
+
+
+@activity.defn
+async def send_flywheel_digest() -> dict[str, Any]:
+    """Weekly digest from the last 7 rollups, via the sanctioned notify path."""
+    config = load_config()
+    since = (datetime.now(timezone.utc) - timedelta(days=8)).isoformat()
+    async with StateClient(config) as sc:
+        resp = await sc.list_audit(
+            action_type="flywheel_rollup", since=since, limit=10
+        )
+    rows = resp.get("entries", []) if isinstance(resp, dict) else resp
+    if not rows:
+        return {"sent": False, "reason": "no rollups"}
+
+    days: list[dict[str, Any]] = []
+    for r in rows:
+        ch = r.get("changes") or r.get("changes_json") or {}
+        if isinstance(ch, str):
+            try:
+                ch = json.loads(ch)
+            except json.JSONDecodeError:
+                ch = {}
+        if isinstance(ch, dict) and ch.get("day"):
+            days.append(ch)
+    days.sort(key=lambda d: d["day"])
+    if not days:
+        return {"sent": False, "reason": "no parseable rollups"}
+
+    def tot(key: str) -> int:
+        return sum(int(d.get(key) or 0) for d in days)
+
+    flat_arms = []
+    if tot("signals_matched_instinct") == 0 and tot("signals_total") > 0:
+        flat_arms.append("instinct matching (0 matches)")
+    if tot("observations_total") == 0 and tot("decisions_total") > 0:
+        flat_arms.append("observation extraction (0 obs)")
+    if tot("tier_events") == 0:
+        flat_arms.append("tier promotion (0 events)")
+
+    lines = [
+        f"Weekly flywheel health ({days[0]['day']} → {days[-1]['day']}):",
+        f"- observations: {tot('observations_total')} "
+        f"(unprocessed at EOD: {tot('observations_unprocessed_eod')})",
+        f"- signals: {tot('signals_total')}, instinct-matched: "
+        f"{tot('signals_matched_instinct')}",
+        f"- decisions: {tot('decisions_total')}, reversals: {tot('reversals')}",
+        f"- tier events: {tot('tier_events')}",
+        f"- orphan open tasks (latest): {days[-1].get('open_tasks_unlinked')}",
+    ]
+    if flat_arms:
+        lines.append("⚠ FLAT ARMS (needs attention): " + "; ".join(flat_arms))
+    text = "\n".join(lines)
+
+    client = VaultClient(config)
+    try:
+        await client.notify("flywheel/weekly", text)
+    finally:
+        await client.close()
+    return {"sent": True, "days": len(days), "flat_arms": flat_arms}

--- a/packages/learn/src/activities/vault.py
+++ b/packages/learn/src/activities/vault.py
@@ -817,6 +817,24 @@ async def apply_instinct_change(proposal: dict[str, Any]) -> None:
                 # Apply field updates to frontmatter
                 updated = _apply_frontmatter_updates(raw, changes)
                 await client.update_record(path, updated)
+                # #332: tier moves are THE flywheel milestone — emit an
+                # audit row so telemetry observes promotions/demotions
+                # instead of declaring them. Best-effort.
+                if "tier" in changes:
+                    try:
+                        from src.utils.state_client import StateClient as _SC
+                        async with _SC(config) as _sc:
+                            await _sc.append_audit(
+                                action_type="instinct_tier_event",
+                                actor="alfred-learn",
+                                source="reflection.apply_instinct_change",
+                                summary=f"{path} tier -> {changes['tier']}",
+                                target_path=path,
+                                target_kind="instinct",
+                                changes={"tier": changes["tier"]},
+                            )
+                    except Exception:  # noqa: BLE001
+                        logger.warning("tier-event audit emit failed for %s", path)
 
         elif action == "merge":
             # Create merged instinct, deprecate sources

--- a/packages/learn/src/utils/vault_client.py
+++ b/packages/learn/src/utils/vault_client.py
@@ -256,6 +256,19 @@ class VaultClient:
         resp.raise_for_status()
         return resp.json().get("items", [])
 
+    async def list_decisions(
+        self, *, since: str | None = None, state: str | None = None, limit: int = 500
+    ) -> list[dict[str, Any]]:
+        """List decision records via ctrl's dedicated decisions route."""
+        params: dict[str, Any] = {"limit": limit}
+        if since:
+            params["since"] = since
+        if state:
+            params["state"] = state
+        resp = await self._client.get("/api/v1/decisions", params=params)
+        resp.raise_for_status()
+        return resp.json().get("decisions", [])
+
     async def notify(self, path: str, summary: str) -> None:
         """Send a notification to the main Alfred agent."""
         message = f"Alfred Learn: {summary}\nPath: {path}"

--- a/packages/learn/src/worker.py
+++ b/packages/learn/src/worker.py
@@ -17,6 +17,7 @@ from src.workflows.learning import LearningWorkflow
 from src.workflows.reflection import ReflectionWorkflow
 from src.workflows.media_ingestion import MediaIngestionWorkflow
 from src.workflows.task_runner import BlockedTaskRecoveryWorkflow, TaskRunnerWorkflow
+from src.workflows.flywheel_telemetry import FlywheelTelemetryWorkflow
 from src.workflows.stream_puller import StreamPullerWorkflow, StreamSweepWorkflow
 from src.workflows.onboarding_pipeline import OnboardingPipelineWorkflow
 from src.workflows.omi_processor import OmiAudioProcessorWorkflow
@@ -218,6 +219,12 @@ from src.activities.classify import (
 # SessionTrackerWorkflow — "session" was never a canonical vault type, so
 # create_session 422'd on every attempt since day one and nothing consumes
 # session records.
+
+# Activities — flywheel telemetry (#332)
+from src.activities.flywheel_telemetry import (
+    compute_flywheel_rollup,
+    send_flywheel_digest,
+)
 
 # Activities — notify
 from src.activities.notify import notify_digest_ready, notify_eod_prompt, escalate_to_user
@@ -774,6 +781,7 @@ _STATIC_WORKFLOWS = [
     MediaIngestionWorkflow,
     TaskRunnerWorkflow,
     BlockedTaskRecoveryWorkflow,
+    FlywheelTelemetryWorkflow,
     # StreamPullerWorkflow kept registered as a tombstone (#53): no
     # longer scheduled per-stream, but callable ad-hoc and harmless to
     # register. StreamSweepWorkflow is the scheduled entity.
@@ -896,6 +904,8 @@ ALL_ACTIVITIES = [
     # Classify
     classify_event,
     extract_metadata,
+    compute_flywheel_rollup,
+    send_flywheel_digest,
     # Notify
     notify_digest_ready,
     notify_eod_prompt,

--- a/packages/learn/src/workflows/flywheel_telemetry.py
+++ b/packages/learn/src/workflows/flywheel_telemetry.py
@@ -1,0 +1,39 @@
+"""Workflow: daily flywheel loop-health rollup + Sunday digest (#332)."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+with workflow.unsafe.imports_passed_through():
+    from src.activities.flywheel_telemetry import (
+        compute_flywheel_rollup,
+        send_flywheel_digest,
+    )
+
+
+@workflow.defn(name="FlywheelTelemetryWorkflow")
+class FlywheelTelemetryWorkflow:
+    """Daily 03:30: persist yesterday's rollup; Sundays also send the
+    weekly digest via the sanctioned notify path."""
+
+    @workflow.run
+    async def run(self) -> dict:
+        retry = RetryPolicy(maximum_attempts=3)
+        rollup = await workflow.execute_activity(
+            compute_flywheel_rollup,
+            start_to_close_timeout=timedelta(seconds=300),
+            retry_policy=retry,
+        )
+        result: dict = {"rollup": rollup}
+        # Deterministic weekday from workflow time (no datetime.now in
+        # workflow code — Temporal sandbox rule).
+        if workflow.now().weekday() == 6:  # Sunday
+            result["digest"] = await workflow.execute_activity(
+                send_flywheel_digest,
+                start_to_close_timeout=timedelta(seconds=120),
+                retry_policy=retry,
+            )
+        return result

--- a/packages/learn/tests/test_flywheel_telemetry_332.py
+++ b/packages/learn/tests/test_flywheel_telemetry_332.py
@@ -1,0 +1,101 @@
+"""#332 — flywheel loop-health telemetry."""
+from __future__ import annotations
+
+import asyncio
+import json
+
+from src.activities import flywheel_telemetry as ft
+
+
+class _SC:
+    def __init__(self):
+        self.audits = []
+
+    async def __aenter__(self): return self
+    async def __aexit__(self, *a): return None
+
+    async def list_observations(self, **kw):
+        return [
+            {"ts": "2026-07-31T10:00:00Z", "kind": "decision", "status": "processed"},
+            {"ts": "2026-07-31T11:00:00Z", "kind": "signal", "status": "open"},
+            {"ts": "2026-07-30T09:00:00Z", "kind": "decision", "status": "open"},  # out of window
+        ]
+
+    async def list_signals(self, **kw):
+        return [
+            {"ts": "2026-07-31T10:05:00Z", "status": "routed_human",
+             "payload_json": json.dumps({"matched_instinct": "instinct/x.md"})},
+            {"ts": "2026-07-31T10:06:00Z", "status": "routed_suppressed", "payload_json": "{}"},
+        ]
+
+    async def list_audit(self, **kw):
+        if kw.get("action_type") == "instinct_tier_event":
+            return {"entries": [{"ts": "2026-07-31T12:00:00Z"}]}
+        return {"entries": []}
+
+    async def append_audit(self, **kw):
+        self.audits.append(kw)
+        return "01A"
+
+
+class _VC:
+    def __init__(self, _cfg=None): pass
+    async def list_decisions(self, **kw):
+        return [
+            {"created": "2026-07-31T10:10:00Z", "intent": "done", "state": "completed"},
+            {"created": "2026-07-31T10:20:00Z", "intent": "delegate", "state": "reversed"},
+        ]
+    async def list_records(self, rtype, **kw):
+        if rtype == "matter":
+            return [{"frontmatter": {"as_of": "2026-07-31T23:00:00Z"}},
+                    {"frontmatter": {"as_of": "2026-06-01T00:00:00Z"}}]
+        return [{"frontmatter": {"parent_matter": "matter/x.md"}},
+                {"frontmatter": {}}]
+    async def notify(self, path, summary):
+        self.notified = (path, summary)
+    async def close(self): return None
+
+
+def test_rollup_counts_and_persists(monkeypatch):
+    sc = _SC()
+    monkeypatch.setattr(ft, "StateClient", lambda _c: sc)
+    monkeypatch.setattr(ft, "VaultClient", _VC)
+    m = asyncio.run(ft.compute_flywheel_rollup("2026-07-31"))
+    assert m["observations_by_kind"] == {"decision": 1, "signal": 1}
+    assert m["observations_unprocessed_eod"] == 1
+    assert m["signals_total"] == 2 and m["signals_matched_instinct"] == 1
+    assert m["signals_routing"]["routed_suppressed"] == 1
+    assert m["decisions_total"] == 2 and m["reversals"] == 1
+    assert m["tier_events"] == 1
+    assert m["matters_active"] == 2
+    assert m["open_tasks_unlinked"] == 1
+    (row,) = [a for a in sc.audits if a["action_type"] == "flywheel_rollup"]
+    assert row["changes"]["day"] == "2026-07-31"
+    assert "flywheel 2026-07-31" in row["summary"]
+
+
+def test_digest_flags_flat_arms(monkeypatch):
+    class _SC2(_SC):
+        async def list_audit(self, **kw):
+            return {"entries": [{"changes": {
+                "day": "2026-07-30", "observations_total": 5,
+                "observations_unprocessed_eod": 0, "signals_total": 9,
+                "signals_matched_instinct": 0, "decisions_total": 4,
+                "reversals": 0, "tier_events": 0, "open_tasks_unlinked": 2,
+            }}]}
+    vc = _VC()
+    monkeypatch.setattr(ft, "StateClient", lambda _c: _SC2())
+    monkeypatch.setattr(ft, "VaultClient", lambda _c: vc)
+    out = asyncio.run(ft.send_flywheel_digest())
+    assert out["sent"] is True
+    assert any("instinct matching" in a for a in out["flat_arms"])
+    assert any("tier promotion" in a for a in out["flat_arms"])
+    assert "FLAT ARMS" in vc.notified[1]
+
+
+def test_digest_no_rollups_no_send(monkeypatch):
+    class _SC3(_SC):
+        async def list_audit(self, **kw): return {"entries": []}
+    monkeypatch.setattr(ft, "StateClient", lambda _c: _SC3())
+    out = asyncio.run(ft.send_flywheel_digest())
+    assert out["sent"] is False


### PR DESCRIPTION
Closes #332 (core); the /study panel over the rollups stays as a Lane III follow-up, noted on the issue.

## What
Daily `FlywheelTelemetryWorkflow` (03:30) → `flywheel_rollup` audit row with the issue's full metric list; Sunday digest via `VaultClient.notify` with an explicit **FLAT ARMS** warning (inert matching / extraction / tier-promotion arms self-report). `apply_instinct_change` now emits `instinct_tier_event` audit rows so the tier metric has a source. Zero new storage or ctrl changes — rollups ride the audit table and its existing filtered GET.

## Smoke evidence
- Local: full learn suite **2472 passed**; 3 new tests (rollup counting incl. window edges + persistence shape; digest flat-arm detection; empty no-send).
- Post-deploy on home: `al-flywheel-telemetry` self-creates; trigger once manually → verify the rollup row lands with real numbers (evidence to the issue). First organic digest lands Sunday.

🤖 Generated with [Claude Code](https://claude.com/claude-code)