### PR TITLE
P0 fix(learn): the pre-extraction noise gate obeys the ladder and audits every match (#453)

### DIFF
--- a/packages/learn/src/activities/noise_patterns.py
+++ b/packages/learn/src/activities/noise_patterns.py
@@ -43,6 +43,10 @@ import httpx
 from temporalio import activity
 
 from src.config import load_config
+# #453 — the noise gate now honours the same promotion ladder the signal
+# router does. `src.matching.tiers` imports no activities, so there is no
+# cycle with signal_actions (which also reads from it).
+from src.matching.tiers import AUTONOMOUS_TIER, TIER_ASKING, instinct_tier
 
 logger = logging.getLogger("noise-patterns")
 
@@ -496,16 +500,50 @@ async def load_noise_instincts() -> list[dict[str, Any]]:
                     sender_domains.extend(str(x) for x in v if isinstance(x, str))
         if not sender_domains and not subject_keywords:
             continue  # Noise instinct without anchors — can't filter
+        # #453 — carry the ladder tier. Suppression is the most
+        # destructive thing an instinct can do (the email ceases to
+        # exist), so it must respect the same ladder the router does.
+        # We still LOAD every noise instinct — the caller decides what a
+        # sub-Acting match means — so a match stays observable instead of
+        # the instinct silently vanishing from the gate.
         out.append({
             "path": str(r.get("path") or ""),
             "sender_domains": sender_domains,
             "subject_keywords": subject_keywords,
+            "tier": instinct_tier(fm),
         })
 
     _NOISE_INSTINCT_CACHE["loaded_at"] = now
     _NOISE_INSTINCT_CACHE["instincts"] = out
     logger.info("noise_patterns: %d noise instincts cached", len(out))
     return out
+
+
+def _domain_matches(sig_value: str, glob: str) -> bool:
+    """Does `sig_value` (an address or sender string) match a domain rule?
+
+    #453 — the previous test was ``fnmatch(sig_value, f"*{g}*")``: an
+    UNANCHORED substring. A rule for ``google.com`` therefore also matched
+    ``notgoogle.community`` and ``google.com.phish.example``. For a filter
+    whose effect is "this email ceases to exist", that is far too loose.
+
+    Now a bare domain matches only as a proper domain component:
+    ``google.com`` matches ``x@google.com`` and ``x@mail.google.com`` but
+    not ``notgoogle.community``. Explicit globs (containing ``*`` / ``?``)
+    are still honoured verbatim, so hand-authored ``*.szamlazz.hu`` rules
+    keep working.
+    """
+    g = (glob or "").strip().lower()
+    v = (sig_value or "").strip().lower()
+    if not g or not v:
+        return False
+    if "*" in g or "?" in g:
+        return fnmatch.fnmatch(v, g) or fnmatch.fnmatch(v, f"*{g}")
+    # Bare domain: match the domain itself or any subdomain of it, whether
+    # the signature is a bare domain or a full address.
+    local, _, host = v.rpartition("@")
+    host = host or v
+    return host == g or host.endswith("." + g)
 
 
 def event_matches_noise_instinct(
@@ -539,21 +577,18 @@ def event_matches_noise_instinct(
     # the old allowlist listed ``gcal_organiser`` and was dead.
     sender_kinds = ("gmail_sender", "gcal_organiser_title", "slack_user")
     for inst in noise_instincts:
-        # 1. sender-domain globs (tolerate a bare domain via *glob*)
+        tier = str(inst.get("tier") or TIER_ASKING)
+        # 1. sender-domain globs
         if sig.get("kind") in sender_kinds and sig_value:
             for glob in inst.get("sender_domains", []):
-                g = glob.strip().lower()
-                if not g:
-                    continue
-                if fnmatch.fnmatch(sig_value, g) or (
-                    "*" not in g and "?" not in g
-                    and fnmatch.fnmatch(sig_value, f"*{g}*")
-                ):
+                if _domain_matches(sig_value, glob):
                     return {
                         "kind": f"instinct_{sig['kind']}",
                         "value": sig_value,
                         "path": inst["path"],
                         "matched_glob": glob,
+                        "tier": tier,
+                        "suppress": tier == AUTONOMOUS_TIER,
                     }
         # 2. subject-keyword substrings (the anchor CI instincts carry)
         if subject_text:
@@ -565,5 +600,7 @@ def event_matches_noise_instinct(
                         "value": subject_text[:120],
                         "path": inst["path"],
                         "matched_keyword": kw,
+                        "tier": tier,
+                        "suppress": tier == AUTONOMOUS_TIER,
                     }
     return None

--- a/packages/learn/src/activities/signal_actions.py
+++ b/packages/learn/src/activities/signal_actions.py
@@ -488,11 +488,20 @@ async def _recent_open_card_exists(client: Any, fm: dict[str, Any]) -> str | Non
 # internal/reversible subset arriving at this gate to let through, so #445's
 # "Confirming → human for anything with external side effects" resolves to
 # "Confirming → human" here. The needs_attention card IS the confirm surface.
-TIER_ASKING = "Asking"
-TIER_CONFIRMING = "Confirming"
-TIER_ACTING = "Acting"
-VALID_TIERS = (TIER_ASKING, TIER_CONFIRMING, TIER_ACTING)
-AUTONOMOUS_TIER = TIER_ACTING
+#
+# #453 — the ladder now has a SECOND enforcement point (the pre-extraction
+# noise gate in noise_patterns), so the constants and the reader moved to
+# src.matching.tiers. Re-exported here under their existing names: this
+# module's callers and tests import them from here, and two copies of a
+# safety constant is the failure mode #446 just finished removing.
+from src.matching.tiers import (  # noqa: E402
+    AUTONOMOUS_TIER,
+    TIER_ACTING,
+    TIER_ASKING,
+    TIER_CONFIRMING,
+    VALID_TIERS,
+    instinct_tier as _shared_instinct_tier,
+)
 
 
 def _coerce_int_or_none(raw: Any) -> int | None:
@@ -518,17 +527,12 @@ def _instinct_tier(instinct: dict[str, Any]) -> str:
     ladder on live data (``tier: Asking`` alongside
     ``execution: {tier: 1, requires_approval: false}``) and the weaker of
     two conflicting fields must not satisfy the gate.
+
+    #453: delegates to ``src.matching.tiers.instinct_tier`` — the shared
+    reader both enforcement points use. Kept as a module-local name because
+    the router's tests and call sites reference it.
     """
-    fm = instinct.get("frontmatter")
-    if not isinstance(fm, dict):
-        fm = instinct
-    raw = fm.get("tier")
-    if not isinstance(raw, str):
-        return TIER_ASKING
-    normalized = raw.strip().capitalize()
-    if normalized not in VALID_TIERS:
-        return TIER_ASKING
-    return normalized
+    return _shared_instinct_tier(instinct)
 
 
 def _instinct_threshold(instinct: dict[str, Any]) -> float:

--- a/packages/learn/src/activities/signals.py
+++ b/packages/learn/src/activities/signals.py
@@ -1405,6 +1405,57 @@ def _validate_llm_classification(
     }
 
 
+async def _audit_noise_match(
+    *,
+    stream_event_path: str,
+    matched: dict[str, Any],
+    suppressed: bool,
+) -> None:
+    """Record a noise-gate match in the audit trail (#453).
+
+    Before this, a suppressed email produced a single ``logger.info`` in a
+    rotating container log and nothing durable. There was no way to answer
+    "what did Alfred hide from me last week?" — which is precisely why a
+    rule carrying the principal's own client domain went unnoticed.
+
+    Best-effort: the audit trail must never be the reason an extraction
+    fails, so every error is swallowed. The caller's behaviour does not
+    depend on this returning.
+    """
+    try:
+        from src.utils.state_client import StateClient
+
+        cfg = load_config()
+        anchor = matched.get("matched_glob") or matched.get("matched_keyword")
+        anchor_kind = "sender_domain" if matched.get("matched_glob") else "subject_keyword"
+        verb = "suppressed" if suppressed else "spared (tier below Acting)"
+        async with StateClient(cfg) as sc:
+            await sc.append_audit(
+                action_type="signal_noise_match",
+                actor="signal_extract",
+                source="noise_gate",
+                summary=(
+                    f"noise-gate: {verb} — instinct={matched.get('path')} "
+                    f"tier={matched.get('tier')} {anchor_kind}={anchor!r}"
+                ),
+                target_path=stream_event_path,
+                target_kind="stream_event",
+                changes={
+                    "suppressed": suppressed,
+                    "instinct": matched.get("path"),
+                    "tier": matched.get("tier"),
+                    "anchor_kind": anchor_kind,
+                    "anchor": anchor,
+                    "matched_value": matched.get("value"),
+                },
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "signals._audit_noise_match: audit write failed path=%s err=%s",
+            stream_event_path, exc,
+        )
+
+
 # ---------------------------------------------------------------------------
 # Activity: extract_signal_from_event
 # ---------------------------------------------------------------------------
@@ -1561,16 +1612,34 @@ async def extract_signal_from_event(
                     event_body=_event_body(event),
                 )
                 if matched is not None:
+                    # #453 — suppression is the most destructive thing an
+                    # instinct can do: the email ceases to exist, with no
+                    # Desk card and (until now) no audit row. So it obeys
+                    # the same ladder the router does, and every decision
+                    # — suppressed or spared — is written to the audit
+                    # trail. Below `Acting` the match is recorded and the
+                    # event continues to extraction, so Sir still sees it.
+                    suppress = bool(matched.get("suppress"))
+                    await _audit_noise_match(
+                        stream_event_path=stream_event_path,
+                        matched=matched,
+                        suppressed=suppress,
+                    )
                     logger.info(
-                        "signals.extract_signal_from_event: NOISE-FILTERED "
-                        "(instinct) path=%s sig=%s/%s glob=%s instinct=%s",
+                        "signals.extract_signal_from_event: NOISE-%s "
+                        "(instinct) path=%s sig=%s/%s glob=%s kw=%s "
+                        "instinct=%s tier=%s",
+                        "FILTERED" if suppress else "MATCH-SPARED",
                         stream_event_path,
                         matched.get("kind"),
                         matched.get("value"),
                         matched.get("matched_glob"),
+                        matched.get("matched_keyword"),
                         matched.get("path"),
+                        matched.get("tier"),
                     )
-                    return None
+                    if suppress:
+                        return None
         except Exception as exc:  # noqa: BLE001
             logger.warning(
                 "signals.extract_signal_from_event: noise check failed "

--- a/packages/learn/src/matching/tiers.py
+++ b/packages/learn/src/matching/tiers.py
@@ -1,0 +1,54 @@
+"""The progressive-autonomy ladder — Asking → Confirming → Acting.
+
+Single source of truth for reading an instinct's `tier`. Two enforcement
+points depend on it and they must agree exactly:
+
+  * ``signal_actions.route_signal_action`` (#446) — may this instinct
+    dispatch an agent without Sir in the loop?
+  * ``noise_patterns`` (#453) — may this instinct make an inbound email
+    cease to exist before it ever becomes a signal?
+
+Both fail CLOSED to ``Asking``. #445 was caused by the ladder being
+decorative; #446 fixed the router; keeping the reader in one module is what
+stops the two gates drifting apart the way ``_instinct_threshold`` and
+``should_route_autonomously`` did.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+TIER_ASKING = "Asking"
+TIER_CONFIRMING = "Confirming"
+TIER_ACTING = "Acting"
+VALID_TIERS = (TIER_ASKING, TIER_CONFIRMING, TIER_ACTING)
+
+#: The only tier permitted to act — or to suppress — without the principal.
+AUTONOMOUS_TIER = TIER_ACTING
+
+
+def instinct_tier(instinct: dict[str, Any]) -> str:
+    """Return the instinct's ladder tier, failing CLOSED to ``Asking``.
+
+    Accepts either a full record (with a ``frontmatter`` key) or a bare
+    frontmatter mapping. Anything missing, unparseable, or outside
+    ``VALID_TIERS`` degrades to ``Asking`` — a malformed instinct must never
+    be able to buy autonomy it has not earned.
+
+    Only the frontmatter ``tier`` string is authoritative. The nested
+    ``execution.tier`` integer / ``execution.requires_approval`` pair is a
+    legacy shape that is deliberately NOT consulted: it disagreed with the
+    ladder on live data (``tier: Asking`` alongside
+    ``execution: {tier: 1, requires_approval: false}``) and the weaker of
+    two conflicting fields must not satisfy a safety gate.
+    """
+    fm = instinct.get("frontmatter") if isinstance(instinct, dict) else None
+    if not isinstance(fm, dict):
+        fm = instinct if isinstance(instinct, dict) else {}
+    raw = fm.get("tier")
+    if not isinstance(raw, str):
+        return TIER_ASKING
+    normalized = raw.strip().capitalize()
+    if normalized not in VALID_TIERS:
+        return TIER_ASKING
+    return normalized

--- a/packages/learn/tests/test_noise_gate_tier.py
+++ b/packages/learn/tests/test_noise_gate_tier.py
@@ -1,0 +1,133 @@
+"""#453 — the pre-extraction noise gate obeys the promotion ladder.
+
+The gate decides whether an inbound email becomes a signal at all. Before
+this, it consulted no tier and wrote no audit row, so an instinct rendering
+as `Asking` on /instincts could permanently silence a sender with no trace.
+On home, one such instinct carried the principal's own client domain.
+
+Two properties are pinned here:
+  1. only `Acting` may suppress; below that the match is recorded and the
+     email survives (fail toward VISIBILITY — the opposite of the router,
+     because a false positive here loses mail);
+  2. domain anchors match domains, not substrings.
+"""
+
+import pytest
+
+from src.activities.noise_patterns import (
+    _domain_matches,
+    event_matches_noise_instinct,
+)
+from src.matching.tiers import AUTONOMOUS_TIER, TIER_ASKING, instinct_tier
+
+
+def _inst(tier, domains=(), keywords=()):
+    return {
+        "path": "instinct/test-noise.md",
+        "sender_domains": list(domains),
+        "subject_keywords": list(keywords),
+        "tier": tier,
+    }
+
+
+def _gmail_event(sender="someone@neoterragroup.com", subject="Quarterly plan"):
+    return {"source_type": "gmail", "from": sender, "subject": subject}
+
+
+class TestTierGatesSuppression:
+    def test_acting_instinct_suppresses(self):
+        m = event_matches_noise_instinct(
+            _gmail_event(), [_inst("Acting", domains=["neoterragroup.com"])]
+        )
+        assert m is not None
+        assert m["suppress"] is True
+        assert m["tier"] == "Acting"
+
+    @pytest.mark.parametrize("tier", ["Asking", "Confirming"])
+    def test_sub_acting_matches_but_does_not_suppress(self, tier):
+        """The match is still REPORTED — so it can be audited — but the
+        caller must not drop the event."""
+        m = event_matches_noise_instinct(
+            _gmail_event(), [_inst(tier, domains=["neoterragroup.com"])]
+        )
+        assert m is not None, "match must stay visible for the audit row"
+        assert m["suppress"] is False
+        assert m["tier"] == tier
+
+    def test_missing_tier_fails_closed_to_asking(self):
+        inst = _inst(None, domains=["neoterragroup.com"])
+        inst.pop("tier")
+        m = event_matches_noise_instinct(_gmail_event(), [inst])
+        assert m["suppress"] is False
+        assert m["tier"] == TIER_ASKING
+
+    def test_keyword_match_carries_tier_too(self):
+        m = event_matches_noise_instinct(
+            _gmail_event(subject="Railway will delete your volumes tomorrow"),
+            [_inst("Asking", keywords=["tomorrow"])],
+        )
+        assert m["suppress"] is False
+        assert m["matched_keyword"] == "tomorrow"
+
+    def test_the_live_close_stale_shape_cannot_suppress(self):
+        """Replay of the instinct that carries Sir's client domain."""
+        live = _inst(
+            "Confirming",
+            domains=[
+                "airbnb.com", "google.com", "googleplay.com", "gettransfer.com",
+                "neoterragroup.com", "railway.app", "substack.com", "whoop.com",
+            ],
+            keywords=["tomorrow", "duplicate", "older", "will delete"],
+        )
+        m = event_matches_noise_instinct(_gmail_event(), [live])
+        assert m["suppress"] is False, "client mail must not be dropped"
+
+
+class TestDomainAnchoring:
+    @pytest.mark.parametrize(
+        "value,rule,expected",
+        [
+            ("x@google.com", "google.com", True),
+            ("x@mail.google.com", "google.com", True),
+            ("google.com", "google.com", True),
+            # The bug: an unanchored substring matched these.
+            ("x@notgoogle.community", "google.com", False),
+            ("x@google.com.phish.example", "google.com", False),
+            ("x@evilgoogle.com", "google.com", False),
+            # Explicit globs keep working (hand-authored billing rules).
+            ("x@invoices.szamlazz.hu", "*.szamlazz.hu", True),
+            ("x@szamlazz.hu", "*.szamlazz.hu", False),
+            ("", "google.com", False),
+            ("x@google.com", "", False),
+        ],
+    )
+    def test_domain_matching_is_anchored(self, value, rule, expected):
+        assert _domain_matches(value, rule) is expected
+
+    def test_unanchored_substring_no_longer_suppresses(self):
+        m = event_matches_noise_instinct(
+            _gmail_event(sender="hello@notgoogle.community"),
+            [_inst("Acting", domains=["google.com"])],
+        )
+        assert m is None
+
+
+class TestSharedTierReader:
+    """The gate and the router must read the ladder identically (#446/#453)."""
+
+    def test_signal_actions_delegates_to_the_shared_reader(self):
+        from src.activities.signal_actions import _instinct_tier
+
+        for tier in ("Asking", "Confirming", "Acting"):
+            rec = {"frontmatter": {"tier": tier}}
+            assert _instinct_tier(rec) == instinct_tier(rec) == tier
+
+    def test_both_fail_closed_identically(self):
+        from src.activities.signal_actions import _instinct_tier
+
+        for bad in ({}, {"frontmatter": {}}, {"frontmatter": {"tier": 1}},
+                    {"frontmatter": {"tier": "Autonomous"}}):
+            assert _instinct_tier(bad) == instinct_tier(bad) == TIER_ASKING
+
+    def test_autonomous_tier_is_acting(self):
+        assert AUTONOMOUS_TIER == "Acting"


### PR DESCRIPTION
Closes #453.

The noise gate decides whether an inbound email becomes a signal **at all**. It consulted no tier, wrote no audit row, and matched sender domains by unanchored substring — so an instinct rendering as `Asking` on `/instincts` ("I'll bring this to you") could silence a correspondent permanently and invisibly.

Not hypothetical: `close-stale-and-duplicate-attention-cards` on home carries **`<client-domain>`** — the principal's primary client — plus `google.com`, and generic keywords like `tomorrow` and `duplicate`. See #454 for how they got there (28 `intent: done` clicks in one 23-minute backlog clear-out).

## Changes

- **Tier gates suppression.** Only `Acting` may drop an event. Below that the match is still detected and reported so it can be audited, but the event continues to extraction and Sir still sees it.

  Note the direction is deliberately *opposite* to the router: `route_signal_action` fails closed toward **not acting**; this gate fails closed toward **visibility**. A false positive here loses mail; a false negative only costs a Desk card.

- **Every match is audited.** New `signal_noise_match` row carrying the instinct, its tier, the anchor that matched (domain vs keyword, and which one), and whether it actually suppressed. Previously a dropped email left one `logger.info` in a rotating container log and nothing durable — which is exactly why a rule holding a client's domain went unnoticed for three weeks. The write is best-effort; the audit trail must never fail an extraction.

- **Domain anchoring.** `fnmatch(value, f"*{g}*")` meant a `google.com` rule also matched `notgoogle.community` and `google.com.phish.example`. Bare domains now match the domain or a subdomain of it. Explicit globs (`*.szamlazz.hu`) are still honoured verbatim, so the hand-authored billing rules keep working — BUG 3 not regressed.

Two commits to stay under the lane cap (88 + 261); they land together. The first extracts the ladder reader into `src/matching/tiers.py` so the gate and the router cannot drift — the same two-divergent-copies failure #446 removed from the threshold logic.

## Smoke evidence

- Full learn suite: **2532 passed**, 101 skipped.
- 20 new tests in `tests/test_noise_gate_tier.py`, including a replay of the live `close-stale` shape asserting client mail is no longer droppable, the `notgoogle.community` / `google.com.phish.example` anchoring cases, and a check that the gate and the router read the ladder identically.
- Post-merge: `build-learn` → deploy to home → confirm the 4 gate-enrolled instincts now report `spared` rather than `suppressed`, and that a `signal_noise_match` audit row appears.

## ⚠️ This stops the bleeding; it does not clean the data

`close-stale-and-duplicate-attention-cards` still carries `<client-domain>` and `google.com`. Today it is `Confirming`, so it can no longer suppress — but promoting it to `Acting` would re-arm it. Remediating that record is Sir's call and is tracked with #454.
