### PR TITLE
fix(hermes): proposals are written as `draft`, not `proposed` (#485)

### DIFF
--- a/packages/hermes/workspace-template/skills/alfred-hours-reconstruction/SKILL.md
+++ b/packages/hermes/workspace-template/skills/alfred-hours-reconstruction/SKILL.md
@@ -96,7 +96,7 @@ Search first, so one period has exactly one proposal. Write
 `note/<matter-slug>-timesheet-proposal-<period-end>.md` with:
 
 ```yaml
-status: proposed
+status: draft
 accepted: false
 period_start: <date>
 period_end: <date>
@@ -106,6 +106,13 @@ scope: <matter-slug>
 source_coverage: <which sources were read, which were unavailable>
 confidence: <overall>
 ```
+
+`status` must be `draft`, not `proposed`. A proposal is a `note`, and the vault
+validator accepts only `active|draft|final|review` there. An invalid value
+written here is inert at creation — the raw-content path skips validation — but
+the validator re-checks the **whole record** on the first PATCH, so it then
+blocks the acceptance and every later write to that record. Acceptance sets
+`final`. `accepted: true/false` is the machine marker either way.
 
 Body:
 


### PR DESCRIPTION
Lane V companion to #494. Without this, every proposal the skill creates is poisoned at birth.

`proposed` is not a valid status for a `note` — the validator accepts only `active|draft|final|review`. Creation succeeds anyway, because the raw-content write path skips validation. The value then sits inert until the first PATCH, at which point the validator re-checks the **whole record** and blocks the acceptance and every later write to it.

That is what 500'd the live acceptance twice: once on the value being written, once on the value already sitting there.

`draft` for a proposal, `final` on acceptance. `accepted: true/false` stays the machine marker. The skill now explains why, so the more natural-sounding word does not get reintroduced.

## Smoke evidence

Tested on home.alfred.black at 2026-08-07T17:52Z — the live failure this fixes.

```
§1 the fixture proposal, created via the raw-content path
   status: proposed        <- accepted at creation, no validation

§2 first PATCH against that record (the acceptance)
   PATCH /vault/records/note/smoke-hours-proposal.md   -> 500
   {"error": "Invalid status 'proposed' for type 'note'.
              Valid: active, draft, final, review"}

§3 the value this PR writes instead, checked against the same allowlist
   draft  ∈ {active, draft, final, review}   -> valid
   final  ∈ {active, draft, final, review}   -> valid  (#494, on acceptance)

§4 no other `proposed` left in the skill
   grep -c "status: proposed" SKILL.md       -> 0

✓ lane V (edges-infra) gate passed — 9 LOC, 1 files, verify ok
```

Skill-prose change; CI compiles nothing here, so the live 500 in §2 is the meaningful evidence.

## After merge

Deploy init, repair the fixture's status, re-run the acceptance end-to-end, and confirm the proposal reaches `accepted: true` with the ledger still holding exactly one row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc