### PR TITLE
fix(retention): COALESCE liveness predicate + preflight fixes (#519)

### DIFF
--- a/docs/operators/hermes-session-retention.md
+++ b/docs/operators/hermes-session-retention.md
@@ -44,8 +44,22 @@ Expected time: under 30 seconds for stores totalling ~43 GB (copy, not compress)
 python3 scripts/hermes-session-retention.py
 ```
 
+Dry-run runs no preflight integrity check — it is read-only and cannot
+corrupt anything.  It returns in seconds regardless of store size.
+
 Review the output.  If `eligible_sessions` is unexpectedly high (e.g. the
 window was 0 days on a misconfigured clone), stop here.
+
+If `eligible_sessions` is 0, the script reports the age of the oldest session
+so you can tell "nothing old enough yet" from "store is truly clean":
+
+```
+  Eligible: 0 sessions 0 msgs | Range: None → None
+  (nothing old enough yet — oldest is 79.2d old; window is 90d)
+```
+
+This is expected for `main` and `heavy` profiles on a store younger than the
+window.  The windows will start catching sessions in the coming weeks.
 
 ### Step 3 — WAL checkpoint  (fast — run before apply)
 
@@ -83,8 +97,26 @@ python3 scripts/hermes-session-retention.py --apply --backup-ok --verbose
 `--backup-ok` is a required attestation flag; omitting it aborts with an
 error before touching any data.
 
-Expected times:
-- workers (~29 k eligible sessions, 14d window): 5–10 min
+**Preflight check on `--apply`**: before deleting anything the script runs
+`PRAGMA quick_check` on each store and prints a warning before it starts:
+
+```
+  PRAGMA quick_check on state.db (may take ~6.5 min on a 13 GB store — normal, not wedged)...
+```
+
+Do not kill the process during this phase — it is not wedged.  On a 13 GB
+workers store `quick_check` takes roughly 6.5 minutes.  If you are re-running
+in the same maintenance window and the store was clean on the first pass, use
+`--skip-integrity` to bypass it:
+
+```bash
+nohup python3 scripts/hermes-session-retention.py \
+  --apply --backup-ok --skip-integrity --verbose \
+  > /tmp/hermes-retention-retry.log 2>&1 &
+```
+
+Expected times (after the preflight completes):
+- workers (~138 k eligible sessions at 14d window): 5–10 min deletion
 - main (90d window, low session count): under 1 min
 - heavy (90d window, very low volume): under 1 min
 
@@ -146,10 +178,32 @@ No restore needed.
 --backup-ok            Required with --apply; attests backup was taken
 --checkpoint           WAL checkpoint (TRUNCATE) each profile store
 --vacuum               VACUUM each profile store (pre-checks free disk)
+--skip-integrity       Skip quick_check preflight on --apply; safe when
+                       re-running in the same maintenance window
 --profile NAME:DAYS    Override window for one profile (repeatable)
 --hermes-home PATH     Override HERMES_HOME (default: /hermes-state)
 --verbose              Print per-batch and per-operation progress
 ```
+
+## Preflight behaviour by mode
+
+| Mode | Preflight | Cost |
+|------|-----------|------|
+| dry-run (default) | None — read-only cannot corrupt | < 1 s |
+| `--apply` | `PRAGMA quick_check` — structural check | ~6.5 min on 13 GB |
+| `--apply --skip-integrity` | None | 0 s |
+
+`PRAGMA integrity_check` (page-by-page full verification) is never run by
+this script.  On a 13 GB store it takes substantially longer than
+`quick_check` and was the root cause of every earlier apply timeout.
+
+## Liveness predicate
+
+A session is eligible when `COALESCE(ended_at, started_at) < cutoff` and
+no live compression lock covers it.  Background agents never write
+`ended_at`; keying on `COALESCE` means an old open session is pruned (a
+14-day-old background run no longer exists), while a session started inside
+the window is protected whether or not it ended.
 
 ## Scheduling
 

--- a/scripts/hermes-session-retention.py
+++ b/scripts/hermes-session-retention.py
@@ -7,10 +7,14 @@ Per-profile windows (not one global number):
   heavy   90d — reflection/onboarding reasoning; low volume, worth keeping.
 
 Liveness predicate — session excluded if ANY holds:
-  1. ended_at IS NULL          — in progress
-  2. started_at > cutoff       — within window
-  3. compression_locks.expires_at > now  — LCM compression in flight
+  1. COALESCE(ended_at, started_at) >= cutoff — within window (or open and recent)
+  2. compression_locks.expires_at > now        — LCM compression in flight
      (expiry-time semantics; there is NO released_at column)
+
+Rationale: background agents never write ended_at.  Keying on
+COALESCE(ended_at, started_at) means an old open session is eligible
+(a 14-day-old background run does not exist), while a session started
+inside the window is protected whether or not it ended.
 
 FTS5: messages_fts is USING fts5(content) — 'content' is a column name, NOT
 the content='tablename' option (very different).  Six triggers maintain both
@@ -49,6 +53,11 @@ def _integrity(con: sqlite3.Connection) -> bool:
     row = con.execute("PRAGMA integrity_check").fetchone()
     return bool(row and row[0] == "ok")
 
+def _quick_check(con: sqlite3.Connection) -> bool:
+    """Faster structural check (~6.5 min on 13 GB vs much longer for integrity_check)."""
+    row = con.execute("PRAGMA quick_check").fetchone()
+    return bool(row and row[0] == "ok")
+
 def _has_fts_triggers(con: sqlite3.Connection) -> bool:
     rows = con.execute(
         "SELECT name FROM sqlite_master WHERE type='trigger' AND tbl_name='messages'"
@@ -60,13 +69,17 @@ def _cutoff(days: int) -> float:
     return time.time() - days * 86400
 
 def _eligible(con: sqlite3.Connection, cutoff_ts: float) -> list[str]:
-    """Session IDs eligible for deletion (ended, outside window, no live lock)."""
+    """Session IDs eligible for deletion (outside window, no live lock).
+
+    Uses COALESCE(ended_at, started_at) so that old open sessions (background
+    agents that never wrote ended_at) are included.  A session started inside
+    the window is protected whether or not it ended.
+    """
     now = time.time()
     rows = con.execute(
         """
         SELECT s.id FROM sessions s
-        WHERE s.ended_at IS NOT NULL
-          AND s.started_at < ?
+        WHERE COALESCE(s.ended_at, s.started_at) < ?
           AND s.id NOT IN (
               SELECT session_id FROM compression_locks WHERE expires_at > ?
           )
@@ -125,12 +138,10 @@ def vacuum_db(db_path: Path, verbose: bool, _free_override: int = -1) -> dict:
 
 
 def dry_run(db_path: Path, profile: str, days: int) -> dict:
+    """Count eligible sessions.  No preflight check — read-only cannot corrupt."""
     if not db_path.exists():
         return {"error": f"missing: {db_path}"}
     con = _open(db_path, readonly=True)
-    if not _integrity(con):
-        con.close()
-        return {"error": "integrity_check failed"}
     cut = _cutoff(days)
     now = time.time()
     # Predicate-based counts — never materialise the session id list.
@@ -139,49 +150,61 @@ def dry_run(db_path: Path, profile: str, days: int) -> dict:
     # and hung.  A single predicate-join query runs in <1 s on 678 k messages.
     n_sess = con.execute(
         "SELECT COUNT(*) FROM sessions"
-        " WHERE ended_at IS NOT NULL AND started_at < ?"
+        " WHERE COALESCE(ended_at, started_at) < ?"
         " AND id NOT IN (SELECT session_id FROM compression_locks WHERE expires_at > ?)",
         (cut, now),
     ).fetchone()[0]
     n_msgs = con.execute(
         "SELECT COUNT(*) FROM messages m"
         " JOIN sessions s ON m.session_id = s.id"
-        " WHERE s.ended_at IS NOT NULL AND s.started_at < ?"
+        " WHERE COALESCE(s.ended_at, s.started_at) < ?"
         " AND s.id NOT IN (SELECT session_id FROM compression_locks WHERE expires_at > ?)",
         (cut, now),
     ).fetchone()[0]
     size_b = _db_bytes(con)
-    oldest = newest = None
+    oldest = newest = oldest_session_days = None
     if n_sess:
         row = con.execute(
             "SELECT MIN(started_at), MAX(started_at) FROM sessions"
-            " WHERE ended_at IS NOT NULL AND started_at < ?"
+            " WHERE COALESCE(ended_at, started_at) < ?"
             " AND id NOT IN (SELECT session_id FROM compression_locks WHERE expires_at > ?)",
             (cut, now),
         ).fetchone()
         ts2d = lambda ts: datetime.fromtimestamp(ts, tz=timezone.utc).date().isoformat() if ts else None
         oldest, newest = ts2d(row[0]), ts2d(row[1])
+    else:
+        # Zero eligible — report oldest session age so the operator can tell
+        # "nothing old enough yet" from "store is empty or truly clean".
+        row = con.execute(
+            "SELECT MIN(COALESCE(ended_at, started_at)) FROM sessions"
+        ).fetchone()
+        if row and row[0]:
+            oldest_session_days = (time.time() - row[0]) / 86400
     con.close()
     return {
         "profile": profile, "window_days": days, "db": str(db_path),
         "db_bytes": size_b, "eligible_sessions": n_sess,
         "eligible_messages": n_msgs, "oldest": oldest, "newest": newest,
+        "oldest_session_days": oldest_session_days,
     }
 
 
-def apply(db_path: Path, profile: str, days: int, verbose: bool) -> dict:
+def apply(db_path: Path, profile: str, days: int, verbose: bool, skip_integrity: bool = False) -> dict:
     if not db_path.exists():
         return {"error": f"missing: {db_path}"}
     con = _open(db_path, readonly=False)
-    if not _integrity(con):
-        con.close()
-        return {"error": "integrity_check failed"}
+    if not skip_integrity:
+        print(f"  PRAGMA quick_check on {db_path.name} "
+              f"(may take ~6.5 min on a 13 GB store — normal, not wedged)...", flush=True)
+        if not _quick_check(con):
+            con.close()
+            return {"error": "quick_check failed"}
     cut = _cutoff(days)
     now = time.time()
     # Count without materialising the id list (same predicate as the LIMIT loop).
     total = con.execute(
         "SELECT COUNT(*) FROM sessions"
-        " WHERE ended_at IS NOT NULL AND started_at < ?"
+        " WHERE COALESCE(ended_at, started_at) < ?"
         " AND id NOT IN (SELECT session_id FROM compression_locks WHERE expires_at > ?)",
         (cut, now),
     ).fetchone()[0]
@@ -197,7 +220,7 @@ def apply(db_path: Path, profile: str, days: int, verbose: bool) -> dict:
     while True:
         rows = con.execute(
             "SELECT id FROM sessions"
-            " WHERE ended_at IS NOT NULL AND started_at < ?"
+            " WHERE COALESCE(ended_at, started_at) < ?"
             " AND id NOT IN (SELECT session_id FROM compression_locks WHERE expires_at > ?)"
             " LIMIT ?",
             (cut, now, BATCH_SIZE),
@@ -239,6 +262,8 @@ def main():
     p.add_argument("--hermes-home", default=HERMES_HOME)
     p.add_argument("--checkpoint", action="store_true", help="WAL checkpoint (TRUNCATE) each profile store")
     p.add_argument("--vacuum", action="store_true", help="VACUUM each profile store (needs ~2x file size free)")
+    p.add_argument("--skip-integrity", action="store_true",
+                   help="Skip quick_check preflight on --apply (safe when re-running in the same window)")
     p.add_argument("--verbose", action="store_true")
     args = p.parse_args()
 
@@ -263,7 +288,7 @@ def main():
         do_scan = args.apply or (not args.checkpoint and not args.vacuum)
         if do_scan:
             if args.apply:
-                r = apply(db_path, profile, days, args.verbose)
+                r = apply(db_path, profile, days, args.verbose, skip_integrity=args.skip_integrity)
                 if "error" in r:
                     print(f"  ERROR: {r['error']}")
                 else:
@@ -278,6 +303,9 @@ def main():
                     print(f"  DB: {r['db_bytes'] / (1024**3):.2f} GB | "
                           f"Eligible: {r['eligible_sessions']:,} sessions {r['eligible_messages']:,} msgs | "
                           f"Range: {r['oldest']} → {r['newest']}")
+                    osd = r.get("oldest_session_days")
+                    if r["eligible_sessions"] == 0 and osd is not None:
+                        print(f"  (nothing old enough yet — oldest is {osd:.1f}d old; window is {days}d)")
         if args.checkpoint:
             cr = checkpoint(db_path, args.verbose)
             if "error" in cr:

--- a/scripts/test_hermes_session_retention.py
+++ b/scripts/test_hermes_session_retention.py
@@ -12,6 +12,7 @@ import tempfile
 import time
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 _mod = importlib.util.module_from_spec(
     s := importlib.util.spec_from_file_location("_hsr", Path(__file__).parent / "hermes-session-retention.py")
@@ -86,11 +87,20 @@ class TestEligibility(unittest.TestCase):
         _ins(con, "new", 5); con.close()
         self.assertNotIn("new", self._eligible_ids())
 
-    def test_open_session_excluded(self):
-        """ended_at IS NULL — must never be pruned."""
+    def test_old_open_session_eligible(self):
+        """ended_at IS NULL but started_at outside window — background agent that never
+        wrote ended_at; must be pruned (COALESCE keying on started_at makes it eligible)."""
         con = sqlite3.connect(str(self.db)); con.row_factory = sqlite3.Row
-        _ins(con, "live", 60, ended=False); con.close()
-        self.assertNotIn("live", self._eligible_ids(), "open session leaked through liveness predicate")
+        _ins(con, "old-open", 60, ended=False); con.close()
+        self.assertIn("old-open", self._eligible_ids(),
+                      "old unended session must be eligible — background agents never write ended_at")
+
+    def test_recent_open_session_excluded(self):
+        """ended_at IS NULL and started_at inside window — may still be active."""
+        con = sqlite3.connect(str(self.db)); con.row_factory = sqlite3.Row
+        _ins(con, "new-open", 5, ended=False); con.close()
+        self.assertNotIn("new-open", self._eligible_ids(),
+                         "recent unended session must not be pruned")
 
     def test_live_lock_excluded(self):
         """expires_at > now — lock held.  NO released_at column in the real schema."""
@@ -128,6 +138,64 @@ class TestDryRun(unittest.TestCase):
         self.assertIn("error", dry_run(Path("/nonexistent/state.db"), "t", 30))
 
 
+class TestDryRunPreflight(unittest.TestCase):
+    """Defect 5 regression: dry_run() called PRAGMA integrity_check (or quick_check),
+    which takes ~6.5 min on a 13 GB store and killed every dry run attempt.
+    A read-only count cannot corrupt anything; there is nothing to guard."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        pd = Path(self.tmp.name) / "profiles" / "workers"; pd.mkdir(parents=True)
+        self.db = pd / "state.db"; _make_db(self.db)
+        con = sqlite3.connect(str(self.db)); con.row_factory = sqlite3.Row
+        _ins(con, "old", 60); con.close()
+
+    def tearDown(self): self.tmp.cleanup()
+
+    def test_dry_run_does_not_call_integrity(self):
+        """dry_run must not invoke _integrity or _quick_check — spy via patch."""
+        with patch.object(_mod, "_integrity",
+                          side_effect=AssertionError("_integrity must not be called in dry_run")):
+            with patch.object(_mod, "_quick_check",
+                              side_effect=AssertionError("_quick_check must not be called in dry_run")):
+                r = dry_run(self.db, "workers", 30)
+        self.assertNotIn("error", r, r)
+        self.assertEqual(r["eligible_sessions"], 1)
+
+
+class TestZeroEligibleReport(unittest.TestCase):
+    """Defect 6 report: when eligible == 0, the output said '0' with no context,
+    making 'nothing old enough yet' indistinguishable from 'truly nothing to do'."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        pd = Path(self.tmp.name) / "profiles" / "main"; pd.mkdir(parents=True)
+        self.db = pd / "state.db"; _make_db(self.db)
+        con = sqlite3.connect(str(self.db)); con.row_factory = sqlite3.Row
+        # Session 70 days old — inside the 90-day main window, not eligible.
+        _ins(con, "almost", 70); con.close()
+
+    def tearDown(self): self.tmp.cleanup()
+
+    def test_zero_eligible_includes_oldest_age(self):
+        r = dry_run(self.db, "main", 90)
+        self.assertNotIn("error", r, r)
+        self.assertEqual(r["eligible_sessions"], 0)
+        self.assertIsNotNone(r.get("oldest_session_days"),
+                             "zero-eligible result must include oldest_session_days so "
+                             "operator can tell 'nothing old enough' from 'store is empty'")
+        self.assertAlmostEqual(r["oldest_session_days"], 69, delta=1,
+                               msg="oldest_session_days should reflect the session's age "
+                                   "(ended_at = started_at + DAY, so ~69d old)")
+
+    def test_has_eligible_omits_oldest_age(self):
+        """oldest_session_days is None when there are eligible sessions — not needed."""
+        r = dry_run(self.db, "main", 30)  # 70d old IS eligible under 30d window
+        self.assertNotIn("error", r, r)
+        self.assertGreater(r["eligible_sessions"], 0)
+        self.assertIsNone(r.get("oldest_session_days"))
+
+
 class TestApply(unittest.TestCase):
     def setUp(self):
         self.tmp = tempfile.TemporaryDirectory()
@@ -139,16 +207,16 @@ class TestApply(unittest.TestCase):
     def tearDown(self): self.tmp.cleanup()
 
     def test_deletes_eligible_only(self):
-        r = apply(self.db, "workers", 30, verbose=False)
+        r = apply(self.db, "workers", 30, verbose=False, skip_integrity=True)
         self.assertEqual(r["deleted_sessions"], 15)
         self.assertEqual(sqlite3.connect(str(self.db)).execute("SELECT COUNT(*) FROM sessions").fetchone()[0], 1)
 
     def test_idempotent(self):
-        apply(self.db, "workers", 30, verbose=False)
-        self.assertEqual(apply(self.db, "workers", 30, verbose=False)["deleted_sessions"], 0)
+        apply(self.db, "workers", 30, verbose=False, skip_integrity=True)
+        self.assertEqual(apply(self.db, "workers", 30, verbose=False, skip_integrity=True)["deleted_sessions"], 0)
 
     def test_preserves_young_sessions(self):
-        apply(self.db, "workers", 30, verbose=False)
+        apply(self.db, "workers", 30, verbose=False, skip_integrity=True)
         self.assertIsNotNone(sqlite3.connect(str(self.db)).execute("SELECT id FROM sessions WHERE id='keep'").fetchone())
 
 
@@ -172,7 +240,7 @@ class TestFts(unittest.TestCase):
         self.assertEqual(con.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0], 1,
                          "insert trigger must have populated messages_fts")
         con.close()
-        apply(db, "workers", 30, verbose=False)
+        apply(db, "workers", 30, verbose=False, skip_integrity=True)
         con2 = sqlite3.connect(str(db))
         self.assertEqual(con2.execute("SELECT COUNT(*) FROM messages").fetchone()[0], 0)
         self.assertEqual(con2.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0], 0,
@@ -297,7 +365,7 @@ class TestDeletedCountAccuracy(unittest.TestCase):
         orig_batch = _mod.BATCH_SIZE
         _mod.BATCH_SIZE = 5  # forces 3 batches (5+5+2); old total_changes bug triples the count
         try:
-            r = apply(self.db, "workers", 30, verbose=False)
+            r = apply(self.db, "workers", 30, verbose=False, skip_integrity=True)
         finally:
             _mod.BATCH_SIZE = orig_batch
         self.assertNotIn("error", r, r)


### PR DESCRIPTION
## Summary

- **Defect 4 (liveness predicate)**: All eligibility queries used `ended_at IS NOT NULL`, which made the feature a near-no-op — 100% of workers sessions have `ended_at IS NULL` because background agents never write it. Changed every predicate to `COALESCE(ended_at, started_at) < cutoff`: a session started outside the window is not in progress regardless of whether `ended_at` was written; a session started inside the window is protected whether or not it ended. Effect: 188 → 138,037 eligible sessions on the measured store.
- **Defect 5 (preflight hang)**: `dry_run()` called `PRAGMA integrity_check` before its read-only counts — a multi-minute full page scan for a scan that cannot corrupt anything. Removed entirely from `dry_run`. On `--apply`, replaced `integrity_check` with `_quick_check()` (`PRAGMA quick_check`), prints a duration warning before it starts ("may take ~6.5 min on a 13 GB store — normal, not wedged"), and adds `--skip-integrity` for repeat runs in the same window.
- **Defect 6 (zero-eligible diagnostic, report-only per spec)**: When `eligible_sessions == 0`, `dry_run` now includes `oldest_session_days` in its return value and prints `(nothing old enough yet — oldest is 79.2d old; window is 90d)` so operators can distinguish "window not reached yet" from "store is truly clean". Windows unchanged.

## Smoke evidence

```
$ python3 -m py_compile scripts/hermes-session-retention.py && echo "syntax OK"
syntax OK

$ python3 scripts/test_hermes_session_retention.py 2>&1
test_deletes_eligible_only (__main__.TestApply.test_deletes_eligible_only) ... ok
test_idempotent (__main__.TestApply.test_idempotent) ... ok
test_preserves_young_sessions (__main__.TestApply.test_preserves_young_sessions) ... ok
test_checkpoint_missing_db (__main__.TestCheckpoint.test_checkpoint_missing_db) ... ok
test_checkpoint_returns_stats (__main__.TestCheckpoint.test_checkpoint_returns_stats) ... ok
test_checkpoint_standalone_skips_eligibility (__main__.TestCheckpointStandalone.test_checkpoint_standalone_skips_eligibility) ... ok
test_deleted_counts_are_exact (__main__.TestDeletedCountAccuracy.test_deleted_counts_are_exact) ... ok
test_does_not_mutate (__main__.TestDryRun.test_does_not_mutate) ... ok
test_missing_db_reports_error (__main__.TestDryRun.test_missing_db_reports_error) ... ok
test_reports_eligible (__main__.TestDryRun.test_reports_eligible) ... ok
test_dry_run_does_not_call_integrity (__main__.TestDryRunPreflight.test_dry_run_does_not_call_integrity) ... ok
test_expired_lock_eligible (__main__.TestEligibility.test_expired_lock_eligible) ... ok
test_live_lock_excluded (__main__.TestEligibility.test_live_lock_excluded) ... ok
test_old_open_session_eligible (__main__.TestEligibility.test_old_open_session_eligible) ... ok
test_old_session_eligible (__main__.TestEligibility.test_old_session_eligible) ... ok
test_recent_excluded (__main__.TestEligibility.test_recent_excluded) ... ok
test_recent_open_session_excluded (__main__.TestEligibility.test_recent_open_session_excluded) ... ok
test_trigger_detection (__main__.TestFts.test_trigger_detection) ... ok
test_triggers_maintain_fts_without_script_intervention (__main__.TestFts.test_triggers_maintain_fts_without_script_intervention) ... ok
test_dry_run_completes_and_counts_correctly (__main__.TestLargeIdList.test_dry_run_completes_and_counts_correctly) ... ok
test_vacuum_insufficient_disk_aborts (__main__.TestVacuum.test_vacuum_insufficient_disk_aborts) ... ok
test_vacuum_missing_db (__main__.TestVacuum.test_vacuum_missing_db) ... ok
test_vacuum_ok (__main__.TestVacuum.test_vacuum_ok) ... ok
test_has_eligible_omits_oldest_age (__main__.TestZeroEligibleReport.test_has_eligible_omits_oldest_age) ... ok
test_zero_eligible_includes_oldest_age (__main__.TestZeroEligibleReport.test_zero_eligible_includes_oldest_age) ... ok

----------------------------------------------------------------------
Ran 25 tests in 0.756s

OK

Lane gate: ✓ lane V (edges-infra) gate passed — 156 LOC, 2 files, verify ok (commit 1)
Lane gate: ✓ lane V (edges-infra) gate passed —  58 LOC, 1 files, verify ok (commit 2)
```

## Files touched

- `scripts/hermes-session-retention.py` — COALESCE predicate in `_eligible()` + all five inline SQL predicates in `dry_run()`/`apply()`; remove `_integrity()` from `dry_run()`; add `_quick_check()` + duration print + `skip_integrity` param to `apply()`; add `oldest_session_days` to `dry_run()` return; add `--skip-integrity` CLI flag
- `scripts/test_hermes_session_retention.py` — replace `test_open_session_excluded` with `test_old_open_session_eligible` + `test_recent_open_session_excluded`; add `TestDryRunPreflight` (patches both `_integrity` and `_quick_check` to assert neither is called); add `TestZeroEligibleReport`; add `skip_integrity=True` to all `apply()` test calls
- `docs/operators/hermes-session-retention.md` — preflight matrix, `--skip-integrity` flag, liveness predicate rationale, zero-eligible diagnostic output, corrected expected elapsed times

References #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)