### PR TITLE
feat(scripts): add --checkpoint and --vacuum to hermes-session-retention (#430)

### DIFF
--- a/scripts/hermes-session-retention.py
+++ b/scripts/hermes-session-retention.py
@@ -20,6 +20,7 @@ FTS5 table — it wipes the index.  WAL/VACUUM: see hermes-retention-maintenance
 
 import argparse
 import os
+import shutil
 import sqlite3
 import sys
 import time
@@ -90,6 +91,45 @@ def _batches(lst: list, n: int):
         yield lst[i : i + n]
 
 
+def checkpoint(db_path: Path, verbose: bool) -> dict:
+    """WAL checkpoint (TRUNCATE mode).  Safe at any time; no data-loss risk."""
+    if not db_path.exists():
+        return {"error": f"missing: {db_path}"}
+    con = _open(db_path, readonly=False)
+    busy, log_pg, ckpt_pg = con.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+    con.close()
+    if verbose:
+        print(f"  checkpoint: busy={busy} log_pages={log_pg} moved={ckpt_pg}", flush=True)
+    return {"busy": bool(busy), "log_pages": log_pg, "ckpt_pages": ckpt_pg}
+
+
+def vacuum_db(db_path: Path, verbose: bool, _free_override: int = -1) -> dict:
+    """VACUUM in-place.  Requires ~2x file size in free disk; aborts if disk is tight.
+
+    _free_override: inject a fake free-bytes value for tests (>=0 to activate).
+    WAL truncation and a full-file rewrite differ from session deletion in disk
+    requirement, risk, and timing — that is why they are opt-in flags rather
+    than steps in --apply.
+    """
+    if not db_path.exists():
+        return {"error": f"missing: {db_path}"}
+    con = _open(db_path, readonly=False)
+    db_bytes = _db_bytes(con)
+    con.close()
+    free = _free_override if _free_override >= 0 else shutil.disk_usage(db_path.parent).free
+    needed = db_bytes * 2
+    if free < needed:
+        return {"error": f"need ~{needed//(1024**3):.1f} GB free, have {free//(1024**3):.1f} GB",
+                "db_bytes": db_bytes, "free_bytes": free}
+    con = _open(db_path, readonly=False)
+    if verbose:
+        print(f"  VACUUM {db_path} ({db_bytes//(1024**3):.1f} GB) ...", flush=True)
+    con.execute("VACUUM")
+    size_after = _db_bytes(con)
+    con.close()
+    return {"bytes_before": db_bytes, "bytes_after": size_after, "freed_bytes": db_bytes - size_after}
+
+
 def dry_run(db_path: Path, profile: str, days: int) -> dict:
     if not db_path.exists():
         return {"error": f"missing: {db_path}"}
@@ -158,6 +198,8 @@ def main():
     p.add_argument("--backup-ok", action="store_true", help="Attest backup taken; required for --apply")
     p.add_argument("--profile", action="append", metavar="NAME:DAYS", default=[])
     p.add_argument("--hermes-home", default=HERMES_HOME)
+    p.add_argument("--checkpoint", action="store_true", help="WAL checkpoint (TRUNCATE) each profile store")
+    p.add_argument("--vacuum", action="store_true", help="VACUUM each profile store (needs ~2x file size free)")
     p.add_argument("--verbose", action="store_true")
     args = p.parse_args()
 
@@ -192,6 +234,19 @@ def main():
                 print(f"  DB: {r['db_bytes'] / (1024**3):.2f} GB | "
                       f"Eligible: {r['eligible_sessions']:,} sessions {r['eligible_messages']:,} msgs | "
                       f"Range: {r['oldest']} → {r['newest']}")
+        if args.checkpoint:
+            cr = checkpoint(db_path, args.verbose)
+            if "error" in cr:
+                print(f"  checkpoint ERROR: {cr['error']}")
+            else:
+                print(f"  WAL checkpoint: busy={cr['busy']} log={cr['log_pages']} moved={cr['ckpt_pages']}")
+        if args.vacuum:
+            vr = vacuum_db(db_path, args.verbose)
+            if "error" in vr:
+                print(f"  VACUUM ERROR: {vr['error']}")
+            else:
+                freed = vr.get("freed_bytes", 0)
+                print(f"  VACUUM freed {freed//(1024**3):.1f} GB ({freed:,} bytes)")
     if not args.apply:
         print("\n[DRY RUN — re-run with --apply --backup-ok to prune]\n")
 

--- a/scripts/test_hermes_session_retention.py
+++ b/scripts/test_hermes_session_retention.py
@@ -20,6 +20,7 @@ s.loader.exec_module(_mod)  # type: ignore[union-attr]
 PROFILE_RETENTION = _mod.PROFILE_RETENTION
 _cutoff = _mod._cutoff; _eligible = _mod._eligible; _has_fts_triggers = _mod._has_fts_triggers
 _open = _mod._open; apply = _mod.apply; dry_run = _mod.dry_run
+checkpoint = _mod.checkpoint; vacuum_db = _mod.vacuum_db
 
 NOW = time.time(); DAY = 86400
 
@@ -178,6 +179,53 @@ class TestFts(unittest.TestCase):
                          "delete trigger must have cleared messages_fts")
         self.assertEqual(con2.execute("SELECT COUNT(*) FROM messages_fts_trigram").fetchone()[0], 0)
         con2.close()
+
+
+class TestCheckpoint(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.db = Path(self.tmp.name) / "state.db"; _make_db(self.db)
+
+    def tearDown(self): self.tmp.cleanup()
+
+    def test_checkpoint_returns_stats(self):
+        """Checkpoint on a newly created WAL db returns log_pages and is not busy."""
+        r = checkpoint(self.db, verbose=False)
+        self.assertNotIn("error", r, r)
+        self.assertIn("log_pages", r)
+        self.assertIn("ckpt_pages", r)
+
+    def test_checkpoint_missing_db(self):
+        r = checkpoint(Path("/nonexistent/state.db"), verbose=False)
+        self.assertIn("error", r)
+
+
+class TestVacuum(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.db = Path(self.tmp.name) / "state.db"; _make_db(self.db)
+        con = sqlite3.connect(str(self.db)); con.row_factory = sqlite3.Row
+        for i in range(5): _ins(con, f"s{i}", 10 + i)
+        con.close()
+
+    def tearDown(self): self.tmp.cleanup()
+
+    def test_vacuum_ok(self):
+        r = vacuum_db(self.db, verbose=False)
+        self.assertNotIn("error", r, r)
+        self.assertIn("bytes_before", r)
+        self.assertIn("bytes_after", r)
+
+    def test_vacuum_insufficient_disk_aborts(self):
+        """_free_override=0 simulates a full disk; tool must refuse, not fill disk."""
+        r = vacuum_db(self.db, verbose=False, _free_override=0)
+        self.assertIn("error", r)
+        self.assertIn("need", r["error"])
+        self.assertIn("db_bytes", r)
+
+    def test_vacuum_missing_db(self):
+        r = vacuum_db(Path("/nonexistent/state.db"), verbose=False)
+        self.assertIn("error", r)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds `checkpoint()` — `PRAGMA wal_checkpoint(TRUNCATE)` per-profile, standalone, safe to run at any time (workers WAL was 3.8 GB before #515)
- Adds `vacuum_db()` — `VACUUM` with a pre-flight free-space check; needs ~2× file size free; aborts rather than filling disk; uses `_free_override` param for test injection without monkeypatching
- `--checkpoint` and `--vacuum` flags wired into the per-profile loop in `main()`; both are independent of `--apply` and of each other
- 5 new fixture tests (TestCheckpoint × 2, TestVacuum × 3); 18/18 pass

**Separation rationale:** WAL truncation and a full-file rewrite differ from session deletion in disk requirement, risk, and timing. A checkpoint is a fast, safe page flush that can run any time. A VACUUM creates a new file on disk (needs ~2× space), holds an exclusive lock for minutes, and should be run detached — see PR 3 runbook for detach instructions. Folding either into `--apply` would force operators to have that disk headroom even for a routine weekly prune. Keeping them as opt-in flags lets each be scheduled independently.

## Smoke evidence

Local fixture run, all 18 tests:

```
test_checkpoint_missing_db ... ok
test_checkpoint_returns_stats ... ok
test_vacuum_insufficient_disk_aborts ... ok
test_vacuum_missing_db ... ok
test_vacuum_ok ... ok
[13 original tests all ok]
Ran 18 tests in 0.091s  OK
```

Gate: `✓ lane V (edges-infra) gate passed — 103 LOC, 2 files, verify ok`

## Test plan

- [ ] CI `lane-gate` passes (scripts/** allowed, 103 LOC < 600 cap)
- [ ] `python3 scripts/test_hermes_session_retention.py` — 18/18
- [ ] Operator runs `--checkpoint` on workers profile; confirms log_pages reports the WAL size
- [ ] Operator runs `--vacuum` on workers profile after deletion; confirms freed bytes

Supersedes #514 (split into #515 + this + PR 3 runbook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)