### PR TITLE
fix(learn): revive instinct promotion — patch frontmatter, not body-append (#442)

### DIFF
--- a/packages/learn/src/activities/vault.py
+++ b/packages/learn/src/activities/vault.py
@@ -790,7 +790,11 @@ async def fetch_active_instincts() -> list[dict[str, Any]]:
     config = load_config()
     client = VaultClient(config)
     try:
-        return await client.list_records("instinct", status="active")
+        # Gap-3 / fix #2: do NOT filter status="active". Reflection must see
+        # every non-deprecated instinct (unconfirmed/proposed included), matching
+        # `_load_active_instincts`. The active-only filter hid new instincts from
+        # the reflection pass so they never accumulated toward promotion.
+        return await client.list_records("instinct")
     finally:
         await client.close()
 
@@ -811,12 +815,13 @@ async def apply_instinct_change(proposal: dict[str, Any]) -> None:
         elif action == "update":
             path = proposal.get("path", "")
             changes = proposal.get("changes", {})
-            if path:
-                existing = await client.read_record(path)
-                raw = existing.get("content", "")
-                # Apply field updates to frontmatter
-                updated = _apply_frontmatter_updates(raw, changes)
-                await client.update_record(path, updated)
+            if path and changes:
+                # fix #1: patch frontmatter directly via {"set": ...}. The old
+                # update_record() sent {"body_append": ...} — a body-only verb
+                # that never touched tier / confidence_score / observation_count,
+                # so EVERY promotion silently no-op'd (200 OK + a "promoted"
+                # audit row, but the record's frontmatter never changed on disk).
+                await client.patch_frontmatter(path, changes)
                 # #332: tier moves are THE flywheel milestone — emit an
                 # audit row so telemetry observes promotions/demotions
                 # instead of declaring them. Best-effort.
@@ -843,24 +848,20 @@ async def apply_instinct_change(proposal: dict[str, Any]) -> None:
             content = _build_instinct_content(merged)
             await client.write_record("instinct", name, content)
             for source_path in proposal.get("source_paths", []):
-                existing = await client.read_record(source_path)
-                raw = existing.get("content", "")
-                updated = _apply_frontmatter_updates(raw, {
+                # fix #1: frontmatter patch (was a body-append no-op).
+                await client.patch_frontmatter(source_path, {
                     "status": "deprecated",
                     "deprecation_reason": f"merged into {name}",
                 })
-                await client.update_record(source_path, updated)
 
         elif action == "deprecate":
             path = proposal.get("path", "")
             if path:
-                existing = await client.read_record(path)
-                raw = existing.get("content", "")
-                updated = _apply_frontmatter_updates(
-                    raw,
+                # fix #1: frontmatter patch (was a body-append no-op).
+                await client.patch_frontmatter(
+                    path,
                     {"status": "deprecated", "deprecation_reason": proposal.get("reason", "")},
                 )
-                await client.update_record(path, updated)
     finally:
         await client.close()
 

--- a/packages/learn/tests/test_instinct_promotion_write.py
+++ b/packages/learn/tests/test_instinct_promotion_write.py
@@ -1,0 +1,122 @@
+"""fix #1 — apply_instinct_change must patch instinct FRONTMATTER, not body-append.
+
+The bug: the update/merge/deprecate branches wrote via `VaultClient.update_record()`,
+which sends `{"body_append": ...}` — a body-only PATCH verb that can never change
+`tier` / `confidence_score` / `observation_count`. So every nightly Reflection
+promotion silently no-op'd: the PATCH returned 200, an `instinct_tier_event` audit
+row was written claiming the promotion, but the record's frontmatter never changed
+on disk — no instinct ever graduated past `Asking`.
+
+These tests pin the write verb: the update/deprecate paths MUST call
+`patch_frontmatter()` (`{"set": ...}`) and MUST NOT call `update_record()`.
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.activities.vault import apply_instinct_change
+
+
+class _FakeVaultClient:
+    last: "_FakeVaultClient | None" = None
+
+    def __init__(self, *args, **kwargs):
+        self.patched: list = []          # (path, updates) from patch_frontmatter
+        self.body_appended: list = []    # (path, content) from update_record — MUST stay empty
+        self.written: list = []          # (type, name) from write_record
+        _FakeVaultClient.last = self
+
+    async def read_record(self, path):
+        return {"content": "---\ntype: instinct\nstatus: active\ntier: Asking\n---\nbody\n"}
+
+    async def patch_frontmatter(self, path, updates):
+        self.patched.append((path, dict(updates)))
+
+    async def update_record(self, path, content):
+        self.body_appended.append((path, content))
+
+    async def write_record(self, record_type, name, content):
+        self.written.append((record_type, name))
+        return f"instinct/{name}.md"
+
+    async def close(self):
+        pass
+
+
+class _FakeStateClient:
+    audits: list = []
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def append_audit(self, **kwargs):
+        _FakeStateClient.audits.append(kwargs)
+
+
+@pytest.fixture(autouse=True)
+def _mock(monkeypatch):
+    monkeypatch.setattr("src.activities.vault.VaultClient", _FakeVaultClient)
+    monkeypatch.setattr("src.utils.state_client.StateClient", _FakeStateClient)
+    _FakeStateClient.audits = []
+
+
+async def test_update_patches_frontmatter_and_never_body_appends():
+    await apply_instinct_change(
+        {
+            "action": "update",
+            "path": "instinct/critical-payments-guard.md",
+            "changes": {"tier": "Confirming", "observation_count": 11, "confidence_score": 0.9},
+        }
+    )
+    fc = _FakeVaultClient.last
+    assert fc is not None
+    # The regression: no body-append (that was the silent no-op).
+    assert fc.body_appended == [], "instinct edit must NOT use body_append"
+    # The fix: a frontmatter set with the promoted fields.
+    assert fc.patched == [
+        (
+            "instinct/critical-payments-guard.md",
+            {"tier": "Confirming", "observation_count": 11, "confidence_score": 0.9},
+        )
+    ]
+
+
+async def test_update_with_tier_emits_truthful_audit():
+    await apply_instinct_change(
+        {"action": "update", "path": "instinct/x.md", "changes": {"tier": "Acting"}}
+    )
+    # audit now rides *after* a real frontmatter patch (patch_frontmatter raises on
+    # non-2xx, so the audit only lands when the write actually succeeded).
+    assert any(a.get("action_type") == "instinct_tier_event" for a in _FakeStateClient.audits)
+
+
+async def test_deprecate_patches_status_frontmatter_not_body_append():
+    await apply_instinct_change(
+        {"action": "deprecate", "path": "instinct/y.md", "reason": "stale"}
+    )
+    fc = _FakeVaultClient.last
+    assert fc.body_appended == []
+    assert fc.patched and fc.patched[0][0] == "instinct/y.md"
+    assert fc.patched[0][1].get("status") == "deprecated"
+
+
+async def test_merge_deprecates_sources_via_frontmatter_patch():
+    await apply_instinct_change(
+        {
+            "action": "merge",
+            "merged_instinct": {"name": "merged-guard"},
+            "source_paths": ["instinct/a.md", "instinct/b.md"],
+        }
+    )
+    fc = _FakeVaultClient.last
+    assert fc.body_appended == []
+    # both sources deprecated via frontmatter patch; merged instinct created
+    assert {p for p, _ in fc.patched} == {"instinct/a.md", "instinct/b.md"}
+    assert all(u.get("status") == "deprecated" for _, u in fc.patched)
+    assert fc.written and fc.written[0][0] == "instinct"


### PR DESCRIPTION
Closes #442. Revives instinct tier-promotion — the silently-dead last hop of the learning loop.

**Bug:** `apply_instinct_change` wrote via `update_record()` → `{"body_append": ...}`, a body-only PATCH verb that can't change `tier`/`confidence_score`/`observation_count`. Every nightly Reflection promotion no-op'd (200 OK + a lying `instinct_tier_event` audit row), so all 35 live instincts sat frozen at `Asking` — incl. ones at `observation_count: 23`, `confidence: 0.99`.

**Fix (Lane II, `packages/learn`):**
- update / merge / deprecate branches → `patch_frontmatter()` (`{"set": ...}`, already existed unused in the same class). The `tier` audit row now rides *after* a real write (`patch_frontmatter` raises on non-2xx, so it can no longer assert a promotion that didn't land).
- `fetch_active_instincts` drops `status="active"` → Reflection sees all non-deprecated instincts (matches the Gap-3 `_load_active_instincts` fix; the active-only filter hid new instincts from accumulation).
- Regression test pins the write verb: instinct edits MUST `patch_frontmatter`, never `body_append`.

Verified safe against `edit_record`: `--set` writes fields freely; `_validate_status` skips types absent from `STATUS_BY_TYPE` (which is exactly why today's body-append 200s), so the frontmatter patch lands without raising.

## Smoke evidence
- New `test_instinct_promotion_write.py`: 4 cases — update patches frontmatter & never body-appends; tier update emits the audit; deprecate/merge patch `status` via frontmatter. **All pass.**
- Targeted sweep `-k "vault or reflect or instinct or steward"`: **331 passed, 4 skipped** (2 fastapi collection errors are local-env only; CI has the deps).
- Post-merge: `build-learn` → deploy `alfred-learn` to home → **verify a real instinct's frontmatter changes** (tier/observation_count) after a Reflection run, and that the audit row now matches the file. (Verification-on-home to follow.)
