### PR TITLE
feat(web): Approve/Decline surface for pending Acting promotions (#459)

### DIFF
--- a/packages/web/main.wasp
+++ b/packages/web/main.wasp
@@ -1892,6 +1892,13 @@ action updateInstinct {
   entities: []
 }
 
+// Approve or decline a pending Acting promotion (#452 / #459).
+// Calls the Lane I endpoint POST /api/v1/learning/instincts/:slug/promotion.
+action resolveInstinctPromotion {
+  fn: import { resolveInstinctPromotion } from "@src/intuition/operations",
+  entities: []
+}
+
 // ============================================================
 // Streams
 // ============================================================

--- a/packages/web/src/intuition/InstinctsPage.tsx
+++ b/packages/web/src/intuition/InstinctsPage.tsx
@@ -36,6 +36,7 @@ import {
   enableIntuition,
   disableIntuition,
   updateInstinct,
+  resolveInstinctPromotion,
 } from "wasp/client/operations";
 import { Frame } from "../client/components/ab/Frame";
 import { Markdown } from "../client/components/ab/Markdown";
@@ -44,6 +45,7 @@ import {
   STAGES,
   autonomyStatement,
   effectiveThreshold,
+  hasPendingPromotion,
   progressNote,
   readTier,
   tierCaption,
@@ -250,6 +252,7 @@ export default function InstinctsPage() {
   const [open, setOpen] = useState<string | null>(null);
   const [toggling, setToggling] = useState(false);
   const [forgetting, setForgetting] = useState<string | null>(null);
+  const [resolving, setResolving] = useState<string | null>(null);
 
   async function toggleEnabled() {
     setToggling(true);
@@ -274,6 +277,22 @@ export default function InstinctsPage() {
       console.error("forget failed", e);
     } finally {
       setForgetting(null);
+    }
+  }
+
+  // Approve or decline a pending Acting promotion (#459).
+  async function resolvePromotion(instinct: any, approved: boolean) {
+    const instPath = String(instinct?.path ?? "");
+    if (!instPath) return;
+    setResolving(instPath);
+    try {
+      await resolveInstinctPromotion({ path: instPath, approved });
+      await refetchInstincts();
+      setOpen(null); // collapse so Sir sees the updated list
+    } catch (e) {
+      console.error("resolve promotion failed", e);
+    } finally {
+      setResolving(null);
     }
   }
 
@@ -400,6 +419,15 @@ export default function InstinctsPage() {
                       style={{ color: "var(--brass)" }}
                     >
                       {stage}
+                      {/* #459 — pending is NOT the tier; show it separately */}
+                      {hasPendingPromotion(p) && (
+                        <span
+                          className="ml-2 font-normal text-[9px] normal-case tracking-normal"
+                          style={{ color: "var(--marginalia)" }}
+                        >
+                          · approval pending
+                        </span>
+                      )}
                     </span>
                     <span style={{ color: "var(--brass)" }}>
                       {isOpen ? "▾" : "▸"}
@@ -407,6 +435,73 @@ export default function InstinctsPage() {
                   </button>
                   {isOpen && (
                     <div className="pb-10 pr-4 max-w-[760px]">
+                      {/* Pending Acting promotion banner (#459) — above the
+                          ladder. This instinct is NOT yet Acting; the tier
+                          is shown correctly below. */}
+                      {hasPendingPromotion(p) && (() => {
+                        const fmRule = String(p?.frontmatter?.rule ?? "").trim();
+                        return (
+                          <div
+                            className="mb-6 p-4 border-l-4"
+                            style={{ borderColor: "var(--brass)" }}
+                          >
+                            <div
+                              className="font-mono text-[10px] uppercase tracking-[0.28em] mb-2"
+                              style={{ color: "var(--brass)" }}
+                            >
+                              Approval required
+                            </div>
+                            <p className="font-body text-[15px] leading-[1.5] mb-2">
+                              I'm proposing to reach{" "}
+                              <strong>Acting</strong> for this pattern.
+                              That means I will handle matches{" "}
+                              <strong>on your behalf, without asking you first</strong>.
+                              Currently I'm at{" "}
+                              <strong>{stage}</strong> — I'll bring things
+                              to you until you approve.
+                            </p>
+                            {fmRule && (
+                              <p
+                                className="font-body italic text-[14px] mb-4 leading-[1.45]"
+                                style={{ color: "var(--marginalia)" }}
+                              >
+                                "{fmRule}"
+                              </p>
+                            )}
+                            <div className="flex gap-3 mt-4">
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  resolvePromotion(p, true);
+                                }}
+                                disabled={resolving === path}
+                                className="font-mono text-[11px] uppercase tracking-[0.18em] px-4 py-1.5 border"
+                                style={{
+                                  borderColor: "var(--brass)",
+                                  color: "var(--brass)",
+                                }}
+                              >
+                                {resolving === path ? "…" : "Approve"}
+                              </button>
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  resolvePromotion(p, false);
+                                }}
+                                disabled={resolving === path}
+                                className="font-mono text-[11px] uppercase tracking-[0.18em] px-4 py-1.5 border"
+                                style={{
+                                  borderColor: "var(--marginalia)",
+                                  color: "var(--marginalia)",
+                                }}
+                              >
+                                Not yet
+                              </button>
+                            </div>
+                          </div>
+                        );
+                      })()}
+
                       {/* Stage progress — single full-width band */}
                       <div className="mb-6">
                         <div className="flex gap-1.5 mb-2">

--- a/packages/web/src/intuition/instinctTierCore.test.ts
+++ b/packages/web/src/intuition/instinctTierCore.test.ts
@@ -13,7 +13,9 @@ import {
   autonomyStatement,
   discretionThreshold,
   effectiveThreshold,
+  hasPendingPromotion,
   nextTier,
+  pendingPromotionFrom,
   progressNote,
   readTier,
   tierCaption,
@@ -134,4 +136,35 @@ test("progressNote pluralises and never promises promotion", () => {
   assert.match(progressNote("Asking", 0), /^0 observations recorded/);
   assert.match(progressNote("Asking", 3), /proposes Confirming/);
   assert.match(progressNote("Acting", 30), /highest tier/);
+});
+
+// --- pending Acting promotion (#452 / #459) ---
+
+test("hasPendingPromotion detects pending Acting promotion only", () => {
+  assert.equal(hasPendingPromotion(inst("Confirming", { pending_promotion: "Acting" })), true);
+  assert.equal(hasPendingPromotion(inst("Asking", { pending_promotion: "Confirming" })), false);
+  assert.equal(hasPendingPromotion(inst("Confirming")), false);
+  assert.equal(hasPendingPromotion(null), false);
+  assert.equal(hasPendingPromotion(undefined), false);
+});
+
+test("hasPendingPromotion never conflates pending with the live tier", () => {
+  // tier=Confirming + pending_promotion=Acting is still Confirming
+  const rec = inst("Confirming", { pending_promotion: "Acting" });
+  assert.equal(readTier(rec), "Confirming");
+  assert.equal(hasPendingPromotion(rec), true);
+  assert.equal(actsUnattended(rec), false);
+});
+
+test("hasPendingPromotion false when already Acting with no pending field", () => {
+  const rec = inst("Acting");
+  assert.equal(readTier(rec), "Acting");
+  assert.equal(hasPendingPromotion(rec), false);
+});
+
+test("pendingPromotionFrom reads the from-tier safely", () => {
+  const rec = inst("Confirming", { pending_promotion: "Acting", pending_promotion_from: "Confirming" });
+  assert.equal(pendingPromotionFrom(rec), "Confirming");
+  assert.equal(pendingPromotionFrom(inst("Asking", { pending_promotion: "Acting" })), "Asking");
+  assert.equal(pendingPromotionFrom(inst("Asking", { pending_promotion_from: "InvalidTier" })), "Asking");
 });

--- a/packages/web/src/intuition/instinctTierCore.ts
+++ b/packages/web/src/intuition/instinctTierCore.ts
@@ -115,6 +115,32 @@ export function nextTier(stage: Stage): Stage | null {
   return i >= 0 && i < STAGES.length - 1 ? STAGES[i + 1] : null;
 }
 
+// --- pending Acting promotion (#452 / #459) ------------------------------------
+// `pending_promotion: Acting` is NOT the tier — the instinct stays at its
+// current rung until Sir approves via `resolve_instinct_promotion` (Lane I).
+
+/** Whether this instinct has a pending promotion to Acting (#459).
+ *  CRITICAL: true does NOT mean the instinct is Acting — readTier disagrees. */
+export function hasPendingPromotion(instinct: any): boolean {
+  const raw =
+    instinct?.frontmatter?.pending_promotion ?? instinct?.pending_promotion;
+  return typeof raw === "string" && raw.trim() === "Acting";
+}
+
+/** The tier the instinct is being promoted FROM. Fails closed to "Asking". */
+export function pendingPromotionFrom(instinct: any): Stage {
+  const raw =
+    instinct?.frontmatter?.pending_promotion_from ??
+    instinct?.pending_promotion_from;
+  if (typeof raw !== "string") return "Asking";
+  const trimmed = raw.trim();
+  const normalized =
+    trimmed.charAt(0).toUpperCase() + trimmed.slice(1).toLowerCase();
+  return (STAGES as string[]).includes(normalized)
+    ? (normalized as Stage)
+    : "Asking";
+}
+
 /**
  * How the evidence line should read. Promotion is Reflection-driven, so
  * this deliberately promises nothing about when it will happen.

--- a/packages/web/src/intuition/operations.ts
+++ b/packages/web/src/intuition/operations.ts
@@ -9,6 +9,7 @@ import type {
   EnableIntuition,
   DisableIntuition,
   UpdateInstinct,
+  ResolveInstinctPromotion,
 } from "wasp/server/operations";
 import { getUserInstance, proxyToTenant } from "../server/tenantProxy";
 
@@ -74,5 +75,21 @@ export const updateInstinct: UpdateInstinct<{ path: string; set: { discretion_th
     method: "PATCH",
     path: `/api/v1/vault/records/${args.path}`,
     body: { set: args.set },
+  });
+};
+
+// Approve or decline a pending Acting promotion (#452 / #459).
+// Lane I ctrl-api endpoint: POST /api/v1/learning/instincts/:slug/promotion
+// Body: { approved: boolean }  Response: { tier, pending_promotion }
+export const resolveInstinctPromotion: ResolveInstinctPromotion<
+  { path: string; approved: boolean },
+  any
+> = async (args, context) => {
+  const instance = await getUserInstance(context);
+  const slug = args.path.split("/").pop() ?? args.path;
+  return proxyToTenant(instance, {
+    method: "POST",
+    path: `/api/v1/learning/instincts/${encodeURIComponent(slug)}/promotion`,
+    body: { approved: args.approved },
   });
 };


### PR DESCRIPTION
Closes #459. References #452 (learn half, already merged #458).

## What this builds

On `/instincts`, every instinct that Reflection proposed to promote to Acting — but which `apply_instinct_change` withheld per #452 — now surfaces an explicit approval UI.

**Collapsed row:** A `· approval pending` label appears next to the current tier badge. The badge still shows the real tier (e.g. Confirming), never Acting. An instinct with `pending_promotion: Acting` cannot render as though it were already Acting.

**Expanded pane:** An "Approval required" banner above the ladder:

- Plain-language description of what Acting means: "I will handle matches on your behalf, without asking you first."
- The instinct's `rule` field (if set), so Sir knows what he's approving.
- The instinct's current tier, so it's clear this is a crossing request.
- **Approve** button → calls `resolveInstinctPromotion({ path, approved: true })`.
- **Not yet** button → calls `resolveInstinctPromotion({ path, approved: false })`.

On either click the list refreshes and the panel collapses.

## Files touched

- `packages/web/src/intuition/instinctTierCore.ts` — `hasPendingPromotion()` and `pendingPromotionFrom()` as the single place the app reads pending state.
- `packages/web/src/intuition/instinctTierCore.test.ts` — 4 new tests (19 total), incl. the isolation invariant that pending ≠ tier and `actsUnattended()` stays false while pending.
- `packages/web/src/intuition/InstinctsPage.tsx` — pending indicator in list row + approval banner in expanded pane.
- `packages/web/src/intuition/operations.ts` — `resolveInstinctPromotion` Wasp action.
- `packages/web/main.wasp` — `action resolveInstinctPromotion` declaration.

## Lane I ctrl-api work still needed

The `resolveInstinctPromotion` action calls:

```
POST /api/v1/learning/instincts/:slug/promotion
Body: { "approved": boolean }
Response: { "tier": string, "pending_promotion": null | string }
```

Where `:slug` is the filename component of the instinct path (e.g. `escalate-foo.md` from `instinct/escalate-foo.md`). The endpoint must invoke `resolve_instinct_promotion(path, approved, actor)` from the learn layer — not patch the frontmatter directly, as a direct patch would skip the audit row (the #442 lesson).

Until this endpoint exists, the buttons render and the UI is correct, but clicking will get a 404 from ctrl-api.

## Smoke evidence

Local test suite, no node_modules (tsc falls back per `.lane` manifest):

```
npx --no-install tsx --test packages/web/src/intuition/instinctTierCore.test.ts
1..19
# tests 19
# suites 0
# pass 19
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 119.658042
```

Lane gate output (commit hook):
```
▶ lane III verify: cd packages/web && npx --no-install tsc --noEmit -p . 2>&1 | tail -5 || echo tsc unavailable — see PR
[tsc unavailable message — no node_modules in worktree]
✓ lane III (web) gate passed — 178 LOC, 5 files, verify ok
```

Key isolation invariant tested (test 17):

```
test("hasPendingPromotion never conflates pending with the live tier")
// tier=Confirming + pending_promotion=Acting → readTier=Confirming, hasPending=true, actsUnattended=false
```

Live UI pass: needs staging deploy — the web surface is built; the ctrl-api endpoint (Lane I) must land first for the buttons to complete the round-trip. Marking **needs live staging UI pass** once Lane I merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)