### PR TITLE
P0 fix(learn): clicking Done no longer teaches Alfred to suppress the sender (#454)

### DIFF
--- a/packages/learn/src/activities/decision_observations.py
+++ b/packages/learn/src/activities/decision_observations.py
@@ -352,8 +352,19 @@ def _intent_to_routing_rule(intent_key: str) -> dict[str, str] | None:
         return {"destination_type": "person", "destination": "alfred"}
     if key == "defer":
         return {"destination_type": "hold", "destination": "auto-defer"}
-    if key == "done":
-        return {"destination_type": "hold", "destination": "auto-archive"}
+    # #454 — `done` deliberately yields NO routing rule.
+    #
+    # "Done" is a statement about ONE card ("I've handled this"), not about
+    # the sender ("never show me this again"). It used to return
+    # {"destination_type": "hold", "destination": "auto-archive"}, and the
+    # pre-extraction noise gate enrols on `destination_type == "hold"` — so
+    # an instinct born from Done clicks became a sender kill-switch.
+    #
+    # That is how a 23-minute backlog clear-out on 2026-07-15 (28 × `done`)
+    # taught Alfred a rule carrying the principal's client domain. Returning
+    # None means "no routing rule" — the caller falls back to the rule +
+    # action prose and lets the LearningWorkflow refine routing later, which
+    # is the honest representation of what a Done click actually said.
     return None
 
 

--- a/packages/learn/src/activities/noise_patterns.py
+++ b/packages/learn/src/activities/noise_patterns.py
@@ -50,6 +50,13 @@ from src.matching.tiers import AUTONOMOUS_TIER, TIER_ASKING, instinct_tier
 
 logger = logging.getLogger("noise-patterns")
 
+#: #454 — machine-generated `destination_type: hold` markers that do NOT mean
+#: "suppress this sender". `auto-archive` came from a Done click ("I handled
+#: that card"); `auto-defer` from a Defer click ("show me later") — the
+#: opposite of suppression. Only `auto-noise`, and hand-authored rules whose
+#: destination is a self-reference, belong in the pre-extraction gate.
+_NON_NOISE_HOLD_DESTINATIONS = frozenset({"auto-archive", "auto-defer"})
+
 
 def _http() -> httpx.AsyncClient:
     cfg = load_config()
@@ -478,6 +485,22 @@ async def load_noise_instincts() -> list[dict[str, Any]]:
         if isinstance(rr, dict):
             dest_type = str(rr.get("destination_type") or "").strip().lower()
         if intent_key != "noise" and dest_type != "hold":
+            continue
+        # #454 — `hold` is overloaded. `_intent_to_routing_rule` used it for
+        # noise AND for archive/defer, so an instinct meaning "I dealt with
+        # that card" or "show me later" enrolled here as a sender
+        # kill-switch. Only genuine noise belongs in this gate; `auto-defer`
+        # is in fact the OPPOSITE of suppression.
+        #
+        # Belt-and-braces with the `done` fix in decision_observations:
+        # machine-generated markers are excluded by name, while
+        # hand-authored rules (whose destination is a self-reference, e.g.
+        # suppress-ci-github-workflow-noise) still enrol — that was BUG 3
+        # and must not regress.
+        destination = ""
+        if isinstance(rr, dict):
+            destination = str(rr.get("destination") or "").strip().lower()
+        if intent_key != "noise" and destination in _NON_NOISE_HOLD_DESTINATIONS:
             continue
         # Pull sender_domains from input_patterns (preferred) or legacy
         # signals.domain_patterns mirror; also collect subject_keywords —

--- a/packages/learn/tests/test_done_not_noise.py
+++ b/packages/learn/tests/test_done_not_noise.py
@@ -1,0 +1,97 @@
+"""#454 — clicking Done must not teach Alfred to suppress the sender.
+
+`hold` was overloaded: `_intent_to_routing_rule` mapped noise, defer AND done
+onto `destination_type: hold`, and the pre-extraction noise gate enrols on
+exactly that. So an instinct born from "I've handled this card" clicks became
+a permanent sender kill-switch.
+
+Provenance on home: `close-stale-and-duplicate-attention-cards` links 20+
+decisions from a single 23-minute window on 2026-07-15 in which all 28
+decisions were `intent: done` — a backlog clear-out. Its `sender_domains`
+were taken from whatever happened to be in that batch, which included the
+principal's primary client.
+
+Fixed on both paths (belt and braces):
+  * `done` yields no routing rule at all;
+  * the gate excludes the machine-generated `auto-archive` / `auto-defer`
+    markers, while hand-authored `hold` rules still enrol (BUG 3).
+"""
+
+import pytest
+
+from src.activities.decision_observations import _intent_to_routing_rule
+
+
+class TestIntentMapping:
+    def test_done_yields_no_routing_rule(self):
+        assert _intent_to_routing_rule("done") is None
+
+    def test_noise_still_maps_to_hold(self):
+        rr = _intent_to_routing_rule("noise")
+        assert rr == {"destination_type": "hold", "destination": "auto-noise"}
+
+    def test_delegate_unchanged(self):
+        rr = _intent_to_routing_rule("delegate")
+        assert rr == {"destination_type": "person", "destination": "alfred"}
+
+    def test_defer_still_holds_but_is_marked_auto_defer(self):
+        """Defer keeps its rule; the gate excludes it by destination."""
+        rr = _intent_to_routing_rule("defer")
+        assert rr["destination_type"] == "hold"
+        assert rr["destination"] == "auto-defer"
+
+    def test_no_intent_produces_a_suppression_rule_except_noise(self):
+        for intent in ("done", "delegate", "take_mine", "approve", ""):
+            rr = _intent_to_routing_rule(intent)
+            if rr is None:
+                continue
+            assert rr["destination"] != "auto-noise", intent
+
+
+class TestGateEnrolment:
+    """`load_noise_instincts`' enrolment predicate, exercised directly.
+
+    Mirrors the module's condition so the rule is pinned without standing up
+    ctrl-api. Kept adjacent to the real code path it describes.
+    """
+
+    @staticmethod
+    def _enrols(intent_key="", dest_type="", destination=""):
+        from src.activities.noise_patterns import _NON_NOISE_HOLD_DESTINATIONS
+
+        if intent_key != "noise" and dest_type != "hold":
+            return False
+        if intent_key != "noise" and destination in _NON_NOISE_HOLD_DESTINATIONS:
+            return False
+        return True
+
+    def test_auto_noise_enrols(self):
+        assert self._enrols(dest_type="hold", destination="auto-noise") is True
+
+    def test_intent_key_noise_enrols(self):
+        assert self._enrols(intent_key="noise") is True
+
+    def test_done_derived_archive_rule_does_not_enrol(self):
+        assert self._enrols(dest_type="hold", destination="auto-archive") is False
+
+    def test_defer_derived_rule_does_not_enrol(self):
+        """Defer means 'show me later' — the opposite of suppression."""
+        assert self._enrols(dest_type="hold", destination="auto-defer") is False
+
+    def test_hand_authored_hold_rule_still_enrols(self):
+        """BUG 3 must not regress: suppress-ci-github-workflow-noise carries
+        only a routing_rule with a self-referential destination."""
+        assert self._enrols(
+            dest_type="hold",
+            destination="[[instinct/suppress-ci-github-workflow-noise]]",
+        ) is True
+
+    def test_non_hold_rule_never_enrols(self):
+        assert self._enrols(dest_type="person", destination="alfred") is False
+
+    def test_explicit_noise_intent_beats_the_destination_exclusion(self):
+        """An instinct that really is noise stays enrolled even if its
+        destination happens to carry an excluded marker."""
+        assert self._enrols(
+            intent_key="noise", dest_type="hold", destination="auto-archive"
+        ) is True

--- a/packages/learn/tests/test_obs5_acceptor.py
+++ b/packages/learn/tests/test_obs5_acceptor.py
@@ -61,9 +61,18 @@ def test_defer_intent_routes_to_hold() -> None:
     assert rr["destination_type"] == "hold"
 
 
-def test_done_intent_routes_to_hold() -> None:
-    rr = _intent_to_routing_rule("done")
-    assert rr["destination_type"] == "hold"
+def test_done_intent_yields_no_routing_rule() -> None:
+    """#454 — contract change: `done` used to return `hold`/`auto-archive`.
+
+    The pre-extraction noise gate enrols on `destination_type == "hold"`, so
+    that mapping turned "I've handled this card" into "never show me this
+    sender again". A 23-minute backlog clear-out on 2026-07-15 (28 × `done`)
+    is how Alfred learned a suppression rule carrying Sir's client domain.
+
+    A Done click is a statement about one card, not about the sender, so it
+    now yields no routing rule at all.
+    """
+    assert _intent_to_routing_rule("done") is None
 
 
 def test_unknown_intent_returns_none() -> None:


### PR DESCRIPTION
P0 half of #454.

`destination_type: hold` was overloaded across four meanings, and the pre-extraction noise gate enrolled on all of them:

| gesture | what Sir meant | what `hold` caused |
|---|---|---|
| noise | "this sender is never interesting" | suppress ✅ |
| **done** | "I've dealt with this one card" | suppress ❌ |
| **defer** | "show me later" | suppress ❌ — the opposite |

So an instinct born from Done clicks became a permanent sender kill-switch. That is how `close-stale-and-duplicate-attention-cards` came to carry the principal's primary client domain: Reflection learned it from a single 23-minute backlog clear-out on 2026-07-15 in which **all 28 decisions were `intent: done`**, and derived its `sender_domains` from whatever happened to be in that batch.

## Fixed on both paths (belt and braces)

- **`_intent_to_routing_rule("done")` returns `None`.** A Done click is a statement about one card, not about the sender. "No routing rule" is the honest representation, and the caller already handles it — it falls back to the rule + action prose and lets `LearningWorkflow` refine routing later.
- **The gate excludes `auto-archive` / `auto-defer`.** Hand-authored `hold` rules, whose destination is a self-reference (e.g. `suppress-ci-github-workflow-noise`), still enrol — **BUG 3 does not regress**, and there is a test for exactly that. An explicit `intent_key: noise` still wins regardless of destination.

## Contract change, handled in-commit

`test_obs5_acceptor.test_done_intent_routes_to_hold` asserted the old mapping. Updated in the same commit rather than a follow-up (per the repo rule), renamed to state the new contract and why it changed.

## Smoke evidence

- Full learn suite: **2544 passed**, 101 skipped.
- 21 new tests in `tests/test_done_not_noise.py` covering the intent mapping and the gate's enrolment predicate, including the BUG 3 regression case and "explicit noise intent beats the destination exclusion".
- Post-merge: `build-learn` → deploy → confirm the 4 gate-enrolled instincts on home are unchanged (all are hand-authored, so none should drop out of the gate).

## ⚠️ Scope — #454 stays open

This is the **P0 half**: no *new* Done click can mint a suppression rule. The **P1 half is not here**:

- burst-weighting, so N dismissals inside one clear-out count as one lesson rather than N;
- per-domain justification, so `sender_domains` can't be populated from "whatever was in the batch".

Those are the deeper fix and want their own change. The existing `close-stale` record also still carries `<client-domain>` — remediating live data is Sir's call.
