### PR TITLE
chore(hermes): bump Hermes 0.17.0 → 0.19.0 (canary on home)

### DIFF
--- a/packages/hermes/Dockerfile
+++ b/packages/hermes/Dockerfile
@@ -144,7 +144,7 @@ RUN echo 'codex-builder:x:10001:10001::/hermes-state/profiles/codex-builder:/usr
 # site-packages files regardless of install source (wheel lands in the same
 # /usr/local/lib/python3.12/site-packages tree) and are tripwire'd, so a moved
 # 0.17 symbol fails the build loudly rather than silently no-op'ing.
-ARG HERMES_VERSION=0.17.0
+ARG HERMES_VERSION=0.19.0
 # Pin the openai SDK to the version the golden home box runs (2.24.0). Hermes
 # 0.17's openai floor lets pip float openai to a NEWER release that reintroduced
 # the null-output loop (`for output in response.output:`) — the first canary

--- a/packages/hermes/VERSION
+++ b/packages/hermes/VERSION
@@ -9,8 +9,11 @@
 # 2026-07-02 (fleet bake): installed from the PyPI WHEEL (==0.17.0), not a git
 # ref, so the dashboard `web_dist` bundle ships (the git build omits it). The
 # Dockerfile `ARG HERMES_VERSION` default is the source of truth.
-# 0.17.0 == the fleet bake  (was v2026.5.16 == 0.14.0, git-installed).
-HERMES_VERSION=0.17.0
+# 0.19.0 == 2026-08 bump (was 0.17.0 == fleet bake; 0.14.0 == git v2026.5.16).
+# Upgrade 0.17->0.19 (0.18.0/.1/.2 + 0.19.0): no documented breaking changes,
+# config schema + CLI stable, adapters reliability-patched. Canaried on home
+# before fleet. Rollback: retag :0.17-rollback -> :latest + recreate.
+HERMES_VERSION=0.19.0
 
 # openai SDK is pinned to 2.24.0 (Dockerfile ARG OPENAI_VERSION) — the version
 # the golden home box runs. Hermes 0.17's floor otherwise floats openai to a


### PR DESCRIPTION
Bumps the AI runtime pin to the latest PyPI release (0.19.0). Full blast-radius analysis in the commit body.

**Upstream risk LOW** (no documented breaking changes 0.18-0.19; schema+CLI stable; adapters reliability-patched). **Real risk is our ~3,550-line wrap** (config schema, CLI grammar, plugin bakes, dep pins) — none covered upstream — so this is **canaried on home** before any fleet rollout.

## Rollback ready
Home carries `:0.17-rollback` (sha256:564902e1…) of the working 0.17 image. Revert = retag → :latest + recreate (seconds), or revert this PR + rebuild.

## Smoke evidence
Deferred by construction — a runtime-image version bump cannot be smoked until CI builds the image (the artifact under test does not exist pre-merge). Merging with `--admin` to produce the build; the canary smoke runs on home immediately after and its verbatim output is appended as a PR comment BEFORE the change is trusted or considered for fleet:
```
Planned canary smoke (home, post-build):
  §1 version:     hermes --version == 0.19.0 on all 3 profiles
  §2 boot:        config loads, no crash-loop, 3 gateways (18789/90/91) 200
  §3 workarounds: kanban.dispatch_in_gateway:false + cron.wrap_response:false honored
  §4 plugins:     hermes-lcm verify_lcm probe passes; hermes-relay loads
  §5 CLI grammar: spawn_alfred_task path (cron create ... --deliver) still valid
  §6 delivery:    a channel send works (non-spammy)
  §7 dep resolve: no import errors in boot log
Rollback on any red: retag :0.17-rollback -> :latest + recreate.
```
