### PR TITLE
docs(contracts): fleet audit OFF by default; record the cron-journal reconciler

### DIFF
--- a/packages/ctrl/CONTRACT.md
+++ b/packages/ctrl/CONTRACT.md
@@ -70,7 +70,7 @@ One row per module in `src/api/routes/` (complete index = the `register*` import
 | `notifications.ts` | `/api/v1/notifications` | Outbound notify via the Hermes main gateway |
 | `context.ts` | `/api/v1/context/cross-channel` | Cross-channel context assembly |
 | `crossTenant.ts` | `/api/v1/cross-tenant/*` | Peer-tenant ask (Bearer = peer apiKey; no X-Tenant-ID) |
-| `alfredJournal.ts` | `/api/v1/alfred-journal*` | One-Alfred continuity journal + principal binding (migration `0002`) |
+| `alfredJournal.ts` | `/api/v1/alfred-journal*` | One-Alfred continuity journal + principal binding (migration `0002`). `POST /api/v1/alfred-journal/reconcile-cron` reads Hermes' session store **read-only** and journals cron-fired (`--deliver`) outbounds that never pass through ctrl; `source_kind='cron'`, idempotent on `hermes_session_id`, 48h window, 50 sessions/call, no backfill. |
 | `alfredDeliver.ts` | `/api/v1/alfred-deliver`, `/api/v1/delegate-outcomes` | Unified outbound delivery + delegate-outcome ingestion |
 | `email.ts` | `/api/v1/email/*` | AgentMail-backed email ops (send/reply/forward/thread/message/attachment) |
 | `channelsEmail.ts` | `/api/v1/channels/email/*` | Email channel card: status/provision/test + the AgentMail inbound webhook |

--- a/packages/learn/CONTRACT.md
+++ b/packages/learn/CONTRACT.md
@@ -127,7 +127,8 @@ succeeded), `recreate_missing_chore_schedules` (F34b).
 | `NightlyMaintenanceWorkflow` | `al-nightly-maintenance` daily 03:00 local | Janitor scan-and-fix + distiller batch. |
 | `FilesColdArchiveWorkflow` | `al-files-cold-archive` daily 03:00 local | Promote ≥90 d-unaccessed file blobs via ctrl-api `POST /api/v1/files/cold-promote/:file_id`. |
 | `ComposioReconnectCleanupWorkflow` | `al-composio-reconnect-cleanup` every 15 min | Safety-net reaper for ctrl-api's persistent reconnect ledger (#645). |
-| `FleetAuditWorkflow` | `al-fleet-audit` daily 02:00 **UTC** — gate `FLEET_AUDIT_ENABLED` (**default ON**) | Wrong-tenant stream contamination check. |
+| `FleetAuditWorkflow` | `al-fleet-audit` daily 02:00 **UTC** — gate `FLEET_AUDIT_ENABLED` (**default OFF**) | Wrong-tenant stream contamination check. Operator diagnostic: the dev tenant opts in explicitly; client tenants must never run it. Findings go to `alfred-state.db` via `POST /api/v1/state/observations` (they were written to the vault until 2026-08-12, which rejects `observation` with 422 — every one was discarded). |
+| `CronJournalReconcileWorkflow` | `al-cron-journal-reconcile` every 6h — gate `CRON_JOURNAL_RECONCILE_ENABLED` (**default OFF**) | Calls `POST /api/v1/alfred-journal/reconcile-cron` so Hermes-native cron outbounds land in `alfred_journal`. Read-side only; idempotent on `hermes_session_id`. |
 
 **#316 target (Lane II; not implemented at this phase-0 head).** Current
 `src/activities/maintenance.py` awaits a synchronous janitor scan, then awaits a
@@ -308,7 +309,8 @@ restart to re-run `register_schedules`)**:
 | `STEWARD_REVERSAL_CALIBRATION_ENABLED` | OFF | `al-reversal-calibration` (+ invocation-time re-check) |
 | `VEXA_ENABLED` | OFF | `al-meeting-capture`, `al-transcript-intake` |
 | `PLANE_SYNC_ENABLED` | OFF — **dormant, not deployed (PR #279)** | the three `al-plane-*` schedules |
-| `FLEET_AUDIT_ENABLED` | ON | `al-fleet-audit` |
+| `FLEET_AUDIT_ENABLED` | OFF | `al-fleet-audit` |
+| `CRON_JOURNAL_RECONCILE_ENABLED` | OFF | `al-cron-journal-reconcile` |
 
 **Mode overrides (invocation-time emergency env — see Invariants for
 precedence)**: `STEWARD_SIGNAL_ACTION_LIVE_MODE`, `STEWARD_LIVE_MODE`,


### PR DESCRIPTION
Forbidden-zone amendments the lanes could not make themselves.

## `packages/learn/CONTRACT.md`

**`FLEET_AUDIT_ENABLED` flipped ON → OFF** (#553). The contract asserted `ON`, and it was right about the old code — which is exactly how five client tenants ended up running an operator diagnostic on a daily schedule for weeks. Now documented as opt-in, dev tenant only.

The same row also records that findings go to `alfred-state.db` via `POST /api/v1/state/observations`. They were written to the vault until 2026-08-12; the promotion contract rejects `observation` with 422, so **every fleet-audit observation produced before that date was discarded.**

**`CronJournalReconcileWorkflow` added** (#557) — `al-cron-journal-reconcile`, every 6h, gate `CRON_JOURNAL_RECONCILE_ENABLED`, default OFF.

## `packages/ctrl/CONTRACT.md`

The `alfredJournal.ts` row now names `POST /api/v1/alfred-journal/reconcile-cron` (#556) with its actual constraints: read-only against Hermes' session store, `source_kind='cron'`, idempotent on `hermes_session_id`, 48-hour window, 50 sessions per call, no backfill.

## Why bother

A contract that documents the opposite of the code is worse than no contract — it is the thing the next person trusts *before* they read the source. The `ON` on that fleet-audit line was accurate when written and quietly became a lie, and nothing would have caught it.

## Smoke evidence

```
$ grep -nE "FLEET_AUDIT_ENABLED|CRON_JOURNAL_RECONCILE_ENABLED" packages/learn/CONTRACT.md
130: ... FLEET_AUDIT_ENABLED` (**default OFF**) ...
131: | `CronJournalReconcileWorkflow` | `al-cron-journal-reconcile` every 6h ... (**default OFF**) |
312: | `FLEET_AUDIT_ENABLED` | OFF | `al-fleet-audit` |
313: | `CRON_JOURNAL_RECONCILE_ENABLED` | OFF | `al-cron-journal-reconcile` |

$ git commit
✓ lane phase0 (orchestrator) gate passed
```

Docs only — no code, no behaviour change.