### PR TITLE
feat(learn): migrate commitment records from task/ to commitment/ (#471)

### DIFF
--- a/packages/learn/scripts/migrate_commitments_to_type.py
+++ b/packages/learn/scripts/migrate_commitments_to_type.py
@@ -1,0 +1,210 @@
+"""Move commitment records from `task/` to the canonical `commitment/` type.
+
+Phase 0d of #467. Depends on #469 (vault schema) and #470 (promotion contract);
+without both, every write below returns 422.
+
+    Dry run (default — writes nothing):
+        python -m scripts.migrate_commitments_to_type
+
+    Execute:
+        python -m scripts.migrate_commitments_to_type --execute
+
+Safety properties, in order of how much they matter:
+
+1. **Dry run by default.** `--execute` is required to write anything.
+2. **Write, verify, then delete.** There is no move primitive on the vault
+   client, so a migration is create + delete. Doing it in that order means a
+   failure leaves a *detectable duplicate* rather than a lost record. Never
+   invert this.
+3. **Idempotent.** A record whose `commitment/` twin already exists is skipped,
+   so a half-finished run can simply be re-run.
+4. **Read-back before delete.** The new record's identity fields are compared
+   against the source. Any mismatch aborts that record and leaves the original
+   in place.
+
+OPERATIONAL HAZARD — read before running with `--execute`:
+
+The reconciliation jobs run every weekday morning against exactly these
+records. A migration racing a reconciliation produces a projection built from a
+half-moved set. **Pause the jobs, migrate, verify, resume.** Do not rely on
+picking a quiet hour.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import re
+import sys
+from typing import Any
+
+from src.config import load_config
+from src.utils.vault_client import VaultClient
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger("migrate-commitments")
+
+#: Fields whose survival defines a correct migration. Checked after the write
+#: and before the delete; a mismatch on any of these aborts that record.
+IDENTITY_FIELDS = (
+    "commitment_id",
+    "commitment_scope",
+    "commitment_kind",
+    "commitment_state",
+    "requested_by",
+    "accountable_party",
+    "next_action",
+    "source_type",
+    "source_ref",
+    "last_verified_at",
+    "status",
+)
+
+
+def _slug(path: str) -> str:
+    return path.rsplit("/", 1)[-1].removesuffix(".md")
+
+
+def _retype(raw: str) -> str:
+    """Rewrite the frontmatter `type:` from task to commitment.
+
+    Operates on the first occurrence inside the frontmatter block only, so a
+    body that happens to mention `type: task` is untouched.
+    """
+    if not raw.startswith("---"):
+        return raw
+    end = raw.find("\n---", 3)
+    if end == -1:
+        return raw
+    head, rest = raw[:end], raw[end:]
+    head = re.sub(
+        r'^type:\s*["\']?task["\']?\s*$',
+        'type: "commitment"',
+        head,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    return head + rest
+
+
+async def _load_candidates(client: VaultClient) -> list[dict[str, Any]]:
+    records = await client.list_records("task", limit=5000)
+    out = []
+    for r in records:
+        fm = r.get("frontmatter") or {}
+        if isinstance(fm, dict) and str(fm.get("commitment_id") or "").strip():
+            out.append(r)
+    return out
+
+
+async def _already_migrated(client: VaultClient, slug: str) -> bool:
+    try:
+        await client.read_record(f"commitment/{slug}.md")
+        return True
+    except Exception:  # noqa: BLE001 — absence is the expected case
+        return False
+
+
+async def migrate(execute: bool) -> int:
+    config = load_config()
+    client = VaultClient(config)
+    moved = skipped = failed = 0
+    try:
+        candidates = await _load_candidates(client)
+        logger.info(
+            "found %d task records carrying commitment_id (%s)",
+            len(candidates),
+            "EXECUTING" if execute else "dry run — nothing will be written",
+        )
+
+        by_scope: dict[str, int] = {}
+        for r in candidates:
+            fm = r.get("frontmatter") or {}
+            by_scope[str(fm.get("commitment_scope") or "?")] = (
+                by_scope.get(str(fm.get("commitment_scope") or "?"), 0) + 1
+            )
+        for scope, n in sorted(by_scope.items(), key=lambda kv: -kv[1]):
+            logger.info("  %-24s %d", scope, n)
+
+        for r in candidates:
+            path = str(r.get("path") or "")
+            slug = _slug(path)
+            fm = r.get("frontmatter") or {}
+            cid = fm.get("commitment_id")
+
+            if await _already_migrated(client, slug):
+                logger.info("SKIP  %s (%s) — commitment/ twin already exists", cid, slug)
+                skipped += 1
+                continue
+
+            if not execute:
+                logger.info("WOULD MOVE  %s  task/%s.md -> commitment/%s.md", cid, slug, slug)
+                moved += 1
+                continue
+
+            try:
+                source = await client.read_record(path)
+                raw = source.get("content") or ""
+                if not raw.strip():
+                    raise ValueError("source record is empty")
+
+                await client.write_record("commitment", slug, _retype(raw))
+
+                # Read back and compare identity before removing the original.
+                check = await client.read_record(f"commitment/{slug}.md")
+                cfm = check.get("frontmatter") or {}
+                drift = [
+                    f
+                    for f in IDENTITY_FIELDS
+                    if str(fm.get(f) or "") != str(cfm.get(f) or "")
+                ]
+                if drift:
+                    raise ValueError(f"identity drift on {drift}; original left in place")
+                if str(cfm.get("type") or "") != "commitment":
+                    raise ValueError("type did not become commitment; original left in place")
+
+                await client.delete_record(path)
+                logger.info("MOVED %s  -> commitment/%s.md", cid, slug)
+                moved += 1
+            except Exception as exc:  # noqa: BLE001
+                logger.error("FAIL  %s (%s): %s", cid, slug, exc)
+                failed += 1
+
+        logger.info(
+            "\n%s: %d moved, %d skipped, %d failed",
+            "RESULT" if execute else "DRY RUN",
+            moved,
+            skipped,
+            failed,
+        )
+        if execute and failed:
+            logger.error(
+                "Some records failed. Their originals are intact under task/. "
+                "Re-running is safe: successful moves are skipped."
+            )
+        if execute and moved:
+            logger.info(
+                "Now verify behaviourally: run ONE scope's reconciliation and "
+                "confirm it finds its records and regenerates an unchanged "
+                "projection. A file listing proves the move; a clean "
+                "reconciliation proves it was correct."
+            )
+        return 1 if failed else 0
+    finally:
+        await client.close()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--execute",
+        action="store_true",
+        help="actually write; omit for a dry run",
+    )
+    args = ap.parse_args()
+    return asyncio.run(migrate(args.execute))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/learn/tests/test_migrate_commitments.py
+++ b/packages/learn/tests/test_migrate_commitments.py
@@ -1,0 +1,74 @@
+"""#471 — the commitment migration must not lose a record.
+
+Phase 0d of #467. The migration is create + delete (there is no move
+primitive), so the ordering and the read-back are the whole safety story.
+These pin them.
+"""
+
+import pytest
+
+from scripts.migrate_commitments_to_type import IDENTITY_FIELDS, _retype, _slug
+
+
+class TestRetype:
+    def test_rewrites_the_frontmatter_type(self):
+        raw = '---\ntype: "task"\ncommitment_id: "AC-COM-2026-001"\n---\nbody\n'
+        assert 'type: "commitment"' in _retype(raw)
+        assert 'type: "task"' not in _retype(raw)
+
+    def test_handles_unquoted_type(self):
+        raw = "---\ntype: task\nstatus: todo\n---\nbody\n"
+        assert 'type: "commitment"' in _retype(raw)
+
+    def test_leaves_the_body_alone(self):
+        """A body mentioning `type: task` must not be rewritten."""
+        raw = '---\ntype: "task"\n---\nThe old record had type: task in prose.\n'
+        out = _retype(raw)
+        assert out.count("commitment") == 1
+        assert "type: task in prose" in out
+
+    def test_only_the_first_occurrence(self):
+        raw = '---\ntype: "task"\nnote: "was type: task"\n---\nbody\n'
+        out = _retype(raw)
+        assert out.count('type: "commitment"') == 1
+
+    def test_passthrough_without_frontmatter(self):
+        assert _retype("no frontmatter here") == "no frontmatter here"
+
+    def test_passthrough_on_unterminated_frontmatter(self):
+        raw = '---\ntype: "task"\nnever closed\n'
+        assert _retype(raw) == raw
+
+
+class TestSlug:
+    @pytest.mark.parametrize(
+        "path,expected",
+        [
+            ("task/ac-com-2026-001.md", "ac-com-2026-001"),
+            ("ac-com-2026-001.md", "ac-com-2026-001"),
+            ("task/nested/x.md", "x"),
+        ],
+    )
+    def test_slug_extraction(self, path, expected):
+        assert _slug(path) == expected
+
+
+class TestIdentityContract:
+    def test_the_fields_that_define_a_correct_move_are_checked(self):
+        """These are compared post-write and pre-delete. Dropping one from the
+        list means a record could be silently mangled and then the original
+        deleted."""
+        for required in (
+            "commitment_id",
+            "commitment_scope",
+            "commitment_state",
+            "source_ref",
+            "last_verified_at",
+            "status",
+        ):
+            assert required in IDENTITY_FIELDS
+
+    def test_provenance_is_not_droppable(self):
+        """source_* is how a commitment proves where it came from."""
+        assert "source_type" in IDENTITY_FIELDS
+        assert "source_ref" in IDENTITY_FIELDS


### PR DESCRIPTION
Phase 0d of #467. Requires #469 (vault schema) and #470 (promotion contract), both merged.

64 records across six scopes move onto the canonical type. They're machine-managed and uniformly shaped — which makes this the right rehearsal for phase 3's ~2,760 far messier ones.

## The safety story is entirely in the ordering

There's no move primitive on the vault client, so a migration is create + delete:

- **Dry run by default.** `--execute` required to write anything.
- **Write → verify → delete.** In that order a failure leaves a *detectable duplicate* rather than a lost record. Inverting it risks losing evidence that can't be reconstructed.
- **Read-back before delete.** Eleven identity fields compared source↔destination, including the whole `source_*` provenance chain and `last_verified_at`. Any drift aborts that record and leaves the original in place.
- **Idempotent.** A record whose `commitment/` twin exists is skipped, so a half-finished run is just re-run.

`_retype` rewrites only the first `type:` inside the frontmatter block, so a body mentioning `type: task` in prose is untouched.

## ⚠️ Operational hazard, documented in the script

Six reconciliation jobs run every weekday morning against exactly these records. **A migration racing a reconciliation produces a projection built from a half-moved set.** Pause the jobs, migrate, verify, resume — don't rely on picking a quiet hour.

## Smoke evidence

Local, pre-deploy:

```
$ pytest tests/test_migrate_commitments.py -q
11 passed

$ pytest tests/ -q  (learn suite)
2582 passed, 101 skipped
```

The 11 tests cover the retype edge cases (unquoted, body-mention, first-occurrence-only, unterminated frontmatter) and pin the identity contract itself — dropping a field from `IDENTITY_FIELDS` would let a record be mangled and *then* have its original deleted, so the list is asserted.

Live on home, once `alfred-learn` and `ctrl-api` deploy — to be pasted here:

```
1. dry run                -> expect: 64 candidates, by scope, 0 written
2. pause reconciliation crons
3. --execute              -> expect: 64 moved, 0 failed
4. task/ retains 0 records with commitment_id
5. run ONE scope's reconciliation -> unchanged projection
6. resume crons
```

Step 5 is the real proof. A file listing shows the move happened; only a clean reconciliation shows it was *correct*.