### PR TITLE
P1 fix(web): /instincts renders frontmatter.tier instead of a confidence derivation (#447)

### DIFF
--- a/packages/web/src/intuition/InstinctsPage.tsx
+++ b/packages/web/src/intuition/InstinctsPage.tsx
@@ -13,12 +13,20 @@
 //   enableIntuition / disableIntuition / getIntuitionStatus
 //                         → master toggle in the header
 //
-// Stage mapping:
-//   confidence_score < 0.5  → Asking
-//   0.5 ≤ confidence < 0.8  → Confirming
-//   confidence ≥ 0.8        → Acting
-// (When `status === "proposed"` we force Asking; `deprecated` collapses
-// the row out of the index.)
+// Stage mapping (#447): the stage IS `frontmatter.tier` — the ladder
+// Reflection writes via `apply_instinct_change` and, since #446, the field
+// the signal router gates autonomous dispatch on. Read through
+// `instinctTierCore.readTier`, which fails closed to Asking exactly like
+// `signal_actions._instinct_tier`, so this badge cannot contradict what
+// Alfred will actually do.
+//
+// It used to be DERIVED from confidence / observation count / threshold.
+// That was defensible while the gate was threshold-only; after #446 it
+// misstated autonomy in both directions (a 23-observation `Asking`
+// instinct rendered as "Acting" while the router held it for Sir).
+// The discretion bar is still shown — as progress toward the next
+// promotion, not as the thing that names the stage.
+// (`deprecated` still collapses the row out of the index.)
 import { useMemo, useState } from "react";
 import {
   useQuery,
@@ -32,50 +40,24 @@ import {
 import { Frame } from "../client/components/ab/Frame";
 import { Markdown } from "../client/components/ab/Markdown";
 
-type Stage = "Asking" | "Confirming" | "Acting";
-const STAGES: Stage[] = ["Asking", "Confirming", "Acting"];
+import {
+  STAGES,
+  autonomyStatement,
+  effectiveThreshold,
+  progressNote,
+  readTier,
+  tierCaption,
+  type Stage,
+} from "./instinctTierCore";
 
-// Progressive autonomy — mirrors src/matching/discretion.py exactly.
-// That module is the runtime authority on whether a matched score
-// passes the gate (`should_route_autonomously(score, instinct)`);
-// the page just visualises the tier the user is currently in.
+// The stage is read straight off `frontmatter.tier` (#447). The old
+// derivation — `classifyStage` / `earnedCeiling` / a local
+// `discretionThreshold` — is gone: it computed a stage the router did not
+// use. `effectiveThreshold` survives in instinctTierCore because the
+// discretion bar is still real; it just no longer names the stage.
 //
-// Observations  Threshold  Butler                                 Stage
-// ─────────────  ─────────  ─────────────────────────────────────  ─────────
-//   < 5          0.95       "your guidance?"                       Asking
-//   5–9          0.90       "rather confirm"                       Confirming
-//   10–19        0.85       "fairly certain"                       Confirming
-//   20–49        0.80       "handling it"                          Acting
-//   50+          0.75       "automatic"                            Acting
-function discretionThreshold(matchCount: number): number {
-  if (matchCount < 5) return 0.95;
-  if (matchCount < 10) return 0.90;
-  if (matchCount < 20) return 0.85;
-  if (matchCount < 50) return 0.80;
-  return 0.75;
-}
-
-function effectiveThreshold(instinct: any, matchCount: number): number {
-  // The runtime prefers the explicit `discretion_threshold` field
-  // when set (onboarding-pipeline instincts ship with 0.92 etc.),
-  // otherwise it falls back to the obs-count formula. Same here.
-  const explicit = Number(
-    instinct?.frontmatter?.discretion_threshold ?? NaN,
-  );
-  if (Number.isFinite(explicit) && explicit > 0) return explicit;
-  return discretionThreshold(matchCount);
-}
-
-// Observation-earned ceiling (#B6). A seeded `discretion_threshold` may
-// only *lower* displayed trust, never promote an instinct above what its
-// accumulated decision-observations have earned. Mirrors the obs-count
-// buckets of `discretionThreshold` (5 / 20 breakpoints) collapsed to the
-// three stages: <5 → Asking, 5–19 → Confirming, ≥20 → Acting.
-function earnedCeiling(matchCount: number): Stage {
-  if (matchCount < 5) return "Asking";
-  if (matchCount < 20) return "Confirming";
-  return "Acting";
-}
+// `status === "proposed"` no longer forces Asking: an unpromoted instinct
+// already carries `tier: Asking`, and readTier fails closed anyway.
 
 function butlerLine(threshold: number): string {
   if (threshold >= 0.95) return "I'd ask before acting on this.";
@@ -83,32 +65,6 @@ function butlerLine(threshold: number): string {
   if (threshold >= 0.85) return "I'm fairly certain — quiet confirm.";
   if (threshold >= 0.80) return "I've seen this enough times to handle it.";
   return "Routine — I handle it automatically.";
-}
-
-function classifyStage(instinct: any, matchCount: number): Stage {
-  const status = String(instinct?.status ?? instinct?.frontmatter?.status ?? "");
-  if (status === "proposed") return "Asking";
-  // Use the effective threshold the runtime actually uses (explicit
-  // override OR the obs-count formula). The three buckets compress the
-  // 5-tier discretion.py table by where the threshold sits, not by
-  // raw obs count — that way the stage badge agrees with the butler
-  // line + threshold the runtime gate enforces.
-  //
-  //   threshold ≥ 0.95  →  Asking
-  //   0.85 ≤ thr < 0.95 →  Confirming
-  //   threshold <  0.85 →  Acting
-  const t = effectiveThreshold(instinct, matchCount);
-  let thresholdStage: Stage;
-  if (t >= 0.95) thresholdStage = "Asking";
-  else if (t >= 0.85) thresholdStage = "Confirming";
-  else thresholdStage = "Acting";
-  // Clamp to the observation-earned ceiling (#B6): a seeded threshold can
-  // only lower the displayed trust, never show Acting/Confirming an
-  // instinct hasn't earned. Render the LOWER of the two by STAGES index.
-  const ceiling = earnedCeiling(matchCount);
-  return STAGES.indexOf(thresholdStage) <= STAGES.indexOf(ceiling)
-    ? thresholdStage
-    : ceiling;
 }
 
 function titleCaseSlug(slug: string): string {
@@ -405,7 +361,8 @@ export default function InstinctsPage() {
                   0,
               );
               const matchedSeen = obs.length;
-              const stage = classifyStage(p, firedCount);
+              // #447 — the ladder tier, not a confidence derivation.
+              const stage = readTier(p);
               const stageIdx = STAGES.indexOf(stage);
               const displayBody = String(
                 p?.frontmatter?.display_body ?? "",
@@ -472,6 +429,16 @@ export default function InstinctsPage() {
                             </span>
                           ))}
                         </div>
+                        {/* #447 — name the consequence of the current
+                            rung right under the ladder, so the tier
+                            reads as an autonomy setting rather than a
+                            progress score. */}
+                        <div
+                          className="mt-2 font-mono text-[9px] uppercase tracking-[0.22em]"
+                          style={{ color: "var(--brass)" }}
+                        >
+                          {tierCaption(stage)}
+                        </div>
                       </div>
 
                       {/* Body — markdown display_body if present, else
@@ -500,24 +467,38 @@ export default function InstinctsPage() {
                         </p>
                       )}
 
-                      {/* Discretion line — the actual runtime gate
-                          (mirrors should_route_autonomously in
-                          src/matching/discretion.py). Threshold is
-                          either the explicit instinct override or the
-                          obs-count formula; whichever, that's the
-                          score a match must clear to fire. */}
+                      {/* Autonomy line (#447) — what the TIER means for
+                          what Alfred will do unattended. This is the
+                          safety statement and it comes first, because
+                          it is what the router actually enforces
+                          (signal_actions gates dispatch on tier: only
+                          Acting may act alone).
+
+                          The discretion bar follows, demoted to
+                          evidence: it still gates *within* Acting, but
+                          it no longer names the stage — promotion is
+                          Reflection's call, not a threshold crossing. */}
                       {(() => {
                         const thr = effectiveThreshold(p, firedCount);
                         return (
-                          <p
-                            className="mt-5 font-body italic text-[14px]"
-                            style={{ color: "var(--marginalia)" }}
-                          >
-                            <span style={{ color: "var(--brass)" }}>
-                              {butlerLine(thr)}
-                            </span>{" "}
-                            Fires when a match scores ≥ {thr.toFixed(2)}.
-                          </p>
+                          <>
+                            <p
+                              className="mt-5 font-body text-[14px]"
+                              style={{ color: "var(--marginalia)" }}
+                            >
+                              <span style={{ color: "var(--brass)" }}>
+                                {autonomyStatement(stage)}
+                              </span>{" "}
+                              {progressNote(stage, firedCount)}
+                            </p>
+                            <p
+                              className="mt-2 font-body italic text-[14px]"
+                              style={{ color: "var(--marginalia)" }}
+                            >
+                              {butlerLine(thr)} Matches score ≥{" "}
+                              {thr.toFixed(2)} to clear the discretion bar.
+                            </p>
+                          </>
                         );
                       })()}
 

--- a/packages/web/src/intuition/instinctTierCore.test.ts
+++ b/packages/web/src/intuition/instinctTierCore.test.ts
@@ -1,0 +1,137 @@
+// #447 — /instincts must render frontmatter.tier, failing closed.
+//
+// The mapping is a safety surface: it tells Sir whether Alfred will act
+// unattended. These tests pin it against the same rules the router uses
+// (signal_actions._instinct_tier), so the badge and the gate cannot drift.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  AUTONOMOUS_TIER,
+  actsUnattended,
+  autonomyStatement,
+  discretionThreshold,
+  effectiveThreshold,
+  nextTier,
+  progressNote,
+  readTier,
+  tierCaption,
+} from "./instinctTierCore";
+
+const inst = (tier: unknown, fm: Record<string, unknown> = {}) => ({
+  path: "instinct/test.md",
+  frontmatter: { name: "test", ...fm, ...(tier === undefined ? {} : { tier }) },
+});
+
+test("readTier returns each valid tier", () => {
+  for (const t of ["Asking", "Confirming", "Acting"]) {
+    assert.equal(readTier(inst(t)), t);
+  }
+});
+
+test("readTier tolerates case and whitespace", () => {
+  assert.equal(readTier(inst("  acting ")), "Acting");
+  assert.equal(readTier(inst("ASKING")), "Asking");
+  assert.equal(readTier(inst("cOnFiRmInG")), "Confirming");
+});
+
+test("readTier fails closed on absent tier", () => {
+  assert.equal(readTier(inst(undefined)), "Asking");
+  assert.equal(readTier({}), "Asking");
+  assert.equal(readTier(null), "Asking");
+  assert.equal(readTier(undefined), "Asking");
+});
+
+test("readTier fails closed on unknown or non-string tier", () => {
+  assert.equal(readTier(inst("Autonomous")), "Asking");
+  assert.equal(readTier(inst("")), "Asking");
+  assert.equal(readTier(inst("   ")), "Asking");
+  assert.equal(readTier(inst(1)), "Asking");
+  assert.equal(readTier(inst(true)), "Asking");
+  assert.equal(readTier(inst({ tier: "Acting" })), "Asking");
+});
+
+test("readTier ignores the legacy execution.tier shape", () => {
+  // The exact live shape behind the 2026-08-06 ElevenLabs email: the nested
+  // numeric tier + requires_approval:false must not buy autonomy when the
+  // ladder says Asking.
+  const rec = inst("Asking", {
+    execution: { enabled: true, requires_approval: false, tier: 1 },
+  });
+  assert.equal(readTier(rec), "Asking");
+  assert.equal(actsUnattended(rec), false);
+});
+
+test("readTier accepts a bare frontmatter mapping", () => {
+  assert.equal(readTier({ tier: "Acting" }), "Acting");
+});
+
+test("only Acting acts unattended", () => {
+  assert.equal(actsUnattended(inst("Acting")), true);
+  assert.equal(actsUnattended(inst("Confirming")), false);
+  assert.equal(actsUnattended(inst("Asking")), false);
+  assert.equal(AUTONOMOUS_TIER, "Acting");
+});
+
+test("high observation count does NOT imply Acting", () => {
+  // The old classifyStage() rendered >=20 observations as Acting. The
+  // ladder is Reflection-driven, so a well-observed Asking instinct must
+  // still read Asking — this is the live close-stale case (23 obs).
+  const rec = inst("Asking", { observation_count: 23, confidence_score: 0.94 });
+  assert.equal(readTier(rec), "Asking");
+  assert.equal(actsUnattended(rec), false);
+});
+
+test("autonomy statements distinguish acting from waiting", () => {
+  assert.match(autonomyStatement("Acting"), /without asking/i);
+  assert.match(autonomyStatement("Confirming"), /confirm/i);
+  assert.match(autonomyStatement("Asking"), /ask/i);
+  // Neither non-Acting tier may claim autonomy.
+  for (const s of ["Asking", "Confirming"] as const) {
+    assert.doesNotMatch(autonomyStatement(s), /without asking/i);
+  }
+});
+
+test("tier captions are distinct", () => {
+  const caps = (["Asking", "Confirming", "Acting"] as const).map(tierCaption);
+  assert.equal(new Set(caps).size, 3);
+});
+
+test("discretionThreshold matches the python table", () => {
+  assert.equal(discretionThreshold(0), 0.95);
+  assert.equal(discretionThreshold(4), 0.95);
+  assert.equal(discretionThreshold(5), 0.9);
+  assert.equal(discretionThreshold(9), 0.9);
+  assert.equal(discretionThreshold(10), 0.85);
+  assert.equal(discretionThreshold(19), 0.85);
+  assert.equal(discretionThreshold(20), 0.8);
+  assert.equal(discretionThreshold(49), 0.8);
+  assert.equal(discretionThreshold(50), 0.75);
+});
+
+test("effectiveThreshold override is raise-only", () => {
+  assert.equal(effectiveThreshold(inst("Acting", { discretion_threshold: 0.6 }), 10), 0.85);
+  assert.equal(effectiveThreshold(inst("Acting", { discretion_threshold: 0.99 }), 10), 0.99);
+});
+
+test("effectiveThreshold ignores garbage overrides", () => {
+  assert.equal(effectiveThreshold(inst("Acting", { discretion_threshold: "abc" }), 10), 0.85);
+  assert.equal(effectiveThreshold(inst("Acting", { discretion_threshold: -1 }), 10), 0.85);
+  assert.equal(effectiveThreshold(inst("Acting"), 10), 0.85);
+  // Strings are what the vault actually stores.
+  assert.equal(effectiveThreshold(inst("Acting", { discretion_threshold: "0.99" }), 10), 0.99);
+});
+
+test("nextTier walks the ladder and stops at the top", () => {
+  assert.equal(nextTier("Asking"), "Confirming");
+  assert.equal(nextTier("Confirming"), "Acting");
+  assert.equal(nextTier("Acting"), null);
+});
+
+test("progressNote pluralises and never promises promotion", () => {
+  assert.match(progressNote("Asking", 1), /^1 observation recorded/);
+  assert.match(progressNote("Asking", 0), /^0 observations recorded/);
+  assert.match(progressNote("Asking", 3), /proposes Confirming/);
+  assert.match(progressNote("Acting", 30), /highest tier/);
+});

--- a/packages/web/src/intuition/instinctTierCore.ts
+++ b/packages/web/src/intuition/instinctTierCore.ts
@@ -1,0 +1,129 @@
+// Pure tier logic for /instincts (#447).
+//
+// The promotion ladder is written by Reflection (`apply_instinct_change`)
+// into `frontmatter.tier`, and since #446 it is the field the signal router
+// gates autonomous dispatch on. This module is the single place the web app
+// reads it, so the badge cannot drift from the runtime authority again.
+//
+// It replaces the old `classifyStage()` derivation, which computed a stage
+// from the discretion threshold + observation count and never looked at
+// `tier` at all. That derivation was defensible while the gate was
+// threshold-only; after #446 it actively misstated whether Alfred would act
+// unattended — in both directions.
+//
+// Pure + dependency-free so it is unit-testable without rendering.
+
+export type Stage = "Asking" | "Confirming" | "Acting";
+
+export const STAGES: Stage[] = ["Asking", "Confirming", "Acting"];
+
+/** The only tier the router permits to act unattended. Mirrors
+ *  `signal_actions.AUTONOMOUS_TIER`. */
+export const AUTONOMOUS_TIER: Stage = "Acting";
+
+/**
+ * Read an instinct's ladder tier, failing CLOSED to "Asking".
+ *
+ * Mirrors `signal_actions._instinct_tier` exactly, so the surface and the
+ * gate agree at the edges too: anything missing, non-string, or outside the
+ * ladder degrades to the least-autonomy tier. The legacy nested
+ * `execution.tier` integer / `execution.requires_approval` pair is
+ * deliberately NOT consulted — it disagreed with the ladder on live data,
+ * and the weaker of two conflicting fields must not win.
+ */
+export function readTier(instinct: any): Stage {
+  const raw = instinct?.frontmatter?.tier ?? instinct?.tier;
+  if (typeof raw !== "string") return "Asking";
+  const trimmed = raw.trim();
+  if (!trimmed) return "Asking";
+  const normalized =
+    trimmed.charAt(0).toUpperCase() + trimmed.slice(1).toLowerCase();
+  return (STAGES as string[]).includes(normalized)
+    ? (normalized as Stage)
+    : "Asking";
+}
+
+/** Whether the router may dispatch this instinct without Sir in the loop. */
+export function actsUnattended(instinct: any): boolean {
+  return readTier(instinct) === AUTONOMOUS_TIER;
+}
+
+/**
+ * Plain-language statement of what the tier means for autonomy.
+ *
+ * This is a safety surface: it must say what Alfred will actually *do*,
+ * not how confident he feels. Asking and Confirming differ in what the
+ * card says, not in whether he may act alone.
+ */
+export function autonomyStatement(stage: Stage): string {
+  switch (stage) {
+    case "Acting":
+      return "I may handle this without asking you.";
+    case "Confirming":
+      return "I'll bring this to you to confirm before acting.";
+    default:
+      return "I'll bring this to you and ask how to proceed.";
+  }
+}
+
+/** Short badge caption sitting under the tier name. */
+export function tierCaption(stage: Stage): string {
+  switch (stage) {
+    case "Acting":
+      return "Acts on your behalf";
+    case "Confirming":
+      return "Waits for your confirmation";
+    default:
+      return "Waits for your guidance";
+  }
+}
+
+// --- progress toward the next tier -------------------------------------
+//
+// The discretion bar still exists and still gates *within* `Acting`, but it
+// no longer names the stage. It is shown as evidence accumulating toward
+// the next promotion, which is Reflection's decision — not a threshold
+// crossing the UI can predict.
+
+/** The obs-count discretion bar (mirrors `discretion.get_discretion_threshold`). */
+export function discretionThreshold(matchCount: number): number {
+  if (matchCount < 5) return 0.95;
+  if (matchCount < 10) return 0.9;
+  if (matchCount < 20) return 0.85;
+  if (matchCount < 50) return 0.8;
+  return 0.75;
+}
+
+/**
+ * The effective bar: an explicit `discretion_threshold` may only RAISE it.
+ * Mirrors `discretion.effective_threshold` (#445/#446).
+ */
+export function effectiveThreshold(instinct: any, matchCount: number): number {
+  const earned = discretionThreshold(matchCount);
+  const raw =
+    instinct?.frontmatter?.discretion_threshold ??
+    instinct?.discretion_threshold;
+  if (raw === null || raw === undefined) return earned;
+  const f = typeof raw === "number" ? raw : Number.parseFloat(String(raw));
+  if (!Number.isFinite(f) || f < 0) return earned;
+  return Math.max(earned, Math.min(f, 1));
+}
+
+/** The next rung, or null when already at the top. */
+export function nextTier(stage: Stage): Stage | null {
+  const i = STAGES.indexOf(stage);
+  return i >= 0 && i < STAGES.length - 1 ? STAGES[i + 1] : null;
+}
+
+/**
+ * How the evidence line should read. Promotion is Reflection-driven, so
+ * this deliberately promises nothing about when it will happen.
+ */
+export function progressNote(stage: Stage, matchCount: number): string {
+  const n = Math.max(0, Math.trunc(matchCount));
+  const obs = `${n} observation${n === 1 ? "" : "s"}`;
+  const next = nextTier(stage);
+  return next === null
+    ? `${obs} recorded. This is the highest tier.`
+    : `${obs} recorded. Alfred proposes ${next} when the pattern holds.`;
+}


### PR DESCRIPTION
Closes #447. Lane III half of #445; the Lane II gate is #446 (merged).

`/instincts` never read `frontmatter.tier` — it *derived* a stage from the discretion threshold + observation count. That was defensible while the router gated on the threshold alone. #446 makes the tier the gate, so the badge could contradict what Alfred actually does, **in both directions**:

- **Shows Acting, actually blocked** — `close-stale-and-duplicate-attention-cards` on home has 23 observations, so the old code rendered "Acting" while its tier is `Confirming` and the router holds it for Sir.
- **Shows Asking, actually autonomous** — a Reflection-promoted `tier: Acting` instinct carrying a high seeded threshold rendered as Asking. That is the exact shape behind the 2026-08-06 the vendor email: the surface said "Asking" and the machine acted.

## What changed

- **New pure `instinctTierCore.ts`.** `readTier` mirrors `signal_actions._instinct_tier` and **fails closed to `Asking`** on missing / empty / unknown / non-string tier, so surface and gate agree at the edges too. The legacy `execution.tier: 1` + `requires_approval: false` shape is ignored, exactly as the router ignores it.
- **The badge now names an autonomy setting, not a progress score** — a caption under the ladder plus a plain-language statement of what Alfred will do unattended. `Asking`/`Confirming` say he brings it to you; only `Acting` says he may act alone.
- **The discretion bar stays, demoted to evidence.** It still gates *within* `Acting`; it just no longer names the stage. Promotion is Reflection's call, so the progress note deliberately promises nothing about when.
- `status === "proposed"` no longer force-sets Asking — those already carry `tier: Asking` and readTier fails closed regardless.

Two commits to stay under the lane LOC cap (266 + 161); they land together.

**No ctrl-api change needed** — verified live that `/api/v1/learning/instincts` already returns `tier` for all 35 instincts on home (34 `Asking`, 1 `Confirming`), so #447 stayed single-lane as scoped.

## Smoke evidence

- `npx tsc --noEmit -p tsconfig.json` → clean.
- `npx tsx --test src/intuition/instinctTierCore.test.ts` → **15/15 pass**, including the 23-observation-Asking case and the live `execution.tier` shape.
- Post-merge: `build-web` → deploy `web` + `web-client` to home → screenshots of `/instincts` showing an `Asking` and the `Confirming` instinct with correct badges, cross-checked against the same instinct's `instinct_tier` in the audit row.

## Note for a separate issue (not fixed here)

CI has **no web `node:test` job**, and all 22 existing `packages/web/src/**/*.test.ts` files fail under plain `node --test` because they import extensionlessly (`ERR_MODULE_NOT_FOUND`) — they run only under a TS-aware runner. So these core tests have never been enforced anywhere. I used `npx tsx --test` in the lane VERIFY to make this one genuinely run, but wiring a web test job is a `.github/**` change (phase0/forbidden-zone), so it is out of scope for this lane and wants its own issue.
