### PR TITLE
fix(learn): NightlyNarrativeWorkflow cold-start — first narrative for quiet matters (#564)

### DIFF
--- a/packages/learn/src/activities/nightly_narrative.py
+++ b/packages/learn/src/activities/nightly_narrative.py
@@ -14,9 +14,10 @@ can read it directly instead of re-walking the same events.
 
 Idempotency:
   * If the matter saw zero signals AND zero task transitions in the
-    last 24h, the workflow skips the LLM entirely. ``current_state``
-    and ``as_of`` are left untouched — the narrative from the previous
-    refresh is still the freshest available description.
+    last 24h AND already has a ``current_state``, the workflow skips
+    the LLM entirely. Cold-start exception (#564): if
+    ``current_state`` is absent the LLM runs to write the first
+    narrative; subsequent runs then short-circuit normally.
 
 All vault writes go through the ctrl-api VaultClient — never direct
 filesystem writes. All LLM calls go through the OpenClaw gateway via
@@ -696,14 +697,14 @@ def _build_propose_prompt(
     signals: list[dict[str, Any]],
     transitions: list[dict[str, Any]],
     events: list[dict[str, Any]],
+    *,
+    cold_start: bool = False,
 ) -> str:
-    """Compose the propose-side prompt asking the clerk whether the
-    narrative should move given the signals + transitions since
-    ``prior_as_of``.
+    """Compose the propose-side prompt.
 
-    Reuses the same voice instructions as ``_build_narrative_prompt``
-    but with an explicit "no change" escape hatch for matters whose
-    activity does not warrant a rewrite.
+    ``cold_start=True`` suppresses the NO_CHANGE escape hatch so the
+    clerk always writes a first narrative for a matter with no prior
+    ``current_state``.
     """
     matter_name = str(matter_summary.get("name") or matter_summary.get("path") or "").strip()
     prior_state = str(matter_summary.get("current_state") or "").strip()
@@ -727,9 +728,19 @@ def _build_propose_prompt(
         "SOURCE EVENTS (back-pointer expanded):",
         json.dumps(events, indent=2, default=str)[:2000],
         "",
-        "Decide: given what you knew at PRIOR as_of, and what arrived",
-        "since, should the narrative change? If nothing material has",
-        "happened, respond with the single token NO_CHANGE.",
+    ])
+    if cold_start:
+        lines.extend([
+            "No prior narrative exists (cold start). Write an initial",
+            "paragraph. If nothing has happened yet, say so plainly.",
+            "NO_CHANGE is not an option for a first draft.",
+        ])
+    else:
+        lines.extend([
+            "Decide: should the narrative change? If nothing material has",
+            "happened, respond with the single token NO_CHANGE.",
+        ])
+    lines.extend([
         "",
         "If the narrative should change, respond with JSON of the shape:",
         '  {"narrative": "<paragraph>", "confidence": 0.0-1.0}',
@@ -762,16 +773,13 @@ async def propose_matter_narrative(
     24h window walks live outside).
 
     Logic:
-      * Both signals + transitions empty → return None (idempotent gate).
-      * Build clerk prompt with prior_state + observed events.
-      * Parse response: NO_CHANGE / JSON {narrative, confidence} / bare
-        paragraph.
-      * On no-change → return None (no PATCH, no audit).
-      * On narrative → build ``ProposedMutation`` with
-        ``fields={"current_state": ..., "as_of": observed.end iso}``
-        and clerk-self-reported confidence (default
-        ``DEFAULT_NARRATIVE_CONFIDENCE`` = 0.85 when the clerk doesn't
-        return one).
+      * Both signals + transitions empty AND a prior narrative exists →
+        return None (idempotency — re-drafting "nothing changed" adds
+        no value). Cold-start exception (#564): if ``current_state``
+        is absent, proceed so the matter gets a first narrative.
+      * Build clerk prompt → parse NO_CHANGE / JSON / bare paragraph.
+      * On no-change → None (no PATCH, no audit).
+      * On narrative → ProposedMutation with clerk confidence.
     """
     signals = args.get("signals") or []
     transitions = args.get("transitions") or []
@@ -785,18 +793,22 @@ async def propose_matter_narrative(
     if not isinstance(events, list):
         events = []
 
-    # Idempotency gate — nothing happened in the window → no rewrite.
-    if not signals and not transitions:
+    target_fm = target.get("frontmatter") if isinstance(target, dict) else None
+    if not isinstance(target_fm, dict):
+        target_fm = {}
+    prior_current_state = str(target_fm.get("current_state") or "").strip()
+    cold_start = not prior_current_state
+
+    # Idempotency gate — short-circuit only when a narrative already
+    # exists AND the observation window is empty.  A cold-start matter
+    # (no prior current_state) must run the clerk regardless.
+    if not signals and not transitions and not cold_start:
         logger.info(
             "nightly_narrative.propose: matter=%s no signals/transitions — no change",
             matter_path,
         )
         return None
 
-    target_fm = target.get("frontmatter") if isinstance(target, dict) else None
-    if not isinstance(target_fm, dict):
-        target_fm = {}
-    prior_current_state = str(target_fm.get("current_state") or "").strip()
     prior_as_of = target.get("as_of") if isinstance(target, dict) else None
     matter_name = str(args.get("matter_name") or target_fm.get("name") or matter_path)
 
@@ -812,6 +824,7 @@ async def propose_matter_narrative(
         signals,
         transitions,
         events,
+        cold_start=cold_start,
     )
 
     result = await _call_clerk(prompt, raw=True)
@@ -930,9 +943,10 @@ async def apply_matter_narrative_v2(
             error_message=f"load_failed: {exc}"[:300],
         ).__dict__
 
-    # Idempotency gate — same as legacy path. Avoid even the v2
-    # round-trip when there's nothing to reason over.
-    if not signals and not transitions:
+    # Idempotency gate (#564): skip only when prior narrative exists AND
+    # the observation window is empty (cold-start must proceed).
+    prior_state = str((summary or {}).get("current_state") or "").strip()
+    if not signals and not transitions and prior_state:
         logger.info(
             "nightly_narrative.apply_matter_narrative_v2: matter=%s no activity — no change",
             canonical,

--- a/packages/learn/src/workflows/nightly_narrative.py
+++ b/packages/learn/src/workflows/nightly_narrative.py
@@ -27,10 +27,11 @@ Per matter the flow is:
   5. ``generate_matter_narrative`` — single clerk call.
   6. ``patch_matter_narrative`` — atomic vault PATCH.
 
-Idempotency: if signals AND transitions are both empty the workflow
-short-circuits — no LLM call, no patch. The previous narrative stays
-in place because re-drafting "nothing happened" would just stamp a
-new as_of without changing anything meaningful.
+Idempotency: if signals AND transitions are both empty AND the matter
+already has a ``current_state`` the workflow short-circuits — no LLM
+call, no patch. Cold-start exception (#564): if ``current_state`` is
+absent the LLM runs so the matter gets a first narrative;
+subsequent runs then short-circuit normally.
 
 Concurrency: matters process sequentially. The clerk is rate-limited
 and a typical matter takes a few seconds; fanning out via
@@ -227,11 +228,11 @@ class NightlyNarrativeWorkflow:
                     retry_policy=retry,
                 )
 
-                # Idempotency gate — skip the LLM AND the patch entirely
-                # when nothing happened. The previous narrative stays
-                # authoritative because re-drafting "nothing changed"
-                # would just bump as_of without producing better text.
-                if not signals and not transitions:
+                # Idempotency gate (#564): short-circuit only when a
+                # prior narrative exists AND the window is empty.
+                # summary was loaded above — no new activity call.
+                prior_state = str((summary or {}).get("current_state") or "").strip()
+                if not signals and not transitions and prior_state:
                     result.matters_skipped_no_activity += 1
                     workflow.logger.info(
                         "nightly_narrative.run: matter=%s no activity — skipped",

--- a/packages/learn/tests/test_nightly_narrative.py
+++ b/packages/learn/tests/test_nightly_narrative.py
@@ -410,7 +410,14 @@ async def _run_one_matter(
     clerk_response: str | Exception = "Carter is on track.",
     current_state: str = "",
 ) -> NightlyNarrativeResult:
-    """Mimic the workflow's per-matter loop with the activity helpers."""
+    """Mimic the workflow's per-matter loop with the activity helpers.
+
+    Re-implements the idempotency gate from ``NightlyNarrativeWorkflow.run``
+    for unit-test purposes. **Must be kept in sync** with that gate — if the
+    production gate changes (e.g. the cold-start check landed in #564), update
+    this helper too, or the tests below will pass on the helper's logic while
+    the workflow's gate goes untested.
+    """
     result = NightlyNarrativeResult(matters_scanned=1)
 
     # Short-circuit only when prior narrative exists (#564 fix).
@@ -587,6 +594,121 @@ async def test_propose_cold_start_no_signals_drafts_first_narrative():
     assert result is not None, "cold-start matter must produce a mutation"
     assert "current_state" in result.fields
     assert result.fields["current_state"].strip() != ""
+
+
+# ---------------------------------------------------------------------------
+# apply_matter_narrative_v2 cold-start gate — direct activity tests (#564)
+# ---------------------------------------------------------------------------
+# These call the activity as a plain async function (valid outside Temporal)
+# to prove the production gate in apply_matter_narrative_v2 itself, not just
+# the helper above. The prior-narrative skip direction is also covered by
+# test_phase_c_no_signals_returns_no_change_and_skips_post (Case 1).
+
+
+@pytest.mark.asyncio
+async def test_apply_matter_narrative_v2_cold_start_no_signals_generates(
+    install_state_mutator_transport, monkeypatch,
+):
+    """No prior current_state + empty window → gate does not fire, clerk runs.
+
+    The production gate:
+      prior_state = str((summary or {}).get("current_state") or "").strip()
+      if not signals and not transitions and prior_state:  # must NOT fire
+    This test proves it does not short-circuit when current_state is absent.
+    """
+    monkeypatch.setenv("STEWARD_LIVE_MODE", "live")
+    now = _now()
+    fake = FakeVaultClient(
+        list_records_map={"task": []},
+        read_records_map={
+            "matter/carter.md": _matter_v2_record(
+                path="matter/carter.md",
+                current_state="",
+                name="Carter",
+            ),
+        },
+    )
+    ctx_a = patch("src.activities.nightly_narrative.VaultClient", return_value=fake)
+    ctx_b = patch("src.activities.state_mutator.VaultClient", return_value=fake)
+    ctx_a.start()
+    ctx_b.start()
+
+    async def fake_clerk(prompt: str, raw: bool = False) -> str:  # noqa: ARG001
+        return _json.dumps({
+            "narrative": "No signals yet; the matter awaits its first development, sir.",
+            "confidence": 0.80,
+        })
+
+    clerk_patch = patch(
+        "src.activities.nightly_narrative._call_clerk", side_effect=fake_clerk
+    )
+    clerk_patch.start()
+    transport = install_state_mutator_transport(
+        httpx.Response(
+            200,
+            json={
+                "audit_record_path": "event/state-change-cold-start-carter.md",
+                "timeline_entry_id": "01HXYZCS",
+                "new_as_of": "2026-08-13T02:00:00Z",
+            },
+        ),
+    )
+    try:
+        outcome = await apply_matter_narrative_v2(
+            "matter/carter.md",
+            now.isoformat(timespec="seconds"),
+        )
+    finally:
+        ctx_a.stop()
+        ctx_b.stop()
+        clerk_patch.stop()
+
+    assert outcome["status"] == "mutated", (
+        "cold-start gate must not fire when current_state is absent"
+    )
+    assert outcome["audit_record_path"] == "event/state-change-cold-start-carter.md"
+    assert len(transport.requests) == 1
+    envelope = _json.loads(transport.requests[0].content.decode("utf-8"))
+    assert "No signals yet" in envelope["fields"]["current_state"]
+
+
+@pytest.mark.asyncio
+async def test_apply_matter_narrative_v2_has_prior_no_signals_skips(
+    install_state_mutator_transport,
+):
+    """Prior current_state + empty window → gate fires, no clerk, no POST.
+
+    Companion to test_apply_matter_narrative_v2_cold_start_no_signals_generates.
+    Protects the cost-optimisation short-circuit from being removed by mistake.
+    """
+    now = _now()
+    fake = FakeVaultClient(
+        list_records_map={"task": []},
+        read_records_map={
+            "matter/carter.md": _matter_v2_record(
+                path="matter/carter.md",
+                current_state="Carter sprint deck is in your inbox, sir.",
+                name="Carter",
+            ),
+        },
+    )
+    ctx_a = patch("src.activities.nightly_narrative.VaultClient", return_value=fake)
+    ctx_b = patch("src.activities.state_mutator.VaultClient", return_value=fake)
+    ctx_a.start()
+    ctx_b.start()
+    transport = install_state_mutator_transport()
+    try:
+        outcome = await apply_matter_narrative_v2(
+            "matter/carter.md",
+            now.isoformat(timespec="seconds"),
+        )
+    finally:
+        ctx_a.stop()
+        ctx_b.stop()
+
+    assert outcome["status"] == "no_change"
+    assert outcome["audit_record_path"] is None
+    assert transport.requests == []
 
 
 # ---------------------------------------------------------------------------

--- a/packages/learn/tests/test_nightly_narrative.py
+++ b/packages/learn/tests/test_nightly_narrative.py
@@ -408,16 +408,13 @@ async def _run_one_matter(
     transitions: list[dict[str, Any]],
     fake: FakeVaultClient,
     clerk_response: str | Exception = "Carter is on track.",
+    current_state: str = "",
 ) -> NightlyNarrativeResult:
-    """Mimic the workflow's per-matter loop with the activity helpers.
-
-    Pure-function path so each unit test stays focused on the contract
-    we promise: signals + transitions both empty → no patch; otherwise
-    one patch with the LLM response (or no patch if the LLM raised).
-    """
+    """Mimic the workflow's per-matter loop with the activity helpers."""
     result = NightlyNarrativeResult(matters_scanned=1)
 
-    if not signals and not transitions:
+    # Short-circuit only when prior narrative exists (#564 fix).
+    if not signals and not transitions and current_state:
         result.matters_skipped_no_activity += 1
         return result
 
@@ -456,13 +453,14 @@ async def _run_one_matter(
 
 @pytest.mark.asyncio
 async def test_workflow_no_signals_no_patch(install_fake_vault):
-    """No signals AND no transitions → no patch_frontmatter call."""
+    """Prior narrative present, empty window → short-circuit (cost gate)."""
     fake = install_fake_vault(FakeVaultClient())
     result = await _run_one_matter(
         "matter/carter.md",
         signals=[],
         transitions=[],
         fake=fake,
+        current_state="Carter sprint deck is in your inbox, sir.",
     )
     assert result.matters_refreshed == 0
     assert result.matters_skipped_no_activity == 1
@@ -507,6 +505,88 @@ async def test_workflow_clerk_error_no_patch(install_fake_vault):
     assert result.matters_errored == 1
     assert result.matters_refreshed == 0
     assert fake.patch_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Cold-start tests (#564)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cold_start_no_signals_generates_narrative(install_fake_vault):
+    """Absent current_state + empty window → LLM runs and patches."""
+    fake = install_fake_vault(FakeVaultClient())
+    result = await _run_one_matter(
+        "matter/carter.md",
+        signals=[],
+        transitions=[],
+        fake=fake,
+        current_state="",
+        clerk_response="No signals; awaiting next development, sir.",
+    )
+    assert result.matters_refreshed == 1, "cold-start must generate a narrative"
+    assert result.matters_skipped_no_activity == 0
+    assert len(fake.patch_calls) == 1
+    _, updates = fake.patch_calls[0]
+    assert updates["current_state"].strip() != ""
+
+
+@pytest.mark.asyncio
+async def test_has_prior_narrative_no_signals_skips(install_fake_vault):
+    """Prior current_state present + empty window → short-circuits, no LLM."""
+    fake = install_fake_vault(FakeVaultClient())
+    clerk_calls: list[str] = []
+
+    async def spy_clerk(prompt: str, raw: bool = False) -> str:  # noqa: ARG001
+        clerk_calls.append(prompt)
+        return "Should not be reached."
+
+    with patch("src.activities.nightly_narrative._call_clerk", side_effect=spy_clerk):
+        result = await _run_one_matter(
+            "matter/carter.md",
+            signals=[],
+            transitions=[],
+            fake=fake,
+            current_state="Carter sprint deck is in your inbox, sir.",
+        )
+    assert result.matters_skipped_no_activity == 1, "prior narrative must short-circuit"
+    assert clerk_calls == []
+    assert fake.patch_calls == []
+
+
+@pytest.mark.asyncio
+async def test_propose_cold_start_no_signals_drafts_first_narrative():
+    """v2 path: absent current_state + no signals → propose runs the clerk."""
+    from src.activities.nightly_narrative import propose_matter_narrative
+    from src.activities.state_mutator import ObservedWindow as _ObservedWindow
+
+    observed = _ObservedWindow(
+        start=_now() - timedelta(hours=12),
+        end=_now(),
+        signal_paths=[],
+        decision_paths=[],
+        other_refs=[],
+    )
+
+    async def fake_clerk(prompt: str, raw: bool = False) -> str:  # noqa: ARG001
+        return "No signals yet; the matter awaits its next step, sir."
+
+    with patch("src.activities.nightly_narrative._call_clerk", side_effect=fake_clerk):
+        result = await propose_matter_narrative(
+            target={"frontmatter": {"current_state": ""}, "as_of": None},
+            observed=observed,
+            args={
+                "signals": [],
+                "transitions": [],
+                "events": [],
+                "matter_path": "matter/carter.md",
+                "matter_name": "Carter",
+            },
+        )
+
+    assert result is not None, "cold-start matter must produce a mutation"
+    assert "current_state" in result.fields
+    assert result.fields["current_state"].strip() != ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- \`NightlyNarrativeWorkflow\` short-circuited unconditionally when the 24h signal/transition window was empty, permanently skipping any matter that had never had a prior \`current_state\` narrative.
- Gate is now conditional: short-circuit fires only when \`current_state\` already exists **and** the window is empty.
- Three gating sites updated consistently: legacy workflow branch, \`apply_matter_narrative_v2\`, and \`propose_matter_narrative\`. The prompt also suppresses the NO_CHANGE escape hatch for cold-start matters.

Closes #564

## Smoke evidence

Local test suite — 2700 passed, 101 skipped (3 ignored: pre-existing \`fastapi\`/\`openpyxl\` missing from local env; both are in \`requirements.txt\` and pass in CI):

\`\`\`
cd packages/learn && python3 -m pytest tests/ -x -q \
  --ignore=tests/test_composio_server.py \
  --ignore=tests/test_composio_server_defaults.py \
  --ignore=tests/test_file_extraction.py

2700 passed, 101 skipped in 21.79s
\`\`\`

Lane gate passed both commits:
- Commit 1: \`✓ lane II (learn) gate passed — 191 LOC, 3 files, verify ok\`
- Commit 2: \`✓ lane II (learn) gate passed — 124 LOC, 1 files, verify ok\`

Tests prove the fix (red-then-green per §11.2):

Workflow helper tests (cover the per-matter loop shape):
- \`test_cold_start_no_signals_generates_narrative\`
- \`test_has_prior_narrative_no_signals_skips\`

Direct activity tests (call production code, not the helper):
- \`test_apply_matter_narrative_v2_cold_start_no_signals_generates\` — empty \`current_state\` + empty window → gate does not fire, clerk runs, POST lands, \`status='mutated'\`
- \`test_apply_matter_narrative_v2_has_prior_no_signals_skips\` — prior \`current_state\` + empty window → gate fires, no HTTP request, no clerk call
- \`test_propose_cold_start_no_signals_drafts_first_narrative\` — v2 \`propose_matter_narrative\` cold-start path

The \`_run_one_matter\` docstring now warns explicitly that it re-implements the production gate and must be kept in sync with \`NightlyNarrativeWorkflow.run\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)