### PR TITLE
fix(learn): adopt raise_if_permanent at three re-raise call sites (#539)

### DIFF
--- a/packages/learn/src/activities/decay_watcher.py
+++ b/packages/learn/src/activities/decay_watcher.py
@@ -58,6 +58,7 @@ import httpx
 from temporalio import activity
 
 from src.config import load_config
+from src.utils.retry_policy import raise_if_permanent
 from src.utils.decay import (
     AUTO_FLIP_THRESHOLD,
     band_for,
@@ -387,6 +388,7 @@ async def adjust_matter_surface_class_v2(
                     "matter_path": canonical,
                     "status": "no_change",
                 }
+            raise_if_permanent(exc, context="adjust_matter_surface_class_v2")
             raise
         fm = record.get("frontmatter") if isinstance(record, dict) else None
         if not isinstance(fm, dict):

--- a/packages/learn/src/activities/fleet_audit.py
+++ b/packages/learn/src/activities/fleet_audit.py
@@ -304,10 +304,12 @@ async def write_fleet_audit_observation(report: dict[str, Any]) -> str:
     """
     # Late-bound imports so the Temporal sandbox never sees httpx at
     # workflow-import time. (Matches the pattern in other activities.)
+    import httpx
     from datetime import datetime, timezone
 
     from src.activities.vault import vault_record_path
     from src.config import load_config
+    from src.utils.retry_policy import raise_if_permanent
     from src.utils.vault_client import VaultClient
 
     config = load_config()
@@ -413,7 +415,16 @@ fleet_audit:
 
         raw_name = f"fleet-audit-{severity}-{date_str}"
         name = vault_record_path("observation", raw_name, created=now)
-        path = await client.write_record("observation", name, content)
+        try:
+            path = await client.write_record("observation", name, content)
+        except httpx.HTTPStatusError as exc:
+            # A 422 from ctrl-api means the promotion contract rejected the
+            # write (observation is a demoted type; the vault rejects it).
+            # The payload is structural — retrying the same request can never
+            # succeed, so surface it immediately as a non-retryable error
+            # instead of burning all three retry slots (#539).
+            raise_if_permanent(exc, context="write_fleet_audit_observation")
+            raise
         logger.info(
             "fleet_audit: wrote observation %s (severity=%s)",
             path, severity,

--- a/packages/learn/src/activities/state_mutator.py
+++ b/packages/learn/src/activities/state_mutator.py
@@ -27,6 +27,7 @@ import httpx
 from temporalio import activity
 
 from src.config import load_config
+from src.utils.retry_policy import raise_if_permanent
 from src.utils.vault_client import VaultClient
 
 logger = logging.getLogger("alfred-learn")
@@ -359,6 +360,7 @@ async def read_target(path: str) -> dict[str, Any]:
         except httpx.HTTPStatusError as exc:
             if exc.response is not None and exc.response.status_code == 404:
                 return {"frontmatter": {}, "body": "", "as_of": None}
+            raise_if_permanent(exc, context="read_target")
             raise
         fm = record.get("frontmatter") or {}
         if not isinstance(fm, dict):

--- a/packages/learn/tests/test_retry_policy_adoption.py
+++ b/packages/learn/tests/test_retry_policy_adoption.py
@@ -1,0 +1,173 @@
+"""raise_if_permanent adoption at three call sites (#539).
+
+A permanent HTTP error (422/400) must become a non-retryable ApplicationError;
+a transient error (503) must still propagate so Temporal retries it.
+
+Live evidence: write_fleet_audit_observation reached attempt 2+3 on 422
+(FleetAuditWorkflow 2026-08-11T02:00:00Z — vault rejects ``observation`` as
+a demoted type). read_target and adjust_matter_surface_class_v2 share the
+same bare-re-raise pattern that caused create_session to run to attempt 7208.
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+from temporalio.exceptions import ApplicationError
+
+
+# ---------------------------------------------------------------------------
+# Shared helper — build a minimal HTTPStatusError
+# ---------------------------------------------------------------------------
+
+def _http_error(status: int) -> httpx.HTTPStatusError:
+    req = httpx.Request("POST", "http://ctrl-api/api/v1/vault/records")
+    resp = httpx.Response(status, request=req)
+    return httpx.HTTPStatusError(str(status), request=req, response=resp)
+
+
+# ---------------------------------------------------------------------------
+# write_fleet_audit_observation — fleet_audit.py
+# ---------------------------------------------------------------------------
+
+_MINIMAL_REPORT = {
+    "status": "green",
+    "owner_email": "owner@example.com",
+    "files_scanned": 1,
+    "total_mismatches": 0,
+}
+
+
+class TestFleetAuditObservationRetry:
+    async def test_422_becomes_non_retryable(self, monkeypatch):
+        from src.activities.fleet_audit import write_fleet_audit_observation
+        from src.utils.vault_client import VaultClient
+
+        async def _bad_write(self, record_type, name, content):  # noqa: ANN001
+            raise _http_error(422)
+
+        monkeypatch.setattr(VaultClient, "write_record", _bad_write)
+
+        with pytest.raises(ApplicationError) as exc_info:
+            await write_fleet_audit_observation(_MINIMAL_REPORT)
+
+        err = exc_info.value
+        assert err.non_retryable is True
+        assert err.type == "PermanentHttpError"
+        assert "422" in str(err)
+        assert "write_fleet_audit_observation" in str(err)
+
+    async def test_503_still_retries(self, monkeypatch):
+        from src.activities.fleet_audit import write_fleet_audit_observation
+        from src.utils.vault_client import VaultClient
+
+        async def _bad_write(self, record_type, name, content):  # noqa: ANN001
+            raise _http_error(503)
+
+        monkeypatch.setattr(VaultClient, "write_record", _bad_write)
+
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            await write_fleet_audit_observation(_MINIMAL_REPORT)
+
+        assert exc_info.value.response.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# read_target — state_mutator.py
+# ---------------------------------------------------------------------------
+
+class TestReadTargetRetry:
+    async def test_404_returns_sentinel(self, monkeypatch):
+        from src.activities.state_mutator import read_target
+        from src.utils.vault_client import VaultClient
+
+        async def _not_found(self, path):  # noqa: ANN001
+            raise _http_error(404)
+
+        monkeypatch.setattr(VaultClient, "read_record", _not_found)
+
+        result = await read_target("matter/missing.md")
+        assert result == {"frontmatter": {}, "body": "", "as_of": None}
+
+    async def test_422_becomes_non_retryable(self, monkeypatch):
+        from src.activities.state_mutator import read_target
+        from src.utils.vault_client import VaultClient
+
+        async def _bad_read(self, path):  # noqa: ANN001
+            raise _http_error(422)
+
+        monkeypatch.setattr(VaultClient, "read_record", _bad_read)
+
+        with pytest.raises(ApplicationError) as exc_info:
+            await read_target("matter/something.md")
+
+        err = exc_info.value
+        assert err.non_retryable is True
+        assert "read_target" in str(err)
+
+    async def test_503_still_retries(self, monkeypatch):
+        from src.activities.state_mutator import read_target
+        from src.utils.vault_client import VaultClient
+
+        async def _bad_read(self, path):  # noqa: ANN001
+            raise _http_error(503)
+
+        monkeypatch.setattr(VaultClient, "read_record", _bad_read)
+
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            await read_target("matter/something.md")
+
+        assert exc_info.value.response.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# adjust_matter_surface_class_v2 — decay_watcher.py
+# ---------------------------------------------------------------------------
+
+class TestAdjustMatterSurfaceClassV2Retry:
+    async def test_404_returns_no_change(self, monkeypatch):
+        from src.activities.decay_watcher import adjust_matter_surface_class_v2
+        from src.utils.vault_client import VaultClient
+
+        async def _not_found(self, path):  # noqa: ANN001
+            raise _http_error(404)
+
+        monkeypatch.setattr(VaultClient, "read_record", _not_found)
+
+        result = await adjust_matter_surface_class_v2(
+            "matter/gone.md", "2026-08-11T02:00:00Z"
+        )
+        assert result["status"] == "no_change"
+
+    async def test_422_becomes_non_retryable(self, monkeypatch):
+        from src.activities.decay_watcher import adjust_matter_surface_class_v2
+        from src.utils.vault_client import VaultClient
+
+        async def _bad_read(self, path):  # noqa: ANN001
+            raise _http_error(422)
+
+        monkeypatch.setattr(VaultClient, "read_record", _bad_read)
+
+        with pytest.raises(ApplicationError) as exc_info:
+            await adjust_matter_surface_class_v2(
+                "matter/something.md", "2026-08-11T02:00:00Z"
+            )
+
+        err = exc_info.value
+        assert err.non_retryable is True
+        assert "adjust_matter_surface_class_v2" in str(err)
+
+    async def test_503_still_retries(self, monkeypatch):
+        from src.activities.decay_watcher import adjust_matter_surface_class_v2
+        from src.utils.vault_client import VaultClient
+
+        async def _bad_read(self, path):  # noqa: ANN001
+            raise _http_error(503)
+
+        monkeypatch.setattr(VaultClient, "read_record", _bad_read)
+
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            await adjust_matter_surface_class_v2(
+                "matter/something.md", "2026-08-11T02:00:00Z"
+            )
+
+        assert exc_info.value.response.status_code == 503


### PR DESCRIPTION
## Summary

Adopts the existing `retry_policy.raise_if_permanent` helper at three activity call sites that were re-raising `HTTPStatusError` to Temporal without classifying the status code. A permanent error (422, 400) at those sites would cause Temporal to retry the same doomed request indefinitely — the same pattern that drove `create_session` to 7,208 attempts and `check_task_prerequisites` to 2,387 (#296).

- **`fleet_audit.write_fleet_audit_observation`** — wrap `write_record` in try/except, call `raise_if_permanent` before re-raising.
- **`state_mutator.read_target`** — call `raise_if_permanent` before the bare `raise` on non-404 statuses.
- **`decay_watcher.adjust_matter_surface_class_v2`** — same pattern.

**`decision_router.py` (3 sites) and `scheduled_dispatch.py` left unconverged:** their 404 handlers call `_retire_source_card_missing` / PATCH `state=completed`, which do more than `raise_if_permanent` (they write an audit row and settle the decision into a terminal state, then `continue` past the error rather than surfacing it to Temporal). Converging would lose the audit row. The divergence is intentional and is noted in the commit.

References #539.

## Smoke evidence

Local pytest run (Lane II VERIFY gate — the pre-commit hook output):

```
▶ lane II verify: cd packages/learn && python3 -m pytest tests/ -q \
    --ignore=tests/test_composio_server.py \
    --ignore=tests/test_composio_server_extra.py \
    --ignore=tests/test_composio_server_defaults.py \
    --ignore=tests/test_file_extraction.py
2667 passed, 101 skipped in 21.62s
✓ lane II (learn) gate passed — 190 LOC, 4 files, verify ok
```

New tests (8 assertions, all green):

```
tests/test_retry_policy_adoption.py::TestFleetAuditObservationRetry::test_422_becomes_non_retryable PASSED
tests/test_retry_policy_adoption.py::TestFleetAuditObservationRetry::test_503_still_retries PASSED
tests/test_retry_policy_adoption.py::TestReadTargetRetry::test_404_returns_sentinel PASSED
tests/test_retry_policy_adoption.py::TestReadTargetRetry::test_422_becomes_non_retryable PASSED
tests/test_retry_policy_adoption.py::TestReadTargetRetry::test_503_still_retries PASSED
tests/test_retry_policy_adoption.py::TestAdjustMatterSurfaceClassV2Retry::test_404_returns_no_change PASSED
tests/test_retry_policy_adoption.py::TestAdjustMatterSurfaceClassV2Retry::test_422_becomes_non_retryable PASSED
tests/test_retry_policy_adoption.py::TestAdjustMatterSurfaceClassV2Retry::test_503_still_retries PASSED
8 passed in 0.11s
```

Live evidence from logs (read-only, no writes):

```
WARNING:temporalio.activity:Completing activity as failed ({'activity_type':
'write_fleet_audit_observation', 'attempt': 2, 'workflow_type':
'FleetAuditWorkflow'})
WARNING:temporalio.activity:Completing activity as failed ({'activity_type':
'write_fleet_audit_observation', 'attempt': 3, ...})
httpx.HTTPStatusError: Client error '422 Unprocessable Entity' for url
'http://ctrl-api:3100/api/v1/vault/records'
```

The 422 is the vault rejecting `observation` as a demoted type (correct ctrl-api behaviour). With this fix it becomes a non-retryable `ApplicationError` on attempt 1 instead of burning the full retry budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)