### PR TITLE
feat(mcp-server): add get_sync_health tool to sure app (#318)

### DIFF
--- a/packages/mcp-server/src/tools/sure.ts
+++ b/packages/mcp-server/src/tools/sure.ts
@@ -40,7 +40,7 @@ const balanceSheetTools: ToolDef[] = [
   {
     name: "get_balance_sheet",
     description:
-      "Returns Sir's net worth in one call: family currency, total net worth, total assets, total liabilities, and the breakdown by classification. Use this when Sir asks 'what's my net worth?' or 'where do I stand?'. Cheap, idempotent, no pagination — call it freely. Backing: REST.",
+      "Returns Sir's net worth in one call: family currency, total net worth, total assets, total liabilities, and the breakdown by classification. The response also carries a data_quality rollup ({fresh_accounts, stale_accounts, unknown_accounts, partial: boolean}); if partial is true the net-worth total includes stale or unknown balances — call get_sync_health to see which accounts are affected before stating the figure as current fact. Use this when Sir asks 'what's my net worth?' or 'where do I stand?'. Cheap, idempotent, no pagination — call it freely. Backing: REST.",
     inputSchema: z.object({}),
     buildRequest: () => ({ method: "GET", path: "/api/v1/sure/balance_sheet" }),
   },
@@ -1068,6 +1068,18 @@ const pipelineTools: ToolDef[] = [
   },
 ];
 
+// ─── sync health ─────────────────────────────────────────────────────────────
+
+const syncHealthTools: ToolDef[] = [
+  {
+    name: "get_sync_health",
+    description:
+      "Returns the sync-health status of every account: freshness (\"fresh\" | \"stale\" | \"unknown\"), last-sync anchor timestamp, and a remediation_hint (string or null). Call this before reporting any balance or net-worth figure to Sir whenever the freshness of the figure matters. If data_quality.partial is true in any balance-sheet or account response, the aggregate total includes stale or unknown balances — do not state that figure as current fact; instead qualify it with the staleness detail from each account's freshness field and remediation_hint. Backing: REST (GET /api/v1/sure/sync-health).",
+    inputSchema: z.object({}),
+    buildRequest: () => ({ method: "GET", path: "/api/v1/sure/sync-health" }),
+  },
+];
+
 // ─── usage ──────────────────────────────────────────────────────────────────
 
 const usageTools: ToolDef[] = [
@@ -1123,6 +1135,7 @@ export const ALL_TOOLS: ToolDef[] = [
   ...settingsTools,
   ...chatTools,
   ...pipelineTools,
+  ...syncHealthTools,
   ...usageTools,
   ...nuclearTools,
 ];


### PR DESCRIPTION
## Summary

- Adds `get_sync_health` tool to `packages/mcp-server/src/tools/sure.ts`, proxying `GET /api/v1/sure/sync-health` (contract-frozen endpoint from PR #337). Tool count 95 → 96.
- Updates `get_balance_sheet` description to mention the `data_quality` rollup it already returns, so the model knows to look there and when to follow up with `get_sync_health`.
- The `get_sync_health` description carries the two load-bearing instructions: (1) call it before reporting any balance or net-worth figure when freshness matters; (2) if `data_quality.partial` is true, do not state the figure as current fact — qualify it with the per-account freshness and `remediation_hint`.

## Smoke evidence

```
Lane V gate output:
▶ lane V verify: cd packages/mcp-server && node -e "console.log('source-level verify — CI-verified')"
source-level verify — CI-verified
✓ lane V (edges-infra) gate passed — 15 LOC, 1 files, verify ok

Local import smoke (built dist from the changed source, imported ALL_TOOLS):
Tool count: 96
get_sync_health present: true
get_sync_health method: GET
get_sync_health path: /api/v1/sure/sync-health
get_balance_sheet mentions data_quality: true
get_sync_health mentions partial: true
SMOKE PASS
```

TypeScript compile clean (`tsc --noEmit` against main repo node_modules — zero errors).

## Files touched

- `packages/mcp-server/src/tools/sure.ts` only

References #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc