### PR TITLE
fix(learn): hours acceptance 500'd on an invalid status, and could double-book (#485)

### DIFF
--- a/packages/learn/src/activities/decision_router.py
+++ b/packages/learn/src/activities/decision_router.py
@@ -76,6 +76,7 @@ from src.config import load_config
 from src.matching.hours_approval import (
     build_acceptance,
     is_already_accepted,
+    ledger_already_has_period,
     ledger_line,
 )
 
@@ -525,12 +526,24 @@ async def _accept_hours_proposal_if_any(
     fields = build_acceptance(proposal, note, decision_id, _now_iso())
     accepted_hours = fields.get("accepted_total_hours")
 
-    # 1. Ledger first. See the ordering note above.
-    lr = await client.patch(
-        f"/api/v1/vault/records/{ledger_ref}",
-        json={"body_append": "\n" + ledger_line(proposal, accepted_hours) + "\n"},
-    )
-    lr.raise_for_status()
+    # 1. Ledger first — but ask the LEDGER whether this period is already
+    #    booked. `is_already_accepted` above reads the proposal, which is
+    #    exactly the record that fails to update when step 2 errors, so it
+    #    cannot protect a retry. Only the ledger knows what the ledger holds.
+    lg = await client.get(f"/api/v1/vault/records/{ledger_ref}")
+    lg.raise_for_status()
+    if ledger_already_has_period((lg.json() or {}).get("body") or "", proposal):
+        logger.info(
+            "decision_router: ledger %s already books %s..%s — not appending "
+            "twice; marking the proposal accepted to close the gap",
+            ledger_ref, proposal.get("period_start"), proposal.get("period_end"),
+        )
+    else:
+        lr = await client.patch(
+            f"/api/v1/vault/records/{ledger_ref}",
+            json={"body_append": "\n" + ledger_line(proposal, accepted_hours) + "\n"},
+        )
+        lr.raise_for_status()
 
     # 2. Only now mark the proposal accepted.
     ar = await client.patch(

--- a/packages/learn/src/matching/hours_approval.py
+++ b/packages/learn/src/matching/hours_approval.py
@@ -74,8 +74,19 @@ def build_acceptance(
     except (TypeError, ValueError):
         estimated_f = None
 
+    # NOTE: deliberately does NOT set `status`. A proposal is a `note`, and the
+    # vault validator allows only active|draft|final|review there — a PATCH
+    # setting `status: accepted` returns 500 and the acceptance never lands.
+    #
+    # Found end-to-end on a live tenant, not by these tests: existing proposal
+    # records carry `status: proposed` only because they were written through
+    # the raw-content path, which bypasses validation. A PATCH goes through the
+    # CLI, which does not. Copying the convention from the record was the
+    # mistake.
+    #
+    # `accepted: true` is the marker. `is_already_accepted` still reads the
+    # legacy `status` too, so records written the old way keep working.
     fields: dict[str, Any] = {
-        "status": "accepted",
         "accepted": True,
         "accepted_at": now_iso,
         "accepted_by": "principal",
@@ -117,3 +128,38 @@ def ledger_line(proposal: dict[str, Any], accepted_hours: float | None) -> str:
     end = proposal.get("period_end") or "?"
     hours = "?" if accepted_hours is None else f"{accepted_hours:g}"
     return f"| {start} | {end} | {hours} | accepted |"
+
+
+def ledger_already_has_period(ledger_body: str, proposal: dict[str, Any]) -> bool:
+    """True when this period is already booked in the ledger body.
+
+    THE GUARD THAT ACTUALLY PROTECTS THE LEDGER. `is_already_accepted` reads
+    the proposal, which is useless in the failure mode that matters: if the
+    ledger append succeeds and the proposal patch then fails, the proposal
+    still says `accepted: false`, so a retry sails past that check and appends
+    the period a second time.
+
+    That is not hypothetical — it happened on the first live run, when the
+    proposal patch 500'd on an invalid `status` value while the ledger row had
+    already landed. The claim that the ordering left "a re-runnable duplicate
+    the idempotency check catches" was simply wrong; the check keyed on the one
+    record that had not been written.
+
+    So the ledger is asked about itself. A duplicate row is not merely a wrong
+    total — the accepted ledger is the cursor for the next window, so it also
+    corrupts the following period's boundary.
+    """
+    start = str(proposal.get("period_start") or "").strip()
+    end = str(proposal.get("period_end") or "").strip()
+    if not start or not end:
+        # Cannot prove absence without a period. Refuse rather than risk a
+        # duplicate: an unbooked period is recoverable, a double-booked one
+        # silently mis-states both this window and the next.
+        return True
+    for line in ledger_body.splitlines():
+        if not line.lstrip().startswith("|"):
+            continue
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        if len(cells) >= 2 and cells[0] == start and cells[1] == end:
+            return True
+    return False

--- a/packages/learn/tests/test_hours_approval.py
+++ b/packages/learn/tests/test_hours_approval.py
@@ -13,6 +13,7 @@ from src.matching.hours_approval import (
     MAX_PLAUSIBLE_PERIOD_HOURS,
     build_acceptance,
     is_already_accepted,
+    ledger_already_has_period,
     ledger_line,
     parse_corrected_hours,
 )
@@ -119,3 +120,70 @@ class TestLedgerLine:
 
     def test_whole_numbers_do_not_render_a_trailing_zero(self):
         assert "| 8 |" in ledger_line({"period_start": "a", "period_end": "b"}, 8.0)
+
+
+class TestStatusIsNotWritten:
+    """A proposal is a `note`, and the validator allows only
+    active|draft|final|review there. Writing `status: accepted` 500s the PATCH
+    and the acceptance never lands.
+
+    Found end-to-end on a live tenant, not here: existing proposals carry
+    `status: proposed` only because they were created through the raw-content
+    path, which skips validation. Copying that convention into a PATCH was the
+    mistake."""
+
+    def test_acceptance_does_not_set_status(self):
+        f = build_acceptance({"total_hours": 8.0}, "", "d1", "t")
+        assert "status" not in f
+
+    def test_accepted_flag_is_the_marker(self):
+        f = build_acceptance({"total_hours": 8.0}, "", "d1", "t")
+        assert f["accepted"] is True
+        assert is_already_accepted(f) is True
+
+    def test_legacy_status_records_are_still_recognised(self):
+        # Records written the old way must keep working.
+        assert is_already_accepted({"status": "accepted"}) is True
+
+
+class TestLedgerGuard:
+    """The guard that actually protects the ledger.
+
+    `is_already_accepted` reads the proposal — useless in the failure mode that
+    matters. When the ledger append succeeds and the proposal patch then fails,
+    the proposal still says accepted:false, so a retry sails past that check
+    and books the period twice. This happened on the first live run."""
+
+    LEDGER = (
+        "# Ledger\n\n| Start | End | Hours | Status |\n|---|---|---|---|\n"
+        "| 2026-08-01 | 2026-08-07 | 6 | accepted |\n"
+    )
+    P = {"period_start": "2026-08-01", "period_end": "2026-08-07"}
+
+    def test_detects_a_period_already_booked(self):
+        assert ledger_already_has_period(self.LEDGER, self.P) is True
+
+    def test_a_different_period_is_not_a_duplicate(self):
+        other = {"period_start": "2026-08-08", "period_end": "2026-08-14"}
+        assert ledger_already_has_period(self.LEDGER, other) is False
+
+    def test_empty_ledger_is_appendable(self):
+        assert ledger_already_has_period("# Ledger\n", self.P) is False
+
+    def test_header_row_is_not_mistaken_for_a_booking(self):
+        assert ledger_already_has_period(
+            "| Start | End | Hours | Status |\n|---|---|---|---|\n", self.P
+        ) is False
+
+    def test_the_exact_retry_scenario_from_the_live_run(self):
+        """Ledger appended, proposal patch failed, retry arrives."""
+        proposal_after_failure = dict(self.P, accepted=False, status="proposed")
+        # The old guard would let this through...
+        assert is_already_accepted(proposal_after_failure) is False
+        # ...the ledger guard stops it.
+        assert ledger_already_has_period(self.LEDGER, proposal_after_failure) is True
+
+    def test_a_period_that_cannot_be_identified_is_refused(self):
+        # Cannot prove absence without a period. An unbooked period is
+        # recoverable; a double-booked one mis-states this window and the next.
+        assert ledger_already_has_period(self.LEDGER, {}) is True

--- a/packages/learn/tests/test_hours_approval_router.py
+++ b/packages/learn/tests/test_hours_approval_router.py
@@ -36,10 +36,11 @@ class FakeResp:
 class FakeClient:
     """Records the order of writes — the property that matters most here."""
 
-    def __init__(self, card_fm, proposal_fm, ledger_fails=False):
+    def __init__(self, card_fm, proposal_fm, ledger_fails=False, ledger_body=""):
         self.card_fm = card_fm
         self.proposal_fm = dict(proposal_fm)
         self.ledger_fails = ledger_fails
+        self.ledger_body = ledger_body
         self.writes: list[str] = []
 
     async def get(self, path):
@@ -48,6 +49,8 @@ class FakeClient:
             return FakeResp({"path": rel, "frontmatter": self.card_fm, "body": ""})
         if rel == PROPOSAL:
             return FakeResp({"path": rel, "frontmatter": self.proposal_fm, "body": ""})
+        if rel == LEDGER:
+            return FakeResp({"path": rel, "frontmatter": {}, "body": self.ledger_body})
         return FakeResp({}, 404)
 
     async def patch(self, path, json=None):
@@ -56,6 +59,7 @@ class FakeClient:
             if self.ledger_fails:
                 return FakeResp({}, 500)
             self.writes.append("ledger")
+            self.ledger_body += "\n" + ((json or {}).get("body_append") or "")
             return FakeResp({"ok": True})
         if rel == PROPOSAL:
             self.writes.append("proposal")
@@ -163,3 +167,22 @@ class TestReadBack:
         c = NoOpPatch(HOURS_CARD, OPEN_PROPOSAL)
         with pytest.raises(RuntimeError, match="did not read back as accepted"):
             run(c)
+
+    def test_a_retry_after_a_failed_proposal_patch_does_not_double_book(self):
+        """The live failure, reproduced.
+
+        On the first real run the ledger row landed and the proposal patch
+        500'd (invalid `status` for a note). The proposal therefore still reads
+        accepted:false, so `is_already_accepted` waves the retry through — and
+        the old code would have appended the period a second time.
+
+        A duplicate is not just a wrong total: the accepted ledger is the
+        cursor for the next window, so it corrupts the following period too.
+        """
+        booked = "| 2026-08-01 | 2026-08-07 | 6 | accepted |\n"
+        c = FakeClient(HOURS_CARD, OPEN_PROPOSAL, ledger_body=booked)
+        out = run(c, note="6")
+        assert c.writes == ["proposal"], "must not append the ledger again"
+        assert c.ledger_body.count("2026-08-01 | 2026-08-07") == 1
+        assert c.proposal_fm["accepted"] is True, "and must close the gap"
+        assert out["hours"] == 6.0


### PR DESCRIPTION
Two bugs, both found by the **first end-to-end run on a live tenant**, neither visible to the unit tests. That is the argument for having run it.

## What the live test did

Created a proposal (8.0 h), a ledger, and a Desk card; posted an approval with the note `6`.

Result: the ledger row landed **correctly showing 6, not 8** — so the correction parsing works in production. The proposal stayed `accepted: false`.

## Bug 1 — `status: accepted` is invalid on a note

```
Invalid status 'accepted' for type 'note'. Valid: active, draft, final, review
```

The PATCH 500'd and the acceptance never landed.

I took `status: accepted` from the convention visible on existing proposal records. Those records only carry non-standard statuses because they were created through the **raw-content write path, which bypasses validation** — a PATCH goes through the CLI, which does not.

The lesson generalises: reading a value off a record is not evidence that the value is writable.

`accepted: true` is now the sole marker; `is_already_accepted` still reads the legacy `status` so nothing written the old way breaks.

## Bug 2 — the idempotency guard could not protect the ledger

This one I got wrong in #487's own description:

> at worst leaves a re-runnable duplicate, which the idempotency check catches

**Wrong.** The check reads the *proposal's* accepted flag — precisely the record that fails to update in this failure mode. After a failed patch the proposal still says `accepted: false`, so a retry sails past it and books the period a second time.

And a duplicate is not merely a wrong total: the accepted ledger is the **cursor** for the next window, so it corrupts the following period's boundary too. One failed patch, two wrong periods.

`ledger_already_has_period` now asks the ledger about itself. When the period is already booked the router skips the append and still marks the proposal accepted — closing the split rather than leaving the records disagreeing. A proposal with no identifiable period is refused outright: an unbooked period is recoverable, a double-booked one silently mis-states two windows.

**The write ordering was right and stays.** It is what made this a recoverable split instead of lost hours.

## Tests

Ten new cases. The one that matters reproduces the live failure exactly — ledger row present, proposal still `accepted: false`, retry arriving — and asserts **both** halves: that `is_already_accepted` waves it through (proving the old guard could not have caught it) and that the ledger guard stops it.

The router fake now serves and accumulates a real ledger body. The existing router tests failing when I added the ledger GET was the fake doing its job.

```
✓ lane II (learn) gate passed — 73 LOC, 2 files, verify ok
✓ lane II (learn) gate passed — 93 LOC, 2 files, verify ok
37 tests across the two hours files · 2618 passed, 101 skipped
```

## After merge

Redeploy learn, re-run the same end-to-end fixture, and confirm the proposal reaches `accepted: true` with `correction_delta_hours: -2` while the ledger keeps exactly one row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc

## Smoke evidence

Tested on home.alfred.black at 2026-08-07T16:43Z — this is the live run that **found** both bugs. The confirming re-run happens post-merge (the fix is not deployed yet); it is tracked and will be posted to #485.

```
§1 fixture created via ctrl-api
   note/smoke-hours-proposal.md      201   (total_hours: 8.0, accepted: false)
   note/smoke-hours-ledger.md        201   (empty table)
   needs_attention/smoke-hours-card.md 201 (approval_kind: hours_proposal)

§2 approval posted with a correction
   POST /api/v1/decisions  intent=done  note="6"   -> 201

§3 DecisionRouter picked it up (60s cadence)
   GET   /vault/records/needs_attention/smoke-hours-card.md   200
   GET   /vault/records/note/smoke-hours-proposal.md          200
   PATCH /vault/records/note/smoke-hours-ledger.md            200   <- ledger row landed
   PATCH /vault/records/note/smoke-hours-proposal.md          500   <- BUG 1
   WARNING decision-router: hours acceptance failed ... NA flip stands, proposal left open

§4 the 500, verbatim from ctrl-api
   {"error": "Invalid status 'accepted' for type 'note'.
              Valid: active, draft, final, review"}

§5 resulting state — the recoverable split the ordering was designed for
   ledger:   | 2026-08-01 | 2026-08-07 | 6 | accepted |   <- 6, not 8: correction parsing works live
   proposal: status: proposed / accepted: false           <- BUG 2 exposure: a retry would re-append

§6 deployed module exercised directly on the tenant (pre-fix build)
   parse("6")                        -> 6.0
   parse("approved, closes issue 6") -> None
   build_acceptance delta            -> -2.0
```

Unit + integration after the fix:

```
37 passed across tests/test_hours_approval.py + tests/test_hours_approval_router.py
2618 passed, 101 skipped  (full learn suite)
✓ lane II (learn) gate passed — 73 LOC, 2 files, verify ok
✓ lane II (learn) gate passed — 93 LOC, 2 files, verify ok
```

§5 is the important line: the ledger holds one row and the proposal is still open, which is exactly the state a retry would have double-booked. The re-run after deploy exercises the new guard against that real state rather than a synthetic one.
