### PR TITLE
feat(hermes): commitment-register references + templates (#466, 1/2)

### DIFF
--- a/packages/hermes/workspace-template/skills/alfred-commitment-register/references/bootstrap-verification.md
+++ b/packages/hermes/workspace-template/skills/alfred-commitment-register/references/bootstrap-verification.md
@@ -1,0 +1,68 @@
+# Bootstrap verification
+
+Use this after the initial records, projection and any schedule have been
+created. Each section is a proof obligation: a successful write response is not
+one of them.
+
+## 1 · Record proof
+
+- Search by the commitment-ID prefix and confirm the expected count.
+- Read every `commitment/` record back in full.
+- Check uniqueness, required fields, tags, `matter_ref`, detailed-state /
+  coarse-status consistency, and evidence handles.
+- Read every deduplicated legacy record and confirm `status: cancelled`,
+  `commitment_state: superseded`, and a `superseded_by` link.
+- **Do not treat a successful PATCH response as read-back proof.**
+
+Searching by ID prefix has a specific trap. YAML serializers may or may not
+quote a scalar, so an exact grep for `commitment_id: ACME-COM-` can silently
+undercount records stored as `commitment_id: "ACME-COM-..."`. Search the bare
+ID stem (`ACME-COM-2026-`) and validate the parsed frontmatter.
+
+A prefix-search hit count is also not a commitment count: policy notes,
+matters and projections quote the ID range and link back to the register once
+it exists. Count only `type: commitment` records with a structurally valid ID
+and the expected `commitment_scope`; report other hits separately rather than
+treating them as duplicates.
+
+## 2 · Projection proof
+
+- Read the rendered projection back through the destination — not the local
+  Markdown you generated.
+- Verify the intended H1 occurs exactly once, every required section exists,
+  the first and highest commitment IDs are present, the update marker occurs
+  exactly once, and the canonical-source footer exists.
+- Verify destination identity separately from content. For a vault note, the
+  path. For Slack, see `slack-projection.md` — `files.info` can return no
+  channel for a correctly attached Canvas.
+- Record the verified projection identity in the policy note.
+
+## 3 · Schedule proof
+
+A control-plane acknowledgement from `create` or `run` proves only that the
+request was accepted.
+
+Require all of the following before calling a schedule test successful:
+
+- the recurring job exists with the intended schedule, skills, toolsets and
+  destination;
+- a completed run is recorded — `last_run_at` present, terminal status
+  successful, no delivery error;
+- records were read during that run;
+- the projection was updated and read back;
+- the expected digest reached the configured destination.
+
+If the workflow logic and projection are exercised manually but the scheduler
+records no completed run, report **workflow path verified; scheduler
+control-plane run unverified**. Leave the job armed if its configuration is
+correct and verify the first natural run later, rather than claiming success.
+
+See also the scheduler self-verification boundary in `SKILL.md`: a run cannot
+attest to its own terminal status.
+
+## 4 · Boundary proof
+
+- Re-read the policy's forbidden destinations.
+- Confirm no shared or client-facing surface, email recipient, invoice route or
+  deliverable was mutated.
+- Distinguish evidence reads from external actions in the final report.

--- a/packages/hermes/workspace-template/skills/alfred-commitment-register/references/bounded-evidence-sweeps.md
+++ b/packages/hermes/workspace-template/skills/alfred-commitment-register/references/bounded-evidence-sweeps.md
@@ -1,0 +1,100 @@
+# Bounded message and calendar evidence sweeps
+
+Use this when a reconciliation depends on recent messages/threads, or on proof
+that a calendar event exists. The recurring failure in both is the same:
+treating an empty first query as a complete answer.
+
+## Messages: include replies to older parents
+
+A bounded channel-history call returns only parent messages whose own
+timestamps fall inside the window. It therefore misses a new reply posted
+during the window to a thread whose parent predates the cutoff.
+
+For a complete bounded sweep:
+
+1. Fetch parent history far enough back to enumerate existing thread parents.
+   Paginate; do not trust one page.
+2. Select both parents whose `ts` falls in the window **and** parents whose
+   `latest_reply` falls in the window, even when the parent is older.
+3. Fetch every selected thread, paginate it, and retain only replies whose own
+   timestamps are inside the window.
+4. Inspect attachments, links and explicit delivery/acceptance wording on both
+   parents and replies.
+5. Record the parent and reply counts checked. **An empty parent-message window
+   is not proof of no evidence** until the older-parent reply check also
+   returns nothing.
+6. Never print or persist secret values encountered during a read-only sweep.
+
+### Slack specifics
+
+For `SLACKBOT_FETCH_CONVERSATION_HISTORY`, pass the conversation as `channel`
+(not `channel_id`), and a bounded cutoff as an epoch-seconds string in
+`oldest`. The action returns parent timeline messages only — its own success
+message says so. When `has_more` is true, continue with
+`response_metadata.next_cursor` as `cursor` until the parent range needed to
+test `latest_reply` is complete, then call
+`SLACKBOT_FETCH_MESSAGE_THREAD_FROM_A_CONVERSATION` for each parent whose
+`latest_reply` is at or after the cutoff.
+
+Treat `messages: []` for an `oldest` query as "no new parents" — never as a
+complete no-signal result until the older-parent test is done.
+
+## Calendar: search every relevant owned calendar
+
+Do not equate "not on the primary calendar" with "the event does not exist".
+
+1. List calendars first.
+2. Search every relevant owned calendar over the exact event window using
+   participant and title aliases. Include work and personal calendars where the
+   event could plausibly live; exclude unrelated read-only or shared calendars
+   unless scope context points at them.
+3. Verify title, exact local start/end, attendees, attendee status, event
+   ID/link and update timestamp where present.
+4. Classify an invitation as absent only after the whole owned-calendar set
+   returns no match.
+
+### Google Calendar specifics
+
+A proven bounded lookup uses `GOOGLECALENDAR_FIND_EVENT` with snake-case
+arguments `calendar_id`, `query`, `time_min`, `time_max`, run once per owned
+calendar after `GOOGLECALENDAR_LIST_CALENDARS`. A successful no-match result is
+nested at `data.event_data.event_data: []` — inspect that array rather than the
+outer success flag or `display_url`. Preserve the exact RFC3339 bounds and
+local offset in the audit so an absence claim is reproducible.
+
+## Fallback is not degradation
+
+A focused or delegated agent is an optimisation, not the authority. If it times
+out or is unavailable, continue through a direct integration, action, or
+authenticated read-only provider API where one is available and permitted.
+
+**If the fallback completes the same bounded evidence contract, the source is
+not degraded.** Label `Source refresh degraded: <source>` only when no fallback
+can complete the required read, or when the fallback is partial.
+
+When a wrapper paginates in unexpectedly small pages, or produces more payload
+than the older-parent check can safely finish, go to the provider's
+authenticated read-only API directly:
+
+1. Load credentials through the profile's normal environment and `.env`
+   fallback order — reuse an existing helper's token loader where one exists.
+   Never print the token.
+2. Paginate history at the largest permitted page size until the cursor is
+   empty.
+3. Count in-window parents, and separately select every parent whose
+   `latest_reply` is at or after the cutoff.
+4. Fetch replies only for those parents, paginate each thread, and retain
+   replies by their own timestamps.
+5. Emit a token-free audit summary: pages, parents scanned, in-window parents,
+   candidate older threads, replies checked, relevant hits. Do not emit
+   unrelated message bodies.
+6. Keep it strictly read-only — no posts, reactions, edits or shares.
+
+Completeness is determined by exhausting the provider's cursor, not by a
+wrapper's apparent page size.
+
+## Intentional non-queries stay distinct
+
+If a conditional source had no trigger and policy says not to query it, record
+the exclusion. That is not degradation, and conflating the two makes a clean
+run look broken and a broken run look clean.

--- a/packages/hermes/workspace-template/skills/alfred-commitment-register/references/direct-delivery-evidence.md
+++ b/packages/hermes/workspace-template/skills/alfred-commitment-register/references/direct-delivery-evidence.md
@@ -1,0 +1,75 @@
+# Direct delivery-evidence reconciliation
+
+Use this when Sir asks whether active commitments have been delivered,
+acknowledged, accepted, paid, or otherwise completed **in a named source** — a
+channel, sent mail, an issue tracker, a Drive folder, a meeting record.
+
+The distinction this whole document protects: *prepared*, *delivered*,
+*acknowledged*, *accepted* and *fulfilled* are five different states, and
+collapsing them is how a register starts lying.
+
+## Required sequence
+
+1. Read **every active commitment in the scope before searching the source.**
+   Build a checklist: ID, obligation, expected artifact or action, current
+   state, delivery evidence, acceptance criteria, known aliases and filenames.
+2. Fetch the named source directly. Resolve the exact container, retrieve
+   paginated raw history, include thread replies. Do not substitute session
+   summaries, projection prose, a prior no-signal check, or the register
+   itself.
+3. Compare the complete checklist against the source. Search message text
+   **and** attachment filenames, using aliases and local-language terms. Read
+   surrounding messages, not isolated keyword hits.
+4. Classify precisely:
+   - **prepared** — the artifact exists privately;
+   - **sent/delivered** — the source contains the outbound message,
+     attachment, permalink or equivalent transaction;
+   - **receipt acknowledged** — the recipient confirms receipt or gives
+     substantive feedback;
+   - **accepted** — the recipient explicitly approves the final deliverable,
+     or the defined acceptance criteria are met;
+   - **fulfilled** — delivery plus acceptance/outcome evidence, or an explicit
+     release under policy.
+5. Treat revision feedback as proof of receipt, not final acceptance. A draft
+   followed by comments and a revised final file is
+   `delivered_awaiting_acceptance` until the revision is accepted.
+6. Capture evidence with source identity, exact timestamp, sender/recipient,
+   artifact filename or action, and the acknowledgement wording. Avoid vague
+   evidence such as "sent in Slack".
+7. Update records immediately — frontmatter state, delivery evidence,
+   acknowledgement, next action, `last_verified_at` — **and** any body text
+   still saying "unsent" or "not delivered".
+8. Read every changed record back. Verify frontmatter and body agree.
+9. Regenerate the projection from records, read it back, and verify changed
+   IDs, counts, states, timestamp and destination identity.
+10. Report three groups: newly evidenced deliveries, previously known
+    delivered-but-open items, and active commitments with no delivery
+    evidence. State explicitly whether anything is actually fulfilled.
+
+## Evidence cautions
+
+- "Here is the latest version" plus an attachment proves delivery of that
+  version, not acceptance.
+- "Looks good" followed by requested changes proves receipt and review, not
+  approval of the revised artifact.
+- An invoice attachment proves sending — not acknowledgement, and not payment.
+- Mentioning that a document exists somewhere else is not the same as
+  attaching it.
+- A client-owned prerequisite stays `waiting_on_client` unless the source
+  proves it happened.
+- Do not close a commitment merely because its original handoff happened, when
+  revisions or acceptance remain open.
+
+## Worked example
+
+Records say an invoice is `ready_to_deliver` and a proposal package is
+`ready_to_deliver`. Raw channel history shows the invoice PDF attached
+yesterday with no reply; two proposal drafts sent Friday, recipient feedback
+Saturday, a revised final offer sent Monday with no later response.
+
+Move both to `delivered_awaiting_acceptance`. Record exact timestamps and
+filenames. Preserve the proposal feedback as `client_acknowledgement` of
+receipt and review — but do not mark the revised offer accepted. Replace the
+stale body prose saying the invoice is unsent.
+
+Report: two deliveries found, **zero commitments fulfilled.**

--- a/packages/hermes/workspace-template/skills/alfred-commitment-register/references/projection-format.md
+++ b/packages/hermes/workspace-template/skills/alfred-commitment-register/references/projection-format.md
@@ -1,0 +1,89 @@
+# Register projection format
+
+Every commitment-register projection follows this hierarchy, whatever the
+destination. A vault note and a Slack Canvas render the same document; only the
+write path differs.
+
+```markdown
+# <Matter name> Commitment Register
+
+<One-sentence statement that this is a projection and the records are canonical.>
+
+## Summary
+- <Immediately actionable, principal-owned count>
+- <Ready to deliver count>
+- <Waiting on client / third party count>
+- <Blocked-behind-another-commitment count>
+- <Delivered, awaiting acceptance count>
+- <Recently fulfilled count>
+
+## Attention required
+- <Only genuine decisions, due/overdue actions and material commercial watches>
+
+## Ready to deliver
+<Items or `None.`>
+
+## Open commitments
+| ID | Commitment | Owner | State | Due | Next action |
+|---|---|---|---|---|---|
+| ... |
+
+## Waiting on others
+- <External prerequisites, each with its commitment ID>
+
+## Dependencies
+- <Explicit A → B chain, or an unresolved blocker>
+
+## Delivered, awaiting acceptance
+- <Delivered item, evidence date, remaining acceptance boundary>
+
+## Recently fulfilled
+- <Rolling 30-day fulfilled items only>
+
+<Optional matter-specific operational sections, such as `## Timesheet`. These
+come after the lifecycle sections and before the footer.>
+
+_Updated <local timestamp> · Canonical source: `commitment/` records for
+`<matter-slug>` in the vault._
+```
+
+## Rendering rules
+
+- Keep exactly one document H1. A destination that injects its own outer
+  heading is chrome, not corruption — see `slack-projection.md`.
+- Use the section order above. Do **not** add a `Changes since yesterday /
+  previous reconciliation` section: the projection shows current state, and
+  evidenced changes belong in the reply or scheduled digest.
+- Keep Summary terse and count-based. Separate immediately actionable
+  principal work from work blocked behind another commitment.
+- Use one consolidated `Open commitments` table rather than a table per state.
+- Preserve state labels where useful, but write owner and next action in plain
+  language.
+- Matter-specific sections are allowed only after `Recently fulfilled`, and
+  must not disturb the lifecycle hierarchy.
+- Timesheets and ledgers must separate accepted periods from proposals. Never
+  merge provisional hours into an accepted total.
+- The projection is a projection. `commitment/` records remain authoritative.
+
+## Count consistency
+
+Before writing, check every Summary count against the rendered document. Each
+count must equal the distinct commitment IDs shown in its section.
+
+`waiting on client / third party` includes commitments awaiting external
+review, acknowledgement, acceptance or a prerequisite — **even when the same
+commitment also appears under `Open commitments` or `Delivered, awaiting
+acceptance`**. Categories may overlap; do not undercount because of the
+overlap. Within a single category, count each ID once.
+
+After read-back, verify the count-bearing phrases *and* their corresponding ID
+rows together — not merely that the headings and the update marker exist.
+
+## Auditability when the lifecycle window hides a record
+
+If the first or highest canonical commitment ID falls outside both the open and
+recently-fulfilled sections — because it was fulfilled more than 30 days ago —
+include a compact archival line naming that ID and its terminal date and state.
+
+This preserves first/highest-ID verification without falsely counting old work
+as recently fulfilled.

--- a/packages/hermes/workspace-template/skills/alfred-commitment-register/templates/commitment-policy-note.md
+++ b/packages/hermes/workspace-template/skills/alfred-commitment-register/templates/commitment-policy-note.md
@@ -1,0 +1,63 @@
+---
+type: note
+name: "<Matter name> commitment management"
+created: "<ISO timestamp>"
+status: active
+matter: "[[matter/<matter-slug>]]"
+tags:
+  - "<matter-slug>"
+  - commitment-management
+---
+
+# <Matter name> commitment management
+
+Operating policy for promises and requests within `<matter-slug>`. Individual
+commitments are `commitment/` vault records with IDs `<PREFIX>-COM-YYYY-NNN`.
+Any note, Canvas, dashboard or briefing is a generated projection and never the
+source of truth.
+
+## Resolved configuration
+
+Recorded here so a later run — or a different agent — can reproduce what this
+register was set up to do. Derived values are marked as such; overrides come
+from the matter's `commitment_register` block.
+
+- Matter: `matter/<matter-slug>.md`
+- Prefix: `<PREFIX>` (derived from the matter slug unless overridden)
+- Participants and aliases: `<list>` (derived from the matter's related
+  persons/orgs unless overridden)
+- Evidence surfaces: `<bounded list of what is actually connected>`
+- Projection: `<note path, or the opted-in external destination>`
+- Forbidden destinations: `<list>` — every client-facing or shared surface
+- External action policy: no sends and no client-facing mutations during
+  reconciliation, ever.
+
+## Required fields
+
+`commitment_id`, `commitment_scope`, `commitment_kind`, `commitment_state`,
+`requested_by`, `accountable_party`, `next_action`, `source_type`,
+`source_ref`, `source_quote`, `last_verified_at`, `matter_ref` — plus
+dependency and delivery/acceptance evidence where relevant.
+
+## Lifecycle
+
+`captured` → `accepted` → `in_progress` → `ready_to_deliver` →
+`delivered_awaiting_acceptance` → `fulfilled`
+
+Holding: `waiting_on_principal`, `waiting_on_alfred`, `waiting_on_client`,
+`blocked`.
+
+Terminal exceptions: `released`, `superseded`.
+
+## Rules
+
+1. Preserve source wording and evidence handles.
+2. Do not infer acceptance from brainstorming.
+3. Deduplicate before creating.
+4. Represent dependency chains explicitly.
+5. Preparation is not delivery; delivery is not acceptance.
+6. Close only with evidence or an explicit release.
+7. Preserve history when scope changes; link both directions.
+8. Client-owned prerequisites remain blockers, not phantom owned records.
+9. Generate projections only from canonical records, and verify every write by
+   reading it back.

--- a/packages/hermes/workspace-template/skills/alfred-commitment-register/templates/register-projection.md
+++ b/packages/hermes/workspace-template/skills/alfred-commitment-register/templates/register-projection.md
@@ -1,0 +1,56 @@
+# <Matter name> Commitment Register
+
+Private projection. Canonical source: `commitment/` records for
+`<matter-slug>` in the vault.
+
+## Summary
+
+- **<n> need action now**
+- **<n> ready to deliver**
+- **<n> in progress**
+- **<n> waiting on others**
+- **<n> blocked by dependencies**
+- **<n> recently fulfilled**
+
+## Attention required
+
+1. **<ID>** — <actionable obligation and next action>
+
+## Ready to deliver
+
+| ID | Deliverable | Owner | Next action |
+|---|---|---|---|
+| <ID> | <deliverable> | <owner> | <next action> |
+
+## Open commitments
+
+| ID | Commitment | Owner | State | Due | Next action |
+|---|---|---|---|---|---|
+| <ID> | <obligation> | <owner> | <state> | <due or —> | <next action> |
+
+## Waiting on others
+
+- **<ID> — <party>:** <prerequisite>
+
+## Dependencies
+
+- **<ID> <dependency>** → **<ID> <dependent commitment>**
+
+## Delivered, awaiting acceptance
+
+- **<ID>** — <delivery evidence and the remaining acceptance boundary>
+
+## Recently fulfilled
+
+- **<ID>** — <outcome and evidence>
+
+## Reconciliation status
+
+- <Evidence-window and source-completeness note only — for example
+  `No evidenced state changes; all active commitments reverified through
+  <cutoff>.` Name any intentionally unqueried conditional source and
+  distinguish it from a degraded one. Do not list lifecycle changes here;
+  those belong in the reply or digest.>
+
+_Updated <local timestamp> · Canonical source: `commitment/` records for
+`<matter-slug>` in the vault._


### PR DESCRIPTION
First half of #466 — porting the commitment-register framework into
`packages/hermes/workspace-template/skills/alfred-commitment-register/`, where
`init/entrypoint.sh:247-277` already distributes every skill directory to every
full-deploy profile, hash-gated so it re-syncs on change.

**These files are inert until the SKILL.md lands in 2/2.** That split is
deliberate: it is a ~700-line port, and provider-before-consumer means the
references exist before anything reads them.

## What changed from the working per-tenant original

| Change | Why |
|---|---|
| Projection format is destination-agnostic; **a vault note is the default**, Slack is opt-in | The original baked a Slack Canvas into the happy path with the note as a degraded fallback. This ships to tenants with no Slack. |
| Every tenant-identifying string removed | Public repo, fleet-wide skill. Verified by grep — see below. |
| Policy note records *resolved* config and marks derived values | Configuration used to live in a hand-written wrapper. Here it is derived from the matter at run time, so without this a later run can't tell an intentional override from a drifted default. |
| ID-prefix search trap moved out of a client example into the verification doc | It applies to every register, not to the client it was first hit on. |
| Slack-only API fallback rewritten as the general provider pattern | Slack becomes one instance rather than the rule. |

## What I deliberately did not compress

The reference docs are the bulk of the port and the obvious thing to trim. They
encode three failure modes that are silent when they happen:

- **An empty first query is not a complete answer.** Bounded history returns
  only parents inside the window, so today's reply to last week's thread is
  invisible. Same shape on calendars.
- **A fallback that completes the same bounded contract is not degradation.**
  Conflating them makes a clean run look broken and a broken run look clean.
- **Prepared / delivered / acknowledged / accepted / fulfilled are five
  states.** An invoice attachment proves sending, not payment. Collapsing them
  is how a register starts lying.

Provider-specific argument shapes are kept because they are load-bearing and
not guessable — a Google Calendar no-match nested at
`data.event_data.event_data: []` is not something a model recovers by trying.

## Smoke evidence

Tenant-string scrub, which is an explicit #466 acceptance criterion:

```
$ grep -rniE "miguel|avenir|neoterra|rapali|nova|zsolt|tommy|rj-|erste|makerspace|\
szabostuban|david|C0[A-Z0-9]{8,}|F0[A-Z0-9]{8,}" \
    packages/hermes/workspace-template/skills/alfred-commitment-register/
(no matches)
```

Lane gate, per commit:

```
✓ lane V (edges-infra) gate passed — 157 LOC, 2 files, verify ok
✓ lane V (edges-infra) gate passed — 119 LOC, 2 files, verify ok
✓ lane V (edges-infra) gate passed — 175 LOC, 2 files, verify ok
```

Three commits because lane V caps at 200 LOC each; 451 total, inside the 600
CI ceiling.

**Environment note:** the lane V verify (`docker compose config -q`) failed
initially because the main checkout had no `.env`. I created one from
`.env.example` rather than using `ALFRED_SKIP_VERIFY` — the gate was correct,
the environment was incomplete.

## Not in this PR

`SKILL.md`, the contract-authority reference, the Slack-projection reference
and the worked example land in 2/2, which is what activates the skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc