### PR TITLE
feat(ctrl): bulk Desk decisions are reversible now that the router supports it

### DIFF
--- a/packages/ctrl/src/api/routes/attention.ts
+++ b/packages/ctrl/src/api/routes/attention.ts
@@ -760,8 +760,9 @@ export function registerAttentionRoutes(): void {
   // POST /api/v1/admin/needs-attention/bulk — bulk done|defer|noise over pending cards.
   // dry_run=true: preview, no writes. Apply: ONE audit row + ONE decision for the batch.
   // delegate excluded. Unknown/resolved ids skipped. The batch decision is NOT
-  // reversible yet (is_reversible: false) — DecisionRouter support for
-  // side_effects.source_records does not exist. See reversal_note.
+  // reversible: the batch decision carries side_effects.source_records and
+  // DecisionRouter re-opens every listed card on reverse (#559), skipping any
+  // that have since been deleted rather than aborting the batch.
   addRoute("POST", "/api/v1/admin/needs-attention/bulk", async ({ res, body }) => {
     const b = (body ?? {}) as Record<string, unknown>;
     const intent = String(b.intent ?? "").trim().toLowerCase();
@@ -787,7 +788,7 @@ export function registerAttentionRoutes(): void {
         would_apply: toApply.length, would_skip: skipped.length, skipped,
         noise_warning: intent !== "noise" ? null :
           `Marking ${toApply.length} card(s) noise trains suppression. This batch is ONE act — suppression still applies.`,
-        reversal_note: "Batch decisions are not reversible yet: DecisionRouter support for source_records does not exist. Undoing requires patching each card's frontmatter manually.",
+        reversal_note: "Reversible: POST /api/v1/decisions/:id/reverse re-opens every card in this batch. Cards deleted since the batch was applied are skipped and reported.",
         note: note || null });
     }
     if (!toApply.length)
@@ -810,14 +811,14 @@ export function registerAttentionRoutes(): void {
     const sideEffects = { bulk: true, count: appliedIds.length, synchronous_flip: true,
       source_records: appliedIds.map((id) => `needs_attention/${id}.md`),
       actions: [`needs_attention.${naStatus}`],
-      reversal_note: "is_reversible=false until DecisionRouter source_records support lands (Lane II queued)" };
+      reversal_note: "reversible via POST /api/v1/decisions/:id/reverse (#559)" };
     const front = [
       `type: "decision"`, `created: ${JSON.stringify(nowIso)}`, `principal: "principal"`,
       `source: "needs_attention"`, `source_record: "needs_attention/bulk"`,
       `source_headline: ${JSON.stringify(`Bulk ${intent}: ${appliedIds.length} cards`)}`,
       `intent: ${JSON.stringify(intent)}`, `note: ${note ? JSON.stringify(note) : "null"}`,
       `matter_ref: null`, `task_ref: null`, `state: "open"`, `outcome_record: null`,
-      `time_to_decision_ms: null`, `reversed_at: null`, `is_reversible: false`,
+      `time_to_decision_ms: null`, `reversed_at: null`, `is_reversible: true`,
       `completed_at: null`, `decision_origin: "bulk_triage"`,
       yaml.dump({ side_effects: sideEffects }, { lineWidth: 200 }).trimEnd(),
     ].join("\n");

--- a/packages/ctrl/tests/attention-bulk.test.ts
+++ b/packages/ctrl/tests/attention-bulk.test.ts
@@ -85,9 +85,11 @@ describe("bulk needs-attention", () => {
     assert.strictEqual(decCount(), 1, "exactly one decision record");
     assert.ok(p.decision_path?.startsWith("decision/"));
     assert.ok(typeof p.audit_id === "string" && p.audit_id.length > 0);
-    // is_reversible must be false until DecisionRouter source_records support lands.
+    // is_reversible is true now that DecisionRouter re-opens every card in
+    // side_effects.source_records on reverse (#559). The flag must track the
+    // actual capability — a true that does not reverse is worse than a false.
     const decRaw = fs.readFileSync(path.join(DEC, fs.readdirSync(DEC)[0]), "utf-8");
-    assert.ok(/^is_reversible: false$/m.test(decRaw));
+    assert.ok(/^is_reversible: true$/m.test(decRaw));
   });
 
   it("skips unknown ids and already-resolved ids; batch still completes over valid subset", async () => {


### PR DESCRIPTION
Completes #542. One boolean and the notes around it.

## Why it was false

#554 shipped `POST /api/v1/admin/needs-attention/bulk` with `is_reversible: false`, deliberately. Reversing the batch decision did nothing — `DecisionRouter` had no handling for `side_effects.source_records`, so `/reverse` would flip the decision to `reversed` and leave all N cards resolved. Undo meant hand-patching frontmatter, potentially 159 times.

A `true` that does not reverse is worse than a `false`, because you only discover it after making the mistake you were relying on it to undo.

## Why it can be true now

#559 added the batch branch to `reverse_decision`: a reversed decision carrying `source_records` re-opens every listed card, skips any deleted since the batch was applied (reporting which and why) rather than aborting partway, stamps `reversal_processed` so the 60s router tick is idempotent, and writes **one** reversal audit row to match the one forward row.

## Changes

- `is_reversible: false` → `true` in the bulk handler's decision frontmatter
- the preview `reversal_note` and the record note now describe real reversal instead of manual recovery
- the header comment, which described the old state
- the test assertion, with a comment saying why the flag must track the capability

## Smoke evidence

```
$ grep -n "is_reversible" packages/ctrl/src/api/routes/attention.ts
304:      is_reversible: intent !== "delegate",        # single-card, unchanged
821:      ... `is_reversible: true`,                   # bulk

$ git commit
▶ lane I verify: node -e "console.log('source-level verify — see PR')"
✓ lane I (ctrl-api) gate passed
```

Local `node:test` cannot run in this worktree (the circular `node_modules` symlink noted on #554); CI is the authoritative runner.