### PR TITLE
feat(ctrl): schedule-time dedup for announce spawns — the durable spam belt (#416)

### DIFF
--- a/packages/ctrl/src/api/routes/agents.ts
+++ b/packages/ctrl/src/api/routes/agents.ts
@@ -8,6 +8,57 @@ import { execAsync, dockerExec, dockerComposeCmd, HERMES_CMD, HERMES_CONTAINER }
 import { resolveDeliveryTarget } from "../hermes-sessions.js";
 import { getStateDb } from "../../db/state.js";
 
+// ── #416: schedule-time dedup for announce:true spawns ───────────────────────
+// spawn_alfred_task creates a fresh Hermes cron per call with zero
+// idempotency (its own doc: "NOT idempotent — calling twice schedules two
+// runs"). On 2026-08-04 the main agent fired three announce:true spawns to the
+// same Slack channel in 15 minutes for one request → three duplicate messages.
+// This collapses near-identical channel-delivering spawns to the same target
+// within a short window. announce:false (silent) spawns are never deduped —
+// they don't reach the principal. In-process TTL map: duplicate spawns arrive
+// seconds apart in the same ctrl process, so a persisted tail isn't needed.
+const ANNOUNCE_DEDUP_WINDOW_MS = (() => {
+  const raw = parseInt(process.env.ANNOUNCE_DEDUP_WINDOW_SECONDS ?? "", 10);
+  return Number.isFinite(raw) && raw > 0 ? raw * 1000 : 600_000; // 10 min
+})();
+const _announceDedup = new Map<string, { at: number; job: string }>();
+export function _resetAnnounceDedupForTests(): void { _announceDedup.clear(); }
+
+export function _normalizeTask(task: string): string {
+  // Strip volatile bits so a retried research reply collapses onto its
+  // first attempt: timestamps, ULIDs/uuids, long digit runs, run ids.
+  return task
+    .toLowerCase()
+    .replace(/\d{4}-\d{2}-\d{2}t[\d:.]+z?/g, "")      // ISO timestamps
+    .replace(/[0-9a-f]{8}-[0-9a-f-]{20,}/g, "")          // uuids
+    .replace(/\b[0-9a-hjkmnp-tv-z]{26}\b/g, "")        // ULIDs
+    .replace(/\d{5,}/g, "")                              // long digit runs
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function announceDedupKey(channel: string, to: string | undefined, task: string): string {
+  const h = crypto.createHash("sha256")
+    .update(`${channel}\u0000${to ?? ""}\u0000${_normalizeTask(task)}`)
+    .digest("hex")
+    .slice(0, 24);
+  return h;
+}
+
+/** Returns the existing job name if a matching announce was scheduled within
+ *  the window, else null (and records this one). Prunes expired entries. */
+export function checkAnnounceDedup(key: string, job: string): string | null {
+  const now = Date.now();
+  for (const [k, v] of _announceDedup) {
+    if (now - v.at > ANNOUNCE_DEDUP_WINDOW_MS) _announceDedup.delete(k);
+  }
+  const hit = _announceDedup.get(key);
+  if (hit && now - hit.at <= ANNOUNCE_DEDUP_WINDOW_MS) return hit.job;
+  _announceDedup.set(key, { at: now, job });
+  return null;
+}
+
+
 // alfred daemon config (the surveyor lives here, not in the Hermes config).
 const ALFRED_DATA_DIR = process.env.ALFRED_DATA_DIR ?? "/alfred-data";
 const CONFIG_PATH = `${ALFRED_DATA_DIR}/config.yaml`;
@@ -605,6 +656,24 @@ export function registerAgentRoutes(): void {
     // - Delivery is a single `--deliver` target: `<platform>:<chat_id>` when
     //   announcing to a resolved channel, `origin` as a fallback, `local` for a
     //   silent background run (no external DM).
+    // #416: collapse duplicate announce:true spawns to the same target
+    // within the dedup window. Silent spawns bypass this — they never reach
+    // the principal, so double-scheduling them is harmless.
+    if (announce) {
+      const dupKey = announceDedupKey(effectiveChannel, toTarget, task);
+      const existing = checkAnnounceDedup(dupKey, jobName);
+      if (existing) {
+        sendJson(res, 202, {
+          status: "deduplicated",
+          reason: "an equivalent announce task was scheduled to this channel recently",
+          existing_job: existing,
+          channel,
+          window_seconds: Math.round(ANNOUNCE_DEDUP_WINDOW_MS / 1000),
+        });
+        return;
+      }
+    }
+
     const scheduleMinutes = Math.max(1, Math.ceil(atSeconds / 60));
     const args = [
       ...HERMES_CMD,

--- a/packages/ctrl/tests/announce-dedup-416.test.ts
+++ b/packages/ctrl/tests/announce-dedup-416.test.ts
@@ -1,0 +1,39 @@
+// #416 — schedule-time dedup for announce:true spawns.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const {
+  _normalizeTask,
+  announceDedupKey,
+  checkAnnounceDedup,
+  _resetAnnounceDedupForTests,
+} = await import("../src/api/routes/agents.js");
+
+test("normalize collapses volatile bits (timestamps/uuids/digit runs)", () => {
+  const a = _normalizeTask("Research pancake route at 2026-08-04T14:25:41Z run 12345678");
+  const b = _normalizeTask("Research pancake route at 2026-08-04T14:40:22Z run 99887766");
+  assert.equal(a, b, "retried research with different ts/ids must normalize equal");
+});
+
+test("same channel+target+task within window dedups; second call sees existing job", () => {
+  _resetAnnounceDedupForTests();
+  const k = announceDedupKey("slack", "D123", "post the pancake route");
+  assert.equal(checkAnnounceDedup(k, "job-1"), null, "first is not a dup");
+  assert.equal(checkAnnounceDedup(k, "job-2"), "job-1", "second returns the first job");
+});
+
+test("different channel is not a dup", () => {
+  _resetAnnounceDedupForTests();
+  const k1 = announceDedupKey("slack", "D123", "post the route");
+  const k2 = announceDedupKey("telegram", "999", "post the route");
+  assert.equal(checkAnnounceDedup(k1, "j1"), null);
+  assert.equal(checkAnnounceDedup(k2, "j2"), null, "telegram target is distinct");
+});
+
+test("different task is not a dup", () => {
+  _resetAnnounceDedupForTests();
+  const k1 = announceDedupKey("slack", "D123", "post the pancake route");
+  const k2 = announceDedupKey("slack", "D123", "send the quarterly invoice");
+  assert.equal(checkAnnounceDedup(k1, "j1"), null);
+  assert.equal(checkAnnounceDedup(k2, "j2"), null, "distinct request goes through");
+});


### PR DESCRIPTION
Part of #415. Closes #416.

The mechanical half of the duplicate-delivery fix: `POST /api/v1/agents/main/task` now collapses near-identical `announce:true` spawns to the same target within a window (default 600s), returning `202 {status:"deduplicated", existing_job}`. Silent spawns are never deduped. Key normalizes out timestamps/uuids/ULIDs so a retried research reply collapses onto its first attempt.

This is the only ctrl chokepoint the spawn path crosses — the actual delivery bypasses `alfred-deliver` (that's #418). Pairs with the behavioural guardrail #417.

## Smoke evidence
- `tsc --noEmit` clean; 4 node:test cases (normalize collapse, dedup hit, channel/task distinctness) — `test-ctrl` gates them in CI (no tsx locally).
- Post-deploy on home: two `spawn_alfred_task(announce:true)` with the same task+channel inside the window → one Slack delivery, second returns `deduplicated`. Evidence to #416.

🤖 Generated with [Claude Code](https://claude.com/claude-code)