### PR TITLE
fix(learn): split summariser_failed into two diagnosable codes (#538)

### DIFF
--- a/packages/learn/src/activities/file_extraction.py
+++ b/packages/learn/src/activities/file_extraction.py
@@ -487,8 +487,12 @@ async def summarise_extracted_text(
     try:
         result = await _call_clerk(prompt, agent_id=f"file-extract-{file_id}")
     except Exception as exc:  # noqa: BLE001
+        # Workers gateway threw — network error, HTTP 5xx, timeout, billing.
+        # These are transient; the file should be re-tried when the gateway
+        # recovers.  Use a distinct code so operators can tell this apart from
+        # a structural failure where the model returned the wrong shape.
         raise ExtractionError(
-            "summariser_failed", f"workers gateway raised: {exc}",
+            "summariser_gateway_error", f"workers gateway raised: {exc}",
         ) from exc
     summary: Any = None
     if isinstance(result, dict):
@@ -496,8 +500,12 @@ async def summarise_extracted_text(
     elif isinstance(result, str):
         summary = result
     if not isinstance(summary, str) or not summary.strip():
+        # Gateway ran successfully but the model returned JSON without a
+        # "summary" key (or with an empty value).  This is more likely a
+        # prompt-shape issue than a transient availability problem — kept
+        # separate so it can be investigated independently.
         raise ExtractionError(
-            "summariser_failed", "workers gateway returned no summary text",
+            "summariser_no_output", "workers gateway returned no summary text",
         )
     # Hard cap (the ctrl-api PATCH route caps at 4 KiB; we trim earlier
     # so a chatty model never breaches it).

--- a/packages/learn/src/workflows/file_extraction.py
+++ b/packages/learn/src/workflows/file_extraction.py
@@ -162,7 +162,14 @@ _VALID_CODE_HEADS = (
     "empty_docx",
     "empty_xlsx",
     "empty_extraction",
+    # summariser_failed is the legacy single-bucket code (pre-#538).  Kept in
+    # the valid set so the split-code logic still correctly passes it through
+    # for rows written before this fix.
     "summariser_failed",
+    # Replaces summariser_failed for new runs — split by root cause so
+    # operators can distinguish transient gateway problems from prompt failures:
+    "summariser_gateway_error",  # workers gateway threw (network/5xx/timeout)
+    "summariser_no_output",      # gateway ran but returned no "summary" key
     "stamp_failed",
     "metadata_fetch_failed",
     "missing_path",
@@ -295,7 +302,10 @@ class FileExtractionWorkflow:
             code = (
                 _extraction_error_code(exc)
                 if _is_extraction_error(exc)
-                else "summariser_failed"
+                # Non-ExtractionError from the summarise step = gateway or
+                # network exception.  Use the transient-error code so
+                # operators know a retry is worth attempting.
+                else "summariser_gateway_error"
             )
             workflow.logger.info(
                 "file_extraction: summarise failed for %s (code=%s): %s",

--- a/packages/learn/tests/test_file_extraction.py
+++ b/packages/learn/tests/test_file_extraction.py
@@ -555,6 +555,9 @@ class TestEmptyExtractionShortCircuit:
 
 class TestSummariserFailure:
     def test_summariser_failure_stamps_error(self):
+        # Legacy code: ExtractionError("summariser_failed", ...) is still in
+        # _VALID_CODE_HEADS for rows written before the #538 split.  The
+        # workflow passes it through unchanged.
         recorder: list[dict[str, Any]] = []
         stubs = _make_stubs(
             summary_raises=ExtractionError("summariser_failed", "boom"),
@@ -565,6 +568,54 @@ class TestSummariserFailure:
         assert d["extraction_error"] == "summariser_failed"
         assert d["alfred_read_at"] is None
         assert recorder[0]["extraction_error"] == "summariser_failed"
+
+    def test_gateway_error_stamps_summariser_gateway_error(self):
+        # New code path (#538): workers gateway threw (HTTP 5xx / timeout /
+        # billing).  The activity raises ExtractionError("summariser_gateway_error")
+        # and the workflow stamps that code.
+        recorder: list[dict[str, Any]] = []
+        stubs = _make_stubs(
+            summary_raises=ExtractionError(
+                "summariser_gateway_error", "HTTP 503 overloaded",
+            ),
+            stamp_recorder=recorder,
+        )
+        result = asyncio.run(_run_workflow(stubs))
+        d = _to_dict(result)
+        assert d["extraction_error"] == "summariser_gateway_error"
+        assert d["alfred_read_at"] is None
+        assert recorder[0]["extraction_error"] == "summariser_gateway_error"
+
+    def test_no_output_stamps_summariser_no_output(self):
+        # New code path (#538): gateway ran OK but returned JSON without a
+        # "summary" key.  Structural — not a transient gateway failure.
+        recorder: list[dict[str, Any]] = []
+        stubs = _make_stubs(
+            summary_raises=ExtractionError(
+                "summariser_no_output", "no summary key in response",
+            ),
+            stamp_recorder=recorder,
+        )
+        result = asyncio.run(_run_workflow(stubs))
+        d = _to_dict(result)
+        assert d["extraction_error"] == "summariser_no_output"
+        assert d["alfred_read_at"] is None
+        assert recorder[0]["extraction_error"] == "summariser_no_output"
+
+    def test_unexpected_exception_stamps_summariser_gateway_error(self):
+        # A raw RuntimeError (not an ExtractionError) from the summarise stub
+        # is treated as a transient gateway failure — the fallback code path
+        # in the workflow's except clause.
+        recorder: list[dict[str, Any]] = []
+        stubs = _make_stubs(
+            summary_raises=RuntimeError("connection refused"),
+            stamp_recorder=recorder,
+        )
+        result = asyncio.run(_run_workflow(stubs))
+        d = _to_dict(result)
+        assert d["extraction_error"] == "summariser_gateway_error"
+        assert d["alfred_read_at"] is None
+        assert recorder[0]["extraction_error"] == "summariser_gateway_error"
 
 
 class TestStampFailureIsRecorded:


### PR DESCRIPTION
## Summary

- Split the single `summariser_failed` error code into two codes with distinct semantics:
  - `summariser_gateway_error` — workers gateway threw (HTTP 5xx / timeout / network). Transient: retry succeeds when the gateway recovers.
  - `summariser_no_output` — gateway ran but the model returned JSON without a `"summary"` key. Structural: investigate the prompt shape.
- Legacy `summariser_failed` is kept in `_VALID_CODE_HEADS` so existing DB rows still decode correctly.
- 3 new workflow-level tests cover both new codes plus the unexpected-exception fallback path.

## Diagnostic answers (issue #538)

**Q1 — one cause or several?**
One root cause, two code paths. ULID-timestamp analysis of the 17 failures against the files table shows all failed files were uploaded in two windows: 2026-07-17 ~10:00 UTC and 2026-07-22 14:56–17:41 UTC. A file uploaded 14 minutes after the second window (17:55) succeeded identically. The Hermes workers container shows the same symptom today: `"Our servers are currently overloaded. Please try again later."` (gpt-5.6-luna, 3-retry sequence). Both code paths — `_call_clerk` throwing, or returning parseable JSON without a `summary` key — map to the same gateway-overload root cause.

**Q2 — size-correlated?**
No. Failures span 895 bytes to 84 KB; a 5 KB text/plain file succeeded in the same upload session (17:55 UTC), 14 minutes after the last failure. Upload timestamp is the only correlating factor.

**Q3 — retry succeeds?**
Yes. The gateway recovered within ~14 minutes. Files uploaded after the overload cleared succeed normally. A bounded retry (manual or automated) will resolve the 17 stuck rows.

## Operator steps for the 17 stuck files

The existing retry endpoint handles each file individually:
```
POST /api/v1/files/:id/extract
```
An automated retry sweep workflow (Lane II activity + Temporal schedule) is the right long-term fix; that requires a schedule registration in `scripts/register_schedules.py` (Lane V follow-up) and optionally a `?extraction_error=…` filter on the files list endpoint (Lane I follow-up).

## Files touched

- `packages/learn/src/activities/file_extraction.py` — changed both `"summariser_failed"` raise sites
- `packages/learn/src/workflows/file_extraction.py` — added two new codes to `_VALID_CODE_HEADS`; updated the workflow's non-ExtractionError fallback from `"summariser_failed"` to `"summariser_gateway_error"`
- `packages/learn/tests/test_file_extraction.py` — 3 new tests; existing test unchanged (legacy code still passes through)

## Smoke evidence

```
lane II verify: cd packages/learn && python3 -m pytest tests/ -q \
  --ignore=tests/test_composio_server.py \
  --ignore=tests/test_composio_server_extra.py \
  --ignore=tests/test_composio_server_defaults.py \
  --ignore=tests/test_file_extraction.py

2659 passed, 101 skipped in 21.38s
✓ lane II (learn) gate passed — 75 LOC, 3 files, verify ok
```

File extraction tests separately (new tests):
```
cd packages/learn && python3 -m pytest tests/test_file_extraction.py -q
4 failed (pre-existing: openpyxl/pypdf/docx not installed locally), 29 passed
(was 26 before this PR — 3 new tests all green)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)