### PR TITLE
fix(hermes): the Slack Canvas helper path was broken by my own genericisation (#466)

### DIFF
--- a/packages/hermes/workspace-template/skills/alfred-commitment-register/references/slack-projection.md
+++ b/packages/hermes/workspace-template/skills/alfred-commitment-register/references/slack-projection.md
@@ -38,14 +38,26 @@ If an intended private Canvas is also visible from a forbidden destination:
 
 ## Canvas helper and read-back
 
-Where a tenant has the Slack Canvas helper installed, it uses **positional**
-arguments, not GNU-style flags:
+Where a tenant has the Slack Canvas helper installed, it lives in a **profile's**
+`bin/` directory — not at the top of `$HERMES_HOME`. Locate it before use rather
+than assuming a path:
 
 ```bash
-python3 "$HERMES_HOME/bin/slack_canvas.py" create "<title>" "<markdown>"
-python3 "$HERMES_HOME/bin/slack_canvas.py" channel-create <channel_id> "<markdown>"
-python3 "$HERMES_HOME/bin/slack_canvas.py" read <canvas_id>
-python3 "$HERMES_HOME/bin/slack_canvas.py" list 500
+HELPER=$(ls "$HERMES_HOME"/profiles/*/bin/slack_canvas.py 2>/dev/null | head -1)
+[ -n "$HELPER" ] || echo "no Canvas helper on this tenant — use a vault note"
+```
+
+It is typically under the `main` profile, because that is where the tenant's
+Slack credentials live. A tenant with no helper has no Slack projection
+available; fall back to the vault note rather than failing the reconciliation.
+
+The helper uses **positional** arguments, not GNU-style flags:
+
+```bash
+python3 "$HELPER" create "<title>" "<markdown>"
+python3 "$HELPER" channel-create <channel_id> "<markdown>"
+python3 "$HELPER" read <canvas_id>
+python3 "$HELPER" list 500
 ```
 
 Do not assume a remembered `--channel-id`, `--title`, `--markdown-file`,


### PR DESCRIPTION
The reference told the agent to run `$HERMES_HOME/bin/slack_canvas.py`. The helper actually lives at `$HERMES_HOME/profiles/<profile>/bin/slack_canvas.py`.

## How I broke it

During the #466 port the original read `/hermes-state/profiles/main/bin/`. I replaced the hardcoded prefix with `$HERMES_HOME` to genericise it and dropped the `profiles/main` segment in the same edit. The result looked plausible and was never executed.

## Why it mattered more than it looks

**All five scopes still on wrapper skills project to Slack Canvases, not vault notes.** This would have failed every one of them on first use.

It also means my #466 pilot proved less than I claimed. That scope projects to a *vault note*, so it never exercised the Slack path — the exact path all five remaining migrations depend on. "The pilot proves the shipped skill is equivalent to the wrapper" was true for the case I tested and untested for the case that matters.

Found only because I checked the helper existed before starting the first Slack migration, rather than after the first failure.

## Fix

The reference now **locates** the helper by glob rather than asserting a path, and states that a tenant without one falls back to the vault note rather than failing the reconciliation. A default capability should degrade on a missing optional dependency, not break.

## Smoke evidence

Tested on home.alfred.black at 2026-08-07T16:56Z.

```
§1 path asserted by the shipped reference (pre-fix)
   $HERMES_HOME/bin/slack_canvas.py                    -> does not exist

§2 actual location on the tenant
   ls -la /hermes-state/profiles/main/bin/slack_canvas.py
   -rwxr-xr-x 1 10000 10000 6644 Jun 30 17:32          -> exists
   HERMES_HOME=/hermes-state

§3 glob form introduced by this PR, evaluated on the tenant
   ls "$HERMES_HOME"/profiles/*/bin/slack_canvas.py | head -1
   /hermes-state/profiles/main/bin/slack_canvas.py     -> resolves

§4 projection medium of the five unmigrated scopes (why this blocks them)
   avenir           channel C0BKUK0PB7Z  canvas F0BN1JZ3RLY
   miguel-alfred    canvas  F0BLEQLTL9J
   rj               canvas  F0BLBCU2NN7  channel C0BL80XS77Y
   neoterra         channel C0BLBTQ6TA5
   erste-makerspace slack-configured (9 references)
   -> 5 of 5 project to Slack; 0 project to a vault note
```

Docs-only change to a skill reference; no runtime code path is compiled or tested by CI, so §1–§3 on the live tenant is the meaningful verification.

```
✓ lane V (edges-infra) gate passed — 24 LOC, 1 files, verify ok
```

## Consequence for #483

The remaining migrations need this deployed first. I am doing `rj` as a second pilot — specifically to exercise the Slack path — and will stop and report if it fails rather than repeating it across four more live client registers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc