### PR TITLE
feat(ctrl): accept `commitment` in the promotion contract (#470)

### DIFF
--- a/packages/ctrl/src/db/promotionContract.ts
+++ b/packages/ctrl/src/db/promotionContract.ts
@@ -22,9 +22,14 @@
 import { ApiError } from "../api/errors.js";
 
 /**
- * The 12 canonical vault record types. Each is a top-level directory under
+ * The 13 canonical vault record types. Each is a top-level directory under
  * VAULT_PATH; a record lives at `<type>/<slug>.md` (state transitions may move
  * it into a `<type>/_closed/` subdirectory — still canonical).
+ *
+ * `commitment` (#467 phase 0b) is a promise inside a matter: who asked, who is
+ * accountable, the evidence, and where it sits in its lifecycle. It always
+ * references a matter — `matter/inbox.md` when Alfred cannot attribute one,
+ * which is an explicit triage queue rather than a dumping ground.
  */
 export const CANONICAL_RECORD_TYPES = [
   "matter",
@@ -39,6 +44,7 @@ export const CANONICAL_RECORD_TYPES = [
   "decision",
   "briefing",
   "daybook",
+  "commitment",
 ] as const;
 
 export type CanonicalRecordType = (typeof CANONICAL_RECORD_TYPES)[number];

--- a/packages/ctrl/tests/promotion-contract-commitment.test.ts
+++ b/packages/ctrl/tests/promotion-contract-commitment.test.ts
@@ -1,0 +1,72 @@
+// #470 — `commitment` is a canonical vault record type.
+//
+// Phase 0b of #467. ctrl-api is the sole vault writer and enforces the
+// promotion contract on the write path; without `commitment` in the canonical
+// set every write to `commitment/` returns 422 PROMOTION_CONTRACT_VIOLATION.
+//
+// These also pin the surrounding behaviour, because the risk in widening a
+// canonical set is widening it too far.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  CANONICAL_RECORD_TYPES,
+  CANONICAL_NON_RECORD_DIRS,
+  assertCanonicalVaultPath,
+} from "../src/db/promotionContract.js";
+
+test("commitment is a canonical record type", () => {
+  assert.ok(
+    (CANONICAL_RECORD_TYPES as readonly string[]).includes("commitment"),
+    "commitment must be canonical or every write to commitment/ 422s",
+  );
+});
+
+test("a commitment record path is accepted", () => {
+  assert.doesNotThrow(() =>
+    assertCanonicalVaultPath("commitment/acme-com-2026-001.md"),
+  );
+});
+
+test("commitment records survive a state-transition subdirectory", () => {
+  // Terminal records may be moved into <type>/_closed/ and stay canonical.
+  assert.doesNotThrow(() =>
+    assertCanonicalVaultPath("commitment/_closed/acme-com-2026-001.md"),
+  );
+});
+
+test("widening the set did not admit the demoted types", () => {
+  // The whole point of the promotion contract. If one of these starts
+  // passing, a demoted record type has leaked back into the vault.
+  for (const demoted of [
+    "observation",
+    "signal",
+    "stream_event",
+    "synthesis",
+    "assumption",
+    "contradiction",
+  ]) {
+    assert.throws(
+      () => assertCanonicalVaultPath(`${demoted}/x.md`),
+      new RegExp(demoted),
+      `${demoted}/ must still be rejected`,
+    );
+  }
+});
+
+test("the documented exemptions are unchanged", () => {
+  for (const p of [
+    "_templates/task.md",
+    "needs_attention/2026-08-07T00-00-00Z-abc.md",
+    "SOUL.md",
+    "RULES.md",
+  ]) {
+    assert.doesNotThrow(() => assertCanonicalVaultPath(p), `${p} must be exempt`);
+  }
+  assert.deepEqual(
+    [...CANONICAL_NON_RECORD_DIRS].sort(),
+    ["_templates", "needs_attention"],
+    "exemption list changed — update CLAUDE.md §5.1 in the same PR",
+  );
+});


### PR DESCRIPTION
Phase 0b of #467. Pairs with #472 (the vault-schema half, #469).

ctrl-api is the sole vault writer and enforces the promotion contract on the write path — without `commitment` in `CANONICAL_RECORD_TYPES`, every write to `commitment/` returns 422. Canonical set goes 12 → 13.

The doc comment records what the type *is*, since the name alone doesn't say: **a promise inside a matter** — who asked, who is accountable, the evidence, and its lifecycle position. It always references a matter, with `matter/inbox.md` as the fallback when Alfred can't attribute one (Sir's decision on #467 question 1 — inbox as an explicit triage queue, not a dumping ground).

## The test does more than the happy path

The risk in widening a canonical set is widening it too far, so `tests/promotion-contract-commitment.test.ts` pins the surroundings:

- commitment accepted, including under a `_closed/` subdirectory
- **the demoted types are still rejected** — `observation`, `signal`, `stream_event`, `synthesis`, `assumption`, `contradiction`. If one starts passing, a demoted type has leaked back into the vault
- the exemption list is asserted to be exactly `{_templates, needs_attention}`, with a failure message telling the next person to update `CLAUDE.md` §5.1 if they change it

## ⚠️ Local verify caveat

The new test needs `tsx` — a **declared** devDependency that isn't installed in this checkout. I did not `npm install` (it corrupts the shared symlinked `node_modules`). So the test did not run locally.

`test-ctrl` is a **required** branch-protection check, so it runs in CI and genuinely gates this merge. The lane verify asserts the same source-level facts the test depends on: 13 canonical types including `commitment`, no demoted type present, exemption list unchanged.

## Not in this PR

`CLAUDE.md` §5.1 still says twelve types. It's phase0/forbidden-zone and can't ride in a lane diff — it lands in the orchestrator commit alongside the rest of phase 0.

## Smoke evidence

Local lane verify — the source-level facts the CI test asserts:

```
$ node verify470.mjs
contract ok — 13 canonical types incl. commitment; exemptions intact
```

Asserted: `commitment` present in `CANONICAL_RECORD_TYPES`; none of
`observation` / `signal` / `stream_event` / `synthesis` leaked in;
`CANONICAL_NON_RECORD_DIRS` still exactly `{_templates, needs_attention}`.

**Not yet smoked on home** — this is the write-path grant, and nothing writes
`commitment/` records until #471 migrates them. Live verification runs with
#471, once ctrl-api is deployed:

```
PATCH commitment/<slug>.md via ctrl-api  -> expect 2xx  (today: 422)
PATCH observation/<slug>.md via ctrl-api -> expect 422  (must stay rejected)
```

Both results will be pasted here.
