### PR TITLE
feat(ctrl): probe /health/detailed for gateway_busy before delegation (#540)

### DIFF
--- a/packages/ctrl/src/api/routes/agents.ts
+++ b/packages/ctrl/src/api/routes/agents.ts
@@ -312,6 +312,52 @@ async function probeWorkersGateway(): Promise<string | null> {
   }
 }
 
+/** Check whether the workers gateway is saturated before committing a
+ *  delegation budget (#540 — slice of #297).
+ *
+ *  Hermes 0.19.0+ exposes GET /health/detailed (requires the workers API
+ *  key).  The response includes `gateway_busy` — Hermes' own saturation
+ *  judgment — and `active_agents`, the raw in-flight count.  We refuse on
+ *  `gateway_busy === true` rather than a hard threshold on `active_agents`
+ *  because Hermes knows its own concurrency cap; we do not.
+ *
+ *  Verified live against Hermes 0.19.0:
+ *    {"status":"ok","active_agents":0,"gateway_busy":false,
+ *     "readiness":{"checks":{"background_queues":{
+ *       "active_api_runs":0,"active_delegations":0,...}},...}}
+ *
+ *  Fail-open design: any probe failure (timeout, 404, parse error) is NOT
+ *  a refusal.  The liveness probe (`probeWorkersGateway`) already surfaces
+ *  hard unavailability.  A flaky /health/detailed must never block a
+ *  delegation that would have succeeded.
+ *
+ *  Returns null when healthy (or when the signal is unavailable), else a
+ *  short human reason — presence means emit HERMES_WORKERS_SATURATED.
+ */
+async function probeSaturation(apiKey: string): Promise<string | null> {
+  if (DELEGATE_PROBE_TIMEOUT_MS === 0) return null; // probing disabled
+  try {
+    const resp = await fetch(
+      `${HERMES_WORKERS_GATEWAY_URL}/health/detailed`,
+      {
+        headers: { Authorization: `Bearer ${apiKey}` },
+        signal: AbortSignal.timeout(DELEGATE_PROBE_TIMEOUT_MS),
+      },
+    );
+    if (!resp.ok) return null; // /health/detailed unavailable — proceed
+    const body = (await resp.json()) as Record<string, unknown>;
+    if (body.gateway_busy === true) {
+      const active =
+        typeof body.active_agents === "number" ? body.active_agents : "?";
+      return `workers gateway is saturated (active_agents=${active}, gateway_busy=true)`;
+    }
+    return null;
+  } catch {
+    // Saturation probe failure is non-blocking — see JSDoc above.
+    return null;
+  }
+}
+
 /** Read API_SERVER_KEY for the workers profile out of its rendered .env.
  *
  *  Same key-resolution pattern as channels_paperclip.ts /
@@ -837,6 +883,24 @@ export function registerAgentRoutes(): void {
         ok: false,
         error: "HERMES_WORKERS_UNAVAILABLE",
         detail: `${unready}. Refused before dispatch — no delegation budget was spent and nothing was started on the gateway.`,
+        session_key: sessionKey,
+        probe_timeout_ms: DELEGATE_PROBE_TIMEOUT_MS,
+        retryable: true,
+      });
+      return;
+    }
+
+    // #540 — liveness is necessary but not sufficient: a gateway that is up
+    // but hopelessly backed up looks identical to an idle one until the
+    // delegation times out 300s later.  Hermes 0.19.0+ exposes
+    // /health/detailed with gateway_busy — check it and refuse immediately
+    // with a distinct code so callers know to retry rather than wait.
+    const saturated = await probeSaturation(workersKey);
+    if (saturated) {
+      sendJson(res, 503, {
+        ok: false,
+        error: "HERMES_WORKERS_SATURATED",
+        detail: `${saturated}. Refused before dispatch — no delegation budget was spent.`,
         session_key: sessionKey,
         probe_timeout_ms: DELEGATE_PROBE_TIMEOUT_MS,
         retryable: true,

--- a/packages/ctrl/tests/agents_focused_subagent.test.ts
+++ b/packages/ctrl/tests/agents_focused_subagent.test.ts
@@ -53,9 +53,26 @@ let nextFetchResponse: { status: number; body: string } = {
 // returns" — otherwise a test simulating a failed dispatch is intercepted by
 // the probe and never reaches the code under test. `lastFetchCall` also stays
 // the dispatch, so every existing assertion below is unaffected.
+//
+// #540 added a saturation probe (GET <gateway>/health/detailed) between the
+// liveness probe and the dispatch.  Stub it too — defaults to "not saturated"
+// so existing tests are unaffected.
 let nextProbeStatus = 200;
+let nextDetailedProbeStatus = 200;
+let nextDetailedProbeBody: Record<string, unknown> = {
+  status: "ok",
+  active_agents: 0,
+  gateway_busy: false,
+  gateway_drainable: true,
+};
 globalThis.fetch = (async (url: any, init?: any) => {
   const target = String(url);
+  if (target.endsWith("/health/detailed")) {
+    return new Response(JSON.stringify(nextDetailedProbeBody), {
+      status: nextDetailedProbeStatus,
+      headers: { "content-type": "application/json" },
+    });
+  }
   if (target.endsWith("/health")) {
     return new Response("{}", {
       status: nextProbeStatus,
@@ -311,5 +328,61 @@ describe("POST /api/v1/agents/focused-subagent — happy path", () => {
       status: 200,
       body: JSON.stringify({ output: [{ content: [{ text: "ok" }] }] }),
     };
+  });
+
+  // ── #540 — saturation probe ──────────────────────────────────────────────
+  //
+  // Hermes 0.19.0+ exposes /health/detailed with gateway_busy.  When the
+  // gateway is up but saturated we should refuse immediately with a distinct
+  // error code, not burn the 300s delegation budget and then time out.
+
+  it("refuses with HERMES_WORKERS_SATURATED when gateway_busy is true", async () => {
+    nextDetailedProbeStatus = 200;
+    nextDetailedProbeBody = { status: "ok", active_agents: 3, gateway_busy: true };
+    lastFetchCall = null;
+
+    const r = await invokeRoute("POST", "/api/v1/agents/focused-subagent", {
+      body: { task: "task", domain: "sure" },
+    });
+
+    assert.equal(r.status, 503);
+    assert.equal(r.payload.ok, false);
+    assert.equal(r.payload.error, "HERMES_WORKERS_SATURATED");
+    assert.equal(r.payload.retryable, true);
+    assert.ok(
+      String(r.payload.detail).includes("saturated"),
+      "detail must mention saturation",
+    );
+    assert.equal(lastFetchCall, null, "must not dispatch when saturated");
+
+    nextDetailedProbeBody = { status: "ok", active_agents: 0, gateway_busy: false };
+  });
+
+  it("proceeds normally when gateway_busy is false", async () => {
+    nextDetailedProbeStatus = 200;
+    nextDetailedProbeBody = { status: "ok", active_agents: 0, gateway_busy: false };
+    lastFetchCall = null;
+
+    const r = await invokeRoute("POST", "/api/v1/agents/focused-subagent", {
+      body: { task: "task", domain: "sure" },
+    });
+
+    assert.equal(r.status, 200);
+    assert.ok(lastFetchCall, "dispatch must proceed when gateway is not busy");
+  });
+
+  it("proceeds normally when /health/detailed is unavailable (fail-open)", async () => {
+    nextDetailedProbeStatus = 404;
+    lastFetchCall = null;
+
+    const r = await invokeRoute("POST", "/api/v1/agents/focused-subagent", {
+      body: { task: "task", domain: "sure" },
+    });
+
+    assert.equal(r.status, 200);
+    assert.ok(lastFetchCall, "dispatch must proceed when /health/detailed is absent");
+
+    nextDetailedProbeStatus = 200;
+    nextDetailedProbeBody = { status: "ok", active_agents: 0, gateway_busy: false };
   });
 });


### PR DESCRIPTION
## Summary

- Hermes 0.19.0+ exposes `GET /health/detailed` (workers API key required) with `gateway_busy` (Hermes' own saturation judgment) and `active_agents` (raw in-flight count)
- Add `probeSaturation(apiKey)` in `agents.ts` that hits this endpoint after the existing liveness probe — if `gateway_busy === true`, refuse immediately with `HERMES_WORKERS_SATURATED` (503, `retryable: true`) rather than burning the 300s delegation budget and timing out
- Fail-open: any probe failure (timeout, 404, parse error) lets dispatch proceed; the liveness probe already covers hard unavailability
- 3 new tests; existing 233 all pass

Closes #540. References #297.

## What was found on the live gateway

Step 1 of the issue spec: verify what the installed Hermes version actually exposes.

`GET /health` (no auth required): returns only `{"status":"ok","platform":"hermes-agent","version":"0.19.0"}` — confirms the issue note.

`GET /health/detailed` (workers API key required, 401 without):

```json
{
  "status": "ok",
  "readiness": {
    "status": "ok",
    "checks": {
      "state_db": {"status": "ok"},
      "config": {"status": "ok"},
      "model": {"status": "ok"},
      "disk": {"status": "ok", "used_percent": 27.5, "free_bytes": 331137097728},
      "gateway": {"status": "ok", "state": "running", "connected_platforms": 1, "platforms": 1},
      "background_queues": {
        "status": "ok",
        "active_api_runs": 0,
        "process_completions": 0,
        "active_delegations": 0
      }
    }
  },
  "platform": "hermes-agent",
  "version": "0.19.0",
  "gateway_state": "running",
  "platforms": {
    "api_server": {"state": "connected", "error_code": null, "error_message": null, "updated_at": "2026-08-10T19:06:40.136713+00:00"}
  },
  "active_agents": 0,
  "gateway_busy": false,
  "gateway_drainable": true,
  "exit_reason": null,
  "updated_at": "2026-08-10T19:06:40.139076+00:00",
  "pid": 58
}
```

All other introspection endpoints (`/v1/sessions`, `/v1/queue`, `/v1/stats`, `/v1/metrics`, `/v1/status`, `/v1/info`, `/v1/capacity`, `/v1/concurrency`, `/v1/load`, `/v1/busy`, `/v1/slots`, `/v1/active`, `/v1/pending`) return 404.

`gateway_busy` is Hermes' own judgment — the right signal to gate on. We do NOT threshold on `active_agents` because Hermes knows its own concurrency cap; we don't.

## Smoke evidence

**Discovery probes (read-only, GET only against the live workers gateway):**

```
$ ssh root@<tenant> 'docker exec alfred-black-hermes-1 bash -c "
  WORKERS_KEY=$(grep API_SERVER_KEY /hermes-state/profiles/workers/.env | head -1 | cut -d= -f2-)
  curl -s -H \"Authorization: Bearer ${WORKERS_KEY}\" http://127.0.0.1:18790/health/detailed
"'
{"status": "ok", ..., "active_agents": 0, "gateway_busy": false, "gateway_drainable": true, ...}
HTTP 200
```

**Test suite: 233/233 pass (lane gate confirmed)**

```
# node --experimental-sqlite ... --test packages/ctrl/tests/agents_focused_subagent.test.ts (and all others)
ok 13 - packages/ctrl/tests/agents_focused_subagent.test.ts
...
# pass 233
# fail 0
```

New tests in `agents_focused_subagent.test.ts`:
- `refuses with HERMES_WORKERS_SATURATED when gateway_busy is true` — stub returns `gateway_busy: true`, asserts 503 + HERMES_WORKERS_SATURATED + no dispatch call + `retryable: true`
- `proceeds normally when gateway_busy is false` — stub returns `gateway_busy: false`, asserts dispatch proceeds
- `proceeds normally when /health/detailed is unavailable (fail-open)` — stub returns 404, asserts dispatch still proceeds

**Lane gate output:**
```
▶ lane I verify: node -e "console.log('source-level verify — see PR')"
source-level verify — see PR
✓ lane I (ctrl-api) gate passed — 137 LOC, 2 files, verify ok
```

## Architecture choice

Chose `gateway_busy` (Hermes' binary self-judgment) over a hard threshold on `active_agents` because:
1. Hermes knows its own concurrency cap configured in config.yaml; we don't
2. A numeric threshold would break on Hermes config changes
3. Fail-open: if the field is absent or the endpoint 404s, we let dispatch proceed

The workers API key is already in scope at the call site (read at line 820, used for the dispatch). No new key reads.

## Files touched

- `packages/ctrl/src/api/routes/agents.ts` — `probeSaturation()` function + saturation check in route handler
- `packages/ctrl/tests/agents_focused_subagent.test.ts` — `/health/detailed` fetch stub + 3 test cases

**137 net LOC, 2 files.**

## Operator steps

None. The workers API key is already read from `/hermes-state/profiles/workers/.env` at delegation time. The new probe reuses it with no configuration changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc
