### PR TITLE
fix(ctrl): main is red — extract the vault type tables so the test can load (#486 follow-up)

### DIFF
--- a/packages/ctrl/src/api/routes/vault.ts
+++ b/packages/ctrl/src/api/routes/vault.ts
@@ -153,103 +153,12 @@ const VAULT_INDEX_TTL_MS = 60_000;
 const VAULT_INDEX_CACHE_KEY = "_self";
 const _vaultIndexCache = new Map<string, { at: number; body: unknown }>();
 
-export const KNOWN_TYPES = [
-  "person", "org", "project", "task", "event", "note", "location",
-  "process", "account", "asset", "conversation", "input", "run",
-  "session", "decision", "triage",
-  "assumption", "constraint", "contradiction", "synthesis",
-  "observation", "instinct", "reflection",
-  "matter", "ledger_entry",
-  "chore",
-  // Phase 6 signal-layer record types (RFC #842):
-  //  - signal           : extracted from stream events; carries target +
-  //                       effect + mutation/action proposal.
-  //  - needs_attention  : Phase 6.4 — actions routed to Sir (low confidence
-  //                       OR no matching instinct).
-  //  - stream_event     : Phase 6.6 — unified replacement for event/ +
-  //                       conversation/ once the migration script runs.
-  //  - signal_noise_pattern : ARCH-12 — materialised when the principal
-  //                       clicks Noise on /desk. signal_extract consults
-  //                       these before the LLM call to filter
-  //                       known-noise events at source. Missing this
-  //                       allowlist entry meant both the writer and the
-  //                       loader got 400 from /vault/list and /vault/records.
-  //  - pattern_proposal  : OBS-3 — clustered proposals from the unified
-  //                       observation pool (decisions + signals).
-  //                       PatternDetectionWorkflow (OBS-4) writes
-  //                       status=proposed; the principal accepts on /desk
-  //                       and OBS-5's acceptor materialises an instinct.
-  //                       Distinct from legacy decision_pattern/ which
-  //                       extracts only from decisions.
-  "signal", "needs_attention", "stream_event", "signal_noise_pattern",
-  "pattern_proposal",
-  // State-mutation contract (#889 spec §8.2):
-  //  - briefing : morning + evening composer output. Frontmatter shape
-  //               validated by alfred-learn (validators/briefing.py).
-  //               ctrl-api just allowlists the type; the BriefingWorkflow
-  //               writes through POST /api/v1/vault/records with the
-  //               structured `content` body.
-  "briefing",
-  // Canonical types (db/promotionContract.ts CANONICAL_RECORD_TYPES) that were
-  // missing from this read allowlist, so GET /vault/list/daybook and /place
-  // 400'd valid records:
-  //  - daybook : the principal's day-by-day journal entries.
-  //  - place   : a location/venue record.
-  // (Demoted legacy types above stay until the C11 contract-enforcement pass.)
-  "daybook", "place",
-  //  - commitment : a promise with an accountable party and an evidence
-  //                 handle (#469/#470). Added to CANONICAL_RECORD_TYPES so
-  //                 the WRITE path accepts commitment/, but missing here —
-  //                 so GET /vault/list/commitment 400'd and every register
-  //                 bootstrap failed. Third instance of this exact split;
-  //                 the test in tests/vault-known-types.test.ts now makes a
-  //                 fourth impossible.
-  "commitment",
-];
-
-export const STATUS_BY_TYPE: Record<string, string[]> = {
-  project: ["active", "paused", "completed", "abandoned", "proposed"],
-  task: ["todo", "active", "blocked", "done", "cancelled"],
-  session: ["active", "paused", "finished"],
-  input: ["unprocessed", "processed", "deferred"],
-  person: ["active", "inactive"],
-  org: ["active", "inactive"],
-  location: ["active", "inactive"],
-  note: ["draft", "active", "review", "final"],
-  decision: ["draft", "final", "superseded", "reversed"],
-  process: ["active", "proposed", "design", "deprecated"],
-  run: ["active", "completed", "blocked", "cancelled"],
-  account: ["active", "suspended", "closed", "pending"],
-  asset: ["active", "retired", "maintenance", "disposed"],
-  conversation: ["active", "waiting", "resolved", "closed", "archived"],
-  assumption: ["active", "challenged", "invalidated", "confirmed"],
-  constraint: ["active", "expired", "waived", "superseded"],
-  contradiction: ["unresolved", "resolved", "accepted"],
-  synthesis: ["draft", "active", "superseded"],
-  observation: ["unprocessed", "processed", "invalid"],
-  instinct: ["active", "proposed", "deprecated", "merged"],
-  matter: ["active", "resolved", "abandoned"],
-  ledger_entry: ["active"],
-  chore: ["active", "paused", "completed"],
-  // commitment carries only the coarse four-value vocabulary here. The real
-  // 11-state lifecycle lives in `commitment_state`, because `status` cannot
-  // express `delivered_awaiting_acceptance` and forcing it would assert a
-  // closure that has not happened. Mirrors alfred-vault's STATUS_BY_TYPE.
-  commitment: ["todo", "active", "blocked", "done"],
-  // pattern_proposal lifecycle (OBS-3..OBS-5):
-  //  - proposed  : freshly written by PatternDetectionWorkflow,
-  //                awaiting principal review on /desk
-  //  - adopted   : principal clicked delegate; OBS-5 acceptor wrote
-  //                the instinct (the loop closure step)
-  //  - rejected  : principal clicked delete; the next detection run
-  //                avoids re-proposing this rule
-  //  - deferred  : principal clicked defer; will resurface later
-  //  - superseded: replaced by a refined cluster in a later run
-  // Status verbs match the existing decision_pattern flow so the
-  // DecisionRouterWorkflow's pattern handler can stay uniform across
-  // both legacy and OBS-era proposals.
-  pattern_proposal: ["proposed", "adopted", "rejected", "deferred", "superseded"],
-};
+// KNOWN_TYPES and STATUS_BY_TYPE moved to ../vaultTypes.js so they can be
+// imported without pulling in this route module, which participates in an
+// import cycle with routes/admin.ts. Re-exported here because callers and
+// the /vault/schema endpoint have always read them from this module.
+import { KNOWN_TYPES, STATUS_BY_TYPE } from "../vaultTypes.js";
+export { KNOWN_TYPES, STATUS_BY_TYPE };
 
 const TYPE_DIRECTORY: Record<string, string> = {
   project: "project",

--- a/packages/ctrl/src/api/vaultTypes.ts
+++ b/packages/ctrl/src/api/vaultTypes.ts
@@ -1,0 +1,112 @@
+// Vault record type tables — data, not route logic.
+//
+// Extracted from `routes/vault.ts` so the read allowlist can be imported
+// without importing the route module. `routes/vault.ts` participates in an
+// import cycle with `routes/admin.ts` (which evaluates `${VAULT_PATH}/chore`
+// at module top level), so importing it outside the app's entry order throws
+// `ReferenceError: Cannot access 'VAULT_PATH' before initialization`.
+//
+// That is what broke `tests/vault-known-types.test.ts` in CI: the test needs
+// these tables, importing the route module to reach them was not viable, and
+// the tables never belonged to the route in the first place.
+//
+// This module must stay import-free. Adding an import risks re-entering the
+// cycle and reintroducing exactly the failure it exists to avoid.
+
+export const KNOWN_TYPES = [
+  "person", "org", "project", "task", "event", "note", "location",
+  "process", "account", "asset", "conversation", "input", "run",
+  "session", "decision", "triage",
+  "assumption", "constraint", "contradiction", "synthesis",
+  "observation", "instinct", "reflection",
+  "matter", "ledger_entry",
+  "chore",
+  // Phase 6 signal-layer record types (RFC #842):
+  //  - signal           : extracted from stream events; carries target +
+  //                       effect + mutation/action proposal.
+  //  - needs_attention  : Phase 6.4 — actions routed to Sir (low confidence
+  //                       OR no matching instinct).
+  //  - stream_event     : Phase 6.6 — unified replacement for event/ +
+  //                       conversation/ once the migration script runs.
+  //  - signal_noise_pattern : ARCH-12 — materialised when the principal
+  //                       clicks Noise on /desk. signal_extract consults
+  //                       these before the LLM call to filter
+  //                       known-noise events at source. Missing this
+  //                       allowlist entry meant both the writer and the
+  //                       loader got 400 from /vault/list and /vault/records.
+  //  - pattern_proposal  : OBS-3 — clustered proposals from the unified
+  //                       observation pool (decisions + signals).
+  //                       PatternDetectionWorkflow (OBS-4) writes
+  //                       status=proposed; the principal accepts on /desk
+  //                       and OBS-5's acceptor materialises an instinct.
+  //                       Distinct from legacy decision_pattern/ which
+  //                       extracts only from decisions.
+  "signal", "needs_attention", "stream_event", "signal_noise_pattern",
+  "pattern_proposal",
+  // State-mutation contract (#889 spec §8.2):
+  //  - briefing : morning + evening composer output. Frontmatter shape
+  //               validated by alfred-learn (validators/briefing.py).
+  //               ctrl-api just allowlists the type; the BriefingWorkflow
+  //               writes through POST /api/v1/vault/records with the
+  //               structured `content` body.
+  "briefing",
+  // Canonical types (db/promotionContract.ts CANONICAL_RECORD_TYPES) that were
+  // missing from this read allowlist, so GET /vault/list/daybook and /place
+  // 400'd valid records:
+  //  - daybook : the principal's day-by-day journal entries.
+  //  - place   : a location/venue record.
+  // (Demoted legacy types above stay until the C11 contract-enforcement pass.)
+  "daybook", "place",
+  //  - commitment : a promise with an accountable party and an evidence
+  //                 handle (#469/#470). Added to CANONICAL_RECORD_TYPES so
+  //                 the WRITE path accepts commitment/, but missing here —
+  //                 so GET /vault/list/commitment 400'd and every register
+  //                 bootstrap failed. Third instance of this exact split;
+  //                 the test in tests/vault-known-types.test.ts now makes a
+  //                 fourth impossible.
+  "commitment",
+];
+
+export const STATUS_BY_TYPE: Record<string, string[]> = {
+  project: ["active", "paused", "completed", "abandoned", "proposed"],
+  task: ["todo", "active", "blocked", "done", "cancelled"],
+  session: ["active", "paused", "finished"],
+  input: ["unprocessed", "processed", "deferred"],
+  person: ["active", "inactive"],
+  org: ["active", "inactive"],
+  location: ["active", "inactive"],
+  note: ["draft", "active", "review", "final"],
+  decision: ["draft", "final", "superseded", "reversed"],
+  process: ["active", "proposed", "design", "deprecated"],
+  run: ["active", "completed", "blocked", "cancelled"],
+  account: ["active", "suspended", "closed", "pending"],
+  asset: ["active", "retired", "maintenance", "disposed"],
+  conversation: ["active", "waiting", "resolved", "closed", "archived"],
+  assumption: ["active", "challenged", "invalidated", "confirmed"],
+  constraint: ["active", "expired", "waived", "superseded"],
+  contradiction: ["unresolved", "resolved", "accepted"],
+  synthesis: ["draft", "active", "superseded"],
+  observation: ["unprocessed", "processed", "invalid"],
+  instinct: ["active", "proposed", "deprecated", "merged"],
+  matter: ["active", "resolved", "abandoned"],
+  ledger_entry: ["active"],
+  chore: ["active", "paused", "completed"],
+  // commitment carries only the coarse four-value vocabulary here. The real
+  // 11-state lifecycle lives in `commitment_state`, because `status` cannot
+  // express `delivered_awaiting_acceptance` and forcing it would assert a
+  // closure that has not happened. Mirrors alfred-vault's STATUS_BY_TYPE.
+  commitment: ["todo", "active", "blocked", "done"],
+  // pattern_proposal lifecycle (OBS-3..OBS-5):
+  //  - proposed  : freshly written by PatternDetectionWorkflow,
+  //                awaiting principal review on /desk
+  //  - adopted   : principal clicked delegate; OBS-5 acceptor wrote
+  //                the instinct (the loop closure step)
+  //  - rejected  : principal clicked delete; the next detection run
+  //                avoids re-proposing this rule
+  //  - deferred  : principal clicked defer; will resurface later
+  //  - superseded: replaced by a refined cluster in a later run
+  // Status verbs match the existing decision_pattern flow so the
+  // DecisionRouterWorkflow's pattern handler can stay uniform across
+  // both legacy and OBS-era proposals.
+  pattern_proposal: ["proposed", "adopted", "rejected", "deferred", "superseded"],
+};

--- a/packages/ctrl/tests/vault-known-types.test.ts
+++ b/packages/ctrl/tests/vault-known-types.test.ts
@@ -18,12 +18,18 @@
 // Each time it was found in production rather than in CI, because no test
 // compared the two lists. This one does, so a fourth occurrence fails here
 // instead of on a live tenant.
+//
+// It imports the tables from `api/vaultTypes.ts`, not from the route module.
+// The first version imported `routes/vault.js` and died at load with
+// `ReferenceError: Cannot access 'VAULT_PATH' before initialization` — that
+// module is in an import cycle with `routes/admin.ts` and is only safely
+// loadable through the app's entry order.
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
 import { CANONICAL_RECORD_TYPES } from "../src/db/promotionContract.js";
-import { KNOWN_TYPES, STATUS_BY_TYPE } from "../src/api/routes/vault.js";
+import { KNOWN_TYPES, STATUS_BY_TYPE } from "../src/api/vaultTypes.js";
 
 test("every canonical record type is listable", () => {
   const listable = new Set(KNOWN_TYPES as readonly string[]);


### PR DESCRIPTION
**main is currently red.** The test I added in #486 fails at load:

```
ReferenceError: Cannot access 'VAULT_PATH' before initialization
```

## What I got wrong

The test imported `routes/vault.js` to reach `KNOWN_TYPES`. That module is in an import cycle with `routes/admin.ts`, which evaluates `` `${VAULT_PATH}/chore` `` at module top level — so it only loads safely through the app's entry order, never standalone from a test.

I could not catch this locally: this checkout has **no `packages/ctrl/node_modules`**, so the ctrl suite does not run here. I flagged exactly that limitation in #486's body, and CI proved the point one merge later.

Worth being clear about what that means: I shipped a test I had never executed. The disclosure was honest but it wasn't a substitute for running it, and this is the second time today that testing-against-something-other-than-the-real-thing has cost a cycle.

## Fix

`KNOWN_TYPES` and `STATUS_BY_TYPE` move to `src/api/vaultTypes.ts` — a module with **no imports at all**. `routes/vault.ts` imports and re-exports them, so every existing caller and `/vault/schema` are unchanged.

This is where they belonged regardless. They are data, not route logic, and their being private to a route module is part of why nothing ever compared them against the promotion contract — the omission that let `daybook`, `place` and `commitment` each ship writable-but-not-listable.

The lane verify now also asserts `vaultTypes.ts` stays import-free. Adding an import would risk re-entering the cycle and reintroducing precisely this failure.

## Smoke evidence

```
ok: 13 canonical types listable, vaultTypes import-free, vault.ts re-exports intact
✓ lane I (ctrl-api) gate passed — 112 LOC, 1 files, verify ok
✓ lane I (ctrl-api) gate passed — 111 LOC, 2 files, verify ok
```

Two commits to stay under the 200-LOC cap without raising it — the new module is inert until the second commit points at it.

**The suite is still CI-verified, not locally verified**, for the same reason as before. The one thing I can now assert with confidence is that both of the test's imports are cycle-free: `vaultTypes.ts` imports nothing, and `promotionContract.ts` imports only `api/errors.js`, which the existing promotion-contract test already loads successfully in CI.

Please merge promptly — main stays red until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc