### PR TITLE
feat(ctrl): `?fields=` on vault list — the matter listing was unreadable at 16 records

### DIFF
--- a/packages/ctrl/src/api/routes/vault.ts
+++ b/packages/ctrl/src/api/routes/vault.ts
@@ -641,6 +641,35 @@ export function registerVaultRoutes(): void {
         (r.frontmatter as Record<string, unknown>).live_observation_count = live;
       }
     }
+    // `?fields=a,b` — return only the named frontmatter keys and drop the
+    // body preview. Without this, listing a type whose records carry long
+    // narrative frontmatter is unusable: 16 matters (each with a multi-
+    // sentence `current_state`) produced a 372 KB response that truncated
+    // before the caller could read the list, so a job iterating matters
+    // could not even discover them.
+    //
+    // Applied after the cache so one cached full payload serves every field
+    // selection, and after the instinct enrichment so `live_observation_count`
+    // remains selectable.
+    const fieldsParam = (query.get("fields") ?? "").trim();
+    if (fieldsParam) {
+      const wanted = new Set(
+        fieldsParam.split(",").map((f) => f.trim()).filter(Boolean),
+      );
+      sendJson(res, 200, {
+        results: payload.results.map((r) => {
+          const fm: Record<string, unknown> = {};
+          for (const k of wanted) {
+            if (k in (r.frontmatter as Record<string, unknown>)) {
+              fm[k] = (r.frontmatter as Record<string, unknown>)[k];
+            }
+          }
+          return { path: r.path, name: r.name, status: r.status, frontmatter: fm };
+        }),
+        count: payload.count,
+      });
+      return;
+    }
     sendJson(res, 200, payload);
   });
 

--- a/packages/ctrl/tests/vault-list-fields.test.ts
+++ b/packages/ctrl/tests/vault-list-fields.test.ts
@@ -1,0 +1,114 @@
+// `GET /api/v1/vault/list/:type?fields=a,b` — compact listing.
+//
+// WHY. The endpoint always returned full frontmatter plus a body preview.
+// Listing a type whose records carry long narrative frontmatter is therefore
+// unusable at scale: 16 matters, each with a multi-sentence `current_state`,
+// produced a 372 KB response that truncated before the caller could read the
+// list. A scheduled job iterating matters could not even discover them — it
+// failed at step one, three runs in a row, and correctly reported that it
+// could not determine the matter set without risking omissions.
+//
+// These tests cover the projection logic directly. The route wiring is
+// exercised on the tenant, because `routes/vault.ts` is not importable
+// standalone (see vault-known-types.test.ts for why).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+type Row = {
+  path: string;
+  name: string;
+  status: string;
+  frontmatter: Record<string, unknown>;
+  body_preview?: string;
+};
+
+/** Mirror of the projection applied in the route. */
+function project(rows: Row[], fieldsParam: string) {
+  const wanted = new Set(
+    fieldsParam.split(",").map((f) => f.trim()).filter(Boolean),
+  );
+  return rows.map((r) => {
+    const fm: Record<string, unknown> = {};
+    for (const k of wanted) {
+      if (k in r.frontmatter) fm[k] = r.frontmatter[k];
+    }
+    return { path: r.path, name: r.name, status: r.status, frontmatter: fm };
+  });
+}
+
+const ROWS: Row[] = [
+  {
+    path: "matter/a.md",
+    name: "A",
+    status: "active",
+    frontmatter: {
+      commitment_register: true,
+      current_state: "x".repeat(4000),
+      as_of: "2026-08-01",
+    },
+    body_preview: "y".repeat(500),
+  },
+  {
+    path: "matter/b.md",
+    name: "B",
+    status: "active",
+    frontmatter: { current_state: "x".repeat(4000) },
+    body_preview: "y".repeat(500),
+  },
+];
+
+test("only the requested frontmatter keys survive", () => {
+  const out = project(ROWS, "commitment_register");
+  assert.deepEqual(Object.keys(out[0].frontmatter), ["commitment_register"]);
+  assert.equal(out[0].frontmatter.commitment_register, true);
+});
+
+test("the narrative that caused the truncation is dropped", () => {
+  const out = project(ROWS, "commitment_register");
+  const size = JSON.stringify(out).length;
+  const full = JSON.stringify(ROWS).length;
+  assert.ok(
+    size < full / 10,
+    `compact listing must be far smaller: ${size} vs ${full}`,
+  );
+  assert.ok(!JSON.stringify(out).includes("current_state"));
+});
+
+test("the body preview is dropped too", () => {
+  const out = project(ROWS, "commitment_register");
+  assert.ok(!("body_preview" in out[0]));
+});
+
+test("identity fields are always kept", () => {
+  // A caller selecting one frontmatter key still needs to know which record
+  // it belongs to; dropping path/name/status would make the response useless.
+  const out = project(ROWS, "commitment_register");
+  assert.equal(out[0].path, "matter/a.md");
+  assert.equal(out[0].name, "A");
+  assert.equal(out[0].status, "active");
+});
+
+test("a record missing the key yields an empty object, not a dropped row", () => {
+  // The caller must still see record B in order to conclude it is NOT
+  // enabled. Omitting it would look identical to the record not existing.
+  const out = project(ROWS, "commitment_register");
+  assert.equal(out.length, 2);
+  assert.deepEqual(out[1].frontmatter, {});
+});
+
+test("several keys can be selected at once", () => {
+  const out = project(ROWS, "commitment_register,as_of");
+  assert.deepEqual(
+    Object.keys(out[0].frontmatter).sort(),
+    ["as_of", "commitment_register"],
+  );
+});
+
+test("whitespace and empty entries are tolerated", () => {
+  const out = project(ROWS, " commitment_register , , as_of ");
+  assert.deepEqual(
+    Object.keys(out[0].frontmatter).sort(),
+    ["as_of", "commitment_register"],
+  );
+});


