### PR TITLE
feat(web): Desk bulk triage panel — select, preview, apply to NA backlog (#542)

### DIFF
--- a/packages/web/main.wasp
+++ b/packages/web/main.wasp
@@ -2008,6 +2008,11 @@ action recordDecision {
   entities: []
 }
 
+action bulkTriageNeedsAttention {
+  fn: import { bulkTriageNeedsAttention } from "@src/dashboard/operations",
+  entities: []
+}
+
 query getRecentDecisions {
   fn: import { getRecentDecisions } from "@src/dashboard/operations",
   entities: []

--- a/packages/web/src/dashboard/DeskPage.tsx
+++ b/packages/web/src/dashboard/DeskPage.tsx
@@ -45,7 +45,12 @@ import {
   getBriefing,
   getLastDismissedBriefing,
   dismissBriefing,
+  bulkTriageNeedsAttention,
 } from "wasp/client/operations";
+import {
+  addToSelection, removeFromSelection, clearSelection, selectAll,
+  canSubmit, mapPreviewResponse, type BulkIntent, type BulkPreviewResult,
+} from "./deskBulkTriageCore";
 import { Frame } from "../client/components/ab/Frame";
 import { Seal } from "../client/components/ab/Seal";
 import { PageOverture } from "../client/components/ab/PageOverture";
@@ -327,6 +332,30 @@ function DeskContent() {
     !!latestBriefSlugDate && latestBriefSlugDate !== dismissedSlugDate;
   const dismissBriefingAction = useAction(dismissBriefing);
   const [briefExpanded, setBriefExpanded] = useState(false);
+
+  // Bulk triage (#542)
+  const bulkAction = useAction(bulkTriageNeedsAttention);
+  const [bulkSel, setBulkSel] = useState<ReadonlySet<string>>(new Set());
+  const [bulkIntent, setBulkIntent] = useState<BulkIntent | null>(null);
+  const [bulkPreview, setBulkPreview] = useState<BulkPreviewResult | null>(null);
+  const [bulkBusy, setBulkBusy] = useState(false);
+  async function runBulkPreview() {
+    if (!canSubmit(bulkSel) || !bulkIntent) return;
+    setBulkBusy(true);
+    try { setBulkPreview(mapPreviewResponse(await bulkAction({ ids: [...bulkSel], intent: bulkIntent, dry_run: true }))); }
+    catch (e) { toast({ title: "Preview failed", description: String((e as any)?.message ?? e) }); }
+    finally { setBulkBusy(false); }
+  }
+  async function runBulkApply() {
+    if (!bulkPreview || !bulkIntent || bulkBusy) return;
+    setBulkBusy(true);
+    try {
+      await bulkAction({ ids: [...bulkSel], intent: bulkIntent, dry_run: false });
+      setHandled((h: string[]) => [...h, ...[...bulkSel].map((id) => `na:${id}`)]);
+      setBulkSel(new Set()); setBulkIntent(null); setBulkPreview(null);
+    } catch (e) { toast({ title: "Bulk apply failed", description: String((e as any)?.message ?? e) }); }
+    finally { setBulkBusy(false); }
+  }
 
   const decisions: Decision[] = useMemo(() => {
     const out: Decision[] = [];
@@ -923,6 +952,61 @@ function DeskContent() {
           animate="show"
           variants={stagger(0.05, 0.08)}
         >
+          {/* Bulk triage panel (#542) — needs_attention items only. */}
+          {(() => {
+            const naItems = [...rest, ...restAging, ...restStale].filter(d => d.source === "needs_attention");
+            if (naItems.length === 0) return null;
+            const naIds = naItems.map(d => d.recordId);
+            const tog = (id: string) => setBulkSel(s => s.has(id) ? removeFromSelection(s, id) : addToSelection(s, id));
+            return (
+              <motion.div variants={fadeUp} className="mb-20 border border-rule p-6">
+                <div className="flex items-baseline justify-between mb-3">
+                  <span className="font-mono text-[11px] uppercase tracking-[0.28em]" style={{ color: "var(--brass)" }}>
+                    Bulk triage — {bulkSel.size} of {naItems.length} selected
+                  </span>
+                  <div className="flex gap-4">
+                    <button className="btn-link text-[12px]" onClick={() => { setBulkSel(selectAll(naIds)); setBulkPreview(null); }}>Select all</button>
+                    <button className="btn-link text-[12px]" onClick={() => { setBulkSel(clearSelection()); setBulkPreview(null); }}>Clear</button>
+                  </div>
+                </div>
+                <div className="space-y-1 mb-4 max-h-40 overflow-y-auto">
+                  {naItems.map(d => (
+                    <label key={d.id} className="flex items-center gap-3 py-1 cursor-pointer">
+                      <input type="checkbox" checked={bulkSel.has(d.recordId)} onChange={() => { tog(d.recordId); setBulkPreview(null); }} />
+                      <span className="font-body text-[14px]" style={{ color: "var(--ink)" }}>{d.headline}</span>
+                    </label>
+                  ))}
+                </div>
+                {canSubmit(bulkSel) && (<div>
+                  <div className="flex gap-4 items-baseline mb-3">
+                    {(["done", "defer", "noise"] as BulkIntent[]).map(v => (
+                      <button key={v} className={bulkIntent === v ? "btn-brass" : "btn-link"} style={{ fontSize: "0.9rem" }}
+                        onClick={() => { setBulkIntent(v); setBulkPreview(null); }}>
+                        {v === "done" ? "Done" : v === "defer" ? "Defer" : "Noise"}
+                      </button>
+                    ))}
+                  </div>
+                  {bulkIntent && !bulkPreview && <button onClick={runBulkPreview} disabled={bulkBusy} className="btn-brass">{bulkBusy ? "…" : "Preview batch"}</button>}
+                  {bulkPreview && (
+                    <div className="mt-3 border-t border-rule pt-3">
+                      <p className="font-mono text-[12px] mb-2">{bulkPreview.would_apply} will apply · {bulkPreview.would_skip} skipped</p>
+                      {bulkPreview.noise_warning && (
+                        <p className="font-body text-[14px] mb-2 p-2 border border-rule" style={{ color: "var(--brass)" }}>{bulkPreview.noise_warning}</p>
+                      )}
+                      {bulkPreview.reversal_note && (
+                        <p className="font-body italic text-[13px] mb-3" style={{ color: "var(--marginalia)" }}>{bulkPreview.reversal_note}</p>
+                      )}
+                      <div className="flex gap-4 items-baseline">
+                        <button onClick={runBulkApply} disabled={bulkBusy} className="btn-brass">{bulkBusy ? "…" : `Apply to ${bulkSel.size}`}</button>
+                        <button onClick={() => { setBulkPreview(null); setBulkIntent(null); }} className="btn-link" disabled={bulkBusy}>Cancel</button>
+                      </div>
+                    </div>
+                  )}
+                </div>)}
+              </motion.div>
+            );
+          })()}
+
           {rest.length > 0 && (
             <motion.div variants={fadeUp} className="mb-20">
               <SectionHead title="Also in the queue" />

--- a/packages/web/src/dashboard/deskBulkTriageCore.test.ts
+++ b/packages/web/src/dashboard/deskBulkTriageCore.test.ts
@@ -1,0 +1,60 @@
+/**
+ * deskBulkTriageCore tests.
+ * Run: cd packages/web && npx tsx --test src/dashboard/deskBulkTriageCore.test.ts
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  addToSelection, removeFromSelection, clearSelection, selectAll,
+  canSubmit, mapPreviewResponse,
+} from "./deskBulkTriageCore";
+
+test("addToSelection adds an id", () => {
+  assert.ok(addToSelection(new Set(), "a").has("a"));
+});
+test("addToSelection is idempotent", () => {
+  assert.equal(addToSelection(new Set(["a"]), "a").size, 1);
+});
+test("addToSelection does not mutate original", () => {
+  const orig = new Set(["a"]); addToSelection(orig, "b");
+  assert.equal(orig.size, 1);
+});
+test("removeFromSelection removes an id", () => {
+  const s = removeFromSelection(new Set(["a", "b"]), "a");
+  assert.ok(!s.has("a")); assert.ok(s.has("b"));
+});
+test("removeFromSelection on missing id is safe", () => {
+  assert.equal(removeFromSelection(new Set(["a"]), "z").size, 1);
+});
+test("clearSelection returns empty set", () => {
+  assert.equal(clearSelection().size, 0);
+});
+test("selectAll selects every id", () => {
+  const s = selectAll(["a", "b", "c"]);
+  assert.equal(s.size, 3); assert.ok(s.has("c"));
+});
+test("selectAll on empty list returns empty set", () => {
+  assert.equal(selectAll([]).size, 0);
+});
+
+test("empty selection cannot submit", () => {
+  assert.equal(canSubmit(new Set()), false);
+});
+test("non-empty selection can submit", () => {
+  assert.equal(canSubmit(new Set(["x"])), true);
+});
+
+test("maps valid server response", () => {
+  const r = mapPreviewResponse({ would_apply: 5, would_skip: 2, noise_warning: "Warning.", reversal_note: "Manual." });
+  assert.equal(r.would_apply, 5); assert.equal(r.noise_warning, "Warning."); assert.equal(r.reversal_note, "Manual.");
+});
+test("null noise_warning when absent", () => {
+  assert.equal(mapPreviewResponse({ would_apply: 3 }).noise_warning, null);
+});
+test("null reversal_note when absent", () => {
+  assert.equal(mapPreviewResponse({ would_apply: 3 }).reversal_note, null);
+});
+test("safe defaults on null input", () => {
+  const r = mapPreviewResponse(null);
+  assert.equal(r.would_apply, 0); assert.equal(r.would_skip, 0);
+});

--- a/packages/web/src/dashboard/deskBulkTriageCore.ts
+++ b/packages/web/src/dashboard/deskBulkTriageCore.ts
@@ -1,0 +1,37 @@
+// deskBulkTriageCore — pure selection/preview state for Desk bulk triage (#542).
+// No React/Wasp imports. Tested by deskBulkTriageCore.test.ts.
+// delegate is NOT offered — the server returns 400 for it.
+
+export type BulkIntent = "done" | "defer" | "noise";
+
+export interface BulkPreviewResult {
+  would_apply: number;
+  would_skip: number;
+  /** Verbatim suppression-training warning (noise intent only). */
+  noise_warning: string | null;
+  /** Verbatim note about manual-only reversal. */
+  reversal_note: string | null;
+}
+
+export const addToSelection = (s: ReadonlySet<string>, id: string): ReadonlySet<string> =>
+  new Set([...s, id]);
+
+export const removeFromSelection = (s: ReadonlySet<string>, id: string): ReadonlySet<string> => {
+  const n = new Set(s); n.delete(id); return n;
+};
+
+export const clearSelection = (): ReadonlySet<string> => new Set();
+
+export const selectAll = (ids: string[]): ReadonlySet<string> => new Set(ids);
+
+export const canSubmit = (s: ReadonlySet<string>): boolean => s.size > 0;
+
+export function mapPreviewResponse(raw: unknown): BulkPreviewResult {
+  const r = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>;
+  return {
+    would_apply: typeof r.would_apply === "number" ? r.would_apply : 0,
+    would_skip: typeof r.would_skip === "number" ? r.would_skip : 0,
+    noise_warning: typeof r.noise_warning === "string" && r.noise_warning ? r.noise_warning : null,
+    reversal_note: typeof r.reversal_note === "string" && r.reversal_note ? r.reversal_note : null,
+  };
+}

--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -4370,6 +4370,19 @@ export const deleteChannelIdentity = async (
 };
 
 
+// ── Bulk triage (#542) — POST /api/v1/admin/needs-attention/bulk ─────────
+// dry_run: true → preview; dry_run: false → apply. delegate = 400 server-side.
+export const bulkTriageNeedsAttention = async (
+  args: { ids: string[]; intent: "done" | "defer" | "noise"; note?: string; dry_run: boolean },
+  context: any,
+): Promise<any> => {
+  if (!Array.isArray(args?.ids) || args.ids.length === 0) throw new HttpError(400, "ids required");
+  if (!["done", "defer", "noise"].includes(args?.intent)) throw new HttpError(400, "invalid intent");
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, { method: "POST", path: "/api/v1/admin/needs-attention/bulk",
+    body: { ids: args.ids, intent: args.intent, note: args.note, dry_run: args.dry_run } });
+};
+
 // ── decision_ref minter ──────────────────────────────────────────────────
 //
 // Crockford base32, 26 chars — the ULID shape PR4's


### PR DESCRIPTION
## Summary

- Adds a **Bulk triage** panel to the Desk (above "Also in queue") visible whenever the queue contains needs_attention items
- Implements all four requirements from #542: preview before apply, verbatim noise_warning and reversal_note, obvious selection (select all / clear / visible count)
- Thin Wasp action `bulkTriageNeedsAttention` proxies `POST /api/v1/admin/needs-attention/bulk` (endpoint merged in #554)
- Pure state module `deskBulkTriageCore.ts` with 14 passing tests

## How the control works on the Desk

The panel appears at the top of the queue section when there are needs_attention cards in the list (including aging/stale bands). It presents:

1. **Selection** — a scrollable checklist of NA card headlines with checkboxes, plus "Select all" / "Clear" controls and a live count (`Bulk triage — N of M selected`)
2. **Intent** — three buttons: Done / Defer / Noise. Delegate is not offered; the server returns 400 for it.
3. **Preview** — "Preview batch" button calls `dry_run: true`. No path goes straight to apply.
4. **Preview result** — shows `N will apply · M skipped`. The `noise_warning` sentence is rendered verbatim in a brass-bordered block. The `reversal_note` sentence is rendered verbatim in italic below it.
5. **Apply** — only enabled after preview. The button label says `Apply to N` so the count is always visible before the click.

## Both warnings render verbatim

- `noise_warning` — the exact string the server returns for noise intent, rendered inside a bordered panel with brass colouring so it is visually distinct and cannot be missed
- `reversal_note` — the exact string from the server, rendered in italic below the preview counts, always visible before the Apply button

## Smoke evidence

Local unit tests (pure state module, no external dependencies):

```
$ cd packages/web && npx tsx --test src/dashboard/deskBulkTriageCore.test.ts
ok 1 - addToSelection adds an id
ok 2 - addToSelection is idempotent
ok 3 - addToSelection does not mutate original
ok 4 - removeFromSelection removes an id
ok 5 - removeFromSelection on missing id is safe
ok 6 - clearSelection returns empty set
ok 7 - selectAll selects every id
ok 8 - selectAll on empty list returns empty set
ok 9 - empty selection cannot submit
ok 10 - non-empty selection can submit
ok 11 - maps valid server response
ok 12 - null noise_warning when absent
ok 13 - null reversal_note when absent
ok 14 - safe defaults on null input
# tests 14
# suites 0
# pass 14
# fail 0
```

Lane gate (local pre-commit hook):
```
✓ lane III (web) gate passed — 199 LOC, 5 files, verify ok
```

TypeScript: no new errors introduced — all pre-existing `wasp/react` module errors are unchanged; `deskBulkTriageCore.ts` (no framework imports) is clean.

The full functional flow (preview → noise_warning → reversal_note → apply) needs a live staging UI pass once the ctrl-api bulk endpoint (#554) is deployed.

## Deploy note (§15.4)

This is a UI change. Requires **both** `web` and `web-client` containers redeployed plus a hard browser refresh — not just one.

## Test plan

- [ ] Queue with NA items shows the "Bulk triage" panel above the cards
- [ ] "Select all" selects every NA card; "Clear" empties the selection; count updates live
- [ ] Done / Defer / Noise buttons are present; no Delegate button
- [ ] "Preview batch" disabled until an intent is chosen and at least one card is selected
- [ ] Preview shows `N will apply · M skipped`
- [ ] With intent=noise, `noise_warning` from the server is rendered verbatim in the brass panel
- [ ] `reversal_note` is rendered verbatim in italic — always visible before Apply
- [ ] "Apply to N" button only appears after preview; clicking it calls `dry_run: false` and removes applied cards from the queue
- [ ] Cancel resets intent and preview without applying anything
- [ ] Empty selection: "Preview batch" cannot be reached

References #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc