### PR TITLE
chore(deploy): stop shipping the Plane Caddyfile to every tenant (#462)

### DIFF
--- a/.github/workflows/deploy-compose.yml
+++ b/.github/workflows/deploy-compose.yml
@@ -8,7 +8,6 @@
 #
 #   * /opt/alfred/docker-compose.yaml — services, profiles, mounts
 #   * /opt/alfred/caddy/Caddyfile     — public ingress
-#   * /opt/alfred/caddy/plane-proxy.Caddyfile
 #   * /opt/alfred/.env.example        — operator reference (does NOT touch .env)
 #
 # Consequence: any PR that adds a new service (e.g. #121, which added the
@@ -23,8 +22,9 @@
 # back up the old copy as `.bak-<sha>`, and `docker compose up -d` to apply.
 # Compose is idempotent — only services whose definition changed restart.
 #
-# Tenant list is hard-coded for now (5 known hosts). When the SaaS Plane app
-# exposes a tenant directory we can pull this from a single source of truth.
+# Tenant list is hard-coded for now. There is no tenant directory to pull it
+# from: the SaaS control surface an earlier version of this comment promised
+# does not exist in alfred-black.
 name: deploy-compose
 
 on:
@@ -33,7 +33,6 @@ on:
     paths:
       - "docker-compose.yaml"
       - "caddy/Caddyfile"
-      - "caddy/plane-proxy.Caddyfile"
       - ".env.example"
       - ".github/workflows/deploy-compose.yml"
   workflow_dispatch:
@@ -126,19 +125,18 @@ jobs:
           ssh "${host}" "
             set -e
             ts=\$(date -u +%Y%m%dT%H%M%SZ)
-            for f in docker-compose.yaml caddy/Caddyfile caddy/plane-proxy.Caddyfile .env.example; do
+            for f in docker-compose.yaml caddy/Caddyfile .env.example; do
               if [ -f /opt/alfred/\${f} ]; then
                 cp -a /opt/alfred/\${f} /opt/alfred/\${f}.bak-${short_sha}-\${ts}
               fi
             done
           "
 
-          # 2. scp the four tracked files. Use -p to preserve mtime so the
+          # 2. scp the three tracked files. Use -p to preserve mtime so the
           #    operator can see when the file was actually changed in the
           #    repo, not when CI ran.
           scp -p docker-compose.yaml "${host}:/opt/alfred/docker-compose.yaml"
           scp -p caddy/Caddyfile "${host}:/opt/alfred/caddy/Caddyfile"
-          scp -p caddy/plane-proxy.Caddyfile "${host}:/opt/alfred/caddy/plane-proxy.Caddyfile"
           scp -p .env.example "${host}:/opt/alfred/.env.example"
 
       - name: Apply (docker compose up -d)

--- a/deploy/BACKUPS.md
+++ b/deploy/BACKUPS.md
@@ -42,7 +42,6 @@ The current compose file defines these named volumes.
 | `mcp_server_data` | MCP server local state. | Medium | Include to preserve connector-local state. |
 | `temporal_data` | Temporal workflow history. | High | Workflows can often be restarted, but history aids recovery. |
 | `ollama_data` | Downloaded embedding/model blobs. | Low | Re-downloadable; backup only to reduce rebuild time. |
-| `plane_pgdata`, `plane_redis`, `plane_rabbitmq`, `plane_uploads` | Plane issue tracker data and artifacts. | High | Include if Plane is used as operational issue memory. |
 | `sure_pgdata`, `sure_redis` | Sure finance database/cache. | Critical | Finance data; backup encrypted and test restore. |
 | `paperclip_data` | Paperclip company/issues/agent state. | High | Include where Paperclip manages operations. |
 | `vexa_redis`, `vexa_postgres`, `vexa_minio`, `vexa_recordings` | Optional Vexa transcript stack. | Medium/High | Include when `--profile vexa` is enabled and recordings/transcripts matter. |

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -22,10 +22,10 @@ These are hard-coded in two places that must stay in sync:
 - `.github/workflows/deploy-compose.yml` (matrix)
 - `Makefile` (`FLEET` variable, `sync-compose-fleet` target)
 
-When a tenant is added or retired, update both. A future refactor will pull
-this from the SaaS Plane app's tenant directory; for now we keep it explicit
-because the cost of a stale list is "a tenant silently misses a deploy" —
-exactly the failure mode this directory exists to prevent.
+When a tenant is added or retired, update both. There is no tenant directory
+to pull this from, so it stays explicit — and the cost of a stale list is "a
+tenant silently misses a deploy", exactly the failure mode this directory
+exists to prevent.
 
 ## What CI deploys vs. what it does NOT
 
@@ -37,7 +37,6 @@ files that compose loads at boot:
 
 - `docker-compose.yaml` — the service definitions
 - `caddy/Caddyfile` — public ingress + Let's Encrypt
-- `caddy/plane-proxy.Caddyfile`
 - `.env.example` — operator reference (never overwrites a tenant's `.env`)
 
 It runs automatically on every push to `main` that touches one of those


### PR DESCRIPTION
Phase0 half of #462. The lane V half is **PR #506**.

## Merge this one first

#506 deletes `caddy/plane-proxy.Caddyfile` from the repo. `deploy-compose.yml` still `scp`s that exact path to every tenant. Merging #506 alone means the next deploy-compose run **fails per-tenant, mid-rollout**, on a missing file.

This PR is safe in either order — removing the `scp` of a file that still exists breaks nothing — so it should land first.

## What changed

From `deploy-compose.yml`: the path trigger, the pre-deploy backup loop entry, the `scp`, and the header comment listing it as a synced artifact. Plus "scp the four tracked files" corrected to three.

From `deploy/` (not lane V, so it belongs here): the plane-proxy entry in the synced-files list, and the `plane_*` volumes row in the backup table — volumes that have not existed on any tenant since #279.

## The comments that promised something impossible

Two SaaS-era comments said the tenant list would eventually come from "the SaaS Plane app's tenant directory". Plane is gone; that directory will never exist. They now state that the list stays explicit, and why.

A comment promising a future that cannot arrive is worse than no comment — someone eventually plans around it.

## Smoke evidence

```
$ grep -rcni "plane" .github/workflows/deploy-compose.yml deploy/README.md deploy/BACKUPS.md
.github/workflows/deploy-compose.yml:0
deploy/README.md:0
deploy/BACKUPS.md:0

$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-compose.yml'))"
(clean)

✓ lane phase0 (orchestrator) gate passed — 22 LOC, 3 files, verify ok
```

Phase0 committed from the **main checkout**, not a worktree — a linked worktree cannot self-declare phase0, and doing this from one is what forced a `--no-verify` on #505.

## Operator cleanup, after both PRs land

```
rm -f /opt/alfred/caddy/plane-proxy.Caddyfile
```

Per tenant. Safe: the main Caddyfile never imported it — which is precisely why dead config shipped to six tenants for months unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc