### PR TITLE
fix(hermes): the matter slug is the filename — my #489 fix contradicted itself

### DIFF
--- a/packages/hermes/workspace-template/skills/alfred-commitment-register/SKILL.md
+++ b/packages/hermes/workspace-template/skills/alfred-commitment-register/SKILL.md
@@ -35,17 +35,23 @@ Everything else is derived:
 | sources | whatever the tenant actually has connected |
 | projection | `note/<matter-slug>-commitment-register.md` |
 | policy note | `note/<matter-slug>-commitment-management.md` |
+| external actions | always forbidden — not a choice |
 
-**`<matter-slug>` means the slug, never the display name.** Derive it once and
-reuse it for every path and for the ID prefix:
+**`<matter-slug>` is the matter's filename without `.md`. Nothing else.**
 
-> lowercase → strip diacritics → replace every run of non-alphanumeric
-> characters with a single `-` → trim leading and trailing `-`
+Read it off the record's path: `matter/neoterra-ai-consulting-ntpos-build.md`
+gives `neoterra-ai-consulting-ntpos-build`. Do **not** derive it by slugifying
+the `name` field. A matter's display name drifts — it gets retitled when a
+product is renamed — while its filename does not, so the two often disagree.
 
-So a matter named `Hungarian Company & Admin Compliance` yields
-`hungarian-company-admin-compliance`, and its projection is
-`note/hungarian-company-admin-compliance-commitment-register.md` — never
-`note/Hungarian Company & Admin Compliance commitment register.md`.
+A live example: a matter whose file is
+`matter/neoterra-ai-consulting-ntpos-build.md` carries the name
+`NeoTerra AI Consulting Ken Build`. Slugifying the name produced
+`...-ken-build-commitment-register.md`, a projection at a path nothing else
+would ever look for. The filename is the stable identifier; the name is prose.
+
+Use that one string for the projection path, the policy-note path, and the
+`commitment_scope`.
 
 This is not cosmetic. A derived path is only useful if it is *predictable*:
 anything that later resolves a register by constructing its path — a rollup, a
@@ -58,7 +64,6 @@ than exists.
 writing the projection, read it back at the exact derived path. A read-back
 that locates the file by any other means passes while the derivation is broken
 — which is precisely how this went unnoticed.
-| external actions | always forbidden — not a choice |
 
 Use the object form only to override a derived value that is wrong — a prefix
 collision, a participant the matter does not list, a different destination:


### PR DESCRIPTION
#489 told the skill:

> **`<matter-slug>` means the slug, never the display name.**

…and then demonstrated the rule by slugifying a display name. The instruction and the worked example disagreed, so the agent followed the example.

## Caught live

A matter whose file is `matter/neoterra-ai-consulting-ntpos-build.md` carries the name `NeoTerra AI Consulting Ken Build` — the product was renamed, the filename was not.

The run derived `note/neoterra-ai-consulting-ken-build-commitment-register.md`: a projection at a path nothing else would ever construct, for a **live client register**. Same failure #489 was supposed to prevent, on the very next run after shipping the fix.

## Fix

There is no slugification. **The slug is the record's filename without `.md`**, read off its path. Unambiguous, stable across renames, and it already matches what `matter_ref` points at.

The live divergence is written into the skill as the worked example, because an abstract rule is exactly what failed here.

## Smoke evidence

Tested on home.alfred.black at 2026-08-07T19:10Z.

```
§1 the divergence, on the tenant
   file:  matter/neoterra-ai-consulting-ntpos-build.md
   name:  NeoTerra AI Consulting Ken Build
   -> filename says ntpos-build, display name says Ken Build

§2 what the run derived from the name (wrong)
   neoterra: projection=note/neoterra-ai-consulting-ken-build-commitment-register.md

§3 what the filename rule gives (right)
   note/neoterra-ai-consulting-ntpos-build-commitment-register.md

§4 no ken-build note was written — the run failed earlier for an unrelated
   reason, so nothing needs renaming
   ls note/ | grep -i ken-build   -> none

✓ lane V (edges-infra) gate passed
```

That §4 is luck, not design: had the run completed, a client register would now sit at an unfindable path.

## Note

This is the second time I have shipped a fix for this exact bug. The first stated the right rule and undercut it with the wrong example — worth recording, because a rule plus a contradicting example is worse than the rule alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc