### PR TITLE
fix(alfred-vault): add instinct to vault schema — stop janitor FM002 (#442 secondary)

### DIFF
--- a/packages/alfred-vault/src/alfred/vault/schema.py
+++ b/packages/alfred-vault/src/alfred/vault/schema.py
@@ -9,6 +9,9 @@ KNOWN_TYPES: set[str] = {
     "location", "note", "decision", "process", "run", "event",
     "account", "asset", "conversation", "assumption", "constraint",
     "contradiction", "synthesis",
+    # Canonical progressive-autonomy record (Asking→Confirming→Acting). Was
+    # absent, so the janitor stamped every instinct FM002 "Unknown type".
+    "instinct",
 }
 
 LEARN_TYPES: set[str] = {
@@ -46,6 +49,7 @@ STATUS_BY_TYPE: dict[str, set[str]] = {
     "constraint": {"active", "expired", "waived", "superseded"},
     "contradiction": {"unresolved", "resolved", "accepted"},
     "synthesis": {"draft", "active", "superseded"},
+    "instinct": {"unconfirmed", "active", "deprecated"},
 }
 
 # Type → expected top-level directory
@@ -67,6 +71,7 @@ TYPE_DIRECTORY: dict[str, str] = {
     "constraint": "constraint",
     "contradiction": "contradiction",
     "synthesis": "synthesis",
+    "instinct": "instinct",
     # session, input have flexible placement
 }
 


### PR DESCRIPTION
Secondary fix from the learn-pipeline investigation (#442). `instinct` was missing from `KNOWN_TYPES`/`STATUS_BY_TYPE`/`TYPE_DIRECTORY`, so the janitor stamped every instinct record `FM002 — Unknown type: instinct`. Added (statuses `unconfirmed|active|deprecated`; dir `instinct/`); deliberately NOT in `LEARN_TYPES` (instincts arent distiller-created).

Lane IV (`packages/alfred-vault`), 3 dicts.

## Smoke evidence
Direct import check: `instinct` present in KNOWN_TYPES + STATUS_BY_TYPE(={unconfirmed,active,deprecated}) + TYPE_DIRECTORY, absent from LEARN_TYPES. (Full pytest runs in CI; local env lacks the editable install — ModuleNotFoundError: alfred — unrelated to this change.)

Note: broader schema drift (project vs matter; missing chore/briefing/daybook) is a separate follow-up.