### PR TITLE
fix(hermes): LCMEngine.__deepcopy__ — stop delegated agents losing LCM on Hermes 0.19 (#424)

### DIFF
--- a/packages/hermes/Dockerfile
+++ b/packages/hermes/Dockerfile
@@ -289,6 +289,31 @@ RUN git clone https://github.com/stephenschoettler/hermes-lcm /opt/hermes-lcm \
     && rm -rf /opt/hermes-lcm/.git
 
 # =============================================================================
+# Patch: LCMEngine.__deepcopy__ for Hermes 0.19 per-agent engine copying
+# (upstream workaround, GH #424).
+#
+# Hermes 0.19 deep-copies the context engine into each delegated / spawned
+# agent. The default deepcopy fails because LCMEngine's three store objects
+# (MessageStore, SummaryDAG, LifecycleStateStore) each hold a live
+# sqlite3.Connection as self._conn; LCMEngine also holds a threading.RLock
+# and threading.local, which are equally unpicklable. Result: 331 WARNING
+# log lines in 7 days on home — every sub-agent silently fell back to the
+# built-in compressor instead of LCM. Main-profile conversation is unaffected.
+#
+# The patch adds __deepcopy__ to LCMEngine: it creates a fresh engine from
+# the same config (re-opening new connections to the shared WAL-mode lcm.db)
+# and copies only the mutable budget / counter scalars. Session-binding state
+# is intentionally NOT carried — the sub-agent starts its own session.
+#
+# Applies against HERMES_LCM_REF 2d108b759e33b72427350dffcb77281f7f61baf9
+# (tag v0.11.1). Re-verify NEEDLE in patch_lcm_deepcopy.py after bumping ref.
+# The durable fix is upstreaming __deepcopy__ to stephenschoettler/hermes-lcm.
+COPY packages/hermes/patch_lcm_deepcopy.py /tmp/patch_lcm_deepcopy.py
+RUN python3 /tmp/patch_lcm_deepcopy.py \
+ && grep -q "alfred-black: LCMEngine __deepcopy__" /opt/hermes-lcm/engine.py \
+ && rm /tmp/patch_lcm_deepcopy.py
+
+# =============================================================================
 # Bake the `one-alfred` plugin (the user-facing continuity layer).
 # =============================================================================
 # Sir's principle: the user must feel they are talking to ONE Alfred, always.

--- a/packages/hermes/patch_lcm_deepcopy.py
+++ b/packages/hermes/patch_lcm_deepcopy.py
@@ -1,0 +1,133 @@
+"""In-place patch of LCMEngine in /opt/hermes-lcm/engine.py, applied at
+image-build time inside packages/hermes/Dockerfile.
+
+Why this exists (GH #424 — Hermes 0.19 per-agent engine copying)
+-----------------------------------------------------------------
+Hermes 0.19 deep-copies the context engine into each delegated / spawned
+agent.  The default ``copy.deepcopy`` fails because LCMEngine's three SQLite
+store objects (MessageStore, SummaryDAG, LifecycleStateStore) each hold a live
+``sqlite3.Connection`` as ``self._conn``.  LCMEngine also holds a
+``threading.RLock`` (``_auxiliary_session_lock``) and a ``threading.local``
+(``_thread_context``), which are equally unpicklable.
+
+The result: every delegated / spawned / background agent silently falls back to
+Hermes' built-in compressor instead of LCM — 331 WARNING log lines in 7 days
+on home (2026-08-06 audit).  Main-profile conversation is unaffected (it keeps
+LCM); the regression is confined to the delegation path.
+
+Fix
+---
+Add ``LCMEngine.__deepcopy__`` following the hint in Hermes' own warning
+message.  The implementation:
+
+  1. Creates a fresh ``LCMEngine`` from the same config and hermes_home —
+     opening NEW connections to the shared WAL-mode ``lcm.db``.  Multiple
+     concurrent readers/writers are safe under WAL.
+  2. Copies only the mutable budget / counter scalars the parent has
+     accumulated (model name, token counts, threshold settings, etc.).
+  3. Intentionally does NOT copy session-binding state (_session_id,
+     _foreground_session_id, cursor, etc.) — the sub-agent starts its own
+     session against the shared durable store and reconciles its ingest
+     cursor on the first write.
+
+Applies against LCM ref 2d108b759e33b72427350dffcb77281f7f61baf9 (tag v0.11.1).
+Re-verify the NEEDLE after bumping HERMES_LCM_REF.
+
+The durable fix is upstreaming ``__deepcopy__`` to
+stephenschoettler/hermes-lcm — that is the repo owner's call, not ours.
+
+Idempotent (SENTINEL check) + tripwire'd (NEEDLE check exits 2 on mismatch).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+TARGET = "/opt/hermes-lcm/engine.py"
+
+SENTINEL = "alfred-black: LCMEngine __deepcopy__"
+
+# The last line of LCMEngine.__init__ and the first line of _set_context_length,
+# verified byte-for-byte against hermes-lcm ref
+# 2d108b759e33b72427350dffcb77281f7f61baf9 on home.alfred.black 2026-08-13.
+NEEDLE = (
+    "        self._auxiliary_session_lock = threading.RLock()\n"
+    "\n"
+    "    def _set_context_length(self, context_length: Any, *, source: str) -> bool:"
+)
+
+# The __deepcopy__ method is inserted between __init__ and _set_context_length.
+_DEEPCOPY_METHOD = '''
+    def __deepcopy__(self, memo):
+        """alfred-black: LCMEngine __deepcopy__ for Hermes 0.19 per-agent
+        engine copying (upstream workaround, GH #424; applies against LCM
+        ref 2d108b759e33b72427350dffcb77281f7f61baf9 / tag v0.11.1).
+
+        sqlite3.Connection, threading.RLock, and threading.local are not
+        picklable, so the default deepcopy raises and Hermes falls back to
+        the built-in compressor for every delegated / spawned agent.  This
+        method creates a fresh LCMEngine from the same config (opening new
+        connections to the shared WAL-mode lcm.db) and copies only the
+        mutable budget / counter scalars the parent has accumulated.
+
+        Session-binding state (_session_id, _foreground_session_id, …) is
+        intentionally NOT copied — the sub-agent starts its own session
+        against the shared durable store and reconciles its ingest cursor
+        on the first write.
+        """
+        new_engine = LCMEngine(config=self._config, hermes_home=self._hermes_home)
+        memo[id(self)] = new_engine
+        _budget_attrs = (
+            "model", "base_url", "api_key", "provider", "api_mode",
+            "context_length", "_context_length_source",
+            "threshold_tokens", "threshold_percent",
+            "last_prompt_tokens", "last_completion_tokens",
+            "last_total_tokens", "last_input_tokens", "last_output_tokens",
+            "last_cache_read_tokens", "last_cache_write_tokens",
+            "last_reasoning_tokens", "cache_metrics_available",
+            "compression_count", "protect_first_n", "protect_last_n",
+            "_context_probed", "_context_probe_persistable",
+            "quiet_mode", "summary_model",
+            "_last_overflow_recovery_failed",
+            "_last_condensation_suppressed_reason",
+            "_last_compression_status",
+            "_last_compression_noop_reason",
+        )
+        for attr in _budget_attrs:
+            if hasattr(self, attr):
+                setattr(new_engine, attr, getattr(self, attr))
+        return new_engine
+'''
+
+REPLACEMENT = (
+    "        self._auxiliary_session_lock = threading.RLock()\n"
+    + _DEEPCOPY_METHOD
+    + "\n"
+    "    def _set_context_length(self, context_length: Any, *, source: str) -> bool:"
+)
+
+
+def main() -> None:
+    p = pathlib.Path(TARGET)
+    src = p.read_text()
+
+    if SENTINEL in src:
+        print("LCMEngine.__deepcopy__: already patched, skipping")
+        return
+
+    if NEEDLE not in src:
+        print(
+            f"LCMEngine.__deepcopy__: NEEDLE_NOT_FOUND in {TARGET} — "
+            f"upstream hermes-lcm may have moved this hunk; "
+            f"re-author the patch after bumping HERMES_LCM_REF.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    p.write_text(src.replace(NEEDLE, REPLACEMENT, 1))
+    print("LCMEngine.__deepcopy__: patched (deepcopy support added for Hermes 0.19)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #424.

## What

Hermes 0.19 deep-copies the context engine into each delegated/spawned agent. `LCMEngine` holds three objects that each contain a live `sqlite3.Connection` (`MessageStore._conn`, `SummaryDAG._conn`, `LifecycleStateStore._conn`), plus a `threading.RLock` and `threading.local`. All five are unpicklable. The default deepcopy therefore fails and every sub-agent silently falls back to the built-in compressor — 331 WARNING lines logged on home in the 7 days before this was filed. Main-profile conversation is unaffected (it keeps LCM); the regression is on the delegation path only.

The fix adds `LCMEngine.__deepcopy__` following the exact hint in Hermes' own warning message. It creates a fresh `LCMEngine` from the same config (opening new connections to the shared WAL-mode `lcm.db`) and copies only the mutable budget/counter scalars the parent has accumulated. Session-binding state is intentionally not carried — the sub-agent starts its own session and reconciles its ingest cursor on the first write.

## How (two files)

- `packages/hermes/patch_lcm_deepcopy.py` — the patch script, following the pattern of the three existing upstream patches (`patch_openai_sdk.py`, `patch_upstream_hermes_auth.py`, `patch_upstream_hermes_channeldir.py`). Idempotent (sentinel) + tripwire'd (exits 2 if the needle has moved, so a future `HERMES_LCM_REF` bump that invalidates the anchor fails loudly at build time, not silently at runtime).
- `packages/hermes/Dockerfile` — COPY + RUN the script immediately after the hermes-lcm clone, with a `grep -q` tripwire in the RUN layer. `HERMES_LCM_REF` pin is unchanged.

The durable fix is upstreaming `__deepcopy__` to `stephenschoettler/hermes-lcm` — that is the repo owner's call.

## Operator steps after merge

1. Wait for `build-hermes` CI to publish a new `:latest`.
2. On home (and fleet): `docker compose pull hermes && docker compose up -d hermes`.
3. Watch hermes logs for 24h — the 331 WARNING/7d rate should drop to zero.

## Smoke evidence

Patch applied locally against the real `engine.py` pulled from `alfred-black-hermes-1` on home (Hermes Agent v0.19.0):

```
$ python3 patch_lcm_deepcopy.py
LCMEngine.__deepcopy__: patched (deepcopy support added for Hermes 0.19)
exit=0
```

Post-patch verification:
```
1. Sentinel present: True
2. __deepcopy__ defined: True
3. Original needle absent (replaced): True
4. ast.parse: OK (valid Python)
```

Idempotency (second run):
```
$ python3 patch_lcm_deepcopy.py
LCMEngine.__deepcopy__: already patched, skipping
exit=0
```

Tripwire (needle absent):
```
Exit code: 2 (expected 2)
Stderr: LCMEngine.__deepcopy__: NEEDLE_NOT_FOUND in fake_engine.py —
  upstream hermes-lcm may have moved this hunk; re-author the patch
  after bumping HERMES_LCM_REF.
```

Lane V gate: `docker compose config -q` passes. Commit gate: 158 LOC, 2 files, verify ok.

A full `build-hermes` image build is needed in CI to prove the patch applies inside Docker — the scratchpad run above proves the patch logic against the real pinned ref, but CI is the authoritative build gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)