### PR TITLE
fix(hermes): heavy = gpt-5.6-sol + purge OpenRouter model IDs from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,13 +47,18 @@ COMPOSIO_WEBHOOK_SECRET=
 # USER MUST FILL — optional. Leave blank to disable the feature.
 # ════════════════════════════════════════════════════════════════════
 
-# Hermes LLM models — bare OpenRouter model IDs (see openrouter.ai/models).
-# Defaults are sane current picks; override if a model ID goes stale or you
-# want a different one. main = user-facing chat; workers = background agents;
-# heavy = Opus-class background reasoning (onboarding + chore heavy steps).
-HERMES_MAIN_MODEL=x-ai/grok-4.3
-HERMES_WORKERS_MODEL=openai/gpt-4.1-nano
-HERMES_HEAVY_MODEL=anthropic/claude-opus-4-6
+# Hermes LLM models — openai-codex tiers ONLY (gpt-5.6-{sol,luna,terra}).
+# These three vars OVERRIDE the code defaults in render_hermes.py, so a stale
+# value here silently wins on a reseed — that is how the OpenRouter-era IDs
+# (grok / gpt-4.1-nano / claude-opus) survived the #435 purge and would have
+# re-provisioned a non-Codex fleet. Keep them on Codex tiers.
+#   main    = Sir's live chat
+#   workers = background agents (clerk, curator, janitor, ephemeral runs)
+#   heavy   = reasoning-bound work — onboarding + Reflection, which is what
+#             proposes instinct promotions, so it gets the strongest tier.
+HERMES_MAIN_MODEL=gpt-5.6-terra
+HERMES_WORKERS_MODEL=gpt-5.6-luna
+HERMES_HEAVY_MODEL=gpt-5.6-sol
 
 # Google OAuth — fully optional. Onboarding does NOT need it: with
 # COMPOSIO_API_KEY set (required above), "Start onboarding" connects Gmail

--- a/packages/hermes/init/render_hermes.py
+++ b/packages/hermes/init/render_hermes.py
@@ -456,7 +456,13 @@ def main() -> int:
         # bump is a one-line fix, not a rebuild.
         main_model=main_model_value,
         workers_model=os.environ.get("HERMES_WORKERS_MODEL", "gpt-5.6-luna"),
-        heavy_model=os.environ.get("HERMES_HEAVY_MODEL", "gpt-5.6-terra"),
+        # heavy = gpt-5.6-sol (Sir, 2026-08-06). The heavy profile carries
+        # the reasoning-bound work — onboarding and Reflection, where
+        # Reflection is what proposes instinct promotions — so it gets the
+        # strongest tier. Baked here, not only on the volume, because
+        # config.yaml is seed-once: a reseed would otherwise silently drop
+        # heavy back to terra (the #433 drift class).
+        heavy_model=os.environ.get("HERMES_HEAVY_MODEL", "gpt-5.6-sol"),
         # codex-builder runs Hermes' supervising agent on the same openai-
         # codex model the CLI it shells out to uses. Overridable so a
         # future Codex model bump is a one-line .env change, not a


### PR DESCRIPTION
Sir asked for the heavy profile to run **gpt-5.6-sol**. Heavy carries the reasoning-bound work — onboarding and Reflection — and Reflection is what proposes instinct promotions, so it gets the strongest tier.

Applied on home first, then baked here because `config.yaml` is seed-once and a reseed would silently revert it (the #433 drift class).

## The bigger find

`.env.example` still shipped **OpenRouter-era model IDs**, including an Anthropic model for heavy:

```
HERMES_MAIN_MODEL=x-ai/grok-4.3
HERMES_WORKERS_MODEL=openai/gpt-4.1-nano
HERMES_HEAVY_MODEL=anthropic/claude-opus-4-6
```

`render_hermes.py` reads these as `os.environ.get(VAR, <code default>)` — so **the env value wins over the code default**. #435 purged OpenRouter from the template and the render defaults but missed this file, which means a fresh deploy would still have provisioned a non-Codex fleet in violation of the codex-only rule. Now pinned to Codex tiers, with a comment recording the override precedence so the next purge doesn't miss it.

## Smoke evidence

- Live on home: heavy `model.default` → `gpt-5.6-sol`, `docker restart` (preserves volume edits), all three gateways return **200**, probe to `:18791` returned `SOL OK`, and the heavy agent log now shows `model=gpt-5.6-sol`. Backup at `config.yaml.bak-sol-20260806-134546`.
- Lane VERIFY: `render_hermes.py` parses; heavy default asserted `gpt-5.6-sol`; all three `.env.example` model vars asserted to be `gpt-5.6-*` with no `anthropic/` `x-ai/` `openai/` `openrouter` IDs remaining. (`docker compose config` can't run in a clean checkout — compose hard-requires a real `.env` — so the verify targets exactly what this diff touches.)

## ⚠️ Needs Sir — not fixed here

`/opt/alfred/.env` **on home** carries its own stale overrides (`HERMES_HEAVY_MODEL=gpt-5.5`, plus main/workers). Because the env var wins, a reseed on home will revert heavy off sol despite this PR. I attempted the edit and it was correctly blocked (secrets file). Please set:

```
HERMES_MAIN_MODEL=gpt-5.6-sol      # main is currently running sol live
HERMES_WORKERS_MODEL=gpt-5.6-luna
HERMES_HEAVY_MODEL=gpt-5.6-sol
```

Related drift worth a decision: the repo default for **main** is `gpt-5.6-terra` (your earlier explicit choice) but home is **live on sol**. I left the repo default alone rather than silently changing what you'd picked — tell me which should win.