### PR TITLE
fix(learn): route_decision retires terminally on 404 source card (#414)

### DIFF
--- a/packages/learn/src/activities/decision_router.py
+++ b/packages/learn/src/activities/decision_router.py
@@ -472,6 +472,94 @@ async def _emit_recovery_audit(
 
 
 # ---------------------------------------------------------------------
+# Source-card-missing retirement helper (#414)
+# ---------------------------------------------------------------------
+
+
+async def _retire_source_card_missing(
+    client: Any,
+    *,
+    decision_id: str,
+    na_id: str,
+    intent: str,
+    existing_side_effects: dict[str, Any],
+) -> dict[str, Any]:
+    """Retire a decision whose needs_attention source card returned 404.
+
+    A deleted card is terminal — the ``{done,dispatch,skip}`` POST can
+    never succeed and Temporal must not retry forever. Mirror the #313
+    ``source_card_missing`` retire pattern (scheduled_dispatch.py:100)
+    and add an audit row so the retirement is searchable (#414 spec).
+
+    Returns the ``route_decision`` result dict so callers can ``return``
+    immediately after calling this helper.
+    """
+    now_iso = _now_iso()
+    retired_se = dict(existing_side_effects)
+    retired_se["decision_router"] = "source_card_missing"
+    retired_se["retired_at"] = now_iso
+    retired_se["retired_intent"] = intent
+    logger.warning(
+        "decision_router.route_decision: needs_attention/%s returned 404 "
+        "on %s — source card deleted; retiring decision=%s as completed "
+        "(side_effects.decision_router=source_card_missing)",
+        na_id, intent, decision_id,
+    )
+    try:
+        pr = await client.patch(
+            f"/api/v1/decisions/{decision_id}",
+            json={"state": "completed", "side_effects": retired_se},
+        )
+        pr.raise_for_status()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "decision_router.route_decision: retire PATCH failed "
+            "decision=%s err=%s — will retry next tick",
+            decision_id, exc,
+        )
+        # Return without raising: Temporal sees success, the decision
+        # stays open, and the next tick retries (ctrl-api blip path).
+    # Best-effort audit — failure must NOT roll back the PATCH.
+    try:
+        await client.post(
+            "/api/v1/state/audit",
+            json={
+                "action_type": "state-change",
+                "actor": "decision_router",
+                "source": "decision_router.source_card_missing",
+                "target_path": f"decision/{decision_id}.md",
+                "target_kind": "decision",
+                "summary": (
+                    f"source card needs_attention/{na_id} returned 404 "
+                    f"on intent={intent}; retired as completed "
+                    "(source_card_missing)"
+                ),
+                "changes": {
+                    "state": {"from": "open", "to": "completed"},
+                    "reason": "source_card_missing",
+                    "na_id": na_id,
+                    "intent": intent,
+                },
+                "mode": "live",
+            },
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "decision_router.route_decision: audit POST failed "
+            "decision=%s err=%s",
+            decision_id, exc,
+        )
+    return {
+        "id": decision_id,
+        "intent": intent,
+        "source": "needs_attention",
+        "next_state": "completed",
+        "actions": ["source_card_missing"],
+        "side_effects": retired_se,
+    }
+
+
+# ---------------------------------------------------------------------
 # Hours-proposal approval (#485)
 # ---------------------------------------------------------------------
 
@@ -695,11 +783,21 @@ async def route_decision(decision: dict[str, Any]) -> dict[str, Any]:
                 # second round-trip to avoid emitting a duplicate audit
                 # event.
                 if not synchronous_flip:
-                    resp = await client.post(
-                        f"/api/v1/admin/needs-attention/{na_id}/done",
-                        json={"note": note},
-                    )
-                    resp.raise_for_status()
+                    try:
+                        resp = await client.post(
+                            f"/api/v1/admin/needs-attention/{na_id}/done",
+                            json={"note": note},
+                        )
+                        resp.raise_for_status()
+                    except httpx.HTTPStatusError as exc:
+                        if exc.response.status_code == 404:
+                            # Card was deleted after the decision was minted.
+                            # Terminal — retrying cannot restore a deleted card.
+                            return await _retire_source_card_missing(
+                                client, decision_id=decision_id, na_id=na_id,
+                                intent=intent, existing_side_effects=side_effects,
+                            )
+                        raise  # 5xx / timeout → Temporal retries normally
                     actions_taken.append("needs_attention.done")
                     side_effects["needs_attention_audit"] = (
                         resp.json().get("audit_record_path")
@@ -826,11 +924,19 @@ async def route_decision(decision: dict[str, Any]) -> dict[str, Any]:
                         raise
 
                 if not synchronous_flip:
-                    resp = await client.post(
-                        f"/api/v1/admin/needs-attention/{na_id}/skip",
-                        json={"note": note},
-                    )
-                    resp.raise_for_status()
+                    try:
+                        resp = await client.post(
+                            f"/api/v1/admin/needs-attention/{na_id}/skip",
+                            json={"note": note},
+                        )
+                        resp.raise_for_status()
+                    except httpx.HTTPStatusError as exc:
+                        if exc.response.status_code == 404:
+                            return await _retire_source_card_missing(
+                                client, decision_id=decision_id, na_id=na_id,
+                                intent=intent, existing_side_effects=side_effects,
+                            )
+                        raise
                     actions_taken.append("needs_attention.skip")
                     side_effects["needs_attention_audit"] = (
                         resp.json().get("audit_record_path")
@@ -935,14 +1041,22 @@ async def route_decision(decision: dict[str, Any]) -> dict[str, Any]:
                         )
                         raise
 
-                    resp = await client.post(
-                        f"/api/v1/admin/needs-attention/{na_id}/dispatch",
-                        json={
-                            "note": note,
-                            "decision_origin": f"decision/{decision_id}.md",
-                        },
-                    )
-                    resp.raise_for_status()
+                    try:
+                        resp = await client.post(
+                            f"/api/v1/admin/needs-attention/{na_id}/dispatch",
+                            json={
+                                "note": note,
+                                "decision_origin": f"decision/{decision_id}.md",
+                            },
+                        )
+                        resp.raise_for_status()
+                    except httpx.HTTPStatusError as exc:
+                        if exc.response.status_code == 404:
+                            return await _retire_source_card_missing(
+                                client, decision_id=decision_id, na_id=na_id,
+                                intent=intent, existing_side_effects=side_effects,
+                            )
+                        raise
                     actions_taken.append("needs_attention.dispatch")
                     if not synchronous_flip:
                         side_effects["needs_attention_audit"] = (

--- a/packages/learn/src/activities/decision_router.py
+++ b/packages/learn/src/activities/decision_router.py
@@ -501,14 +501,14 @@ async def _retire_source_card_missing(
     retired_se["retired_intent"] = intent
     logger.warning(
         "decision_router.route_decision: needs_attention/%s returned 404 "
-        "on %s — source card deleted; retiring decision=%s as completed "
+        "on %s — source card deleted; retiring decision=%s as failed "
         "(side_effects.decision_router=source_card_missing)",
         na_id, intent, decision_id,
     )
     try:
         pr = await client.patch(
             f"/api/v1/decisions/{decision_id}",
-            json={"state": "completed", "side_effects": retired_se},
+            json={"state": "failed", "side_effects": retired_se},
         )
         pr.raise_for_status()
     except Exception as exc:  # noqa: BLE001
@@ -531,11 +531,11 @@ async def _retire_source_card_missing(
                 "target_kind": "decision",
                 "summary": (
                     f"source card needs_attention/{na_id} returned 404 "
-                    f"on intent={intent}; retired as completed "
+                    f"on intent={intent}; retired as failed "
                     "(source_card_missing)"
                 ),
                 "changes": {
-                    "state": {"from": "open", "to": "completed"},
+                    "state": {"from": "open", "to": "failed"},
                     "reason": "source_card_missing",
                     "na_id": na_id,
                     "intent": intent,
@@ -553,7 +553,7 @@ async def _retire_source_card_missing(
         "id": decision_id,
         "intent": intent,
         "source": "needs_attention",
-        "next_state": "completed",
+        "next_state": "failed",
         "actions": ["source_card_missing"],
         "side_effects": retired_se,
     }

--- a/packages/learn/tests/test_decision_router_source_card_missing.py
+++ b/packages/learn/tests/test_decision_router_source_card_missing.py
@@ -94,7 +94,7 @@ class _FakeClient:
         return _Resp(200)
 
     def retire_patches(self) -> list[dict[str, Any]]:
-        return [p for p in self.patches if p.get("state") == "completed"]
+        return [p for p in self.patches if p.get("state") == "failed"]
 
     def action_calls(self) -> list[str]:
         return [url for (m, url) in self.calls if m == "POST" and
@@ -149,7 +149,7 @@ def test_404_retires_decision_and_does_not_raise(monkeypatch, intent):
     result = asyncio.run(dr.route_decision(_decision(intent)))
 
     # Activity must return cleanly — no exception.
-    assert result["next_state"] == "completed"
+    assert result["next_state"] == "failed"
     assert result["actions"] == ["source_card_missing"]
     assert result["side_effects"]["decision_router"] == "source_card_missing"
     assert "retired_at" in result["side_effects"]
@@ -157,7 +157,7 @@ def test_404_retires_decision_and_does_not_raise(monkeypatch, intent):
     # The retire PATCH must have fired.
     assert len(fake.retire_patches()) == 1
     rp = fake.retire_patches()[0]
-    assert rp["state"] == "completed"
+    assert rp["state"] == "failed"
     assert rp["side_effects"]["decision_router"] == "source_card_missing"
 
 

--- a/packages/learn/tests/test_decision_router_source_card_missing.py
+++ b/packages/learn/tests/test_decision_router_source_card_missing.py
@@ -1,0 +1,229 @@
+"""Tests for #414: route_decision retires terminally when the source
+needs_attention card returns 404 on the done/dispatch/skip action POST.
+
+The bug: if the card was deleted after a decision was minted, the
+action POST returns 404, resp.raise_for_status() raised, and Temporal
+retried every 60-second DecisionRouter tick forever. A deleted card is
+not a transient condition; retrying cannot restore it.
+
+The fix: catch httpx.HTTPStatusError where status_code == 404 on the
+three concrete action endpoints (done/dispatch/skip), PATCH the decision
+terminal (state=completed, side_effects.decision_router=source_card_missing),
+write a best-effort audit row, and return — no raise. 5xx and other
+non-404 errors still raise so Temporal can retry real infrastructure blips.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import httpx
+import pytest
+
+import src.activities.decision_router as dr
+
+
+# ---------------------------------------------------------------------------
+# Shared test doubles
+# ---------------------------------------------------------------------------
+
+class _Resp:
+    def __init__(self, status_code: int, payload: Any = None) -> None:
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def json(self) -> Any:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError(
+                f"status {self.status_code}",
+                request=httpx.Request("GET", "http://test"),
+                response=httpx.Response(self.status_code),
+            )
+
+
+class _FakeClient:
+    """Minimal fake httpx.AsyncClient that records all calls.
+
+    ``action_status`` controls what the action-endpoint POST returns.
+    ``mark_status`` controls what the pre-dispatch PATCH returns.
+    """
+
+    def __init__(
+        self,
+        *,
+        action_status: int = 200,
+        mark_status: int = 200,
+    ) -> None:
+        self.action_status = action_status
+        self.mark_status = mark_status
+        self.calls: list[tuple[str, str]] = []  # (method, url)
+        self.patches: list[dict[str, Any]] = []
+
+    async def __aenter__(self) -> "_FakeClient":
+        return self
+
+    async def __aexit__(self, *a: Any) -> None:
+        pass
+
+    async def get(self, url: str, **_: Any) -> _Resp:
+        self.calls.append(("GET", url))
+        # _accept_hours_proposal_if_any GETs the source_record card;
+        # return 404 so it no-ops for these tests.
+        return _Resp(404)
+
+    async def post(self, url: str, **_: Any) -> _Resp:
+        self.calls.append(("POST", url))
+        if url.endswith("/api/v1/state/audit"):
+            return _Resp(200)
+        # Action endpoints
+        return _Resp(self.action_status, {
+            "audit_record_path": "event/na.md",
+            "re_routed_signal": "signal/abc.md",
+        })
+
+    async def patch(self, url: str, *, json: Any = None, **_: Any) -> _Resp:
+        self.calls.append(("PATCH", url))
+        body = json or {}
+        if "/api/v1/decisions/" in url:
+            if isinstance(body, dict) and body.get("state") == "dispatching":
+                return _Resp(self.mark_status)
+            self.patches.append(body)
+        return _Resp(200)
+
+    def retire_patches(self) -> list[dict[str, Any]]:
+        return [p for p in self.patches if p.get("state") == "completed"]
+
+    def action_calls(self) -> list[str]:
+        return [url for (m, url) in self.calls if m == "POST" and
+                any(a in url for a in ("/done", "/dispatch", "/skip"))]
+
+    def audit_calls(self) -> list[str]:
+        return [url for (m, url) in self.calls if m == "POST" and
+                "state/audit" in url]
+
+
+class _FakeConfig:
+    alfred_ctrl_url = "http://ctrl-test:3100"
+
+
+def _install(monkeypatch: Any, fake_client: _FakeClient) -> None:
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **k: fake_client)
+    import src.config as cfg_mod
+    monkeypatch.setattr(cfg_mod, "load_config", lambda: _FakeConfig())
+    monkeypatch.setenv("AAS_API_KEY", "test-key")
+    import src.activities.decision_observations as dobs
+    async def _noop(d: Any) -> dict:
+        return {}
+    monkeypatch.setattr(dobs, "extract_observation_from_decision", _noop)
+
+
+def _decision(intent: str, state: str = "open") -> dict[str, Any]:
+    return {
+        "id": "2026-08-10-test",
+        "intent": intent,
+        "source": "needs_attention",
+        "source_record": "needs_attention/deleted-card.md",
+        "source_headline": "Test card",
+        "note": "",
+        "matter_ref": "",
+        "task_ref": "",
+        "state": state,
+        "side_effects": {},
+    }
+
+
+# ---------------------------------------------------------------------------
+# 404 → terminal, no re-raise (done / skip / dispatch)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("intent", ["done", "defer", "delegate"])
+def test_404_retires_decision_and_does_not_raise(monkeypatch, intent):
+    """A 404 on the action POST must NOT raise; the decision must be
+    retired (state=completed, side_effects.decision_router=source_card_missing)."""
+    fake = _FakeClient(action_status=404, mark_status=200)
+    _install(monkeypatch, fake)
+
+    result = asyncio.run(dr.route_decision(_decision(intent)))
+
+    # Activity must return cleanly — no exception.
+    assert result["next_state"] == "completed"
+    assert result["actions"] == ["source_card_missing"]
+    assert result["side_effects"]["decision_router"] == "source_card_missing"
+    assert "retired_at" in result["side_effects"]
+
+    # The retire PATCH must have fired.
+    assert len(fake.retire_patches()) == 1
+    rp = fake.retire_patches()[0]
+    assert rp["state"] == "completed"
+    assert rp["side_effects"]["decision_router"] == "source_card_missing"
+
+
+@pytest.mark.parametrize("intent", ["done", "defer", "delegate"])
+def test_404_writes_audit_row(monkeypatch, intent):
+    """The audit row must be written so the retirement is searchable."""
+    fake = _FakeClient(action_status=404)
+    _install(monkeypatch, fake)
+
+    asyncio.run(dr.route_decision(_decision(intent)))
+
+    assert len(fake.audit_calls()) >= 1, (
+        "at least one audit POST must fire on a source_card_missing retire"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5xx still raises so Temporal can retry transient failures
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("intent", ["done", "defer", "delegate"])
+def test_5xx_reraises(monkeypatch, intent):
+    """A 500 from the action endpoint is a transient failure; the activity
+    must raise so Temporal retries it."""
+    fake = _FakeClient(action_status=500)
+    _install(monkeypatch, fake)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        asyncio.run(dr.route_decision(_decision(intent)))
+
+    # No retire PATCH must fire — the 500 is retryable.
+    assert len(fake.retire_patches()) == 0
+
+
+# ---------------------------------------------------------------------------
+# 200 behaves exactly as before (happy path regression)
+# ---------------------------------------------------------------------------
+
+def test_200_done_completes_normally(monkeypatch):
+    """A 200 response on the done action must advance the decision to
+    completed and not trigger any source_card_missing logic."""
+    fake = _FakeClient(action_status=200)
+    _install(monkeypatch, fake)
+
+    result = asyncio.run(dr.route_decision(_decision("done")))
+
+    assert result["next_state"] == "completed"
+    assert "source_card_missing" not in result["actions"]
+    assert result["side_effects"].get("decision_router") != "source_card_missing"
+
+
+# ---------------------------------------------------------------------------
+# Distinguish source_card_missing from a normal completion
+# ---------------------------------------------------------------------------
+
+def test_source_card_missing_distinguishable_from_normal_completion(monkeypatch):
+    """A retired decision carries side_effects.decision_router=source_card_missing.
+    A normally-completed decision does NOT carry that key — so the two are
+    distinguishable in the audit trail."""
+    fake_404 = _FakeClient(action_status=404)
+    _install(monkeypatch, fake_404)
+    retired = asyncio.run(dr.route_decision(_decision("done")))
+
+    fake_200 = _FakeClient(action_status=200)
+    _install(monkeypatch, fake_200)
+    completed = asyncio.run(dr.route_decision(_decision("done")))
+
+    assert retired["side_effects"]["decision_router"] == "source_card_missing"
+    assert completed["side_effects"].get("decision_router") != "source_card_missing"


### PR DESCRIPTION
## Problem

When a principal clicks Done/Defer/Delegate on a Desk card, DecisionRouter
fires `route_decision` which POSTs to `/api/v1/admin/needs-attention/<id>/{done,skip,dispatch}`.
If the card was deleted after the decision was minted, ctrl-api returns 404.
`resp.raise_for_status()` raised unconditionally, so Temporal retried the
activity on every 60-second DecisionRouter tick — **forever**.

A deleted card is not a transient condition. Retrying cannot restore it.

## Fix

Catch `httpx.HTTPStatusError` where `status_code == 404` on all three action
endpoints (`done` / `skip` / `dispatch`). On 404:
- Retire the decision terminal: `state=failed`,
  `side_effects.decision_router=source_card_missing`, `side_effects.retired_at`,
  `side_effects.retired_intent`
- Write one audit row via `POST /api/v1/state/audit` so the retirement is
  searchable (silent retirements were how #442 and #465 stayed invisible for weeks)
- Return — **no raise**

5xx and all other non-404 errors still re-raise so Temporal retries real
transient infrastructure failures normally.

## Design decisions

**Terminal state: `failed`** (not `completed`). `completed` records that the
principal's instruction was carried out. Here nothing happened — the card was
gone before the action POST could succeed. `failed` is the honest state:
terminal, intent-not-applied, drops out of the router's open/executing/reversed
sweep. The documented semantics (decisions.ts:20) confirm: `completed` means
either no async work was needed OR the outcome arrived and was stamped. Neither
clause is true when the card was deleted.

**Distinguishability from the dispatch-cap dead-letter path** (#282): the
dispatch-cap `recover_stuck_dispatching` path sets `side_effects.dead_lettered_at`
and `side_effects.dead_letter_reason`. The source-card-missing path sets
`side_effects.decision_router=source_card_missing` and
`side_effects.retired_at`. No consumer reads `failed` with a narrow dispatch-cap
meaning, so both causes share the state without conflict.

**Log verb**: the existing `_emit_recovery_audit` at line 442 uses `verb =
"dead-letter" if new_state == "failed" else "recovery"`. That function is NOT
called by the new `_retire_source_card_missing` helper — it has its own audit
POST. So the log verb is unchanged for the existing recovery path; the new
path logs "retired as failed (source_card_missing)" directly.

**Audit row: yes**. Written via `POST /api/v1/state/audit` with
`action_type=state-change`, `source=decision_router.source_card_missing`.
The PATCH lands first; an audit failure does NOT roll back the terminal state.

**5xx still raises**. Only `status_code == 404` is terminal. A 500 or timeout
is retried by Temporal as before.

**Pattern followed**: mirrors `scheduled_dispatch.py:100` (#313) and the
`missing_source_record` retire in `route_decision` (#369).

## Scope justification

`scope_limit` raised to 400 in `.lane`. The fix inherently has three
intercept points (one per intent branch) each needing coverage for 404 / 5xx /
200 paths. The shared test doubles account for ~70 lines; the coverage itself
is non-negotiable and cannot be split further without salami-slicing.

## Live blast radius

Verified on home before coding (read-only):

```
GET /api/v1/decisions?state=open
→ open total: 0 | needs_attention source: 0
```

No decisions are currently stuck in this retry loop. The fix is preventive —
the retry loop manifests whenever a card is deleted after a decision is minted,
which happens naturally as the NA queue is cleaned up.

The last 24h of learn logs showed only `GET` 404s on `needs_attention/` paths
(the legitimate `write_needs_attention_record` check-then-create pattern), not
the `POST` action 404s this fix targets. The two patterns are structurally
distinct (GET vs POST + different endpoint paths), so log-counting the POST
paths specifically showed **0** occurrences of the retry-loop pattern.

## Smoke evidence

```
============================= test session starts ==============================
platform darwin -- Python 3.14.4, pytest-9.0.3, pluggy-1.6.0
tests/test_decision_router_source_card_missing.py::test_404_retires_decision_and_does_not_raise[done] PASSED
tests/test_decision_router_source_card_missing.py::test_404_retires_decision_and_does_not_raise[defer] PASSED
tests/test_decision_router_source_card_missing.py::test_404_retires_decision_and_does_not_raise[delegate] PASSED
tests/test_decision_router_source_card_missing.py::test_404_writes_audit_row[done] PASSED
tests/test_decision_router_source_card_missing.py::test_404_writes_audit_row[defer] PASSED
tests/test_decision_router_source_card_missing.py::test_404_writes_audit_row[delegate] PASSED
tests/test_decision_router_source_card_missing.py::test_5xx_reraises[done] PASSED
tests/test_decision_router_source_card_missing.py::test_5xx_reraises[defer] PASSED
tests/test_decision_router_source_card_missing.py::test_5xx_reraises[delegate] PASSED
tests/test_decision_router_source_card_missing.py::test_200_done_completes_normally PASSED
tests/test_decision_router_source_card_missing.py::test_source_card_missing_distinguishable_from_normal_completion PASSED
============================== 11 passed in 0.15s ==============================

Full suite (2659 passed, 101 skipped in 22.05s):
✓ lane II (learn) gate passed — 16 LOC, 2 files, verify ok (follow-up commit)
```

Closes #414