### PR TITLE
fix(sure): stop Lunchflow re-stamping known account currencies to USD (#340)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1068,6 +1068,14 @@ services:
     # CRUD endpoints and the sure-init one-shot.
     volumes:
       - alfred_data:/alfred-data
+      # #340 — Lunchflow sends no currency, so Sure re-stamps every account to
+      # USD on every sync and non-USD balances compute to zero. This Rails
+      # initializer preserves an already-known currency instead of overwriting
+      # it with the default. Mounted rather than baked because Sure is an
+      # upstream image; a prepended module survives Sure upgrades where a
+      # copied model file would silently revert them. Remove when Lunchflow
+      # sends a currency or Sure stops defaulting.
+      - ./scripts/sure-patches/preserve_lunchflow_currency.rb:/rails/config/initializers/zz_alfred_preserve_lunchflow_currency.rb:ro
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:3000/up >/dev/null 2>&1 || exit 1"]
       interval: 15s

--- a/scripts/sure-patches/preserve_lunchflow_currency.rb
+++ b/scripts/sure-patches/preserve_lunchflow_currency.rb
@@ -1,0 +1,78 @@
+# Sure patch — stop Lunchflow resetting a known account currency to USD (#340)
+#
+# WHY
+# ---
+# Lunchflow/GoCardless does not send a `currency` for these accounts. Sure's
+# `LunchflowAccount#upsert_lunchflow_snapshot!` therefore does:
+#
+#     currency: parse_currency(snapshot[:currency]) || "USD"
+#
+# That runs on EVERY sync for EVERY account, so a hand-corrected currency is
+# overwritten on the next poll. Observed live: an account correctly set to HUF
+# reverted to USD mid-investigation. Seven accounts holding real money were
+# therefore valued as dollars and displayed as zero — a seven-figure HUF
+# balance among them.
+#
+# THE PATCH
+# ---------
+# One rule: never overwrite a currency we already have with a guess.
+#
+#   payload currency (if valid)  ->  use it
+#   else existing stored value   ->  keep it
+#   else                         ->  "USD" (unchanged for genuinely new records)
+#
+# So a currency set once — by hand, or by the operator UI — now survives every
+# subsequent sync, and the upstream default still applies to accounts nobody
+# has classified.
+#
+# WHY AN INITIALIZER, NOT A FILE OVERLAY
+# --------------------------------------
+# Sure is self-hosted, so patching is legitimate. But bind-mounting a modified
+# copy of `app/models/lunchflow_account.rb` would pin us to one upstream
+# revision: any Sure update changes that file and our copy silently reverts
+# their fixes. A prepended module touches one method and composes with whatever
+# the upstream file becomes.
+#
+# It also fails loudly rather than silently: if upstream renames or removes
+# `upsert_lunchflow_snapshot!`, the guard below logs and skips instead of
+# monkey-patching a method that no longer means what we think.
+#
+# REMOVE THIS when Sure accepts a currency from the account record or Lunchflow
+# starts sending one. Check on upgrade.
+
+Rails.application.config.to_prepare do
+  unless defined?(::LunchflowAccount)
+    Rails.logger.warn("[alfred #340] LunchflowAccount not defined — currency patch skipped")
+    next
+  end
+
+  unless ::LunchflowAccount.method_defined?(:upsert_lunchflow_snapshot!)
+    Rails.logger.warn(
+      "[alfred #340] LunchflowAccount#upsert_lunchflow_snapshot! is gone — " \
+      "currency patch skipped. Upstream changed; re-check whether #340 still applies."
+    )
+    next
+  end
+
+  module AlfredPreserveLunchflowCurrency
+    def upsert_lunchflow_snapshot!(snapshot)
+      known = currency.presence
+      super
+      # `super` re-derives currency from the payload and falls back to "USD".
+      # If it landed on USD only because the payload was silent, and we already
+      # knew better, put the known value back.
+      payload_ccy = snapshot.is_a?(Hash) ? (snapshot[:currency] || snapshot["currency"]) : nil
+      if known.present? && payload_ccy.blank? && currency != known
+        Rails.logger.info(
+          "[alfred #340] preserving currency #{known} for lunchflow account " \
+          "#{account_id} (payload sent none; upstream default would have been #{currency})"
+        )
+        self.currency = known
+        save! if persisted?
+      end
+    end
+  end
+
+  ::LunchflowAccount.prepend(AlfredPreserveLunchflowCurrency)
+  Rails.logger.info("[alfred #340] Lunchflow currency-preservation patch loaded")
+end


### PR DESCRIPTION
Seven accounts holding real money display as **zero** — the largest a seven-figure HUF balance.

## Correcting my own framing first

I reported this as unfixable: "the adapter is upstream, nothing in this repo can change it", and proposed only labelling the wrong numbers as unreliable.

**Sure is self-hosted.** We run the container. Treating it as someone else's SaaS turned a fixable defect into a proposal to caption it. That was wrong, and this is the actual fix.

## Root cause

`LunchflowAccount#upsert_lunchflow_snapshot!` (`app/models/lunchflow_account.rb:40`):

```ruby
currency: parse_currency(snapshot[:currency]) || "USD",
```

Lunchflow sends no `currency`, and this runs on **every sync for every account** — so a hand-corrected value is overwritten on the next poll. Verified live: an account correctly set to HUF reverted to USD mid-investigation.

Worth noting the importer's `|| "USD"` at `lunchflow_item/importer.rb:65` is a red herring — it only fires for accounts never seen before. The clobber is in the snapshot upsert.

## The patch

One rule: **never overwrite a currency we already have with a guess.**

```
payload currency (if valid)  -> use it
else existing stored value   -> keep it
else                         -> "USD", unchanged for genuinely new records
```

## Why an initializer, not a file overlay

Bind-mounting a modified `lunchflow_account.rb` would pin us to one upstream revision — any Sure update changes that file and our copy silently reverts their fixes. A prepended module touches one method and composes with whatever upstream becomes.

It also **fails loudly**: if upstream renames or removes the method, the guard logs and skips rather than patching something that no longer means what we assume.

Mounted read-only via compose, so it survives `up -d --force-recreate` — a `docker cp` hot-patch would not.

It lives under `scripts/` because lane V owns that path. My first attempt put it in a new top-level `sure/` directory and the commit gate correctly refused it as unowned by any lane.

## Smoke evidence

Probed live at 2026-08-10.

```
§1 the clobber, in the running container
   app/models/lunchflow_account.rb:40
     currency: parse_currency(snapshot[:currency]) || "USD",
   called from importer.rb:178 via upsert_lunchflow_snapshot! on EVERY sync

§2 declared vs actual currency, from the accounts' own transactions
   account            declared   from txns   n
   CIB Joint          USD        HUF         493
   David EUR          USD        EUR          11
   David HUF          USD        HUF         514
   Joint HUF          USD        HUF         944
   Revolut … GBP      USD        GBP           3
   Revolut … HUF      USD        HUF          18
   (Kft) HUF          USD        HUF          21
   Wise - HUF         USD        HUF         937
   -> 8 accounts where the account NAME and its transaction history agree
      with each other and disagree with what Sure stores

§3 recurrence confirmed
   one account previously corrected to HUF was re-stamped USD during the
   investigation window — manual correction does not survive a sync

§4 patch validation
   $ ruby -c scripts/sure-patches/preserve_lunchflow_currency.rb
   Syntax OK
   $ docker compose config -q
   (clean)

✓ lane V (edges-infra) gate passed — 86 LOC, 2 files, verify ok
```

## Still required after this merges

The patch stops the clobber; it does not know the correct values. The eight accounts need their currency set **once**, after deploy. Names and transaction histories agree on all eight, so it is mechanical — but it is a data write and belongs in its own step, verified account by account.

Two accounts remain genuinely ambiguous and are deliberately excluded: one whose declared currency and transactions disagree with only five transactions to go on, and one whose name says EUR while its single transaction says USD. Those need Sir, not inference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc