### PR TITLE
fix(mcp-server): the test glob skipped every top-level test file (#499, #315)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -219,6 +219,13 @@ TAILSCALE_TAGS=
 # mcp-server tool-approval signing secret.
 #MCP_APPROVAL_SECRET=
 
+# Number of reverse-proxy hops in front of the MCP server (#315).
+# REQUIRED in production — the server refuses to start without it, because
+# guessing here is how a client spoofs its own IP and bypasses rate limiting.
+# 1 for the standard single-Caddy topology; 2 when cloudflared is a distinct
+# hop. Bounded to 0-5; `true`, `*`, `all` and wildcard CIDRs are rejected.
+TRUST_PROXY_HOPS=1
+
 
 # Sure — Rails secret + datastore credentials.
 #SURE_SECRET_KEY_BASE=

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -10,7 +10,7 @@
     "build": "tsc",
     "start": "node --experimental-sqlite dist/index.js",
     "typecheck": "tsc --noEmit",
-    "test": "node --import tsx --test src/**/*.test.ts"
+    "test": "node --import tsx --test 'src/**/*.test.ts'"
   },
   "engines": {
     "node": ">=22.0.0"


### PR DESCRIPTION
```json
"test": "node --import tsx --test src/**/*.test.ts"
```

Unquoted, `**` is one directory deep — the shell expands it to `src/*/*.test.ts` and every test file directly under `src/` is silently skipped. Quoting hands the pattern to Node, which does support recursive `**`.

## What was hidden

**`src/trustProxy.test.ts` imported a module that did not exist in `main`.** The repo carried #391's *test* without #391's *implementation*, and CI stayed green — because a glob that matches nothing extra is not an error.

**`src/scopedTokens.test.ts` had never run.** That covers the per-app scoped Bearer tokens from #278 — the authentication surface external MCP clients use.

Twelve tests, never once executed, including the bound check that would have caught the `TRUST_PROXY_HOPS=999` gap in the inline #315 fix.

## Ordering

#391 was merged **first**, deliberately, so it could supply the missing module. Fixing the glob first would have turned `main` red.

## The env template graft

`TRUST_PROXY_HOPS` is required in production — the server refuses to start without it — but was missing from `.env.example`. A fresh deploy would fail at boot with no indication which variable was absent. Taken from #385, which got this detail right while losing the consolidation on everything else.

The comment names the bound and the rejected values, because the realistic failure is someone setting `true` to make a proxy problem go away and quietly reopening #315.

## Smoke evidence

Tested against `main` at 2026-08-08, locally with the real toolchain.

```
§1 the broken glob, current main
   $ npm test
   # tests 208   # pass 208   # fail 0

§2 the same tree with the pattern quoted, BEFORE #391 merged
   $ node --import tsx --test 'src/**/*.test.ts'
   # tests 217   # pass 216   # fail 1
   not ok 6 - src/trustProxy.test.ts
   Cannot find module '.../src/trustProxy.js'
   -> the failure was real and had been invisible

§3 which files the two globs reach
   never run: src/scopedTokens.test.ts, src/trustProxy.test.ts
   run:       src/tools/{alfred,files,hass,paperclip}.test.ts

§4 after #391 merged, with this PR's fix
   $ npm test
   # tests 220   # pass 220   # fail 0

§5 gate
   ✓ lane V (edges-infra) gate passed — 9 LOC, 2 files, verify ok
```

§2 is the important line: the corrected glob fails on `main` as it stood, which is what proves the test was unrunnable rather than merely unrun.

Closes #499.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc