### PR TITLE
feat(learn): batch Desk reversal — re-opens all source cards when bulk_triage decision reversed

### DIFF
--- a/packages/learn/src/activities/decision_router.py
+++ b/packages/learn/src/activities/decision_router.py
@@ -1481,6 +1481,101 @@ async def reverse_decision(decision: dict[str, Any]) -> dict[str, Any]:
     source_record = str(decision.get("source_record") or "")
     side_effects = decision.get("side_effects") or {}
 
+    # ----------------------------------------------------------------
+    # Batch reversal path — bulk_triage decisions (#554 forward pass)
+    # ----------------------------------------------------------------
+    # A bulk decision carries side_effects.source_records: the list of
+    # all individual card paths resolved in the forward pass. Re-open
+    # each card; skip deleted ones rather than aborting the batch.
+    # Writes exactly one audit row. Returns early so the single-card
+    # path below runs unchanged.
+    _batch_records: list[Any] | None = None
+    if isinstance(side_effects, dict):
+        _cand = side_effects.get("source_records")
+        if isinstance(_cand, list) and _cand:
+            _batch_records = _cand
+
+    if _batch_records is not None:
+        async with _http() as client:
+            _reopened: list[str] = []
+            _skipped: list[dict[str, Any]] = []
+            for _path in _batch_records:
+                if not isinstance(_path, str) or not _path.startswith("needs_attention/"):
+                    _skipped.append({"path": str(_path), "reason": "unrecognised_path"})
+                    continue
+                _na_id = _path.removeprefix("needs_attention/").removesuffix(".md")
+                try:
+                    _pr = await client.patch(
+                        f"/api/v1/vault/records/needs_attention/{_na_id}.md",
+                        json={"set": {"status": "pending", "resolved_at": "", "resolution_note": ""}},
+                    )
+                    if _pr.status_code == 404:
+                        _skipped.append({"path": _path, "reason": "not_found"})
+                    elif _pr.status_code < 400:
+                        _reopened.append(_path)
+                    else:
+                        _skipped.append({"path": _path, "reason": f"http_{_pr.status_code}"})
+                except Exception as _exc:  # noqa: BLE001
+                    _skipped.append({"path": _path, "reason": str(_exc)[:200]})
+
+            # One audit row for the whole batch — best-effort.
+            try:
+                await client.post(
+                    "/api/v1/state/audit",
+                    json={
+                        "action_type": "state-change",
+                        "actor": "decision_router",
+                        "source": "decision_router.batch_reversal",
+                        "target_path": f"decision/{decision_id}.md",
+                        "target_kind": "decision",
+                        "summary": (
+                            f"batch reversal: reopened {len(_reopened)} of "
+                            f"{len(_batch_records)} cards, skipped {len(_skipped)}"
+                        ),
+                        "changes": {
+                            "total": len(_batch_records),
+                            "reopened": len(_reopened),
+                            "skipped": len(_skipped),
+                            "skipped_details": _skipped[:20],
+                        },
+                        "mode": "live",
+                    },
+                )
+            except Exception as _exc:  # noqa: BLE001
+                logger.warning(
+                    "decision_router.reverse_decision: batch audit POST failed "
+                    "decision=%s err=%s",
+                    decision_id, _exc,
+                )
+
+            # Stamp reversal_processed so the workflow skips this decision
+            # on subsequent ticks (idempotency at the workflow level).
+            _bse = dict(side_effects)
+            _bse["reversal_processed"] = True
+            _bse["reversal_undone"] = [f"batch.reopened_{len(_reopened)}"]
+            _bse["batch_reversal_reopened"] = len(_reopened)
+            _bse["batch_reversal_skipped"] = len(_skipped)
+            if _skipped:
+                _bse["batch_reversal_skipped_details"] = _skipped[:20]
+            await client.patch(
+                f"/api/v1/decisions/{decision_id}",
+                json={"side_effects": _bse},
+            )
+
+        logger.info(
+            "decision_router: batch reversal decision=%s reopened=%d skipped=%d",
+            decision_id, len(_reopened), len(_skipped),
+        )
+        return {
+            "id": decision_id,
+            "actions_undone": [f"batch.reopened_{len(_reopened)}"],
+            "batch_reversal": {
+                "total": len(_batch_records),
+                "reopened": len(_reopened),
+                "skipped": len(_skipped),
+            },
+        }
+
     actions_undone: list[str] = []
     async with _http() as client:
         # needs_attention reversal: PATCH the source record's status

--- a/packages/learn/tests/test_decision_router_batch_reversal.py
+++ b/packages/learn/tests/test_decision_router_batch_reversal.py
@@ -1,0 +1,102 @@
+"""Batch reversal of bulk_triage decisions — five requirements tested."""
+from __future__ import annotations
+import asyncio
+from typing import Any
+import httpx
+import src.activities.decision_router as dr
+
+
+class _R:
+    def __init__(self, code: int = 200) -> None:
+        self.status_code = code
+    def json(self) -> dict:
+        return {}
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("e", request=httpx.Request("G","http://t"), response=httpx.Response(self.status_code))
+
+
+class _FC:
+    def __init__(self, card_404s: set[str] | None = None) -> None:
+        self.calls: list[tuple[str, str, Any]] = []
+        self._404s = card_404s or set()
+    async def __aenter__(self): return self
+    async def __aexit__(self, *a): pass
+    async def get(self, u, **_): return _R(404)
+    async def post(self, u, **k):
+        self.calls.append(("POST", u, k.get("json")))
+        return _R()
+    async def patch(self, u, **k):
+        self.calls.append(("PATCH", u, k.get("json")))
+        for na in self._404s:
+            if na in u:
+                return _R(404)
+        return _R()
+    def card_patches(self): return [u for m,u,_ in self.calls if m=="PATCH" and "needs_attention" in u]
+    def decision_patches(self): return [b for m,u,b in self.calls if m=="PATCH" and "decisions/" in u]
+    def audit_posts(self): return [b for m,u,b in self.calls if m=="POST" and "state/audit" in u]
+
+
+class _Cfg:
+    alfred_ctrl_url = "http://ctrl-test:3100"
+
+
+def _install(monkeypatch, card_404s=None):
+    fc = _FC(card_404s)
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **k: fc)
+    import src.config as c; monkeypatch.setattr(c, "load_config", lambda: _Cfg())
+    monkeypatch.setenv("AAS_API_KEY", "k")
+    return fc
+
+
+def _bd(cards, extra_se=None):
+    return {"id": "b-001", "intent": "done", "source": "needs_attention",
+            "source_record": "", "decision_origin": "bulk_triage", "state": "reversed",
+            "side_effects": {"source_records": cards, **(extra_se or {})}}
+
+
+def test_reopens_all_cards(monkeypatch):
+    fc = _install(monkeypatch)
+    cards = ["needs_attention/a.md", "needs_attention/b.md", "needs_attention/c.md"]
+    r = asyncio.run(dr.reverse_decision(_bd(cards)))
+    assert r["batch_reversal"]["reopened"] == 3
+    assert r["batch_reversal"]["skipped"] == 0
+    assert len(fc.card_patches()) == 3
+
+
+def test_stamps_reversal_processed(monkeypatch):
+    fc = _install(monkeypatch)
+    asyncio.run(dr.reverse_decision(_bd(["needs_attention/x.md"])))
+    stamped = any(
+        isinstance(b, dict) and b.get("side_effects", {}).get("reversal_processed") is True
+        for b in fc.decision_patches()
+    )
+    assert stamped, f"reversal_processed not stamped; patches={fc.decision_patches()}"
+
+
+def test_skips_missing_card(monkeypatch):
+    fc = _install(monkeypatch, card_404s={"card-gone"})
+    r = asyncio.run(dr.reverse_decision(_bd(["needs_attention/card-gone.md", "needs_attention/card-ok.md"])))
+    assert r["batch_reversal"]["reopened"] == 1
+    assert r["batch_reversal"]["skipped"] == 1
+    se = next(b["side_effects"] for b in fc.decision_patches() if isinstance(b, dict) and "batch_reversal_skipped" in (b.get("side_effects") or {}))
+    assert se["batch_reversal_skipped_details"][0]["reason"] == "not_found"
+
+
+def test_writes_exactly_one_audit_row(monkeypatch):
+    fc = _install(monkeypatch)
+    asyncio.run(dr.reverse_decision(_bd(["needs_attention/a.md", "needs_attention/b.md"])))
+    assert len(fc.audit_posts()) == 1
+    a = fc.audit_posts()[0]
+    assert a["source"] == "decision_router.batch_reversal"
+    assert a["changes"]["total"] == 2 and a["changes"]["reopened"] == 2
+
+
+def test_single_card_path_unchanged(monkeypatch):
+    fc = _install(monkeypatch)
+    r = asyncio.run(dr.reverse_decision({
+        "id": "s-001", "intent": "done", "source": "needs_attention",
+        "source_record": "needs_attention/solo.md", "state": "reversed", "side_effects": {},
+    }))
+    assert "batch_reversal" not in r
+    assert any("solo" in u for u in fc.card_patches())


### PR DESCRIPTION
## Summary

- `reverse_decision` (`packages/learn/src/activities/decision_router.py`) now handles decisions where `side_effects.source_records` is a non-empty list (written by the `#554` bulk endpoint's forward pass).
- Each listed `needs_attention/` card is PATCHed back to `status: pending`. Cards returning 404 are skipped with a reason; the rest of the batch completes.
- Exactly one audit row (`source: decision_router.batch_reversal`) is written for the whole reversal — not N rows.
- `reversal_processed: true` is stamped on the decision after the batch completes, so subsequent 60-second router ticks are no-ops.
- The existing single-card reversal path is untouched (guarded by the presence/absence of `source_records`).

## Idempotency key

`side_effects.reversal_processed = true` — the workflow's Pass 2 already checks this flag before calling `reverse_decision`. Once stamped after the batch completes, the decision is never re-processed.

## Partial failure reporting

Per-card errors are caught individually. A 404 is recorded as `{"path": ..., "reason": "not_found"}`; HTTP errors as `http_<code>`; exceptions as the first 200 chars of the exception string. The counts and first 20 skipped details are stored in `side_effects.batch_reversal_skipped_details`. The audit row's `changes.skipped_details` carries the same list.

## Single-card path

Confirmed untouched: `test_single_card_path_unchanged` passes — a decision with no `source_records` in its `side_effects` flows through the original `needs_attention` reopen branch without change.

## Flag flip for Lane I

`is_reversible` is now safe to set `true` for `bulk_triage` decisions. The value is set in:

**`packages/ctrl/src/api/routes/attention.ts`** — search for `is_reversible: false` in the bulk handler added by #554. Flip that one boolean. No other ctrl-api changes needed.

## Smoke evidence

```
platform darwin -- Python 3.14.4, pytest-9.0.3, pluggy-1.6.0
collected 2700 items / 4 deselected / 2696 selected

tests/test_decision_router_batch_reversal.py::test_reopens_all_cards PASSED
tests/test_decision_router_batch_reversal.py::test_stamps_reversal_processed PASSED
tests/test_decision_router_batch_reversal.py::test_skips_missing_card PASSED
tests/test_decision_router_batch_reversal.py::test_writes_exactly_one_audit_row PASSED
tests/test_decision_router_batch_reversal.py::test_single_card_path_unchanged PASSED
2695 passed, 101 skipped in 25.24s

✓ lane II (learn) gate passed — 197 LOC, 2 files, verify ok
```

## Files touched

- `packages/learn/src/activities/decision_router.py` — batch reversal branch in `reverse_decision` (+95 lines)
- `packages/learn/tests/test_decision_router_batch_reversal.py` — 5 tests (+102 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc