### PR TITLE
fix(sure): register the anchor-state route with routes.append, not routes.draw (#318)

### DIFF
--- a/docs/operators/sure-anchor-state.md
+++ b/docs/operators/sure-anchor-state.md
@@ -92,15 +92,29 @@ row is not an account.
 
 ## Verifying on a tenant
 
+**Step 1 — confirm the route exists.** A missing route and "not deployed" are
+indistinguishable from a 404; check the route table first:
+
 ```bash
-# From any host with curl and the tenant's SURE_API_KEY:
-curl -s -H "X-Api-Key: <SURE_API_KEY>" \
-  https://sure.<DOMAIN>/api/v1/alfred/balance_anchor_state | jq .
+docker exec sure-web bin/rails routes | grep anchor
+# Must print one line containing balance_anchor_state
 ```
 
-From inside the compose stack (e.g. for local smoke):
+**Step 2 — confirm the patch loaded.** Look for the boot log line:
 
 ```bash
+docker logs sure-web 2>&1 | grep "alfred #318"
+# Expected: [alfred #318] balance anchor state patch loaded — GET /api/v1/alfred/balance_anchor_state
+```
+
+**Step 3 — exercise the endpoint:**
+
+```bash
+# From any host with the tenant's SURE_API_KEY:
+curl -s -H "X-Api-Key: <SURE_API_KEY>" \
+  https://sure.<DOMAIN>/api/v1/alfred/balance_anchor_state | jq .
+
+# From inside the compose stack:
 docker exec sure-web \
   curl -s -H "X-Api-Key: ${SURE_API_KEY}" \
   http://127.0.0.1:3000/api/v1/alfred/balance_anchor_state
@@ -116,11 +130,22 @@ curl -s -H "X-Api-Key: <SURE_API_KEY>" \
 # Every line must print 36.
 ```
 
-To confirm the patch loaded, check sure-web logs at startup for:
+## The API key appears in sure-web logs
 
-```
-[alfred #318] ...
-```
+Sure's request logger writes full request headers — including `X-Api-Key` — to
+stdout on every request. This means `SURE_API_KEY` will appear in
+`docker logs sure-web` on every poll of this endpoint.
+
+The initializer adds `HTTP_X_API_KEY` and `X_Api_Key` to Rails'
+`filter_parameters`, which redacts the key from Rails' own controller-level
+param logs. It does **not** cover Sure's middleware-level header dump
+(`headers_json`), which runs before Rails' filter machinery.
+
+A structural fix would require either configuring Sure's own request logger to
+redact authentication headers, or adding a header-stripping Rack middleware
+before Sure's logger — both of which are outside the scope of an initializer
+patch. Anyone reading `docker logs sure-web` should know the log stream
+contains a credential. Rotation of the key is Sir's call.
 
 ## Degradation modes
 

--- a/scripts/sure-patches/expose_balance_anchor_state.rb
+++ b/scripts/sure-patches/expose_balance_anchor_state.rb
@@ -86,6 +86,13 @@
 # Check on upgrade: if GET /api/v1/accounts includes a freshness or anchor
 # field, this patch is redundant. Remove the initializer and its mount.
 
+# Partial mitigation: filter the key from Rails' own controller/params logs.
+# NOTE: this does NOT cover Sure's middleware-level header dump (headers_json
+# in docker logs). That requires configuring Sure's request logger or adding a
+# header-stripping Rack middleware — outside the scope of this initializer.
+# See docs/operators/sure-anchor-state.md for the full note.
+Rails.application.config.filter_parameters |= %w[HTTP_X_API_KEY X_Api_Key]
+
 Rails.application.config.to_prepare do
   next if defined?(::AlfredBalanceAnchorStateController)
 
@@ -184,9 +191,15 @@ Rails.application.config.to_prepare do
       nil
     end
   end
+
+  Rails.logger.info("[alfred #318] balance anchor state patch loaded — GET /api/v1/alfred/balance_anchor_state")
 end
 
-Rails.application.routes.draw do
+# Use `append` (not `draw`) so the route is registered AFTER config/routes.rb
+# is evaluated. `draw` from an initializer runs before the main routes file,
+# so the app's route set replaces it and the endpoint 404s silently.
+Rails.application.routes.append do
   get "/api/v1/alfred/balance_anchor_state",
-      to: "alfred_balance_anchor_state#show"
+      to: "alfred_balance_anchor_state#show",
+      defaults: { format: :json }
 end


### PR DESCRIPTION
Follow-up to #527. Those commits were pushed to the branch after it had already been squash-merged, so this change never reached `main`. Cherry-picked onto a fresh branch.

## What was wrong

The endpoint registered its route with `Rails.application.routes.draw` from an initializer. Initializers run **before** the app evaluates `config/routes.rb`, so the application's own route set replaced it. The block executed, the route was discarded, and nothing said so.

Deployed and confirmed on the tenant:

```
$ curl -H 'X-Api-Key: <valid>'  .../api/v1/alfred/balance_anchor_state   -> 404
$ curl -H 'X-Api-Key: nope'     .../api/v1/alfred/balance_anchor_state   -> 404
$ docker exec sure-web bin/rails routes | grep -i anchor
(no output)
```

Both keys returning 404 is the tell: a registered route with bad auth returns 401. Identical 404s mean there is no route at all.

## Fix

`Rails.application.routes.append`, which defers the block until after the main routes file — the supported pattern for injecting a route from outside `config/routes.rb`.

Two things added because this failed **silently**, which is the part worth fixing:

- **A boot log line**, matching the `[alfred #340]` convention. The #340 patch logs on load, which is the only reason I could tell it was working while this one was not. Without it, "not deployed" and "deployed but broken" look identical.
- **A runbook check** — `bin/rails routes | grep anchor` — as the first verification step, plus the 401-vs-404 distinction above.

## The API key appears in sure-web logs

Documented in the runbook, not fixed here, and worth stating plainly.

Sure's request logger dumps raw Rack headers, so `X-Api-Key` is written to `docker logs` in plaintext on every authenticated call. `filter_parameters` is set in the initializer and covers Rails' own controller/params logging, but it does **not** reach the middleware-level `headers_json` dump, which runs before Rails' filtering. Fixing that layer needs either upstream logger config or a header-stripping Rack middleware — both beyond what an initializer patch should do.

This predates the endpoint, but a regularly-polled authenticated route makes it continuous rather than occasional. Key rotation is the operator's call.

## Smoke evidence

```
$ ruby -c scripts/sure-patches/expose_balance_anchor_state.rb
Syntax OK

$ docker compose config >/dev/null && echo ok
ok

✓ lane V (edges-infra) gate passed — 58 LOC, 2 files, verify ok
```

Runtime verification happens on deploy — `grep "alfred #318"` in the boot log, `bin/rails routes | grep anchor`, then a 200 with 36-char UUIDs and a 401 on a bad key.