### PR TITLE
fix(ctrl): idempotent backfill for legacy webhook stream_event records (#465)

### DIFF
--- a/packages/ctrl/scripts/backfill-webhook-legacy.mjs
+++ b/packages/ctrl/scripts/backfill-webhook-legacy.mjs
@@ -18,9 +18,19 @@
  * Apply inserts:
  *   node packages/ctrl/scripts/backfill-webhook-legacy.mjs --execute
  *
- * Run from inside the ctrl-api container where ingest.db is live:
- *   docker exec alfred-ctrl node /app/scripts/backfill-webhook-legacy.mjs
- *   docker exec alfred-ctrl node /app/scripts/backfill-webhook-legacy.mjs --execute
+ * Running it on a tenant: the ctrl-api image copies only `dist/api.mjs` into
+ * /app, so this file is NOT present in the container and cannot be exec'd from
+ * a path there. Copy it in first, run it, then remove it. (Do not add scripts/
+ * to the image for this — it is a one-shot recovery, not a recurring job.)
+ *
+ *   CTRL=alfred-black-ctrl-api-1
+ *   docker cp packages/ctrl/scripts/backfill-webhook-legacy.mjs $CTRL:/tmp/bf.mjs
+ *   docker exec $CTRL node /tmp/bf.mjs              # dry run — writes nothing
+ *   docker exec $CTRL node /tmp/bf.mjs --execute    # apply
+ *   docker exec $CTRL rm -f /tmp/bf.mjs
+ *
+ * A `docker cp` overlay does not survive `docker compose up -d --force-recreate`,
+ * which is fine here — the inserted ingest.db rows are what persists.
  *
  * Environment (same defaults as ctrl-api):
  *   VAULT_PATH     (default: /vault)

--- a/packages/ctrl/scripts/backfill-webhook-legacy.mjs
+++ b/packages/ctrl/scripts/backfill-webhook-legacy.mjs
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+/**
+ * Backfill legacy webhook stream_event records into ingest.db.
+ *
+ * Before PR #508, POST /api/v1/webhooks/in/:token wrote a `stream_event`
+ * markdown file into vault/stream_event/ and returned 202 unconditionally.
+ * Nothing reads that directory — the canonical pipeline consumes ingest.db
+ * after the #78 migration. Any delivery that arrived before #508 was silently
+ * stranded; the sender believed it succeeded.
+ *
+ * This script scans vault/stream_event/webhook-*.md, identifies legacy webhook
+ * records (source_type starts with "webhook:"), and inserts the missing
+ * ingest.db rows idempotently so the existing EventProcessor picks them up.
+ *
+ * Usage (dry-run by default — reports what would be inserted, writes nothing):
+ *   node packages/ctrl/scripts/backfill-webhook-legacy.mjs
+ *
+ * Apply inserts:
+ *   node packages/ctrl/scripts/backfill-webhook-legacy.mjs --execute
+ *
+ * Run from inside the ctrl-api container where ingest.db is live:
+ *   docker exec alfred-ctrl node /app/scripts/backfill-webhook-legacy.mjs
+ *   docker exec alfred-ctrl node /app/scripts/backfill-webhook-legacy.mjs --execute
+ *
+ * Environment (same defaults as ctrl-api):
+ *   VAULT_PATH     (default: /vault)
+ *   INGEST_DB_PATH (default: ./data/ingest.db)
+ */
+
+import { DatabaseSync } from "node:sqlite";
+import { fileURLToPath } from "node:url";
+import fs from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+
+// ── Crockford-base32 ULID (inlined — no npm deps in operator scripts) ─────────
+const CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+function ulid(now = Date.now()) {
+  let tp = "";
+  let t = now;
+  for (let i = 0; i < 10; i++) { tp = CROCKFORD[t % 32] + tp; t = Math.floor(t / 32); }
+  const rb = crypto.randomBytes(10);
+  let acc = 0n;
+  for (const b of rb) acc = (acc << 8n) | BigInt(b);
+  let rp = "";
+  for (let i = 0; i < 16; i++) { rp = CROCKFORD[Number(acc & 31n)] + rp; acc >>= 5n; }
+  return tp + rp;
+}
+
+// ── Pure helpers (exported so the test file can verify them) ──────────────────
+
+/** Minimal YAML frontmatter parser — handles the flat shapes used by ctrl-api. */
+export function parseFrontmatter(content) {
+  if (!content.startsWith("---")) return {};
+  const end = content.indexOf("\n---", 3);
+  if (end === -1) return {};
+  const out = {};
+  for (const rawLine of content.slice(4, end).split("\n")) {
+    const line = rawLine.replace(/\r$/, "");
+    const idx = line.indexOf(":");
+    if (idx <= 0) continue;
+    const key = line.slice(0, idx).trim();
+    if (!key) continue;
+    let val = line.slice(idx + 1).trim();
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'")))
+      val = val.slice(1, -1);
+    out[key] = val === "null" || val === "~" ? null : val;
+  }
+  return out;
+}
+
+/**
+ * Extract the JSON payload from the ```json code block written by the old
+ * webhook handler. Returns { text, parsed } or null if no block found.
+ */
+export function extractPayload(content) {
+  const MARKER = "```json\n";
+  const start = content.indexOf(MARKER);
+  if (start === -1) return null;
+  const bodyStart = start + MARKER.length;
+  const end = content.indexOf("\n```", bodyStart);
+  if (end === -1) return null;
+  const text = content.slice(bodyStart, end);
+  try { return { text, parsed: JSON.parse(text) }; } catch { return { text, parsed: null }; }
+}
+
+/**
+ * Compute the external_id for a legacy webhook record using the same formula
+ * as PR #508's content-hash fallback: `token:sha256(token:payloadText)[0:32]`.
+ * This is stable and deterministic — running the backfill twice deduplicates
+ * via the UNIQUE(stream, external_id) constraint.
+ */
+export function computeExternalId(token, payloadText) {
+  return `${token}:${crypto.createHash("sha256").update(`${token}:${payloadText}`).digest("hex").slice(0, 32)}`;
+}
+
+// ── Main (only runs when executed directly, not on import by tests) ───────────
+async function main() {
+  const DRY_RUN = !process.argv.includes("--execute");
+  const VAULT_ROOT = process.env.VAULT_PATH ?? "/vault";
+  const INGEST_DB_PATH = process.env.INGEST_DB_PATH ?? path.join(process.cwd(), "data", "ingest.db");
+  const STREAM_EVENT_DIR = path.join(VAULT_ROOT, "stream_event");
+
+  console.log(`[backfill] mode=${DRY_RUN ? "DRY-RUN (pass --execute to apply)" : "EXECUTE"}`);
+  console.log(`[backfill] vault/stream_event = ${STREAM_EVENT_DIR}`);
+  console.log(`[backfill] ingest.db          = ${INGEST_DB_PATH}`);
+
+  let db;
+  try {
+    db = new DatabaseSync(INGEST_DB_PATH);
+    db.exec("PRAGMA busy_timeout = 5000");
+  } catch (err) {
+    console.error(`[backfill] ERROR: cannot open ingest.db: ${err}`);
+    process.exit(1);
+  }
+
+  if (!fs.existsSync(STREAM_EVENT_DIR)) {
+    console.log("[backfill] stream_event dir not found — nothing to backfill");
+    return;
+  }
+
+  // Only look at files written by the webhook handler: `webhook-<tokenPrefix>-<ts>-<uuid>.md`
+  const entries = fs.readdirSync(STREAM_EVENT_DIR)
+    .filter(f => f.endsWith(".md") && f.startsWith("webhook-"))
+    .sort();
+
+  console.log(`[backfill] ${entries.length} candidate file(s) (webhook-*.md)\n`);
+
+  let inserted = 0, alreadyPresent = 0, skipped = 0;
+  const failed = [];
+
+  for (const filename of entries) {
+    const label = filename;
+    let content;
+    try { content = fs.readFileSync(path.join(STREAM_EVENT_DIR, filename), "utf-8"); }
+    catch (err) { console.log(`  SKIP    ${label} — unreadable: ${err.message}`); skipped++; continue; }
+
+    const fm = parseFrontmatter(content);
+    const sourceType = String(fm.source_type ?? "");
+    if (!sourceType.startsWith("webhook:")) {
+      console.log(`  SKIP    ${label} — source_type="${sourceType}" not webhook:`);
+      skipped++; continue;
+    }
+
+    // Token lives in source_ref as "<token>:<shortUuid>"; split on last colon.
+    const sourceRef = String(fm.source_ref ?? "");
+    const colonIdx = sourceRef.lastIndexOf(":");
+    if (colonIdx <= 0) {
+      console.log(`  SKIP    ${label} — source_ref="${sourceRef}" malformed`);
+      skipped++; continue;
+    }
+    const token = sourceRef.slice(0, colonIdx);
+
+    const result = extractPayload(content);
+    if (!result || !result.parsed) {
+      console.log(`  SKIP    ${label} — ${!result ? "no ```json block" : "malformed JSON"}`);
+      skipped++; continue;
+    }
+
+    const receivedAt = String(fm.received_at ?? new Date().toISOString());
+    const externalId = computeExternalId(token, result.text);
+    const shortId = externalId.slice(0, 28) + "…";
+
+    const existing = db.prepare(
+      "SELECT 1 FROM stream_event WHERE stream='webhook' AND external_id=?",
+    ).get(externalId);
+    if (existing) {
+      console.log(`  PRESENT ${label}  (external_id=${shortId})`);
+      alreadyPresent++; continue;
+    }
+
+    if (DRY_RUN) {
+      console.log(`  WOULD-INSERT ${label}  channel="${sourceType}"  external_id=${shortId}`);
+      inserted++; continue;
+    }
+
+    try {
+      db.prepare(
+        `INSERT INTO stream_event (id, ts, stream, channel, external_id, kind, payload_json)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        ulid(), receivedAt, "webhook", sourceType, externalId, "webhook",
+        JSON.stringify({ source_type: sourceType, source_ref: sourceRef, received_at: receivedAt, payload: result.parsed }),
+      );
+      console.log(`  INSERTED ${label}  external_id=${shortId}`);
+      inserted++;
+    } catch (err) {
+      if (String(err).includes("UNIQUE")) {
+        console.log(`  PRESENT (race) ${label}`);
+        alreadyPresent++;
+      } else {
+        console.log(`  ERROR   ${label} — ${String(err).slice(0, 120)}`);
+        failed.push(filename);
+      }
+    }
+  }
+
+  const verb = DRY_RUN ? "would-insert" : "inserted";
+  console.log(`\n[backfill] ${verb}=${inserted}  already-present=${alreadyPresent}  skipped=${skipped}  errors=${failed.length}`);
+  if (failed.length) {
+    console.error("[backfill] Failed files:\n" + failed.map(f => "  " + f).join("\n"));
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/packages/ctrl/tests/backfill-webhook-legacy.test.ts
+++ b/packages/ctrl/tests/backfill-webhook-legacy.test.ts
@@ -1,0 +1,86 @@
+// Tests for the pure helper functions exported by the backfill script.
+// The main() execution path is guarded by import.meta.url so it does not
+// run on import — only the pure parsing + keying functions are exercised here.
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+// @ts-ignore — the script is a .mjs file with no TypeScript declarations
+const { parseFrontmatter, extractPayload, computeExternalId } = await import(
+  "../scripts/backfill-webhook-legacy.mjs"
+);
+
+// ── parseFrontmatter ──────────────────────────────────────────────────────────
+describe("parseFrontmatter", () => {
+  it("extracts source_type and source_ref from a legacy webhook record", () => {
+    const content =
+      `---\ntype: stream_event\nsource_type: "webhook:Test Label"\nreceived_at: "2026-07-21T10:00:00.000Z"\nsource_ref: "abc123:deadbeef"\nprocessed: false\n---\n\n# body`;
+    const fm = parseFrontmatter(content);
+    assert.equal(fm.source_type, "webhook:Test Label");
+    assert.equal(fm.source_ref, "abc123:deadbeef");
+    assert.equal(fm.received_at, "2026-07-21T10:00:00.000Z");
+  });
+
+  it("returns empty object when no frontmatter block", () => {
+    assert.deepEqual(parseFrontmatter("no frontmatter here"), {});
+  });
+
+  it("handles null values", () => {
+    const fm = parseFrontmatter("---\nkey: null\n---\n");
+    assert.equal(fm.key, null);
+  });
+});
+
+// ── extractPayload ────────────────────────────────────────────────────────────
+describe("extractPayload", () => {
+  const BODY = [
+    "---\ntype: stream_event\n---\n",
+    "\n# Inbound webhook payload\n\nLabel: Test\n\n",
+    "```json\n",
+    JSON.stringify({ recording_id: "171112331", meeting_title: "RJ sync" }),
+    "\n```\n",
+  ].join("");
+
+  it("extracts valid JSON from code block", () => {
+    const result = extractPayload(BODY);
+    assert.ok(result !== null);
+    assert.equal(result!.parsed.recording_id, "171112331");
+  });
+
+  it("returns null when no ```json block", () => {
+    assert.equal(extractPayload("no code block here"), null);
+  });
+
+  it("returns parsed=null for malformed JSON", () => {
+    const bad = "---\n---\n\n```json\n{not json\n```\n";
+    const result = extractPayload(bad);
+    assert.ok(result !== null);
+    assert.equal(result!.parsed, null);
+    assert.ok(result!.text.includes("{not json"));
+  });
+});
+
+// ── computeExternalId ─────────────────────────────────────────────────────────
+describe("computeExternalId", () => {
+  it("produces a stable, deterministic key", () => {
+    const id1 = computeExternalId("abc123token", '{"recording_id":"171112331"}');
+    const id2 = computeExternalId("abc123token", '{"recording_id":"171112331"}');
+    assert.equal(id1, id2);
+  });
+
+  it("differs across tokens (scoped to the webhook endpoint)", () => {
+    const id1 = computeExternalId("tokenA", "payload");
+    const id2 = computeExternalId("tokenB", "payload");
+    assert.notEqual(id1, id2);
+  });
+
+  it("starts with token prefix and a colon", () => {
+    const id = computeExternalId("mytoken", "{}");
+    assert.ok(id.startsWith("mytoken:"));
+  });
+
+  it("hash segment is 32 hex chars", () => {
+    const id = computeExternalId("tok", "{}");
+    const hash = id.split(":")[1];
+    assert.match(hash, /^[0-9a-f]{32}$/);
+  });
+});


### PR DESCRIPTION
## Summary

- Before PR #508, `POST /api/v1/webhooks/in/:token` wrote markdown files into `vault/stream_event/` and returned 202 unconditionally. Nothing reads that directory after the #78 migration — any delivery arriving before #508 was silently stranded.
- This PR adds the backfill half of #465 (scope item 4): a one-shot operator script that reads the legacy markdown records and inserts the missing `ingest.db` rows so `EventProcessorWorkflow` picks them up.
- The vault markdown records are left untouched (read-only) — they remain as the audit trail.

## Why a script, not a route

A permanent `POST /api/v1/...` route would be visible in the MCP tool list forever, need auth plumbing, and convey the wrong signal that this is a recurring operation. The backfill is a one-time recovery for stranded deliveries. A script in `packages/ctrl/scripts/` can be invoked once via `docker exec`, verified against dry-run output, and ignored thereafter. The same pattern as `diagnose-tenant.mjs` and `bootstrap-alfred-learn.mjs` already in that directory.

## How idempotency is enforced

External ID: `token:sha256(token:payloadText)[0:32]` — the same content-hash formula as PR #508's fallback for deliveries without a `X-Webhook-Delivery` header. The `UNIQUE(stream, external_id)` constraint on `ingest.db.stream_event` is the enforcement mechanism. A collision means the row is already present; the script reports `PRESENT` and continues. Running it twice inserts nothing on the second pass.

## How to filter to webhook-only records

Two discriminators, both required:
1. Filename starts with `webhook-` (the exact prefix the old handler used in `safeIdent(token).slice(0,12)` + timestamp)
2. `source_type` frontmatter field starts with `webhook:` (e.g. `webhook:Fathom meeting content`)

Files written by other producers (composio streams, state-changes, etc.) don't match either criterion and are silently skipped. The script reports the skip reason per file.

## Operator commands

**Step 1 — dry-run first (always):**
```sh
docker exec alfred-ctrl node /app/scripts/backfill-webhook-legacy.mjs
```

Sample output:
```
[backfill] mode=DRY-RUN (pass --execute to apply)
[backfill] vault/stream_event = /vault/stream_event
[backfill] ingest.db          = /data/ingest.db
[backfill] 8 candidate file(s) (webhook-*.md)

  WOULD-INSERT webhook-abc123-2026-07-21T10-00-00-deadbeef.md  channel="webhook:Fathom meeting content"  external_id=abc123:be5a0b392d40d87af441de87...
  WOULD-INSERT webhook-abc123-2026-07-22T11-00-00-cafe1234.md  channel="webhook:Fathom meeting content"  external_id=abc123:4d45fa1f37358a62dc48d4a1...
  ...
[backfill] would-insert=8  already-present=0  skipped=0  errors=0
```

**Step 2 — apply:**
```sh
docker exec alfred-ctrl node /app/scripts/backfill-webhook-legacy.mjs --execute
```

**Step 3 — verify:**
```sh
docker exec alfred-ctrl node --experimental-sqlite -e "
import { DatabaseSync } from 'node:sqlite';
const db = new DatabaseSync('/data/ingest.db');
const n = db.prepare(\"SELECT COUNT(*) AS n FROM stream_event WHERE stream='webhook' AND processed_at IS NULL\").get();
console.log('unprocessed webhook events:', n.n);
" --input-type=module
```

EventProcessorWorkflow runs every 15 minutes; the backfilled events will be consumed on its next cycle.

## Smoke evidence

Local run against a 3-file fixture (2 legacy webhook records + 1 non-webhook file the filename filter ignores):

```
=== DRY-RUN ===
[backfill] mode=DRY-RUN (pass --execute to apply)
[backfill] vault/stream_event = .../vault/stream_event
[backfill] ingest.db          = .../data/ingest.db
[backfill] 2 candidate file(s) (webhook-*.md)

  WOULD-INSERT webhook-abc123def456-2026-07-21T10-00-00-deadbeef.md  channel="webhook:Fathom meeting content"  external_id=abc123def456abc123def456abc1…
  WOULD-INSERT webhook-abc123def456-2026-07-22T11-00-00-cafe1234.md  channel="webhook:Fathom meeting content"  external_id=abc123def456abc123def456abc1…

[backfill] would-insert=2  already-present=0  skipped=0  errors=0

=== EXECUTE (first run) ===
[backfill] mode=EXECUTE
[backfill] 2 candidate file(s) (webhook-*.md)

  INSERTED webhook-abc123def456-2026-07-21T10-00-00-deadbeef.md  external_id=abc123def456abc123def456abc1…
  INSERTED webhook-abc123def456-2026-07-22T11-00-00-cafe1234.md  external_id=abc123def456abc123def456abc1…

[backfill] inserted=2  already-present=0  skipped=0  errors=0

=== DB verification ===
Row count: 2
  {"stream":"webhook","channel":"webhook:Fathom meeting content","external_id":"abc123def456abc123def456abc123de:be5a0b392d40d87af441de879bfada9f","kind":"webhook","ts":"2026-07-21T10:00:00.000Z"}
  {"stream":"webhook","channel":"webhook:Fathom meeting content","external_id":"abc123def456abc123def456abc123de:4d45fa1f37358a62dc48d4a1a886b1e4","kind":"webhook","ts":"2026-07-22T11:00:00.000Z"}

=== IDEMPOTENCY — second --execute run ===
[backfill] mode=EXECUTE
[backfill] 2 candidate file(s) (webhook-*.md)

  PRESENT webhook-abc123def456-2026-07-21T10-00-00-deadbeef.md  (external_id=abc123def456abc123def456abc1…)
  PRESENT webhook-abc123def456-2026-07-22T11-00-00-cafe1234.md  (external_id=abc123def456abc123def456abc1…)

[backfill] inserted=0  already-present=2  skipped=0  errors=0
```

Lane gate line:
```
✓ lane I (ctrl-api) gate passed — 294 LOC, 2 files, verify ok
```

Test file `packages/ctrl/tests/backfill-webhook-legacy.test.ts` covers `parseFrontmatter`, `extractPayload`, and `computeExternalId` in isolation (pure function tests, no DB or filesystem). Runs in CI with the full ctrl-api test suite (`npm test`).

References #465.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc