### PR TITLE
feat(web): deterministic fast-path router — simple lookups from ctrl-api, skip the LLM (#425)

### DIFF
--- a/packages/web/src/server/chatProxy.ts
+++ b/packages/web/src/server/chatProxy.ts
@@ -10,6 +10,7 @@ import {
   resolveChatCorsOrigin,
   resolveGatewayTokenFromEnv,
 } from "./chatProxyCore";
+import { tryFastPath } from "./intentRouterCore";
 
 /**
  * Chat proxy — single-VM edition, Hermes runtime.
@@ -41,6 +42,28 @@ import {
 // compose network and serves the `/v1/*` API. Overridable for local dev.
 const HERMES_GATEWAY_URL =
   process.env.HERMES_GATEWAY_URL ?? "http://hermes:18789";
+
+// ctrl-api for the #425 deterministic fast-path (same access pattern as
+// filesProxy: CTRL_API_URL + the shared AAS_API_KEY bearer). Simple data
+// lookups (decisions/matters/chores/balance) are answered here directly,
+// skipping a full ~2s+ LLM turn. Fail-open — any error falls through to Hermes.
+const CTRL_API_URL = process.env.CTRL_API_URL ?? "http://ctrl-api:3100";
+const CTRL_API_KEY = process.env.AAS_API_KEY ?? "";
+
+async function ctrlGet(path: string): Promise<unknown> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), 4000);
+  try {
+    const r = await fetch(`${CTRL_API_URL}${path}`, {
+      headers: CTRL_API_KEY ? { Authorization: `Bearer ${CTRL_API_KEY}` } : {},
+      signal: ctrl.signal,
+    });
+    if (!r.ok) throw new Error(`ctrl-api ${r.status}`);
+    return await r.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
 
 // Hermes upstream auth. The Hermes API server validates inbound requests
 // against the gateway token written by the init container to
@@ -184,6 +207,15 @@ export function registerChatProxy(app: Application): void {
         return;
       }
 
+      // #425 deterministic fast-path — answer simple lookups from ctrl-api,
+      // skip the LLM. Fail-open: a miss/unfamiliar-shape/error returns null.
+      const fastTurn = await tryFastPath(input, ctrlGet);
+      if (fastTurn) {
+        res.status(200).setHeader("Content-Type", "application/json");
+        res.send(JSON.stringify(fastTurn));
+        return;
+      }
+
       // Hermes `/v1/responses` payload. `store:true` makes the response
       // retrievable and chainable via `previous_response_id`.
       const payload: Record<string, unknown> = { input, store: true };
@@ -245,6 +277,15 @@ export function registerChatProxy(app: Application): void {
       const input = typeof body.input === "string" ? body.input : "";
       if (!input.trim()) {
         res.status(400).json({ error: "input is required" });
+        return;
+      }
+
+      // #425 fast-path (streaming path too): the widget renders a completed
+      // envelope immediately without opening SSE. Fail-open to a real run.
+      const fastRun = await tryFastPath(input, ctrlGet);
+      if (fastRun) {
+        res.status(200).setHeader("Content-Type", "application/json");
+        res.send(JSON.stringify(fastRun));
         return;
       }
 

--- a/packages/web/src/server/intentRouterCore.test.ts
+++ b/packages/web/src/server/intentRouterCore.test.ts
@@ -1,0 +1,135 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  classifyIntent,
+  formatIntent,
+  buildFastPathEnvelope,
+  tryFastPath,
+} from "./intentRouterCore";
+
+// ── classifier: hits ─────────────────────────────────────────────────────────
+test("classifies pending-decision asks", () => {
+  for (const q of [
+    "pending decisions",
+    "what's on my desk",
+    "show my open decisions",
+    "any decisions waiting?",
+    "list my decisions",
+  ]) {
+    const r = classifyIntent(q);
+    assert.equal(r?.key, "decisions", q);
+    assert.equal(r?.ctrlPath, "/api/v1/decisions?state=open");
+  }
+});
+
+test("classifies matters / plate asks", () => {
+  for (const q of ["my matters", "what's on my plate", "active matters"]) {
+    assert.equal(classifyIntent(q)?.key, "matters", q);
+  }
+});
+
+test("classifies chores asks", () => {
+  for (const q of ["my chores", "chore status", "what chores are due"]) {
+    assert.equal(classifyIntent(q)?.key, "chores", q);
+  }
+});
+
+test("classifies Sure balance asks", () => {
+  for (const q of ["my balance", "account balances", "net worth", "sure balance"]) {
+    assert.equal(classifyIntent(q)?.key, "balance", q);
+  }
+});
+
+// ── classifier: fail-open non-matches ────────────────────────────────────────
+test("does not fast-path command-shaped or nuanced asks", () => {
+  for (const q of [
+    "create a decision about the wall",
+    "why do I have so many chores?",
+    "how is my balance trending vs last month and what should I cut",
+    "draft an email about the matters",
+    "mark that chore done",
+    "should I defer this decision",
+    "plan my week around these matters",
+  ]) {
+    assert.equal(classifyIntent(q), null, q);
+  }
+});
+
+test("does not fast-path empty, long, or unrelated input", () => {
+  assert.equal(classifyIntent(""), null);
+  assert.equal(classifyIntent("   "), null);
+  assert.equal(classifyIntent("tell me a joke about bees"), null);
+  assert.equal(classifyIntent("x".repeat(200)), null);
+  assert.equal(classifyIntent("what is the meaning of decisions in philosophy generally speaking today"), null); // >90 chars
+});
+
+// ── formatters ───────────────────────────────────────────────────────────────
+test("fmt decisions: count + items, empty state, bad shape", () => {
+  assert.match(
+    formatIntent("decisions", { decisions: [{ summary: "Pay NAV" }, { title: "Reply Rob" }], count: 2 }) ?? "",
+    /2 pending decision/,
+  );
+  assert.match(formatIntent("decisions", { decisions: [], count: 0 }) ?? "", /no pending decisions/i);
+  assert.equal(formatIntent("decisions", { nope: 1 }), null); // unfamiliar → null
+});
+
+test("fmt matters: names + state", () => {
+  const out = formatIntent("matters", { matters: [{ name: "NeoTerra", state: "active" }], count: 1 });
+  assert.match(out ?? "", /NeoTerra — active/);
+});
+
+test("fmt chores: name + status + next", () => {
+  const out = formatIntent("chores", {
+    chores: [{ name: "Weekly review", status: "active", next_run_at: "2026-08-10" }],
+  });
+  assert.match(out ?? "", /Weekly review/);
+});
+
+test("fmt balance: account + balance + currency", () => {
+  const out = formatIntent("balance", {
+    accounts: [{ name: "Checking", balance: 1234.5, currency: "HUF" }],
+  });
+  assert.match(out ?? "", /Checking: 1234.5 HUF/);
+  assert.equal(formatIntent("balance", { total: 5 }), null); // no accounts array → null
+});
+
+// ── envelope ─────────────────────────────────────────────────────────────────
+test("envelope is a completed /v1/responses shape the widget renders", () => {
+  const env: any = buildFastPathEnvelope("hello", "fastpath-1");
+  assert.equal(env.status, "completed");
+  assert.equal(env.object, "response");
+  assert.equal(env.output[0].content[0].text, "hello");
+  assert.equal(env.fast_path, true);
+});
+
+// ── tryFastPath orchestration (fail-open) ────────────────────────────────────
+test("tryFastPath: hit returns envelope", async () => {
+  const env = await tryFastPath(
+    "my chores",
+    async () => ({ chores: [{ name: "A", status: "active" }] }),
+    () => "id-1",
+  );
+  assert.equal((env as any)?.status, "completed");
+  assert.match((env as any).output[0].content[0].text, /You have 1 chore/);
+});
+
+test("tryFastPath: classifier miss → null", async () => {
+  const env = await tryFastPath("why is the sky blue", async () => ({}), () => "id");
+  assert.equal(env, null);
+});
+
+test("tryFastPath: unfamiliar ctrl shape → null (fall through)", async () => {
+  const env = await tryFastPath("my chores", async () => ({ unexpected: true }), () => "id");
+  assert.equal(env, null);
+});
+
+test("tryFastPath: ctrl-api error → null (fail-open)", async () => {
+  const env = await tryFastPath(
+    "my chores",
+    async () => {
+      throw new Error("ctrl-api down");
+    },
+    () => "id",
+  );
+  assert.equal(env, null);
+});

--- a/packages/web/src/server/intentRouterCore.ts
+++ b/packages/web/src/server/intentRouterCore.ts
@@ -1,0 +1,209 @@
+// intentRouterCore.ts — #425 deterministic fast-path.
+//
+// Answers a small set of *simple, unambiguous data-lookup* chat asks directly
+// from ctrl-api, skipping the LLM entirely (a full agent turn is ~2s+ and can
+// chain several tool calls; these are one HTTP read). This is the biggest
+// interactive-latency lever (see EPIC #434) — Codex-only is unaffected, the LLM
+// path is simply bypassed for these asks.
+//
+// SAFETY / DESIGN:
+//   * CONSERVATIVE classifier — fires only on short, clearly-scoped asks; any
+//     command-shaped or nuanced ask (create/why/how/plan/…) returns null.
+//   * FAIL-OPEN everywhere — a non-match, an unexpected ctrl-api shape, or any
+//     error returns null, and the caller falls through to the full agent. A
+//     false-positive that returned a canned answer instead of engaging Alfred
+//     is the failure mode we design against, so formatters return null rather
+//     than guess when the data shape is unfamiliar.
+//   * PURE — the ctrl-api fetch is injected (`CtrlGet`) so this is unit-testable
+//     with no network.
+
+export type IntentKey = "decisions" | "matters" | "chores" | "balance";
+
+export interface IntentSpec {
+  key: IntentKey;
+  /** ctrl-api path to GET (already includes any query string). */
+  ctrlPath: string;
+}
+
+/** Injected ctrl-api GET → parsed JSON (or throws / returns null on failure). */
+export type CtrlGet = (path: string) => Promise<unknown>;
+
+// Only fast-path short, direct asks. A long message is almost never a bare
+// lookup — let the agent handle nuance.
+const MAX_INPUT_CHARS = 90;
+
+// If any of these appear, it's not a bare read — defer to the agent.
+const NON_LOOKUP = /\b(create|add|new|update|change|edit|set|delete|remove|close|done|defer|snooze|draft|write|send|email|message|schedule|remind|pay|why|how|when|should|could|would|explain|plan|help|make|move|assign|complete|mark)\b/;
+
+/**
+ * Classify a chat input into a deterministic intent, or null to fall through.
+ * Deliberately narrow: requires the intent noun plus a possessive/list signal,
+ * rejects anything command-shaped.
+ */
+export function classifyIntent(rawInput: string): IntentSpec | null {
+  if (typeof rawInput !== "string") return null;
+  const s = rawInput.trim().toLowerCase().replace(/\s+/g, " ");
+  if (!s || s.length > MAX_INPUT_CHARS) return null;
+  if (NON_LOOKUP.test(s)) return null;
+
+  // pending / open decisions ("what's on my desk", "pending decisions")
+  if (
+    (/\bdecisions?\b/.test(s) &&
+      /\b(pending|open|await(?:ing)?|waiting|outstanding|my|list|show|any|queue)\b/.test(s)) ||
+    /\bmy desk\b/.test(s) ||
+    /\bdecision queue\b/.test(s)
+  ) {
+    return { key: "decisions", ctrlPath: "/api/v1/decisions?state=open" };
+  }
+
+  // matters / plate ("what's on my plate", "my matters", "active matters")
+  if (
+    /\bmatters?\b/.test(s) ||
+    /\bon my plate\b/.test(s) ||
+    /\bmy plate\b/.test(s)
+  ) {
+    return { key: "matters", ctrlPath: "/api/v1/matters" };
+  }
+
+  // chores ("my chores", "chore status", "chores due")
+  if (/\bchores?\b/.test(s)) {
+    return { key: "chores", ctrlPath: "/api/v1/chores" };
+  }
+
+  // Sure balance ("my balance", "account balances", "net worth", "sure balance")
+  if (
+    /\bnet ?worth\b/.test(s) ||
+    (/\bbalances?\b/.test(s) && /\b(my|account|accounts|sure|show|what)\b/.test(s)) ||
+    (/\baccounts?\b/.test(s) && /\b(my|balance|balances|sure|show|list)\b/.test(s))
+  ) {
+    return { key: "balance", ctrlPath: "/api/v1/sure/accounts" };
+  }
+
+  return null;
+}
+
+// ── Formatters — defensive; return null on an unfamiliar shape ───────────────
+
+function asArray(v: unknown): unknown[] | null {
+  return Array.isArray(v) ? v : null;
+}
+function str(v: unknown): string {
+  return typeof v === "string" ? v : "";
+}
+
+function fmtDecisions(data: any): string | null {
+  const items = asArray(data?.decisions);
+  if (!items) return null;
+  if (items.length === 0) return "You have no pending decisions right now. ✅";
+  const lines = items.slice(0, 10).map((d: any) => {
+    const label =
+      str(d?.summary) || str(d?.title) || str(d?.name) || str(d?.intent) || "(decision)";
+    return `• ${label}`;
+  });
+  const more = items.length > 10 ? `\n…and ${items.length - 10} more.` : "";
+  return `You have ${items.length} pending decision(s):\n${lines.join("\n")}${more}`;
+}
+
+function fmtMatters(data: any): string | null {
+  const items = asArray(data?.matters);
+  if (!items) return null;
+  if (items.length === 0) return "No active matters.";
+  const lines = items.slice(0, 12).map((m: any) => {
+    const name = str(m?.name) || str(m?.path) || "(matter)";
+    const state = str(m?.state);
+    return state ? `• ${name} — ${state}` : `• ${name}`;
+  });
+  const more = items.length > 12 ? `\n…and ${items.length - 12} more.` : "";
+  return `${items.length} matter(s) on your plate:\n${lines.join("\n")}${more}`;
+}
+
+function fmtChores(data: any): string | null {
+  const items = asArray(data?.chores);
+  if (!items) return null;
+  if (items.length === 0) return "No chores configured.";
+  const lines = items.slice(0, 12).map((c: any) => {
+    const name = str(c?.name) || str(c?.slug) || "(chore)";
+    const status = str(c?.status);
+    const next = str(c?.next_run_at);
+    const tail = [status, next && `next ${next}`].filter(Boolean).join(", ");
+    return tail ? `• ${name} (${tail})` : `• ${name}`;
+  });
+  const more = items.length > 12 ? `\n…and ${items.length - 12} more.` : "";
+  return `You have ${items.length} chore(s):\n${lines.join("\n")}${more}`;
+}
+
+function fmtBalance(data: any): string | null {
+  const items = asArray(data?.accounts);
+  if (!items) return null;
+  if (items.length === 0) return "No accounts found in Sure.";
+  const lines = items.slice(0, 15).map((a: any) => {
+    const name = str(a?.name) || str(a?.institution_name) || "(account)";
+    const bal = a?.balance ?? a?.cash_balance;
+    const cur = str(a?.currency) || "";
+    const shown =
+      typeof bal === "number" || typeof bal === "string" ? `${bal} ${cur}`.trim() : "—";
+    return `• ${name}: ${shown}`;
+  });
+  const more = items.length > 15 ? `\n…and ${items.length - 15} more.` : "";
+  return `Your accounts (${items.length}):\n${lines.join("\n")}${more}`;
+}
+
+export function formatIntent(key: IntentKey, data: unknown): string | null {
+  switch (key) {
+    case "decisions":
+      return fmtDecisions(data);
+    case "matters":
+      return fmtMatters(data);
+    case "chores":
+      return fmtChores(data);
+    case "balance":
+      return fmtBalance(data);
+    default:
+      return null;
+  }
+}
+
+/**
+ * The Hermes `/v1/responses` envelope the chat widget renders as a completed
+ * turn (it reads `output[].content[].text` and requires `status: "completed"`).
+ * A `fast_path` marker is added for observability; the widget ignores it.
+ */
+export function buildFastPathEnvelope(text: string, id: string): Record<string, unknown> {
+  return {
+    id,
+    object: "response",
+    status: "completed",
+    fast_path: true,
+    output: [
+      {
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text }],
+      },
+    ],
+    usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
+  };
+}
+
+/**
+ * Attempt the deterministic fast-path. Returns a ready `/v1/responses`
+ * envelope on a confident hit, or null to fall through to the full agent.
+ * FAIL-OPEN: any classification miss, unfamiliar ctrl-api shape, or thrown
+ * error yields null.
+ */
+export async function tryFastPath(
+  input: string,
+  ctrlGet: CtrlGet,
+  idFactory: () => string = () => `fastpath-${Date.now()}`,
+): Promise<Record<string, unknown> | null> {
+  const spec = classifyIntent(input);
+  if (!spec) return null;
+  try {
+    const data = await ctrlGet(spec.ctrlPath);
+    const text = formatIntent(spec.key, data);
+    if (!text) return null; // unfamiliar shape — let the agent handle it
+    return buildFastPathEnvelope(text, idFactory());
+  } catch {
+    return null; // ctrl-api unreachable / parse error — fall through
+  }
+}


### PR DESCRIPTION
Implements **#425** (from EPIC #434). Answers simple data-lookup chat asks directly from ctrl-api, skipping a full ~2s+ LLM turn — the biggest interactive-latency lever. **Codex-only is unaffected** (the LLM path is simply bypassed for these asks).

**Intents (v1):** pending decisions, matters/plate, chores, Sure balance. (Briefing deferred — it's prose + a 2nd fetch, better from Alfred.)

**Design / safety**
- `intentRouterCore.ts` — pure, unit-testable. **Conservative** classifier: only short, unambiguous asks; anything command-shaped (`create/why/how/plan/…`) or >90 chars defers. **Defensive** formatters return `null` on an unfamiliar ctrl-api shape. **Fail-open** everywhere — a false-positive *canned* answer (instead of engaging Alfred) is the failure mode designed against, so any miss/odd-shape/error falls through to the full agent.
- `chatProxy.ts` — fast-path in **both** `/turn` and `/run` before the Hermes fetch. The streaming widget renders a `status:"completed"` envelope immediately (no SSE). `ctrlGet` reuses filesProxy's `CTRL_API_URL` + `AAS_API_KEY` pattern (4s timeout).

**Scope note:** 385 LOC (module + wiring + 15 tests) — over the ~200 lane guideline, but a cohesive single feature; the module is inert without its wiring, and the tests are the safety net for the fail-open contract. Deferred to separate issues: model routing (#431, needs #427) + working-indicator (#429).

## Smoke evidence
Pre-deploy (local):
- `tsc --noEmit --strict` clean on `intentRouterCore.ts`.
- **15/15** `node:test` cases green — classifier hits (decisions/matters/chores/balance), fail-open non-matches (commands, long/empty/unrelated input), defensive formatters (null on bad shape), orchestration (hit → envelope; miss/bad-shape/error → null).
- Classifier + formatters validated against the **real ctrl-api response shapes** probed live on home (`{decisions|matters|chores|accounts:[…]}`).

Post-deploy verification on home (fast-path hit → instant answer; nuanced ask → still engages Alfred) will follow the `build-web`/`build-web-client` deploy.
