### PR TITLE
ops(deploy-compose): ship the sure-patch files the compose bind-mounts

### DIFF
--- a/.github/workflows/deploy-compose.yml
+++ b/.github/workflows/deploy-compose.yml
@@ -139,6 +139,16 @@ jobs:
           scp -p caddy/Caddyfile "${host}:/opt/alfred/caddy/Caddyfile"
           scp -p .env.example "${host}:/opt/alfred/.env.example"
 
+          # 3. Host-side files the compose file BIND-MOUNTS must ship with it.
+          #    If compose references a path the tenant does not have, Docker
+          #    creates the missing source as a DIRECTORY, Rails then tries to
+          #    load a directory as an initializer, and sure-web crash-loops.
+          #    That happened on the dev tenant on 2026-08-10 (~4 min outage);
+          #    rolling the same compose to the fleet would have repeated it
+          #    five times. Any new bind-mount of a repo path must be added here.
+          ssh "${host}" "mkdir -p /opt/alfred/scripts/sure-patches"
+          scp -p scripts/sure-patches/*.rb "${host}:/opt/alfred/scripts/sure-patches/"
+
       - name: Apply (docker compose up -d)
         if: steps.preflight.outputs.reachable == 'true'
         run: |


### PR DESCRIPTION
## The gap

`docker-compose.yaml` mounts two host-side Rails initializers:

```yaml
- ./scripts/sure-patches/preserve_lunchflow_currency.rb:...:ro
- ./scripts/sure-patches/expose_balance_anchor_state.rb:...:ro
```

`deploy-compose.yml` scps exactly three files — `docker-compose.yaml`, `caddy/Caddyfile`, `.env.example`. `scripts/` is not among them.

So a tenant receives a compose file referencing paths it does not have. Docker creates each missing bind-mount source as a **directory**, Rails tries to load a directory named `*.rb` as an initializer, and `sure-web` crash-loops.

## This already happened

On the dev tenant on 2026-08-10, when the merge-triggered deploy pushed the compose ahead of the file. About four minutes of downtime on the finance app, caught only because someone was watching the deploy.

The next fleet rollout would have done it to every remaining tenant at once. Found while preparing exactly that rollout.

## Fix

Sync the directory alongside the compose file, with the invariant stated in a comment: **a new bind-mount of a repo path must be added here too.** The failure mode is silent at deploy time and lands on the service.

## Smoke evidence

```
$ python3 -c "import yaml;yaml.safe_load(open('.github/workflows/deploy-compose.yml'));print('yaml ok')"
yaml ok

$ git commit
▶ lane phase0 verify: true
✓ lane phase0 (orchestrator) gate passed
```

The scp glob resolves against the repo checkout in CI, where both files are tracked. `mkdir -p` runs first so a tenant that has never had the directory gets it.