### PR TITLE
feat: daemon vault writes through ctrl-api — one write channel (#327)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -519,6 +519,9 @@ services:
       # volume, which this service mounts at /app/data (ctrl-api mounts
       # the same volume at /alfred-data). The claimant reads this env.
       - ALFRED_DATA_DIR=/app/data
+      # #327: daemons write canonical records through ctrl-api; the
+      # client authenticates with the tenant API key.
+      - AAS_API_KEY=${AAS_API_KEY}
       # Surveyor cluster-labeling routes through Hermes (workers profile);
       # the gateway owns the model + provider key. Empty = standalone mode.
       - SURVEYOR_HERMES_GATEWAY_URL=http://hermes:18790

--- a/packages/alfred-vault/src/alfred/ctrl_client.py
+++ b/packages/alfred-vault/src/alfred/ctrl_client.py
@@ -1,0 +1,92 @@
+"""ctrl-api write client for the vault daemons (#327).
+
+Sir's 2026-07-20 decision: daemons lose independent write access to
+canonical vault records — every repair / link-write goes through
+ctrl-api so it gets the promotion contract, state-field enforcement,
+vault_index maintenance and steward-signal emission. The `alfred vault`
+CLI remains ctrl-api's docker-exec BACKEND, which is why routing is
+decided in vault/ops.py with a loop-breaker:
+
+  * daemons (no ALFRED_CTRL_BACKEND in env, ALFRED_CTRL_URL set)
+      → ops delegates here → HTTP → ctrl → docker-exec → CLI → file
+  * ctrl's own exec (ALFRED_CTRL_BACKEND=1, set in VAULT_ENV)
+      → ops writes directly, exactly as before
+
+Sync httpx on purpose — every current caller is synchronous.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+import structlog
+
+log = structlog.get_logger("alfred.ctrl_client")
+
+_TIMEOUT = httpx.Timeout(60.0, connect=10.0)
+
+
+def via_ctrl_enabled() -> bool:
+    """True when writes must route through ctrl-api (#327)."""
+    if os.environ.get("ALFRED_CTRL_BACKEND") == "1":
+        return False  # we ARE ctrl's backend — write directly, no loop
+    if os.environ.get("ALFRED_VAULT_DIRECT_WRITES") == "1":
+        return False  # explicit operator escape hatch
+    return bool(os.environ.get("ALFRED_CTRL_URL"))
+
+
+def _client() -> httpx.Client:
+    base = os.environ["ALFRED_CTRL_URL"].rstrip("/")
+    headers = {}
+    key = os.environ.get("AAS_API_KEY", "")
+    if key:
+        headers["Authorization"] = f"Bearer {key}"
+    return httpx.Client(base_url=base, headers=headers, timeout=_TIMEOUT)
+
+
+def ctrl_edit(
+    rel_path: str,
+    *,
+    set_fields: dict[str, Any] | None = None,
+    body_append: str | None = None,
+) -> dict:
+    """PATCH a vault record through ctrl-api (§15.1 wrapped body shape)."""
+    payload: dict[str, Any] = {}
+    if set_fields:
+        payload["set"] = set_fields
+    if body_append:
+        payload["body_append"] = body_append
+    if not payload:
+        return {"path": rel_path, "fields_changed": []}
+    with _client() as c:
+        resp = c.patch(f"/api/v1/vault/records/{rel_path}", json=payload)
+        resp.raise_for_status()
+        out = resp.json()
+    return {
+        "path": out.get("path", rel_path),
+        "fields_changed": sorted((set_fields or {}).keys())
+        + (["body"] if body_append else []),
+    }
+
+
+def ctrl_create(record_type: str, name: str, content: str) -> dict:
+    """POST a new vault record through ctrl-api."""
+    with _client() as c:
+        resp = c.post(
+            "/api/v1/vault/records",
+            json={"type": record_type, "name": name, "content": content},
+        )
+        resp.raise_for_status()
+        out = resp.json()
+    return {"path": out.get("path", f"{record_type}/{name}.md")}
+
+
+def ctrl_reconcile_index() -> None:
+    """Best-effort post-sweep vault_index reconcile (#327 interim hardening)."""
+    try:
+        with _client() as c:
+            c.post("/api/v1/vault-index/reconcile")
+    except Exception as exc:  # noqa: BLE001
+        log.warning("ctrl_client.reconcile_failed", err=str(exc)[:120])

--- a/packages/alfred-vault/src/alfred/janitor/pipeline.py
+++ b/packages/alfred-vault/src/alfred/janitor/pipeline.py
@@ -706,4 +706,10 @@ async def run_pipeline(
         stubs_enriched=result.stubs_enriched,
     )
 
+    # #327 interim hardening: reconcile the vault_index after every sweep
+    # (not only at ctrl boot) so any residual direct-fs write can't leave
+    # the mirror stale for hours. Best-effort no-op when ctrl is absent.
+    from alfred.ctrl_client import ctrl_reconcile_index
+    ctrl_reconcile_index()
+
     return result

--- a/packages/alfred-vault/src/alfred/surveyor/writer.py
+++ b/packages/alfred-vault/src/alfred/surveyor/writer.py
@@ -205,7 +205,35 @@ class VaultWriter:
         log.info("writer.relationships_written", path=rel_path, added=added)
 
     def _write_atomic(self, full_path: Path, rel_path: str, post: frontmatter.Post) -> None:
-        """Write file atomically and register expected hash in state."""
+        """Persist a mutated record; route through ctrl-api when enabled.
+
+        #327: canonical-record writes go through ctrl-api (contract +
+        index + steward signal). We diff post.metadata against the
+        on-disk frontmatter and PATCH only the changed fields — the
+        surveyor never edits bodies. The self-write watcher hash is NOT
+        marked on this path (the write lands via ctrl→CLI, so content
+        bytes may serialize in a different key order); the follow-up
+        watcher pass is a no-op by the writers' own idempotence.
+        """
+        from alfred.ctrl_client import via_ctrl_enabled
+        if via_ctrl_enabled():
+            from alfred.vault.ops import VaultError, vault_edit, vault_read
+            try:
+                current = vault_read(self.vault_path, rel_path)["frontmatter"]
+            except (VaultError, KeyError):
+                current = {}
+            changed = {
+                k: v for k, v in post.metadata.items()
+                if current.get(k) != v
+            }
+            if not changed:
+                return
+            try:
+                vault_edit(self.vault_path, rel_path, set_fields=changed)
+            except Exception as e:  # noqa: BLE001
+                log.error("writer.ctrl_write_error", path=rel_path, error=str(e)[:200])
+            return
+
         content = frontmatter.dumps(post)
         content_bytes = content.encode("utf-8")
         expected_md5 = compute_md5_bytes(content_bytes)

--- a/packages/alfred-vault/src/alfred/vault/ops.py
+++ b/packages/alfred-vault/src/alfred/vault/ops.py
@@ -336,6 +336,48 @@ def vault_context(
     return {"records_by_type": by_type, "total": sum(len(v) for v in by_type.values())}
 
 
+
+def _render_new_record(
+    vault_path: Path,
+    record_type: str,
+    name: str,
+    set_fields: dict,
+    body: str | None,
+) -> str:
+    """Render a new record's full markdown (template + fields + body).
+
+    #327: shared by the ctrl-routing branch of vault_create so ctrl-api
+    receives exactly the markdown the direct path would have written.
+    """
+    template = _load_template(vault_path, record_type)
+    if template:
+        fm, template_body = template
+    else:
+        fm = {}
+        template_body = f"# {name}\n"
+    fm["type"] = record_type
+    title_field = NAME_FIELD_BY_TYPE.get(record_type, "name")
+    fm[title_field] = name
+    if "created" not in fm or fm["created"] == "{{date}}":
+        fm["created"] = date.today().isoformat()
+    for k, v in (set_fields or {}).items():
+        fm[k] = v
+    _validate_status(record_type, fm.get("status", ""))
+    _validate_list_fields(fm)
+    _validate_required_fields(fm)
+    if body is not None:
+        final_body = body
+        if template:
+            base_embeds = _extract_base_embeds(template_body, name)
+            if base_embeds and base_embeds not in final_body:
+                final_body = final_body.rstrip("\n") + "\n\n---\n" + base_embeds
+    else:
+        final_body = template_body.replace("{{title}}", name).replace(
+            "{{date}}", date.today().isoformat()
+        )
+    return _serialize_record(fm, final_body)
+
+
 def vault_create(
     vault_path: Path,
     record_type: str,
@@ -347,6 +389,15 @@ def vault_create(
     """Create a new vault record. Returns {path, warnings}."""
     _validate_type(record_type)
     set_fields = set_fields or {}
+
+    # #327: same routing rule as vault_edit. Content is rendered locally
+    # (template + fields) so ctrl receives the exact markdown; ctrl owns
+    # contract/index/signal.
+    from alfred.ctrl_client import ctrl_create, via_ctrl_enabled
+    if via_ctrl_enabled():
+        rendered = _render_new_record(vault_path, record_type, name, set_fields, body)
+        out = ctrl_create(record_type, name, rendered)
+        return {"path": out["path"], "warnings": []}
 
     # Determine directory and path
     directory = TYPE_DIRECTORY.get(record_type, record_type)
@@ -419,6 +470,25 @@ def vault_edit(
     body_append: str | None = None,
 ) -> dict:
     """Edit a vault record. Returns {path, fields_changed}."""
+    # #327: daemons route canonical writes through ctrl-api (contract +
+    # index + steward signal). ctrl's own docker-exec backend carries
+    # ALFRED_CTRL_BACKEND=1 and takes the direct path below — no loop.
+    # append_fields has no ctrl PATCH verb; merge client-side first.
+    from alfred.ctrl_client import ctrl_edit, via_ctrl_enabled
+    if via_ctrl_enabled():
+        merged_sets = dict(set_fields or {})
+        if append_fields:
+            fm_now, _ = _parse_record(_resolve_vault_path(vault_path, rel_path))
+            for k, v in append_fields.items():
+                existing = fm_now.get(k)
+                if existing is None:
+                    merged_sets[k] = [v] if k in LIST_FIELDS else v
+                elif isinstance(existing, list):
+                    merged_sets[k] = existing + [v]
+                else:
+                    merged_sets[k] = [existing, v]
+        return ctrl_edit(rel_path, set_fields=merged_sets or None, body_append=body_append)
+
     file_path = _resolve_vault_path(vault_path, rel_path)
     if not file_path.exists():
         raise VaultError(f"File not found: {rel_path}")

--- a/packages/alfred-vault/tests/test_ctrl_write_routing_327.py
+++ b/packages/alfred-vault/tests/test_ctrl_write_routing_327.py
@@ -1,0 +1,87 @@
+"""#327 — canonical writes route through ctrl-api; loop-breaker respected."""
+from __future__ import annotations
+
+import pytest
+
+from alfred import ctrl_client
+from alfred.vault import ops
+
+
+@pytest.fixture
+def vault(tmp_path):
+    (tmp_path / "matter").mkdir()
+    (tmp_path / "matter" / "house.md").write_text(
+        "---\ntype: matter\nname: House\nstatus: active\ntags: []\n---\nbody\n"
+    )
+    return tmp_path
+
+
+class TestRoutingDecision:
+    def test_daemons_route_via_ctrl(self, monkeypatch):
+        monkeypatch.setenv("ALFRED_CTRL_URL", "http://ctrl-api:3100")
+        monkeypatch.delenv("ALFRED_CTRL_BACKEND", raising=False)
+        assert ctrl_client.via_ctrl_enabled() is True
+
+    def test_ctrl_backend_writes_direct(self, monkeypatch):
+        monkeypatch.setenv("ALFRED_CTRL_URL", "http://ctrl-api:3100")
+        monkeypatch.setenv("ALFRED_CTRL_BACKEND", "1")
+        assert ctrl_client.via_ctrl_enabled() is False
+
+    def test_escape_hatch(self, monkeypatch):
+        monkeypatch.setenv("ALFRED_CTRL_URL", "http://ctrl-api:3100")
+        monkeypatch.setenv("ALFRED_VAULT_DIRECT_WRITES", "1")
+        assert ctrl_client.via_ctrl_enabled() is False
+
+    def test_no_ctrl_url_direct(self, monkeypatch):
+        monkeypatch.delenv("ALFRED_CTRL_URL", raising=False)
+        assert ctrl_client.via_ctrl_enabled() is False
+
+
+class TestOpsRouting:
+    def test_edit_routes_to_ctrl(self, vault, monkeypatch):
+        monkeypatch.setenv("ALFRED_CTRL_URL", "http://x")
+        monkeypatch.delenv("ALFRED_CTRL_BACKEND", raising=False)
+        calls = []
+        monkeypatch.setattr(
+            ctrl_client, "ctrl_edit",
+            lambda rel, **kw: calls.append((rel, kw)) or {"path": rel, "fields_changed": ["status"]},
+        )
+        out = ops.vault_edit(vault, "matter/house.md", set_fields={"status": "dormant"})
+        assert calls and calls[0][0] == "matter/house.md"
+        assert calls[0][1]["set_fields"] == {"status": "dormant"}
+        assert out["path"] == "matter/house.md"
+        # file untouched — ctrl owns the write
+        assert "status: active" in (vault / "matter" / "house.md").read_text()
+
+    def test_edit_append_fields_merged_clientside(self, vault, monkeypatch):
+        monkeypatch.setenv("ALFRED_CTRL_URL", "http://x")
+        monkeypatch.delenv("ALFRED_CTRL_BACKEND", raising=False)
+        calls = []
+        monkeypatch.setattr(
+            ctrl_client, "ctrl_edit",
+            lambda rel, **kw: calls.append(kw) or {"path": rel, "fields_changed": []},
+        )
+        ops.vault_edit(vault, "matter/house.md", append_fields={"tags": "hot"})
+        assert calls[0]["set_fields"]["tags"] == ["hot"]
+
+    def test_backend_env_keeps_direct_write(self, vault, monkeypatch):
+        monkeypatch.setenv("ALFRED_CTRL_URL", "http://x")
+        monkeypatch.setenv("ALFRED_CTRL_BACKEND", "1")
+        out = ops.vault_edit(vault, "matter/house.md", set_fields={"status": "dormant"})
+        assert out["fields_changed"] == ["status"]
+        assert "status: dormant" in (vault / "matter" / "house.md").read_text()
+
+    def test_create_routes_rendered_content(self, vault, monkeypatch):
+        monkeypatch.setenv("ALFRED_CTRL_URL", "http://x")
+        monkeypatch.delenv("ALFRED_CTRL_BACKEND", raising=False)
+        calls = []
+        monkeypatch.setattr(
+            ctrl_client, "ctrl_create",
+            lambda rt, name, content: calls.append((rt, name, content)) or {"path": f"{rt}/{name}.md"},
+        )
+        out = ops.vault_create(vault, "note", "test-note", body="hello")
+        rt, name, content = calls[0]
+        assert (rt, name) == ("note", "test-note")
+        assert content.startswith("---") and "type: note" in content and "hello" in content
+        assert out["path"] == "note/test-note.md"
+        assert not (vault / "note" / "test-note.md").exists()

--- a/packages/ctrl/src/api/routes/vault.ts
+++ b/packages/ctrl/src/api/routes/vault.ts
@@ -33,7 +33,10 @@ import {
 // bind-mounted into ctrl-api at /vault by default. VAULT_PATH overrides it.
 export const VAULT_PATH = process.env.VAULT_PATH ?? "/vault";
 const INBOX_PATH = `${VAULT_PATH}/inbox`;
-export const VAULT_ENV = { ALFRED_VAULT_PATH: "/vault" };
+// #327: ALFRED_CTRL_BACKEND marks "this CLI invocation IS ctrl's
+// backend" so vault/ops.py takes the direct write path instead of
+// looping back through ctrl-api over HTTP.
+export const VAULT_ENV = { ALFRED_VAULT_PATH: "/vault", ALFRED_CTRL_BACKEND: "1" };
 
 // ---------------------------------------------------------------------------
 // Steward signal stream (#838 Phase 2)


### PR DESCRIPTION
Closes #327 (the write-channel closure; #328's state-change enforcement flip and #329's data campaign remain as the epic's other children).

## What
See commit body for the full mechanism. Net: janitor/curator/surveyor canonical writes → ctrl-api (contract + index + steward signal); the `alfred vault` CLI remains ctrl's exec backend via the `ALFRED_CTRL_BACKEND=1` loop-breaker in `VAULT_ENV`; `ALFRED_VAULT_DIRECT_WRITES=1` is the operator escape hatch; janitor sweeps now end with an index reconcile.

## ⚠ Deploy ordering (per tenant, incl. fleet rollout)
1. ctrl-api image FIRST (VAULT_ENV marker) — 2. compose rsync — 3. alfred-worker recreate. Old-ctrl + new-worker recurses.

## Smoke evidence
- 8 routing tests green (decision matrix, payload shapes, direct-path preservation, no-local-write proof); full package suite unchanged otherwise.
- Post-deploy on home (ordering respected): trigger a janitor fix run via the (now working, #407) durable path → repairs land THROUGH ctrl (ctrl access log shows the PATCHes; steward-signals ledger gains vault:edit entries; index stays fresh without a boot). Evidence to #327/#326.

🤖 Generated with [Claude Code](https://claude.com/claude-code)