### PR DESCRIPTION
`GET /api/v1/vault/list/:type` always returned full frontmatter plus a body preview, with no way to ask for less.

That makes the endpoint unusable for its most obvious job. Listing 16 matters — each carrying a multi-sentence `current_state` narrative — produced a **372 KB response that truncated before the caller could read the list.**

The scheduled commitment-register job failed at step one on three consecutive runs. Its own words:

> `GET /api/v1/vault/list/matter` returned full frontmatter despite the required cheap-discovery contract, producing a 372 KB response that was truncated before the complete matter list could be recovered. I therefore could not determine the selected matters without risking omissions.

It refused to guess. That is the correct behaviour and the reason the bug is precisely located rather than showing up as a mysteriously incomplete run.

## Fix

`?fields=commitment_register` returns `path`, `name`, `status` and only the named frontmatter keys, dropping the body preview.

Applied **after** the cache, so one cached payload serves every field selection, and **after** the instinct enrichment, so `live_observation_count` remains selectable.

Two behaviours the tests pin:

- **Identity fields are always kept.** Selecting one frontmatter key still has to tell you which record it came from.
- **A record missing the key yields an empty frontmatter object, not a dropped row.** The caller needs to see that record to conclude it is *not* enabled — omitting it is indistinguishable from the record not existing, which is exactly how a matter would go silently missing from a sweep.

## Smoke evidence

Tested on home.alfred.black at 2026-08-07T18:31Z — three runs of the register job, each blocked at discovery.

```
§1 run 18:02 — 14 of 14 failed
   "could not complete the required per-record bounded sweeps ... within
    the job execution window"
   (I misread this as a capacity problem and fixed the wrong thing first)

§2 run 18:29 — 16 of 16 failed, clearer
   "the vault listing response exceeded the tool's retrievable output limit"

§3 run 18:31 — after instructing the job to use the list endpoint
   "GET /api/v1/vault/list/matter returned full frontmatter despite the
    required cheap-discovery contract, producing a 372 KB response"
   TOTAL matters=unknown routine=0 bootstrap=0 deferred=0 failed=0
   -> the endpoint, not the prompt, was the blocker

§4 endpoint inspected in source
   routes/vault.ts:619-626 pushes `frontmatter: rec.fm` unconditionally,
   plus a body_preview defaulting to 500 chars. `?preview=0` trims the body
   but nothing trims frontmatter, which is the bulk.

§5 projection logic
   7 tests, including a size assertion that the compact form is <10% of full

✓ lane I (ctrl-api) gate passed — 143 LOC, 2 files, verify ok
```

Post-deploy I will confirm `?fields=commitment_register` on the live tenant returns all 16 matters in a readable payload, and re-run the job.

## Note on my own diagnosis

I called §1 an execution-window problem and changed the job's prompt to do cheap work first. That change is fine on its own merits, but it was not the binding constraint — §2 and §3 were the same discovery failure surfacing more precisely each time. Worth recording, because I acted on the first plausible reading rather than the confirmed one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc