### PR TITLE
P0 fix(learn): gate autonomous dispatch on the promotion-ladder tier (#445)

### DIFF
--- a/packages/learn/src/activities/signal_actions.py
+++ b/packages/learn/src/activities/signal_actions.py
@@ -477,6 +477,60 @@ async def _recent_open_card_exists(client: Any, fm: dict[str, Any]) -> str | Non
     return None
 
 
+# Progressive-autonomy ladder (#445). The ONLY tier permitted to route a
+# signal to the agent without the principal in the loop. `Asking` and
+# `Confirming` both mean "the principal decides"; they differ in what the
+# card says, not in whether Alfred may act unilaterally.
+#
+# Why `Confirming` is also blocked here: ``route_signal_action`` only ever
+# sees signals with ``effect == "action"`` (validated at step 2) — external,
+# side-effecting work like sending mail or calling a vendor API. There is no
+# internal/reversible subset arriving at this gate to let through, so #445's
+# "Confirming → human for anything with external side effects" resolves to
+# "Confirming → human" here. The needs_attention card IS the confirm surface.
+TIER_ASKING = "Asking"
+TIER_CONFIRMING = "Confirming"
+TIER_ACTING = "Acting"
+VALID_TIERS = (TIER_ASKING, TIER_CONFIRMING, TIER_ACTING)
+AUTONOMOUS_TIER = TIER_ACTING
+
+
+def _coerce_int_or_none(raw: Any) -> int | None:
+    """Best-effort int for audit observability — never raises (#445)."""
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def _instinct_tier(instinct: dict[str, Any]) -> str:
+    """Return the instinct's promotion-ladder tier, failing CLOSED.
+
+    Anything missing, unparseable, or outside ``VALID_TIERS`` degrades to
+    ``Asking`` — the least-autonomy tier. A malformed instinct must never
+    be able to buy autonomy it hasn't earned (#445).
+
+    Only the frontmatter ``tier`` string is authoritative. The nested
+    ``execution.tier`` integer / ``execution.requires_approval`` pair is a
+    legacy shape that is deliberately NOT consulted: it disagreed with the
+    ladder on live data (``tier: Asking`` alongside
+    ``execution: {tier: 1, requires_approval: false}``) and the weaker of
+    two conflicting fields must not satisfy the gate.
+    """
+    fm = instinct.get("frontmatter")
+    if not isinstance(fm, dict):
+        fm = instinct
+    raw = fm.get("tier")
+    if not isinstance(raw, str):
+        return TIER_ASKING
+    normalized = raw.strip().capitalize()
+    if normalized not in VALID_TIERS:
+        return TIER_ASKING
+    return normalized
+
+
 def _instinct_threshold(instinct: dict[str, Any]) -> float:
     """Compute the effective per-instinct discretion bar from frontmatter.
 
@@ -503,40 +557,15 @@ def _instinct_threshold(instinct: dict[str, Any]) -> float:
     Falling back to the stored ``observation_count`` keeps the gate
     sane if ctrl-api is on an older build that doesn't enrich the
     response yet.
+
+    #445: delegates to ``discretion.effective_threshold`` — the single
+    shared implementation. This used to be a second, divergent copy of
+    the raise-only rule, and it was the copy the live router actually
+    used while the tests exercised the other one.
     """
-    fm = instinct.get("frontmatter")
-    if not isinstance(fm, dict):
-        fm = instinct
+    from src.matching.discretion import effective_threshold
 
-    # Floor: the bar the live observation count has earned. Prefer the
-    # ctrl-api-enriched live count over the stored snapshot.
-    obs_count_raw = (
-        fm.get("live_observation_count")
-        if fm.get("live_observation_count") is not None
-        else fm.get("observation_count", 0)
-    )
-    try:
-        obs_count = int(obs_count_raw)
-    except (TypeError, ValueError):
-        obs_count = 0
-    if obs_count < 0:
-        obs_count = 0
-
-    from src.matching.discretion import get_discretion_threshold
-    earned = get_discretion_threshold(obs_count)
-
-    # Raise-only override: an explicit threshold can only make the bar
-    # stricter, never lower it below the earned floor.
-    raw = fm.get("discretion_threshold")
-    if raw is not None:
-        try:
-            f = float(raw)
-        except (TypeError, ValueError):
-            f = None
-        if f is not None and f == f and f >= 0.0:
-            return max(earned, min(f, 1.0))
-
-    return earned
+    return effective_threshold(instinct)
 
 
 def _safe_filename_slug(s: str) -> str:
@@ -722,6 +751,9 @@ async def _emit_signal_action_audit(
     matched_instinct_name: str | None,
     match_score: float,
     threshold: float,
+    matched_instinct_tier: str = TIER_ASKING,
+    observation_count: int | None = None,
+    live_observation_count: int | None = None,
     combined_confidence: float,
     chosen_path: str,
     decision_reason: str,
@@ -762,6 +794,13 @@ async def _emit_signal_action_audit(
         "match_score": round(match_score, 4),
         "threshold": round(threshold, 4),
         "combined_confidence": round(combined_confidence, 4),
+        # #445 — the gate's inputs, so a routing decision can be
+        # reconstructed from the audit row alone. Before this, the
+        # effective bar was invisible after the fact and diagnosing the
+        # 2026-08-06 ElevenLabs incident meant reading source to infer it.
+        "instinct_tier": matched_instinct_tier,
+        "observation_count": observation_count,
+        "live_observation_count": live_observation_count,
         "effective_mode": effective_mode,
         "env_mode": env_mode,
         "needs_attention_path": needs_attention_path,
@@ -774,7 +813,8 @@ async def _emit_signal_action_audit(
 
     summary = (
         f"signal-action: {chosen_path} ({decision_reason}) — "
-        f"conf={combined_confidence:.2f} mode={effective_mode}"
+        f"conf={combined_confidence:.2f} bar={threshold:.2f} "
+        f"tier={matched_instinct_tier} mode={effective_mode}"
     )
 
     cfg = load_config()
@@ -1874,12 +1914,24 @@ async def route_signal_action(
         matched_path: str | None = None
         matched_name: str | None = None
         threshold = DEFAULT_DISCRETION_THRESHOLD
+        # #445 — fail closed: with no matched instinct there is no earned
+        # autonomy at all, so the tier defaults to the blocking value.
+        matched_tier = TIER_ASKING
+        matched_obs_count: int | None = None
+        matched_live_obs_count: int | None = None
         if matched is not None:
             matched_path = str(matched.get("path") or "").strip() or None
             inst_fm = matched.get("frontmatter") or matched
             if isinstance(inst_fm, dict):
                 matched_name = str(inst_fm.get("name") or "").strip() or None
+                matched_obs_count = _coerce_int_or_none(
+                    inst_fm.get("observation_count")
+                )
+                matched_live_obs_count = _coerce_int_or_none(
+                    inst_fm.get("live_observation_count")
+                )
             threshold = _instinct_threshold(matched)
+            matched_tier = _instinct_tier(matched)
 
         # 5. Combined confidence — for actions, target_confidence only
         # gates when there IS a target (target_kind set). Many actions
@@ -1941,7 +1993,15 @@ async def route_signal_action(
         #      clicked Delegate from /desk that's the opposite case and
         #      shadow shouldn't apply.
         #   2. shadow mode for autonomous signals → human.
-        #   3. confidence / instinct-match tier gates.
+        #   3. the promotion-ladder tier ceiling (#445).
+        #   4. confidence / discretion-bar gate.
+        #
+        # #445 — the tier is a CEILING evaluated BEFORE confidence, not a
+        # tiebreaker after it. No amount of confidence promotes an `Asking`
+        # or `Confirming` instinct into autonomy; the discretion bar still
+        # applies underneath for instincts that have reached `Acting`.
+        # Ordering matters: checking tier first means the audit reason
+        # names the real blocker instead of masking it as `low_confidence`.
         if principal_delegate_override:
             chosen_path = "agent"
             decision_reason = "principal_delegated"
@@ -1951,6 +2011,9 @@ async def route_signal_action(
         elif matched is None or matched_path is None:
             chosen_path = "human"
             decision_reason = "no_matching_instinct"
+        elif matched_tier != AUTONOMOUS_TIER:
+            chosen_path = "human"
+            decision_reason = f"tier_gate_{matched_tier.lower()}"
         elif combined_confidence < threshold:
             chosen_path = "human"
             decision_reason = "low_confidence"
@@ -2117,6 +2180,9 @@ async def route_signal_action(
             matched_instinct_name=matched_name,
             match_score=match_score,
             threshold=threshold,
+            matched_instinct_tier=matched_tier,
+            observation_count=matched_obs_count,
+            live_observation_count=matched_live_obs_count,
             combined_confidence=combined_confidence,
             chosen_path=chosen_path,
             decision_reason=decision_reason,

--- a/packages/learn/src/matching/discretion.py
+++ b/packages/learn/src/matching/discretion.py
@@ -30,6 +30,45 @@ def get_discretion_threshold(observation_count: int) -> float:
         return 0.75
 
 
+def effective_threshold(instinct: dict[str, Any]) -> float:
+    """The instinct's effective discretion bar (#445).
+
+    SINGLE source of truth for the raise-only override rule. Previously
+    this logic existed twice — here and in
+    ``signal_actions._instinct_threshold`` — with only the latter wired
+    into the live router, so the tested copy was not the running copy.
+    ``_instinct_threshold`` now delegates here.
+
+    Accepts either a bare frontmatter mapping or a full record dict with
+    a ``frontmatter`` key.
+    """
+    fm = instinct.get("frontmatter")
+    if not isinstance(fm, dict):
+        fm = instinct
+
+    obs_raw = fm.get("live_observation_count")
+    if obs_raw is None:
+        obs_raw = fm.get("observation_count", 0)
+    try:
+        obs_count = int(obs_raw)
+    except (TypeError, ValueError):
+        obs_count = 0
+    earned = get_discretion_threshold(max(obs_count, 0))
+
+    explicit = fm.get("discretion_threshold")
+    if explicit is not None:
+        try:
+            f = float(explicit)
+        except (TypeError, ValueError):
+            f = None
+        # ``f == f`` rejects NaN, which would make every comparison False.
+        if f is not None and f == f and f >= 0.0:
+            # Raise-only: an explicit override may only make the bar
+            # stricter, never looser than what observations earned.
+            return max(earned, min(f, 1.0))
+    return earned
+
+
 def should_route_autonomously(
     score: float,
     instinct: dict[str, Any],
@@ -47,28 +86,14 @@ def should_route_autonomously(
 
     Prefers the ctrl-api-enriched ``live_observation_count`` (the same
     decision-sourced count the badge uses) over the stored snapshot.
-    """
-    obs_raw = instinct.get("live_observation_count")
-    if obs_raw is None:
-        obs_raw = instinct.get("observation_count", 0)
-    try:
-        obs_count = int(obs_raw)
-    except (TypeError, ValueError):
-        obs_count = 0
-    earned = get_discretion_threshold(max(obs_count, 0))
 
-    explicit = instinct.get("discretion_threshold")
-    threshold = earned
-    if explicit is not None:
-        try:
-            f = float(explicit)
-        except (TypeError, ValueError):
-            f = None
-        if f is not None and f == f:
-            # Raise-only: an explicit override may only make the bar
-            # stricter, never looser than what observations earned.
-            threshold = max(earned, f)
-    return score >= threshold
+    NOTE (#445): this answers "does the score clear the numeric bar", NOT
+    "may this instinct act autonomously". The promotion-ladder tier is a
+    separate, stricter ceiling enforced in
+    ``signal_actions.route_signal_action`` — an ``Asking`` instinct never
+    routes to the agent no matter what this returns.
+    """
+    return score >= effective_threshold(instinct)
 
 
 def format_discretion_level(observation_count: int) -> str:

--- a/packages/learn/tests/test_tier_gate.py
+++ b/packages/learn/tests/test_tier_gate.py
@@ -1,0 +1,186 @@
+"""#445 — the promotion-ladder tier gates autonomous dispatch.
+
+Regression pin for the 2026-08-06 ElevenLabs incident: an instinct the UI
+displayed as ``tier: Asking`` (observation_count 1) routed a signal to the
+agent, which sent an irreversible cancellation email to a third party from
+the principal's own Gmail. The tier was never consulted by the router.
+
+The tier is a CEILING evaluated BEFORE the confidence bar: only ``Acting``
+may route autonomously, and a malformed/absent tier fails closed.
+"""
+
+import pytest
+
+from src.activities.signal_actions import (
+    AUTONOMOUS_TIER,
+    TIER_ASKING,
+    TIER_CONFIRMING,
+    _instinct_tier,
+)
+from src.matching.discretion import effective_threshold
+
+
+def _instinct(tier, **fm):
+    """A matched-instinct record as ``_load_active_instincts`` returns it."""
+    frontmatter = {"name": "test-instinct", **fm}
+    if tier is not None:
+        frontmatter["tier"] = tier
+    return {"path": "instinct/test-instinct.md", "frontmatter": frontmatter}
+
+
+class TestInstinctTier:
+    def test_reads_each_valid_tier(self):
+        for tier in ("Asking", "Confirming", "Acting"):
+            assert _instinct_tier(_instinct(tier)) == tier
+
+    def test_absent_tier_fails_closed(self):
+        assert _instinct_tier(_instinct(None)) == TIER_ASKING
+
+    def test_unknown_tier_fails_closed(self):
+        assert _instinct_tier(_instinct("Autonomous")) == TIER_ASKING
+        assert _instinct_tier(_instinct("")) == TIER_ASKING
+
+    def test_non_string_tier_fails_closed(self):
+        # The legacy nested shape stored an integer (execution.tier: 1).
+        assert _instinct_tier(_instinct(1)) == TIER_ASKING
+        assert _instinct_tier(_instinct(None)) == TIER_ASKING
+
+    def test_case_and_whitespace_tolerated(self):
+        assert _instinct_tier(_instinct("  acting ")) == "Acting"
+        assert _instinct_tier(_instinct("ASKING")) == TIER_ASKING
+
+    def test_bare_frontmatter_mapping_accepted(self):
+        assert _instinct_tier({"tier": "Acting"}) == "Acting"
+
+    def test_execution_tier_cannot_buy_autonomy(self):
+        """The exact live shape that fired the incident.
+
+        ``execution.tier: 1`` + ``requires_approval: false`` must NOT
+        satisfy the gate when the ladder says Asking.
+        """
+        rec = _instinct(
+            "Asking",
+            execution={"enabled": True, "requires_approval": False, "tier": 1},
+        )
+        assert _instinct_tier(rec) == TIER_ASKING
+        assert _instinct_tier(rec) != AUTONOMOUS_TIER
+
+
+class TestTierGateDecision:
+    """The branch logic from ``route_signal_action`` steps 6.
+
+    Mirrors the precedence exactly: delegate > shadow > no-match > tier >
+    confidence. Kept as a pure function so the ordering is pinned without
+    standing up Temporal + ctrl-api.
+    """
+
+    @staticmethod
+    def _decide(
+        *,
+        instinct,
+        combined_confidence,
+        principal_delegate_override=False,
+        effective_mode="live",
+    ):
+        threshold = effective_threshold(instinct) if instinct else 0.95
+        matched_tier = _instinct_tier(instinct) if instinct else TIER_ASKING
+        if principal_delegate_override:
+            return "agent", "principal_delegated"
+        if effective_mode == "shadow":
+            return "human", "shadow_mode"
+        if instinct is None:
+            return "human", "no_matching_instinct"
+        if matched_tier != AUTONOMOUS_TIER:
+            return "human", f"tier_gate_{matched_tier.lower()}"
+        if combined_confidence < threshold:
+            return "human", "low_confidence"
+        return "agent", "high_confidence_match"
+
+    def test_asking_never_acts_even_at_full_confidence(self):
+        # 50+ observations would earn a 0.75 bar; the tier still blocks.
+        rec = _instinct("Asking", observation_count=100)
+        path, reason = self._decide(instinct=rec, combined_confidence=1.0)
+        assert path == "human"
+        assert reason == "tier_gate_asking"
+
+    def test_confirming_never_acts_autonomously(self):
+        rec = _instinct("Confirming", observation_count=100)
+        path, reason = self._decide(instinct=rec, combined_confidence=1.0)
+        assert path == "human"
+        assert reason == "tier_gate_confirming"
+
+    def test_acting_dispatches_when_bar_cleared(self):
+        rec = _instinct("Acting", observation_count=50)  # bar 0.75
+        path, reason = self._decide(instinct=rec, combined_confidence=0.80)
+        assert path == "agent"
+        assert reason == "high_confidence_match"
+
+    def test_acting_still_blocked_below_bar(self):
+        """Tier is a ceiling, not a bypass — the bar still applies."""
+        rec = _instinct("Acting", observation_count=0)  # bar 0.95
+        path, reason = self._decide(instinct=rec, combined_confidence=0.90)
+        assert path == "human"
+        assert reason == "low_confidence"
+
+    def test_absent_tier_blocks(self):
+        rec = _instinct(None, observation_count=100)
+        path, reason = self._decide(instinct=rec, combined_confidence=1.0)
+        assert path == "human"
+        assert reason == "tier_gate_asking"
+
+    def test_principal_delegate_overrides_tier(self):
+        """An explicit Delegate click is not autonomy — must still fire."""
+        rec = _instinct("Asking", observation_count=0)
+        path, reason = self._decide(
+            instinct=rec,
+            combined_confidence=0.0,
+            principal_delegate_override=True,
+        )
+        assert path == "agent"
+        assert reason == "principal_delegated"
+
+    def test_shadow_mode_still_precedes_tier(self):
+        rec = _instinct("Acting", observation_count=100)
+        path, reason = self._decide(
+            instinct=rec, combined_confidence=1.0, effective_mode="shadow"
+        )
+        assert path == "human"
+        assert reason == "shadow_mode"
+
+    def test_the_elevenlabs_incident_would_now_be_blocked(self):
+        """Replay of the exact live instinct + confidence that fired."""
+        rec = _instinct(
+            "Asking",
+            observation_count=1,
+            confidence_score=0.9,
+            discretion_threshold=0.9,
+            live_observation_count=8,  # what got the bar down to 0.90
+            execution={"enabled": True, "requires_approval": False, "tier": 1},
+        )
+        # Pre-fix: bar 0.90, conf 0.90 → agent → email sent.
+        assert effective_threshold(rec) == pytest.approx(0.90)
+        path, reason = self._decide(instinct=rec, combined_confidence=0.90)
+        assert path == "human", "Asking-tier instinct must never dispatch"
+        assert reason == "tier_gate_asking"
+
+
+class TestSharedThresholdImplementation:
+    """#445 — one raise-only implementation, not two divergent copies."""
+
+    def test_signal_actions_delegates_to_discretion(self):
+        from src.activities.signal_actions import _instinct_threshold
+
+        rec = _instinct("Acting", observation_count=10, discretion_threshold=0.99)
+        assert _instinct_threshold(rec) == effective_threshold(rec)
+
+    def test_raise_only_override_preserved(self):
+        # 10 obs earns 0.85; an explicit 0.60 may not loosen it.
+        rec = _instinct("Acting", observation_count=10, discretion_threshold=0.60)
+        assert effective_threshold(rec) == pytest.approx(0.85)
+        # ...but 0.99 may tighten it.
+        rec = _instinct("Acting", observation_count=10, discretion_threshold=0.99)
+        assert effective_threshold(rec) == pytest.approx(0.99)
+
+    def test_garbage_threshold_ignored(self):
+        rec = _instinct("Acting", observation_count=10, discretion_threshold="abc")
+        assert effective_threshold(rec) == pytest.approx(0.85)


### PR DESCRIPTION
Closes #445.

The `Asking → Confirming → Acting` ladder was decorative: nothing in the routing path read an instinct's `tier`. Autonomy came purely from observation count + confidence, so an instinct the UI showed as **Asking** could dispatch an agent that took irreversible external action — which is exactly what happened on home on 2026-08-06 (cancellation email to `the vendor's support address` from Sir's Gmail, four minutes after he'd been setting that service up in Slack).

## What changed

`tier` is now a **ceiling checked before confidence** in `route_signal_action` — only `Acting` may route autonomously. The discretion bar still applies underneath it.

- **`Confirming` is blocked here too.** `route_signal_action` only ever sees `effect == "action"` signals (external, side-effecting — validated at step 2), so there is no internal/reversible subset to let through; #445's "Confirming → human for anything with external side effects" resolves to "Confirming → human" at this gate. The needs_attention card *is* the confirm surface.
- **Fails closed** — missing / unparseable / unknown tier, and the no-matched-instinct path, all degrade to `Asking`. The legacy `execution.tier: 1` + `requires_approval: false` shape is deliberately not consulted: it disagreed with the ladder on live data, and the weaker of two conflicting fields must not satisfy the gate.
- **`principal_delegate_override` keeps precedence** — an explicit Delegate click is not autonomy.
- **Observability**: new `tier_gate_asking` / `tier_gate_confirming` reasons; the audit row now carries `instinct_tier`, `observation_count`, `live_observation_count` and the effective bar, and the summary reads `conf=… bar=… tier=…`. Diagnosing the incident previously required reading source to infer the bar.
- **De-duplicated** the raise-only threshold rule into `discretion.effective_threshold`; `_instinct_threshold` delegates to it. The two copies had diverged and the *tested* one was not the *running* one.

Two commits only to stay under the lane LOC cap (201 + 186); they land together.

## ⚠️ Deploy consequence

Every live instinct on home is currently below `Acting`, so **this stops autonomous signal→agent dispatch entirely until an instinct is promoted**. That is the intended safety posture, and promotion now actually works after #443. Signals still reach Sir as Desk cards; only the unattended-action path closes.

## Smoke evidence

- `packages/learn`: **2506 passed, 101 skipped** — 20 of them new in `tests/test_tier_gate.py`.
- 4 failures in `tests/test_file_extraction.py` are pre-existing and environmental (missing `openpyxl`/pdf deps on the dev laptop) — verified identical on stashed `main`, and excluded from the local lane VERIFY only; CI installs those deps and runs them.
- Incident replay test asserts the exact live instinct (tier `Asking`, obs 1, `discretion_threshold` 0.9, live obs 8 → bar 0.90) at `conf=0.90` now yields `human` / `tier_gate_asking` instead of dispatching.
- Post-merge: `build-learn` → deploy to home → live smoke that a matching signal routes to a Desk card with the new reason in the audit row, plus `/instincts` screenshots.
