### PR TITLE
feat(hermes): ship alfred-hours-reconstruction as a per-matter opt-in (#468)

### DIFF
--- a/packages/hermes/workspace-template/skills/alfred-hours-reconstruction/SKILL.md
+++ b/packages/hermes/workspace-template/skills/alfred-hours-reconstruction/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: alfred-hours-reconstruction
+description: Reconstruct Sir's work on a matter from bounded cross-source evidence — calendar, messages, mail, commits, transcripts, sessions, artifacts — and produce an auditable per-period proposal for his approval. Never accepts hours automatically. Use when a tracked period closes, when Sir asks "how much did I work on X?", or for a one-off retrospective backfill. Activates for matters carrying `hours_tracking` in their frontmatter.
+version: "1.0"
+metadata:
+  openclaw:
+    emoji: "⏱️"
+---
+
+# Alfred — Hours reconstruction
+
+Reconstruct what Sir actually worked on, from evidence, and propose it.
+
+Two rules sit above everything else here:
+
+> **Nothing enters the ledger without Sir's explicit approval.**
+> **The accepted ledger is the cursor — not the calendar, not the schedule.**
+
+This is an evidence-based estimate. It is not a timer export, not an invoice,
+and not automatically accepted time.
+
+## Switching it on
+
+```yaml
+hours_tracking: true
+```
+
+Off by default. Everything is derived: the period is weekly, closing at the end
+of Sir's Friday in his timezone; the approval request goes wherever Alfred
+normally reaches him; the ledger is `note/<matter-slug>-timesheet.md` and the
+proposals are `note/<matter-slug>-timesheet-proposal-<period-end>.md`.
+
+Object form only to override:
+
+```yaml
+hours_tracking:
+  enabled: true
+  period: weekly
+  approval_channel: <channel>
+  rate: 125            # optional, for later invoicing; not needed to track
+```
+
+Same boolean-or-object shape as `commitment_register`. **A capability is a
+shipped skill, switched on by a boolean on the matter, with an object form as
+the escape hatch.**
+
+## The window comes from the ledger
+
+The window runs from the **last date covered by the accepted ledger**
+(exclusive) to this period's cutoff (inclusive).
+
+Not from the calendar, and not from the last time the schedule fired. That
+distinction is the whole point: if a run is missed, the next window widens to
+cover the gap. Keyed to the schedule instead, a missed Friday silently loses a
+week of Sir's work, and nothing ever reports it.
+
+Before reconstructing anything, read the existing ledger and record its latest
+covered date, closing balance, credits and rate. Reconstruct **only the
+uncovered period** — never lay a partial reconstruction over a period a fuller
+ledger already represents.
+
+Weekend work therefore carries into the following period rather than vanishing.
+
+## Gather bounded evidence
+
+Read only the window. Keep a source handle for everything.
+
+1. **Calendar** — every owned calendar, not just the primary. Count meetings at
+   actual start/end. Corroborate with transcripts or meeting notes where
+   available.
+2. **Messages** — Sir-authored messages, threads, attachments and file
+   deliveries in matter-related channels and DMs. Include replies whose own
+   timestamps are in-window even when the thread parent is older.
+3. **Mail** — sent and received threads in the window. Metadata first, then
+   fetch only relevant threads. Reading an email is not automatically work.
+4. **Transcripts and meeting notes** — to classify discussion, preparation,
+   follow-up and deliverables. Transcript length is not duration.
+5. **Repositories** — commits, PRs, reviews, issues, releases attributable to
+   the matter. Commits prove activity and output, not duration.
+6. **Sessions** — Sir's own conversations with Alfred about this work.
+   Exclude register refreshes, cron maintenance and repeated summaries unless
+   he was actively directing substantive work.
+7. **Vault and artifacts** — record transitions, generated files, delivery
+   evidence. Timestamps anchor work; they do not determine hours.
+
+If a configured source is unavailable, **say so and lower confidence.** Never
+compensate by inventing time.
+
+Then convert evidence to hours by the method in
+`references/evidence-to-hours.md`. The union-of-intervals rule is not optional:
+the same hour seen in four sources is one hour.
+
+## Write the proposal — never the ledger
+
+Search first, so one period has exactly one proposal. Write
+`note/<matter-slug>-timesheet-proposal-<period-end>.md` with:
+
+```yaml
+status: proposed
+accepted: false
+period_start: <date>
+period_end: <date>
+generated_at: <ISO timestamp>
+total_hours: <number>
+scope: <matter-slug>
+source_coverage: <which sources were read, which were unavailable>
+confidence: <overall>
+```
+
+Body:
+
+1. **Daily table** — date, proposed hours, short work summary, linked
+   commitment IDs where a register exists, per-day confidence.
+2. **Evidence table** — time, source, exact handle, activity, interval used.
+3. **Exclusions and uncertainties.**
+4. **Total and its effect on capacity, clearly labelled provisional.** Never
+   present unapproved excess as billable — see
+   `../alfred-commitment-register/references/contract-authority.md`.
+
+Read the note back before delivering anything.
+
+**The ledger is not touched.** Not on generation, not on a test run, not
+because the reconstruction was thorough.
+
+## Ask for approval
+
+Deliver a concise but itemised request: the period and total; one line per
+non-zero day; the confidence and coverage caveat; the proposal note's path; and
+an explicit prompt to approve or supply corrected days and hours.
+
+Only Sir's explicit approval of the identified period is acceptance. **A
+generated proposal is not approval. Silence is not approval. A successful
+scheduled run is not approval. A reaction or a "thanks" is not approval.**
+
+## On approval
+
+1. Read the exact proposal note. Confirm its period overlaps no other accepted
+   or proposed record.
+2. Patch it to `status: accepted`, `accepted: true`, `accepted_at`,
+   `accepted_by`. Preserve the original evidence.
+3. Append the accepted period to the ledger — which advances the cursor for the
+   next window.
+4. Read both back and verify the period appears exactly once and the totals
+   agree.
+
+## On correction
+
+When Sir supplies different hours instead of approving, **record both his
+figure and the original estimate, with the delta.**
+
+That delta is the only feedback signal in this whole feature. Without it the
+estimator is permanently as good as it was on day one — and it is the thing
+most easily dropped as a nicety, because storing only the correct number
+obviously "works".
+
+Then patch the proposal, recompute totals, read it back, and repost the
+corrected proposal. Do not silently accept a corrected figure.
+
+## Retrospective backfill
+
+Reconstructing history is a different job from closing a period: a broad sweep
+rather than a bounded one, and it should stay manual and on demand. It is not
+part of the scheduled run.
+
+When Sir asks for one, establish the contract first — inclusive dates, timezone,
+opening balance, credits and their effective dates, whether the estimate should
+be conservative, central or generous, and the matter's aliases. Preserve his
+exact ordering when he gives a rule such as "start at zero on the 18th, then
+add 40 hours on the 19th":
+
+    closing = opening + credits effective that day − estimated work that day
+
+For long ranges, produce a Markdown or CSV artifact with date, estimated hours,
+concise work, credit and closing balance, plus a methodology section. Read it
+back and verify the totals, end date and final balance.
+
+If Sir first asks for a generous estimate and then a conservative commercial
+presentation, **re-estimate the daily rows** — do not scale the headline.
+Reduce uncertain prep, editorial and follow-up time before touching exact
+meetings or directly evidenced work. A requested ceiling is a scenario
+constraint, not permission to fabricate contemporaneous time; if it cannot be
+met without contradicting exact evidence, surface the conflict rather than
+forcing the ledger.
+
+## Failure behaviour
+
+- One optional source fails → continue, and label source coverage degraded.
+- Delivery fails after the proposal is saved → **do not create a duplicate
+  note.** Retry delivery only.
+- Vault access fails → do not post a proposal as though it were durable.
+- Never send client-facing messages, invoices or timesheets from this workflow.
+
+## Pitfalls
+
+- Do not sweep unbounded history when the period is known.
+- Do not trust one keyword; a generic product name matches unrelated threads.
+- Do not count automated jobs, digests or dashboard refreshes as Sir's labour.
+- Do not silently convert an estimate into an authoritative timesheet.
+- Do not infer billability or client debt from a negative balance — resolve
+  commercial treatment from the executed agreement first.
+- Do not hide uncertainty. Label the method and the confidence.
+- Do not omit zero days.
+- **Do not accept hours at any confidence level, ever.**

--- a/packages/hermes/workspace-template/skills/alfred-hours-reconstruction/references/evidence-to-hours.md
+++ b/packages/hermes/workspace-template/skills/alfred-hours-reconstruction/references/evidence-to-hours.md
@@ -1,0 +1,86 @@
+# Converting evidence into hours
+
+The method. Get this wrong and the estimate is either fiction or unusable.
+
+## Build one timeline, then estimate from the union of intervals
+
+The same hour of work appears in Slack, in email, in a commit, and in an Alfred
+session. Four sources, one hour.
+
+Build a single chronological activity ledger across every source, then estimate
+from the **union of time intervals**. Never sum per-source estimates — that is
+the single largest error available, and it inflates silently because each
+source looks individually reasonable.
+
+## Rules
+
+1. **A verified meeting counts at its actual duration.** Add preparation or
+   follow-up only when separately evidenced — normally 0.25–0.5 h. Never as an
+   automatic multiplier.
+2. **Cluster non-meeting events into work episodes** when the gap between
+   timestamped events is at most 30 minutes. Estimate the episode from first to
+   last activity, plus at most 10 minutes for setup and close-down.
+3. **An isolated event is 0.25 h**, unless a linked artifact or session gives
+   stronger evidence.
+4. **A long artifact does not equal its apparent authoring time.** Neither does
+   a commit burst, nor a transcript's length. Use surrounding activity, session
+   logs and delivery timestamps.
+5. **Merge overlapping intervals** across meetings, messages, commits and
+   sessions before totalling.
+6. **Include invisible planning or review only when evidenced** by a resulting
+   artifact, an explicit session statement, or a preparation trail. Mark it
+   medium or low confidence.
+7. **Round each day to 0.25 h after deduplication.** Never round each event up
+   — that is how twelve five-minute exchanges become three hours.
+8. **Sanity-check against the day's elapsed span.** A daily estimate cannot
+   exceed the evidenced work window without an explicit explanation.
+
+## Always exclude
+
+- Automation, notifications, inbox noise.
+- Passive calendar blocks, and blocks later cancelled or contradicted.
+- Waiting time and client-owned delay.
+- Duplicated transcript processing.
+- **The register's and this skill's own maintenance runs.** A reconciliation
+  that refreshes a dashboard is not billable work, and it is the exclusion most
+  easily forgotten because it looks exactly like activity.
+- Agent or background execution, unless the accounting basis explicitly
+  includes it or Sir actively directed and reviewed the work.
+
+## Confidence, per day
+
+- **High** — exact meeting or call duration, or a continuous timestamped work
+  session.
+- **Medium** — several corroborating events defining a bounded episode.
+- **Low** — an isolated artifact or message of uncertain duration. Stay
+  conservative and surface it for correction.
+
+**A missing source lowers confidence. It is never silently compensated for.**
+If a configured source is unavailable, say so and drop the affected days'
+confidence; do not fill the gap with an estimate that looks like evidence.
+
+Per-day confidence is what makes a proposal reviewable rather than a number to
+rubber-stamp. Without it, Sir cannot tell which rows to check.
+
+## False positives
+
+Require corroboration before attributing activity to a matter. A generic
+product or project name will match unrelated newsletters, vendors and threads.
+A keyword alone is not attribution — require the participant, domain, or
+surrounding context to agree.
+
+## Arithmetic
+
+Use a deterministic calculation, never mental arithmetic over a long ledger.
+For each date: apply that day's credit, subtract that day's estimated work,
+record the closing balance.
+
+Then verify:
+
+- every date in the period appears exactly once, including zero-work days;
+- daily hours sum to the reported total;
+- credits sum to the reported purchased amount;
+- the final balance equals opening + credits − work.
+
+**Keep zero days.** The uninterrupted daily ledger is what makes the running
+balance auditable; a table with gaps cannot be checked.


### PR DESCRIPTION
Ships evidence-based hours reconstruction to every tenant as a per-matter
opt-in. Independent of #477/#478 — different skill directory, no shared files.

```yaml
hours_tracking: true
```

Off by default. Period, approval destination, ledger path and proposal paths
derive; object form only as an override.

## Two rules sit above everything else

**Nothing enters the ledger without Sir's explicit approval.** A generated
proposal is not approval. Silence is not approval. A successful scheduled run
is not approval. Same propose-don't-apply pattern as #452's promotion gate — and
the same reason: the system may propose, the principal decides.

**The accepted ledger is the cursor, not the schedule.** The obvious
implementation keys the window to the calendar or the cron. Then a missed
Friday silently loses a week of Sir's work and nothing reports it. Keyed to the
accepted ledger, a missed run widens the next window and self-heals.

## The method is the valuable part

`references/evidence-to-hours.md` carries it:

- **Union of intervals, never the sum of per-source estimates.** The same hour
  appears in Slack, email, a commit and a session. Summing them is the largest
  error available here, and it inflates *silently* because each source looks
  individually reasonable.
- **Round the day after deduplication, not each event** — otherwise twelve
  five-minute exchanges become three hours.
- **Exclude the register's own maintenance runs.** The most easily forgotten
  exclusion, because a reconciliation refreshing a dashboard looks exactly like
  activity.
- **A missing source lowers confidence; it is never silently compensated for.**

## Kept deliberately

**Storing the delta when Sir corrects an estimate.** It reads as a
nice-to-have, and it is the easiest thing to drop — recording only the correct
number obviously "works". But it is the only feedback signal in the whole
feature; without it the estimator is permanently as good as it is on day one.

**Per-day confidence.** It is what makes the proposal reviewable rather than a
number to rubber-stamp — without it Sir cannot tell which rows to check.

## Generalised from the working original

The live version is one client's Friday job: hard-coded channel and canvas IDs,
a fixed matter path, a client alias list, a baseline note nobody may touch, and
a Hungarian approval prompt. All of it now derives or is gone.

Retrospective backfill is folded in as an explicitly **manual, on-demand** mode
— a broad sweep rather than a bounded one, deliberately not part of the
scheduled run, exactly as #468 specifies.

## Smoke evidence

```
$ grep -rniE "miguel|avenir|neoterra|rapali|zsolt|tommy|erste|makerspace|\
szabostuban|david|jóváhagyom|C0[A-Z0-9]{8,}|F0[A-Z0-9]{8,}" \
    packages/hermes/workspace-template/skills/alfred-hours-reconstruction/
(no matches)

✓ lane V (edges-infra) gate passed — 86 LOC, 1 files, verify ok
✓ lane V (edges-infra) gate passed — 203 LOC, 1 files, verify ok
```

`.lane` `scope_limit` 200 → 210 for the SKILL.md commit; it is 203 lines and
indivisible. PR total 289 LOC, well inside CI's 600.

## Still to verify on home (not claimed here)

Deploy `build-init`, then on a test matter with the block: confirm the window
is computed from the ledger and not the calendar, that a proposal is written
with `accepted: false`, and that **the ledger is untouched until approval**.
Evidence goes to #468 rather than being asserted now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc