### PR TITLE
docs: commitment as the 13th canonical type + the per-matter capability convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,13 +165,22 @@ avoid a filename collision with Hermes' own gateway-session store at
 > **A record exists in the vault only if the principal has a reason to read
 > or edit it. Everything else is SQLite.**
 
-The vault (Store 1) holds **exactly 12 canonical record types**:
+The vault (Store 1) holds **exactly 13 canonical record types**:
 
 ```
 matter  task  note  person  org  place  asset  chore  instinct  decision  briefing  daybook
+commitment
 ```
 
 Plus the `SOUL.md` / `RULES.md` singletons and `_templates/`.
+
+`commitment` joined the set in #469/#470/#471 (phase 0 of #467). A commitment
+is a promise with an accountable party and an evidence handle — one Sir made,
+or one made to him. It hangs off a matter via `matter_ref`: the matter is the
+ongoing concern, the commitments are the promises inside it. Its coarse
+`status` uses the normal four-value vocabulary; the real 11-state lifecycle
+lives in `commitment_state`, because the coarse field cannot express
+`delivered_awaiting_acceptance` and forcing it would mean a false closure.
 
 **ctrl-api is the sole vault writer.** Most vault write routes enforce the
 contract in code by calling `assertCanonicalVaultPath()`
@@ -262,6 +271,35 @@ in_progress; `waiting` = otherwise.
 a `state_change` audit row to alfred-state.db AND patches frontmatter.
 
 **Mode-gated**: `state_mutator_mode` setting (see §8). Default `"live"`.
+
+**Per-matter capabilities.** A matter's frontmatter can switch on shipped
+skills. The convention, which any future capability should follow:
+
+> **A capability is a shipped skill, switched on by a boolean on the matter,
+> with an object form as the escape hatch.**
+
+```yaml
+commitment_register: true     # #466 — alfred-commitment-register
+hours_tracking: true          # #468 — alfred-hours-reconstruction
+```
+
+Everything is derived — ID prefix from the matter slug, participants from its
+related persons/orgs, sources from what the tenant has connected, projection
+paths from the slug. The object form (`{enabled: true, prefix: ACME, …}`)
+exists only to override a derived value that is wrong.
+
+Two rules that are not configurable, because they are not choices: the skills
+never perform external sends or client-facing writes during reconciliation, and
+`hours_tracking` never accepts hours without Sir's explicit approval, at any
+confidence level.
+
+Defaults are chosen so a capability works on a tenant with **no integrations at
+all** — `commitment_register`'s projection defaults to a vault note, with Slack
+as an opt-in (`projection: slack:<channel>`).
+
+The skills act only on matters carrying the block, so a matter driven by a
+bespoke per-tenant wrapper skill keeps running on it, untouched. Migration is
+per matter: add the block, delete the wrapper, verify one reconciliation.
 
 ### 6.2 Task
 


### PR DESCRIPTION
Two forbidden-zone (phase0) edits that belong with #466/#467 rather than
trailing them. Satisfies #466's "CLAUDE.md documents the block" acceptance
criterion and the documentation half of #467 phase 0.

## §5.1 — 12 canonical types becomes 13

`commitment` landed in #469/#470/#471: registered in the vault schema
(`KNOWN_TYPES`, `TYPE_DIRECTORY`, `STATUS_BY_TYPE`) and accepted by
`assertCanonicalVaultPath()`.

Records why the coarse `status` and the 11-state `commitment_state` coexist
rather than reading as redundancy: the vault's four-value vocabulary cannot
express `delivered_awaiting_acceptance`, and collapsing it into `done` would be
a false closure. The coarse field is for the validator; the truth lives in
`commitment_state`.

## §6.1 — the per-matter capability convention, named once

```
A capability is a shipped skill, switched on by a boolean on the matter,
with an object form as the escape hatch.
```

#466 and #468 arrived at this shape independently, in their own thinness
reviews. Naming it here makes #468 a second instance of a documented convention
rather than a second bespoke thing, and any future per-matter capability
inherits it. It is cheaper to state than to rediscover.

Also recorded, because they are properties rather than defaults:

- no external sends or client-facing writes during reconciliation;
- `hours_tracking` never accepts hours without Sir's explicit approval, **at
  any confidence level**;
- defaults are chosen so a capability works on a tenant with **no integrations
  at all** — which is the reason the register projects to a vault note and
  Slack is opt-in;
- the skills act only on matters carrying the block, so matters driven by
  bespoke per-tenant wrappers keep running untouched.

## Smoke evidence

```
✓ lane phase0 (orchestrator) gate passed — 40 LOC, 1 files, verify ok
```

Docs-only; CLAUDE.md is forbidden-zone and orchestrator-owned, so this is a
phase0 commit from the main checkout with no `.lane` present, per §11.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc