### PR TITLE
feat(infra): Hermes session-store retention — core delete path (#430)

### DIFF
--- a/scripts/hermes-session-retention.py
+++ b/scripts/hermes-session-retention.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Hermes session-store retention tool.  refs #430
+
+Per-profile windows (not one global number):
+  workers 14d — ephemeral background-agent transcripts; durable output in state.db/vault.
+  main    90d — principal's conversation history; highest audit value.
+  heavy   90d — reflection/onboarding reasoning; low volume, worth keeping.
+
+Liveness predicate — session excluded if ANY holds:
+  1. ended_at IS NULL          — in progress
+  2. started_at > cutoff       — within window
+  3. compression_locks.expires_at > now  — LCM compression in flight
+     (expiry-time semantics; there is NO released_at column)
+
+FTS5: messages_fts is USING fts5(content) — 'content' is a column name, NOT
+the content='tablename' option (very different).  Six triggers maintain both
+FTS indexes on DELETE; verified at runtime.  Never call 'rebuild' on a plain
+FTS5 table — it wipes the index.  WAL/VACUUM: see hermes-retention-maintenance.
+"""
+
+import argparse
+import os
+import sqlite3
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+PROFILE_RETENTION: dict[str, int] = {
+    "workers": 14,
+    "main":    90,
+    "heavy":   90,
+}
+HERMES_HOME = os.environ.get("HERMES_HOME", "/hermes-state")
+BATCH_SIZE = 500
+
+def _open(db_path: Path, readonly: bool) -> sqlite3.Connection:
+    uri = f"file:{db_path}{'?mode=ro' if readonly else ''}"
+    con = sqlite3.connect(uri, uri=True, timeout=30)
+    con.row_factory = sqlite3.Row
+    if not readonly:
+        con.execute("PRAGMA journal_mode=WAL")
+        con.execute("PRAGMA busy_timeout=10000")
+    return con
+
+
+def _integrity(con: sqlite3.Connection) -> bool:
+    row = con.execute("PRAGMA integrity_check").fetchone()
+    return bool(row and row[0] == "ok")
+
+def _has_fts_triggers(con: sqlite3.Connection) -> bool:
+    rows = con.execute(
+        "SELECT name FROM sqlite_master WHERE type='trigger' AND tbl_name='messages'"
+    ).fetchall()
+    return any("fts" in (r["name"] or "").lower() for r in rows)
+
+
+def _cutoff(days: int) -> float:
+    return time.time() - days * 86400
+
+def _eligible(con: sqlite3.Connection, cutoff_ts: float) -> list[str]:
+    """Session IDs eligible for deletion (ended, outside window, no live lock)."""
+    now = time.time()
+    rows = con.execute(
+        """
+        SELECT s.id FROM sessions s
+        WHERE s.ended_at IS NOT NULL
+          AND s.started_at < ?
+          AND s.id NOT IN (
+              SELECT session_id FROM compression_locks WHERE expires_at > ?
+          )
+        """,
+        (cutoff_ts, now),
+    ).fetchall()
+    return [r["id"] for r in rows]
+
+def _msg_count(con: sqlite3.Connection, ids: list[str]) -> int:
+    if not ids:
+        return 0
+    ph = ",".join("?" * len(ids))
+    return con.execute(f"SELECT COUNT(*) FROM messages WHERE session_id IN ({ph})", ids).fetchone()[0]
+
+def _db_bytes(con: sqlite3.Connection) -> int:
+    ps = con.execute("PRAGMA page_size").fetchone()[0]
+    pc = con.execute("PRAGMA page_count").fetchone()[0]
+    return ps * pc
+
+def _batches(lst: list, n: int):
+    for i in range(0, len(lst), n):
+        yield lst[i : i + n]
+
+
+def dry_run(db_path: Path, profile: str, days: int) -> dict:
+    if not db_path.exists():
+        return {"error": f"missing: {db_path}"}
+    con = _open(db_path, readonly=True)
+    if not _integrity(con):
+        con.close()
+        return {"error": "integrity_check failed"}
+    cut = _cutoff(days)
+    ids = _eligible(con, cut)
+    msgs = _msg_count(con, ids)
+    size_b = _db_bytes(con)
+    oldest = newest = None
+    if ids:
+        row = con.execute(f"SELECT MIN(started_at), MAX(started_at) FROM sessions WHERE id IN ({','.join('?'*len(ids))})", ids).fetchone()
+        ts2d = lambda ts: datetime.fromtimestamp(ts, tz=timezone.utc).date().isoformat() if ts else None
+        oldest, newest = ts2d(row[0]), ts2d(row[1])
+    con.close()
+    return {
+        "profile": profile, "window_days": days, "db": str(db_path),
+        "db_bytes": size_b, "eligible_sessions": len(ids),
+        "eligible_messages": msgs, "oldest": oldest, "newest": newest,
+    }
+
+
+def apply(db_path: Path, profile: str, days: int, verbose: bool) -> dict:
+    if not db_path.exists():
+        return {"error": f"missing: {db_path}"}
+    con = _open(db_path, readonly=False)
+    if not _integrity(con):
+        con.close()
+        return {"error": "integrity_check failed"}
+    cut = _cutoff(days)
+    ids = _eligible(con, cut)
+    if not ids:
+        con.close()
+        return {"profile": profile, "deleted_sessions": 0, "deleted_messages": 0}
+    size_before = _db_bytes(con)
+    has_triggers = _has_fts_triggers(con)
+    del_msgs = del_sess = 0
+    for batch in _batches(ids, BATCH_SIZE):
+        ph = ",".join("?" * len(batch))
+        if not has_triggers:
+            # No triggers: plain FTS5 owns its data — delete by rowid.
+            # Do NOT call 'rebuild'; on a plain FTS5 table that wipes the index.
+            con.execute(f"DELETE FROM messages_fts WHERE rowid IN (SELECT id FROM messages WHERE session_id IN ({ph}))", batch)
+        con.execute(f"DELETE FROM messages WHERE session_id IN ({ph})", batch)
+        del_msgs += con.total_changes
+        con.execute(f"DELETE FROM sessions WHERE id IN ({ph})", batch)
+        del_sess += len(batch)
+        con.commit()
+        if verbose:
+            print(f"  [{profile}] {del_sess}/{len(ids)} sessions deleted", flush=True)
+    size_after = _db_bytes(con)
+    con.close()
+    return {
+        "profile": profile, "window_days": days,
+        "deleted_sessions": del_sess, "deleted_messages": del_msgs,
+        "bytes_before": size_before, "bytes_after": size_after,
+        "freed_bytes": size_before - size_after,
+    }
+
+
+def main():
+    p = argparse.ArgumentParser(description="Hermes session-store retention.  Dry-run by default.")
+    p.add_argument("--apply", action="store_true")
+    p.add_argument("--backup-ok", action="store_true", help="Attest backup taken; required for --apply")
+    p.add_argument("--profile", action="append", metavar="NAME:DAYS", default=[])
+    p.add_argument("--hermes-home", default=HERMES_HOME)
+    p.add_argument("--verbose", action="store_true")
+    args = p.parse_args()
+
+    windows = dict(PROFILE_RETENTION)
+    for ov in args.profile:
+        name, _, days_s = ov.partition(":")
+        if not days_s.isdigit():
+            sys.exit(f"Bad --profile '{ov}': expected NAME:DAYS")
+        windows[name] = int(days_s)
+    if args.apply and not args.backup_ok:
+        sys.exit("ERROR: --apply requires --backup-ok")
+    profiles_root = Path(args.hermes_home) / "profiles"
+    if not profiles_root.exists():
+        sys.exit(f"ERROR: profiles directory not found: {profiles_root}")
+
+    for profile, days in windows.items():
+        db_path = profiles_root / profile / "state.db"
+        print(f"\n=== {profile} (window: {days}d) ===")
+        if args.apply:
+            r = apply(db_path, profile, days, args.verbose)
+            if "error" in r:
+                print(f"  ERROR: {r['error']}")
+            else:
+                freed = r.get("freed_bytes", 0)
+                print(f"  Deleted: {r['deleted_sessions']} sessions, {r['deleted_messages']} messages")
+                print(f"  Freed: {freed // (1024**3):.1f} GB ({freed:,} bytes) [pre-VACUUM estimate]")
+        else:
+            r = dry_run(db_path, profile, days)
+            if "error" in r:
+                print(f"  ERROR: {r['error']}")
+            else:
+                print(f"  DB: {r['db_bytes'] / (1024**3):.2f} GB | "
+                      f"Eligible: {r['eligible_sessions']:,} sessions {r['eligible_messages']:,} msgs | "
+                      f"Range: {r['oldest']} → {r['newest']}")
+    if not args.apply:
+        print("\n[DRY RUN — re-run with --apply --backup-ok to prune]\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_hermes_session_retention.py
+++ b/scripts/test_hermes_session_retention.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Fixture tests for hermes-session-retention.py  refs #430
+
+Load-bearing cases: eligibility window, liveness exclusion,
+batch/resume, dry-run-mutates-nothing, trigger-maintained FTS.
+
+Run: python3 scripts/test_hermes_session_retention.py
+"""
+import importlib.util
+import sqlite3
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+_mod = importlib.util.module_from_spec(
+    s := importlib.util.spec_from_file_location("_hsr", Path(__file__).parent / "hermes-session-retention.py")
+)
+s.loader.exec_module(_mod)  # type: ignore[union-attr]
+PROFILE_RETENTION = _mod.PROFILE_RETENTION
+_cutoff = _mod._cutoff; _eligible = _mod._eligible; _has_fts_triggers = _mod._has_fts_triggers
+_open = _mod._open; apply = _mod.apply; dry_run = _mod.dry_run
+
+NOW = time.time(); DAY = 86400
+
+
+def _make_db(path: Path, triggers: bool = True) -> None:
+    """Real Hermes DDL — verbatim schema.
+
+    compression_locks uses expires_at (NOT released_at).
+    messages_fts is plain fts5(content) — 'content' is a column name,
+    not the content='tablename' external-content option.
+    """
+    con = sqlite3.connect(str(path))
+    con.executescript("""
+CREATE TABLE sessions(id TEXT PRIMARY KEY, source TEXT, started_at REAL, ended_at REAL);
+CREATE TABLE messages(id INTEGER PRIMARY KEY, session_id TEXT REFERENCES sessions(id), timestamp REAL, content TEXT);
+CREATE VIRTUAL TABLE messages_fts USING fts5(content);
+CREATE VIRTUAL TABLE messages_fts_trigram USING fts5(content, tokenize='trigram');
+CREATE TABLE compression_locks(session_id TEXT PRIMARY KEY, holder TEXT NOT NULL, acquired_at REAL NOT NULL, expires_at REAL NOT NULL);
+CREATE INDEX idx_sessions_started ON sessions(started_at DESC);
+CREATE INDEX idx_messages_session ON messages(session_id, timestamp);
+    """)
+    if triggers:
+        con.executescript("""
+CREATE TRIGGER messages_fts_insert    AFTER INSERT ON messages BEGIN INSERT INTO messages_fts(rowid,content) VALUES(new.id,new.content); END;
+CREATE TRIGGER messages_fts_delete    AFTER DELETE ON messages BEGIN DELETE FROM messages_fts WHERE rowid=old.id; END;
+CREATE TRIGGER messages_fts_update    AFTER UPDATE ON messages BEGIN DELETE FROM messages_fts WHERE rowid=old.id; INSERT INTO messages_fts(rowid,content) VALUES(new.id,new.content); END;
+CREATE TRIGGER messages_fts_trigram_insert AFTER INSERT ON messages BEGIN INSERT INTO messages_fts_trigram(rowid,content) VALUES(new.id,new.content); END;
+CREATE TRIGGER messages_fts_trigram_delete AFTER DELETE ON messages BEGIN DELETE FROM messages_fts_trigram WHERE rowid=old.id; END;
+CREATE TRIGGER messages_fts_trigram_update AFTER UPDATE ON messages BEGIN DELETE FROM messages_fts_trigram WHERE rowid=old.id; INSERT INTO messages_fts_trigram(rowid,content) VALUES(new.id,new.content); END;
+        """)
+    con.commit(); con.close()
+
+
+def _ins(con, sid, days_old, ended=True, lock_offset=None):
+    """Insert a session. lock_offset>0=live lock, <0=expired lock, None=no lock."""
+    t = NOW - days_old * DAY
+    con.execute("INSERT INTO sessions VALUES(?,?,?,?)", (sid, "t", t, t + DAY if ended else None))
+    con.execute("INSERT INTO messages(session_id,timestamp,content) VALUES(?,?,?)", (sid, t + 60, f"m:{sid}"))
+    if lock_offset is not None:
+        con.execute("INSERT INTO compression_locks VALUES(?,?,?,?)", (sid, "w", t, NOW + lock_offset))
+    con.commit()
+
+
+class TestEligibility(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.db = Path(self.tmp.name) / "state.db"
+        _make_db(self.db)
+
+    def tearDown(self): self.tmp.cleanup()
+
+    def _eligible_ids(self, days=30):
+        con = sqlite3.connect(str(self.db)); con.row_factory = sqlite3.Row
+        ids = _eligible(con, _cutoff(days)); con.close(); return ids
+
+    def test_old_session_eligible(self):
+        con = sqlite3.connect(str(self.db)); con.row_factory = sqlite3.Row
+        _ins(con, "old", 40); con.close()
+        self.assertIn("old", self._eligible_ids())
+
+    def test_recent_excluded(self):
+        con = sqlite3.connect(str(self.db)); con.row_factory = sqlite3.Row
+        _ins(con, "new", 5); con.close()
+        self.assertNotIn("new", self._eligible_ids())
+
+    def test_open_session_excluded(self):
+        """ended_at IS NULL — must never be pruned."""
+        con = sqlite3.connect(str(self.db)); con.row_factory = sqlite3.Row
+        _ins(con, "live", 60, ended=False); con.close()
+        self.assertNotIn("live", self._eligible_ids(), "open session leaked through liveness predicate")
+
+    def test_live_lock_excluded(self):
+        """expires_at > now — lock held.  NO released_at column in the real schema."""
+        con = sqlite3.connect(str(self.db)); con.row_factory = sqlite3.Row
+        _ins(con, "locked", 50, lock_offset=+3600); con.close()
+        self.assertNotIn("locked", self._eligible_ids(), "live-lock session leaked through")
+
+    def test_expired_lock_eligible(self):
+        """expires_at < now — lock expired; session is eligible."""
+        con = sqlite3.connect(str(self.db)); con.row_factory = sqlite3.Row
+        _ins(con, "expired", 50, lock_offset=-3600); con.close()
+        self.assertIn("expired", self._eligible_ids())
+
+
+class TestDryRun(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        pd = Path(self.tmp.name) / "profiles" / "workers"; pd.mkdir(parents=True)
+        self.db = pd / "state.db"; _make_db(self.db)
+        con = sqlite3.connect(str(self.db)); con.row_factory = sqlite3.Row
+        _ins(con, "prune", 60); _ins(con, "keep", 5); con.close()
+
+    def tearDown(self): self.tmp.cleanup()
+
+    def test_reports_eligible(self):
+        r = dry_run(self.db, "workers", 30)
+        self.assertNotIn("error", r); self.assertEqual(r["eligible_sessions"], 1)
+
+    def test_does_not_mutate(self):
+        dry_run(self.db, "workers", 30)
+        n = sqlite3.connect(str(self.db)).execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+        self.assertEqual(n, 2, "dry_run must not delete any sessions")
+
+    def test_missing_db_reports_error(self):
+        self.assertIn("error", dry_run(Path("/nonexistent/state.db"), "t", 30))
+
+
+class TestApply(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.db = Path(self.tmp.name) / "state.db"; _make_db(self.db)
+        con = sqlite3.connect(str(self.db)); con.row_factory = sqlite3.Row
+        for i in range(15): _ins(con, f"old-{i}", 40 + i)
+        _ins(con, "keep", 5); con.close()
+
+    def tearDown(self): self.tmp.cleanup()
+
+    def test_deletes_eligible_only(self):
+        r = apply(self.db, "workers", 30, verbose=False)
+        self.assertEqual(r["deleted_sessions"], 15)
+        self.assertEqual(sqlite3.connect(str(self.db)).execute("SELECT COUNT(*) FROM sessions").fetchone()[0], 1)
+
+    def test_idempotent(self):
+        apply(self.db, "workers", 30, verbose=False)
+        self.assertEqual(apply(self.db, "workers", 30, verbose=False)["deleted_sessions"], 0)
+
+    def test_preserves_young_sessions(self):
+        apply(self.db, "workers", 30, verbose=False)
+        self.assertIsNotNone(sqlite3.connect(str(self.db)).execute("SELECT id FROM sessions WHERE id='keep'").fetchone())
+
+
+class TestFts(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+
+    def tearDown(self): self.tmp.cleanup()
+
+    def test_trigger_detection(self):
+        db = Path(self.tmp.name) / "t.db"; _make_db(db, triggers=True)
+        con = _open(db, readonly=True); self.assertTrue(_has_fts_triggers(con)); con.close()
+        db2 = Path(self.tmp.name) / "n.db"; _make_db(db2, triggers=False)
+        con2 = _open(db2, readonly=True); self.assertFalse(_has_fts_triggers(con2)); con2.close()
+
+    def test_triggers_maintain_fts_without_script_intervention(self):
+        """apply() deletes from messages; triggers cascade to both FTS indexes. No extra step needed."""
+        db = Path(self.tmp.name) / "fts.db"; _make_db(db, triggers=True)
+        con = sqlite3.connect(str(db)); con.row_factory = sqlite3.Row
+        _ins(con, "s1", 50)
+        self.assertEqual(con.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0], 1,
+                         "insert trigger must have populated messages_fts")
+        con.close()
+        apply(db, "workers", 30, verbose=False)
+        con2 = sqlite3.connect(str(db))
+        self.assertEqual(con2.execute("SELECT COUNT(*) FROM messages").fetchone()[0], 0)
+        self.assertEqual(con2.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0], 0,
+                         "delete trigger must have cleared messages_fts")
+        self.assertEqual(con2.execute("SELECT COUNT(*) FROM messages_fts_trigram").fetchone()[0], 0)
+        con2.close()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- Adds `scripts/hermes-session-retention.py` (200 LOC) — dry-run-by-default SQLite pruning tool for the Hermes session store.
- Adds `scripts/test_hermes_session_retention.py` (184 LOC) — 13 stdlib fixture tests against the real DDL.

This is PR 1 of 3 for #430. PR 2 adds `--checkpoint` and `--vacuum`; PR 3 adds the runbook.

Split motivated by CI's 600 LOC/PR cap: the original #514 (now closed as superseded) summed to 946 LOC. Each PR here is under 400 LOC.

## Design choices

**Per-profile windows** (not one global number):

| Profile | Default | Rationale |
|---------|---------|-----------|
| `workers` | 14 days | Ephemeral background-agent transcripts. Durable output already in alfred-state.db + vault. |
| `main` | 90 days | Principal's conversation history. Highest audit value. |
| `heavy` | 90 days | Reflection/onboarding reasoning. Low volume. |

Override any profile with `--profile <name>:<days>`.

**Liveness predicate** — session excluded if ANY holds:
1. `ended_at IS NULL` — in progress
2. `started_at > cutoff` — within the retention window
3. `compression_locks.expires_at > now` — LCM compression in flight. The real `compression_locks` schema uses **`expires_at REAL NOT NULL`**, not `released_at` (which does not exist).

**FTS5**: `messages_fts` is `USING fts5(content)` — `content` is a column name, NOT the `content='messages'` external-content option (these look similar but are entirely different). Six triggers maintain both `messages_fts` and `messages_fts_trigram` on DELETE from `messages`. The script verifies trigger presence at runtime via sqlite_master; when triggers are absent it deletes FTS rows by rowid. It never calls `rebuild` — on a plain FTS5 table that call wipes the entire index.

**Batched, resumable**: 500 rows/batch, committed per batch. Interrupted run leaves DB consistent; re-running continues.

**Preflight aborts before any mutation**: DB missing, `integrity_check` fails, or `--apply` without `--backup-ok`.

`--checkpoint` and `--vacuum` are intentionally absent from this PR — they are genuinely separate maintenance operations (WAL truncation and full file rewrite) that shouldn't be bundled with session deletion. They land in PR 2.

## Smoke evidence

```
test_deletes_eligible_only (__main__.TestApply.test_deletes_eligible_only) ... ok
test_idempotent (__main__.TestApply.test_idempotent) ... ok
test_preserves_young_sessions (__main__.TestApply.test_preserves_young_sessions) ... ok
test_does_not_mutate (__main__.TestDryRun.test_does_not_mutate) ... ok
test_missing_db_reports_error (__main__.TestDryRun.test_missing_db_reports_error) ... ok
test_reports_eligible (__main__.TestDryRun.test_reports_eligible) ... ok
test_expired_lock_eligible (__main__.TestEligibility.test_expired_lock_eligible) ... ok
test_live_lock_excluded (__main__.TestEligibility.test_live_lock_excluded) ... ok
test_old_session_eligible (__main__.TestEligibility.test_old_session_eligible) ... ok
test_open_session_excluded (__main__.TestEligibility.test_open_session_excluded) ... ok
test_recent_excluded (__main__.TestEligibility.test_recent_excluded) ... ok
test_trigger_detection (__main__.TestFts.test_trigger_detection) ... ok
test_triggers_maintain_fts_without_script_intervention (__main__.TestFts.test_triggers_maintain_fts_without_script_intervention) ... ok

----------------------------------------------------------------------
Ran 13 tests in 0.064s

OK

Lane gate:
✓ lane V (edges-infra) gate passed — 200 LOC, 1 files, verify ok  [script]
✓ lane V (edges-infra) gate passed — 184 LOC, 1 files, verify ok  [tests]
PR total: 384 LOC (under CI's 600 cap)
```

Supersedes #514 (which hit 946 LOC across three files).

Reference #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc