### PR TITLE
feat(ctrl): Codex OAuth ceremony from the dashboard (#565)

### DIFF
--- a/packages/ctrl/src/api/routes/hermes.ts
+++ b/packages/ctrl/src/api/routes/hermes.ts
@@ -19,6 +19,7 @@ import yaml from "js-yaml";
 import { addRoute } from "../server.js";
 import { sendJson } from "../errors.js";
 import { dockerExec, dockerComposeCmd, HERMES_CMD, HERMES_CONTAINER } from "../helpers.js";
+import { registerCodexAuthRoutes } from "./hermes_codex_auth.js";
 
 // ---------------------------------------------------------------------------
 // Per-MCP-server live tool catalogue cache (issue #185).
@@ -831,6 +832,9 @@ export function registerHermesRoutes(): void {
       sendJson(res, 200, { profile, ok: true, output: stdout.trim() });
     },
   );
+
+  // ── Codex OAuth ceremony from the dashboard (#300) ────────────────────────
+  registerCodexAuthRoutes();
 }
 
 // -----------------------------------------------------------------------------

--- a/packages/ctrl/src/api/routes/hermes_codex_auth.ts
+++ b/packages/ctrl/src/api/routes/hermes_codex_auth.ts
@@ -1,4 +1,4 @@
-// Codex OAuth ceremony from the dashboard (issue #300).
+// Codex OAuth ceremony from the dashboard (issue #565).
 //
 // Hermes uses a standard OAuth2 device-authorization flow to authenticate with
 // OpenAI Codex. The flow is entirely non-interactive — no TTY reads, no browser
@@ -35,7 +35,9 @@ const COMPOSE_FILE =
 const HERMES_SVC = "hermes";
 const CODEX_VERIFY_URI = "https://auth.openai.com/codex/device";
 const CEREMONY_TTL_MS = 15 * 60 * 1_000; // matches hermes CLI's own window
-const TERMINAL_REUSE_MS = 60_000;
+let _terminalReuseMs = 60_000;
+
+export function _setTerminalReuseMs(ms: number): void { _terminalReuseMs = ms; } // test-only
 
 type Status = "not_started" | "awaiting_approval" | "complete" | "failed" | "timeout";
 
@@ -112,7 +114,7 @@ async function handleStart({ res }: ApiRequest): Promise<void> {
     return;
   }
   // Terminal state within the reuse window: return it without re-spawning.
-  if (_s.status !== "not_started" && Date.now() - _s.startedAt < TERMINAL_REUSE_MS) {
+  if (_s.status !== "not_started" && Date.now() - _s.startedAt < _terminalReuseMs) {
     res.writeHead(200, { "content-type": "application/json" });
     res.end(JSON.stringify({ status: _s.status, ...(_s.error && { error: _s.error }) }));
     return;

--- a/packages/ctrl/src/api/routes/hermes_codex_auth.ts
+++ b/packages/ctrl/src/api/routes/hermes_codex_auth.ts
@@ -1,0 +1,139 @@
+// Codex OAuth ceremony from the dashboard (issue #300).
+//
+// Hermes uses a standard OAuth2 device-authorization flow to authenticate with
+// OpenAI Codex. The flow is entirely non-interactive — no TTY reads, no browser
+// auto-open — which lets us drive it from the ctrl-api server process.
+//
+// Architecture:
+//   POST /api/v1/hermes/codex-auth/start
+//     Spawns `docker compose exec -T hermes hermes auth add openai-codex --type oauth`
+//     as a background child process.  Returns 202 immediately; client polls /status.
+//     Parses user_code + verification_uri from the CLI's stdout once emitted (~3 s).
+//     The hermes CLI handles the full ceremony: device code request → polling →
+//     token exchange → credential persistence in /hermes-state/auth.json.
+//     On hermes restart, supervisor.sh propagates the credential to all profiles.
+//
+//   GET  /api/v1/hermes/codex-auth/status
+//     Returns the current session: not_started | awaiting_approval | complete | failed | timeout.
+//     Includes user_code + verification_uri while awaiting_approval.
+//
+// Safety guarantees:
+//   - ctrl-api NEVER reads, logs, or returns any token value.
+//     All credential I/O belongs to the hermes CLI subprocess.
+//   - A failed ceremony cannot corrupt a previously saved credential:
+//     ctrl-api writes nothing to auth.json; the hermes CLI is atomic on failure.
+//   - Starting a new ceremony while one is in progress is a no-op (idempotent).
+//   - Starting within 60 s of a terminal state returns that state rather than
+//     spawning again (prevents accidental double-click races).
+
+import { spawn } from "node:child_process";
+import { addRoute, type ApiRequest } from "../server.js";
+
+const COMPOSE_FILE =
+  process.env.COMPOSE_FILE ??
+  `${process.env.COMPOSE_DIR ?? "/srv/alfred-black"}/docker-compose.yaml`;
+const HERMES_SVC = "hermes";
+const CODEX_VERIFY_URI = "https://auth.openai.com/codex/device";
+const CEREMONY_TTL_MS = 15 * 60 * 1_000; // matches hermes CLI's own window
+const TERMINAL_REUSE_MS = 60_000;
+
+type Status = "not_started" | "awaiting_approval" | "complete" | "failed" | "timeout";
+
+interface Session {
+  status: Status;
+  user_code?: string;
+  verification_uri?: string;
+  error?: string;
+  startedAt: number;
+}
+
+let _s: Session = { status: "not_started", startedAt: 0 };
+let _proc: ReturnType<typeof spawn> | null = null;
+
+/** Strip ANSI escape codes from CLI output. */
+function stripAnsi(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/\x1b\[\d+(?:;\d+)*m/g, "").trim();
+}
+
+/** Extract the user_code from the hermes CLI's printed instructions. */
+function parseUserCode(buf: string): string | undefined {
+  // CLI prints:  "  2. Enter this code:\n     <ANSI>XXXX-XXXX<ANSI>\n"
+  const m = buf.match(/Enter this code[^]*?\n[ \t]+(\S+)/);
+  return m ? stripAnsi(m[1]) : undefined;
+}
+
+function startCeremony(): void {
+  _s = { status: "awaiting_approval", startedAt: Date.now() };
+  const args = [
+    "compose", "-f", COMPOSE_FILE, "exec", "-T", HERMES_SVC,
+    "hermes", "auth", "add", "openai-codex", "--type", "oauth",
+  ];
+  const proc = spawn("docker", args, { stdio: ["ignore", "pipe", "pipe"] });
+  _proc = proc;
+  let buf = "";
+  proc.stdout.on("data", (d: Buffer) => {
+    buf += d.toString();
+    if (!_s.user_code && buf.includes("Enter this code")) {
+      const code = parseUserCode(buf);
+      if (code) {
+        _s.user_code = code;
+        _s.verification_uri = CODEX_VERIFY_URI;
+      }
+    }
+    // Never log buf — it contains the user_code but not the token;
+    // still safer to discard rather than risk surfacing it via docker logs.
+  });
+  const killTimer = setTimeout(() => {
+    proc.kill();
+    if (_s.status === "awaiting_approval") {
+      _s = { status: "timeout", startedAt: _s.startedAt };
+    }
+  }, CEREMONY_TTL_MS);
+  killTimer.unref();
+  proc.on("close", (code: number | null) => {
+    clearTimeout(killTimer);
+    _proc = null;
+    if (_s.status !== "awaiting_approval") return; // already timed out
+    _s.status = code === 0 ? "complete" : "failed";
+    if (code !== 0) _s.error = `hermes auth exited with code ${code}`;
+  });
+}
+
+async function handleStart({ res }: ApiRequest): Promise<void> {
+  // In-progress: return current state without spawning again.
+  if (_s.status === "awaiting_approval") {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({
+      status: _s.status,
+      verification_uri: CODEX_VERIFY_URI,
+      ...(_s.user_code && { user_code: _s.user_code }),
+    }));
+    return;
+  }
+  // Terminal state within the reuse window: return it without re-spawning.
+  if (_s.status !== "not_started" && Date.now() - _s.startedAt < TERMINAL_REUSE_MS) {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ status: _s.status, ...(_s.error && { error: _s.error }) }));
+    return;
+  }
+  // Kill any orphaned process before starting fresh.
+  if (_proc) { _proc.kill(); _proc = null; }
+  startCeremony();
+  res.writeHead(202, { "content-type": "application/json" });
+  res.end(JSON.stringify({ status: "awaiting_approval", verification_uri: CODEX_VERIFY_URI }));
+}
+
+async function handleStatus({ res }: ApiRequest): Promise<void> {
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(JSON.stringify({
+    status: _s.status,
+    ...(_s.user_code && { user_code: _s.user_code, verification_uri: CODEX_VERIFY_URI }),
+    ...(_s.error && { error: _s.error }),
+  }));
+}
+
+export function registerCodexAuthRoutes(): void {
+  addRoute("POST", "/api/v1/hermes/codex-auth/start", handleStart);
+  addRoute("GET",  "/api/v1/hermes/codex-auth/status", handleStatus);
+}

--- a/packages/ctrl/tests/hermes-codex-auth.test.ts
+++ b/packages/ctrl/tests/hermes-codex-auth.test.ts
@@ -2,26 +2,27 @@
 //                GET  /api/v1/hermes/codex-auth/status
 //
 // Coverage:
-//   1. Unauthenticated calls are rejected (both routes).
-//   2. POST /start spawns the hermes CLI and returns awaiting_approval.
-//   3. GET /status exposes user_code once the CLI emits it (distinct from complete).
-//   4. Status transitions to complete after CLI exits 0; no token value in response.
-//   5. A failed ceremony (CLI exits non-zero) leaves prior credentials intact —
-//      ctrl-api writes nothing itself; hermes CLI atomically handles persistence.
+//   1. Auth gate rejects unauthenticated callers (both routes).
+//   2. POST /start spawns `hermes auth add openai-codex --type oauth`.
+//   3. GET /status exposes user_code once the CLI emits it.
+//   4. Failed ceremony (CLI exits non-zero) → status=failed + error field;
+//      ctrl-api writes nothing to the credential store (hermes CLI is the
+//      sole writer, verified to use atomic_replace under an O_EXCL lock).
+//   5. POST /start after failure → fresh spawn (reuse window bypassed);
+//      CLI exits 0 → status=complete; no token value in response.
+//
+// Timeout case omitted — adding it would push total to ~363 LOC (13 over
+// the 350 cap); the killTimer + early-return guard are on the next slot.
 
 import { mock, describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 
-// ---------------------------------------------------------------------------
-// Spawn mock — captures the stdout/close callbacks so tests can drive them.
-// ---------------------------------------------------------------------------
-
+// Spawn mock — captures stdout/close callbacks so tests can drive the CLI.
 let onData: (d: Buffer) => void = () => {};
 let onClose: (code: number | null) => void = () => {};
 const killFn = mock.fn();
-
 const mockProc = {
   stdout: {
     on: mock.fn((event: string, cb: (d: Buffer) => void) => {
@@ -34,9 +35,7 @@ const mockProc = {
   }),
   kill: killFn,
 };
-
 const spawnFn = mock.fn(() => mockProc);
-
 mock.module("node:child_process", {
   namedExports: {
     spawn: spawnFn,
@@ -47,10 +46,7 @@ mock.module("node:child_process", {
   },
 });
 
-// ---------------------------------------------------------------------------
-// Minimal fs mock.
-// ---------------------------------------------------------------------------
-
+// fs mock — writeFileSync call count verifies ctrl-api never touches auth.json.
 const fsMock = {
   existsSync: mock.fn(() => false),
   readFileSync: mock.fn(() => {
@@ -70,31 +66,21 @@ const fsMock = {
   Dirent: class Dirent { name = ""; isFile() { return true; } isDirectory() { return false; } },
   promises: { mkdir: mock.fn(async () => undefined), writeFile: mock.fn(async () => undefined) },
 };
-
 mock.module("node:fs", { defaultExport: fsMock, namedExports: { ...fsMock } });
-
-// ---------------------------------------------------------------------------
-// Bootstrap the server.
-// ---------------------------------------------------------------------------
 
 const { createApiServer } = await import("../src/api/server.js");
 const { setApiKey } = await import("../src/api/auth.js");
+const { _setTerminalReuseMs } = await import("../src/api/routes/hermes_codex_auth.js");
 setApiKey("tk-test-codex-auth");
 
 let server: http.Server;
-
 before(async () => {
   server = createApiServer();
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
 });
-
 after(async () => {
   await new Promise<void>((resolve) => server.close(() => resolve()));
 });
-
-// ---------------------------------------------------------------------------
-// Request helper.
-// ---------------------------------------------------------------------------
 
 async function req(
   method: string,
@@ -124,16 +110,13 @@ async function req(
   });
 }
 
-// ---------------------------------------------------------------------------
-// Tests — sequential (session state accumulates across the describe block).
-// ---------------------------------------------------------------------------
+// Tests are sequential — session state accumulates across the describe block.
 
 describe("hermes codex auth — unauthenticated", () => {
   it("POST /start rejects without bearer", async () => {
     const r = await req("POST", "/api/v1/hermes/codex-auth/start", { auth: false });
     assert.equal(r.status, 401);
   });
-
   it("GET /status rejects without bearer", async () => {
     const r = await req("GET", "/api/v1/hermes/codex-auth/status", { auth: false });
     assert.equal(r.status, 401);
@@ -149,11 +132,10 @@ describe("hermes codex auth — ceremony lifecycle", () => {
     assert.ok(spawnFn.mock.callCount() > 0, "spawn was called");
     const spawnArgs = spawnFn.mock.calls[0].arguments[1] as string[];
     assert.ok(spawnArgs.includes("openai-codex"), "spawn targets openai-codex");
-    assert.ok(spawnArgs.includes("oauth"), "spawn uses oauth type");
-    // No token value in the initial response.
+    assert.ok(spawnArgs.includes("oauth"), "spawn uses --type oauth");
     const body = JSON.stringify(r.data);
-    assert.ok(!body.includes("access_token"), "no access_token in response");
-    assert.ok(!body.includes("refresh_token"), "no refresh_token in response");
+    assert.ok(!body.includes("access_token"), "no access_token in initial response");
+    assert.ok(!body.includes("refresh_token"), "no refresh_token in initial response");
   });
 
   it("GET /status is distinct from complete while awaiting approval", async () => {
@@ -163,7 +145,6 @@ describe("hermes codex auth — ceremony lifecycle", () => {
   });
 
   it("GET /status exposes user_code once the CLI emits it", async () => {
-    // Simulate the hermes CLI printing the device code instructions to stdout.
     onData(Buffer.from(
       "To continue, follow these steps:\n\n" +
       "  1. Open this URL in your browser:\n     https://auth.openai.com/codex/device\n\n" +
@@ -175,30 +156,32 @@ describe("hermes codex auth — ceremony lifecycle", () => {
     assert.equal(r.data.verification_uri, "https://auth.openai.com/codex/device");
   });
 
-  it("status transitions to complete after CLI exits 0; no token in response", async () => {
-    onClose(0);
+  it("failed ceremony reports status=failed with error; ctrl-api writes nothing to credential store", async () => {
+    const writesBefore = fsMock.writeFileSync.mock.callCount();
+    onClose(1); // drive ceremony to non-zero exit
     const r = await req("GET", "/api/v1/hermes/codex-auth/status");
-    assert.equal(r.data.status, "complete");
-    const body = JSON.stringify(r.data);
-    assert.ok(!body.includes("access_token"), "no access_token on complete");
-    assert.ok(!body.includes("refresh_token"), "no refresh_token on complete");
+    assert.equal(r.data.status, "failed");
+    assert.ok(typeof r.data.error === "string" && r.data.error.length > 0,
+      "error field is a non-empty string");
+    assert.ok((r.data.error as string).includes("1"), "error references the exit code");
+    assert.equal(fsMock.writeFileSync.mock.callCount(), writesBefore,
+      "ctrl-api must not call writeFileSync during or after a failed ceremony");
   });
 
-  it("failed ceremony leaves prior credential intact — ctrl-api writes nothing itself", async () => {
-    // The session is currently 'complete'. POST /start within 60 s returns the
-    // current terminal state without spawning (prior credential unaffected).
+  it("status transitions to complete after reuse-window bypass + CLI exits 0; no token in response", async () => {
+    // Collapse the reuse window so POST /start spawns fresh rather than
+    // returning the cached 'failed' terminal state.
+    _setTerminalReuseMs(0);
     spawnFn.mock.resetCalls();
-    const r = await req("POST", "/api/v1/hermes/codex-auth/start");
-    assert.equal(r.data.status, "complete");
-    assert.equal(spawnFn.mock.callCount(), 0, "no new spawn within reuse window");
-    // Verify ctrl-api wrote nothing to the credential store itself.
-    // (The hermes CLI is the sole writer; if we called writeFileSync, that
-    //  would indicate ctrl-api is managing credentials directly — a violation.)
-    const writes = fsMock.writeFileSync.mock.callCount();
-    // Now simulate a fresh failed ceremony by advancing state directly.
-    // We can't wait 60 s, so we verify the invariant: on CLI exit non-zero,
-    // ctrl-api only updates the in-memory session — it does not writeFileSync.
-    const writesAfter = fsMock.writeFileSync.mock.callCount();
-    assert.equal(writes, writesAfter, "ctrl-api never calls writeFileSync for credentials");
+    const r1 = await req("POST", "/api/v1/hermes/codex-auth/start");
+    assert.equal(r1.status, 202, "new ceremony spawned after window bypass");
+    assert.equal(r1.data.status, "awaiting_approval");
+    assert.equal(spawnFn.mock.callCount(), 1, "exactly one new spawn");
+    onClose(0); // drive to success
+    const r2 = await req("GET", "/api/v1/hermes/codex-auth/status");
+    assert.equal(r2.data.status, "complete");
+    const body = JSON.stringify(r2.data);
+    assert.ok(!body.includes("access_token"), "no access_token on complete");
+    assert.ok(!body.includes("refresh_token"), "no refresh_token on complete");
   });
 });

--- a/packages/ctrl/tests/hermes-codex-auth.test.ts
+++ b/packages/ctrl/tests/hermes-codex-auth.test.ts
@@ -1,0 +1,204 @@
+// Tests for POST /api/v1/hermes/codex-auth/start
+//                GET  /api/v1/hermes/codex-auth/status
+//
+// Coverage:
+//   1. Unauthenticated calls are rejected (both routes).
+//   2. POST /start spawns the hermes CLI and returns awaiting_approval.
+//   3. GET /status exposes user_code once the CLI emits it (distinct from complete).
+//   4. Status transitions to complete after CLI exits 0; no token value in response.
+//   5. A failed ceremony (CLI exits non-zero) leaves prior credentials intact —
+//      ctrl-api writes nothing itself; hermes CLI atomically handles persistence.
+
+import { mock, describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+// ---------------------------------------------------------------------------
+// Spawn mock — captures the stdout/close callbacks so tests can drive them.
+// ---------------------------------------------------------------------------
+
+let onData: (d: Buffer) => void = () => {};
+let onClose: (code: number | null) => void = () => {};
+const killFn = mock.fn();
+
+const mockProc = {
+  stdout: {
+    on: mock.fn((event: string, cb: (d: Buffer) => void) => {
+      if (event === "data") onData = cb;
+    }),
+  },
+  stderr: { on: mock.fn() },
+  on: mock.fn((event: string, cb: (code: number | null) => void) => {
+    if (event === "close") onClose = cb;
+  }),
+  kill: killFn,
+};
+
+const spawnFn = mock.fn(() => mockProc);
+
+mock.module("node:child_process", {
+  namedExports: {
+    spawn: spawnFn,
+    execFile: mock.fn((...args: unknown[]) => {
+      (args[args.length - 1] as Function)(null, "", "");
+    }),
+    execFileSync: mock.fn(() => ""),
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Minimal fs mock.
+// ---------------------------------------------------------------------------
+
+const fsMock = {
+  existsSync: mock.fn(() => false),
+  readFileSync: mock.fn(() => {
+    throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+  }),
+  writeFileSync: mock.fn(),
+  mkdirSync: mock.fn(),
+  readdirSync: mock.fn(() => [] as unknown[]),
+  statSync: mock.fn(() => ({ mtimeMs: 0, isDirectory: () => false, isFile: () => false })),
+  unlinkSync: mock.fn(),
+  renameSync: mock.fn(),
+  appendFileSync: mock.fn(),
+  openSync: mock.fn(() => 0),
+  readSync: mock.fn(() => 0),
+  closeSync: mock.fn(),
+  createReadStream: mock.fn(() => ({ pipe: mock.fn(), on: mock.fn() })),
+  Dirent: class Dirent { name = ""; isFile() { return true; } isDirectory() { return false; } },
+  promises: { mkdir: mock.fn(async () => undefined), writeFile: mock.fn(async () => undefined) },
+};
+
+mock.module("node:fs", { defaultExport: fsMock, namedExports: { ...fsMock } });
+
+// ---------------------------------------------------------------------------
+// Bootstrap the server.
+// ---------------------------------------------------------------------------
+
+const { createApiServer } = await import("../src/api/server.js");
+const { setApiKey } = await import("../src/api/auth.js");
+setApiKey("tk-test-codex-auth");
+
+let server: http.Server;
+
+before(async () => {
+  server = createApiServer();
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+});
+
+after(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+// ---------------------------------------------------------------------------
+// Request helper.
+// ---------------------------------------------------------------------------
+
+async function req(
+  method: string,
+  path: string,
+  { auth = true }: { auth?: boolean } = {},
+): Promise<{ status: number; data: Record<string, unknown> }> {
+  const { port } = server.address() as AddressInfo;
+  return new Promise((resolve, reject) => {
+    const r = http.request(
+      {
+        hostname: "127.0.0.1", port, method, path,
+        headers: {
+          "content-type": "application/json",
+          ...(auth && { authorization: "Bearer tk-test-codex-auth" }),
+        },
+      },
+      (res) => {
+        let body = "";
+        res.on("data", (d: Buffer) => { body += d.toString(); });
+        res.on("end", () =>
+          resolve({ status: res.statusCode!, data: JSON.parse(body || "{}") as Record<string, unknown> }),
+        );
+      },
+    );
+    r.on("error", reject);
+    r.end();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests — sequential (session state accumulates across the describe block).
+// ---------------------------------------------------------------------------
+
+describe("hermes codex auth — unauthenticated", () => {
+  it("POST /start rejects without bearer", async () => {
+    const r = await req("POST", "/api/v1/hermes/codex-auth/start", { auth: false });
+    assert.equal(r.status, 401);
+  });
+
+  it("GET /status rejects without bearer", async () => {
+    const r = await req("GET", "/api/v1/hermes/codex-auth/status", { auth: false });
+    assert.equal(r.status, 401);
+  });
+});
+
+describe("hermes codex auth — ceremony lifecycle", () => {
+  it("POST /start spawns hermes auth add openai-codex and returns awaiting_approval", async () => {
+    spawnFn.mock.resetCalls();
+    const r = await req("POST", "/api/v1/hermes/codex-auth/start");
+    assert.equal(r.status, 202);
+    assert.equal(r.data.status, "awaiting_approval");
+    assert.ok(spawnFn.mock.callCount() > 0, "spawn was called");
+    const spawnArgs = spawnFn.mock.calls[0].arguments[1] as string[];
+    assert.ok(spawnArgs.includes("openai-codex"), "spawn targets openai-codex");
+    assert.ok(spawnArgs.includes("oauth"), "spawn uses oauth type");
+    // No token value in the initial response.
+    const body = JSON.stringify(r.data);
+    assert.ok(!body.includes("access_token"), "no access_token in response");
+    assert.ok(!body.includes("refresh_token"), "no refresh_token in response");
+  });
+
+  it("GET /status is distinct from complete while awaiting approval", async () => {
+    const r = await req("GET", "/api/v1/hermes/codex-auth/status");
+    assert.equal(r.data.status, "awaiting_approval");
+    assert.notEqual(r.data.status, "complete");
+  });
+
+  it("GET /status exposes user_code once the CLI emits it", async () => {
+    // Simulate the hermes CLI printing the device code instructions to stdout.
+    onData(Buffer.from(
+      "To continue, follow these steps:\n\n" +
+      "  1. Open this URL in your browser:\n     https://auth.openai.com/codex/device\n\n" +
+      "  2. Enter this code:\n     TEST-7890\n\nWaiting for sign-in...",
+    ));
+    const r = await req("GET", "/api/v1/hermes/codex-auth/status");
+    assert.equal(r.data.status, "awaiting_approval");
+    assert.equal(r.data.user_code, "TEST-7890");
+    assert.equal(r.data.verification_uri, "https://auth.openai.com/codex/device");
+  });
+
+  it("status transitions to complete after CLI exits 0; no token in response", async () => {
+    onClose(0);
+    const r = await req("GET", "/api/v1/hermes/codex-auth/status");
+    assert.equal(r.data.status, "complete");
+    const body = JSON.stringify(r.data);
+    assert.ok(!body.includes("access_token"), "no access_token on complete");
+    assert.ok(!body.includes("refresh_token"), "no refresh_token on complete");
+  });
+
+  it("failed ceremony leaves prior credential intact — ctrl-api writes nothing itself", async () => {
+    // The session is currently 'complete'. POST /start within 60 s returns the
+    // current terminal state without spawning (prior credential unaffected).
+    spawnFn.mock.resetCalls();
+    const r = await req("POST", "/api/v1/hermes/codex-auth/start");
+    assert.equal(r.data.status, "complete");
+    assert.equal(spawnFn.mock.callCount(), 0, "no new spawn within reuse window");
+    // Verify ctrl-api wrote nothing to the credential store itself.
+    // (The hermes CLI is the sole writer; if we called writeFileSync, that
+    //  would indicate ctrl-api is managing credentials directly — a violation.)
+    const writes = fsMock.writeFileSync.mock.callCount();
+    // Now simulate a fresh failed ceremony by advancing state directly.
+    // We can't wait 60 s, so we verify the invariant: on CLI exit non-zero,
+    // ctrl-api only updates the in-memory session — it does not writeFileSync.
+    const writesAfter = fsMock.writeFileSync.mock.callCount();
+    assert.equal(writes, writesAfter, "ctrl-api never calls writeFileSync for credentials");
+  });
+});


### PR DESCRIPTION
## Summary

Adds two ctrl-api endpoints that drive the Codex OAuth device-authorization
ceremony so the dashboard can replace the current SSH-only flow:

- `POST /api/v1/hermes/codex-auth/start` — spawns `hermes auth add openai-codex --type oauth`; returns `{status, verification_uri, user_code}` once the CLI emits the device code
- `GET  /api/v1/hermes/codex-auth/status` — polls current state: `not_started | awaiting_approval | complete | failed | timeout`

Both routes are auth-gated (bearer token, same as every other admin route). The subprocess writes `auth.json` atomically via the hermes CLI — ctrl-api never handles the token, only the temporary `user_code` and the constant `verification_uri`.

## STEP 1 finding — TTY requirement investigation

`hermes auth add openai-codex --type oauth` has NO TTY requirement. The Python `_codex_device_code_login()` function at `auth.py:7357` is pure HTTP — it calls `POST https://auth.openai.com/api/accounts/deviceauth/usercode`, prints the user_code to stdout with ANSI codes, then polls `POST https://auth.openai.com/api/accounts/deviceauth/token` in a loop. No `input()`, no `getpass`, no `termios`. Confirmed live by inspecting the wheel on `home.alfred.black`.

## Banner fix needed — Lane III note

`HermesAuthBanner.tsx:66` tells the operator:
```
docker exec -it alfred-black-hermes-1 hermes auth login --provider openai-codex
```

**`hermes auth login` does not exist on 0.19.0.** The complete subcommand set is: `add, list, remove, reset, status, logout, spotify`. The correct invocation is:
```
hermes auth add openai-codex --type oauth
```
Lane III must fix the banner. This command has never worked on the current wheel, which explains why the issue sat.

## Restart requirement — Lane III note

`hermes auth add openai-codex --type oauth` writes to `profiles/main/auth.json`. Workers and heavy profiles have their own `auth.json` files that are only synced at container startup by `supervisor.sh` (lines 320-333). A `docker compose restart hermes` is required after the ceremony for workers/heavy to pick up the new credential.

There is already a `POST /api/v1/hermes/restart` endpoint at `hermes.ts:229`. **Lane III should call it after polling `status: complete`** and indicate "done, restarting Hermes" to the user (takes ~30s).

## Credential safety — verified against the installed wheel

On failure or timeout the subprocess exits non-zero, which the route records as `status: failed` without touching `auth.json`. The previous credential survives intact.

Verified against the installed wheel at `hermes_cli/auth.py`: `_codex_device_code_login()` writes credentials through `atomic_replace(tmp, auth_file)` under a cross-process advisory lock with `O_EXCL`/`0o600`. On any failure path the function raises rather than returning partial credentials. ctrl-api's subprocess model is therefore sound: it delegates all credential I/O to the CLI, and the CLI's own atomicity guarantee covers failure cases.

A second `POST /start` while a ceremony is in flight returns the in-progress state (HTTP 200, same `user_code`) rather than spawning a duplicate process. 60-second terminal reuse window prevents a failed ceremony from locking out a fresh attempt.

## Scope

332 net LOC (route 141 + tests 187 + hermes.ts wire-up 4). Scope_limit raised to 350 in `.lane` with coordinator approval (see PR #566 thread). Route + tests is one atomic change per CLAUDE.md §11.3; mock harness requires ~50 lines by `--experimental-test-module-mocks` structural requirements; 332 is well below CI's hard 3× cap (600).

## Smoke evidence

Local test run — 7/7 pass:

```
# tests 7
# suites 2
# pass 7
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 195.195042
```

Tests cover:
1. POST /start rejects without bearer (401)
2. GET /status rejects without bearer (401)
3. POST /start spawns `hermes auth add openai-codex` and returns `awaiting_approval` (202)
4. GET /status is distinct from complete while awaiting approval
5. GET /status exposes user_code once the CLI emits it
6. Failed ceremony (onClose(1)) → status=failed + non-empty error field referencing exit code; writeFileSync count verified unchanged ACROSS the failure (not two adjacent reads of the same counter)
7. Reuse-window bypass + fresh spawn + onClose(0) → status=complete; no token in response

Existing suite: 1427/1459 pass (10 fail, all in `.ci-quarantine`: `ha_ws_client`, `channels_ha_hacs`, `phone-outbound-call`). No regressions.

Closes #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)