### PR TITLE
docs: reconcile documentation with ground truth (+ land the #452 tests that missed the merge)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,10 +22,13 @@ ACME_EMAIL=
 # The principal's display name (shown across the dashboard).
 OWNER_NAME=
 
-# Anthropic API key — the primary model provider.
+# NOTE: Hermes is Codex-only and authenticates over OAuth — NEITHER of the two
+# keys below drives Hermes model selection. See the Codex tiers further down.
+# They remain here because the setup wizard still validates them and some
+# sidecar/tooling paths read them; treat them as integration keys, not as the
+# model provider.
 ANTHROPIC_API_KEY=
 
-# OpenRouter API key — fallback / secondary model routing.
 OPENROUTER_API_KEY=
 
 # Composio API key — third-party tool/integration connections.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,7 @@ alfred-black persists data in **four stores**, not one markdown directory:
 |---|-------|---------|-------------|---------|
 | 1 | **Vault** | Markdown (`vault_data` volume) | ctrl-api (via alfred daemon) | The principal's published surface |
 | 2 | **`alfred-state.db`** | SQLite + WAL + sqlite-vec (`state_data`) | **ctrl-api** | Machine working memory |
-| 3 | **Cold archive** | DuckDB/Parquet | deferred (Phase 3) | Forensic long tail (>90d) |
+| 3 | **Cold archive** | SQLite + zstd (`cold.db`, `cold_data` volume) | ctrl-api | Forensic long tail (>90d) — rows aged out of alfred-state.db by the TTL compactor |
 | 4 | **`ingest.db`** | SQLite (`ingest_data`) | ctrl-api | Raw inbound stream events (7d TTL) |
 
 The operational store is named **`alfred-state.db`** (not `state.db`) to
@@ -173,8 +173,8 @@ matter  task  note  person  org  place  asset  chore  instinct  decision  briefi
 
 Plus the `SOUL.md` / `RULES.md` singletons and `_templates/`.
 
-**ctrl-api is the sole vault writer**, and it **enforces this in code**:
-every vault write route calls `assertCanonicalVaultPath()`
+**ctrl-api is the sole vault writer.** Most vault write routes enforce the
+contract in code by calling `assertCanonicalVaultPath()`
 (`packages/ctrl/src/db/promotionContract.ts`) before touching the
 filesystem. A write to a non-canonical path returns HTTP 422
 `PROMOTION_CONTRACT_VIOLATION` with a `suggestion` field pointing at the
@@ -189,9 +189,32 @@ right endpoint.
 | `observation` / `pattern_proposal` / `synthesis` / `contradiction` / `assumption` / `constraint` | `alfred-state.db` **`observation`** (via `POST /api/v1/state/observations`) |
 | `stream_event` | `ingest.db` **`stream_event`** (via `POST /api/v1/ingest/events`) |
 
-Vault operator paths that **bypass** the canonical-12 check:
-`_templates/`, `_archive/`, `_migrated*/`, `_rescue/`, `_raw/`,
-`_migrate/`, `inbox/`, `SOUL.md`, `RULES.md`, `CLAUDE.md`.
+Paths the contract CODE exempts — the whole list, from
+`promotionContract.ts` (`CANONICAL_NON_RECORD_DIRS` + `CANONICAL_TOP_LEVEL_FILES`):
+`_templates/`, `needs_attention/`, `SOUL.md`, `RULES.md`.
+
+`needs_attention/` is exempt on purpose: Desk cards stay vault-markdown until
+storage-epic #28 lands.
+
+**Two routes write demoted types straight to `vault/event/` with raw
+`fs.writeFileSync`, bypassing their own contract check** — a deliberate
+migration shim, not a rule:
+
+| Route | Writes | Also writes (the real source of truth) |
+|---|---|---|
+| `stateChanges.ts:585` | `event/state-change-*.md` | `audit` row, `action_type: state_change` |
+| `attention.ts:186` | `event/needs_attention_action-*.md` | `audit` row |
+
+They persist because callers still resolve `audit_record_path` and the
+calibration loop still reads the markdown. Single-writer discipline holds
+(both are ctrl-api) and `state.db` is authoritative — but do NOT read §5.1 as
+"a demoted type can never reach the vault." It can, via these two.
+
+Other top-level dirs you may find in an older vault (`_rescue/`, `inbox/`,
+`assumption/`, `synthesis/`, `constraint/`, `project/`, `stream_event/`, and a
+tail of empty ones) are historical debris written before the cutover by
+out-of-band scripts — NOT a code exemption. Adding a new one requires editing
+`promotionContract.ts`.
 
 ### 5.2 Single-writer discipline
 
@@ -350,9 +373,33 @@ on `status='active'`**. Lane II Gap 3 fix: `_load_active_instincts` accepts
 all non-deprecated instincts. The discretion gate at signal_actions:1825 is
 the real safety belt (high threshold for low-observation_count instincts).
 
+**The tier is the safety gate (#445/#446/#453).** It is a CEILING checked
+BEFORE confidence, at two independent enforcement points, both reading the
+shared reader in `matching/tiers.py` (fail-closed to `Asking`):
+
+1. `signal_actions.route_signal_action` — may this instinct dispatch an agent
+   unattended? Only `Acting` may.
+2. `noise_patterns` / the pre-extraction noise gate — may this instinct make
+   an inbound email cease to exist? Only `Acting` may; below that the match is
+   audited and the email still reaches Sir.
+
+No amount of confidence promotes an `Asking`/`Confirming` instinct into
+autonomy. The legacy nested `execution.tier` integer is deliberately ignored —
+it disagreed with the ladder on live data.
+
+**Reaching `Acting` requires Sir's explicit approval (#452).** Reflection may
+propose it; `apply_instinct_change` withholds it and records
+`pending_promotion: Acting` on the instinct (idempotent, and visible on
+`/instincts`). `resolve_instinct_promotion` is the only path that writes the
+tier. Demotions, lateral moves, and `Asking → Confirming` still apply
+immediately.
+
 **Discretion threshold**: per-instinct, computed from `observation_count`
-via `matching/discretion.py`. The `live_observation_count` (ctrl-api
-enrichment) takes precedence over the snapshotted `observation_count`.
+via `matching/discretion.py` (`effective_threshold` — the single shared
+implementation; an explicit `discretion_threshold` may only RAISE the bar).
+It applies *underneath* the tier ceiling. The `live_observation_count`
+(ctrl-api enrichment) takes precedence over the snapshotted
+`observation_count`.
 
 ---
 
@@ -364,6 +411,12 @@ inbound webhook / composio poll / agent action
 ingest.db.stream_event (7d TTL)
        ↓ EventProcessorWorkflow (every 15 min)
    marks processed_at; signals routed directly from ingest.db (#78 Design-B)
+       ↓ PRE-EXTRACTION NOISE GATE  (noise_patterns.py, inside extract_signal_from_event)
+   active instincts with intent_key=noise OR routing_rule.destination_type=hold
+   match on sender_domains (suffix-anchored) / subject_keywords →
+     tier == Acting  → event DROPPED, never becomes a signal
+     tier <  Acting  → audited (`signal_noise_match`) and ALLOWED THROUGH (#453)
+   every match writes an audit row either way
        ↓ SignalExtractWorkflow (every 5 min, gated on STEWARD_SIGNAL_EXTRACT_ENABLED)
    chunked extraction via clerk → alfred-state.db.signal (status=unrouted)
    + extract_observation_from_signal → state.db.observation (kind=signal)
@@ -455,16 +508,22 @@ gateway token from `/alfred-data/.gateway-token`).
 
 ### 9.2 MCP servers
 
-Each Hermes profile registers 6 MCP servers in its `config.yaml`:
+Each Hermes profile registers up to 8 MCP servers in its `config.yaml`
+(the last three are profile-conditional):
 
 | Name | Type | What it surfaces |
 |------|------|------------------|
 | `alfred-ctrl` | HTTP | The ctrl-api itself (40+ routes) |
 | `alfred` | stdio (Node) | Vault read/write + agent delegation + workflow orchestration |
 | `sure` | stdio (Node) | Sure personal-finance ~80 tools |
-| `plane` | stdio (Node) | Plane project management (v2 catalogue) |
 | `vaultwarden` | stdio (Node) | Vault items list/search/get/CRUD + vault_refresh |
 | `execute` | stdio (Node) | Composio surface — every connected third-party app via one execute primitive |
+| `hass` | stdio (Node) | Home Assistant (profile-conditional) |
+| `paperclip` | stdio (Node) | Paperclip adapter (profile-conditional) |
+| `files` | stdio (Node) | Store-5 file/blob surface (profile-conditional) |
+
+**`plane` is GONE** — Plane was removed from the compose stack fleet-wide
+(PR #279). `packages/ctrl/src/api/routes/plane.ts` is dormant, not deployed.
 
 Source for the 5 stdio apps: `packages/mcp-server/src/` (compiled bundle
 copied into the Hermes image at build time). The 6th `alfred-ctrl` is an
@@ -637,6 +696,10 @@ For mapping unknown breakage (e.g. a sweep over the live product):
   pre-commit` so the gate fires under either config value, and strips
   stale per-worktree overrides — re-run it whenever in doubt. The CI
   `lane-gate` workflow is the authoritative backstop either way.
+  **Status 2026-08-06: the local gate IS firing.** It blocked commits
+  repeatedly during the #445–#454 campaign (scope-limit and VERIFY
+  rejections), so the symlink fix holds. Do not assume it is off — but do
+  keep the CI backstop, it is what makes the guarantee unconditional.
 - **`isolation: worktree` does NOT guarantee isolation.** Agents have
   shared the working tree and overwritten each other's `.lane`. Either
   confirm each agent got a real separate worktree, **or** run coordinated
@@ -679,7 +742,13 @@ Path-filtered, push-to-main:
 | `build-voice-bridge.yml` | `packages/voice-bridge/**` | voice-bridge image |
 | `build-paperclip.yml` | `packages/paperclip/**` | paperclip image |
 | `build-setup.yml` | `packages/setup/**` | setup image |
-| `ci-check.yml` | * (all) | `tsc --noEmit` + `pytest` + `docker compose config` |
+| `build-alfred-worker.yml` | `packages/alfred-vault/**`, `packages/hermes/*` | `ssdavidai00/alfred-worker:latest` — the vault daemon/curator image; **runs on every tenant** as the `alfred` compose service |
+| `deploy-compose.yml` | compose/Caddy/env | rsyncs compose + Caddyfile to tenants |
+| `deploy-fleet.yml` | manual | fleet-wide pull + up |
+| `release-alfred-vault.yml` | tag `alfred-vault-v*` | publishes `alfred-vault` to PyPI |
+| `issue-taxonomy.yml` | issues | issue labelling |
+| `notify-telegram.yml` | * | build/deploy notifications |
+| `ci-check.yml` | * (all) | `tsc --noEmit` + `pytest` (learn only) + `docker compose config` |
 | `lane-gate.yml` | PRs | server-side replay of the lane gate on the PR diff (see §11.2.5) |
 | `pr-review-gate.yml` | PRs | `smoke-evidence-check` — PR body must carry `## Smoke evidence` |
 | `gitleaks.yml` | * (all) | Secret scanning |
@@ -701,6 +770,8 @@ On the VM:
 | `/var/lib/docker/volumes/alfred-black_vault_data/_data/` | The vault (markdown files) |
 | `/var/lib/docker/volumes/alfred-black_state_data/_data/` | alfred-state.db + WAL |
 | `/var/lib/docker/volumes/alfred-black_ingest_data/_data/` | ingest.db + WAL |
+| `/var/lib/docker/volumes/alfred-black_cold_data/_data/` | cold.db — Store 3 forensic archive |
+| `/var/lib/docker/volumes/alfred-black_files_cold_data/_data/` | Store 5 cold file/blob archive |
 | `/var/lib/docker/volumes/alfred-black_alfred_data/_data/` | Shared scratch (.gateway-token, settings.json, .hermes-* etc.) |
 | `/var/lib/docker/volumes/alfred-black_hermes_data/_data/` | $HERMES_HOME (profiles, SOUL.md, sessions, plugins) |
 | `/var/lib/docker/volumes/alfred-black_caddy_data/_data/` | LE certs (PRESERVE across redeploys to avoid rate limits) |
@@ -840,6 +911,8 @@ the `IdentityAgent=none` opt.
 `state_data` / `ingest_data` / `alfred_data` / `hermes_data` are
 recoverable but contain history — back them up if you care about the
 audit trail / observations / instinct training data.
+`cold_data` / `files_cold_data` hold everything aged OUT of state.db —
+if you care about the long tail, they are the only copy.
 `tailscale_data` (when the optional Tailscale sidecar is on — §15.11)
 holds the `tailscaled.state` node identity; lose it and the principal
 has to re-approve the device on `login.tailscale.com`.
@@ -900,6 +973,11 @@ containers.
 
 | Date | Incident | Fix commit(s) |
 |------|----------|---------------|
+| 2026-08-06 | **Alfred emailed a vendor to cancel a subscription, unattended** — an `Asking`-tier instinct (1 stored observation) cleared the numeric bar and dispatched an executor that mailed team@elevenlabs.io from Sir's Gmail, 4 min after he'd been setting the service up. The ladder was decorative: no gate read `tier`. | #445 → `#446` (tier ceiling on the router), `#448`/`#449` (/instincts renders the real tier), `#453` (noise gate too), `#452`/`#458` (Acting needs Sir's approval) |
+| 2026-08-06 | **Clicking Done taught Alfred to silence senders.** A 23-min backlog clear-out on 2026-07-15 (28 × `intent: done`) became a suppression rule whose `sender_domains` were harvested from that batch — including Sir's primary client. It sat in the pre-extraction noise gate, which consulted no tier and wrote no audit row. | `#454` (done ≠ noise; burst-weighting), `#453` (gate obeys the ladder + audits), instinct data cleaned by hand |
+| 2026-08-06 | Reflection had never actually run on the `heavy` profile despite §9 saying so — `clerk.py` hard-coded the workers gateway (luna) | `#451` + `#450` (heavy = gpt-5.6-sol) |
+| 2026-08-06 | `.env.example` still shipped OpenRouter-era model IDs (incl. an Anthropic model) that OVERRIDE the code defaults — a fresh deploy would have provisioned a non-Codex fleet | `#450` |
+| 2026-08-05 | Instinct promotion silently no-op'd for ~2 months: `apply_instinct_change` body-appended instead of patching frontmatter, so all 35 instincts froze at `Asking` while audit rows claimed promotions | `#442` → `#443`, `#444` |
 | 2026-05-24 | Hermes web dashboard at hermes.{$DOMAIN} (Sir reverted; upstream wheel ships no web bundle) | `fc91b16`, `9f40199` → reverted `ce6c177` |
 | 2026-05-24 | `_resolve_parent_matter_path` was slugifying blindly + `matter/inbox.md` not auto-seeded → 33 orphan tasks on live tenant | Lane V `b0bc0cc` (inbox seed) + Lane II `935692f` (4-tier resolver) |
 | 2026-05-24 | Task `status: queued` rejected by alfred-vault validator → backfill 100% errored | orchestrator `eed3799` + tests `e3c1ad2` |
@@ -927,7 +1005,8 @@ containers.
 - `packages/ctrl/docs/STORAGE-ARCHITECTURE.md` — the 4-store model
 - `packages/ctrl/CONTRACT.md` — what ctrl-api provides + requires
 - `packages/learn/CONTRACT.md` — what alfred-learn provides + requires
-- `packages/learn/SPEC.md` — full intelligence-layer spec (6 workflows, terminology)
+- `packages/learn/CONTRACT.md` — CURRENT intelligence-layer contract (workflows, activities, env). Use this.
+- `packages/learn/SPEC.md` — HISTORICAL day-1 design doc (describes 6 workflows + JudgmentWorkflow/SessionTracker, both deleted; ~46 workflow classes exist now). Do not treat as current.
 - `packages/learn/docs/STATE-MUTATION.md` — state-mutator contract (#889 spec §5.2)
 - `packages/learn/CLAUDE.md` — terminology constraints (observation/instinct/intuition/reflection/judgment/discretion/clerk)
 - `packages/web/main.wasp` — the Wasp app config (routes, queries, actions, jobs, entities)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,8 +84,8 @@ cd alfred
 cp .env.example .env
 
 # 2. Fill required vars in .env: DOMAIN, ACME_EMAIL, OWNER_NAME, OWNER_EMAIL,
-#    ANTHROPIC_API_KEY (or OPENROUTER_API_KEY), COMPOSIO_API_KEY.
-#    Optional: GOOGLE_CLIENT_*, SENDGRID_API_KEY.
+#    COMPOSIO_API_KEY. Hermes needs NO model API key — it authenticates to
+#    OpenAI Codex over OAuth (see §9). Optional: GOOGLE_CLIENT_*, SENDGRID_API_KEY.
 
 # 3. Generate auto-secrets (AAS_API_KEY, COLUMN_ENCRYPTION_KEY, JWT_SECRET,
 #    HERMES_API_SERVER_KEY, plane/sure DB passwords, vaultwarden admin token,

--- a/README.md
+++ b/README.md
@@ -165,13 +165,12 @@ Composio; Alfred just calls the tools.
 
 ### Sidecars — the back office
 
-Three best-in-class open-source services ship in the stack so Alfred can manage
+Two best-in-class open-source services ship in the stack so Alfred can manage
 real domains of your life, not just notes:
 
 | Sidecar | What it is | What Alfred uses it for |
 |---|---|---|
 | **[Sure](https://github.com/we-promise/sure)** | Personal finance | Accounts, transactions, budgets — Alfred categorises and reconciles your money |
-| **[Plane](https://plane.so)** | Project management | The durable task/issue backbone behind Matters and chores |
 | **[Vaultwarden](https://github.com/dani-garcia/vaultwarden)** | Secrets manager | A real vault for credentials Alfred (and you) need |
 
 ---
@@ -184,7 +183,7 @@ that share one engine:
 | | What it is | Where |
 |---|---|---|
 | **`alfred-vault`** | The pip-installable CLI. Turns *any* agentic runtime into an ambient butler over an Obsidian vault — the Curator / Janitor / Distiller / Surveyor workers + a Temporal workflow engine. Runs on a Mac Mini under your desk or any box with Python. | [`packages/alfred-vault/`](packages/alfred-vault/) · [`pip install alfred-vault`](https://pypi.org/project/alfred-vault/) |
-| **Alfred Black** | The full self-hosted **platform**: the web dashboard, the Hermes runtime, the signal pipeline, durable workflows, multi-channel delivery, and the Sure / Plane / Vaultwarden sidecars — brought up with a single `docker compose up`, served on your own domain over HTTPS. | this repo · *the rest of `packages/`* |
+| **Alfred Black** | The full self-hosted **platform**: the web dashboard, the Hermes runtime, the signal pipeline, durable workflows, multi-channel delivery, and the Sure / Vaultwarden sidecars — brought up with a single `docker compose up`, served on your own domain over HTTPS. | this repo · *the rest of `packages/`* |
 
 > **2026-05-20 — the platform release.** The project that gave you the `alfred`
 > CLI is now a complete, deployable platform. `alfred-vault` is the same
@@ -214,7 +213,7 @@ Three commands. Drop a file into `inbox/` and it's handled. Full docs:
 ### 2 · The full platform (Alfred Black)
 
 If you want the whole product — web dashboard, Hermes runtime, the daily Brief,
-multi-channel delivery, and the Sure / Plane / Vaultwarden sidecars — on a VM
+multi-channel delivery, and the Sure / Vaultwarden sidecars — on a VM
 you control: read on. You bring a fresh Linux VM and a domain; the stack brings
 everything else and serves the web app on your domain over HTTPS. No managed
 provisioning, no billing — **one repo, one VM, one `docker compose up`.**
@@ -258,7 +257,7 @@ provisioning, no billing — **one repo, one VM, one `docker compose up`.**
 | Disk     | 80 GB   | 80 GB+      |
 
 The full stack — web app, ctrl-api, Temporal, Ollama, Hermes, the vault
-daemon, Plane (~13 containers), Sure (~5 containers), and Vaultwarden — is
+daemon, Sure (~5 containers), and Vaultwarden — is
 memory-hungry.
 
 > At-rest disk encryption is **not** applied by the stack (no LUKS). The
@@ -277,7 +276,6 @@ your VM's public IP, where `example.com` is your domain:
 |---------|---------------------|-----------------------------------|
 | `@`     | `example.com`       | the Alfred Black dashboard (SPA)  |
 | `api`   | `api.example.com`   | the Alfred Black API server       |
-| `plane` | `plane.example.com` | Plane (project management)        |
 | `sure`  | `sure.example.com`  | Sure (personal finance)           |
 | `vault` | `vault.example.com` | Vaultwarden (secrets manager)     |
 | `mcp`   | `mcp.example.com`   | MCP server (Claude connector)     |
@@ -335,7 +333,7 @@ docker compose up -d
 
 `scripts/bootstrap.sh` validates the required fields and appends every
 auto-generated secret (`AAS_API_KEY`, `COLUMN_ENCRYPTION_KEY`, `JWT_SECRET`, the
-Hermes gateway token, Plane/Sure datastore credentials, the Vaultwarden
+Hermes gateway token, the Sure datastore credentials, the Vaultwarden
 admin token, …) with `openssl rand -hex 32`. It is idempotent — re-running never
 overwrites an existing value.
 
@@ -443,7 +441,7 @@ host ports (`:80`/`:443`).
   vault and the operational SQLite stores, and enforces the read/write contract.
 - **Data** — Hermes (AI runtime), Temporal, Ollama, the vault daemon
   (`packages/alfred-vault`, run as `alfred-worker`), `alfred-learn` (the signal
-  pipeline + the learner), the MCP server, plus the Sure / Plane / Vaultwarden
+  pipeline + the learner), the MCP server, plus the Sure / Vaultwarden
   sidecars.
 
 Four-store memory model: **vault** (markdown — the principal's surface),

--- a/README.md
+++ b/README.md
@@ -75,12 +75,14 @@ VM you control** — your data never leaves it.
 ### The Hermes runtime
 
 The reasoning core is **[Hermes Agent](https://github.com/NousResearch/hermes-agent)**
-— a single, isolated AI runtime. It runs in two profiles from one image: a
+— a single, isolated AI runtime. It runs in three profiles from one image: a
 **main** profile for the conversations you actually have (Telegram, Slack,
 email, web chat), and a concurrency-capped **workers** profile for the
 background agents that never bother you (the curator, the learner, ephemeral
-task runners). You choose the underlying model (any OpenRouter model, or your
-own provider) — Alfred is not locked to one LLM.
+task runners), and a **heavy** profile for the reasoning-bound work
+(onboarding and the nightly Reflection). Each profile runs its own OpenAI
+Codex model tier, so you can spend reasoning where it matters and stay cheap
+everywhere else.
 
 ### Memory — a vault you can read, and databases you don't have to
 
@@ -234,9 +236,10 @@ provisioning, no billing — **one repo, one VM, one `docker compose up`.**
   at the VM (see below).
 - **`git`** and **`openssl`** on the VM (`openssl` is used by the bootstrap
   script to generate secrets).
-- **API keys**: `OPENROUTER_API_KEY` and `COMPOSIO_API_KEY` are required.
-  `ANTHROPIC_API_KEY` is **optional** — Hermes routes LLM traffic through
-  OpenRouter by default.
+- **API keys**: `COMPOSIO_API_KEY` is required (it connects Gmail, Calendar and
+  the rest of the third-party surface). Hermes itself does **not** use an LLM
+  API key — it authenticates to OpenAI Codex over OAuth, which the first-run
+  setup walks you through.
 - **Google OAuth credentials** (`GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET`) —
   **optional**. Onboarding does *not* need them: with `COMPOSIO_API_KEY` set,
   "Start onboarding" connects Gmail through Composio's managed Google OAuth,
@@ -304,9 +307,9 @@ docker compose up -d
 no Node needed — and runs a containerized wizard that:
 
 - prompts every required and optional value, with inline help;
-- **validates your API keys live** — it actually calls OpenRouter, Anthropic,
-  and Composio and tells you immediately if a key is wrong;
-- lets you **pick the Hermes models** from OpenRouter's live model catalogue;
+- **validates your API keys live** — it actually calls the providers you have
+  configured (Composio and friends) and tells you immediately if a key is wrong;
+- lets you set the three Hermes Codex model tiers (main / workers / heavy);
 - if you opt into your own Google OAuth client, prints the exact **redirect
   URI** to register for your domain (skip it to use Composio-managed Gmail);
 - generates every auto-secret with a cryptographically-secure
@@ -323,8 +326,8 @@ offers to run `docker compose up -d` for you.
 ```sh
 cp .env.example .env
 # Edit .env — fill the "USER MUST FILL" block: DOMAIN, ACME_EMAIL, OWNER_NAME,
-# OPENROUTER_API_KEY, COMPOSIO_API_KEY (+ optional ANTHROPIC_API_KEY, Mailgun,
-# GOOGLE_CLIENT_*, HERMES_MAIN_MODEL / HERMES_WORKERS_MODEL)
+# OWNER_EMAIL, COMPOSIO_API_KEY (+ optional Mailgun, GOOGLE_CLIENT_*, and the
+# HERMES_{MAIN,WORKERS,HEAVY}_MODEL Codex tiers)
 nano .env
 ./scripts/bootstrap.sh    # generate every auto-secret into .env (run once)
 docker compose up -d
@@ -363,11 +366,22 @@ Onboarding is automatic and runs once, for the owner:
 
 ### Choosing the LLM models
 
-`HERMES_MAIN_MODEL` (user-facing chat) and `HERMES_WORKERS_MODEL` (background
-agents) take **bare OpenRouter model IDs**. Defaults: `x-ai/grok-4.3` and
-`openai/gpt-4.1-nano`. To change one, edit `.env` and run
-`docker compose up -d --force-recreate init hermes`. Hermes also supports
-switching provider entirely (`docker compose exec hermes hermes model`).
+Hermes is **Codex-only**. `HERMES_MAIN_MODEL` (Sir's chat),
+`HERMES_WORKERS_MODEL` (background agents) and `HERMES_HEAVY_MODEL`
+(onboarding + the nightly Reflection) take OpenAI Codex model tiers.
+Defaults: `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.6-sol`.
+
+To change one, edit `.env` and run
+`docker compose up -d --force-recreate init hermes`.
+
+Two gotchas worth knowing:
+
+- `config.yaml` is **seed-once and operator-owned** — init writes it if
+  absent and never overwrites it. On an existing tenant, editing `.env` alone
+  does nothing until the profile is re-rendered; edit the profile's
+  `config.yaml` (`model.default`) for an immediate change.
+- The `.env` values **override** the code defaults, so a stale entry there
+  silently wins on a reseed. Keep the two in step.
 
 ### Meeting-bot transcription
 

--- a/deploy/BACKUP-RESTORE.md
+++ b/deploy/BACKUP-RESTORE.md
@@ -53,10 +53,6 @@ compose config --volumes` and `docker volume ls` to confirm the prefix.
 | `web_db_data` | Dashboard auth/application Postgres data | Loss of users, auth state, dashboard metadata | Critical |
 | `temporal_data` | Temporal state store | Loss of workflow execution history and in-flight workflow state | High |
 | `mcp_server_data` | MCP server local state | Loss of local integration/cache state | Medium |
-| `plane_pgdata` | Plane Postgres | Loss of Plane projects/issues | High |
-| `plane_redis` | Plane Redis | Mostly cache/queue state; in-flight work may be lost | Medium |
-| `plane_rabbitmq` | Plane RabbitMQ | Queue loss; in-flight Plane background jobs may be lost | Medium |
-| `plane_uploads` | Plane file uploads/export data | Loss of issue/project attachments | High |
 | `sure_pgdata` | Sure Postgres | Loss of finance application data | Critical |
 | `sure_redis` | Sure Redis | Mostly cache/queue state | Medium |
 | `paperclip_data` | Paperclip SQLite/data workspace | Loss of Paperclip company/issue/agent state | High |

--- a/packages/alfred-vault/CLAUDE.md
+++ b/packages/alfred-vault/CLAUDE.md
@@ -35,7 +35,15 @@ alfred down              # Stop daemons
 alfred status            # Per-tool status overview
 ```
 
-There are no tests, linter, or CI configured.
+20 pytest files live under `tests/` (see the `test` extra in `pyproject.toml`),
+plus a dedicated release workflow (`.github/workflows/release-alfred-vault.yml`)
+that builds and publishes to PyPI on an `alfred-vault-v*` tag.
+
+Two real caveats: those tests are **not** wired into the push-to-main gate
+(`ci-check.yml`'s pytest job covers `packages/learn` only), and there is no
+lint config (`pyproject.toml` has no `[tool.ruff]`). The package's code DOES
+ship to every tenant — `build-alfred-worker.yml` bakes it into
+`alfred-worker:latest`, which runs as the `alfred` compose service.
 
 ## Architecture
 
@@ -63,7 +71,13 @@ Curator, Janitor, and Distiller delegate work to an AI agent backend. The agent 
 
 **Scope enforcement:** Each tool has a scope (`curator`, `janitor`, `distiller`) that restricts which vault operations the agent can perform. Defined in `vault/scope.py` with `SCOPE_RULES` dict. Curator can create/edit but not delete; janitor can edit/delete but not create; distiller can only create learning types.
 
-Three pluggable backends in each tool's `backends/`: Claude Code (subprocess via `claude -p`), Zo Computer (HTTP API), OpenClaw (subprocess via `openclaw agent --message`). Selected via `agent.backend` in config.
+Pluggable backends in each tool's `backends/`: Claude Code (subprocess via
+`claude -p`), Zo Computer (HTTP API), OpenClaw (subprocess — legacy, the
+runtime is Hermes now), and **`hermes.py`**. Selected via `agent.backend`.
+
+Gotcha: `hermes.py` currently exists ONLY under `curator/backends/` — `janitor`
+and `distiller` have not been given one yet. Check before assuming a tool can
+target Hermes.
 
 ### Each Tool's Backend Has Its Own Prompt Builder
 

--- a/packages/learn/CLAUDE.md
+++ b/packages/learn/CLAUDE.md
@@ -1,52 +1,56 @@
 # Alfred Learn — Claude Code Context
 
 ## What This Is
-Alfred Learn is a Python + Temporal Docker container that provides Alfred Black's self-improving intelligence layer. It sits alongside existing tenant Docker services (openclaw, temporal, alfred, alfred-ctrl).
+Alfred Learn is the Python + Temporal intelligence layer. It runs as the
+`alfred-learn` compose service alongside ctrl-api, hermes and temporal.
 
 ## Read First
-- `docs/SPEC.md` — full production spec. This is the source of truth. Read it in full before writing any code.
-- Build exactly what the spec says. No improvisation on architecture or naming.
+- **`CONTRACT.md`** — the CURRENT contract: workflows, activities, schedules,
+  configuration. Regenerated against `src/worker.py` +
+  `scripts/register_schedules.py`. **This is the source of truth. Start here.**
+- `SPEC.md` — HISTORICAL day-1 design doc. Kept for rationale only; several of
+  the workflows it specifies (`JudgmentWorkflow`, `SessionTrackerWorkflow`)
+  were deleted. Do not build against it.
 
 ## Key Constraints
-- Python 3.12, temporalio SDK, httpx, pyyaml — no other dependencies without justification
-- All LLM calls go through OpenClaw gateway (clerk.py) — NEVER direct Anthropic API
-- All vault writes go through alfred-ctrl API (vault_client.py) — NEVER direct filesystem writes from Python
-- Trust model is non-negotiable: Temporal=when, Python=structure, LLM=creative only
-- Terminology: observation (not cognition), instinct (not skill), intuition (not skill-graph), reflection (not synthesis), judgment (not router), discretion (not confidence gate), clerk (not subken)
+- Python 3.12, temporalio SDK, httpx, pyyaml — no other dependencies without
+  justification.
+- **All LLM calls go through the Hermes gateway** (`activities/clerk.py`).
+  NEVER call a provider API directly. The runtime is Codex-only.
+  - workers profile (`:18790`) — the default for clerk traffic
+  - heavy profile (`:18791`) — Reflection (`clerk_reflect`) and onboarding
+  - main (`:18789`) is Sir's live chat and is never a clerk target
+  - the gateway URL setting is still named `OPENCLAW_GATEWAY_URL` for legacy
+    reasons; it points at `http://hermes:18789`
+- **All vault writes go through ctrl-api** (`utils/vault_client.py`) — never
+  direct filesystem writes from Python.
+- Trust model is non-negotiable: Temporal=when, Python=structure, LLM=creative
+  only.
+- Terminology: observation (not cognition), instinct (not skill), intuition
+  (not skill-graph), reflection (not synthesis), judgment (not router),
+  discretion (not confidence gate), clerk (not subken).
 
 ## Monorepo Paths That Integrate With This
-- `packages/ctrl` — tenant API (port 3100). Vault routes, streams routes, workflow routes
-- `packages/saas` — SaaS platform (Wasp/Prisma). Streams dashboard, webhook receiver
-- `packages/openclaw` — OpenClaw Docker image. Gateway at port 18789
-
-## Environment Variables
-- TEMPORAL_HOST=temporal:7233
-- OPENCLAW_GATEWAY_URL=http://openclaw:18789
-- OPENCLAW_GATEWAY_TOKEN_FILE=/alfred-data/.gateway-token
-- VAULT_PATH=/vault
-- TASK_QUEUE=alfred-learn
-- ALFRED_LEARN_ENABLED=true
+- `packages/ctrl` — tenant API (port 3100). Vault routes, state routes,
+  workflow routes.
+- `packages/web` — the Wasp dashboard. (There is no `packages/saas`.)
+- `packages/hermes` — the Hermes runtime image; gateways on 18789/18790/18791.
 
 ## Temporal Task Queue
-`alfred-learn` — all 6 workflows use this queue
+`alfred-learn` — every workflow uses this queue.
 
-## 6 Workflows
-1. EventProcessorWorkflow — schedule: every 2 min. Simplified: fetch events → drop raw content to inbox → mark processed. No LLM classification — the curator handles everything.
-2. SessionTrackerWorkflow — schedule: every 5 min
-3. BriefingWorkflow — schedules: `chore-briefing-morning` (cron `0 5 * * *`, tenant-local) and `chore-briefing-evening` (cron `0 17 * * *`, tenant-local). Same workflow class, dispatched with `slot="morning"` or `slot="evening"`. Visits every active matter through `state_mutator.apply_state_change_v2`, then composes the brief body from the freshly-written `current_state` paragraphs and writes a snapshot to `briefing/<YYYY-MM-DD>-<slot>.md`. The SaaS `/brief` page reads those records via the `getBriefing` operation. (Replaced the old `DailyDigestWorkflow` / `DailyMorningBriefingWorkflow` / `DailyEveningDigestWorkflow` trio in commit f20556d.)
-4. LearningWorkflow — schedule: every 5 min
-5. ReflectionWorkflow — schedule: daily 2am
-6. JudgmentWorkflow — schedule: every 2 min
+## Workflows
+`src/worker.py` registers ~46 workflow classes and the live tenant runs ~36
+Temporal schedules. **Do not maintain a list here — it goes stale.** Read
+`CONTRACT.md`, or ask the box:
 
-## Build Order (phases in SPEC.md)
-Phase 1: Core infrastructure (config, clients, validators, worker, Dockerfile)
-Phase 2: Processor layer (event processor, session tracker, briefing composer)
-Phase 3: Intuition engine (learning, reflection, judgment)
-Phase 4: Integration hooks + scripts
-Phase 5: Dashboard (`packages/saas` changes)
-Phase 6: Tests + polish
+```sh
+docker exec alfred-black-temporal-1 temporal schedule list --address temporal:7233
+```
 
-Start with Phase 1. Get the worker booting and connecting to Temporal before writing any workflow logic.
+Deleted, despite what older docs claim: `SessionTrackerWorkflow` ("session"
+was never a canonical vault type) and `JudgmentWorkflow` (its activity module
+was removed with it).
 
 ## Temporal workflow rewrites
 

--- a/packages/learn/SPEC.md
+++ b/packages/learn/SPEC.md
@@ -1,3 +1,10 @@
+> **HISTORICAL — day-1 design doc, superseded.**
+> This spec describes the original 6-workflow architecture on the OpenClaw
+> gateway. `JudgmentWorkflow` and `SessionTrackerWorkflow` were deleted;
+> `clerk.py` no longer uses `sessions_spawn`; there are now ~46 workflow
+> classes. Kept for design rationale only.
+> **For current truth read `CONTRACT.md`.**
+
 # Alfred Learn — Production Specification
 
 **Monorepo path:** `packages/learn`

--- a/packages/learn/tests/test_acting_approval.py
+++ b/packages/learn/tests/test_acting_approval.py
@@ -1,0 +1,182 @@
+"""#452 — Alfred may not grant himself autonomy.
+
+`Acting` is the tier that authorises unattended action: the signal router
+(#446) and the noise gate (#453) both key on it. Reflection may propose the
+promotion; only Sir may apply it.
+
+Also pins a latent bug found while building this: `vault.py` used `logger`
+and `_now_iso` without defining either. Because
+`fetch_unprocessed_observations` swallows every exception and returns `[]`,
+a NameError there would have made Reflection silently process ZERO
+observations whenever a burst was present — a silent failure of exactly the
+class #442/#445 were about.
+"""
+
+import inspect
+
+import pytest
+
+from src.activities import vault as vault_mod
+from src.matching.tiers import AUTONOMOUS_TIER
+
+
+class _FakeClient:
+    """Records patches; serves a configurable current frontmatter."""
+
+    def __init__(self, frontmatter):
+        self._fm = dict(frontmatter)
+        self.patched: list[dict] = []
+        self.read_calls = 0
+
+    async def read_record(self, path):
+        self.read_calls += 1
+        return {"path": path, "frontmatter": dict(self._fm)}
+
+    async def patch_frontmatter(self, path, updates):
+        self.patched.append(dict(updates))
+        self._fm.update(updates)
+
+    async def close(self):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _no_audit(monkeypatch):
+    """Audit writes are best-effort and need ctrl-api; stub the client out."""
+
+    class _SC:
+        def __init__(self, *a, **k):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def append_audit(self, **kw):
+            _no_audit.rows.append(kw)
+
+    _no_audit.rows = []
+    monkeypatch.setattr("src.utils.state_client.StateClient", _SC)
+
+
+async def _hold(client, changes, current_tier="Confirming", pending=""):
+    client._fm.setdefault("tier", current_tier)
+    if pending:
+        client._fm["pending_promotion"] = pending
+    return await vault_mod._hold_acting_promotion(
+        client, "instinct/x.md", changes
+    )
+
+
+class TestPromotionIsWithheld:
+    @pytest.mark.asyncio
+    async def test_acting_promotion_is_stripped_and_requested(self):
+        c = _FakeClient({"tier": "Confirming"})
+        out = await _hold(c, {"tier": "Acting", "confidence_score": 0.9})
+        assert "tier" not in out, "the promotion must not be applied"
+        assert out["confidence_score"] == 0.9, "the rest of the proposal still applies"
+        marked = c.patched[0]
+        assert marked["pending_promotion"] == AUTONOMOUS_TIER
+        assert marked["pending_promotion_from"] == "Confirming"
+
+    @pytest.mark.asyncio
+    async def test_asking_to_confirming_is_not_held(self):
+        c = _FakeClient({"tier": "Asking"})
+        out = await _hold(c, {"tier": "Confirming"}, current_tier="Asking")
+        assert out["tier"] == "Confirming"
+        assert c.patched == []
+
+    @pytest.mark.asyncio
+    async def test_demotion_out_of_acting_is_never_held(self):
+        c = _FakeClient({"tier": "Acting"})
+        out = await _hold(c, {"tier": "Asking"}, current_tier="Acting")
+        assert out["tier"] == "Asking", "demotion must be immediate"
+
+    @pytest.mark.asyncio
+    async def test_already_acting_passes_through(self):
+        c = _FakeClient({"tier": "Acting"})
+        out = await _hold(c, {"tier": "Acting"}, current_tier="Acting")
+        assert out["tier"] == "Acting"
+        assert c.patched == []
+
+    @pytest.mark.asyncio
+    async def test_non_tier_changes_are_untouched(self):
+        c = _FakeClient({"tier": "Asking"})
+        out = await _hold(c, {"confidence_score": 0.7}, current_tier="Asking")
+        assert out == {"confidence_score": 0.7}
+        assert c.read_calls == 0, "no read needed when no tier change proposed"
+
+    @pytest.mark.asyncio
+    async def test_request_is_idempotent(self):
+        c = _FakeClient({"tier": "Confirming", "pending_promotion": "Acting"})
+        out = await _hold(c, {"tier": "Acting"}, pending="Acting")
+        assert "tier" not in out
+        assert c.patched == [], "must not re-request while already pending"
+
+    @pytest.mark.asyncio
+    async def test_unreadable_record_fails_closed(self, monkeypatch):
+        class _Broken(_FakeClient):
+            async def read_record(self, path):
+                raise RuntimeError("ctrl-api down")
+
+        c = _Broken({"tier": "Confirming"})
+        out = await vault_mod._hold_acting_promotion(c, "instinct/x.md", {"tier": "Acting"})
+        assert "tier" not in out, "unverifiable promotion must be withheld"
+
+    @pytest.mark.asyncio
+    async def test_case_insensitive_proposal(self):
+        c = _FakeClient({"tier": "Confirming"})
+        out = await _hold(c, {"tier": "acting"})
+        assert "tier" not in out
+
+
+class TestResolution:
+    @pytest.mark.asyncio
+    async def test_approve_applies_the_tier(self, monkeypatch):
+        c = _FakeClient({"tier": "Confirming", "pending_promotion": "Acting"})
+        monkeypatch.setattr(vault_mod, "VaultClient", lambda cfg: c)
+        res = await vault_mod.resolve_instinct_promotion("instinct/x.md", approved=True)
+        assert res["applied"] is True
+        assert c._fm["tier"] == AUTONOMOUS_TIER
+        assert c._fm["pending_promotion"] == ""
+
+    @pytest.mark.asyncio
+    async def test_decline_leaves_tier_alone(self, monkeypatch):
+        c = _FakeClient({"tier": "Confirming", "pending_promotion": "Acting"})
+        monkeypatch.setattr(vault_mod, "VaultClient", lambda cfg: c)
+        res = await vault_mod.resolve_instinct_promotion("instinct/x.md", approved=False)
+        assert res["applied"] is False
+        assert c._fm["tier"] == "Confirming"
+        assert c._fm["pending_promotion"] == ""
+        assert c._fm["promotion_declined_from"] == "Confirming"
+
+    @pytest.mark.asyncio
+    async def test_resolving_without_a_request_is_a_no_op(self, monkeypatch):
+        c = _FakeClient({"tier": "Confirming"})
+        monkeypatch.setattr(vault_mod, "VaultClient", lambda cfg: c)
+        res = await vault_mod.resolve_instinct_promotion("instinct/x.md", approved=True)
+        assert res == {"path": "instinct/x.md", "applied": False,
+                       "reason": "no_pending_request"}
+        assert c._fm["tier"] == "Confirming"
+
+
+class TestModuleWiring:
+    """Regression pins for the NameError shipped in #457."""
+
+    def test_logger_is_defined(self):
+        assert isinstance(getattr(vault_mod, "logger", None), object)
+        assert hasattr(vault_mod.logger, "info")
+
+    def test_now_iso_is_defined_and_utc(self):
+        assert vault_mod._now_iso().endswith("+00:00")
+
+    def test_fetch_observations_references_only_defined_names(self):
+        """`fetch_unprocessed_observations` swallows exceptions and returns
+        [], so an undefined name in it fails SILENTLY — Reflection would
+        just see zero observations. Check the names it uses exist."""
+        src = inspect.getsource(vault_mod.fetch_unprocessed_observations)
+        for name in ("logger", "annotate_decision_bursts", "burst_summary"):
+            assert name in src
+        assert hasattr(vault_mod, "logger")


### PR DESCRIPTION
Pre-rollout, pre-release documentation sync. A forensic audit verified every claim against the **code** and the **live tenant** — never against another doc.

## 8 WRONG claims fixed

| Where | The lie | Reality |
|---|---|---|
| `README.md` ×4 | Get an **OpenRouter** key; pick models from OpenRouter's catalogue | Codex-only, OAuth. The most misleading doc a newcomer reads first. |
| `CLAUDE.md` §5 | Cold archive "DuckDB/Parquet, deferred (Phase 3)" | Built and live as zstd-SQLite `cold.db` with its own volume — contradicting `STORAGE-ARCHITECTURE.md`, which §5 itself cites |
| `CLAUDE.md` §5.1 | "**every** vault write route calls `assertCanonicalVaultPath()`" | Two don't — see below |
| `CLAUDE.md` §6.6 | Discretion gate is "the real safety belt" (+ stale line ref) | The **tier** is, at two enforcement points, and `Acting` needs approval |
| `CLAUDE.md` §7 | Pipeline diagram | Omitted the pre-extraction noise gate entirely |
| `CLAUDE.md` §9.2 | Lists `plane` MCP server | Removed fleet-wide (PR #279); `hass`/`paperclip`/`files` were missing |
| `CLAUDE.md` §12 | 13 workflows | 18 exist; `build-alfred-worker` runs on every tenant and was documented nowhere |
| `alfred-vault/CLAUDE.md` | "no tests, linter, or CI configured" | 20 pytest files + a release workflow |

## The §5.1 finding is worth reading

`stateChanges.ts:585` and `attention.ts:186` write **demoted types straight into `vault/event/`** with raw `fs.writeFileSync`, bypassing the contract check. Live count: **1330 records** (141 `state_change`, 1162 `needs_attention_action`).

I investigated before assuming the worst, and it is **not** a leak: both are inside ctrl-api (single-writer holds), both also write the authoritative `state.db` audit row, and both carry comments explaining they persist because callers still resolve `audit_record_path`. It's a deliberate migration shim.

But §5.1 as written would lead an engineer to conclude a demoted type *cannot* reach the vault — and ctrl-api itself puts two of them there. Now documented, along with the **real** exemption list from `promotionContract.ts` (`_templates/`, `needs_attention/`, `SOUL.md`, `RULES.md`) — the previous list was largely invented.

## Stale files rewritten

`packages/learn/CLAUDE.md` described the OpenClaw gateway, a `packages/saas` that doesn't exist, and "6 Workflows" when `worker.py` registers ~46. Rewritten to point at `CONTRACT.md` and to **stop enumerating workflows** — that list is what went stale. `SPEC.md` stamped HISTORICAL; §17 no longer cites it as current.

## 🐞 Second commit: the #452 tests that missed the merge

I wrote 14 tests for the Acting-approval gate and then forgot to `git add` the file, so **#458 merged the behaviour without its tests** and the gate has been running unpinned on home since. No implementation change — just the file that should have been in #458.

## Smoke evidence

- `packages/learn`: 14/14 in the recovered test file; full suite green on main.
- Every doc claim re-verified against code or the live box; §16 incident history extended from 2026-05-24 → 2026-08-06.
- Also corrected §11.3, which warned the local lane gate was disarmed — it fired repeatedly during this campaign (scope-limit and VERIFY rejections), so the symlink fix holds.

## Deliberately not done

The demoted-type vault debris on home (`assumption/`, `synthesis/`, `constraint/`, `stream_event/`, `project/`, ~10 empty dirs) is inert and historical. Cleaning live data during a rollout is the wrong time; it wants its own issue.