### PR TITLE
feat(learn): approving an hours Desk card actually books the hours (#485)

### DIFF
--- a/packages/learn/src/activities/decision_router.py
+++ b/packages/learn/src/activities/decision_router.py
@@ -73,6 +73,11 @@ from src.activities.state_mutator import (
     propose_fn,
 )
 from src.config import load_config
+from src.matching.hours_approval import (
+    build_acceptance,
+    is_already_accepted,
+    ledger_line,
+)
 
 logger = logging.getLogger("decision-router")
 
@@ -466,6 +471,93 @@ async def _emit_recovery_audit(
 
 
 # ---------------------------------------------------------------------
+# Hours-proposal approval (#485)
+# ---------------------------------------------------------------------
+
+
+async def _accept_hours_proposal_if_any(
+    client: Any,
+    source_record: str,
+    note: str,
+    decision_id: str,
+) -> dict[str, Any] | None:
+    """Book an approved hours period, when the Desk card is an hours approval.
+
+    Returns None for every other card — the overwhelmingly common case — so
+    this is a cheap no-op on the normal `done` path.
+
+    ORDERING IS LOAD-BEARING: the ledger is appended BEFORE the proposal is
+    marked accepted. The reverse order loses hours on a partial failure — a
+    proposal marked accepted with nothing in the ledger means those hours
+    vanish AND the next window silently skips the period, because the accepted
+    ledger is the cursor. This order at worst leaves a re-runnable duplicate,
+    which `is_already_accepted` catches.
+    """
+    card = await client.get(f"/api/v1/vault/records/{source_record}")
+    if card.status_code >= 400:
+        return None
+    card_fm = (card.json() or {}).get("frontmatter") or {}
+    if str(card_fm.get("approval_kind") or "") != "hours_proposal":
+        return None
+
+    proposal_ref = str(card_fm.get("proposal_ref") or "")
+    ledger_ref = str(card_fm.get("ledger_ref") or "")
+    if not proposal_ref or not ledger_ref:
+        logger.warning(
+            "decision_router: hours card %s lacks proposal_ref/ledger_ref — "
+            "nothing booked",
+            source_record,
+        )
+        return None
+
+    pr = await client.get(f"/api/v1/vault/records/{proposal_ref}")
+    pr.raise_for_status()
+    proposal = (pr.json() or {}).get("frontmatter") or {}
+
+    if is_already_accepted(proposal):
+        logger.info(
+            "decision_router: hours proposal %s already accepted — "
+            "not appending twice",
+            proposal_ref,
+        )
+        return {"proposal": proposal_ref, "skipped": "already_accepted"}
+
+    fields = build_acceptance(proposal, note, decision_id, _now_iso())
+    accepted_hours = fields.get("accepted_total_hours")
+
+    # 1. Ledger first. See the ordering note above.
+    lr = await client.patch(
+        f"/api/v1/vault/records/{ledger_ref}",
+        json={"body_append": "\n" + ledger_line(proposal, accepted_hours) + "\n"},
+    )
+    lr.raise_for_status()
+
+    # 2. Only now mark the proposal accepted.
+    ar = await client.patch(
+        f"/api/v1/vault/records/{proposal_ref}", json={"set": fields}
+    )
+    ar.raise_for_status()
+
+    # 3. Read back — a 200 on this route can be a silent no-op when the body
+    #    shape is wrong (CLAUDE.md §15.1), so the write is not proof.
+    check = await client.get(f"/api/v1/vault/records/{proposal_ref}")
+    check_fm = (check.json() or {}).get("frontmatter") or {}
+    if not is_already_accepted(check_fm):
+        raise RuntimeError(
+            f"hours proposal {proposal_ref} did not read back as accepted; "
+            "ledger row was appended — re-run will be blocked by the "
+            "idempotency guard, so reconcile by hand"
+        )
+
+    return {
+        "proposal": proposal_ref,
+        "ledger": ledger_ref,
+        "hours": accepted_hours,
+        "corrected": "correction_delta_hours" in fields,
+    }
+
+
+# ---------------------------------------------------------------------
 # Forward routing (state=open → executing | completed)
 # ---------------------------------------------------------------------
 
@@ -629,6 +721,24 @@ async def route_decision(decision: dict[str, Any]) -> dict[str, Any]:
                             "done decision=%s: %s — NA flip stands",
                             task_ref, decision_id, exc,
                         )
+
+                # #485 — an hours-proposal card is an approval, and approving
+                # it must actually book the hours. Without this the card is
+                # decorative, and worse than decorative: it looks like
+                # approval happened while the ledger stays empty.
+                try:
+                    booked = await _accept_hours_proposal_if_any(
+                        client, source_record, note, decision_id
+                    )
+                    if booked:
+                        actions_taken.append("hours.accepted")
+                        side_effects["hours_accepted"] = booked
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "decision_router: hours acceptance failed for %s on "
+                        "decision=%s: %s — NA flip stands, proposal left open",
+                        source_record, decision_id, exc,
+                    )
             elif intent == "defer":
                 # #5: resolve the resurface intent FIRST, independent of (and
                 # before) the skip flip. The hourly DeferResurfaceWorkflow only

--- a/packages/learn/src/matching/hours_approval.py
+++ b/packages/learn/src/matching/hours_approval.py
@@ -1,0 +1,119 @@
+"""Pure logic for approving an hours proposal from a Desk card (#485).
+
+Kept separate from `decision_router` and free of HTTP so it can be tested
+against real inputs rather than a mock. The migration script in #471 failed on
+a live tenant precisely because its logic sat behind an unmocked call and its
+tests only exercised helpers — the shape it assumed was never checked.
+
+Two rules from #468 that this module exists to protect:
+
+1. **Nothing is booked that Sir did not approve.** A note that cannot be parsed
+   as a figure is a comment, never a number. Guessing at hours from prose would
+   write a wrong total into the ledger under the appearance of his approval,
+   which is worse than recording no correction at all.
+
+2. **A correction records both figures.** The delta between the estimate and
+   Sir's real number is the only feedback signal the estimator ever gets.
+   Storing only the corrected value looks equivalent and quietly removes the
+   feature's ability to improve.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+#: A correction is a bare number, optionally followed by an `h`/`hr`/`hours`
+#: unit, at the very start of the note. Anchored deliberately: "6" and
+#: "6.5 h — Tuesday ran short" are corrections; "looks about right, maybe
+#: check Tuesday" is not, and neither is "approved, see thread 6".
+_CORRECTION = re.compile(
+    r"^\s*(\d{1,3}(?:[.,]\d{1,2})?)\s*(?:h|hr|hrs|hours)?\b",
+    re.IGNORECASE,
+)
+
+#: Above this, a "correction" is far more likely a typo or a misparse than a
+#: real weekly figure. A week has 168 hours; nobody bills them.
+MAX_PLAUSIBLE_PERIOD_HOURS = 168.0
+
+
+def parse_corrected_hours(note: str) -> float | None:
+    """Return Sir's corrected total, or None when the note is just a comment.
+
+    Returns None rather than raising: an unparseable note is the normal case,
+    not an error. The caller books the original estimate unchanged.
+    """
+    if not note or not note.strip():
+        return None
+    m = _CORRECTION.match(note)
+    if not m:
+        return None
+    try:
+        value = float(m.group(1).replace(",", "."))
+    except ValueError:  # pragma: no cover — regex guarantees a number
+        return None
+    if value < 0 or value > MAX_PLAUSIBLE_PERIOD_HOURS:
+        return None
+    return value
+
+
+def build_acceptance(
+    proposal: dict[str, Any],
+    note: str,
+    decision_id: str,
+    now_iso: str,
+) -> dict[str, Any]:
+    """Build the frontmatter patch that marks a proposal accepted.
+
+    When Sir corrected the figure, BOTH his number and the original estimate
+    are recorded, plus the delta. See rule 2 in the module docstring.
+    """
+    estimated = proposal.get("total_hours")
+    try:
+        estimated_f = float(estimated) if estimated is not None else None
+    except (TypeError, ValueError):
+        estimated_f = None
+
+    fields: dict[str, Any] = {
+        "status": "accepted",
+        "accepted": True,
+        "accepted_at": now_iso,
+        "accepted_by": "principal",
+        "accepted_via": f"decision/{decision_id}.md",
+    }
+
+    corrected = parse_corrected_hours(note)
+    if corrected is None:
+        fields["accepted_total_hours"] = estimated_f
+        if note.strip():
+            # Preserve the comment even though it changed no number, so the
+            # record shows Sir said something rather than silently approving.
+            fields["acceptance_note"] = note.strip()
+        return fields
+
+    fields["accepted_total_hours"] = corrected
+    fields["estimated_total_hours"] = estimated_f
+    if estimated_f is not None:
+        fields["correction_delta_hours"] = round(corrected - estimated_f, 2)
+    fields["acceptance_note"] = note.strip()
+    return fields
+
+
+def is_already_accepted(proposal: dict[str, Any]) -> bool:
+    """True when this proposal has already been booked.
+
+    Guards the ledger append. A double append is a silently wrong total AND
+    corrupts the next window, because the accepted ledger is the cursor that
+    decides where the next period starts.
+    """
+    if proposal.get("accepted") is True:
+        return True
+    return str(proposal.get("status") or "").lower() == "accepted"
+
+
+def ledger_line(proposal: dict[str, Any], accepted_hours: float | None) -> str:
+    """One append-only ledger row for an accepted period."""
+    start = proposal.get("period_start") or "?"
+    end = proposal.get("period_end") or "?"
+    hours = "?" if accepted_hours is None else f"{accepted_hours:g}"
+    return f"| {start} | {end} | {hours} | accepted |"

--- a/packages/learn/tests/test_hours_approval.py
+++ b/packages/learn/tests/test_hours_approval.py
@@ -1,0 +1,121 @@
+"""#485 — approving an hours proposal from a Desk card.
+
+The two behaviours worth defending, per #468:
+
+1. Nothing is booked that Sir did not approve. An unparseable note is a
+   comment, never a guessed number.
+2. A correction records both figures. The delta is the only feedback signal
+   the estimator gets; storing only the corrected value looks equivalent and
+   silently removes the feature's ability to improve.
+"""
+
+from src.matching.hours_approval import (
+    MAX_PLAUSIBLE_PERIOD_HOURS,
+    build_acceptance,
+    is_already_accepted,
+    ledger_line,
+    parse_corrected_hours,
+)
+
+
+class TestParseCorrectedHours:
+    def test_bare_number(self):
+        assert parse_corrected_hours("6") == 6.0
+
+    def test_decimal_and_unit(self):
+        assert parse_corrected_hours("6.5h") == 6.5
+        assert parse_corrected_hours("6.5 hours") == 6.5
+        assert parse_corrected_hours("7 hrs") == 7.0
+
+    def test_comma_decimal(self):
+        # Sir writes in a locale where the comma is the decimal separator.
+        assert parse_corrected_hours("6,25") == 6.25
+
+    def test_number_then_explanation(self):
+        assert parse_corrected_hours("6.5 — Tuesday ran short") == 6.5
+
+    def test_prose_is_a_comment_not_a_number(self):
+        """The rule that keeps a misparse out of the ledger."""
+        for note in (
+            "looks about right",
+            "approved",
+            "fine, but check Tuesday next time",
+            "see thread 6 for context",
+            "",
+            "   ",
+        ):
+            assert parse_corrected_hours(note) is None, note
+
+    def test_implausible_totals_are_rejected(self):
+        # A week has 168 hours. A bigger "correction" is a typo or a misparse.
+        assert parse_corrected_hours("800") is None
+        assert parse_corrected_hours(str(MAX_PLAUSIBLE_PERIOD_HOURS + 1)) is None
+        assert parse_corrected_hours("168") == 168.0
+
+    def test_a_trailing_number_is_not_a_correction(self):
+        # Anchored at the start on purpose: "issue 6" must not book 6 hours.
+        assert parse_corrected_hours("approved, closes issue 6") is None
+
+
+class TestBuildAcceptance:
+    PROPOSAL = {"total_hours": 8.0, "period_start": "2026-08-01", "period_end": "2026-08-07"}
+
+    def test_plain_approval_books_the_estimate(self):
+        f = build_acceptance(self.PROPOSAL, "", "abc123", "2026-08-07T18:00:00+02:00")
+        assert f["accepted"] is True
+        assert f["accepted_total_hours"] == 8.0
+        assert "correction_delta_hours" not in f
+
+    def test_correction_records_both_figures_and_the_delta(self):
+        """The feedback signal. Without this the estimator never improves."""
+        f = build_acceptance(self.PROPOSAL, "6", "abc123", "2026-08-07T18:00:00+02:00")
+        assert f["accepted_total_hours"] == 6.0
+        assert f["estimated_total_hours"] == 8.0
+        assert f["correction_delta_hours"] == -2.0
+
+    def test_comment_without_a_number_preserves_the_comment(self):
+        f = build_acceptance(
+            self.PROPOSAL, "fine but tighten Tuesday", "abc", "2026-08-07T18:00:00+02:00"
+        )
+        assert f["accepted_total_hours"] == 8.0
+        assert f["acceptance_note"] == "fine but tighten Tuesday"
+        assert "correction_delta_hours" not in f
+
+    def test_records_which_decision_booked_it(self):
+        f = build_acceptance(self.PROPOSAL, "", "d-99", "2026-08-07T18:00:00+02:00")
+        assert f["accepted_via"] == "decision/d-99.md"
+
+    def test_missing_estimate_does_not_crash_or_invent_a_delta(self):
+        f = build_acceptance({"period_start": "a", "period_end": "b"}, "6", "x", "t")
+        assert f["accepted_total_hours"] == 6.0
+        assert "correction_delta_hours" not in f
+
+
+class TestIdempotency:
+    def test_accepted_flag_blocks_a_second_append(self):
+        assert is_already_accepted({"accepted": True}) is True
+
+    def test_status_blocks_a_second_append(self):
+        assert is_already_accepted({"status": "accepted"}) is True
+
+    def test_open_proposal_is_appendable(self):
+        assert is_already_accepted({"accepted": False, "status": "proposed"}) is False
+
+    def test_double_append_would_corrupt_the_next_window(self):
+        # Not just a wrong total: the accepted ledger is the cursor that
+        # decides where the next period starts.
+        p = {"accepted": False}
+        assert is_already_accepted(p) is False
+        p.update(build_acceptance(p, "", "d1", "t"))
+        assert is_already_accepted(p) is True
+
+
+class TestLedgerLine:
+    def test_row_shape(self):
+        line = ledger_line(
+            {"period_start": "2026-08-01", "period_end": "2026-08-07"}, 6.5
+        )
+        assert line == "| 2026-08-01 | 2026-08-07 | 6.5 | accepted |"
+
+    def test_whole_numbers_do_not_render_a_trailing_zero(self):
+        assert "| 8 |" in ledger_line({"period_start": "a", "period_end": "b"}, 8.0)

--- a/packages/learn/tests/test_hours_approval_router.py
+++ b/packages/learn/tests/test_hours_approval_router.py
@@ -1,0 +1,165 @@
+"""#485 — the router wiring, not just the pure logic.
+
+WHY THIS FILE EXISTS SEPARATELY. `test_hours_approval.py` covers the pure
+module and proves nothing about whether the router calls it correctly, in the
+right order, against the real response shape. That gap is exactly how the #471
+migration shipped broken: its helpers were tested, its read path was not.
+
+The fake client below mirrors ctrl-api's actual response shape —
+`{path, frontmatter, body}` — because assuming a `content` key is the specific
+mistake that cost a live run today.
+"""
+
+import asyncio
+
+import pytest
+
+from src.activities.decision_router import _accept_hours_proposal_if_any
+
+CARD = "needs_attention/2026-08-07T18-00-00Z-abc.md"
+PROPOSAL = "note/acme-timesheet-proposal-2026-08-07.md"
+LEDGER = "note/acme-timesheet.md"
+
+
+class FakeResp:
+    def __init__(self, payload, status=200):
+        self._p, self.status_code = payload, status
+
+    def json(self):
+        return self._p
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class FakeClient:
+    """Records the order of writes — the property that matters most here."""
+
+    def __init__(self, card_fm, proposal_fm, ledger_fails=False):
+        self.card_fm = card_fm
+        self.proposal_fm = dict(proposal_fm)
+        self.ledger_fails = ledger_fails
+        self.writes: list[str] = []
+
+    async def get(self, path):
+        rel = path.replace("/api/v1/vault/records/", "")
+        if rel == CARD:
+            return FakeResp({"path": rel, "frontmatter": self.card_fm, "body": ""})
+        if rel == PROPOSAL:
+            return FakeResp({"path": rel, "frontmatter": self.proposal_fm, "body": ""})
+        return FakeResp({}, 404)
+
+    async def patch(self, path, json=None):
+        rel = path.replace("/api/v1/vault/records/", "")
+        if rel == LEDGER:
+            if self.ledger_fails:
+                return FakeResp({}, 500)
+            self.writes.append("ledger")
+            return FakeResp({"ok": True})
+        if rel == PROPOSAL:
+            self.writes.append("proposal")
+            self.proposal_fm.update((json or {}).get("set") or {})
+            return FakeResp({"ok": True})
+        return FakeResp({}, 404)
+
+
+HOURS_CARD = {
+    "approval_kind": "hours_proposal",
+    "proposal_ref": PROPOSAL,
+    "ledger_ref": LEDGER,
+}
+OPEN_PROPOSAL = {
+    "accepted": False,
+    "status": "proposed",
+    "total_hours": 8.0,
+    "period_start": "2026-08-01",
+    "period_end": "2026-08-07",
+}
+
+
+def run(c, note=""):
+    return asyncio.run(_accept_hours_proposal_if_any(c, CARD, note, "dec-1"))
+
+
+class TestNoOpPaths:
+    def test_ordinary_card_is_untouched(self):
+        """The common case. Every non-hours `done` click must be unaffected."""
+        c = FakeClient({"action_what": "reply to the plumber"}, OPEN_PROPOSAL)
+        assert run(c) is None
+        assert c.writes == []
+
+    def test_card_missing_refs_books_nothing(self):
+        c = FakeClient({"approval_kind": "hours_proposal"}, OPEN_PROPOSAL)
+        assert run(c) is None
+        assert c.writes == []
+
+
+class TestOrdering:
+    def test_ledger_is_written_before_the_proposal_is_marked_accepted(self):
+        """The ordering rule, asserted rather than commented.
+
+        Reversed, a partial failure marks the proposal accepted with nothing
+        in the ledger — the hours vanish AND the next window skips the period,
+        because the accepted ledger is the cursor.
+        """
+        c = FakeClient(HOURS_CARD, OPEN_PROPOSAL)
+        run(c)
+        assert c.writes == ["ledger", "proposal"]
+
+    def test_a_failed_ledger_write_leaves_the_proposal_open(self):
+        c = FakeClient(HOURS_CARD, OPEN_PROPOSAL, ledger_fails=True)
+        with pytest.raises(Exception):
+            run(c)
+        assert "proposal" not in c.writes
+        assert c.proposal_fm["accepted"] is False
+
+
+class TestBooking:
+    def test_plain_approval_books_the_estimate(self):
+        c = FakeClient(HOURS_CARD, OPEN_PROPOSAL)
+        out = run(c)
+        assert out["hours"] == 8.0 and out["corrected"] is False
+        assert c.proposal_fm["accepted"] is True
+
+    def test_correction_books_the_corrected_figure(self):
+        c = FakeClient(HOURS_CARD, OPEN_PROPOSAL)
+        out = run(c, note="6")
+        assert out["hours"] == 6.0 and out["corrected"] is True
+        assert c.proposal_fm["estimated_total_hours"] == 8.0
+        assert c.proposal_fm["correction_delta_hours"] == -2.0
+
+    def test_prose_note_books_the_estimate_and_guesses_nothing(self):
+        c = FakeClient(HOURS_CARD, OPEN_PROPOSAL)
+        out = run(c, note="approved, closes issue 6")
+        assert out["hours"] == 8.0
+        assert "correction_delta_hours" not in c.proposal_fm
+
+
+class TestIdempotency:
+    def test_second_approval_does_not_append_again(self):
+        already = dict(OPEN_PROPOSAL, accepted=True, status="accepted")
+        c = FakeClient(HOURS_CARD, already)
+        out = run(c)
+        assert out["skipped"] == "already_accepted"
+        assert c.writes == []
+
+
+class TestReadBack:
+    def test_a_silent_no_op_patch_is_caught(self):
+        """CLAUDE.md 15.1 — this PATCH route can 200 while writing nothing.
+
+        The ledger row is already appended at that point, so failing loudly is
+        the only way the discrepancy gets noticed.
+        """
+
+        class NoOpPatch(FakeClient):
+            async def patch(self, path, json=None):
+                rel = path.replace("/api/v1/vault/records/", "")
+                if rel == LEDGER:
+                    self.writes.append("ledger")
+                return FakeResp({"ok": True})  # 200, wrote nothing
+
+        c = NoOpPatch(HOURS_CARD, OPEN_PROPOSAL)
+        with pytest.raises(RuntimeError, match="did not read back as accepted"):
+            run(c)


### PR DESCRIPTION
The Lane II half of #485 — the part that makes the click mean something. The skill-side card write follows in a Lane V PR.

## Two findings that made this thinner than the issue assumed

**The correction path already existed.** I'd flagged "let Sir correct the number" as the hard part needing new Desk UI. It doesn't: a `note` already flows `DeskPage.tsx:608` → `POST /decisions` → the decision record → `route_decision`. So correcting is "approve, and type `6`". No new UI, no new intent.

That matters because the correction path is what makes the card worth having. If correcting is awkward and approving is one click, everyone approves — and the feature then books wrong hours *and* never improves, since the delta is its only feedback signal.

**The card lifecycle was already wired.** The `done` branch already closes a linked `task_ref`, so "closing a card also acts on what the card was about" is an established pattern here, not a new one.

## Write ordering is load-bearing

**Ledger first, then mark the proposal accepted.**

Reversed, a partial failure marks a proposal accepted with nothing in the ledger: the hours vanish, *and* the next window silently skips the period, because the accepted ledger is the cursor deciding where the next period starts. One failure corrupts two periods.

This order at worst leaves a re-runnable duplicate, which the idempotency guard catches. The test asserts the order as an ordered list of writes — a comment cannot fail.

## Never guess a number

`parse_corrected_hours` is anchored at the start of the note. `6` and `6.5 h — Tuesday ran short` are corrections; **`approved, closes issue 6` is not**. Totals above 168 are rejected as typos. A misparse writes wrong hours under the appearance of Sir's approval, which is worse than recording no correction.

## Tested at the seam, not just the helpers

Two files, deliberately:

- `test_hours_approval.py` — 18 tests over the pure module.
- `test_hours_approval_router.py` — 9 tests over the wiring, with a fake client mirroring ctrl-api's **real** `{path, frontmatter, body}` shape.

The second exists because of what happened this morning: the #471 migration's helpers were tested, its read path was not, and it failed all 64 records on first contact with the live API. Pure-helper coverage proves nothing about the seam. One of the new tests specifically catches a `200`-but-wrote-nothing PATCH, which CLAUDE.md §15.1 warns this route can do.

## Smoke evidence

```
✓ lane II (learn) gate passed — 119 LOC, 1 files, verify ok   (module)
✓ lane II (learn) gate passed — 121 LOC, 1 files, verify ok   (module tests)
✓ lane II (learn) gate passed — 110 LOC, 1 files, verify ok   (router wiring)
✓ lane II (learn) gate passed — 165 LOC, 1 files, verify ok   (router tests)

2608 passed, 101 skipped
```

Four commits because lane II caps at 200 LOC each; 515 total, inside CI's 600.

## Not in this PR

The skill writing the card (Lane V), and the shared surface with #459. On the latter I'd keep a common card shape and `approval_kind` discriminator but separate handlers — one appends a ledger, one writes a tier, and forcing two unlike consequences through one path buys nothing.

## Still to verify on home

End-to-end: card → click → ledger row + accepted proposal, and a decline leaving the ledger byte-identical. Evidence goes to #485 rather than being asserted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc