### PR TITLE
ops(deploy-fleet): default auto-rollout to the dev tenant, not the whole fleet

### DIFF
--- a/.github/workflows/deploy-fleet.yml
+++ b/.github/workflows/deploy-fleet.yml
@@ -83,7 +83,16 @@ jobs:
               build-alfred-worker) services="alfred" ;;
               *) echo "::error::unknown trigger workflow: $wf"; exit 1 ;;
             esac
-            hosts="${{ vars.ALFRED_FLEET_HOSTS || 'home,rj,joe,zsolt,miguel,rami' }}"
+            # Fail SAFE, not open. An auto-rollout triggered by a merge goes to
+            # the dev tenant only unless someone has explicitly widened it via
+            # the ALFRED_FLEET_HOSTS repo variable. The previous default here
+            # was the full fleet, so deleting or never setting that variable
+            # silently rolled every merge to all six tenants — which is what
+            # happened on 2026-08-10 (six fleet-wide deploys before anyone
+            # noticed). Reaching the rest of the fleet is a deliberate act:
+            # set the variable, or use workflow_dispatch with an explicit
+            # `hosts` input.
+            hosts="${{ vars.ALFRED_FLEET_HOSTS || 'home' }}"
           fi
           services_space="${services//,/ }"
           hosts_space="${hosts//,/ }"


### PR DESCRIPTION
## What

`deploy-fleet.yml` resolved its target hosts as:

```yaml
hosts="${{ vars.ALFRED_FLEET_HOSTS || 'home,rj,joe,zsolt,miguel,rami' }}"
```

The behaviour when nobody has set the repo variable is therefore *deploy to every tenant*. The variable was not set.

## Why it matters

On 2026-08-10, six merge-triggered rollouts went to all six tenants while the standing instruction was to change only the dev tenant:

```
06:48  alfred-learn
07:59  ctrl-api
11:18  ctrl-api
11:23  web
11:47  ctrl-api
12:18  alfred-learn
```

```
hosts:    home rj joe zsolt miguel rami
```

The changes involved were backward compatible — an optional activity parameter defaulted to `None`, an additive query projection, and a script that is not copied into any image — so no tenant is known to be harmed. But the blast radius was six times what was intended, and nothing surfaced it: the target hosts appear only in a log line that is read when someone goes looking for it.

A default that fails open to "everyone" is the defect. The narrow case is the safe one and should be what you get for free.

## Change

One line: the fallback becomes `home`. Widening stays available and deliberate — set `ALFRED_FLEET_HOSTS`, or use `workflow_dispatch` with an explicit `hosts` input. Neither path is modified.

I have also set `ALFRED_FLEET_HOSTS=home` on the repo, so the fleet is already contained; this commit makes that containment survive the variable being deleted.

Refs #377, which proposed exactly this ("re-enable deploy-fleet with a home-only default"). The workflow was already enabled and already supported per-host dispatch — the only missing piece was the default.

## Smoke evidence

```
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-fleet.yml')); print('yaml ok')"
yaml ok

$ git commit
▶ lane phase0 verify: true
✓ lane phase0 (orchestrator) gate passed — 11 LOC, 1 files, verify ok
```

Repo variable now set:

```
$ gh variable list
ALFRED_FLEET_HOSTS   home   2026-08-10T13:05:30Z
```

Behaviour is unchanged for anyone who sets the variable; the diff only moves the unset-variable case from "all six" to "home".