### PR TITLE
feat(alfred-vault): register `commitment` as a known vault type (#469)

### DIFF
--- a/packages/alfred-vault/src/alfred/vault/schema.py
+++ b/packages/alfred-vault/src/alfred/vault/schema.py
@@ -12,6 +12,10 @@ KNOWN_TYPES: set[str] = {
     # Canonical progressive-autonomy record (Asking→Confirming→Acting). Was
     # absent, so the janitor stamped every instinct FM002 "Unknown type".
     "instinct",
+    # A promise inside a matter — who asked, who is accountable, the evidence,
+    # and where it is in its lifecycle. The unit the commitment register
+    # reconciles against.
+    "commitment",
 }
 
 LEARN_TYPES: set[str] = {
@@ -50,6 +54,13 @@ STATUS_BY_TYPE: dict[str, set[str]] = {
     "contradiction": {"unresolved", "resolved", "accepted"},
     "synthesis": {"draft", "active", "superseded"},
     "instinct": {"unconfirmed", "active", "deprecated"},
+    # COARSE rollup only. The real lifecycle (captured → accepted →
+    # in_progress → ready_to_deliver → delivered_awaiting_acceptance →
+    # fulfilled, plus waiting_*/blocked and released/superseded) lives in
+    # `commitment_state` and is validated in the intelligence layer. This
+    # daemon has no business enforcing that state machine, so `status` stays
+    # the same four-value rollup every other reader already understands.
+    "commitment": {"todo", "active", "blocked", "done"},
 }
 
 # Type → expected top-level directory
@@ -72,6 +83,7 @@ TYPE_DIRECTORY: dict[str, str] = {
     "contradiction": "contradiction",
     "synthesis": "synthesis",
     "instinct": "instinct",
+    "commitment": "commitment",
     # session, input have flexible placement
 }
 


### PR DESCRIPTION
Phase 0a of #467 — **the provider**. #470 and #471 depend on this.

Adds `commitment` to `KNOWN_TYPES`, `TYPE_DIRECTORY` and `STATUS_BY_TYPE` so commitment records validate rather than being stamped `FM002 Unknown type`, and so status validation actually runs. Not in `LEARN_TYPES` — commitments aren't distiller-created.

**`status` gets the coarse four-value rollup** (`todo/active/blocked/done`), same as tasks. The real 11-state lifecycle lives in `commitment_state` and is validated in the intelligence layer. Putting it here would couple the vault daemon to a state machine it has no business enforcing — that's the one design decision in this diff and it's deliberate.

Same shape as the `instinct` registration in #444, which ended an identical stream of janitor noise. Doing it *before* commitments exist at scale rather than after.

## Smoke evidence

Direct import assertion (12 LOC, one file):

```
commitment in KNOWN_TYPES ✓
STATUS_BY_TYPE['commitment'] == {todo, active, blocked, done} ✓
TYPE_DIRECTORY['commitment'] == 'commitment' ✓
commitment NOT in LEARN_TYPES ✓
```

Lane gate passed. Note this package's tests aren't in the push-to-main gate (`ci-check.yml` covers `packages/learn` only) — a known gap, not introduced here.

Post-merge: deploy `alfred-worker` to home and confirm the running container reports `commitment` in the schema.