### PR TITLE
feat(learn): per-chore notify_channel — destination routing for chore notifications (#498)

### DIFF
--- a/packages/learn/src/activities/chore_actions.py
+++ b/packages/learn/src/activities/chore_actions.py
@@ -325,33 +325,116 @@ async def save_digest_to_vault(matter_slug: str, digest: str) -> None:
 # ---------------------------------------------------------------------------
 
 @activity.defn
-async def send_chore_notification(chore_slug: str, session_id: str, message: str) -> None:
-    """Send a notification via the existing tenant notification route.
+async def send_chore_notification(
+    chore_slug: str,
+    session_id: str,  # kept for Temporal backward compat; dead param since 2026-05-25
+    message: str,
+    notify_channel: str | None = None,
+) -> dict:
+    """Send a notification via the tenant notification route.
 
-    POSTs to ctrl-api /api/v1/notifications, which forwards to the OpenClaw
-    gateway via the sessions_send tool. The session_id determines which
-    Alfred session (and therefore which delivery channel) receives the
-    message.
+    POSTs to ctrl-api /api/v1/notifications.  When the chore record carries a
+    ``notify_channel`` frontmatter field (or the caller passes ``notify_channel``
+    directly), it is forwarded as the ``channel`` parameter so ctrl-api routes
+    to that specific Slack/Telegram destination.  When absent, ``channel`` is
+    omitted and ctrl-api applies its home-channel default
+    (SLACK_HOME_CHANNEL / TELEGRAM_HOME_CHANNEL).  If neither resolves there,
+    ctrl-api returns 424 and this activity raises, allowing Temporal to retry
+    and surface the misconfiguration visibly.
+
+    The ``session_id`` positional parameter is kept for backward compatibility
+    with in-flight generated chore workflows that call this activity with
+    positional ``args=[slug, session_id, msg]``.  It has been a no-op since
+    the 2026-05-25 "one-Alfred" hard switch: ctrl-api's notifications route
+    never forwarded it downstream.
+
+    Temporal replay safety: ``notify_channel`` is a regular optional positional
+    parameter with a default of ``None``.  Existing callers that dispatch via
+    ``args=[slug, session_id, msg]`` (three positional args) keep working
+    unchanged — Python fills the fourth arg from its default.  The activity
+    name is unchanged, so Temporal's history lookup still resolves.  No
+    workflow code needs to change for the activity contract to stay valid.
+    (Temporal's SDK rejects keyword-only ``*`` args entirely; see
+    temporalio/activity.py:601.)
+
+    Returns structured delivery evidence::
+
+        {
+            "delivered": bool,
+            "destination": str,    # resolved channel value or "auto"
+            "http_status": int,
+            "error": str | None,
+        }
+
+    Raises ``httpx.HTTPStatusError`` on non-2xx so Temporal can retry on
+    transient failures.  Transport errors propagate as-is.
     """
     config = load_config()
     api_key = os.environ.get("AAS_API_KEY", "")
-    url = f"{config.alfred_ctrl_url}/api/v1/notifications"
-    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
-    async with httpx.AsyncClient(timeout=30.0) as http:
+
+    # 1. Resolve destination: kwarg → chore frontmatter → omit (ctrl-api decides).
+    # Priority: explicit kwarg wins (allows in-repo workflows to pass it
+    # directly after loading ctx); else read from the chore record itself so
+    # generated chores on live tenants benefit without any code change.
+    resolved_channel = notify_channel
+    if resolved_channel is None:
         try:
-            await http.post(
-                url,
-                json={
-                    "message": f"[Chore: {chore_slug}]\n\n{message}",
-                    "urgency": "normal",
-                    "session_id": session_id,
-                },
-                headers=headers,
-            )
+            ch_client = VaultClient(config)
+            try:
+                record = await ch_client.read_record(f"chore/{chore_slug}.md")
+                ch = (record.get("frontmatter") or {}).get("notify_channel")
+                if ch and isinstance(ch, str) and ch.strip():
+                    resolved_channel = ch.strip()
+            finally:
+                await ch_client.close()
         except Exception:
-            # Best-effort: don't fail the whole chore run because notification
-            # delivery flaked.
-            pass
+            pass  # treat as no channel — ctrl-api home default applies
+
+    # 2. Build POST body; include channel only when explicitly resolved so that
+    #    ctrl-api's home-channel default (SLACK_HOME_CHANNEL / TELEGRAM_HOME_CHANNEL)
+    #    is the sole fallback, not any ambient session.
+    body: dict[str, Any] = {
+        "message": f"[Chore: {chore_slug}]\n\n{message}",
+        "urgency": "normal",
+    }
+    if resolved_channel:
+        body["channel"] = resolved_channel
+
+    destination = resolved_channel or "auto"
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+
+    async with httpx.AsyncClient(timeout=30.0) as http:
+        resp = await http.post(
+            f"{config.alfred_ctrl_url}/api/v1/notifications",
+            json=body,
+            headers=headers,
+        )
+        resp.raise_for_status()
+
+    # 3. Best-effort: append a delivery audit line to the chore body so the
+    #    resolved destination is auditable even when the calling workflow's
+    #    record_chore_run summary omits it.  Generated chore workflows that do
+    #    not capture the return value of this activity still get the destination
+    #    recorded in the vault run log.
+    ts_iso = datetime.now(timezone.utc).isoformat()
+    try:
+        audit_client = VaultClient(config)
+        try:
+            await audit_client.update_record(
+                f"chore/{chore_slug}.md",
+                f"\n- {ts_iso}: notification sent → destination={destination}",
+            )
+        finally:
+            await audit_client.close()
+    except Exception:
+        pass  # best-effort; vault offline must not block delivery evidence
+
+    return {
+        "delivered": True,
+        "destination": destination,
+        "http_status": resp.status_code,
+        "error": None,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/packages/learn/src/activities/chore_actions.py
+++ b/packages/learn/src/activities/chore_actions.py
@@ -334,13 +334,35 @@ async def send_chore_notification(
     """Send a notification via the tenant notification route.
 
     POSTs to ctrl-api /api/v1/notifications.  When the chore record carries a
-    ``notify_channel`` frontmatter field (or the caller passes ``notify_channel``
-    directly), it is forwarded as the ``channel`` parameter so ctrl-api routes
-    to that specific Slack/Telegram destination.  When absent, ``channel`` is
-    omitted and ctrl-api applies its home-channel default
-    (SLACK_HOME_CHANNEL / TELEGRAM_HOME_CHANNEL).  If neither resolves there,
-    ctrl-api returns 424 and this activity raises, allowing Temporal to retry
-    and surface the misconfiguration visibly.
+    ``notify_channel`` frontmatter field (or the caller passes it as the 4th
+    positional arg), the value is parsed as ``platform:destination`` and
+    forwarded to ctrl-api as separate ``channel`` (platform enum) and ``to``
+    (chat/channel id) fields, matching the alfredDeliver.ts body contract::
+
+        body: { message, channel?: "auto"|"telegram"|"slack"|"email", to?: str }
+
+    ``channel`` selects the adapter; ``to`` is the recipient id.  They are
+    separate fields and a destination id in ``channel`` falls to the default
+    case in ``deliverByChannel()`` (``channel=<id> has no delivery adapter``).
+
+    **notify_channel format** (the same convention as commitment_register's
+    ``projection`` field in CLAUDE.md §6.1)::
+
+        slack:C0123456789        → channel="slack",    to="C0123456789"
+        telegram:-1001234567     → channel="telegram",  to="-1001234567"
+        email:user@example.com   → channel="email",     to="user@example.com"
+
+    **Bare values with no ``:`` separator are treated as unset** and the
+    notification falls through to ctrl-api's home-channel default
+    (SLACK_HOME_CHANNEL / TELEGRAM_HOME_CHANNEL).  Guessing the platform from
+    an id's shape is how you get a Telegram id posted to Slack — treat
+    unparseable values as unset rather than guessing.  Invalid platform names
+    (anything not in ``slack|telegram|email``) are likewise treated as unset.
+
+    When absent or unparseable, ``channel`` and ``to`` are both omitted and
+    ctrl-api applies its home-channel default.  If neither a home channel nor
+    an explicit destination resolves, ctrl-api returns 424 and this activity
+    raises, surfacing the misconfiguration visibly for Temporal retry.
 
     The ``session_id`` positional parameter is kept for backward compatibility
     with in-flight generated chore workflows that call this activity with
@@ -361,7 +383,7 @@ async def send_chore_notification(
 
         {
             "delivered": bool,
-            "destination": str,    # resolved channel value or "auto"
+            "destination": str,    # "platform:id" or "auto"
             "http_status": int,
             "error": str | None,
         }
@@ -369,38 +391,59 @@ async def send_chore_notification(
     Raises ``httpx.HTTPStatusError`` on non-2xx so Temporal can retry on
     transient failures.  Transport errors propagate as-is.
     """
+    _VALID_PLATFORMS = frozenset({"slack", "telegram", "email"})
+
+    def _parse_notify_channel(raw: str) -> tuple[str, str] | None:
+        """Parse 'platform:destination' → (platform, destination) or None.
+
+        Returns None when the value has no colon, uses an unrecognised platform,
+        or produces an empty destination.  None causes the caller to omit
+        channel + to entirely, falling through to ctrl-api's home default.
+        """
+        if ":" not in raw:
+            return None
+        platform, _, dest = raw.partition(":")
+        platform = platform.strip().lower()
+        dest = dest.strip()
+        if platform not in _VALID_PLATFORMS or not dest:
+            return None
+        return platform, dest
+
     config = load_config()
     api_key = os.environ.get("AAS_API_KEY", "")
 
     # 1. Resolve destination: kwarg → chore frontmatter → omit (ctrl-api decides).
-    # Priority: explicit kwarg wins (allows in-repo workflows to pass it
-    # directly after loading ctx); else read from the chore record itself so
+    # Priority: explicit kwarg wins; else read from the chore record so
     # generated chores on live tenants benefit without any code change.
-    resolved_channel = notify_channel
-    if resolved_channel is None:
+    resolved_raw = notify_channel
+    if resolved_raw is None:
         try:
             ch_client = VaultClient(config)
             try:
                 record = await ch_client.read_record(f"chore/{chore_slug}.md")
                 ch = (record.get("frontmatter") or {}).get("notify_channel")
                 if ch and isinstance(ch, str) and ch.strip():
-                    resolved_channel = ch.strip()
+                    resolved_raw = ch.strip()
             finally:
                 await ch_client.close()
         except Exception:
             pass  # treat as no channel — ctrl-api home default applies
 
-    # 2. Build POST body; include channel only when explicitly resolved so that
-    #    ctrl-api's home-channel default (SLACK_HOME_CHANNEL / TELEGRAM_HOME_CHANNEL)
-    #    is the sole fallback, not any ambient session.
+    # 2. Parse platform:destination. Unparseable → fall through to ctrl-api auto.
+    parsed = _parse_notify_channel(resolved_raw) if resolved_raw else None
+    destination = f"{parsed[0]}:{parsed[1]}" if parsed else "auto"
+
+    # 3. Build POST body; split channel (platform enum) and to (recipient id)
+    #    per alfredDeliver.ts:35.  Omit both when no explicit destination so
+    #    ctrl-api's home-channel default is the sole fallback.
     body: dict[str, Any] = {
         "message": f"[Chore: {chore_slug}]\n\n{message}",
         "urgency": "normal",
     }
-    if resolved_channel:
-        body["channel"] = resolved_channel
+    if parsed:
+        body["channel"] = parsed[0]  # platform enum: "slack"|"telegram"|"email"
+        body["to"] = parsed[1]       # recipient id
 
-    destination = resolved_channel or "auto"
     headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
 
     async with httpx.AsyncClient(timeout=30.0) as http:

--- a/packages/learn/tests/test_chore_notify_channel.py
+++ b/packages/learn/tests/test_chore_notify_channel.py
@@ -1,15 +1,18 @@
 """Tests for `send_chore_notification` — per-chore destination routing (#498).
 
 Covers:
-  - Chore with ``notify_channel`` in frontmatter → ``channel`` key in POST body
-  - Chore without ``notify_channel`` → ``channel`` key absent from POST body
+  - Chore with ``notify_channel: slack:<id>`` → ``channel="slack", to="<id>"``
+    (NOT ``channel="<id>"``, which would fall to the default case in
+    alfredDeliver.ts:deliverByChannel and produce a no-delivery error)
+  - Chore without ``notify_channel`` → both ``channel`` and ``to`` absent
+  - Bare value with no ``platform:`` separator → treated as unset (falls through)
+  - Unknown platform → treated as unset
   - Resolved destination recorded in chore body (run notes)
   - HTTP error raises so Temporal can retry (no longer swallowed)
   - Explicit 4th positional arg overrides frontmatter value
 
 All tests run through ``ActivityEnvironment`` and mock httpx + VaultClient
-so no network or filesystem calls are made.  Pattern follows the rest of
-the learn test suite: ``asyncio.run(env.run(fn, *args))``.
+so no network or filesystem calls are made.
 """
 from __future__ import annotations
 
@@ -69,29 +72,58 @@ def _run(fn: Any, *args: Any) -> Any:
     return asyncio.run(env.run(fn, *args))
 
 
+def _posted_body(http_mock: MagicMock) -> dict:
+    return http_mock.post.call_args.kwargs.get("json", {})
+
+
 # ---------------------------------------------------------------------------
-# 1. Explicit channel from chore frontmatter is forwarded to ctrl-api
+# 1. notify_channel with valid platform:id → correct field split in POST body
 # ---------------------------------------------------------------------------
 
-class TestExplicitChannelInFrontmatter:
-    def test_notify_channel_forwarded_in_post_body(self) -> None:
-        """When the chore record has notify_channel, it appears as ``channel``."""
-        vc_factory, vc = _vault_factory(notify_channel="slack-home-123")
+class TestValidChannelFieldSplit:
+    def test_slack_channel_splits_into_channel_and_to(self) -> None:
+        """slack:C0123456789 → channel='slack', to='C0123456789' (not channel=id)."""
+        vc_factory, _ = _vault_factory(notify_channel="slack:C0123456789")
         http_cls, http_mock = _make_http_mock(200)
 
         with patch("src.activities.chore_actions.VaultClient", vc_factory):
             with patch("httpx.AsyncClient", http_cls):
                 result = _run(send_chore_notification, "test-chore", "session", "msg")
 
-        call_kwargs = http_mock.post.call_args
-        body = call_kwargs.kwargs.get("json", {})
-        assert body.get("channel") == "slack-home-123"
+        body = _posted_body(http_mock)
+        assert body.get("channel") == "slack"
+        assert body.get("to") == "C0123456789"
         assert result["delivered"] is True
-        assert result["destination"] == "slack-home-123"
-        assert result["http_status"] == 200
-        assert result["error"] is None
+        assert result["destination"] == "slack:C0123456789"
 
-    def test_session_id_not_forwarded_in_post_body(self) -> None:
+    def test_telegram_channel_splits_correctly(self) -> None:
+        """telegram:-1001234567 → channel='telegram', to='-1001234567'."""
+        vc_factory, _ = _vault_factory(notify_channel="telegram:-1001234567")
+        http_cls, http_mock = _make_http_mock(200)
+
+        with patch("src.activities.chore_actions.VaultClient", vc_factory):
+            with patch("httpx.AsyncClient", http_cls):
+                result = _run(send_chore_notification, "test-chore", "session", "msg")
+
+        body = _posted_body(http_mock)
+        assert body.get("channel") == "telegram"
+        assert body.get("to") == "-1001234567"
+        assert result["destination"] == "telegram:-1001234567"
+
+    def test_email_channel_splits_correctly(self) -> None:
+        """email:user@example.com → channel='email', to='user@example.com'."""
+        vc_factory, _ = _vault_factory(notify_channel="email:user@example.com")
+        http_cls, http_mock = _make_http_mock(200)
+
+        with patch("src.activities.chore_actions.VaultClient", vc_factory):
+            with patch("httpx.AsyncClient", http_cls):
+                result = _run(send_chore_notification, "test-chore", "session", "msg")
+
+        body = _posted_body(http_mock)
+        assert body.get("channel") == "email"
+        assert body.get("to") == "user@example.com"
+
+    def test_session_id_never_forwarded(self) -> None:
         """The dead session_id param must NOT appear in the POST body."""
         vc_factory, _ = _vault_factory(notify_channel=None)
         http_cls, http_mock = _make_http_mock(200)
@@ -100,18 +132,17 @@ class TestExplicitChannelInFrontmatter:
             with patch("httpx.AsyncClient", http_cls):
                 _run(send_chore_notification, "test-chore", "main", "msg")
 
-        call_kwargs = http_mock.post.call_args
-        body = call_kwargs.kwargs.get("json", {})
+        body = _posted_body(http_mock)
         assert "session_id" not in body
 
 
 # ---------------------------------------------------------------------------
-# 2. Chore without notify_channel — channel key absent from POST body
+# 2. No notify_channel → both channel and to absent (ctrl-api decides)
 # ---------------------------------------------------------------------------
 
 class TestNoChannelConfigured:
-    def test_channel_key_absent_when_no_notify_channel(self) -> None:
-        """ctrl-api home-channel default is not overridden when no channel declared."""
+    def test_channel_and_to_absent_when_no_notify_channel(self) -> None:
+        """When the chore has no notify_channel, ctrl-api home default is used."""
         vc_factory, _ = _vault_factory(notify_channel=None)
         http_cls, http_mock = _make_http_mock(200)
 
@@ -119,14 +150,14 @@ class TestNoChannelConfigured:
             with patch("httpx.AsyncClient", http_cls):
                 result = _run(send_chore_notification, "test-chore", "main", "msg")
 
-        call_kwargs = http_mock.post.call_args
-        body = call_kwargs.kwargs.get("json", {})
+        body = _posted_body(http_mock)
         assert "channel" not in body
+        assert "to" not in body
         assert result["destination"] == "auto"
         assert result["delivered"] is True
 
     def test_vault_read_error_falls_back_to_auto(self) -> None:
-        """If the vault read fails, we proceed without a channel (auto)."""
+        """Vault read failure → proceed without channel (auto)."""
         failing_vc = MagicMock()
         failing_vc.read_record = AsyncMock(side_effect=Exception("vault down"))
         failing_vc.close = AsyncMock(return_value=None)
@@ -136,20 +167,58 @@ class TestNoChannelConfigured:
             with patch("httpx.AsyncClient", http_cls):
                 result = _run(send_chore_notification, "test-chore", "main", "msg")
 
-        call_kwargs = http_mock.post.call_args
-        body = call_kwargs.kwargs.get("json", {})
+        body = _posted_body(http_mock)
         assert "channel" not in body
+        assert "to" not in body
         assert result["destination"] == "auto"
 
 
 # ---------------------------------------------------------------------------
-# 3. Destination recorded in chore body (run notes)
+# 3. Bare values (no separator) are treated as unset — never guessed
+# ---------------------------------------------------------------------------
+
+class TestBareValueFallsThrough:
+    def test_bare_id_no_platform_treated_as_unset(self) -> None:
+        """A raw id with no 'platform:' prefix falls through to auto.
+
+        Guessing the platform from an id's shape would send a Telegram id to
+        Slack or vice versa.  Treat as unset instead.
+        """
+        vc_factory, _ = _vault_factory(notify_channel="C0123456789")  # no prefix
+        http_cls, http_mock = _make_http_mock(200)
+
+        with patch("src.activities.chore_actions.VaultClient", vc_factory):
+            with patch("httpx.AsyncClient", http_cls):
+                result = _run(send_chore_notification, "test-chore", "main", "msg")
+
+        body = _posted_body(http_mock)
+        assert "channel" not in body
+        assert "to" not in body
+        assert result["destination"] == "auto"
+
+    def test_unknown_platform_treated_as_unset(self) -> None:
+        """An unrecognised platform name is not forwarded."""
+        vc_factory, _ = _vault_factory(notify_channel="discord:some-id")
+        http_cls, http_mock = _make_http_mock(200)
+
+        with patch("src.activities.chore_actions.VaultClient", vc_factory):
+            with patch("httpx.AsyncClient", http_cls):
+                result = _run(send_chore_notification, "test-chore", "main", "msg")
+
+        body = _posted_body(http_mock)
+        assert "channel" not in body
+        assert "to" not in body
+        assert result["destination"] == "auto"
+
+
+# ---------------------------------------------------------------------------
+# 4. Destination recorded in chore body (run notes)
 # ---------------------------------------------------------------------------
 
 class TestDestinationAuditTrail:
-    def test_destination_appended_to_chore_body_with_channel(self) -> None:
-        """Run log appends 'destination=<channel>' when notify_channel is set."""
-        vc_factory, vc = _vault_factory(notify_channel="slack-home-123")
+    def test_destination_appended_when_channel_set(self) -> None:
+        """Run log appends 'destination=slack:C0123456789' when channel set."""
+        vc_factory, vc = _vault_factory(notify_channel="slack:C0123456789")
         http_cls, _ = _make_http_mock(200)
 
         with patch("src.activities.chore_actions.VaultClient", vc_factory):
@@ -157,9 +226,9 @@ class TestDestinationAuditTrail:
                 _run(send_chore_notification, "test-chore", "main", "msg")
 
         update_calls = " ".join(str(c) for c in vc.update_record.call_args_list)
-        assert "destination=slack-home-123" in update_calls
+        assert "destination=slack:C0123456789" in update_calls
 
-    def test_destination_appended_to_chore_body_when_auto(self) -> None:
+    def test_destination_appended_as_auto_when_no_channel(self) -> None:
         """Run log appends 'destination=auto' when no notify_channel."""
         vc_factory, vc = _vault_factory(notify_channel=None)
         http_cls, _ = _make_http_mock(200)
@@ -173,12 +242,12 @@ class TestDestinationAuditTrail:
 
 
 # ---------------------------------------------------------------------------
-# 4. HTTP errors raise so Temporal can retry (no longer swallowed)
+# 5. HTTP errors raise so Temporal can retry (no longer swallowed)
 # ---------------------------------------------------------------------------
 
 class TestHttpErrorPropagation:
     def test_http_4xx_raises(self) -> None:
-        """Non-2xx from ctrl-api must raise httpx.HTTPStatusError."""
+        """Non-2xx from ctrl-api raises httpx.HTTPStatusError (Temporal retries)."""
         vc_factory, _ = _vault_factory(notify_channel=None)
         http_cls, _ = _make_http_mock(424)
 
@@ -189,14 +258,14 @@ class TestHttpErrorPropagation:
 
 
 # ---------------------------------------------------------------------------
-# 5. Explicit 4th positional arg overrides frontmatter
+# 6. Explicit 4th positional arg overrides frontmatter
 # ---------------------------------------------------------------------------
 
 class TestExplicitChannelArgOverridesFrontmatter:
     def test_4th_arg_wins_over_frontmatter(self) -> None:
         """When notify_channel is passed as 4th positional arg, it takes precedence."""
-        # Frontmatter says "frontmatter-ch" but arg should win
-        vc_factory, vc = _vault_factory(notify_channel="frontmatter-ch")
+        # Frontmatter says "slack:FRONTMATTER" but arg should win
+        vc_factory, vc = _vault_factory(notify_channel="slack:FRONTMATTER")
         http_cls, http_mock = _make_http_mock(200)
 
         with patch("src.activities.chore_actions.VaultClient", vc_factory):
@@ -206,12 +275,12 @@ class TestExplicitChannelArgOverridesFrontmatter:
                     "test-chore",
                     "ignored-session",
                     "hello",
-                    "caller-override-ch",
+                    "telegram:-9999",
                 )
 
-        call_kwargs = http_mock.post.call_args
-        body = call_kwargs.kwargs.get("json", {})
-        assert body.get("channel") == "caller-override-ch"
-        assert result["destination"] == "caller-override-ch"
+        body = _posted_body(http_mock)
+        assert body.get("channel") == "telegram"
+        assert body.get("to") == "-9999"
+        assert result["destination"] == "telegram:-9999"
         # Frontmatter read is skipped when 4th arg is provided
         vc.read_record.assert_not_called()

--- a/packages/learn/tests/test_chore_notify_channel.py
+++ b/packages/learn/tests/test_chore_notify_channel.py
@@ -1,0 +1,217 @@
+"""Tests for `send_chore_notification` — per-chore destination routing (#498).
+
+Covers:
+  - Chore with ``notify_channel`` in frontmatter → ``channel`` key in POST body
+  - Chore without ``notify_channel`` → ``channel`` key absent from POST body
+  - Resolved destination recorded in chore body (run notes)
+  - HTTP error raises so Temporal can retry (no longer swallowed)
+  - Explicit 4th positional arg overrides frontmatter value
+
+All tests run through ``ActivityEnvironment`` and mock httpx + VaultClient
+so no network or filesystem calls are made.  Pattern follows the rest of
+the learn test suite: ``asyncio.run(env.run(fn, *args))``.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from temporalio.testing import ActivityEnvironment
+
+from src.activities.chore_actions import send_chore_notification
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _mock_httpx_response(status_code: int = 200) -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    if status_code >= 400:
+        req = httpx.Request("POST", "http://ctrl-api/api/v1/notifications")
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            f"HTTP {status_code}", request=req, response=resp
+        )
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+def _make_http_mock(status_code: int = 200) -> tuple[Any, MagicMock]:
+    """Return (mock class, inner mock with .post captured)."""
+    mock_http = AsyncMock()
+    mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+    mock_http.__aexit__ = AsyncMock(return_value=False)
+    mock_http.post = AsyncMock(return_value=_mock_httpx_response(status_code))
+    mock_cls = MagicMock(return_value=mock_http)
+    return mock_cls, mock_http
+
+
+def _vault_factory(notify_channel: str | None = None) -> tuple[Any, MagicMock]:
+    """Return (factory callable, inner VaultClient mock)."""
+    record = {
+        "frontmatter": {"notify_channel": notify_channel} if notify_channel else {},
+        "body": "",
+    }
+    vc = MagicMock()
+    vc.read_record = AsyncMock(return_value=record)
+    vc.update_record = AsyncMock(return_value=None)
+    vc.close = AsyncMock(return_value=None)
+    return (lambda _cfg: vc), vc
+
+
+def _run(fn: Any, *args: Any) -> Any:
+    env = ActivityEnvironment()
+    return asyncio.run(env.run(fn, *args))
+
+
+# ---------------------------------------------------------------------------
+# 1. Explicit channel from chore frontmatter is forwarded to ctrl-api
+# ---------------------------------------------------------------------------
+
+class TestExplicitChannelInFrontmatter:
+    def test_notify_channel_forwarded_in_post_body(self) -> None:
+        """When the chore record has notify_channel, it appears as ``channel``."""
+        vc_factory, vc = _vault_factory(notify_channel="slack-home-123")
+        http_cls, http_mock = _make_http_mock(200)
+
+        with patch("src.activities.chore_actions.VaultClient", vc_factory):
+            with patch("httpx.AsyncClient", http_cls):
+                result = _run(send_chore_notification, "test-chore", "session", "msg")
+
+        call_kwargs = http_mock.post.call_args
+        body = call_kwargs.kwargs.get("json", {})
+        assert body.get("channel") == "slack-home-123"
+        assert result["delivered"] is True
+        assert result["destination"] == "slack-home-123"
+        assert result["http_status"] == 200
+        assert result["error"] is None
+
+    def test_session_id_not_forwarded_in_post_body(self) -> None:
+        """The dead session_id param must NOT appear in the POST body."""
+        vc_factory, _ = _vault_factory(notify_channel=None)
+        http_cls, http_mock = _make_http_mock(200)
+
+        with patch("src.activities.chore_actions.VaultClient", vc_factory):
+            with patch("httpx.AsyncClient", http_cls):
+                _run(send_chore_notification, "test-chore", "main", "msg")
+
+        call_kwargs = http_mock.post.call_args
+        body = call_kwargs.kwargs.get("json", {})
+        assert "session_id" not in body
+
+
+# ---------------------------------------------------------------------------
+# 2. Chore without notify_channel — channel key absent from POST body
+# ---------------------------------------------------------------------------
+
+class TestNoChannelConfigured:
+    def test_channel_key_absent_when_no_notify_channel(self) -> None:
+        """ctrl-api home-channel default is not overridden when no channel declared."""
+        vc_factory, _ = _vault_factory(notify_channel=None)
+        http_cls, http_mock = _make_http_mock(200)
+
+        with patch("src.activities.chore_actions.VaultClient", vc_factory):
+            with patch("httpx.AsyncClient", http_cls):
+                result = _run(send_chore_notification, "test-chore", "main", "msg")
+
+        call_kwargs = http_mock.post.call_args
+        body = call_kwargs.kwargs.get("json", {})
+        assert "channel" not in body
+        assert result["destination"] == "auto"
+        assert result["delivered"] is True
+
+    def test_vault_read_error_falls_back_to_auto(self) -> None:
+        """If the vault read fails, we proceed without a channel (auto)."""
+        failing_vc = MagicMock()
+        failing_vc.read_record = AsyncMock(side_effect=Exception("vault down"))
+        failing_vc.close = AsyncMock(return_value=None)
+        http_cls, http_mock = _make_http_mock(200)
+
+        with patch("src.activities.chore_actions.VaultClient", lambda _: failing_vc):
+            with patch("httpx.AsyncClient", http_cls):
+                result = _run(send_chore_notification, "test-chore", "main", "msg")
+
+        call_kwargs = http_mock.post.call_args
+        body = call_kwargs.kwargs.get("json", {})
+        assert "channel" not in body
+        assert result["destination"] == "auto"
+
+
+# ---------------------------------------------------------------------------
+# 3. Destination recorded in chore body (run notes)
+# ---------------------------------------------------------------------------
+
+class TestDestinationAuditTrail:
+    def test_destination_appended_to_chore_body_with_channel(self) -> None:
+        """Run log appends 'destination=<channel>' when notify_channel is set."""
+        vc_factory, vc = _vault_factory(notify_channel="slack-home-123")
+        http_cls, _ = _make_http_mock(200)
+
+        with patch("src.activities.chore_actions.VaultClient", vc_factory):
+            with patch("httpx.AsyncClient", http_cls):
+                _run(send_chore_notification, "test-chore", "main", "msg")
+
+        update_calls = " ".join(str(c) for c in vc.update_record.call_args_list)
+        assert "destination=slack-home-123" in update_calls
+
+    def test_destination_appended_to_chore_body_when_auto(self) -> None:
+        """Run log appends 'destination=auto' when no notify_channel."""
+        vc_factory, vc = _vault_factory(notify_channel=None)
+        http_cls, _ = _make_http_mock(200)
+
+        with patch("src.activities.chore_actions.VaultClient", vc_factory):
+            with patch("httpx.AsyncClient", http_cls):
+                _run(send_chore_notification, "test-chore", "main", "msg")
+
+        update_calls = " ".join(str(c) for c in vc.update_record.call_args_list)
+        assert "destination=auto" in update_calls
+
+
+# ---------------------------------------------------------------------------
+# 4. HTTP errors raise so Temporal can retry (no longer swallowed)
+# ---------------------------------------------------------------------------
+
+class TestHttpErrorPropagation:
+    def test_http_4xx_raises(self) -> None:
+        """Non-2xx from ctrl-api must raise httpx.HTTPStatusError."""
+        vc_factory, _ = _vault_factory(notify_channel=None)
+        http_cls, _ = _make_http_mock(424)
+
+        with pytest.raises(httpx.HTTPStatusError):
+            with patch("src.activities.chore_actions.VaultClient", vc_factory):
+                with patch("httpx.AsyncClient", http_cls):
+                    _run(send_chore_notification, "test-chore", "main", "msg")
+
+
+# ---------------------------------------------------------------------------
+# 5. Explicit 4th positional arg overrides frontmatter
+# ---------------------------------------------------------------------------
+
+class TestExplicitChannelArgOverridesFrontmatter:
+    def test_4th_arg_wins_over_frontmatter(self) -> None:
+        """When notify_channel is passed as 4th positional arg, it takes precedence."""
+        # Frontmatter says "frontmatter-ch" but arg should win
+        vc_factory, vc = _vault_factory(notify_channel="frontmatter-ch")
+        http_cls, http_mock = _make_http_mock(200)
+
+        with patch("src.activities.chore_actions.VaultClient", vc_factory):
+            with patch("httpx.AsyncClient", http_cls):
+                result = _run(
+                    send_chore_notification,
+                    "test-chore",
+                    "ignored-session",
+                    "hello",
+                    "caller-override-ch",
+                )
+
+        call_kwargs = http_mock.post.call_args
+        body = call_kwargs.kwargs.get("json", {})
+        assert body.get("channel") == "caller-override-ch"
+        assert result["destination"] == "caller-override-ch"
+        # Frontmatter read is skipped when 4th arg is provided
+        vc.read_record.assert_not_called()


### PR DESCRIPTION
## Summary

- Adds `notify_channel` (optional 4th positional arg, default `None`) to `send_chore_notification` in `chore_actions.py`
- Parses `notify_channel` as `platform:destination` (e.g. `slack:C0123456789`) and sends separate `channel` (platform enum) and `to` (recipient id) fields to ctrl-api's `alfredDeliver.ts`, per its body contract: `{ channel?: "auto"|"telegram"|"slack"|"email", to?: string }`
- When absent or unparseable, both fields are omitted — ctrl-api's `resolveAutoTarget()` (wired to `SLACK_HOME_CHANNEL`/`TELEGRAM_HOME_CHANNEL` in Lane I, PR #499) is the sole fallback
- Every delivery appends `- <ts>: notification sent → destination=platform:id` to the chore body for post-hoc auditability
- `raise_for_status()` replaces the blanket `except Exception: pass` — HTTP errors propagate for Temporal retry

## Body shape sent to ctrl-api

```
POST /api/v1/notifications
{
  "message": "[Chore: <slug>]\n\n<msg>",
  "urgency": "normal",
  "channel": "slack",           ← platform enum, present only when parsed
  "to": "C0123456789"           ← recipient id, present only when parsed
}
```

When `notify_channel` is absent or unparseable: `channel` and `to` are both omitted, ctrl-api's home default resolves.

## notify_channel format (same convention as commitment_register's projection — CLAUDE.md §6.1)

```yaml
notify_channel: slack:C0123456789        # Slack channel id
notify_channel: telegram:-1001234567     # Telegram chat id
notify_channel: email:user@example.com  # email address
```

Bare values with no `platform:` separator → treated as unset (falls to auto). Unknown platform names (e.g. `discord:...`) → same. Guessing platform from an id's shape would send a Telegram id to Slack; treat unparseable as unset instead.

## Temporal replay safety

`notify_channel` is a regular optional positional parameter with `default=None`. The Temporal Python SDK rejects keyword-only `*` args entirely (`TypeError: Activity cannot have keyword-only arguments` at `temporalio/activity.py:601`), so the parameter must be positional. Existing callers using `args=[slug, session_id, msg]` (three positional args) keep working unchanged — Python fills the fourth arg from its default. The activity name is unchanged. No workflow code on live tenants needs to change.

## Operator action

To route a specific chore to a dedicated channel, add to its vault record (`vault/chore/<slug>.md` frontmatter):

```yaml
notify_channel: slack:C0123456789
```

When absent, the global home-channel default (`SLACK_HOME_CHANNEL` / `TELEGRAM_HOME_CHANNEL`) applies through ctrl-api.

## Bug fixed in commit 2

The first commit (`d467012e`) set `body["channel"] = resolved_channel` where `resolved_channel` was a raw destination id. `alfredDeliver.ts:35` defines `channel` as a platform enum; a raw id falls to the `default:` case in `deliverByChannel()` and returns `{ ok: false, error: "channel=<id> has no delivery adapter yet" }` — the feature was non-functional for every chore that declared `notify_channel`. The second commit (`047915e3`) fixes the field split and corrects all 8 tests that had encoded the wrong contract.

## Scope

`scope_limit` set to 350 in `.lane`: activity rewrite + 12-test suite for a single bounded change. Both commits passed the gate (338 LOC and 234 LOC respectively within the 3× hard cap).

References #498. The ctrl-api half (PR #499) shipped first; this is the chore-schema half.

## Smoke evidence

### Commit 2 fix — full suite (2630 passed, 0 regressions):

```
$ cd packages/learn && python3 -m pytest tests/ -q \
  --ignore=tests/test_composio_server.py \
  --ignore=tests/test_composio_server_extra.py \
  --ignore=tests/test_composio_server_defaults.py \
  --ignore=tests/test_file_extraction.py
2630 passed, 101 skipped in 22.88s
```

### New tests (12/12 green):

```
$ python3 -m pytest tests/test_chore_notify_channel.py -v
TestValidChannelFieldSplit::test_slack_channel_splits_into_channel_and_to PASSED
TestValidChannelFieldSplit::test_telegram_channel_splits_correctly PASSED
TestValidChannelFieldSplit::test_email_channel_splits_correctly PASSED
TestValidChannelFieldSplit::test_session_id_never_forwarded PASSED
TestNoChannelConfigured::test_channel_and_to_absent_when_no_notify_channel PASSED
TestNoChannelConfigured::test_vault_read_error_falls_back_to_auto PASSED
TestBareValueFallsThrough::test_bare_id_no_platform_treated_as_unset PASSED
TestBareValueFallsThrough::test_unknown_platform_treated_as_unset PASSED
TestDestinationAuditTrail::test_destination_appended_when_channel_set PASSED
TestDestinationAuditTrail::test_destination_appended_as_auto_when_no_channel PASSED
TestHttpErrorPropagation::test_http_4xx_raises PASSED
TestExplicitChannelArgOverridesFrontmatter::test_4th_arg_wins_over_frontmatter PASSED
12 passed in 0.21s
```

### Lane gate:

```
✓ lane II (learn) gate passed — 234 LOC, 2 files, verify ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc
