### PR TITLE
fix(learn): matter-completion via state-changes + STATE_CHANGE_ENFORCEMENT=reject (#328)

### DIFF
--- a/packages/learn/src/activities/tasks.py
+++ b/packages/learn/src/activities/tasks.py
@@ -503,19 +503,41 @@ async def evaluate_consequentials(
                             all_done = False
                             break
                 if all_done:
-                    # Update matter status to resolved
-                    matter_rec = await client.read_record(_normalize_record_path(matter))
-                    raw = _reconstruct_markdown(matter_rec)
-                    if raw:
-                        from src.activities.vault import _apply_frontmatter_updates
-                        updated = _apply_frontmatter_updates(
-                            raw, {"status": "resolved"}
+                    # #328: route the matter-completion through the audited
+                    # state-change primitive instead of a full-record PATCH.
+                    # The old path wrote `status: resolved` (a) bypassing the
+                    # mutex/ledger/enforcement gate and (b) using legacy vocab
+                    # (`resolved` isn't in matter's canonical set
+                    # active|dormant|completed|archived — §6.1). Canonical
+                    # target is `completed`. mode="live" so the env veto
+                    # (STEWARD_LIVE_MODE) governs, exactly like every other
+                    # state writer.
+                    from datetime import timezone as _tz
+                    from src.activities.state_mutator import (
+                        ObservedWindow,
+                        apply_state_change_v2,
+                    )
+                    now_dt = datetime.now(_tz.utc)
+                    try:
+                        await apply_state_change_v2(
+                            target_path=_normalize_record_path(matter),
+                            source="task_runner.matter_resolved",
+                            observed=ObservedWindow(
+                                start=now_dt, end=now_dt,
+                                signal_paths=[], decision_paths=[],
+                                other_refs=[task.get("path", "")] if task.get("path") else [],
+                            ),
+                            propose_fn_name="task_runner.matter_resolved",
+                            propose_fn_args={"trigger_task": task.get("path", "")},
+                            mode="live",
                         )
-                        # Extract type from matter path
-                        matter_type = matter.split("/")[0] if "/" in matter else "matter"
-                        await client.write_record(matter_type, matter, updated)
                         activity.logger.info(
-                            "Matter resolved — all tasks done: %s", matter
+                            "Matter completed — all tasks done: %s", matter
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        activity.logger.warning(
+                            "matter-completion state-change failed matter=%s err=%s",
+                            matter, exc,
                         )
             except Exception as exc:
                 activity.logger.warning(
@@ -795,3 +817,42 @@ async def recover_stale_blocked_tasks(
         await client.close()
         await state.close()
     return {"recovered": recovered, "parked": parked}
+
+
+# ---------------------------------------------------------------------------
+# #328: matter-completion propose function (registry-dispatched, not an
+# activity). Marks a matter `completed` when its last open task finishes,
+# through apply_state_change_v2 so the write is audited + enforced. Canonical
+# vocab (`completed`, not the legacy `resolved`); idempotent — returns None
+# when the matter is already terminal so no state_change round-trip happens.
+# ---------------------------------------------------------------------------
+from src.activities.state_mutator import (  # noqa: E402
+    ObservedWindow as _ObservedWindow,
+    ProposedMutation as _ProposedMutation,
+    propose_fn as _propose_fn,
+)
+
+_MATTER_TERMINAL_STATUS = {"completed", "archived", "abandoned"}
+
+
+@_propose_fn("task_runner.matter_resolved")
+async def propose_matter_resolved(
+    *,
+    target: dict[str, Any],
+    observed: "_ObservedWindow",
+    args: dict[str, Any],
+) -> "_ProposedMutation | None":
+    fm = target.get("frontmatter", target) if isinstance(target, dict) else {}
+    current = str(fm.get("status", "")).strip().lower()
+    if current in _MATTER_TERMINAL_STATUS:
+        return None  # already terminal — no-op, preserves idempotency
+    trigger = args.get("trigger_task", "") if isinstance(args, dict) else ""
+    return _ProposedMutation(
+        fields={"status": "completed"},
+        reason=(
+            "All linked tasks are done/cancelled — matter completed "
+            f"(trigger: {trigger or 'unknown'})."
+        ),
+        confidence=1.0,
+        fan_out=(),
+    )

--- a/packages/learn/src/worker.py
+++ b/packages/learn/src/worker.py
@@ -503,6 +503,7 @@ from src.activities.state_mutator import (
 # populated before any workflow asks the mutator for a propose function
 # by name. See ``docs/STATE-MUTATION.md`` §6.1+§6.2.
 import src.activities.archival_sweep  # noqa: F401 — register archival_sweep.cold
+import src.activities.tasks  # noqa: F401 — register task_runner.matter_resolved (#328)
 
 # Steward Phase 4 (#840) — Vexa transcript intake. Activities back the
 # MeetingCaptureWorkflow + TranscriptIntakeWorkflow. NO direct Plane

--- a/packages/learn/tests/test_matter_resolved_328.py
+++ b/packages/learn/tests/test_matter_resolved_328.py
@@ -1,0 +1,46 @@
+"""#328 — matter-completion routes through apply_state_change_v2 (canonical
+`completed`, audited), and the legacy `resolved` full-record PATCH is gone.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+
+from src.activities import tasks as tasks_mod
+from src.activities.state_mutator import ObservedWindow, _resolve_propose_fn
+
+
+def _ow():
+    from datetime import datetime, timezone
+    n = datetime.now(timezone.utc)
+    return ObservedWindow(start=n, end=n, signal_paths=[], decision_paths=[], other_refs=[])
+
+
+class TestProposeMatterResolved:
+    def test_registered_under_name(self):
+        fn = _resolve_propose_fn("task_runner.matter_resolved")
+        assert fn is not None
+
+    def test_proposes_completed_canonical(self):
+        fn = _resolve_propose_fn("task_runner.matter_resolved")
+        out = asyncio.run(fn(target={"frontmatter": {"status": "active"}},
+                             observed=_ow(), args={"trigger_task": "task/x.md"}))
+        assert out is not None
+        assert out.fields == {"status": "completed"}   # NOT legacy 'resolved'
+        assert out.confidence == 1.0
+
+    def test_idempotent_on_terminal(self):
+        fn = _resolve_propose_fn("task_runner.matter_resolved")
+        for st in ("completed", "archived", "abandoned"):
+            out = asyncio.run(fn(target={"frontmatter": {"status": st}},
+                                 observed=_ow(), args={}))
+            assert out is None, st
+
+
+class TestLegacyWriterGone:
+    def test_no_status_resolved_fullrecord_write(self):
+        src = inspect.getsource(tasks_mod.evaluate_consequentials)
+        assert '"status": "resolved"' not in src
+        assert 'apply_state_change_v2' in src
+        # the old full-record matter overwrite is gone
+        assert 'write_record(matter_type' not in src

--- a/packages/learn/tests/test_task_pipeline_364_367.py
+++ b/packages/learn/tests/test_task_pipeline_364_367.py
@@ -177,19 +177,29 @@ class TestMatterRefNormalization:
     404 — matter refs need the same wikilink normalization as depends_on."""
 
     def test_matter_resolution_normalizes_wikilink(self, monkeypatch):
+        """#328: matter completion now routes through apply_state_change_v2;
+        its target_path must be the wikilink-normalized matter path."""
         fake_state = _FakeStateClient()
-        fake_vault = _FakeVaultClient(
-            records={"matter/house.md": {"frontmatter": {"status": "active"}}}
-        )
+        fake_vault = _FakeVaultClient(records={})  # list_records -> [] => all_done
         monkeypatch.setattr(tasks_mod, "StateClient", lambda _cfg: fake_state)
         monkeypatch.setattr(tasks_mod, "VaultClient", lambda _cfg: fake_vault)
 
+        seen = {}
+
+        async def fake_v2(*, target_path, **kw):
+            seen["target_path"] = target_path
+            seen["propose"] = kw.get("propose_fn_name")
+            class _R: pass
+            return _R()
+
+        monkeypatch.setattr(
+            "src.activities.state_mutator.apply_state_change_v2", fake_v2
+        )
         asyncio.run(
             tasks_mod.evaluate_consequentials(
                 {"title": "Parent", "path": "task/parent.md", "matter": "[[matter/house]]"},
                 {"summary": "done", "follow_up_tasks": []},
             )
         )
-        # The matter read must hit the normalized path, not the wikilink.
-        assert "matter/house.md" in fake_vault.read_paths
-        assert all("[[" not in p for p in fake_vault.read_paths)
+        assert seen["target_path"] == "matter/house.md"   # normalized, no [[ ]]
+        assert seen["propose"] == "task_runner.matter_resolved"


### PR DESCRIPTION
Closes #328 (code + home enforcement; the fleet-wide env flip rides the eventual rollout).

## What
- **Writer #1** (`evaluate_consequentials`): `status: resolved` full-record PATCH → `apply_state_change_v2` + new propose fn `task_runner.matter_resolved` → canonical `completed`, audited, env-veto-gated. See commit for the full rationale.
- **Writer #2** (`patch_matter_narrative`): left in place — `workflow.patched`-gated replay-only dead code; deleting it is replay-unsafe and `reject` can't reach it. Documented.
- **Enforcement**: `STATE_CHANGE_ENFORCEMENT=reject` on home's ctrl-api (env), deployed AFTER the learn image so the migrated writer is live first.

## Smoke evidence
- Local: full learn suite **2476 passed**; new #328 tests + updated #367 test green.
- Post-deploy on home (ordered learn→ctrl-flip): a synthetic all-tasks-done matter completes via POST /state-changes (audited, `status: completed`), and a direct legacy-shape `PATCH /vault/records` touching a matter state field returns 422. Soak-watch ctrl logs for any unexpected 422 (revert to `warn` if a legit writer surfaces). Evidence to the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)