### PR TITLE
ci: compute voice-bridge diff on push events using github.event.before (#491)

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -140,8 +140,23 @@ jobs:
             else
               echo "changed=false" >> "$GITHUB_OUTPUT"
             fi
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            before="${{ github.event.before }}"
+            # before is all-zeros on a force-push or the very first commit on a
+            # branch; in that case there is no reliable base to diff against, so
+            # fall back to changed=true (run the suite rather than silently skip).
+            if printf '%s' "$before" | grep -qE '^0+$'; then
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+            else
+              git fetch --depth=1 origin "$before" >/dev/null 2>&1 || true
+              if git diff --name-only "$before" HEAD 2>/dev/null | grep -q '^packages/voice-bridge/'; then
+                echo "changed=true" >> "$GITHUB_OUTPUT"
+              else
+                echo "changed=false" >> "$GITHUB_OUTPUT"
+              fi
+            fi
           else
-            # push to main / manual: always run the real test.
+            # workflow_dispatch or any other trigger: always run.
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
           echo "voice-bridge changed: $(grep changed= "$GITHUB_OUTPUT" || true)"


### PR DESCRIPTION
## Summary

- The `test-voice-bridge` path-gate used `github.event.pull_request.base.sha` for computing its diff, which is only available on `pull_request` events. On a push to main the `else` branch unconditionally set `changed=true`, triggering the full suite on every push, hitting the slow-stall, timing out at 10 minutes, and surfacing as `cancelled`.
- Because `cancelled` looks like infrastructure noise rather than a real result, ci-check on main could never be fully green — which let a genuine `test-ctrl` regression hide behind the noise for three commits.
- Fix: add an explicit `push` branch using `github.event.before..HEAD` (the diff pair GitHub provides for push events). Fall back to `changed=true` only when `before` is all-zeros (force-push or initial commit). The `pull_request` branch is byte-identical to before. `workflow_dispatch` keeps its existing `changed=true` fallback.

## Test plan

- [ ] After merge: push a commit that does not touch `packages/voice-bridge/` to main — `test-voice-bridge` should pass in seconds (short-circuit path).
- [ ] After merge: push a commit that touches `packages/voice-bridge/` to main — `test-voice-bridge` should run the full suite.

## Smoke evidence

Shell-level dry-run of the changed-detection logic against real repo SHAs, run locally in the worktree:

```
Repo root: /Users/ssd/dev/alfred/.claude/worktrees/agent-a672adec829b579d1

--- CASE A (voice-bridge commit f7e07e3e) ---
  before: 3e2d1dc0e97f07e3cc47ec725f16873854e6dae7
  sha:    f7e07e3e
  files changed:
    packages/ctrl/src/api/routes/phone.ts
    packages/ctrl/tests/phone-outbound-call.test.ts
    packages/voice-bridge/src/outbound-metadata.test.ts
    packages/voice-bridge/src/outbound-metadata.ts
    packages/voice-bridge/src/server.ts
    packages/voice-bridge/src/voice-call.ts
  result: changed=true
  PASS (expected true)

--- CASE B (non-voice-bridge commit 09ede4df) ---
  before: 88f698816d96d3102d8e10f22feb6387c1d2286c
  sha:    09ede4df
  files changed:
    .env.example
    packages/mcp-server/package.json
  result: changed=false
  PASS (expected false)

--- CASE C (zero-SHA fallback) ---
  before: 0000000000000000000000000000000000000000
  sha:    09ede4df
  reason: before is all-zeros — fallback to changed=true
  result: changed=true
  PASS (expected true)

All cases passed.
```

YAML parse: `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ci-check.yml')); print('OK')"` → **OK**

actionlint: `actionlint -shellcheck= .github/workflows/ci-check.yml` → **no output (zero errors)**

Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)