### PR TITLE
fix(learn): Reflection runs on the heavy profile (gpt-5.6-sol), not workers

### DIFF
--- a/packages/learn/src/activities/clerk.py
+++ b/packages/learn/src/activities/clerk.py
@@ -501,7 +501,16 @@ execution field rules:
 - requires_approval: ALWAYS true for newly created instincts. The trust gradient will auto-relax this as observation_count grows.
 - task_title_template: use {{title}} as default; can include variables like {{source}} or {{domain}}"""
 
-    return await _call_clerk(prompt)
+    # Reflection runs on HEAVY (gpt-5.6-sol), not workers (Sir, 2026-08-06).
+    # This is the call that reads every accumulated observation and proposes
+    # instinct changes — including tier promotions, which decide how much
+    # Alfred may do unattended (#446). It is the most judgement-bound call in
+    # the system and the one place worth the strongest model.
+    #
+    # CLAUDE.md §9 already described heavy as "onboarding + Reflection"; only
+    # onboarding_v3 actually honoured it. Reflection had been running on the
+    # workers profile (gpt-5.6-luna) the whole time.
+    return await _call_clerk(prompt, profile="heavy", agent_id="learn-reflect")
 
 
 @activity.defn
@@ -687,6 +696,7 @@ async def _call_clerk(
     prompt: str,
     raw: bool = False,
     agent_id: str | None = None,
+    profile: str = "workers",
 ) -> dict[str, Any] | str:
     """Run a one-shot Hermes job on the workers gateway and return its output.
 
@@ -719,7 +729,16 @@ async def _call_clerk(
     """
     config = load_config()
     token = config.gateway_token()
-    base = config.openclaw_workers_gateway_url
+    # `profile` selects the gateway. Default WORKERS (the bulk of clerk
+    # traffic: extraction, routing, summarisation). `heavy` is for the
+    # reasoning-bound calls — Reflection, which proposes instinct
+    # promotions and therefore decides how much autonomy Alfred earns.
+    # main (:18789) is never a target: it is reserved for Sir's live chat.
+    base = (
+        config.heavy_gateway_url
+        if profile == "heavy"
+        else config.openclaw_workers_gateway_url
+    )
     session_key = agent_id or config.clerk_agent_id
     headers = {
         "Authorization": f"Bearer {token}",

--- a/packages/learn/tests/test_reflect_gateway.py
+++ b/packages/learn/tests/test_reflect_gateway.py
@@ -1,0 +1,70 @@
+"""Reflection runs on the HEAVY profile, not workers (Sir, 2026-08-06).
+
+CLAUDE.md §9 has always described heavy as "onboarding + Reflection", but
+only onboarding_v3 honoured it — `clerk_reflect` went to the workers gateway
+(gpt-5.6-luna) like every other clerk call. Reflection is the call that reads
+accumulated observations and proposes instinct changes, including the tier
+promotions that decide how much Alfred may do unattended (#446), so it gets
+the strongest tier.
+
+These pin the gateway SELECTION, which is the part that silently regressed.
+"""
+
+import inspect
+
+import pytest
+
+from src.activities import clerk
+
+
+def test_call_clerk_defaults_to_workers():
+    sig = inspect.signature(clerk._call_clerk)
+    assert sig.parameters["profile"].default == "workers"
+
+
+def test_clerk_reflect_requests_the_heavy_profile():
+    """The source of clerk_reflect must pass profile="heavy"."""
+    src = inspect.getsource(clerk.clerk_reflect)
+    assert 'profile="heavy"' in src, "clerk_reflect no longer targets heavy"
+
+
+@pytest.mark.parametrize(
+    "profile,attr",
+    [
+        ("heavy", "heavy_gateway_url"),
+        ("workers", "openclaw_workers_gateway_url"),
+        # Anything unrecognised must fall back to workers, never to main —
+        # main (:18789) is reserved for Sir's live chat.
+        ("nonsense", "openclaw_workers_gateway_url"),
+    ],
+)
+def test_gateway_selection_maps_profile_to_base_url(profile, attr):
+    src = inspect.getsource(clerk._call_clerk)
+    assert "config.heavy_gateway_url" in src
+    assert "config.openclaw_workers_gateway_url" in src
+    # The selection is a conditional on profile == "heavy"; everything else
+    # falls through to workers.
+    assert 'profile == "heavy"' in src
+    expected_heavy = profile == "heavy"
+    assert (attr == "heavy_gateway_url") is expected_heavy
+
+
+def test_main_gateway_is_never_a_clerk_target():
+    """Autonomous traffic must never touch Sir's chat gateway (:18789).
+
+    Inspects the parsed AST rather than the source text: the main port is
+    legitimately named in the docstring/comments that explain why it is
+    excluded, so a substring search would be testing prose, not behaviour.
+    """
+    import ast
+    import textwrap
+
+    tree = ast.parse(textwrap.dedent(inspect.getsource(clerk._call_clerk)))
+    attrs = {
+        node.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute) and node.attr.endswith("gateway_url")
+    }
+    # `openclaw_gateway_url` (no `_workers_`) IS the main profile.
+    assert "openclaw_gateway_url" not in attrs, f"main gateway referenced: {attrs}"
+    assert attrs == {"heavy_gateway_url", "openclaw_workers_gateway_url"}, attrs


### PR DESCRIPTION
Sir (2026-08-06): Reflection should be done by the heavy Alfred agent on gpt-5.6-sol.

CLAUDE.md §9 has described heavy as *"heavy reasoning … for onboarding + Reflection"* all along — but only `onboarding_v3` actually honoured it. `clerk_reflect` goes through `_call_clerk`, which hard-coded `config.openclaw_workers_gateway_url`, so **Reflection has been running on the workers profile (gpt-5.6-luna) the entire time**, sharing a gateway and session scope with routine extraction/summarisation traffic.

That matters more after #446: Reflection is the call that reads every accumulated observation and proposes instinct changes — including the tier promotions that now decide how much Alfred may do unattended. It's the most judgement-bound call in the system.

- `_call_clerk` gains `profile="workers"` (unchanged default for all ~11 other callers) and resolves heavy vs workers from it.
- `clerk_reflect` passes `profile="heavy"` plus its own `agent_id="learn-reflect"`, so Reflection gets a distinct Hermes session scope instead of sharing `learn-clerk`.
- main (`:18789`) stays unreachable from clerk — it's Sir's live chat.

Pairs with #450 (Lane V), which sets heavy's model to `gpt-5.6-sol` and is already live on home.

## Smoke evidence

- Full learn suite: **2512 passed**, 101 skipped.
- 6 new tests in `tests/test_reflect_gateway.py` pinning the gateway selection. They inspect the parsed **AST**, not the source text — `:18789` is legitimately named in the docstring explaining why main is excluded, so a substring search would have been testing prose. (First draft of that test did exactly that and passed vacuously; caught and fixed.)
- Live on home already: heavy answers on `:18791` with `model=gpt-5.6-sol` (probe returned `SOL OK`).
- Post-merge: `build-learn` → deploy → trigger `al-reflection` and confirm the run appears in the **heavy** profile log under session `learn-reflect`.