### PR TITLE
fix(hermes): slugify derived paths; hours proposals write a Desk card (#489, #485)

### DIFF
--- a/packages/hermes/workspace-template/skills/alfred-commitment-register/SKILL.md
+++ b/packages/hermes/workspace-template/skills/alfred-commitment-register/SKILL.md
@@ -35,6 +35,29 @@ Everything else is derived:
 | sources | whatever the tenant actually has connected |
 | projection | `note/<matter-slug>-commitment-register.md` |
 | policy note | `note/<matter-slug>-commitment-management.md` |
+
+**`<matter-slug>` means the slug, never the display name.** Derive it once and
+reuse it for every path and for the ID prefix:
+
+> lowercase → strip diacritics → replace every run of non-alphanumeric
+> characters with a single `-` → trim leading and trailing `-`
+
+So a matter named `Hungarian Company & Admin Compliance` yields
+`hungarian-company-admin-compliance`, and its projection is
+`note/hungarian-company-admin-compliance-commitment-register.md` — never
+`note/Hungarian Company & Admin Compliance commitment register.md`.
+
+This is not cosmetic. A derived path is only useful if it is *predictable*:
+anything that later resolves a register by constructing its path — a rollup, a
+digest, the next reconciliation — looks for the slug form. A title-cased
+filename is not lost, but it is unaddressable by the rule meant to find it,
+and a check that trusts the convention will silently report one fewer register
+than exists.
+
+**Verify by constructing the path, not by listing the directory.** After
+writing the projection, read it back at the exact derived path. A read-back
+that locates the file by any other means passes while the derivation is broken
+— which is precisely how this went unnoticed.
 | external actions | always forbidden — not a choice |
 
 Use the object form only to override a derived value that is wrong — a prefix

--- a/packages/hermes/workspace-template/skills/alfred-hours-reconstruction/SKILL.md
+++ b/packages/hermes/workspace-template/skills/alfred-hours-reconstruction/SKILL.md
@@ -122,17 +122,50 @@ Read the note back before delivering anything.
 **The ledger is not touched.** Not on generation, not on a test run, not
 because the reconstruction was thorough.
 
-## Ask for approval
+## Ask for approval — on the Desk
 
-Deliver a concise but itemised request: the period and total; one line per
+A proposal delivered only as a message is a message: easy to miss, easy to
+defer, invisible once scrolled past. Write a Desk card, so the decision sits
+where Sir's other decisions sit.
+
+Create a `needs_attention` record carrying:
+
+```yaml
+approval_kind: hours_proposal
+proposal_ref: note/<matter-slug>-timesheet-proposal-<period-end>.md
+ledger_ref:   note/<matter-slug>-timesheet.md
+action_what:  "Approve <n.nn> h for <matter name> — <period-start> to <period-end>"
+suggested_actor: human
+```
+
+Those three fields are a contract, not decoration. `route_decision` reads
+`approval_kind` to recognise the card, and `proposal_ref` / `ledger_ref` to
+know what to book. **A card missing any of them books nothing** — the click
+will close the card and silently do nothing else.
+
+Then deliver the itemised request as well: the period and total; one line per
 non-zero day; the confidence and coverage caveat; the proposal note's path; and
-an explicit prompt to approve or supply corrected days and hours.
+an explicit prompt to approve or supply a corrected figure.
+
+Tell Sir he can correct the number **in the note when approving** — typing
+`6`, or `6.5 — Tuesday ran short`, books that figure instead of the estimate.
+A note that is only prose (`looks fine`) approves the estimate unchanged; the
+number is never guessed from wording.
 
 Only Sir's explicit approval of the identified period is acceptance. **A
 generated proposal is not approval. Silence is not approval. A successful
 scheduled run is not approval. A reaction or a "thanks" is not approval.**
 
 ## On approval
+
+Approving the Desk card does the booking automatically — `route_decision`
+appends the period to the ledger, then marks the proposal accepted, then reads
+both back. Do **not** perform these writes yourself when the card path was
+used; you would double-append, and the ledger is the cursor for the next
+window, so a duplicate corrupts the following period too.
+
+When approval arrives some other way — Sir replies in chat, or no card was
+written — do it by hand, in this order:
 
 1. Read the exact proposal note. Confirm its period overlaps no other accepted
    or proposed record.


### PR DESCRIPTION
Two skill fixes, both found by running the thing rather than reading it.

## #489 — a derived path must be predictable

The first full bootstrap (11 of 11 matters) wrote ten projections as `<matter-slug>-commitment-register.md` and one as:

```
Hungarian company and admin compliance commitment register.md
```

The display name, not the slug.

**Why it is not cosmetic.** Anything that later resolves a register by *constructing* its path — a rollup view, a digest, the next reconciliation — looks for the slug form. The odd one out isn't lost; it's unaddressable by the rule meant to find it.

It also breaks counting silently. My own verification grepped `commitment-register` and returned **10 of 11**. The gap only surfaced because the run's rollup listed 11 projections and the two numbers disagreed. A check that trusted the filename convention would have reported a clean pass while quietly losing a matter.

The skill now states the slug rule explicitly with a worked example, and requires read-back **at the constructed path**. A read-back that locates the file by any other means passes while the derivation is broken — which is precisely how this survived.

## #485 — the hours proposal becomes a Desk card

Completes the feature whose router half merged in #487.

The skill now writes a `needs_attention` card carrying `approval_kind: hours_proposal`, `proposal_ref` and `ledger_ref`. The skill states plainly that these are a contract the router reads, because **a card missing any of them closes on click and silently books nothing** — which would look exactly like working.

Two behaviours documented for Sir and for the model:

- **Correcting the figure rides on the approval note.** Typing `6` books 6 hours; `looks fine` books the estimate unchanged; a number is never guessed from prose. This matters because the estimate/correction delta is the feature's only feedback signal — if correcting is undiscoverable, everyone approves and the estimator is permanently as good as day one.
- **Do not double-book.** When the card path is used the router performs the writes, so the skill must not repeat them. A duplicate append is not just a wrong total: the ledger is the cursor for the next window, so it corrupts the following period's boundary too.

## Smoke evidence

```
✓ lane V (edges-infra) gate passed — 62 LOC, 2 files, verify ok
```

The #489 defect, as observed on the tenant:

```
$ ls note/ | grep -iE "commitment.register"
  alfred-project-commitment-register.md
  family-life-hannas-first-year-commitment-register.md
  ...
  Hungarian company and admin compliance commitment register.md   <-- the outlier
  --- total: 11   (a `commitment-register` grep finds only 10)
```

## Still to do after this

Rename the one existing offender on the tenant, and verify end-to-end that an hours card actually books a period. Evidence goes to #489 and #485.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc