### PR TITLE
feat(ctrl): matter/task narrative_provenance — extend #318 freshness pattern (#543)

### DIFF
--- a/packages/ctrl/src/api/lib/matter_freshness.ts
+++ b/packages/ctrl/src/api/lib/matter_freshness.ts
@@ -1,0 +1,34 @@
+// Matter/task narrative provenance classifier (#543, extends #318 pattern).
+// Rules: (1) "unknown" never renders as "fresh" — absent narrative ≠ current.
+//        (2) observed_at is the as_of value verbatim — never now() or generated_at.
+
+export interface NarrativeProvenance {
+  source: "nightly_narrative" | null;
+  observed_at: string | null;   // as_of verbatim — never the request timestamp
+  freshness: "fresh" | "stale" | "unknown";
+}
+
+/** Age threshold beyond which a narrative is stale. NightlyNarrativeWorkflow
+ *  runs ~every 24 h; 36 h buffer covers delayed runs. */
+export const NARRATIVE_STALE_HOURS = 36;
+
+/** Classify the narrative provenance from a matter/task `as_of` frontmatter field.
+ *  @param nowMs  Injectable for deterministic tests; defaults to Date.now(). */
+export function classifyNarrativeProvenance(
+  asOf: string | null | undefined,
+  nowMs: number = Date.now(),
+): NarrativeProvenance {
+  if (!asOf || !asOf.trim()) {
+    return { source: null, observed_at: null, freshness: "unknown" };
+  }
+  const observedMs = Date.parse(asOf.trim());
+  if (!Number.isFinite(observedMs) || Number.isNaN(observedMs)) {
+    return { source: null, observed_at: null, freshness: "unknown" };
+  }
+  const ageHours = (nowMs - observedMs) / (1_000 * 60 * 60);
+  return {
+    source: "nightly_narrative",
+    observed_at: asOf.trim(),
+    freshness: ageHours < NARRATIVE_STALE_HOURS ? "fresh" : "stale",
+  };
+}

--- a/packages/ctrl/src/api/routes/matters.ts
+++ b/packages/ctrl/src/api/routes/matters.ts
@@ -40,6 +40,7 @@ import { addRoute } from "../server.js";
 import { sendJson, NotFoundError } from "../errors.js";
 import { VAULT_PATH, walkMd, readRecord } from "./vault.js";
 import { getStateDb } from "../../db/state.js";
+import { classifyNarrativeProvenance, type NarrativeProvenance } from "../lib/matter_freshness.js";
 
 const IGNORE_DIRS = new Set([".git", ".obsidian", "node_modules", ".trash"]);
 
@@ -60,6 +61,10 @@ interface MatterIndexRow {
   counts: MatterCounts;
   state: "done" | "active" | "waiting";
   current_state: string | null;
+  /** Provenance of the narrative layer (current_state / as_of).
+   *  Written by NightlyNarrativeWorkflow; stamped here so consumers know
+   *  whether the narrative is current or stale without an extra fetch. */
+  narrative_provenance: NarrativeProvenance;
 }
 
 interface VaultLink {
@@ -148,6 +153,8 @@ interface MatterTask {
    *    - `external`       signal-sourced but no resolvable sender
    *    - `unknown`        pre-stamp grandfather / unrouted */
   owner: string | null;
+  /** Provenance of the task narrative layer (current_state / as_of). */
+  narrative_provenance: NarrativeProvenance;
 }
 
 interface MatterDetail extends Omit<MatterIndexRow, "state"> {
@@ -592,6 +599,7 @@ function buildMatterIndex(): MatterIndexResult {
       key_entities: buildKeyEntities(rec.fm, entityIndex),
       current_state: currentState,
       as_of: asOf,
+      narrative_provenance: classifyNarrativeProvenance(asOf),
       signal_count_24h: signalCount24h,
       timeline: [...stateChangeEntries],
       tasks: [],
@@ -778,6 +786,9 @@ function buildMatterIndex(): MatterIndexResult {
             : null,
         as_of:
           typeof asOfRaw === "string" && asOfRaw.trim() ? asOfRaw : null,
+        narrative_provenance: classifyNarrativeProvenance(
+          typeof asOfRaw === "string" && asOfRaw.trim() ? asOfRaw : null,
+        ),
         decision_origin:
           typeof decisionOriginRaw === "string" && decisionOriginRaw.trim() && decisionOriginRaw !== "null"
             ? decisionOriginRaw
@@ -1114,6 +1125,7 @@ export function registerMatterRoutes(): void {
       counts: m.counts,
       state: m.state,
       current_state: m.current_state,
+      narrative_provenance: m.narrative_provenance,
     }));
     // `?fields=a,b` — return only the named keys plus the identity triple
     // (id, path, name). Omitting `?fields=` returns the full shape unchanged.
@@ -1167,3 +1179,4 @@ export const _internal = {
   deriveMatterState,
   firstSentence,
 };
+export type { NarrativeProvenance };

--- a/packages/ctrl/tests/matter-freshness-core.test.ts
+++ b/packages/ctrl/tests/matter-freshness-core.test.ts
@@ -1,0 +1,141 @@
+// #543 — narrative provenance on matter/task records (extends #318).
+// Rules: (1) unknown never → fresh; (2) observed_at is as_of verbatim, never now().
+
+import { describe, it, before } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ServerResponse } from "node:http";
+import { classifyNarrativeProvenance } from "../src/api/lib/matter_freshness.js";
+
+const NOW_MS = new Date("2026-08-11T08:00:00Z").getTime();
+
+describe("classifyNarrativeProvenance — unit", () => {
+  it("null/undefined/empty as_of → unknown, source null, observed_at null (rules 1+2)", () => {
+    for (const v of [null, undefined, ""] as const) {
+      const p = classifyNarrativeProvenance(v, NOW_MS);
+      assert.equal(p.freshness, "unknown");
+      assert.notEqual(p.freshness, "fresh");  // rule 1
+      assert.equal(p.source, null);
+      assert.equal(p.observed_at, null);      // rule 2 — no substitution
+    }
+  });
+
+  it("recent as_of → fresh / nightly_narrative / observed_at is the as_of not now()", () => {
+    const twelveHoursAgo = new Date(NOW_MS - 12 * 60 * 60 * 1000).toISOString();
+    const p = classifyNarrativeProvenance(twelveHoursAgo, NOW_MS);
+    assert.equal(p.freshness, "fresh");
+    assert.equal(p.source, "nightly_narrative");
+    assert.equal(p.observed_at, twelveHoursAgo);
+    assert.notEqual(p.observed_at, new Date(NOW_MS).toISOString()); // rule 2
+  });
+
+  it("three-week-old as_of → stale / observed_at preserved", () => {
+    const old = new Date(NOW_MS - 21 * 24 * 60 * 60 * 1000).toISOString();
+    const p = classifyNarrativeProvenance(old, NOW_MS);
+    assert.equal(p.freshness, "stale");
+    assert.equal(p.source, "nightly_narrative");
+    assert.equal(p.observed_at, old);
+  });
+
+  it("unparseable as_of → unknown, observed_at null (rule 2 — no fabrication)", () => {
+    const p = classifyNarrativeProvenance("not-a-date", NOW_MS);
+    assert.equal(p.freshness, "unknown");
+    assert.equal(p.observed_at, null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration — matters endpoints carry narrative_provenance
+// ---------------------------------------------------------------------------
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "matter-fresh-"));
+process.env.VAULT_PATH = path.join(tmp, "vault");
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.STATE_DB_PATH = path.join(tmp, "state.db");
+process.env.SQLITE_VEC_PATH = "";
+
+const V = process.env.VAULT_PATH!;
+for (const d of ["matter", "task"]) fs.mkdirSync(path.join(V, d), { recursive: true });
+
+const { matchRoute } = await import("../src/api/server.js");
+const { registerMatterRoutes } = await import("../src/api/routes/matters.js");
+registerMatterRoutes();
+
+const wv = (rel: string, lines: string[]) =>
+  fs.writeFileSync(path.join(V, rel), lines.join("\n") + "\n", "utf-8");
+
+async function call(method: string, url: string): Promise<{ status: number; payload: any }> {
+  const m = matchRoute(method, url);
+  assert.ok(m, `${method} ${url} must be registered`);
+  let status = 0; let payload: any;
+  const res = {
+    writeHead(c: number) { status = c; return res; },
+    end(j?: string) { payload = j ? JSON.parse(j) : undefined; },
+  } as unknown as ServerResponse;
+  await m!.handler({ req: { url } as any, res, params: m!.params,
+    body: undefined, query: new URLSearchParams() });
+  return { status, payload };
+}
+
+describe("matters narrative_provenance — integration (#543)", () => {
+  before(() => {
+    wv("matter/active-m.md", ["---", "type: matter", "name: Active matter",
+      "summary: Test", "current_state: Going well.", "as_of: '2099-12-31T00:00:00Z'", "---"]);
+    wv("matter/no-narrative.md", ["---", "type: matter", "name: No narrative",
+      "summary: Test", "---"]);
+    wv("task/fresh-t.md", ["---", "type: task", "name: Fresh task",
+      "matter: '[[matter/active-m]]'", "state: pending", "status: todo",
+      "as_of: '2099-12-31T00:00:00Z'", "---"]);
+    wv("task/bare-t.md", ["---", "type: task", "name: Bare task",
+      "matter: '[[matter/active-m]]'", "state: pending", "status: todo", "---"]);
+  });
+
+  it("list carries narrative_provenance with valid freshness on every matter", async () => {
+    const { status, payload } = await call("GET", "/api/v1/matters");
+    assert.equal(status, 200);
+    for (const m of payload.matters) {
+      assert.ok("narrative_provenance" in m, `${m.id} must carry narrative_provenance`);
+      assert.ok(["fresh", "stale", "unknown"].includes(m.narrative_provenance.freshness));
+    }
+  });
+
+  it("far-future as_of → fresh, observed_at is the as_of (not now — rule 2)", async () => {
+    const { payload } = await call("GET", "/api/v1/matters");
+    const row = payload.matters.find((m: any) => m.id === "active-m");
+    assert.ok(row);
+    assert.equal(row.narrative_provenance.freshness, "fresh");
+    assert.equal(row.narrative_provenance.observed_at, "2099-12-31T00:00:00Z");
+  });
+
+  it("no as_of → unknown, never fresh, observed_at null (rules 1+2)", async () => {
+    const { payload } = await call("GET", "/api/v1/matters");
+    const row = payload.matters.find((m: any) => m.id === "no-narrative");
+    assert.ok(row);
+    assert.equal(row.narrative_provenance.freshness, "unknown");
+    assert.notEqual(row.narrative_provenance.freshness, "fresh");  // rule 1
+    assert.equal(row.narrative_provenance.observed_at, null);      // rule 2
+  });
+
+  it("detail tasks carry narrative_provenance; bare task → unknown (rule 1+2)", async () => {
+    const { payload } = await call("GET", "/api/v1/matters/active-m");
+    const fresh = payload.matter.tasks.find((t: any) => t.id === "fresh-t");
+    const bare = payload.matter.tasks.find((t: any) => t.id === "bare-t");
+    assert.ok(fresh && bare);
+    assert.equal(fresh.narrative_provenance.freshness, "fresh");
+    assert.equal(fresh.narrative_provenance.observed_at, "2099-12-31T00:00:00Z");
+    assert.equal(bare.narrative_provenance.freshness, "unknown");
+    assert.equal(bare.narrative_provenance.observed_at, null);
+  });
+
+  it("pre-existing response fields unchanged — narrative_provenance is additive", async () => {
+    const { payload } = await call("GET", "/api/v1/matters");
+    const row = payload.matters.find((m: any) => m.id === "active-m");
+    assert.ok(row);
+    assert.equal(typeof row.id, "string");
+    assert.equal(typeof row.counts, "object");
+    assert.equal(row.current_state, "Going well.");
+    assert.ok("narrative_provenance" in row);
+  });
+});


### PR DESCRIPTION
## What

Extends the #318 balance-provenance pattern to matter and task records. Every matter and task now carries `narrative_provenance: { source, observed_at, freshness }` alongside its `current_state` field — so a consumer knows whether the narrative is current or stale without guessing.

Closes #543

## Survey findings

Three candidates from CLAUDE.md §6.1/6.2:

| Field | Verdict | Why |
|---|---|---|
| matter `current_state` / `as_of` | **Stamped** | Written by `NightlyNarrativeWorkflow`; `as_of` is exactly the `observed_at`. A three-week-old narrative should not read as current. |
| task `current_state` / `as_of` | **Stamped** | Same workflow, same logic. |
| matter roll-up `state` (`done/active/waiting`) | **Not stamped** | Derived fresh on every vault walk from linked tasks — always current, no staleness to report. Stamping it would be decorative noise. |

## The two rules — held throughout

1. `unknown` never renders as `fresh`. A matter whose narrative has never been written is `unknown`, not current. Getting this backwards reintroduces the false-assurance failure #318 exists to prevent.
2. `observed_at` is never `now()` or the request timestamp. It is the `as_of` value verbatim — the time the nightly workflow last wrote the narrative.

## Where `observed_at` comes from

`as_of` is written by `NightlyNarrativeWorkflow` as the ISO-8601 end of the observation window (e.g. `2026-08-11T02:00:00Z`). It is read verbatim from frontmatter and forwarded as `observed_at` — no clock substitution at any point.

## What a never-derived record reports

`{ source: null, observed_at: null, freshness: "unknown" }`. It is never `"fresh"`.

## Additive only

- `MatterIndexRow` gains `narrative_provenance` (list endpoint includes it).
- `MatterTask` gains `narrative_provenance` (detail endpoint tasks include it).
- `MatterDetail` inherits via `Omit<MatterIndexRow, "state">` — no extra field.
- No existing field changes name, type, or position.

## Files touched

- `packages/ctrl/src/api/lib/matter_freshness.ts` (new — the classifier)
- `packages/ctrl/src/api/routes/matters.ts` (13 net lines — import + field declarations + two call sites + list-mapping)
- `packages/ctrl/tests/matter-freshness-core.test.ts` (new — 4 unit + 5 integration)

## Smoke evidence

Local run against a seeded tmp vault, 9/9 tests green:

```
TAP version 13
# Subtest: classifyNarrativeProvenance — unit
    ok 1 - null/undefined/empty as_of → unknown, source null, observed_at null (rules 1+2)
    ok 2 - recent as_of → fresh / nightly_narrative / observed_at is the as_of not now()
    ok 3 - three-week-old as_of → stale / observed_at preserved
    ok 4 - unparseable as_of → unknown, observed_at null (rule 2 — no fabrication)
    1..4
ok 1 - classifyNarrativeProvenance — unit
# Subtest: matters narrative_provenance — integration (#543)
    ok 1 - list carries narrative_provenance with valid freshness on every matter
    ok 2 - far-future as_of → fresh, observed_at is the as_of (not now — rule 2)
    ok 3 - no as_of → unknown, never fresh, observed_at null (rules 1+2)
    ok 4 - detail tasks carry narrative_provenance; bare task → unknown (rule 1+2)
    ok 5 - pre-existing response fields unchanged — narrative_provenance is additive
    1..5
ok 2 - matters narrative_provenance — integration (#543)
1..2
# tests 9
# suites 2
# pass 9
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 186.214791
```

Lane gate: `✓ lane I (ctrl-api) gate passed — 188 LOC, 3 files, verify ok`

Regression: existing `matters-task-count-consistency.test.ts` (#229) still passes (2/2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc