### PR TITLE
fix(learn): acceptance writes `final`, a status the note validator accepts (#485)

### DIFF
--- a/packages/learn/src/matching/hours_approval.py
+++ b/packages/learn/src/matching/hours_approval.py
@@ -74,19 +74,22 @@ def build_acceptance(
     except (TypeError, ValueError):
         estimated_f = None
 
-    # NOTE: deliberately does NOT set `status`. A proposal is a `note`, and the
-    # vault validator allows only active|draft|final|review there — a PATCH
-    # setting `status: accepted` returns 500 and the acceptance never lands.
+    # A proposal is a `note`, and the validator allows only
+    # active|draft|final|review. `accepted` is not a valid status, so writing
+    # it 500s the PATCH and the acceptance never lands — found end-to-end on a
+    # live tenant, twice.
     #
-    # Found end-to-end on a live tenant, not by these tests: existing proposal
-    # records carry `status: proposed` only because they were written through
-    # the raw-content path, which bypasses validation. A PATCH goes through the
-    # CLI, which does not. Copying the convention from the record was the
-    # mistake.
+    # The valid vocabulary maps cleanly: a proposal is a `draft`, an accepted
+    # period is `final`. `accepted: true` remains the machine marker, and
+    # `is_already_accepted` also reads a legacy `status: accepted` so records
+    # written before this keep working.
     #
-    # `accepted: true` is the marker. `is_already_accepted` still reads the
-    # legacy `status` too, so records written the old way keep working.
+    # The wider lesson, since this cost two live runs: the validator re-checks
+    # the WHOLE record on any edit. An invalid value written through the
+    # raw-content path (which skips validation) is inert until the first PATCH,
+    # then blocks every subsequent write to that record.
     fields: dict[str, Any] = {
+        "status": "final",
         "accepted": True,
         "accepted_at": now_iso,
         "accepted_by": "principal",

--- a/packages/learn/tests/test_hours_approval.py
+++ b/packages/learn/tests/test_hours_approval.py
@@ -124,17 +124,22 @@ class TestLedgerLine:
 
 class TestStatusIsNotWritten:
     """A proposal is a `note`, and the validator allows only
-    active|draft|final|review there. Writing `status: accepted` 500s the PATCH
-    and the acceptance never lands.
+    active|draft|final|review. Writing `accepted` — or leaving a `proposed`
+    already on the record — 500s the PATCH and the acceptance never lands.
 
-    Found end-to-end on a live tenant, not here: existing proposals carry
-    `status: proposed` only because they were created through the raw-content
-    path, which skips validation. Copying that convention into a PATCH was the
-    mistake."""
+    Cost two live runs. The second is the subtler one: the validator re-checks
+    the WHOLE record on any edit, so an invalid value written through the
+    raw-content path (which skips validation) sits inert until the first PATCH
+    and then blocks every subsequent write to that record.
 
-    def test_acceptance_does_not_set_status(self):
+    Hence the skill writes `draft` for a proposal and this writes `final` on
+    acceptance — the valid vocabulary maps cleanly, and `accepted: true`
+    remains the machine marker."""
+
+    def test_acceptance_sets_a_status_the_validator_accepts(self):
         f = build_acceptance({"total_hours": 8.0}, "", "d1", "t")
-        assert "status" not in f
+        assert f["status"] in {"active", "draft", "final", "review"}
+        assert f["status"] == "final"
 
     def test_accepted_flag_is_the_marker(self):
         f = build_acceptance({"total_hours": 8.0}, "", "d1", "t")


### PR DESCRIPTION
Third attempt at the same seam, and the one that explains the previous two.

## What happened

Second live run, after removing `status: accepted`: the PATCH **still** 500'd — now on `Invalid status 'proposed'`.

Removing the invalid value I was *writing* did not help, because **the validator re-checks the whole record on any edit**, and the proposal already carried `status: proposed` from creation.

That value was accepted at creation only because the raw-content write path skips validation. So an invalid value written that way is **inert until the first PATCH, then blocks every subsequent write to that record** — including its own acceptance.

The generalisable bit: a record existing with a value is not evidence the value is legal. Creation succeeding is not evidence the record is writable.

## Fix

The valid note vocabulary is `active|draft|final|review`, which maps cleanly onto what these records mean: a proposal is a **draft**, an accepted period is **final**.

- This PR: acceptance writes `status: final`.
- Companion Lane V change: the skill writes `status: draft` at creation, so the record is PATCHable from the start rather than poisoned at birth.
- `accepted: true/false` remains the machine marker; `is_already_accepted` still reads a legacy `status: accepted`.

## Smoke evidence

Tested on home.alfred.black at 2026-08-07T17:52Z — the run that found this.

```
§1 deployed build confirmed to contain the previous fix
   grep -c ledger_already_has_period decision_router.py   -> 2

§2 retry approval posted against the existing card
   POST /api/v1/decisions  intent=done  note="6"          -> 201

§3 THE LEDGER GUARD WORKS — this is the fix from #492, verified live
   ledger rows before: 1
   ledger rows after : 1     <- no double-append
   | 2026-08-01 | 2026-08-07 | 6 | accepted |
   (the previous code would have appended a second identical row here,
    corrupting both this total and the next window's boundary)

§4 remaining failure, which this PR fixes
   PATCH /vault/records/note/smoke-hours-proposal.md      -> 500
   {"error": "Invalid status 'proposed' for type 'note'.
              Valid: active, draft, final, review"}
   proposal: status: proposed / accepted: false  (unchanged, correctly)

§5 unit + integration after this fix
   37 passed across tests/test_hours_approval.py + tests/test_hours_approval_router.py
   2618 passed, 101 skipped  (full learn suite)
   ✓ lane II (learn) gate passed — 44 LOC, 2 files, verify ok
```

**§3 is the good news.** The ledger guard shipped in #492 did exactly its job against a real duplicate-risk state, not a synthetic one. The write ordering plus that guard means three failed attempts have produced zero data damage: one ledger row, correct at 6 hours, and a proposal correctly still open.

## After merge

Redeploy learn, fix the fixture's `status` to `draft` (it was created with the invalid value), re-run, and confirm the proposal reaches `accepted: true` with `correction_delta_hours: -2` and the ledger still at one row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc