### PR TITLE
P1 fix(learn): Alfred may not grant himself Acting — Sir approves it (#452)

### DIFF
--- a/packages/learn/src/activities/vault.py
+++ b/packages/learn/src/activities/vault.py
@@ -3,15 +3,23 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Optional
 
 from temporalio import activity
 
 from src.config import load_config
 from src.utils.vault_client import VaultClient
+
+logger = logging.getLogger("alfred-learn.vault")
+
+
+def _now_iso() -> str:
+    """UTC now, ISO-8601 — for frontmatter timestamps."""
+    return datetime.now(timezone.utc).isoformat()
 
 
 def slugify(name: str) -> str:
@@ -815,6 +823,172 @@ async def fetch_active_instincts() -> list[dict[str, Any]]:
         await client.close()
 
 
+async def _hold_acting_promotion(
+    client: VaultClient,
+    path: str,
+    changes: dict[str, Any],
+) -> dict[str, Any]:
+    """Withhold a self-granted promotion to ``Acting`` (#452).
+
+    Reaching ``Acting`` is what authorises Alfred to act unattended — the
+    router (#446) and the noise gate (#453) both key on it. Reflection may
+    still propose the promotion; it may not apply it. This converts such a
+    proposal into a pending request and returns ``changes`` with the tier
+    stripped, so the rest of the proposal lands normally.
+
+    Deliberately NOT held:
+      * demotions and lateral moves — dropping OUT of Acting must always be
+        immediate;
+      * Asking → Confirming — Alfred earns that rung himself;
+      * an instinct already at Acting (nothing is being granted).
+
+    Idempotent by construction: the request is a ``pending_promotion`` field
+    on the instinct itself, so a nightly Reflection proposing the same
+    promotion again finds it already pending and does not re-request. That
+    also makes the request visible on /instincts rather than living only in
+    an audit table.
+    """
+    from src.matching.tiers import AUTONOMOUS_TIER, instinct_tier
+
+    proposed = changes.get("tier")
+    if not isinstance(proposed, str) or proposed.strip().capitalize() != AUTONOMOUS_TIER:
+        return changes
+
+    remaining = {k: v for k, v in changes.items() if k != "tier"}
+    try:
+        existing = await client.read_record(path)
+        fm = existing.get("frontmatter") or {}
+        current = instinct_tier(fm if isinstance(fm, dict) else {})
+        already_pending = str(fm.get("pending_promotion") or "").strip()
+    except Exception:  # noqa: BLE001
+        # Can't read the record — fail CLOSED: withhold the promotion rather
+        # than grant autonomy we couldn't verify was warranted.
+        logger.warning("_hold_acting_promotion: read failed for %s — withheld", path)
+        return remaining
+
+    if current == AUTONOMOUS_TIER:
+        return changes  # already there; nothing is being granted
+
+    if already_pending == AUTONOMOUS_TIER:
+        logger.info("_hold_acting_promotion: %s already pending — no re-request", path)
+        return remaining
+
+    requested_at = _now_iso()
+    try:
+        await client.patch_frontmatter(path, {
+            "pending_promotion": AUTONOMOUS_TIER,
+            "pending_promotion_requested": requested_at,
+            "pending_promotion_from": current,
+        })
+    except Exception:  # noqa: BLE001
+        logger.warning("_hold_acting_promotion: could not mark %s pending", path)
+
+    try:
+        from src.utils.state_client import StateClient as _SC
+        async with _SC(load_config()) as _sc:
+            await _sc.append_audit(
+                action_type="instinct_promotion_requested",
+                actor="alfred-learn",
+                source="reflection.apply_instinct_change",
+                summary=(
+                    f"{path} requests {current} -> {AUTONOMOUS_TIER}; "
+                    "awaiting Sir's approval"
+                ),
+                target_path=path,
+                target_kind="instinct",
+                changes={
+                    "from_tier": current,
+                    "to_tier": AUTONOMOUS_TIER,
+                    "requested_at": requested_at,
+                },
+            )
+    except Exception:  # noqa: BLE001
+        logger.warning("_hold_acting_promotion: audit emit failed for %s", path)
+
+    logger.info(
+        "_hold_acting_promotion: WITHHELD %s -> %s for %s (awaiting approval)",
+        current, AUTONOMOUS_TIER, path,
+    )
+    return remaining
+
+
+@activity.defn
+async def resolve_instinct_promotion(
+    path: str,
+    approved: bool,
+    actor: str = "sir",
+) -> dict[str, Any]:
+    """Approve or decline a pending ``Acting`` promotion (#452).
+
+    The only path by which an instinct reaches ``Acting``. On approval the
+    tier is written and the usual ``instinct_tier_event`` audit row is
+    emitted — the same row telemetry already watches — so an approved
+    promotion is indistinguishable downstream from any other tier move.
+
+    On refusal the tier is untouched and the refusal is recorded, so
+    Reflection has evidence not to keep proposing it.
+    """
+    from src.matching.tiers import AUTONOMOUS_TIER, instinct_tier
+
+    config = load_config()
+    client = VaultClient(config)
+    try:
+        existing = await client.read_record(path)
+        fm = existing.get("frontmatter") or {}
+        pending = str(fm.get("pending_promotion") or "").strip()
+        current = instinct_tier(fm if isinstance(fm, dict) else {})
+        if pending != AUTONOMOUS_TIER:
+            return {"path": path, "applied": False, "reason": "no_pending_request"}
+
+        clear = {
+            "pending_promotion": "",
+            "pending_promotion_requested": "",
+            "pending_promotion_from": "",
+        }
+        if approved:
+            await client.patch_frontmatter(path, {"tier": AUTONOMOUS_TIER, **clear})
+        else:
+            await client.patch_frontmatter(path, {
+                **clear,
+                "promotion_declined_at": _now_iso(),
+                "promotion_declined_from": current,
+            })
+
+        try:
+            from src.utils.state_client import StateClient as _SC
+            async with _SC(config) as _sc:
+                if approved:
+                    await _sc.append_audit(
+                        action_type="instinct_tier_event",
+                        actor=actor,
+                        source="promotion.approved",
+                        summary=f"{path} tier -> {AUTONOMOUS_TIER} (approved by {actor})",
+                        target_path=path,
+                        target_kind="instinct",
+                        changes={"tier": AUTONOMOUS_TIER, "approved_by": actor},
+                    )
+                else:
+                    await _sc.append_audit(
+                        action_type="instinct_promotion_declined",
+                        actor=actor,
+                        source="promotion.declined",
+                        summary=f"{path} promotion to {AUTONOMOUS_TIER} declined by {actor}",
+                        target_path=path,
+                        target_kind="instinct",
+                        changes={"from_tier": current, "declined_by": actor},
+                    )
+        except Exception:  # noqa: BLE001
+            logger.warning("resolve_instinct_promotion: audit emit failed for %s", path)
+
+        return {
+            "path": path,
+            "applied": approved,
+            "tier": AUTONOMOUS_TIER if approved else current,
+        }
+    finally:
+        await client.close()
+
+
 @activity.defn
 async def apply_instinct_change(proposal: dict[str, Any]) -> None:
     """Apply a single instinct change proposal (create/update/merge/deprecate)."""
@@ -831,6 +1005,14 @@ async def apply_instinct_change(proposal: dict[str, Any]) -> None:
         elif action == "update":
             path = proposal.get("path", "")
             changes = proposal.get("changes", {})
+            # #452 — Alfred may climb to Confirming on his own, but crossing
+            # into Acting is what authorises unattended action (#446 for the
+            # router, #453 for the noise gate). That crossing is Sir's to
+            # make, so a proposal for it is held as a request instead of
+            # being applied. Everything else in the same proposal still
+            # applies — only the tier field is withheld.
+            if path and changes:
+                changes = await _hold_acting_promotion(client, path, changes)
             if path and changes:
                 # fix #1: patch frontmatter directly via {"set": ...}. The old
                 # update_record() sent {"body_append": ...} — a body-only verb

--- a/packages/learn/src/worker.py
+++ b/packages/learn/src/worker.py
@@ -189,6 +189,7 @@ from src.activities.enrichment import (
 # Activities — vault
 from src.activities.vault import (
     apply_instinct_change,
+    resolve_instinct_promotion,
     assign_records_to_session,
     collect_daily_activity,
     collect_living_brief_data,
@@ -884,6 +885,7 @@ ALL_ACTIVITIES = [
     update_cursor,
     # Vault
     apply_instinct_change,
+    resolve_instinct_promotion,
     assign_records_to_session,
     collect_daily_activity,
     collect_living_brief_data,

--- a/packages/learn/tests/test_instinct_promotion_write.py
+++ b/packages/learn/tests/test_instinct_promotion_write.py
@@ -88,12 +88,32 @@ async def test_update_patches_frontmatter_and_never_body_appends():
 
 
 async def test_update_with_tier_emits_truthful_audit():
+    # Confirming, not Acting: since #452 a self-granted promotion to Acting
+    # is WITHHELD for Sir's approval, so it deliberately does NOT emit a
+    # tier_event (it emits instinct_promotion_requested instead — covered in
+    # tests/test_acting_approval.py). Every other tier move still applies and
+    # still audits, which is what this test is for.
     await apply_instinct_change(
-        {"action": "update", "path": "instinct/x.md", "changes": {"tier": "Acting"}}
+        {"action": "update", "path": "instinct/x.md", "changes": {"tier": "Confirming"}}
     )
     # audit now rides *after* a real frontmatter patch (patch_frontmatter raises on
     # non-2xx, so the audit only lands when the write actually succeeded).
     assert any(a.get("action_type") == "instinct_tier_event" for a in _FakeStateClient.audits)
+
+
+async def test_self_granted_acting_promotion_is_withheld():
+    """#452 — the promotion that authorises unattended action is Sir's."""
+    await apply_instinct_change(
+        {"action": "update", "path": "instinct/x.md", "changes": {"tier": "Acting"}}
+    )
+    fc = _FakeVaultClient.last
+    written = [u for _, u in fc.patched]
+    assert not any(u.get("tier") == "Acting" for u in written), (
+        "Acting must never be written without Sir's approval"
+    )
+    assert any("pending_promotion" in u for u in written), (
+        "the request must be recorded on the instinct"
+    )
 
 
 async def test_deprecate_patches_status_frontmatter_not_body_append():


### PR DESCRIPTION
Lane II half of #452.

`Acting` is the tier that authorises unattended action — the signal router (#446) and the noise gate (#453) both key on it. Until now Reflection could propose `tier: Acting` and `apply_instinct_change` wrote it straight through, so the system could hand itself the autonomy that produced the 2026-08-06 the vendor incident. It just took a nightly Reflection run.

## Changes

- **`_hold_acting_promotion`** strips a self-granted `Acting` from the proposal and records a request instead. The rest of the proposal still applies — only the tier is withheld.
- **The request lives as `pending_promotion` on the instinct**, which makes it idempotent by construction (a nightly re-proposal finds it pending and doesn't re-request) and visible on `/instincts` rather than buried in an audit table.
- **Deliberately not held:** demotions and lateral moves (dropping *out* of Acting must always be immediate), `Asking → Confirming` (Alfred earns that rung himself), and an instinct already at Acting.
- **Fails closed:** if the record can't be read, the promotion is withheld rather than granted unverified.
- **`resolve_instinct_promotion`** is the only path to Acting. Approval writes the tier and emits the usual `instinct_tier_event`, so an approved promotion is indistinguishable downstream from any other tier move. Refusal leaves the tier untouched and records the refusal so Reflection has evidence not to keep proposing it.

## 🐞 Also fixes a bug I shipped in #457

`vault.py` used `logger` and `_now_iso` without defining either. `fetch_unprocessed_observations` swallows every exception and returns `[]`, so the `NameError` would not have crashed anything — it would have made **Reflection silently process zero observations whenever a burst was present**. A silent failure of exactly the class #442/#445 were about. Both names are now defined, with a regression test asserting the function references only defined names.

## Smoke evidence

- Full learn suite: **2571 passed**, 101 skipped.
- 14 new tests in `tests/test_acting_approval.py`: withheld/not-held cases, idempotency, fail-closed on unreadable record, approve, decline, no-op resolve, plus the module-wiring pins.
- Contract change handled in-commit: `test_update_with_tier_emits_truthful_audit` used `tier: Acting`, now withheld by design — retargeted to `Confirming`, with a companion test asserting Acting is never written without approval.

## ⚠️ Scope — #452 stays open for the UI half

This delivers the hard guarantee: **Alfred cannot self-promote to Acting.** It does not yet give Sir a one-click Approve/Reject affordance.

I checked, and the Desk card has a fixed button set (`done` / `defer` / `noise` / `delegate` / `take_mine`) with no support for custom actions. Mapping `done` → "approve" would recreate exactly the gesture-conflation that #454 was filed to remove, so I deliberately did not do it. A proper affordance is Lane III (and possibly Lane I) work and wants its own issue — the `pending_promotion` field is the contract it will render against.

Until then a promotion is resolved by calling `resolve_instinct_promotion`, and pending requests are visible in the instinct's frontmatter.
