### PR TITLE
feat(sure): expose balance anchor state endpoint for freshness provenance (#318)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1076,6 +1076,10 @@ services:
       # copied model file would silently revert them. Remove when Lunchflow
       # sends a currency or Sure stops defaulting.
       - ./scripts/sure-patches/preserve_lunchflow_currency.rb:/rails/config/initializers/zz_alfred_preserve_lunchflow_currency.rb:ro
+      # #318 — expose per-account Lunchflow anchor state so ctrl-api can report
+      # balance freshness honestly. REST-visible timestamps are insufficient (see
+      # docs/operators/sure-anchor-state.md). Remove when Sure exposes this natively.
+      - ./scripts/sure-patches/expose_balance_anchor_state.rb:/rails/config/initializers/zz_alfred_expose_balance_anchor_state.rb:ro
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:3000/up >/dev/null 2>&1 || exit 1"]
       interval: 15s

--- a/docs/operators/sure-anchor-state.md
+++ b/docs/operators/sure-anchor-state.md
@@ -20,18 +20,19 @@ Response:
 {
   "accounts": [
     {
-      "account_id": "<lunchflow account identifier>",
+      "account_id": "550e8400-e29b-41d4-a716-446655440000",
       "has_provider_anchor": true,
       "provider_status": "active",
       "provider_observed_at": "2026-08-10T09:14:00Z"
     },
     {
-      "account_id": "<another account>",
+      "account_id": "550e8400-e29b-41d4-a716-446655440001",
       "has_provider_anchor": false,
       "provider_status": "token_expired",
       "provider_observed_at": "2026-08-01T18:00:00Z"
     }
   ],
+  "unlinked_provider_accounts": 3,
   "generated_at": "2026-08-10T10:00:00Z"
 }
 ```
@@ -40,11 +41,13 @@ Field semantics:
 
 | Field | Type | Meaning |
 |-------|------|---------|
+| `account_id` | 36-char UUID | `accounts.id` — Sure's internal account identifier, **not** the provider's external short id |
 | `has_provider_anchor` | `true` | `current_balance IS NOT NULL` — provider delivered data this sync cycle |
 | `has_provider_anchor` | `false` | `current_balance IS NULL` — Sure is falling back to a cached balance |
 | `has_provider_anchor` | `null` | Column absent or unreadable — consumer must treat as **unknown**, never as fresh |
 | `provider_status` | string | `raw_payload->>'status'` from the lunchflow_accounts row; `null` if column absent |
 | `provider_observed_at` | ISO8601 | `lunchflow_accounts.updated_at` — when Sure last wrote this row |
+| `unlinked_provider_accounts` | integer | Lunchflow provider rows with no linked Sure account — omitted from `accounts[]` |
 
 ## Why REST-visible timestamps were insufficient
 
@@ -59,15 +62,33 @@ signals were measured against live fleet data:
 Measurement result:
 
 ```
-stale accounts (lunchflow_accounts.current_balance IS NULL):   6
-of those, max(balances.date) was today-or-yesterday:           4
+provider-backed accounts (linked via account_providers):         13
+of those, has_provider_anchor = false (current_balance IS NULL): 12
+of those, max(balances.date) was today-or-yesterday:              9
 ```
 
-Four out of six genuinely stale accounts would have reported as fresh.
+Nine of twelve genuinely stale accounts would have reported as fresh.
 For a feature whose purpose is trust about financial data, a confident lie is
 worse than reporting nothing. The only accurate signal is
 `lunchflow_accounts.current_balance IS NULL`, which lives exclusively in the
 vendor-internal table this endpoint surfaces.
+
+## Account linkage
+
+`lunchflow_accounts.account_id` is the **provider's external id** (5 chars
+on the measured tenant), not Sure's `accounts.id` UUID (36 chars). The
+endpoint traverses the polymorphic `account_providers` table:
+
+```
+LunchflowAccount
+  → account_providers (provider_type = 'LunchflowAccount', provider_id = lunchflow_accounts.id)
+  → accounts.id  (the 36-char UUID)
+```
+
+Of 16 lunchflow rows on the measured tenant, 13 resolved to a Sure account.
+The 3 unlinked rows appear in `unlinked_provider_accounts` and are omitted
+from `accounts[]`. Do not attempt to match them by name — an unlinked provider
+row is not an account.
 
 ## Verifying on a tenant
 
@@ -85,8 +106,15 @@ docker exec sure-web \
   http://127.0.0.1:3000/api/v1/alfred/balance_anchor_state
 ```
 
-Expected: JSON with `accounts` array and `generated_at`. An empty `accounts`
-array means no Lunchflow accounts are linked yet (not an error).
+**UUID validation check** — all returned `account_id` values must be 36-char
+UUIDs. If any are shorter, the association traversal is broken:
+
+```bash
+curl -s -H "X-Api-Key: <SURE_API_KEY>" \
+  https://sure.<DOMAIN>/api/v1/alfred/balance_anchor_state \
+  | jq '.accounts[].account_id | length'
+# Every line must print 36.
+```
 
 To confirm the patch loaded, check sure-web logs at startup for:
 
@@ -94,14 +122,12 @@ To confirm the patch loaded, check sure-web logs at startup for:
 [alfred #318] ...
 ```
 
-If `LunchflowAccount` is not defined (tenant with no Lunchflow integration),
-the endpoint returns `{"accounts":[],"generated_at":"..."}` and logs a warning.
-
 ## Degradation modes
 
 | Condition | Behaviour |
 |-----------|-----------|
-| `LunchflowAccount` model absent | `accounts: []`, logs warning, no crash |
+| `LunchflowAccount` model absent | `accounts: []`, `unlinked_provider_accounts: 0`, logs warning, no crash |
+| `account` association absent | `has_provider_anchor` resolved, account omitted from `accounts[]`, counted in `unlinked_provider_accounts` |
 | `current_balance` column absent | `has_provider_anchor: null` for affected rows |
 | `raw_payload` column absent | `provider_status: null` for affected rows |
 | `lunchflow_accounts` table missing | `accounts: []`, logs error, no crash |

--- a/docs/operators/sure-anchor-state.md
+++ b/docs/operators/sure-anchor-state.md
@@ -1,0 +1,125 @@
+# Sure balance anchor state endpoint
+
+Operator runbook for the `GET /api/v1/alfred/balance_anchor_state` endpoint
+injected into `sure-web` by
+`scripts/sure-patches/expose_balance_anchor_state.rb` (#318).
+
+## What the endpoint reports
+
+Per-account ground-truth anchor state from the vendor-internal
+`lunchflow_accounts` table, which Sure's own REST API does not expose.
+
+```
+GET https://sure.<DOMAIN>/api/v1/alfred/balance_anchor_state
+X-Api-Key: <SURE_API_KEY>
+```
+
+Response:
+
+```json
+{
+  "accounts": [
+    {
+      "account_id": "<lunchflow account identifier>",
+      "has_provider_anchor": true,
+      "provider_status": "active",
+      "provider_observed_at": "2026-08-10T09:14:00Z"
+    },
+    {
+      "account_id": "<another account>",
+      "has_provider_anchor": false,
+      "provider_status": "token_expired",
+      "provider_observed_at": "2026-08-01T18:00:00Z"
+    }
+  ],
+  "generated_at": "2026-08-10T10:00:00Z"
+}
+```
+
+Field semantics:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `has_provider_anchor` | `true` | `current_balance IS NOT NULL` — provider delivered data this sync cycle |
+| `has_provider_anchor` | `false` | `current_balance IS NULL` — Sure is falling back to a cached balance |
+| `has_provider_anchor` | `null` | Column absent or unreadable — consumer must treat as **unknown**, never as fresh |
+| `provider_status` | string | `raw_payload->>'status'` from the lunchflow_accounts row; `null` if column absent |
+| `provider_observed_at` | ISO8601 | `lunchflow_accounts.updated_at` — when Sure last wrote this row |
+
+## Why REST-visible timestamps were insufficient
+
+Sure's `/api/v1/accounts` payload carries exactly two timestamps per account
+(`created_at`, `updated_at`) and no balance-specific date. The two candidate
+signals were measured against live fleet data:
+
+- **`accounts.updated_at`**: advances on every sync, including failed ones.
+- **`max(balances.date)`**: advances because Sure's cached-fallback path is
+  itself a write that advances this date.
+
+Measurement result:
+
+```
+stale accounts (lunchflow_accounts.current_balance IS NULL):   6
+of those, max(balances.date) was today-or-yesterday:           4
+```
+
+Four out of six genuinely stale accounts would have reported as fresh.
+For a feature whose purpose is trust about financial data, a confident lie is
+worse than reporting nothing. The only accurate signal is
+`lunchflow_accounts.current_balance IS NULL`, which lives exclusively in the
+vendor-internal table this endpoint surfaces.
+
+## Verifying on a tenant
+
+```bash
+# From any host with curl and the tenant's SURE_API_KEY:
+curl -s -H "X-Api-Key: <SURE_API_KEY>" \
+  https://sure.<DOMAIN>/api/v1/alfred/balance_anchor_state | jq .
+```
+
+From inside the compose stack (e.g. for local smoke):
+
+```bash
+docker exec sure-web \
+  curl -s -H "X-Api-Key: ${SURE_API_KEY}" \
+  http://127.0.0.1:3000/api/v1/alfred/balance_anchor_state
+```
+
+Expected: JSON with `accounts` array and `generated_at`. An empty `accounts`
+array means no Lunchflow accounts are linked yet (not an error).
+
+To confirm the patch loaded, check sure-web logs at startup for:
+
+```
+[alfred #318] ...
+```
+
+If `LunchflowAccount` is not defined (tenant with no Lunchflow integration),
+the endpoint returns `{"accounts":[],"generated_at":"..."}` and logs a warning.
+
+## Degradation modes
+
+| Condition | Behaviour |
+|-----------|-----------|
+| `LunchflowAccount` model absent | `accounts: []`, logs warning, no crash |
+| `current_balance` column absent | `has_provider_anchor: null` for affected rows |
+| `raw_payload` column absent | `provider_status: null` for affected rows |
+| `lunchflow_accounts` table missing | `accounts: []`, logs error, no crash |
+| Wrong or missing `X-Api-Key` | HTTP 401 `{"error":"Unauthorized"}` |
+| `SURE_API_KEY` env unset | HTTP 401 (empty expected key always rejects) |
+
+## Removing this patch
+
+Remove when Sure exposes balance anchor state through its own REST API. Signs:
+
+- `GET /api/v1/accounts` response includes a `freshness`, `anchor`, or
+  `provider_balance_at` field per account.
+- Sure release notes mention "balance freshness" or "provider anchor" exposure.
+
+Removal steps:
+
+1. Delete `scripts/sure-patches/expose_balance_anchor_state.rb`
+2. Remove the corresponding `volumes:` line from `sure-web` in `docker-compose.yaml`
+3. Update `packages/ctrl/src/api/routes/sure.ts` to use the native field instead
+   of calling this endpoint
+4. Restart `sure-web`

--- a/scripts/sure-patches/expose_balance_anchor_state.rb
+++ b/scripts/sure-patches/expose_balance_anchor_state.rb
@@ -16,14 +16,34 @@
 # (created_at, updated_at) and no balance-specific date. Measured fleet-wide
 # against live data:
 #
-#   stale accounts (lunchflow_accounts.current_balance IS NULL):   6
-#   of those, max(balances.date) was today-or-yesterday:           4
+#   provider-backed accounts (linked via account_providers):         13
+#   of those, has_provider_anchor = false (current_balance IS NULL): 12
+#   of those, max(balances.date) was today-or-yesterday:              9
 #
-# Two-thirds of stale accounts would report as fresh via max(balances.date)
-# because Sure's cached-fallback write path is itself a write that advances
-# that date. Reporting confident freshness on stale data is worse than
-# reporting nothing — it replaces silent staleness with a confident lie.
-# The only accurate signal is lunchflow_accounts.current_balance IS NULL.
+# Nine of twelve genuinely stale accounts would report as fresh via
+# max(balances.date) because Sure's cached-fallback write path is itself a
+# write that advances that date. Reporting confident freshness on stale data
+# is worse than reporting nothing — it replaces silent staleness with a
+# confident lie. The only accurate signal is lunchflow_accounts.current_balance
+# IS NULL.
+#
+# ACCOUNT LINKAGE
+# ---------------
+# lunchflow_accounts.account_id is the provider's external id (5 chars on the
+# measured tenant), NOT Sure's accounts.id UUID (36 chars). They cannot be
+# joined directly. The correct traversal is via account_providers:
+#
+#   LunchflowAccount
+#     has_one :account_provider, as: :provider  (provider_type = 'LunchflowAccount')
+#     has_one :account, through: :account_provider
+#
+# In SQL: account_providers ap ON ap.provider_id = la.id AND
+#         ap.provider_type = 'LunchflowAccount' JOIN accounts a ON a.id = ap.account_id
+#
+# Measured: 13 of 16 lunchflow rows resolve to a Sure account via this path.
+# The 3 unlinked rows are omitted from accounts[] — do not guess a match for
+# them. An unlinked provider row is not an account. They are counted separately
+# under unlinked_provider_accounts.
 #
 # THE PATCH
 # ---------
@@ -33,11 +53,12 @@
 #
 # Response shape:
 #   { "accounts": [
-#       { "account_id": "…",
+#       { "account_id": "<36-char UUID matching accounts.id>",
 #         "has_provider_anchor": true|false|null,
 #         "provider_status": "…"|null,
 #         "provider_observed_at": "ISO8601"|null }
 #     ],
+#     "unlinked_provider_accounts": <integer>,
 #     "generated_at": "ISO8601" }
 #
 # has_provider_anchor semantics:
@@ -47,6 +68,11 @@
 #
 # Authentication: X-Api-Key header — the same SURE_API_KEY credential used by
 # every other Sure API endpoint. No new credential introduced.
+#
+# VERIFY: account_id values in accounts[] must be 36-char UUIDs matching
+# accounts.id. If any returned id is shorter (e.g. 5 chars), the association
+# traversal is broken and the results must not be used for freshness attribution.
+# Check: curl … | jq '.accounts[].account_id | length' — all must be 36.
 #
 # WHY AN INITIALIZER, NOT A FILE OVERLAY
 # ----------------------------------------
@@ -74,29 +100,55 @@ Rails.application.config.to_prepare do
         return
       end
 
+      linked, unlinked_count = anchor_state_partition
       render json: {
-        accounts: anchor_state_rows,
+        accounts: linked,
+        unlinked_provider_accounts: unlinked_count,
         generated_at: Time.now.utc.iso8601
       }
     end
 
     private
 
-    def anchor_state_rows
+    # Partition all LunchflowAccount rows into linked (have a Sure accounts.id)
+    # and unlinked (no account_providers row). Returns [linked_rows, unlinked_count].
+    # Unlinked rows are NOT included in accounts[] — never invent a match.
+    def anchor_state_partition
       unless defined?(::LunchflowAccount)
         Rails.logger.warn("#{ALFRED_TAG} LunchflowAccount not defined — returning empty anchor state")
-        return []
+        return [[], 0]
       end
 
-      ::LunchflowAccount.all.map { |acct| anchor_row(acct) }
+      linked = []
+      unlinked = 0
+      ::LunchflowAccount.all.each do |acct|
+        sure_id = resolve_sure_account_id(acct)
+        if sure_id.nil?
+          unlinked += 1
+          next
+        end
+        linked << anchor_row(sure_id, acct)
+      end
+      [linked, unlinked]
     rescue => e
       Rails.logger.error("#{ALFRED_TAG} error reading lunchflow_accounts: #{e.message}")
-      []
+      [[], 0]
     end
 
-    def anchor_row(acct)
+    # Traverse lunchflow_account → account_provider (polymorphic) → account.id.
+    # Returns the 36-char Sure accounts.id UUID, or nil for unlinked rows.
+    # Never returns lunchflow_accounts.account_id (the provider's external short id).
+    def resolve_sure_account_id(acct)
+      return nil unless acct.respond_to?(:account)
+      acct.account&.id
+    rescue => e
+      Rails.logger.warn("#{ALFRED_TAG} account association error for provider row #{acct.try(:id)}: #{e.message}")
+      nil
+    end
+
+    def anchor_row(sure_account_id, acct)
       {
-        account_id:           safe_attr(acct, :account_id),
+        account_id:           sure_account_id,
         has_provider_anchor:  anchor_flag(acct),
         provider_status:      provider_status(acct),
         provider_observed_at: safe_iso8601(acct, :updated_at)
@@ -110,7 +162,7 @@ Rails.application.config.to_prepare do
       return nil unless acct.respond_to?(:current_balance)
       !acct.current_balance.nil?
     rescue => e
-      Rails.logger.warn("#{ALFRED_TAG} anchor_flag error for #{acct.try(:account_id)}: #{e.message}")
+      Rails.logger.warn("#{ALFRED_TAG} anchor_flag error for #{acct.try(:id)}: #{e.message}")
       nil
     end
 
@@ -120,13 +172,7 @@ Rails.application.config.to_prepare do
       return nil unless payload.is_a?(Hash)
       payload["status"]
     rescue => e
-      Rails.logger.warn("#{ALFRED_TAG} provider_status error for #{acct.try(:account_id)}: #{e.message}")
-      nil
-    end
-
-    def safe_attr(acct, attr)
-      acct.respond_to?(attr) ? acct.public_send(attr) : nil
-    rescue
+      Rails.logger.warn("#{ALFRED_TAG} provider_status error for #{acct.try(:id)}: #{e.message}")
       nil
     end
 

--- a/scripts/sure-patches/expose_balance_anchor_state.rb
+++ b/scripts/sure-patches/expose_balance_anchor_state.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+#
+# Sure patch — expose per-account Lunchflow balance anchor state (#318)
+#
+# WHY
+# ---
+# Alfred's finance surface consumed Sure balances without freshness provenance.
+# When the Lunchflow provider token expires, Sure falls back to cached balances
+# and logs "No current balance anchor found … Using cached balance instead".
+# ctrl-api had no signal to propagate this to the principal — figures looked
+# current while relying on stale cached values.
+#
+# WHY NOT USE REST-VISIBLE TIMESTAMPS
+# ------------------------------------
+# Sure's /api/v1/accounts payload carries exactly two timestamps per account
+# (created_at, updated_at) and no balance-specific date. Measured fleet-wide
+# against live data:
+#
+#   stale accounts (lunchflow_accounts.current_balance IS NULL):   6
+#   of those, max(balances.date) was today-or-yesterday:           4
+#
+# Two-thirds of stale accounts would report as fresh via max(balances.date)
+# because Sure's cached-fallback write path is itself a write that advances
+# that date. Reporting confident freshness on stale data is worse than
+# reporting nothing — it replaces silent staleness with a confident lie.
+# The only accurate signal is lunchflow_accounts.current_balance IS NULL.
+#
+# THE PATCH
+# ---------
+# Adds GET /api/v1/alfred/balance_anchor_state — a read-only endpoint that
+# exposes per-account anchor state drawn directly from the vendor-internal
+# lunchflow_accounts table Sure's REST API never surfaces.
+#
+# Response shape:
+#   { "accounts": [
+#       { "account_id": "…",
+#         "has_provider_anchor": true|false|null,
+#         "provider_status": "…"|null,
+#         "provider_observed_at": "ISO8601"|null }
+#     ],
+#     "generated_at": "ISO8601" }
+#
+# has_provider_anchor semantics:
+#   true  = current_balance IS NOT NULL   (provider delivered data this cycle)
+#   false = current_balance IS NULL       (Sure is using a cached fallback)
+#   null  = column absent or unreadable   (consumer MUST treat as unknown, not fresh)
+#
+# Authentication: X-Api-Key header — the same SURE_API_KEY credential used by
+# every other Sure API endpoint. No new credential introduced.
+#
+# WHY AN INITIALIZER, NOT A FILE OVERLAY
+# ----------------------------------------
+# Same rationale as preserve_lunchflow_currency.rb: a file overlay pins us to
+# one upstream revision and silently reverts upstream fixes on upgrade. An
+# initializer composes with whatever the upstream file becomes. If
+# LunchflowAccount or its columns are absent (upstream schema change), the
+# endpoint degrades gracefully rather than crashing sure-web on boot.
+#
+# REMOVE THIS when Sure exposes balance anchor state via its own REST API.
+# Check on upgrade: if GET /api/v1/accounts includes a freshness or anchor
+# field, this patch is redundant. Remove the initializer and its mount.
+
+Rails.application.config.to_prepare do
+  next if defined?(::AlfredBalanceAnchorStateController)
+
+  class ::AlfredBalanceAnchorStateController < ActionController::API
+    ALFRED_TAG = "[alfred #318]"
+
+    def show
+      provided = request.headers["X-Api-Key"].to_s.strip
+      expected = ENV["SURE_API_KEY"].to_s.strip
+      if expected.empty? || !ActiveSupport::SecurityUtils.secure_compare(provided, expected)
+        render json: { error: "Unauthorized" }, status: :unauthorized
+        return
+      end
+
+      render json: {
+        accounts: anchor_state_rows,
+        generated_at: Time.now.utc.iso8601
+      }
+    end
+
+    private
+
+    def anchor_state_rows
+      unless defined?(::LunchflowAccount)
+        Rails.logger.warn("#{ALFRED_TAG} LunchflowAccount not defined — returning empty anchor state")
+        return []
+      end
+
+      ::LunchflowAccount.all.map { |acct| anchor_row(acct) }
+    rescue => e
+      Rails.logger.error("#{ALFRED_TAG} error reading lunchflow_accounts: #{e.message}")
+      []
+    end
+
+    def anchor_row(acct)
+      {
+        account_id:           safe_attr(acct, :account_id),
+        has_provider_anchor:  anchor_flag(acct),
+        provider_status:      provider_status(acct),
+        provider_observed_at: safe_iso8601(acct, :updated_at)
+      }
+    end
+
+    # true  = current_balance IS NOT NULL (provider anchor present)
+    # false = current_balance IS NULL     (cached fallback path)
+    # nil   = column absent or error (consumer MUST NOT infer fresh)
+    def anchor_flag(acct)
+      return nil unless acct.respond_to?(:current_balance)
+      !acct.current_balance.nil?
+    rescue => e
+      Rails.logger.warn("#{ALFRED_TAG} anchor_flag error for #{acct.try(:account_id)}: #{e.message}")
+      nil
+    end
+
+    def provider_status(acct)
+      return nil unless acct.respond_to?(:raw_payload)
+      payload = acct.raw_payload
+      return nil unless payload.is_a?(Hash)
+      payload["status"]
+    rescue => e
+      Rails.logger.warn("#{ALFRED_TAG} provider_status error for #{acct.try(:account_id)}: #{e.message}")
+      nil
+    end
+
+    def safe_attr(acct, attr)
+      acct.respond_to?(attr) ? acct.public_send(attr) : nil
+    rescue
+      nil
+    end
+
+    def safe_iso8601(acct, attr)
+      return nil unless acct.respond_to?(attr)
+      val = acct.public_send(attr)
+      val&.utc&.iso8601
+    rescue
+      nil
+    end
+  end
+end
+
+Rails.application.routes.draw do
+  get "/api/v1/alfred/balance_anchor_state",
+      to: "alfred_balance_anchor_state#show"
+end


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/alfred/balance_anchor_state` to `sure-web` via a Rails initializer (`scripts/sure-patches/expose_balance_anchor_state.rb`) mounted read-only at boot — same pattern as #340.
- Reports `has_provider_anchor: true/false/null` per account from `lunchflow_accounts.current_balance IS NULL`, the only accurate freshness signal.
- Account linkage traverses `account_providers` (not `lunchflow_accounts.account_id`, which is the provider's external short id). Unlinked rows counted in `unlinked_provider_accounts`, omitted from `accounts[]`.
- Route registered via `routes.append` (deferred until after `config/routes.rb`) — `routes.draw` was replaced by the app's routes and caused the 404.
- Logs `[alfred #318] balance anchor state patch loaded` on boot, matching the #340 convention.
- `filter_parameters` entry for the API key header (covers Rails' controller logs; does not cover Sure's middleware-level `headers_json` dump — documented plainly in the runbook).

References #318. Does not close — Lane I consumer PR follows.

## Smoke evidence

Verbatim VERIFY output from the lane gate (all four commits):

```
lane V verify: ruby -c scripts/sure-patches/expose_balance_anchor_state.rb && docker compose config >/dev/null
Syntax OK
lane V (edges-infra) gate passed — 150 LOC, 2 files, verify ok

lane V verify: ruby -c scripts/sure-patches/expose_balance_anchor_state.rb && docker compose config >/dev/null
Syntax OK
lane V (edges-infra) gate passed — 125 LOC, 1 files, verify ok

lane V verify: ruby -c scripts/sure-patches/expose_balance_anchor_state.rb && docker compose config >/dev/null
Syntax OK
lane V (edges-infra) gate passed — 140 LOC, 2 files, verify ok

lane V verify: ruby -c scripts/sure-patches/expose_balance_anchor_state.rb && docker compose config >/dev/null
Syntax OK
lane V (edges-infra) gate passed — 58 LOC, 2 files, verify ok
```

Runtime smoke (route presence + response correctness) requires Sir's deploy and:

```bash
# 1. Route present:
docker exec sure-web bin/rails routes | grep anchor

# 2. Boot log present:
docker logs sure-web 2>&1 | grep "alfred #318"

# 3. Endpoint responds 401 to bad key, 200 with valid key:
curl -s -o /dev/null -w "%{http_code}" -H "X-Api-Key: wrong" \
  https://sure.<DOMAIN>/api/v1/alfred/balance_anchor_state  # must be 401
curl -s -H "X-Api-Key: <SURE_API_KEY>" \
  https://sure.<DOMAIN>/api/v1/alfred/balance_anchor_state | jq .accounts[0]

# 4. UUID lengths:
curl -s -H "X-Api-Key: <SURE_API_KEY>" \
  https://sure.<DOMAIN>/api/v1/alfred/balance_anchor_state \
  | jq '.accounts[].account_id | length'  # all must print 36
```

## Route registration

`routes.draw` from an initializer runs *before* `config/routes.rb` and is overwritten by it, causing a 404 with no error logged. `routes.append` queues the block to run *after* the main routes file, which is the correct idiom for adding routes from outside the main file.

The exact command that proves the route exists after deploy:

```bash
docker exec sure-web bin/rails routes | grep anchor
# Expected: GET /api/v1/alfred/balance_anchor_state  alfred_balance_anchor_state#show
```

## Header redaction

The initializer adds `HTTP_X_API_KEY` and `X_Api_Key` to `filter_parameters`. This redacts the key from Rails' own controller-level param logs. It does not cover Sure's middleware-level `headers_json` dump, which writes the full header set to stdout on every request. A structural fix for that requires configuring Sure's request logger or a header-stripping Rack middleware — both outside the scope of an initializer patch. The runbook documents this under "The API key appears in sure-web logs". Key rotation is Sir's call.

## Files touched

- `scripts/sure-patches/expose_balance_anchor_state.rb` (new + 3 fixes, 181 lines final)
- `docker-compose.yaml` (+4 lines)
- `docs/operators/sure-anchor-state.md` (new + updates, 189 lines final)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
