### PR TITLE
fix(learn): a backlog clear-out is one gesture, not N lessons (#454 P1)

### DIFF
--- a/packages/learn/src/activities/clerk.py
+++ b/packages/learn/src/activities/clerk.py
@@ -418,6 +418,19 @@ CURRENT INSTINCTS (learned patterns):
 NEW OBSERVATIONS (today's routing decisions):
 {json.dumps(observations, indent=2)}
 {distiller_section}{janitor_section}
+BURSTS (#454): observations sharing a `burst_id` were a single bulk gesture —
+the principal clearing a backlog in one sitting, not N separate judgements.
+Weigh a whole burst as ONE observation. In particular:
+- Do NOT treat a burst as evidence that its senders are unwanted. Clicking
+  "done" on a card means "I have handled this", never "never show me this
+  sender again".
+- Do NOT collect `sender_domains` from the senders that happened to appear in
+  a burst. A domain belongs in a rule only when the evidence is about THAT
+  domain specifically.
+- A suppression rule (`routing_rule.destination_type: hold`) is the only kind
+  that can make information disappear before the principal sees it. Propose
+  one only from explicit `noise` intent, never from `done` or `defer`.
+
 Analyze the observations against existing instincts. For each observation, determine:
 
 1. Does it strengthen an existing instinct? → UPDATE (add signals, increment count)

--- a/packages/learn/src/activities/vault.py
+++ b/packages/learn/src/activities/vault.py
@@ -779,7 +779,23 @@ async def fetch_unprocessed_observations() -> list[dict[str, Any]]:
         batch = int(os.environ.get("REFLECTION_BATCH_SIZE", "250") or "250")
         async with StateClient(config) as sc:
             rows = await sc.list_observations(status="unprocessed", limit=batch)
-        return [observation_row_to_record(r) for r in rows]
+        records = [observation_row_to_record(r) for r in rows]
+        # #454 — mark backlog clear-outs. A run of same-intent decisions in
+        # quick succession is ONE gesture; Reflection previously read the
+        # 2026-07-15 clear-out (28 × `done` in 23 min) as 28 independent
+        # lessons and generalised a suppression rule from whoever happened
+        # to be in the batch. Annotated, never dropped: every row must stay
+        # in the batch so the workflow still marks it processed.
+        from src.matching.bursts import annotate_decision_bursts, burst_summary
+
+        records = annotate_decision_bursts(records)
+        bursts = burst_summary(records)
+        if bursts:
+            logger.info(
+                "fetch_unprocessed_observations: %d burst(s) annotated %s",
+                len(bursts), bursts,
+            )
+        return records
     except Exception:  # noqa: BLE001
         return []
 

--- a/packages/learn/src/matching/bursts.py
+++ b/packages/learn/src/matching/bursts.py
@@ -1,0 +1,112 @@
+"""Burst detection for decision observations (#454, P1).
+
+A backlog clear-out is ONE gesture, not N lessons. On 2026-07-15 Sir cleared
+28 Desk cards in 23 minutes — all `intent: done` — and Reflection read that
+as 28 independent pieces of evidence, inferring a suppression rule whose
+`sender_domains` were simply whoever happened to be in the batch (including
+his primary client). See #454.
+
+This module marks such runs so Reflection can weigh them as a single
+gesture.
+
+DESIGN NOTE — annotate, never drop. It is tempting to collapse a burst to
+one representative observation before handing the batch to the clerk. That
+would break the bookkeeping: `ReflectionWorkflow` marks the observations it
+fetched as processed, so any observation removed here would never be marked
+and would be re-fetched forever, growing the backlog silently. Annotating
+keeps every row in the batch (and therefore in the mark-processed set) while
+still telling the model what it is looking at.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+#: Max gap between consecutive decisions for them to belong to the same
+#: gesture. 2026-07-15's clear-out averaged ~50s between clicks.
+BURST_GAP_SECONDS = 180
+
+#: Minimum run length before we call it a burst rather than ordinary work.
+BURST_MIN_SIZE = 5
+
+
+def _parse_ts(value: Any) -> datetime | None:
+    if not value:
+        return None
+    text = str(value).strip().replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+def annotate_decision_bursts(
+    observations: list[dict[str, Any]],
+    gap_seconds: int = BURST_GAP_SECONDS,
+    min_size: int = BURST_MIN_SIZE,
+) -> list[dict[str, Any]]:
+    """Stamp `burst_id` / `burst_size` on observations that form a run.
+
+    A run is >= ``min_size`` decision-sourced observations sharing the same
+    ``intent``, each within ``gap_seconds`` of the previous one. Members get:
+
+      ``burst_id``    stable id of the run (intent + first timestamp)
+      ``burst_size``  how many observations the run contains
+
+    Every input observation is returned, in the input order, mutated in
+    place. Non-decision observations, and runs shorter than ``min_size``,
+    are returned untouched.
+    """
+    by_intent: dict[str, list[dict[str, Any]]] = {}
+    for obs in observations:
+        fm = obs.get("frontmatter") or {}
+        if str(fm.get("source_kind") or "").strip().lower() != "decision":
+            continue
+        intent = str(fm.get("intent") or "").strip().lower()
+        if not intent:
+            continue
+        if _parse_ts(fm.get("created")) is None:
+            continue
+        by_intent.setdefault(intent, []).append(obs)
+
+    for intent, group in by_intent.items():
+        group.sort(key=lambda o: _parse_ts((o.get("frontmatter") or {}).get("created")))
+        run: list[dict[str, Any]] = []
+
+        def flush(run: list[dict[str, Any]]) -> None:
+            if len(run) < min_size:
+                return
+            first = _parse_ts((run[0].get("frontmatter") or {}).get("created"))
+            burst_id = f"{intent}-{first.isoformat()}"
+            for member in run:
+                fm = member.setdefault("frontmatter", {})
+                fm["burst_id"] = burst_id
+                fm["burst_size"] = len(run)
+
+        for obs in group:
+            ts = _parse_ts((obs.get("frontmatter") or {}).get("created"))
+            if not run:
+                run = [obs]
+                continue
+            prev = _parse_ts((run[-1].get("frontmatter") or {}).get("created"))
+            if (ts - prev).total_seconds() <= gap_seconds:
+                run.append(obs)
+            else:
+                flush(run)
+                run = [obs]
+        flush(run)
+
+    return observations
+
+
+def burst_summary(observations: list[dict[str, Any]]) -> dict[str, int]:
+    """`{burst_id: size}` for the bursts present — for logging."""
+    out: dict[str, int] = {}
+    for obs in observations:
+        fm = obs.get("frontmatter") or {}
+        bid = fm.get("burst_id")
+        if bid:
+            out[str(bid)] = int(fm.get("burst_size") or 0)
+    return out

--- a/packages/learn/tests/test_burst_weighting.py
+++ b/packages/learn/tests/test_burst_weighting.py
@@ -1,0 +1,114 @@
+"""#454 P1 — a backlog clear-out is one gesture, not N lessons.
+
+Replays the 2026-07-15 shape: 28 `intent: done` decisions inside 23 minutes,
+which Reflection read as 28 independent lessons and generalised into a
+suppression rule carrying the principal's client domain.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from src.matching.bursts import (
+    BURST_MIN_SIZE,
+    annotate_decision_bursts,
+    burst_summary,
+)
+
+BASE = datetime(2026, 7, 15, 9, 6, 25, tzinfo=timezone.utc)
+
+
+def _obs(offset_s, intent="done", kind="decision", sender="x@example.com"):
+    return {
+        "path": f"obs-{offset_s}",
+        "frontmatter": {
+            "source_kind": kind,
+            "intent": intent,
+            "sender": sender,
+            "created": (BASE + timedelta(seconds=offset_s)).isoformat(),
+        },
+    }
+
+
+class TestBurstDetection:
+    def test_the_2026_07_15_clearout_is_one_burst(self):
+        # 28 clicks, ~50s apart — the real shape.
+        obs = [_obs(i * 50) for i in range(28)]
+        annotate_decision_bursts(obs)
+        sizes = burst_summary(obs)
+        assert len(sizes) == 1
+        assert list(sizes.values()) == [28]
+        assert all(o["frontmatter"]["burst_size"] == 28 for o in obs)
+        assert len({o["frontmatter"]["burst_id"] for o in obs}) == 1
+
+    def test_nothing_is_dropped(self):
+        """Bookkeeping: every row must survive so it gets marked processed."""
+        obs = [_obs(i * 50) for i in range(28)]
+        out = annotate_decision_bursts(obs)
+        assert len(out) == 28
+        assert [o["path"] for o in out] == [f"obs-{i * 50}" for i in range(28)]
+
+    def test_ordinary_spaced_decisions_are_not_a_burst(self):
+        obs = [_obs(i * 3600) for i in range(6)]  # one an hour
+        annotate_decision_bursts(obs)
+        assert burst_summary(obs) == {}
+
+    def test_short_run_below_threshold_is_not_a_burst(self):
+        obs = [_obs(i * 30) for i in range(BURST_MIN_SIZE - 1)]
+        annotate_decision_bursts(obs)
+        assert burst_summary(obs) == {}
+
+    def test_different_intents_do_not_merge(self):
+        obs = [_obs(i * 30, intent="done") for i in range(6)]
+        obs += [_obs(i * 30 + 5, intent="noise") for i in range(6)]
+        annotate_decision_bursts(obs)
+        ids = {o["frontmatter"]["burst_id"] for o in obs}
+        assert len(ids) == 2
+
+    def test_signal_observations_are_ignored(self):
+        obs = [_obs(i * 30, kind="signal") for i in range(10)]
+        annotate_decision_bursts(obs)
+        assert burst_summary(obs) == {}
+
+    def test_two_separate_sittings_are_two_bursts(self):
+        morning = [_obs(i * 30) for i in range(6)]
+        evening = [_obs(40000 + i * 30) for i in range(6)]
+        obs = morning + evening
+        annotate_decision_bursts(obs)
+        assert len(burst_summary(obs)) == 2
+
+    def test_gap_inside_a_run_splits_it(self):
+        obs = [_obs(i * 30) for i in range(6)] + [_obs(6 * 30 + 600)]
+        annotate_decision_bursts(obs)
+        assert obs[-1]["frontmatter"].get("burst_id") is None
+
+
+class TestRobustness:
+    def test_missing_or_bad_timestamps_are_skipped(self):
+        obs = [_obs(i * 30) for i in range(6)]
+        obs.append({"path": "no-ts", "frontmatter": {
+            "source_kind": "decision", "intent": "done"}})
+        obs.append({"path": "bad-ts", "frontmatter": {
+            "source_kind": "decision", "intent": "done", "created": "nonsense"}})
+        annotate_decision_bursts(obs)
+        assert obs[-1]["frontmatter"].get("burst_id") is None
+        assert obs[-2]["frontmatter"].get("burst_id") is None
+
+    def test_missing_intent_is_skipped(self):
+        obs = [{"path": f"o{i}", "frontmatter": {
+            "source_kind": "decision",
+            "created": (BASE + timedelta(seconds=i * 30)).isoformat(),
+        }} for i in range(10)]
+        annotate_decision_bursts(obs)
+        assert burst_summary(obs) == {}
+
+    def test_empty_input(self):
+        assert annotate_decision_bursts([]) == []
+        assert burst_summary([]) == {}
+
+    def test_naive_timestamps_are_handled(self):
+        obs = [{"path": f"o{i}", "frontmatter": {
+            "source_kind": "decision", "intent": "done",
+            "created": (BASE + timedelta(seconds=i * 30))
+            .replace(tzinfo=None).isoformat(),
+        }} for i in range(6)]
+        annotate_decision_bursts(obs)
+        assert len(burst_summary(obs)) == 1


### PR DESCRIPTION
Closes #454 (second half; the P0 half merged as #456).

#456 stopped `done` from *minting* a routing rule. This stops Reflection reading a bulk dismissal as bulk *evidence* in the first place.

On 2026-07-15 Sir cleared 28 Desk cards in 23 minutes, all `intent: done`. Reflection saw 28 independent observations, concluded the pattern was well-supported, and wrote a suppression rule whose `sender_domains` were simply whoever happened to be in that batch — including his primary client. The lesson was real ("these stale cards should close"); the *weight* and the *generalisation* were not.

## Changes

- **New `src/matching/bursts.py`** — `annotate_decision_bursts` stamps `burst_id` + `burst_size` on runs of ≥5 same-intent decision observations spaced ≤180s apart. (The real clear-out averaged ~50s between clicks.)
- **`fetch_unprocessed_observations`** annotates the batch before it reaches the clerk, and logs what it found.
- **The Reflection prompt** now states that a shared `burst_id` is ONE bulk gesture; that "done" never implies the sender is unwanted; that `sender_domains` must be justified per domain rather than harvested from a batch; and that suppression rules may only come from explicit `noise` intent.

## Design note — annotate, never drop

Collapsing a burst to one representative before handing it to the clerk was the obvious implementation, and it is a trap: `ReflectionWorkflow` marks the observations it **fetched** as processed, so any row removed here would never be marked and would be re-fetched forever, growing the backlog silently. Every row stays in the batch; only the metadata changes. There's a test asserting nothing is dropped, and the module docstring explains it so the next person doesn't "optimise" it back.

## Smoke evidence

- Full learn suite: **2556 passed**, 101 skipped.
- 12 new tests in `tests/test_burst_weighting.py`: a replay of the exact 2026-07-15 shape (28 clicks → one burst of 28), an explicit nothing-is-dropped assertion, separate-sittings, gap-splits-a-run, different-intents-don't-merge, signal-observations-ignored, plus naive-timestamp / bad-timestamp / missing-intent robustness.
- Post-merge: `build-learn` → deploy → trigger `al-reflection` and confirm the burst annotation appears in the learn log.

## Honest limits

The prompt instructions are guidance to a model, not an enforced constraint — a determined LLM can still propose a bad `sender_domains` list. The hard guarantees remain the ones from #453 (a sub-`Acting` instinct cannot suppress) and #452 (reaching `Acting` needs Sir's approval). This change reduces how often a bad rule is *proposed*; those two stop a bad rule from *acting*.