### PR TITLE
fix(learn): extract webhook body from payload.payload (#465 gap 3)

### DIFF
--- a/packages/learn/src/activities/signals.py
+++ b/packages/learn/src/activities/signals.py
@@ -725,6 +725,38 @@ def _ingest_row_to_record(row: dict[str, Any]) -> dict[str, Any]:
         body = str(payload["raw"].get("messageText") or "")
     if not body:
         body = str(payload.get("summary") or "")
+    # Webhook envelope: the nested content lives at payload["payload"].
+    # ctrl-api's inbound webhook route stores the full provider JSON under
+    # that key; none of the composio-shape keys above (metadata.body,
+    # raw.messageText, summary) exist in a webhook row, so without this
+    # branch every webhook event is pre-filtered as "body too short (0 < 20)".
+    #
+    # Strategy: try well-known text fields in provider-agnostic priority
+    # order (a transcript or summary is far more useful to the clerk than
+    # raw JSON). Fall back to compact JSON serialisation when no recognisable
+    # text field is present — this guarantees the clerk always has *something*
+    # to work with regardless of the provider's schema, while keeping the
+    # fallback as compact as possible (no indent, ASCII-safe).
+    #
+    # The MAX_CLERK_BODY_CHARS cap is applied here so a 50–242 KB transcript
+    # payload does not propagate as a large in-memory string. The LLM call
+    # site applies the same cap again as defence-in-depth.
+    if not body:
+        nested = payload.get("payload")
+        if isinstance(nested, dict):
+            for _wh_field in (
+                "transcript", "summary", "body", "text", "content", "description"
+            ):
+                _candidate = str(nested.get(_wh_field) or "").strip()
+                if _candidate:
+                    body = _candidate
+                    break
+            if not body:
+                body = json.dumps(nested, ensure_ascii=False, separators=(",", ":"))
+        elif isinstance(nested, str) and nested.strip():
+            body = nested.strip()
+        if body:
+            body = _cap_at_word_boundary(body, MAX_CLERK_BODY_CHARS)
     created = str(payload.get("received_at") or row.get("ts") or "")
     tags = [source_type] if source_type else []
 

--- a/packages/learn/tests/test_ingest_signal_source.py
+++ b/packages/learn/tests/test_ingest_signal_source.py
@@ -17,6 +17,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 from src.activities.signals import (  # noqa: E402
+    MAX_CLERK_BODY_CHARS,
     _INGEST_REF_PREFIX,
     _ingest_row_to_record,
     _infer_source_type,
@@ -248,3 +249,83 @@ def test_no_transport_markers_still_unknown_and_defers() -> None:
     accepted, reason = _pre_filter(rec)
     assert not accepted and "unknown" in reason
     assert _is_unknown_source_only_drop(rec) is True
+
+
+# ---------------------------------------------------------------------------
+# Webhook body extraction — #465 gap 3
+#
+# The real webhook envelope ctrl-api writes to ingest.db has exactly four
+# top-level keys: source_type, source_ref, received_at, payload.  None of
+# the composio-shape body keys (metadata.body, raw.messageText, summary)
+# exist.  Before the gap-3 fix _ingest_row_to_record produced body="" for
+# every webhook row, so _pre_filter dropped all of them as "body too short".
+#
+# Fixtures here use the verified four-key shape.  No "summary" workaround,
+# no extra keys — the exact shape the live store had at the time of the bug.
+# ---------------------------------------------------------------------------
+
+
+def _real_webhook_ingest_row(
+    label: str = "meeting-notes",
+    nested_payload: dict | None = None,
+) -> dict:
+    """Ingest row with the exact four-key envelope shape ctrl-api writes.
+
+    payload_json is a JSON string with exactly:
+      source_type, source_ref, received_at, payload
+    No "summary", no "metadata", no "raw".
+    """
+    if nested_payload is None:
+        nested_payload = {
+            "transcript": "The team agreed to deliver the feature spec by end of sprint."
+        }
+    return {
+        "id": "test-real-wh-001",
+        "kind": "webhook",
+        "channel": f"webhook:{label}",
+        "ts": _recent_iso,
+        "payload_json": json.dumps({
+            "source_type": f"webhook:{label}",
+            "source_ref": f"wh-{label}-001",
+            "received_at": _recent_iso,
+            "payload": nested_payload,
+        }),
+    }
+
+
+def test_real_webhook_row_body_from_nested_transcript_field() -> None:
+    """Body must come from payload.payload.transcript for the real envelope shape."""
+    rec = _ingest_row_to_record(_real_webhook_ingest_row())
+    body = _event_body(rec)
+    assert body, "body must be non-empty when payload.payload has a transcript field"
+    assert "feature spec" in body
+
+
+def test_real_webhook_row_passes_pre_filter() -> None:
+    """A real webhook row (no summary key) must pass _pre_filter after the gap-3 fix."""
+    rec = _ingest_row_to_record(_real_webhook_ingest_row())
+    accepted, reason = _pre_filter(rec)
+    assert accepted, f"expected accept, got: {reason!r}"
+
+
+def test_real_webhook_oversized_payload_capped_at_word_boundary() -> None:
+    """A 25 000-char nested payload must be capped at MAX_CLERK_BODY_CHARS."""
+    oversized = {"transcript": ("word " * 5000).strip()}  # ~25 000 chars
+    rec = _ingest_row_to_record(_real_webhook_ingest_row(nested_payload=oversized))
+    body = _event_body(rec)
+    # Cap leaves at most MAX_CLERK_BODY_CHARS chars before the ellipsis.
+    assert len(body) <= MAX_CLERK_BODY_CHARS + 1  # +1 for the appended "…"
+    assert body.endswith("…"), "capped body must end with ellipsis"
+    # Word boundary: the cut must not land inside the word "word".
+    assert not body[:-1].endswith("wor"), "cut must not land mid-word"
+
+
+def test_real_webhook_json_fallback_for_opaque_schema() -> None:
+    """When nested payload has no text field, compact JSON is the body fallback."""
+    opaque = {"meeting_id": "mtg-42", "attendee_count": 5, "status": "completed"}
+    rec = _ingest_row_to_record(_real_webhook_ingest_row(nested_payload=opaque))
+    body = _event_body(rec)
+    assert body, "JSON fallback must yield non-empty body for an opaque schema"
+    assert "meeting_id" in body, "compact JSON must include the key"
+    accepted, reason = _pre_filter(rec)
+    assert accepted, f"opaque-schema webhook must pass pre_filter: {reason!r}"


### PR DESCRIPTION
## Problem

After two earlier fixes (#520/#522), webhook events now classify correctly but are still all dropped:

```
signal_extract.done listed=7 extracted=7 written=0 noise_filtered=7 errors=0
pre-filtered path=ingest:<id> reason=body too short (0 < 20)
```

Root cause: `_ingest_row_to_record` tries three composio-shaped body keys — `metadata.body`, `raw.messageText`, `payload.summary` — none of which exist in the ctrl-api webhook envelope. The real content (50–242 KB of provider JSON) is at `payload["payload"]`. Nothing read it. Every webhook event produced `content=""` and was dropped by `_pre_filter`'s minimum-length gate.

## Fix (`packages/learn/src/activities/signals.py`)

After the composio body fallbacks, if `body` is still empty:
1. Read `payload["payload"]` (the nested provider dict).
2. Try well-known text fields in priority order: `transcript`, `summary`, `body`, `text`, `content`, `description`.
3. If none match, fall back to compact JSON — guarantees the clerk always has something to classify regardless of provider schema.
4. Apply `MAX_CLERK_BODY_CHARS` cap via `_cap_at_word_boundary` before storing, since webhook payloads can be 50–242 KB.

The 16 KB cap is confirmed: it applies here in `_ingest_row_to_record` (in-memory protection) and again at the LLM call site (line 1715) as defence-in-depth.

## Unpopulated fields — confirmed safe

| Field | Value | Why safe |
|---|---|---|
| `sender`/`from` | `""` | No email sender concept; newsletter check is gated on `src_type == "gmail"` |
| `subject` | `""` | Only used in `_extract_raw_quote`'s gmail branch |
| `name` | `""` | Garbage patterns require non-empty prefix; empty string matches neither |
| `stream_id` | `""` | Webhook is not composio; `_composio_app_from_stream_id("")` = `""` (correct) |
| `action_items` | absent | Prompt upstream-hints rule fires only when non-empty |
| `related_matters` | absent | Same — absent means LLM evaluates body normally |

## Tests (`packages/learn/tests/test_ingest_signal_source.py`)

Four new test functions — all start from the verified four-key ingest row shape (`source_type`, `source_ref`, `received_at`, `payload`) with no "summary" workaround:

1. **Body from transcript field** — `payload.payload.transcript` is extracted as the body.
2. **Pre-filter acceptance** — the resulting record passes `_pre_filter`.
3. **Oversized payload capped** — a 25 000-char transcript is capped at `MAX_CLERK_BODY_CHARS` at a word boundary.
4. **JSON fallback** — when `payload.payload` has no recognisable text field, compact JSON is the body and the event still passes `_pre_filter`.

## Smoke evidence

```
tests/test_ingest_signal_source.py::test_real_webhook_row_body_from_nested_transcript_field PASSED
tests/test_ingest_signal_source.py::test_real_webhook_row_passes_pre_filter PASSED
tests/test_ingest_signal_source.py::test_real_webhook_oversized_payload_capped_at_word_boundary PASSED
tests/test_ingest_signal_source.py::test_real_webhook_json_fallback_for_opaque_schema PASSED

Full suite: 2648 passed, 101 skipped in 21.72s

Lane gate: lane II (learn) gate passed — 113 LOC, 2 files, verify ok
```

References #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc
