### PR TITLE
fix(ctrl): commitment is writable but not listable — the read allowlist missed it

### DIFF
--- a/packages/ctrl/src/api/routes/vault.ts
+++ b/packages/ctrl/src/api/routes/vault.ts
@@ -153,7 +153,7 @@ const VAULT_INDEX_TTL_MS = 60_000;
 const VAULT_INDEX_CACHE_KEY = "_self";
 const _vaultIndexCache = new Map<string, { at: number; body: unknown }>();
 
-const KNOWN_TYPES = [
+export const KNOWN_TYPES = [
   "person", "org", "project", "task", "event", "note", "location",
   "process", "account", "asset", "conversation", "input", "run",
   "session", "decision", "triage",
@@ -197,9 +197,17 @@ const KNOWN_TYPES = [
   //  - place   : a location/venue record.
   // (Demoted legacy types above stay until the C11 contract-enforcement pass.)
   "daybook", "place",
+  //  - commitment : a promise with an accountable party and an evidence
+  //                 handle (#469/#470). Added to CANONICAL_RECORD_TYPES so
+  //                 the WRITE path accepts commitment/, but missing here —
+  //                 so GET /vault/list/commitment 400'd and every register
+  //                 bootstrap failed. Third instance of this exact split;
+  //                 the test in tests/vault-known-types.test.ts now makes a
+  //                 fourth impossible.
+  "commitment",
 ];
 
-const STATUS_BY_TYPE: Record<string, string[]> = {
+export const STATUS_BY_TYPE: Record<string, string[]> = {
   project: ["active", "paused", "completed", "abandoned", "proposed"],
   task: ["todo", "active", "blocked", "done", "cancelled"],
   session: ["active", "paused", "finished"],
@@ -223,6 +231,11 @@ const STATUS_BY_TYPE: Record<string, string[]> = {
   matter: ["active", "resolved", "abandoned"],
   ledger_entry: ["active"],
   chore: ["active", "paused", "completed"],
+  // commitment carries only the coarse four-value vocabulary here. The real
+  // 11-state lifecycle lives in `commitment_state`, because `status` cannot
+  // express `delivered_awaiting_acceptance` and forcing it would assert a
+  // closure that has not happened. Mirrors alfred-vault's STATUS_BY_TYPE.
+  commitment: ["todo", "active", "blocked", "done"],
   // pattern_proposal lifecycle (OBS-3..OBS-5):
   //  - proposed  : freshly written by PatternDetectionWorkflow,
   //                awaiting principal review on /desk

--- a/packages/ctrl/tests/vault-known-types.test.ts
+++ b/packages/ctrl/tests/vault-known-types.test.ts
@@ -1,0 +1,74 @@
+// The write path and the read path must agree about which types exist.
+//
+// WHY THIS FILE EXISTS. `promotionContract.ts` decides what may be WRITTEN to
+// the vault. `routes/vault.ts` has a separate `KNOWN_TYPES` allowlist deciding
+// what may be LISTED. Adding a canonical type to the first and forgetting the
+// second produces a type you can create but cannot enumerate: writes return
+// 201, `GET /vault/list/<type>` returns 400.
+//
+// That split has now bitten three times:
+//
+//   1. `daybook` — fixed after GET /vault/list/daybook 400'd valid records
+//   2. `place`   — same commit, same cause
+//   3. `commitment` (#469/#470) — the write path was added and the read path
+//      was not. Every commitment register bootstrap failed with
+//      "Unknown vault type: commitment", while the promotion-contract tests
+//      passed, because they only ever exercised the write side.
+//
+// Each time it was found in production rather than in CI, because no test
+// compared the two lists. This one does, so a fourth occurrence fails here
+// instead of on a live tenant.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { CANONICAL_RECORD_TYPES } from "../src/db/promotionContract.js";
+import { KNOWN_TYPES, STATUS_BY_TYPE } from "../src/api/routes/vault.js";
+
+test("every canonical record type is listable", () => {
+  const listable = new Set(KNOWN_TYPES as readonly string[]);
+  const missing = (CANONICAL_RECORD_TYPES as readonly string[]).filter(
+    (t) => !listable.has(t),
+  );
+  assert.deepEqual(
+    missing,
+    [],
+    `These types can be written but not listed — GET /vault/list/<type> will ` +
+      `400 for each: ${missing.join(", ")}. Add them to KNOWN_TYPES in ` +
+      `routes/vault.ts.`,
+  );
+});
+
+test("commitment specifically is listable", () => {
+  // The regression that motivated the file. Kept as its own case so a failure
+  // names the type rather than only the invariant.
+  assert.ok(
+    (KNOWN_TYPES as readonly string[]).includes("commitment"),
+    "commitment must be listable or every register bootstrap fails",
+  );
+});
+
+test("commitment exposes only the coarse status vocabulary", () => {
+  // The 11-state lifecycle lives in `commitment_state`. If the coarse list
+  // ever grows lifecycle values, the two state surfaces have been conflated
+  // and a false closure becomes expressible.
+  assert.deepEqual(
+    [...(STATUS_BY_TYPE["commitment"] ?? [])].sort(),
+    ["active", "blocked", "done", "todo"],
+  );
+});
+
+test("a listable type is not thereby canonical", () => {
+  // The invariant is one-directional on purpose. KNOWN_TYPES still carries
+  // demoted legacy types (signal, observation, stream_event…) so their
+  // historical records remain readable. Asserting set equality would demand
+  // deleting that read compatibility, which is a separate decision.
+  const canonical = new Set(CANONICAL_RECORD_TYPES as readonly string[]);
+  const readOnlyLegacy = (KNOWN_TYPES as readonly string[]).filter(
+    (t) => !canonical.has(t),
+  );
+  assert.ok(
+    readOnlyLegacy.length > 0,
+    "expected legacy read-only types to remain listable",
+  );
+});


### PR DESCRIPTION
Found by the first live run of the all-matters register job (#484): **1 of 11 matters reconciled**, the other 10 failed with `Unknown vault type: commitment`.

## Two lists, one type

`promotionContract.ts` decides what may be **written**. `routes/vault.ts` `KNOWN_TYPES` decides what may be **listed**. #470 added `commitment` to the first and not the second — a type you can create but cannot enumerate. Writes return 201; `GET /vault/list/commitment` returns 400.

**Third instance of this exact split.** The comment directly above the line I edited documents the previous two — `daybook` and `place` — both found the same way, by a 400 on valid records in production. Each was fixed by adding a string, and nothing was ever added to stop it happening again.

The promotion-contract tests passed the whole time, because they only exercised the write side. That is why this reached a live tenant rather than CI.

## The fix is the test, not the string

- `commitment` in `KNOWN_TYPES`, plus the coarse four-value `STATUS_BY_TYPE` entry mirroring alfred-vault (the 11-state lifecycle stays in `commitment_state`).
- **`tests/vault-known-types.test.ts` asserts every `CANONICAL_RECORD_TYPES` entry is listable.** A fourth occurrence now fails in CI.
- `KNOWN_TYPES` / `STATUS_BY_TYPE` exported — they were module-private, which is part of why no test ever compared them.

The invariant is one-directional deliberately: listable-but-not-canonical is fine, because `KNOWN_TYPES` still carries demoted legacy types so their historical records stay readable. Set equality would demand deleting that compatibility — a separate decision, and one this PR should not smuggle in.

## Smoke evidence

The failure, from the live run's own rollup — note it reported honestly rather than claiming success:

```
alfred-product-and-operating-system: run=routine records=11 changes=0 projection=note/...
Kondorosi út Apartment Sale: run=FAILED records=0 changes=0 projection=none
  reason=Bootstrap blocked: vault API rejects commitment record type
... (×10)
```

Reproduced directly against the running tenant:

```
list/commitment -> 400  {"code":"VALIDATION_ERROR","message":"Unknown vault type: commitment..."}
list/task       -> 200
```

Gate:

```
invariant ok: 13 canonical types all listable
✓ lane I (ctrl-api) gate passed — 91 LOC, 2 files, verify ok
```

## Honest limitation on verification

This checkout has **no `packages/ctrl/node_modules`** — no `tsc`, no `tsx` — so the ctrl suite cannot run locally, and agents must not `npm install`. **The new test is CI-verified, not locally verified.**

Rather than let the gate pass vacuously, the lane verify parses both source files and checks the exact invariant the test asserts. That is a real check of this change, but it is not the suite, and I would rather say so than imply coverage I did not run.

## Follow-up

Once merged and deployed, re-run the #484 job and confirm 11 of 11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc