### PR TITLE
fix(learn): classify webhook:<label> transport so inbound webhooks extract signals (#465)

### DIFF
--- a/packages/learn/src/activities/signals.py
+++ b/packages/learn/src/activities/signals.py
@@ -234,6 +234,19 @@ TARGET_CANDIDATE_LIMIT: int = 5
 # evaluate_state prompt, long enough to disambiguate intent.
 RAW_QUOTE_MAX: int = 200
 
+# Maximum body length forwarded to the LLM extraction prompt.
+# Verbatim webhook payloads (e.g. meeting transcripts) can be 50–242 KB.
+# Passing them unbounded triggers the context-overflow class from
+# CLAUDE.md §14 / #193 ("max compression attempts"), which is why
+# onboarding fact-extraction had to be chunked.  16 KB captures any
+# meeting summary or short transcript in full while keeping the
+# extraction pipeline well under context budget.  The prompt builder
+# applies a tighter internal cap (2 KB) when assembling the LLM prompt;
+# this outer cap limits in-memory footprint and is defence-in-depth
+# against prompt-builder changes.  Apply via _cap_at_word_boundary so
+# the cut never lands mid-word.
+MAX_CLERK_BODY_CHARS: int = 16_000
+
 
 # ---------------------------------------------------------------------------
 # Phase 6.7 (T6.7.4) — per-source-type confidence priors
@@ -540,6 +553,17 @@ def _normalize_source_type(raw: str) -> str:
         return "vault_edit"
     if raw.startswith("sure"):
         return "sure"
+
+    # webhook:<label> is a structured, explicit transport marker stamped
+    # by ctrl-api's inbound webhook route (webhooksInbound.ts).  The label
+    # is the handler name (e.g. "fathom").  Return the full token so the
+    # open-world gate in _pre_filter accepts it and the event rides the
+    # generic extraction path — same contract as an unenumerated composio
+    # app, which also returns its raw token rather than "unknown".
+    if raw.startswith("webhook:"):
+        label = raw[len("webhook:"):]
+        if label:
+            return raw  # "webhook:<label>" — never "unknown"
 
     return "unknown"
 
@@ -912,6 +936,24 @@ def _is_unknown_source_only_drop(event_dict: dict[str, Any]) -> bool:
     return _infer_source_type(event_dict) == "unknown"
 
 
+def _cap_at_word_boundary(text: str, max_chars: int) -> str:
+    """Truncate *text* to *max_chars* at a word boundary where possible.
+
+    Prefers the last space within the budget so the cut does not land
+    mid-word; falls back to a hard slice when there is no space in the
+    final 40 chars (e.g. a long URL or base64 blob).  Appends '…' to
+    signal the truncation to downstream consumers; returns *text*
+    unchanged when it is already within budget.
+    """
+    if len(text) <= max_chars:
+        return text
+    cut = text[:max_chars]
+    last_space = cut.rfind(" ")
+    if last_space > max_chars - 40:
+        cut = cut[:last_space]
+    return cut.rstrip() + "…"
+
+
 def _extract_raw_quote(event_dict: dict[str, Any]) -> str:
     """Build the 200-char ground-truth excerpt preserved on the signal.
 
@@ -967,16 +1009,7 @@ def _extract_raw_quote(event_dict: dict[str, Any]) -> str:
 
     # Collapse whitespace for YAML-friendliness.
     quote = re.sub(r"\s+", " ", quote).strip()
-    if len(quote) <= RAW_QUOTE_MAX:
-        return quote
-
-    # Word-boundary truncation. Prefer the last space within budget;
-    # fall back to a hard slice if there's no space (e.g. a long URL).
-    cut = quote[: RAW_QUOTE_MAX]
-    last_space = cut.rfind(" ")
-    if last_space > RAW_QUOTE_MAX - 40:
-        cut = cut[:last_space]
-    return cut.rstrip() + "…"
+    return _cap_at_word_boundary(quote, RAW_QUOTE_MAX)
 
 
 def _strip_gmail_headers(body: str) -> str:
@@ -1654,7 +1687,7 @@ async def extract_signal_from_event(
         prompt = build_signal_extraction_prompt(
             source_type=source_type,
             event_frontmatter=event.get("frontmatter") or {},
-            event_body=_event_body(event),
+            event_body=_cap_at_word_boundary(_event_body(event), MAX_CLERK_BODY_CHARS),
             raw_quote=raw_quote,
         )
 
@@ -2301,7 +2334,7 @@ async def extract_signals_from_event(
         prompt = build_signal_extraction_prompt_multi(
             source_type=source_type,
             event_frontmatter=event.get("frontmatter") or {},
-            event_body=_event_body(event),
+            event_body=_cap_at_word_boundary(_event_body(event), MAX_CLERK_BODY_CHARS),
             raw_quote=event_level_raw_quote,
             soul_md=soul_md,
         )

--- a/packages/learn/tests/test_webhook_transport_classification.py
+++ b/packages/learn/tests/test_webhook_transport_classification.py
@@ -1,0 +1,104 @@
+"""Webhook transport classification and body-cap tests (#465).
+
+ctrl-api stamps ``source_type: webhook:<label>`` on inbound webhook events.
+Before this fix, ``_normalize_source_type`` returned ``"unknown"`` for that
+token, causing a permanent retry loop (``UnknownSourceTypeRetry`` every 5 min,
+0 signals written).  The fix treats ``webhook:<label>`` as a classified
+transport — same open-world contract as unenumerated composio apps.
+
+Body-cap tests: large webhook payloads (50–242 KB transcripts) must be
+truncated before the LLM call to prevent the #193 context-overflow class.
+
+Regression: an event with NO source_type must still classify as ``"unknown"``
+and trigger the retry valve (#9/C6) — not a silent terminal drop.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from src.activities.signals import (  # noqa: E402
+    MAX_CLERK_BODY_CHARS,
+    _cap_at_word_boundary,
+    _infer_source_type,
+    _is_unknown_source_only_drop,
+    _normalize_source_type,
+    _pre_filter,
+)
+
+_recent_iso = (datetime.now(timezone.utc) - timedelta(days=1)).strftime(
+    "%Y-%m-%dT%H:%M:%SZ"
+)
+
+
+def _webhook_rec(label: str, body: str) -> dict:
+    return {
+        "frontmatter": {
+            "source_type": f"webhook:{label}",
+            "stream_type": f"webhook:{label}",
+            "created": _recent_iso,
+        },
+        "content": body,
+    }
+
+
+def test_webhook_label_normalizes_to_stable_token() -> None:
+    assert _normalize_source_type("webhook:fathom") == "webhook:fathom"
+    assert _normalize_source_type("webhook:zapier") == "webhook:zapier"
+
+
+def test_bare_webhook_without_label_stays_unknown() -> None:
+    """'webhook:' with empty label is not a classified transport."""
+    assert _normalize_source_type("webhook:") == "unknown"
+
+
+def test_webhook_event_inferred_source_type() -> None:
+    rec = _webhook_rec("fathom", "Meeting summary: discussed Q3 roadmap and action items.")
+    assert _infer_source_type(rec) == "webhook:fathom"
+
+
+def test_webhook_event_accepted_by_pre_filter() -> None:
+    rec = _webhook_rec("fathom", "Meeting notes: agreed to deliver the spec by end of sprint.")
+    accepted, reason = _pre_filter(rec)
+    assert accepted, f"webhook event must be accepted, got: {reason!r}"
+
+
+def test_webhook_event_not_unknown_source_only_drop() -> None:
+    rec = _webhook_rec("fathom", "Meeting notes: budget approved, next review in two weeks.")
+    assert _is_unknown_source_only_drop(rec) is False
+
+
+def test_cap_at_word_boundary_within_budget_unchanged() -> None:
+    text = "Short text within budget."
+    assert _cap_at_word_boundary(text, 100) == text
+
+
+def test_cap_at_word_boundary_result_length() -> None:
+    """Content before the ellipsis must be within budget."""
+    big_body = ("word " * 5000).strip()  # ~25 000 chars
+    result = _cap_at_word_boundary(big_body, MAX_CLERK_BODY_CHARS)
+    assert result.endswith("…")
+    assert len(result[:-1]) <= MAX_CLERK_BODY_CHARS
+
+
+def test_webhook_large_body_pre_filter_still_accepts() -> None:
+    """Pre-filter uses full body only for MIN_CONTENT_LENGTH; cap is LLM-step only."""
+    rec = _webhook_rec("fathom", "word " * 50_000)
+    accepted, reason = _pre_filter(rec)
+    assert accepted, f"large-body webhook must pass pre-filter: {reason!r}"
+
+
+def test_no_source_type_returns_unknown_and_defers() -> None:
+    """No transport markers → 'unknown' → retry valve fires, not a terminal drop."""
+    rec = {
+        "frontmatter": {"name": "some event"},
+        "content": "Content long enough to clear the minimum length check for pre-filter.",
+    }
+    assert _infer_source_type(rec) == "unknown"
+    accepted, reason = _pre_filter(rec)
+    assert accepted is False and "unknown" in reason
+    assert _is_unknown_source_only_drop(rec) is True


### PR DESCRIPTION
## Summary

- `_normalize_source_type` returned `"unknown"` for the `webhook:<label>` token stamped by ctrl-api on every inbound webhook delivery, causing `_pre_filter` to reject every event and `_is_unknown_source_only_drop` to defer indefinitely — a permanent retry loop every 5 minutes, 0 signals written, 7 of 9 backfilled deliveries still stranded after #512.
- Fix: add a `webhook:*` branch to `_normalize_source_type` returning the full `webhook:<label>` token. Same open-world contract as unenumerated composio apps (a structured transport marker is never `"unknown"`). `_pre_filter` already accepts any non-unknown token; no allowlist change needed.
- Body cap (`MAX_CLERK_BODY_CHARS = 16_000`): verbatim Fathom transcripts are 50–242 KB. Extract the existing word-boundary truncation from `_extract_raw_quote` into `_cap_at_word_boundary` and apply it at both LLM prompt-build call sites before the body reaches the clerk. Guards the #193 context-overflow class; the prompt builder applies a tighter 2 KB inner cap.

## What a `webhook:<label>` maps to

`webhook:fathom` normalizes to `"webhook:fathom"` — the full token, never `"unknown"`. `_pre_filter`'s open-world gate accepts any non-unknown token, so the event rides the generic extraction path. No specialized branch (no sender-domain check, no gcal staleness filter) — a webhook event is generic input by definition.

## Body cap rationale

16 KB (`MAX_CLERK_BODY_CHARS = 16_000`) captures full meeting summaries and short transcripts while keeping the extraction pipeline well under context budget. The prompt builder applies a tighter 2 KB internal cap; this outer cap limits in-memory footprint and is defence-in-depth against prompt-builder changes. Word-boundary truncation via the extracted `_cap_at_word_boundary` helper (replaces identical inline code in `_extract_raw_quote`).

## Scope

Classify and extract. No meeting-note materialization, no new vault record type, no Fathom-specific parser. A webhook event becoming a normal signal through the generic path is the correct minimal outcome.

## Smoke evidence

```
tests/test_webhook_transport_classification.py::test_webhook_label_normalizes_to_stable_token PASSED
tests/test_webhook_transport_classification.py::test_bare_webhook_without_label_stays_unknown PASSED
tests/test_webhook_transport_classification.py::test_webhook_event_inferred_source_type PASSED
tests/test_webhook_transport_classification.py::test_webhook_event_accepted_by_pre_filter PASSED
tests/test_webhook_transport_classification.py::test_webhook_event_not_unknown_source_only_drop PASSED
tests/test_webhook_transport_classification.py::test_cap_at_word_boundary_within_budget_unchanged PASSED
tests/test_webhook_transport_classification.py::test_cap_at_word_boundary_result_length PASSED
tests/test_webhook_transport_classification.py::test_webhook_large_body_pre_filter_still_accepts PASSED
tests/test_webhook_transport_classification.py::test_no_source_type_returns_unknown_and_defers PASSED

9 passed in 0.12s

Full verify suite (VERIFY command from .lane):
2639 passed, 101 skipped in 22.03s

Lane gate: ✓ lane II (learn) gate passed — 161 LOC, 2 files, verify ok
```

## Files touched

- `packages/learn/src/activities/signals.py` — `_normalize_source_type` webhook branch, `_cap_at_word_boundary` helper, `MAX_CLERK_BODY_CHARS` constant, refactored `_extract_raw_quote` tail, two LLM call sites capped
- `packages/learn/tests/test_webhook_transport_classification.py` — 9 tests (new file)

References #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)