### PR TITLE
fix(hermes): purge OpenRouter — Codex-only, terra/luna defaults (#433)

### DIFF
--- a/packages/hermes/hermes-config.yaml.njk
+++ b/packages/hermes/hermes-config.yaml.njk
@@ -57,7 +57,7 @@
 # this profile shells out to authenticates via ChatGPT OAuth, and the
 # supervising agent's LLM turns should use the same provider so the system
 # stays internally consistent. NOT overridable from .env: a future tenant
-# .env edit cannot accidentally swing this profile back to openrouter.
+# .env edit cannot accidentally swing this profile to a non-Codex provider.
 model:
   default: "{{ codex_builder_model | default('gpt-5-codex') }}"
   provider: "openai-codex"
@@ -68,7 +68,7 @@ model:
 model:
 {%- if is_main %}
   # User-facing Alfred — a capable model for the live chat surface.
-  # Bare OpenRouter model ID; provider/base_url below do the routing.
+  # Codex model tier (e.g. gpt-5.6-terra / gpt-5.6-luna).
   default: "{{ main_model }}"
 {%- elif profile == "heavy" %}
   # Heavy background reasoning (onboarding + chore heavy steps) — an
@@ -80,23 +80,13 @@ model:
   # high-volume (clerk classification, vault curation, ephemeral executors).
   default: "{{ workers_model }}"
 {%- endif %}
-  provider: "openrouter"
-  base_url: "https://openrouter.ai/api/v1"
-  # Per-request output-token ceiling.
-  #
-  # OpenRouter's affordability gate reserves `max_tokens × upstream-output
-  # cost` before billing. With the default (unset → model max ≈ 65 536) on
-  # gpt-5.5, the reservation exceeds the typical $50–100 credit floor and
-  # OpenRouter returns 402 ("can only afford N tokens of 65 536 requested")
-  # before the request ever runs. 8 192 is well above any chore or chat
-  # turn's real need, and small enough to stay under the reserve gate.
-  #
-  # When a profile is later flipped to `provider: openai-codex` this value
-  # is harmless — run_agent translates it via `_max_tokens_param()` into
-  # `max_completion_tokens` for direct-OpenAI / Codex endpoints.
-  #
-  # Sir 2026-05-27 — see joe.alfred.black cdsk incident: tool routing died
-  # on this exact gate while the OpenRouter key still had $46 of credit.
+  # Codex-only (Sir, 2026-08-05): OpenRouter is permanently banned. Every
+  # profile runs on openai-codex, authenticated via the shared ChatGPT
+  # auth.json. No base_url — Hermes resolves the Codex endpoint internally.
+  provider: "openai-codex"
+  # Per-request output-token ceiling. 8 192 is well above any chore or
+  # chat turn's real need. run_agent maps it to `max_completion_tokens`
+  # for the Codex endpoint via `_max_tokens_param()`.
   max_tokens: 8192
 {%- endif %}
 

--- a/packages/hermes/hermes-profile.env.njk
+++ b/packages/hermes/hermes-profile.env.njk
@@ -24,7 +24,6 @@
     api_server_host     bind address (default 0.0.0.0 — reached over the
                         compose network now the shim is gone)
     api_server_cors     comma-separated CORS allowlist  (optional)
-    openrouter_api_key  OPENROUTER_API_KEY              (required)
     anthropic_api_key   ANTHROPIC_API_KEY               (optional)
     openai_api_key      OPENAI_API_KEY                  (optional)
     composio_api_key    COMPOSIO_API_KEY                (optional)
@@ -67,7 +66,7 @@ API_SERVER_MODEL_NAME={{ profile }}
 # another profile cannot leak in.
 #
 # Specifically OMITTED (and why):
-#   OPENROUTER_API_KEY  — profile uses openai-codex provider exclusively.
+#   (Codex-only: no model-provider API key here — auth via ChatGPT auth.json.)
 #   ANTHROPIC_API_KEY   — same.
 #   OPENAI_API_KEY      — codex CLI auth is OAuth-via-ChatGPT, not REST.
 #   COMPOSIO_API_KEY    — no MCP catalogue, nothing to authenticate to.
@@ -119,9 +118,10 @@ HERMES_HUMAN_DELAY_MODE=off
 {%- else %}
 
 # -----------------------------------------------------------------------------
-# LLM provider keys
+# LLM provider keys — Codex-only (Sir, 2026-08-05): OpenRouter permanently
+# removed. Profiles authenticate to openai-codex via the shared ChatGPT
+# auth.json, not an API key here.
 # -----------------------------------------------------------------------------
-OPENROUTER_API_KEY={{ openrouter_api_key | default("") }}
 {%- if anthropic_api_key %}
 ANTHROPIC_API_KEY={{ anthropic_api_key }}
 {%- endif %}

--- a/packages/hermes/init/render_hermes.py
+++ b/packages/hermes/init/render_hermes.py
@@ -15,7 +15,7 @@ Usage:
     render_hermes.py <profile> <profile_dir> <template_dir> <gateway_token>
 
 Environment (read for template variables):
-    OPENROUTER_API_KEY, ANTHROPIC_API_KEY, OPENAI_API_KEY
+    ANTHROPIC_API_KEY, OPENAI_API_KEY
     COMPOSIO_API_KEY, COMPOSIO_USER_ID
     AAS_API_KEY
     ALFRED_PRIME, CROSS_TENANT_PEERS
@@ -105,12 +105,12 @@ _RESERVED_PORT = {
 # (packages/ctrl/src/db/agentProfiles.ts: _SLUG_RE).
 _SLUG_RE = re.compile(r"^[a-z][a-z0-9-]{1,30}$")
 
-# The template renders the `model:` block with `provider: openrouter`. Hermes
-# owns provider/model selection natively (`hermes model`, with a live model
-# picker) and that edit lands in config.yaml — which this script re-renders
-# on every boot. To avoid clobbering a deliberate switch, a re-render keeps
-# the existing `model:` block whenever its provider is no longer the default.
-_DEFAULT_PROVIDER = "openrouter"
+# Codex-only (Sir, 2026-08-05): the template renders `provider: openai-codex`
+# for every profile. OpenRouter is permanently banned. On re-render we keep an
+# existing `model:` block ONLY when it is already openai-codex (so a hand-tuned
+# Codex model tier survives a reseed); any legacy non-codex block is forced
+# back to the template's Codex render.
+_DEFAULT_PROVIDER = "openai-codex"
 
 
 def _model_block_span(text: str):
@@ -164,10 +164,13 @@ def _preserve_switched_model_block(rendered: str, config_path: Path) -> str:
     old_lines = old_text.splitlines(keepends=True)
     old_block = "".join(old_lines[old_span[0]:old_span[1]])
     provider = _block_provider(old_block)
-    if not provider or provider == _DEFAULT_PROVIDER:
-        return rendered  # still on the default — re-render from the template
+    # Codex-only: preserve ONLY an existing openai-codex block (keeps a
+    # hand-tuned Codex model tier across reseed). A legacy non-codex block
+    # (e.g. openrouter) is NOT preserved — it re-renders to the Codex template.
+    if not provider or provider != _DEFAULT_PROVIDER:
+        return rendered
     new_lines = rendered.splitlines(keepends=True)
-    print(f"[render] preserving user-switched model: block (provider={provider})")
+    print(f"[render] preserving codex model: block (provider={provider})")
     return (
         "".join(new_lines[: new_span[0]])
         + old_block
@@ -423,7 +426,7 @@ def main() -> int:
     # --- config.yaml ---------------------------------------------------------
     # #120 Lane II — user-facing profiles (anything NOT in the reserved set)
     # render through the same template branch as main: a capable
-    # conversational model via OpenRouter, with the standard agent posture.
+    # conversational model via openai-codex, with the standard agent posture.
     # The HERMES_RENDER_MODEL env var (set by entrypoint.sh from the registry
     # row) overrides the template's main_model default — so a profile created
     # with model="anthropic/claude-opus-4-6" gets that model in its config.
@@ -433,7 +436,7 @@ def main() -> int:
     main_model_value = (
         model_override
         if (is_main_like and model_override)
-        else os.environ.get("HERMES_MAIN_MODEL", "x-ai/grok-4.3")
+        else os.environ.get("HERMES_MAIN_MODEL", "gpt-5.6-terra")
     )
 
     config_tmpl = env.get_template("hermes-config.yaml.njk")
@@ -448,12 +451,12 @@ def main() -> int:
         runtime_profile_dir=runtime_profile_dir,
         alfred_prime=alfred_prime,
         cross_tenant_peers=cross_tenant_peers,
-        # Bare OpenRouter model IDs (no `openrouter/` prefix — `provider:
-        # openrouter` + base_url route it). Overridable via .env so a
-        # stale model ID is a one-line fix, not a rebuild.
+        # Codex model tiers (gpt-5.6-terra / gpt-5.6-luna). Overridable via
+        # .env (HERMES_MAIN_MODEL / _WORKERS_MODEL / _HEAVY_MODEL) so a model
+        # bump is a one-line fix, not a rebuild.
         main_model=main_model_value,
-        workers_model=os.environ.get("HERMES_WORKERS_MODEL", "openai/gpt-4.1-nano"),
-        heavy_model=os.environ.get("HERMES_HEAVY_MODEL", "anthropic/claude-opus-4-6"),
+        workers_model=os.environ.get("HERMES_WORKERS_MODEL", "gpt-5.6-luna"),
+        heavy_model=os.environ.get("HERMES_HEAVY_MODEL", "gpt-5.6-terra"),
         # codex-builder runs Hermes' supervising agent on the same openai-
         # codex model the CLI it shells out to uses. Overridable so a
         # future Codex model bump is a one-line .env change, not a
@@ -518,7 +521,6 @@ def main() -> int:
         # the compose network (the shim that used to front it is gone).
         api_server_host="0.0.0.0",
         api_server_cors=os.environ.get("HERMES_API_CORS_ORIGINS", ""),
-        openrouter_api_key=os.environ.get("OPENROUTER_API_KEY", ""),
         anthropic_api_key=os.environ.get("ANTHROPIC_API_KEY", ""),
         openai_api_key=os.environ.get("OPENAI_API_KEY", ""),
         # Relay/dashboard voice: Groq Whisper STT + the OpenAI realtime model.


### PR DESCRIPTION
Closes #433. **OpenRouter is permanently banned — Codex only, forever** (Sir, 2026-08-05).

Purges OpenRouter from the load-bearing Hermes config seam so a fresh deploy / reseed can never render a non-Codex provider:
- `render_hermes.py` — model defaults → `gpt-5.6-terra` (main/heavy), `gpt-5.6-luna` (workers); `_DEFAULT_PROVIDER` → `openai-codex`; the model-block splice now preserves **only** an existing `openai-codex` block (a legacy `openrouter` block re-renders to Codex, never persists across reseed); dropped the `openrouter_api_key` kwarg.
- `hermes-config.yaml.njk` — `provider: openai-codex`, no OpenRouter `base_url`, stale OpenRouter comments scrubbed.
- `hermes-profile.env.njk` — removed the `OPENROUTER_API_KEY` emit.

Provider auth is the shared ChatGPT `auth.json` (already how home runs live). **Rollout note:** any tenant that renders this template needs Codex/ChatGPT auth; fleet rollout remains HELD.

Scope: Lane V (`packages/hermes/**`), 74 LOC, 3 files. This is the durable/reseed-safe half of the perf baseline; home already runs Codex live.

## Smoke evidence
Rendered all three profiles from the updated template (`render_hermes.py <profile> …`):
```
main:    default: "gpt-5.6-terra"   provider: "openai-codex"
workers: default: "gpt-5.6-luna"    provider: "openai-codex"
heavy:   default: "gpt-5.6-terra"   provider: "openai-codex"
```
- `OPENROUTER_API_KEY` in rendered `.env`: **0**
- `openrouter` remaining in source: only intentional "permanently banned" ban-doc comments.
- Hermes test suite: **199 passed**. 6 failures (`test_patch_upstream_hermes_auth.py`, `test_supervisor_auth_propagation.py`) are **pre-existing** — they fail identically on a clean tree (`git stash` verified), unrelated to this change (auth-patch/supervisor drift from the 0.19 bump; tracked separately).
