### PR TITLE
feat(learn): CronJournalReconcileWorkflow — wire cron-journal caller (#418)

### DIFF
--- a/packages/learn/scripts/register_schedules.py
+++ b/packages/learn/scripts/register_schedules.py
@@ -156,6 +156,21 @@ REVERSAL_CALIBRATION_SCHEDULE_ID = "al-reversal-calibration"
 REVERSAL_CALIBRATION_WORKFLOW = "ReversalCalibrationWorkflow"
 REVERSAL_CALIBRATION_INTERVAL = timedelta(minutes=10)
 
+# Cron-journal reconciler (#418 / GH #556) — call
+# POST /api/v1/alfred-journal/reconcile-cron every 6 h.
+#
+# Interval arithmetic: window=48 h, cap=50 sessions/call.
+# Hermes cron jobs with ``deliver`` are outbound-delivery chores (daily
+# briefings, weekly digests, etc.) — a busy tenant has at most ~5 such
+# jobs.  At 6-hour intervals that is ~1.25 sessions/interval, far under
+# the 50-session cap.  A session missed just after one run waits at most
+# 6 h, leaving 42 h of the 48-hour window intact.  Default OFF (lesson
+# from FLEET_AUDIT_ENABLED defaulting ON and silently running on five
+# client tenants for weeks as an operator diagnostic).
+CRON_JOURNAL_RECONCILE_SCHEDULE_ID = "al-cron-journal-reconcile"
+CRON_JOURNAL_RECONCILE_WORKFLOW = "CronJournalReconcileWorkflow"
+CRON_JOURNAL_RECONCILE_INTERVAL = timedelta(hours=6)
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("register-schedules")
 
@@ -860,6 +875,20 @@ def _stream_event_purge_enabled() -> bool:
     ).strip().lower() in ("true", "1", "yes")
 
 
+def _cron_journal_reconcile_enabled() -> bool:
+    """Feature flag for the cron-journal reconciler (#418). Default OFF.
+
+    Tenants opt in by setting ``CRON_JOURNAL_RECONCILE_ENABLED=true``.
+    Defaults OFF — lesson from FLEET_AUDIT_ENABLED defaulting ON and
+    silently running as an operator diagnostic on client tenants.
+    The activity re-checks at invocation time so flipping the flag off
+    without a redeploy immediately stops new runs.
+    """
+    return os.environ.get(
+        "CRON_JOURNAL_RECONCILE_ENABLED", "",
+    ).strip().lower() in ("true", "1", "yes")
+
+
 async def _register_or_delete_singleton_schedule(
     client: Client,
     schedule_id: str,
@@ -1053,6 +1082,25 @@ async def register_reversal_calibration(
         REVERSAL_CALIBRATION_INTERVAL,
         _reversal_calibration_enabled(),
         label="reversal_calibration",
+    )
+
+
+async def register_cron_journal_reconcile(
+    client: Client, task_queue: str,
+) -> None:
+    """Create-or-delete ``al-cron-journal-reconcile`` based on the flag.
+
+    Gate: ``CRON_JOURNAL_RECONCILE_ENABLED=true``.  Default OFF.
+    Interval: 6 h.  See the constant block above for the arithmetic.
+    """
+    await _register_or_delete_singleton_schedule(
+        client,
+        CRON_JOURNAL_RECONCILE_SCHEDULE_ID,
+        CRON_JOURNAL_RECONCILE_WORKFLOW,
+        task_queue,
+        CRON_JOURNAL_RECONCILE_INTERVAL,
+        _cron_journal_reconcile_enabled(),
+        label="cron_journal_reconcile",
     )
 
 
@@ -1872,6 +1920,10 @@ async def register_all() -> None:
     # soak, fleet rollout once the per-source-type confidence shifts
     # have been observed to track real reversal patterns.
     await register_reversal_calibration(client, config.task_queue)
+    # Cron-journal reconciler (#418 / GH #556) — 6-hourly call to
+    # POST /api/v1/alfred-journal/reconcile-cron to journal Hermes cron
+    # outbounds.  Gated on CRON_JOURNAL_RECONCILE_ENABLED (default OFF).
+    await register_cron_journal_reconcile(client, config.task_queue)
     try:  # F33c — sweep the brief-duplicate chore (brief is a built-in now).
         await delete_duplicate_briefing_chore(client)
     except Exception as exc:  # noqa: BLE001

--- a/packages/learn/src/activities/cron_journal.py
+++ b/packages/learn/src/activities/cron_journal.py
@@ -1,0 +1,79 @@
+"""Cron-journal reconciler activity (#418 / GH #556).
+
+The ctrl-api endpoint POST /api/v1/alfred-journal/reconcile-cron reads
+Hermes' session store read-only, finds sessions with source='cron' whose
+job id maps to a jobs.json entry with a non-empty ``deliver`` field, and
+journals each into alfred_journal (source_kind='cron').  Idempotent on
+hermes_session_id; window 48 h, cap 50 sessions per call.
+
+This activity is the sole caller.  It never raises on a ctrl-api failure
+(log + return) so Temporal does not enter an unbounded retry loop.  The
+endpoint is idempotent — the next scheduled run (6 h) will pick up any
+sessions still inside the 48-hour window.
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+import httpx
+from temporalio import activity
+
+from src.config import load_config
+from src.utils.retry_policy import classify_status
+
+logger = logging.getLogger("alfred-learn")
+
+_ENV_FLAG = "CRON_JOURNAL_RECONCILE_ENABLED"
+
+
+def _flag_on() -> bool:
+    """True when CRON_JOURNAL_RECONCILE_ENABLED is a truthy value.
+
+    Default OFF so the fleet does not run this before Sir enables it
+    explicitly (lesson from FLEET_AUDIT_ENABLED defaulting ON).
+    """
+    return os.environ.get(_ENV_FLAG, "").strip().lower() in ("true", "1", "yes")
+
+
+@activity.defn
+async def cron_journal_reconcile_is_enabled() -> bool:
+    """Invocation-time gate — mirrors the registration-time check.
+
+    Exposed as an activity so the workflow's flag read is deterministic
+    from Temporal's perspective (env reads inside activities, not in
+    workflow bodies — same pattern as fleet_audit_is_enabled).
+    """
+    return _flag_on()
+
+
+@activity.defn
+async def reconcile_cron_journal() -> dict:
+    """Call POST /api/v1/alfred-journal/reconcile-cron.
+
+    Never raises — catches all HTTP and transport errors, classifies them
+    via retry_policy.classify_status, logs a warning, and returns a dict
+    with ok=False.  The endpoint is idempotent; missed runs are recovered
+    at the next 6-hour tick as long as sessions remain inside the 48-hour
+    window.
+    """
+    config = load_config()
+    api_key = os.environ.get("AAS_API_KEY", "")
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    try:
+        async with httpx.AsyncClient(
+            base_url=config.alfred_ctrl_url, timeout=30.0, headers=headers,
+        ) as http:
+            resp = await http.post("/api/v1/alfred-journal/reconcile-cron")
+            resp.raise_for_status()
+            return resp.json()
+    except Exception as exc:  # noqa: BLE001
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        activity.logger.warning(
+            "reconcile_cron_journal: ctrl-api call failed "
+            "(status=%s classification=%s) — skipping, next run picks up in 6 h: %s",
+            status,
+            classify_status(status),
+            str(exc)[:200],
+        )
+        return {"ok": False, "error": str(exc)[:200]}

--- a/packages/learn/src/worker.py
+++ b/packages/learn/src/worker.py
@@ -62,6 +62,7 @@ from src.workflows.reversal_calibration import ReversalCalibrationWorkflow
 from src.workflows.briefing import BriefingWorkflow
 from src.workflows.recall_dispatcher import RecallDispatcherWorkflow
 from src.workflows.ha_bootstrap import HaBootstrapWorkflow
+from src.workflows.cron_journal import CronJournalReconcileWorkflow
 
 # Chore template workflows (static + dynamic)
 from src.workflows.chores import ALL_CHORE_TEMPLATES
@@ -718,6 +719,12 @@ from src.activities.ha_gap_detection import (
     generate_ha_proposals,
 )
 
+# Cron-journal reconciler (#418) — activities back CronJournalReconcileWorkflow.
+from src.activities.cron_journal import (
+    cron_journal_reconcile_is_enabled,
+    reconcile_cron_journal,
+)
+
 # Validators used as activities
 from src.validators.frontmatter import validate_classification
 
@@ -832,6 +839,11 @@ _STATIC_WORKFLOWS = [
     # register_schedules.py; also triggered on demand by the HaCard
     # "Refresh registry" CTA via ctrl-api's /registry/refresh route.
     HaBootstrapWorkflow,
+    # Cron-journal reconciler (#418) — every 6h calls
+    # POST /api/v1/alfred-journal/reconcile-cron to journal Hermes cron
+    # outbounds that carry a ``deliver`` field into alfred_journal.
+    # Gated on CRON_JOURNAL_RECONCILE_ENABLED (default OFF).
+    CronJournalReconcileWorkflow,
     *ALL_CHORE_TEMPLATES,
 ]
 
@@ -1258,6 +1270,9 @@ ALL_ACTIVITIES = [
     # run inside the same HaBootstrapWorkflow after Phase A's write.
     detect_ha_gaps,
     generate_ha_proposals,
+    # Cron-journal reconciler (#418) — backs CronJournalReconcileWorkflow.
+    cron_journal_reconcile_is_enabled,
+    reconcile_cron_journal,
 ]
 
 

--- a/packages/learn/src/workflows/cron_journal.py
+++ b/packages/learn/src/workflows/cron_journal.py
@@ -1,0 +1,72 @@
+"""CronJournalReconcileWorkflow — journal Hermes cron outbounds (#418).
+
+Scheduled every 6 hours (``al-cron-journal-reconcile``).  Thin wrapper:
+checks the feature flag at invocation time, then calls the ctrl-api
+reconcile endpoint via the ``reconcile_cron_journal`` activity.
+
+Interval arithmetic
+-------------------
+Window: 48 h.  Cap: 50 sessions/call.
+
+Hermes cron jobs with a ``deliver`` field (the only kind journaled) are
+configured by Sir for outbound chores: daily briefings, weekly digests,
+etc.  A busy tenant has at most ~5 such jobs.  At 6-hour intervals that
+is ~1.25 sessions/interval — well under the 50-session cap.  A session
+fired just after one run waits at most 6 h before the next run picks it
+up, leaving 42 h of the 48-hour window to spare.  The cap would only be
+exceeded if 50+ cron sessions fired in the same 6-hour window, which is
+structurally impossible on any real tenant at present cadences.
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+with workflow.unsafe.imports_passed_through():
+    from src.activities.cron_journal import (
+        cron_journal_reconcile_is_enabled,
+        reconcile_cron_journal,
+    )
+
+
+@workflow.defn(name="CronJournalReconcileWorkflow")
+class CronJournalReconcileWorkflow:
+    """Invoke the cron-journal reconciler on a 6-hour schedule.
+
+    Checks CRON_JOURNAL_RECONCILE_ENABLED at invocation time so flipping
+    the flag off does not require a container restart to re-run
+    register_schedules (same pattern as ReversalCalibrationWorkflow).
+
+    Never wedges — ``reconcile_cron_journal`` catches all ctrl-api
+    failures and returns a dict rather than raising.
+    """
+
+    @workflow.run
+    async def run(self) -> dict:
+        workflow.logger.info("cron_journal_reconcile.start")
+
+        enabled: bool = await workflow.execute_activity(
+            cron_journal_reconcile_is_enabled,
+            start_to_close_timeout=timedelta(seconds=5),
+            retry_policy=RetryPolicy(maximum_attempts=1),
+        )
+        if not enabled:
+            workflow.logger.info(
+                "cron_journal_reconcile: flag off — skipping"
+            )
+            return {"skipped": True, "reason": "flag_off"}
+
+        result: dict = await workflow.execute_activity(
+            reconcile_cron_journal,
+            start_to_close_timeout=timedelta(minutes=2),
+            retry_policy=RetryPolicy(
+                maximum_attempts=2,
+                initial_interval=timedelta(seconds=5),
+                backoff_coefficient=2.0,
+                maximum_interval=timedelta(seconds=30),
+            ),
+        )
+        workflow.logger.info("cron_journal_reconcile.done result=%s", result)
+        return result

--- a/packages/learn/tests/test_cron_journal.py
+++ b/packages/learn/tests/test_cron_journal.py
@@ -1,0 +1,201 @@
+"""Tests for the cron-journal reconciler (#418).
+
+Covers:
+* Activity posts to the correct ctrl-api route.
+* ctrl-api errors are classified and returned (never raise into Temporal retry).
+* Feature flag defaults OFF; truthy values enable.
+* Registration-time flag controls schedule creation vs deletion.
+* Chosen interval is 6 hours (window=48h, cap=50 sessions/call).
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from temporalio.testing import ActivityEnvironment
+
+from src.activities.cron_journal import (
+    _flag_on,
+    cron_journal_reconcile_is_enabled,
+    reconcile_cron_journal,
+)
+from scripts.register_schedules import (
+    CRON_JOURNAL_RECONCILE_INTERVAL,
+    CRON_JOURNAL_RECONCILE_SCHEDULE_ID,
+    CRON_JOURNAL_RECONCILE_WORKFLOW,
+    _cron_journal_reconcile_enabled,
+)
+
+_ENDPOINT = "/api/v1/alfred-journal/reconcile-cron"
+
+
+# ---------------------------------------------------------------------------
+# Shared mock helpers
+# ---------------------------------------------------------------------------
+
+def _make_resp(status_code: int, json_body: dict | None = None) -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = json_body or {}
+    if status_code >= 400:
+        req = httpx.Request("POST", f"http://ctrl-api:3100{_ENDPOINT}")
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            f"HTTP {status_code}", request=req, response=resp
+        )
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+def _make_http_mock(status_code: int = 200, json_body: dict | None = None) -> tuple[Any, MagicMock]:
+    mock_http = AsyncMock()
+    mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+    mock_http.__aexit__ = AsyncMock(return_value=False)
+    mock_http.post = AsyncMock(return_value=_make_resp(status_code, json_body))
+    mock_cls = MagicMock(return_value=mock_http)
+    return mock_cls, mock_http
+
+
+# ---------------------------------------------------------------------------
+# Feature flag
+# ---------------------------------------------------------------------------
+
+class TestFeatureFlag:
+    def test_defaults_off(self, monkeypatch):
+        monkeypatch.delenv("CRON_JOURNAL_RECONCILE_ENABLED", raising=False)
+        assert _flag_on() is False
+
+    def test_true_enables(self, monkeypatch):
+        monkeypatch.setenv("CRON_JOURNAL_RECONCILE_ENABLED", "true")
+        assert _flag_on() is True
+
+    def test_one_enables(self, monkeypatch):
+        monkeypatch.setenv("CRON_JOURNAL_RECONCILE_ENABLED", "1")
+        assert _flag_on() is True
+
+    def test_false_stays_off(self, monkeypatch):
+        monkeypatch.setenv("CRON_JOURNAL_RECONCILE_ENABLED", "false")
+        assert _flag_on() is False
+
+    async def test_is_enabled_activity_false_by_default(self, monkeypatch):
+        monkeypatch.delenv("CRON_JOURNAL_RECONCILE_ENABLED", raising=False)
+        env = ActivityEnvironment()
+        assert await env.run(cron_journal_reconcile_is_enabled) is False
+
+    async def test_is_enabled_activity_true_when_set(self, monkeypatch):
+        monkeypatch.setenv("CRON_JOURNAL_RECONCILE_ENABLED", "true")
+        env = ActivityEnvironment()
+        assert await env.run(cron_journal_reconcile_is_enabled) is True
+
+
+# ---------------------------------------------------------------------------
+# Activity: posts to the right route
+# ---------------------------------------------------------------------------
+
+class TestReconcileCronJournalRoute:
+    async def test_posts_to_reconcile_cron_endpoint(self, monkeypatch):
+        """Activity must POST to /api/v1/alfred-journal/reconcile-cron."""
+        monkeypatch.setenv("ALFRED_CTRL_URL", "http://ctrl-api:3100")
+        monkeypatch.setenv("AAS_API_KEY", "test-key")
+
+        http_cls, http_mock = _make_http_mock(200, {"journaled": 3, "skipped": 0})
+
+        env = ActivityEnvironment()
+        with patch("src.activities.cron_journal.httpx.AsyncClient", http_cls):
+            result = await env.run(reconcile_cron_journal)
+
+        http_mock.post.assert_called_once_with(_ENDPOINT)
+        assert result == {"journaled": 3, "skipped": 0}
+
+    async def test_sends_bearer_auth(self, monkeypatch):
+        """AsyncClient must be initialised with Authorization header."""
+        monkeypatch.setenv("ALFRED_CTRL_URL", "http://ctrl-api:3100")
+        monkeypatch.setenv("AAS_API_KEY", "my-secret-key")
+
+        http_cls, _ = _make_http_mock(200, {})
+
+        env = ActivityEnvironment()
+        with patch("src.activities.cron_journal.httpx.AsyncClient", http_cls):
+            await env.run(reconcile_cron_journal)
+
+        call_kwargs = http_cls.call_args.kwargs
+        assert call_kwargs.get("headers", {}).get("Authorization") == "Bearer my-secret-key"
+
+
+# ---------------------------------------------------------------------------
+# Activity: ctrl-api errors are logged and returned, not raised
+# ---------------------------------------------------------------------------
+
+class TestReconcileCronJournalErrors:
+    async def test_http_500_returns_error_dict(self, monkeypatch):
+        """Transient server error must be logged and returned, not raised."""
+        monkeypatch.setenv("ALFRED_CTRL_URL", "http://ctrl-api:3100")
+        monkeypatch.setenv("AAS_API_KEY", "k")
+
+        http_cls, _ = _make_http_mock(500)
+        env = ActivityEnvironment()
+        with patch("src.activities.cron_journal.httpx.AsyncClient", http_cls):
+            result = await env.run(reconcile_cron_journal)
+
+        assert result.get("ok") is False
+        assert "error" in result
+
+    async def test_http_422_returns_error_dict(self, monkeypatch):
+        """Permanent HTTP error (422) must also be logged and returned."""
+        monkeypatch.setenv("ALFRED_CTRL_URL", "http://ctrl-api:3100")
+        monkeypatch.setenv("AAS_API_KEY", "k")
+
+        http_cls, _ = _make_http_mock(422)
+        env = ActivityEnvironment()
+        with patch("src.activities.cron_journal.httpx.AsyncClient", http_cls):
+            result = await env.run(reconcile_cron_journal)
+
+        assert result.get("ok") is False
+
+    async def test_connect_error_returns_error_dict(self, monkeypatch):
+        """Network-level failure must be logged and returned, not raised."""
+        monkeypatch.setenv("ALFRED_CTRL_URL", "http://ctrl-api:3100")
+        monkeypatch.setenv("AAS_API_KEY", "k")
+
+        mock_http = AsyncMock()
+        mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+        mock_http.__aexit__ = AsyncMock(return_value=False)
+        mock_http.post = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        http_cls = MagicMock(return_value=mock_http)
+
+        env = ActivityEnvironment()
+        with patch("src.activities.cron_journal.httpx.AsyncClient", http_cls):
+            result = await env.run(reconcile_cron_journal)
+
+        assert result.get("ok") is False
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# Schedule constants
+# ---------------------------------------------------------------------------
+
+class TestScheduleConstants:
+    def test_interval_is_six_hours(self):
+        """6-hour interval fits the endpoint constraints.
+
+        Window=48h: a session missed just after one run waits ≤6h,
+        leaving ≥42h of the window for the next pick-up.
+        Cap=50/call: a busy tenant has ~5 deliver jobs → ~1.25/interval,
+        far below the 50-session cap.
+        """
+        assert CRON_JOURNAL_RECONCILE_INTERVAL == timedelta(hours=6)
+
+    def test_schedule_id(self):
+        assert CRON_JOURNAL_RECONCILE_SCHEDULE_ID == "al-cron-journal-reconcile"
+
+    def test_workflow_name(self):
+        assert CRON_JOURNAL_RECONCILE_WORKFLOW == "CronJournalReconcileWorkflow"
+
+    def test_registrar_flag_defaults_off(self, monkeypatch):
+        """Registration-time flag must also default OFF."""
+        monkeypatch.delenv("CRON_JOURNAL_RECONCILE_ENABLED", raising=False)
+        assert _cron_journal_reconcile_enabled() is False


### PR DESCRIPTION
## Summary

- Builds the Temporal half of GH #418. PR #556 merged `POST /api/v1/alfred-journal/reconcile-cron` (ctrl-api) but nothing ever called it. This PR adds the scheduled caller.
- `CronJournalReconcileWorkflow` runs every 6 hours, checks `CRON_JOURNAL_RECONCILE_ENABLED` at invocation time (default OFF), then calls the endpoint via `reconcile_cron_journal` activity.
- On any ctrl-api failure (HTTP error or network) the activity logs with `classify_status` and returns `{"ok": False, ...}` — it never raises, so Temporal never enters an unbounded retry loop.

## Interval arithmetic (window=48h, cap=50 sessions/call)

A busy tenant has at most ~5 Hermes cron jobs with a `deliver` field (daily briefings, weekly digests, etc.). At a 6-hour interval that is ~1.25 sessions/interval — far under the 50-session cap. A session fired just after one run waits at most 6 h before the next pick-up, leaving 42 h of the 48-hour window. The cap would only be exceeded if 50+ cron sessions fired in the same 6-hour window, which is structurally impossible at current tenant cadences.

## Feature flag

`CRON_JOURNAL_RECONCILE_ENABLED` (default OFF). The lesson from `FLEET_AUDIT_ENABLED` defaulting ON and running silently on client tenants for weeks. Set `"true"`, `"1"`, or `"yes"` in the env to enable.

## Files touched

- `packages/learn/src/activities/cron_journal.py` — NEW: `cron_journal_reconcile_is_enabled`, `reconcile_cron_journal`
- `packages/learn/src/workflows/cron_journal.py` — NEW: `CronJournalReconcileWorkflow`
- `packages/learn/src/worker.py` — registered workflow + activities
- `packages/learn/scripts/register_schedules.py` — `register_cron_journal_reconcile` + `register_all()` call
- `packages/learn/tests/test_cron_journal.py` — NEW: 15 tests

## Smoke evidence

```
$ cd packages/learn && python3 -m pytest tests/test_cron_journal.py -v
============================= test session starts ==============================
platform darwin -- Python 3.14.4, pytest-9.0.3, pluggy-1.6.0
asyncio: mode=Mode.AUTO
collected 15 items

tests/test_cron_journal.py::TestFeatureFlag::test_defaults_off PASSED
tests/test_cron_journal.py::TestFeatureFlag::test_true_enables PASSED
tests/test_cron_journal.py::TestFeatureFlag::test_one_enables PASSED
tests/test_cron_journal.py::TestFeatureFlag::test_false_stays_off PASSED
tests/test_cron_journal.py::TestFeatureFlag::test_is_enabled_activity_false_by_default PASSED
tests/test_cron_journal.py::TestFeatureFlag::test_is_enabled_activity_true_when_set PASSED
tests/test_cron_journal.py::TestReconcileCronJournalRoute::test_posts_to_reconcile_cron_endpoint PASSED
tests/test_cron_journal.py::TestReconcileCronJournalRoute::test_sends_bearer_auth PASSED
tests/test_cron_journal.py::TestReconcileCronJournalErrors::test_http_500_returns_error_dict PASSED
tests/test_cron_journal.py::TestReconcileCronJournalErrors::test_http_422_returns_error_dict PASSED
tests/test_cron_journal.py::TestReconcileCronJournalErrors::test_connect_error_returns_error_dict PASSED
tests/test_cron_journal.py::TestScheduleConstants::test_interval_is_six_hours PASSED
tests/test_cron_journal.py::TestScheduleConstants::test_schedule_id PASSED
tests/test_cron_journal.py::TestScheduleConstants::test_workflow_name PASSED
tests/test_cron_journal.py::TestScheduleConstants::test_registrar_flag_defaults_off PASSED

============================== 15 passed in 0.23s ==============================

Full suite: 2690 passed, 101 skipped in 22.52s

Lane gate: ✓ lane II (learn) gate passed — 419 LOC, 5 files, verify ok
```

References #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)