### PR TITLE
purge(learn): remove OpenRouter references — Codex-only (#438)

### DIFF
--- a/packages/learn/docs/GENERATORS.md
+++ b/packages/learn/docs/GENERATORS.md
@@ -271,21 +271,20 @@ writes to the vault during onboarding, traced from the workflow.
 
 ---
 
-## Direct-OpenRouter callers (Hermes bypass check)
+## Direct provider-API callers (Hermes bypass check)
 
-`grep -rn 'openrouter\\|OPENROUTER\\|api\\.openai\\|api\\.anthropic\\.com'
+`grep -rn 'api\\.openai\\|api\\.anthropic\\.com\\|openrouter\\.ai'
 src/`:
 
-| File:Line | What | Status |
-|-----------|------|--------|
-| `src/activities/onboarding_v3.py:48` | Comment explaining the #118 migration off OpenRouter onto Hermes | **NOT a bypass** — historical doc only |
-| `src/profiler/transaction_clustering.py:139` | Regex `\\bopenrouter\\b` to classify a "OpenRouter, Inc" receipt as a Subscription | **NOT a bypass** — text-matching a merchant |
-
-**Conclusion:** zero direct-OpenRouter (or direct-Anthropic / direct-OpenAI)
+No matches. Zero direct-provider (OpenAI, Anthropic, or gateway-bypass)
 callers remain in `packages/learn/src/`. Every LLM call routes through
-`_call_clerk` (`src/activities/clerk.py`, main/workers Hermes profiles)
-or `_call_llm` (`src/activities/onboarding_v3.py:39`, heavy Hermes
-profile :18791). Lane-II is Hermes-clean.
+`_call_clerk` (`src/activities/clerk.py`, workers Hermes profile :18790)
+or `_call_llm` (`src/activities/onboarding_v3.py`, heavy Hermes
+profile :18791). Lane-II is Hermes/Codex-only.
+
+Note: `src/profiler/transaction_clustering.py` contains the regex
+`\\bopenrouter\\b` to classify "OpenRouter, Inc" payment receipts as
+Subscriptions — this is text matching on merchant names, not an API call.
 
 ---
 

--- a/packages/learn/src/activities/chore_generation.py
+++ b/packages/learn/src/activities/chore_generation.py
@@ -10,8 +10,8 @@ source as a string. Static validation (S4-5), smoke testing (S4-6), and
 deployment (S4-7) are separate activities that consume the output.
 
 Design contract:
-  - Uses _call_llm direct OpenRouter (claude-opus-4-6, lower temperature
-    than the brief generator since we want less creativity)
+  - Uses _call_llm via the Hermes heavy profile (model is Hermes-config-owned,
+    lower temperature than the brief generator since we want less creativity)
   - Up to 3 attempts with retry-feedback prompts on failure
   - Hard total timeout enforced via _call_llm's asyncio.wait_for budget
   - Returns {module_name, workflow_class_name, python_source, ...metadata}

--- a/packages/learn/src/activities/clerk.py
+++ b/packages/learn/src/activities/clerk.py
@@ -570,7 +570,7 @@ _CLERK_COMPLETION_BUDGET_SECONDS = 900.0
 
 # F35 — priced-ceiling cap. Hermes' ``POST /v1/responses`` otherwise asks
 # the model for its full output window (65536 on the heavy/clerk models),
-# and OpenRouter prices the request against that ceiling — so a call 402s
+# and the gateway prices the request against that ceiling — so a call 402s
 # ("requested up to 65536 tokens, can only afford 31301") even when the
 # actual reply is short. Forwarding a bounded ``max_output_tokens`` shrinks
 # the priced ceiling below the affordable budget. 31000 sits just under the

--- a/packages/learn/src/activities/enrichment.py
+++ b/packages/learn/src/activities/enrichment.py
@@ -28,7 +28,7 @@ logger = logging.getLogger("alfred-learn")
 # (Erste/makerspace cases) without blowing a single event's cost.
 MAX_BODY_CHARS_PER_EVENT = 20_000
 
-# Size-based batch target. Clerk (fast-tier OpenRouter models) comfortably
+# Size-based batch target. Clerk (workers-profile Hermes gateway) comfortably
 # takes 128k tokens of context; we want to leave room for output (entities
 # + action_items JSON can run 5-10k tokens for a busy batch). 40k chars of
 # input gives ~10-13k tokens under the ~3 chars/token rule — leaving

--- a/packages/learn/src/activities/onboarding_v3.py
+++ b/packages/learn/src/activities/onboarding_v3.py
@@ -2,8 +2,8 @@
 
 Replaces the 101-sequential-Clerk-call pipeline with 4 heavy-reasoning
 LLM calls. As of #118 those run through the HEAVY Hermes profile
-(``POST /v1/responses`` on :18791), not a direct OpenRouter call — the
-model is owned by the Hermes profile config. Full email corpus as context.
+(``POST /v1/responses`` on :18791) — the model is owned by the Hermes
+profile config. Full email corpus as context.
 
 Steps:
 1. Fetch metadata + snippets for all emails (30-60s)
@@ -68,9 +68,8 @@ async def _call_llm(
 ) -> str:
     """Run the heavy-reasoning agent via Hermes. Returns raw text response.
 
-    #118: this no longer POSTs OpenRouter ``chat/completions`` with an
-    ``OPENROUTER_API_KEY`` and a hardcoded ``anthropic/claude-opus-4-6``
-    model. It now mirrors ``clerk._call_clerk``: a single synchronous
+    #118: migrated off direct provider calls. Now mirrors
+    ``clerk._call_clerk``: a single synchronous
     ``POST /v1/responses`` (the OpenAI Responses API) against the HEAVY
     Hermes profile (:18791). Hermes runs the agent to completion
     server-side and returns the final ``output`` in the HTTP response. The
@@ -80,8 +79,8 @@ async def _call_llm(
 
     ``max_tokens`` is forwarded as ``max_output_tokens`` (F35), clamped to
     ``_MAX_OUTPUT_TOKENS_CAP``. Without it, Hermes asks the model for its
-    full output window (65536) and OpenRouter prices the call against that
-    ceiling — so a request 402s even when the reply is short. The clamp
+    full output window (65536) and the gateway prices the request against
+    that ceiling — so a request 402s even when the reply is short. The clamp
     keeps the priced ceiling under the affordable budget.
 
     ``response_format`` (kw-only) is the OpenAI Responses API's

--- a/packages/learn/src/activities/packs_opus.py
+++ b/packages/learn/src/activities/packs_opus.py
@@ -20,8 +20,8 @@ Design:
 
 Env flags:
 - ``ALFRED_OPUS_PACKS_ENABLED`` — default ``"true"``. Set to ``"false"``
-  to force the rule-based fallback for every pack (useful if OpenRouter
-  is flaky or budget-constrained).
+  to force the rule-based fallback for every pack (useful if the Hermes
+  gateway is unavailable or during testing).
 """
 from __future__ import annotations
 

--- a/packages/learn/src/activities/signals.py
+++ b/packages/learn/src/activities/signals.py
@@ -1754,7 +1754,7 @@ async def extract_signal_from_event(
             # CRITICAL: raise instead of returning None. Returning None
             # is the workflow's signal for "LLM classified as noise" —
             # which would mark the event permanently processed. When the
-            # LLM provider is down (OpenRouter timeout, MiniMax outage,
+            # LLM provider is down (gateway timeout or upstream outage,
             # rate-limit) we want Temporal to retry the activity on the
             # next chunk OR the next tick, NOT bury the event as noise.
             # The workflow's per-event try/except catches this as

--- a/packages/learn/tests/test_chore_generation.py
+++ b/packages/learn/tests/test_chore_generation.py
@@ -1,8 +1,8 @@
 """Tests for the chore code generation activity (Step 4, S4-4).
 
 Most coverage is on the helpers (envelope validator, profile slicer, JSON
-parser) since the actual `_call_llm` invocation requires OpenRouter and is
-exercised end-to-end in the smoke test on the owner tenant.
+parser) since the actual `_call_llm` invocation reaches the Hermes heavy
+gateway and is exercised end-to-end in the smoke test on the owner tenant.
 """
 from __future__ import annotations
 

--- a/packages/learn/tests/test_chore_promotion.py
+++ b/packages/learn/tests/test_chore_promotion.py
@@ -8,7 +8,7 @@ Covers:
   - `_parse_promotion_response` malformed / missing / fenced inputs
 
 Filesystem and LLM I/O are mocked via tmp_path + monkeypatch so
-nothing touches the real /alfred-data directory or OpenRouter.
+nothing touches the real /alfred-data directory or the Hermes gateway.
 """
 from __future__ import annotations
 
@@ -278,7 +278,7 @@ class TestDraftPromotionProposal:
         candidate = self._candidate()
         with patch(
             "src.activities.chore_promotion._call_llm",
-            new=AsyncMock(side_effect=RuntimeError("openrouter 503")),
+            new=AsyncMock(side_effect=RuntimeError("gateway 503")),
         ):
             result = _run(draft_promotion_proposal, candidate)
         assert result["ok"] is False

--- a/packages/learn/tests/test_llm_max_output_tokens.py
+++ b/packages/learn/tests/test_llm_max_output_tokens.py
@@ -1,7 +1,7 @@
 """F35 — the clerk/brief LLM request must cap ``max_output_tokens``.
 
 Live symptom: every Hermes ``POST /v1/responses`` asked for the model's
-full output ceiling (65536), and OpenRouter prices the request against
+full output ceiling (65536), and the gateway prices the request against
 that ceiling, so calls 402'd ("requested up to 65536 tokens, can only
 afford 31301") even when the actual response was small.
 

--- a/packages/learn/tests/test_packs_opus_matter.py
+++ b/packages/learn/tests/test_packs_opus_matter.py
@@ -458,7 +458,7 @@ class TestGenerateMatterPackOpus:
 
         fallback_mock = AsyncMock(return_value={"created": 1, "skipped_existing": 0})
         with patch("src.activities.packs_opus._call_llm",
-                   new=AsyncMock(side_effect=RuntimeError("openrouter 503"))), \
+                   new=AsyncMock(side_effect=RuntimeError("gateway 503"))), \
              patch("src.activities.packs.generate_matter_pack", new=fallback_mock):
             result = _run_activity(lambda: generate_matter_pack_opus(onboard))
 


### PR DESCRIPTION
## Summary

- Replaced all 11 OpenRouter references in packages/learn with accurate Hermes/gateway language.
- All were comments referencing the pre-#118 era; zero live API calls, model IDs, or credentials existed.
- Test error-simulation strings changed from 'openrouter 503' to 'gateway 503'; assertions checking for '503' still pass unchanged.

## What was changed

| File | Change |
|------|--------|
| src/activities/packs_opus.py | Env flag comment: 'if OpenRouter is flaky' to 'if the Hermes gateway is unavailable' |
| src/activities/chore_generation.py | Module docstring: 'direct OpenRouter' to 'Hermes heavy profile' |
| src/activities/enrichment.py | Batch-size comment: 'fast-tier OpenRouter models' to 'workers-profile Hermes gateway' |
| src/activities/onboarding_v3.py | Module docstring + _call_llm docstring: removed pre-#118 OpenRouter migration prose; updated pricing comment |
| src/activities/signals.py | Error-handling comment: '(OpenRouter timeout, MiniMax outage,' to '(gateway timeout or upstream outage,' |
| src/activities/clerk.py | F35 comment: 'OpenRouter prices the request' to 'the gateway prices the request' |
| docs/GENERATORS.md | 'Direct-OpenRouter callers' section rewritten as 'Direct provider-API callers'; grep updated; conclusion states Codex-only |
| tests/test_chore_generation.py | Docstring: '_call_llm invocation requires OpenRouter' to 'reaches the Hermes heavy gateway' |
| tests/test_chore_promotion.py | Docstring + error fixture string updated |
| tests/test_llm_max_output_tokens.py | F35 docstring updated |
| tests/test_packs_opus_matter.py | Error fixture string updated |

## What was intentionally kept

- src/profiler/transaction_clustering.py:139 — regex classifies 'OpenRouter, Inc' payment receipts as Subscriptions. This is a merchant name pattern, not an API reference.
- tests/test_instinct_scorer_matches_payment_failure.py:60 — 'openrouter.ai' in the payment-failure instinct sender_domains fixture. It's a real email sender domain; the fixture must stay faithful to the live instinct it exercises.
- packages/learn/CONTRACT.md — forbidden zone.

## Temporal / workflow safety

Comment-only changes. No activity renamed, no workflow signature altered, no execution-order change. Temporal replay not affected.

## Smoke evidence

Local — lane VERIFY ran twice (manual + pre-commit hook):

```
cd packages/learn && python3 -m pytest tests/ -q   --ignore=tests/test_composio_server.py   --ignore=tests/test_composio_server_extra.py   --ignore=tests/test_composio_server_defaults.py   --ignore=tests/test_file_extraction.py

2618 passed, 101 skipped in 22.52s
```

Lane gate line:
```
lane II (learn) gate passed — 60 LOC, 11 files, verify ok
```

Post-change grep confirms zero executable OpenRouter references remain:
```
packages/learn/tests/test_instinct_scorer_matches_payment_failure.py:60: openrouter.ai <- real sender domain in payment-failure fixture (kept)
packages/learn/src/profiler/transaction_clustering.py:139: \bopenrouter\b <- merchant name pattern for receipts (kept)
```

Closes #438

Generated with Claude Code