### PR TITLE
feat(web): Codex OAuth device-code ceremony in HermesAuthBanner (#565)

### DIFF
--- a/packages/web/main.wasp
+++ b/packages/web/main.wasp
@@ -1034,6 +1034,23 @@ query getTailscalePeers {
   entities: []
 }
 
+// Codex OAuth ceremony (#565 / PR #566).
+// Three ops backed by hermes_codex_auth.ts (ctrl-api) + hermes.ts (restart).
+query getCodexAuthStatus {
+  fn: import { getCodexAuthStatus } from "@src/dashboard/operations",
+  entities: []
+}
+
+action startCodexAuth {
+  fn: import { startCodexAuth } from "@src/dashboard/operations",
+  entities: []
+}
+
+action restartHermes {
+  fn: import { restartHermes } from "@src/dashboard/operations",
+  entities: []
+}
+
 // Lane III (Recall.ai, #113 PR3) — operator-facing /channels card. Five ops
 // against the ctrl-api routes shipped in PR2 (#129). The composite
 // getRecallChannelStatus stitches /config + /usage + /bots/active into the

--- a/packages/web/src/dashboard/HermesAuthBanner.tsx
+++ b/packages/web/src/dashboard/HermesAuthBanner.tsx
@@ -5,7 +5,7 @@
 // reads ``progress.degraded_stages``, which Phase-4 ``_safe_stage_wrapper``
 // stamps on ``onboard.json`` whenever an Opus-tier activity raises AuthError.
 // Dismissal is per-session (sessionStorage) — on refresh, if auth is still
-// bad, the banner returns. No new endpoints, no Wasp SDK regen.
+// bad, the banner returns.
 //
 // Auth flow (#565): operator clicks "Connect from browser" → polls
 // getCodexAuthStatus every 2.5 s → shows user_code + link → on complete
@@ -23,6 +23,12 @@ import {
   restartHermes,
 } from "wasp/client/operations";
 import { deriveHermesHealthFromProgress } from "./hermesHealthCore";
+import {
+  deriveCodexViewState,
+  isTerminal,
+  shouldDispatchRestart,
+  type CodexStatusPayload,
+} from "./codexAuthCore";
 
 const DISMISS_KEY = "hermes_auth_banner_dismissed_v1";
 const POLL_MS = 30_000;
@@ -39,8 +45,6 @@ function writeDismissed(): void {
   try { window.sessionStorage.setItem(DISMISS_KEY, "1"); } catch { /* quota */ }
 }
 
-type CPhase = "idle"|"pending"|"show_code"|"restarting"|"done"|"failed"|"timeout";
-
 export default function HermesAuthBanner() {
   const { data: progress } = useQuery(getOnboardingProgress, undefined, {
     refetchInterval: POLL_MS,
@@ -49,35 +53,31 @@ export default function HermesAuthBanner() {
   const [dismissed, setDismissed] = useState<boolean>(() => readDismissed());
   useEffect(() => { setDismissed(readDismissed()); }, []);
 
-  const [phase, setPhase] = useState<CPhase>("idle");
-  const [userCode, setUserCode] = useState<string | null>(null);
-  const [verifyUri, setVerifyUri] = useState<string | null>(null);
+  // flowActive gates fast polling; goes false when a terminal status arrives.
+  const [flowActive, setFlowActive] = useState(false);
+  const [restarting, setRestarting] = useState(false);
   const [cErr, setCErr] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const sentRestart = useRef(false);
 
-  const polling = phase === "pending" || phase === "show_code";
   const { data: sData } = useQuery(getCodexAuthStatus, undefined, {
-    refetchInterval: polling ? 2_500 : 60_000,
+    refetchInterval: flowActive ? 2_500 : 60_000,
   });
 
+  const vs = deriveCodexViewState(sData as CodexStatusPayload, restarting);
+  // Before the first poll response arrives after start, show waiting_for_code.
+  const displayPhase = flowActive && vs.phase === "idle" ? "waiting_for_code" : vs.phase;
+
   useEffect(() => {
-    const s = (sData as any);
-    if (!s) return;
-    const st: string = s.status ?? "not_started";
-    if (st === "awaiting_approval") {
-      if (s.user_code && s.verification_uri) { setUserCode(s.user_code); setVerifyUri(s.verification_uri); setPhase("show_code"); }
-      else setPhase("pending");
-    } else if (st === "complete") {
-      if (!sentRestart.current) {
-        sentRestart.current = true;
-        setPhase("restarting");
-        (restartHermes as (a: Record<string, never>) => Promise<unknown>)({}).finally(() => setPhase("done"));
-      }
-    } else if (st === "failed") {
-      setCErr(s.error ?? "hermes auth exited non-zero"); setPhase("failed");
-    } else if (st === "timeout") {
-      setPhase("timeout");
+    const p = sData as CodexStatusPayload | null;
+    if (!p) return;
+    if (isTerminal(p.status)) setFlowActive(false);
+    if (p.status === "failed") setCErr(p.error ?? "authentication failed");
+    if (shouldDispatchRestart(p.status, sentRestart.current)) {
+      sentRestart.current = true;
+      setRestarting(true);
+      (restartHermes as (a: Record<string, never>) => Promise<unknown>)({})
+        .finally(() => setRestarting(false));
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sData]);
@@ -86,10 +86,10 @@ export default function HermesAuthBanner() {
   if (health.healthy || dismissed) return null;
 
   async function onConnect() {
-    setBusy(true); setCErr(null);
+    setBusy(true); setCErr(null); sentRestart.current = false;
     try {
       await (startCodexAuth as (a: Record<string, never>) => Promise<unknown>)({});
-      setPhase("pending");
+      setFlowActive(true);
     } catch (e: any) { setCErr(e?.message ?? "start failed"); }
     finally { setBusy(false); }
   }
@@ -102,7 +102,7 @@ export default function HermesAuthBanner() {
           <div className="mb-2 font-mono text-[11px] uppercase tracking-[0.22em] text-amber-300">
             Alfred can&apos;t reach the language model
           </div>
-          {phase === "idle" && <>
+          {displayPhase === "idle" && <>
             <div className="font-serif text-sm leading-relaxed">
               Deeper analysis finished with reduced fidelity{stages ? ` (${stages})` : ""}. Re-authenticate from this page, or from the host:
             </div>
@@ -114,17 +114,17 @@ export default function HermesAuthBanner() {
               {cErr && <span className="font-serif text-[13px] text-red-300">{cErr}</span>}
             </div>
           </>}
-          {phase === "pending" && <div className="font-serif text-sm text-amber-100">Waiting for device code…</div>}
-          {phase === "show_code" && userCode && <div className="font-serif text-sm leading-relaxed">
-            Visit <a href={verifyUri!} target="_blank" rel="noopener noreferrer" className="underline text-amber-200 hover:text-white">{verifyUri}</a> and enter:
-            <div className="mt-2 font-mono text-2xl tracking-[0.3em] text-white">{userCode}</div>
+          {displayPhase === "waiting_for_code" && <div className="font-serif text-sm text-amber-100">Waiting for device code…</div>}
+          {vs.phase === "show_code" && <div className="font-serif text-sm leading-relaxed">
+            Visit <a href={vs.verification_uri} target="_blank" rel="noopener noreferrer" className="underline text-amber-200 hover:text-white">{vs.verification_uri}</a> and enter:
+            <div className="mt-2 font-mono text-2xl tracking-[0.3em] text-white">{vs.user_code}</div>
             <div className="mt-1 font-mono text-[11px] uppercase tracking-[0.18em] text-amber-300/70">Waiting for approval…</div>
           </div>}
-          {phase === "restarting" && <div className="font-serif text-sm text-amber-100">Connected. Restarting Hermes to apply the credential — takes ~30 seconds.</div>}
-          {phase === "done" && <div className="font-serif text-sm text-amber-100">Hermes is back online. Dismiss this banner.</div>}
-          {phase === "failed" && <div className="font-serif text-sm">Authentication failed: {cErr}.{" "}
+          {displayPhase === "restarting" && <div className="font-serif text-sm text-amber-100">Connected. Restarting Hermes to apply the credential — takes ~30 seconds.</div>}
+          {displayPhase === "done" && <div className="font-serif text-sm text-amber-100">Hermes is back online. Dismiss this banner.</div>}
+          {vs.phase === "failed" && <div className="font-serif text-sm">Authentication failed: {vs.error}.{" "}
             <button type="button" onClick={onConnect} disabled={busy} className="underline hover:text-white">Retry</button></div>}
-          {phase === "timeout" && <div className="font-serif text-sm">The code expired.{" "}
+          {displayPhase === "timeout" && <div className="font-serif text-sm">The code expired.{" "}
             <button type="button" onClick={onConnect} disabled={busy} className="underline hover:text-white">Retry</button> to start a new ceremony.</div>}
           <div className="mt-2 font-serif text-[13px] text-amber-200/80">Then retry onboarding. Existing data is preserved.</div>
         </div>

--- a/packages/web/src/dashboard/HermesAuthBanner.tsx
+++ b/packages/web/src/dashboard/HermesAuthBanner.tsx
@@ -6,31 +6,40 @@
 // stamps on ``onboard.json`` whenever an Opus-tier activity raises AuthError.
 // Dismissal is per-session (sessionStorage) — on refresh, if auth is still
 // bad, the banner returns. No new endpoints, no Wasp SDK regen.
+//
+// Auth flow (#565): operator clicks "Connect from browser" → polls
+// getCodexAuthStatus every 2.5 s → shows user_code + link → on complete
+// dispatches POST /hermes/restart → "Restarting…" (~30 s) → "Done."
+//
+// CLI fallback corrected: `hermes auth add openai-codex --type oauth`
+// (`hermes auth login --provider openai-codex` does NOT exist on 0.19.0)
 
-import { useEffect, useState } from "react";
-import { useQuery, getOnboardingProgress } from "wasp/client/operations";
+import { useEffect, useRef, useState } from "react";
+import {
+  useQuery,
+  getOnboardingProgress,
+  getCodexAuthStatus,
+  startCodexAuth,
+  restartHermes,
+} from "wasp/client/operations";
 import { deriveHermesHealthFromProgress } from "./hermesHealthCore";
 
 const DISMISS_KEY = "hermes_auth_banner_dismissed_v1";
 const POLL_MS = 30_000;
+const CORRECT_CLI =
+  "docker exec -it alfred-black-hermes-1 hermes auth add openai-codex --type oauth\n" +
+  "docker compose restart hermes";
 
 function readDismissed(): boolean {
   if (typeof window === "undefined") return false;
-  try {
-    return window.sessionStorage.getItem(DISMISS_KEY) === "1";
-  } catch {
-    return false;
-  }
+  try { return window.sessionStorage.getItem(DISMISS_KEY) === "1"; } catch { return false; }
 }
-
 function writeDismissed(): void {
   if (typeof window === "undefined") return;
-  try {
-    window.sessionStorage.setItem(DISMISS_KEY, "1");
-  } catch {
-    /* ignore quota errors */
-  }
+  try { window.sessionStorage.setItem(DISMISS_KEY, "1"); } catch { /* quota */ }
 }
+
+type CPhase = "idle"|"pending"|"show_code"|"restarting"|"done"|"failed"|"timeout";
 
 export default function HermesAuthBanner() {
   const { data: progress } = useQuery(getOnboardingProgress, undefined, {
@@ -40,35 +49,84 @@ export default function HermesAuthBanner() {
   const [dismissed, setDismissed] = useState<boolean>(() => readDismissed());
   useEffect(() => { setDismissed(readDismissed()); }, []);
 
+  const [phase, setPhase] = useState<CPhase>("idle");
+  const [userCode, setUserCode] = useState<string | null>(null);
+  const [verifyUri, setVerifyUri] = useState<string | null>(null);
+  const [cErr, setCErr] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const sentRestart = useRef(false);
+
+  const polling = phase === "pending" || phase === "show_code";
+  const { data: sData } = useQuery(getCodexAuthStatus, undefined, {
+    refetchInterval: polling ? 2_500 : 60_000,
+  });
+
+  useEffect(() => {
+    const s = (sData as any);
+    if (!s) return;
+    const st: string = s.status ?? "not_started";
+    if (st === "awaiting_approval") {
+      if (s.user_code && s.verification_uri) { setUserCode(s.user_code); setVerifyUri(s.verification_uri); setPhase("show_code"); }
+      else setPhase("pending");
+    } else if (st === "complete") {
+      if (!sentRestart.current) {
+        sentRestart.current = true;
+        setPhase("restarting");
+        (restartHermes as (a: Record<string, never>) => Promise<unknown>)({}).finally(() => setPhase("done"));
+      }
+    } else if (st === "failed") {
+      setCErr(s.error ?? "hermes auth exited non-zero"); setPhase("failed");
+    } else if (st === "timeout") {
+      setPhase("timeout");
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sData]);
+
   const health = deriveHermesHealthFromProgress(progress);
   if (health.healthy || dismissed) return null;
 
+  async function onConnect() {
+    setBusy(true); setCErr(null);
+    try {
+      await (startCodexAuth as (a: Record<string, never>) => Promise<unknown>)({});
+      setPhase("pending");
+    } catch (e: any) { setCErr(e?.message ?? "start failed"); }
+    finally { setBusy(false); }
+  }
+
   const stages = health.degradedStages.join(", ");
   return (
-    <div
-      role="alert"
-      className="sticky top-0 z-30 border-b border-amber-500/40 bg-amber-950/90 px-6 py-4 backdrop-blur-md"
-      style={{ color: "#FCE3A1" }}
-    >
+    <div role="alert" className="sticky top-0 z-30 border-b border-amber-500/40 bg-amber-950/90 px-6 py-4 backdrop-blur-md" style={{ color: "#FCE3A1" }}>
       <div className="mx-auto flex max-w-[1180px] items-start justify-between gap-6">
         <div className="flex-1">
           <div className="mb-2 font-mono text-[11px] uppercase tracking-[0.22em] text-amber-300">
             Alfred can&apos;t reach the language model
           </div>
-          <div className="font-serif text-sm leading-relaxed">
-            Deeper analysis finished with reduced fidelity{stages ? ` (${stages})` : ""}.
-            Hermes needs a re-authentication. From the host:
-          </div>
-          <pre
-            className="mt-3 overflow-x-auto rounded-sm border border-amber-700/40 bg-black/40 px-3 py-2 font-mono text-[12px] leading-relaxed"
-            style={{ color: "#E8E4DE" }}
-          >
-            {"docker exec -it alfred-black-hermes-1 hermes auth login --provider openai-codex\n" +
-              "docker compose restart hermes"}
-          </pre>
-          <div className="mt-2 font-serif text-[13px] text-amber-200/80">
-            Then retry onboarding. Existing data is preserved.
-          </div>
+          {phase === "idle" && <>
+            <div className="font-serif text-sm leading-relaxed">
+              Deeper analysis finished with reduced fidelity{stages ? ` (${stages})` : ""}. Re-authenticate from this page, or from the host:
+            </div>
+            <pre className="mt-3 overflow-x-auto rounded-sm border border-amber-700/40 bg-black/40 px-3 py-2 font-mono text-[12px] leading-relaxed" style={{ color: "#E8E4DE" }}>{CORRECT_CLI}</pre>
+            <div className="mt-3 flex items-center gap-3">
+              <button type="button" onClick={onConnect} disabled={busy} className="border border-amber-500/60 px-4 py-2 font-mono text-[11px] uppercase tracking-[0.22em] text-amber-200 transition-colors hover:border-amber-300 hover:text-white disabled:opacity-50">
+                {busy ? "Starting…" : "Connect from browser"}
+              </button>
+              {cErr && <span className="font-serif text-[13px] text-red-300">{cErr}</span>}
+            </div>
+          </>}
+          {phase === "pending" && <div className="font-serif text-sm text-amber-100">Waiting for device code…</div>}
+          {phase === "show_code" && userCode && <div className="font-serif text-sm leading-relaxed">
+            Visit <a href={verifyUri!} target="_blank" rel="noopener noreferrer" className="underline text-amber-200 hover:text-white">{verifyUri}</a> and enter:
+            <div className="mt-2 font-mono text-2xl tracking-[0.3em] text-white">{userCode}</div>
+            <div className="mt-1 font-mono text-[11px] uppercase tracking-[0.18em] text-amber-300/70">Waiting for approval…</div>
+          </div>}
+          {phase === "restarting" && <div className="font-serif text-sm text-amber-100">Connected. Restarting Hermes to apply the credential — takes ~30 seconds.</div>}
+          {phase === "done" && <div className="font-serif text-sm text-amber-100">Hermes is back online. Dismiss this banner.</div>}
+          {phase === "failed" && <div className="font-serif text-sm">Authentication failed: {cErr}.{" "}
+            <button type="button" onClick={onConnect} disabled={busy} className="underline hover:text-white">Retry</button></div>}
+          {phase === "timeout" && <div className="font-serif text-sm">The code expired.{" "}
+            <button type="button" onClick={onConnect} disabled={busy} className="underline hover:text-white">Retry</button> to start a new ceremony.</div>}
+          <div className="mt-2 font-serif text-[13px] text-amber-200/80">Then retry onboarding. Existing data is preserved.</div>
         </div>
         <button
           type="button"

--- a/packages/web/src/dashboard/codexAuthCore.test.ts
+++ b/packages/web/src/dashboard/codexAuthCore.test.ts
@@ -1,0 +1,67 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { deriveCodexViewState, isTerminal, shouldDispatchRestart } from "./codexAuthCore.ts";
+
+describe("deriveCodexViewState", () => {
+  test("null/undefined/not_started → idle", () => {
+    assert.deepEqual(deriveCodexViewState(null, false), { phase: "idle" });
+    assert.deepEqual(deriveCodexViewState(undefined, false), { phase: "idle" });
+    assert.deepEqual(deriveCodexViewState({ status: "not_started" }, false), { phase: "idle" });
+  });
+  // Key case: user_code arrives seconds after start() — the UI must not assume
+  // it is present in the first response. awaiting_approval WITHOUT code = waiting.
+  test("awaiting_approval without user_code → waiting_for_code", () => {
+    assert.deepEqual(deriveCodexViewState({ status: "awaiting_approval" }, false), { phase: "waiting_for_code" });
+    // Also catches partial response (code present but no uri)
+    assert.deepEqual(deriveCodexViewState({ status: "awaiting_approval", user_code: "X" }, false), { phase: "waiting_for_code" });
+  });
+  test("awaiting_approval with both fields → show_code, fields surfaced", () => {
+    const vs = deriveCodexViewState(
+      { status: "awaiting_approval", user_code: "ABCD-1234", verification_uri: "https://example.com/activate" },
+      false,
+    );
+    assert.deepEqual(vs, { phase: "show_code", user_code: "ABCD-1234", verification_uri: "https://example.com/activate" });
+  });
+  test("complete → done", () => {
+    assert.deepEqual(deriveCodexViewState({ status: "complete" }, false), { phase: "done" });
+  });
+  test("failed → failed phase with error surfaced (or non-empty fallback)", () => {
+    assert.deepEqual(deriveCodexViewState({ status: "failed", error: "exit 1" }, false), { phase: "failed", error: "exit 1" });
+    const noErr = deriveCodexViewState({ status: "failed" }, false);
+    assert.equal(noErr.phase, "failed");
+    assert.ok((noErr as { phase: "failed"; error: string }).error.length > 0);
+  });
+  // timeout and failed must produce DISTINCT phases; collapsing them is the failure mode.
+  test("timeout → timeout (distinct from failed)", () => {
+    const vs = deriveCodexViewState({ status: "timeout" }, false);
+    assert.equal(vs.phase, "timeout");
+    assert.notEqual(vs.phase, "failed");
+  });
+  test("restarting=true overrides any server status", () => {
+    for (const s of ["complete", "failed", "timeout", "awaiting_approval"] as const)
+      assert.equal(deriveCodexViewState({ status: s }, true).phase, "restarting", `override ${s}`);
+  });
+});
+
+describe("isTerminal", () => {
+  test("complete / failed / timeout are terminal", () => {
+    assert.ok(isTerminal("complete") && isTerminal("failed") && isTerminal("timeout"));
+  });
+  test("not_started / awaiting_approval / undefined are not terminal", () => {
+    assert.ok(!isTerminal("not_started") && !isTerminal("awaiting_approval") && !isTerminal(undefined));
+  });
+});
+
+describe("shouldDispatchRestart", () => {
+  test("complete + not yet sent → dispatch", () => {
+    assert.ok(shouldDispatchRestart("complete", false));
+  });
+  // Reaching complete twice must dispatch restart once — the guard holds.
+  test("complete + already sent → no second dispatch", () => {
+    assert.ok(!shouldDispatchRestart("complete", true));
+  });
+  test("non-complete statuses never restart", () => {
+    assert.ok(!shouldDispatchRestart("failed", false) && !shouldDispatchRestart("timeout", false)
+      && !shouldDispatchRestart("awaiting_approval", false) && !shouldDispatchRestart(undefined, false));
+  });
+});

--- a/packages/web/src/dashboard/codexAuthCore.ts
+++ b/packages/web/src/dashboard/codexAuthCore.ts
@@ -1,0 +1,63 @@
+// codexAuthCore.ts — pure state derivation for the Codex OAuth device-code
+// ceremony surface in HermesAuthBanner. Zero imports; runs in any JS env.
+// Mirrors the five statuses emitted by hermes_codex_auth.ts (Lane I #566).
+
+export type CodexStatus =
+  | "not_started" | "awaiting_approval" | "complete" | "failed" | "timeout";
+
+export interface CodexStatusPayload {
+  status: CodexStatus;
+  user_code?: string;
+  verification_uri?: string;
+  error?: string;
+}
+
+// Seven view phases:
+//   idle            — no ceremony started; show CLI fallback + Connect button
+//   waiting_for_code — started; user_code not yet in the response (~2 s later)
+//   show_code       — user_code + uri ready; principal must visit the URL
+//   restarting      — complete ACK'd; restart in flight (~30 s)
+//   done            — restart finished; banner may be dismissed
+//   failed          — ceremony exited non-zero
+//   timeout         — device code expired; principal must Retry
+export type CodexViewState =
+  | { phase: "idle" }
+  | { phase: "waiting_for_code" }
+  | { phase: "show_code"; user_code: string; verification_uri: string }
+  | { phase: "restarting" }
+  | { phase: "done" }
+  | { phase: "failed"; error: string }
+  | { phase: "timeout" };
+
+/** Maps a raw status payload to a view phase. `restarting` overrides server status. */
+export function deriveCodexViewState(
+  payload: CodexStatusPayload | null | undefined,
+  restarting: boolean,
+): CodexViewState {
+  if (restarting) return { phase: "restarting" };
+  if (!payload || payload.status === "not_started") return { phase: "idle" };
+  switch (payload.status) {
+    case "awaiting_approval":
+      // user_code arrives seconds AFTER start fires — never assume it is present.
+      if (payload.user_code && payload.verification_uri)
+        return { phase: "show_code", user_code: payload.user_code, verification_uri: payload.verification_uri };
+      return { phase: "waiting_for_code" };
+    case "complete": return { phase: "done" };
+    case "failed": return { phase: "failed", error: payload.error ?? "authentication failed" };
+    case "timeout": return { phase: "timeout" };
+  }
+}
+
+/** True for the three server-terminal statuses: complete / failed / timeout. */
+export function isTerminal(status: CodexStatus | undefined): boolean {
+  return status === "complete" || status === "failed" || status === "timeout";
+}
+
+/**
+ * Whether the component should fire the hermes restart call.
+ * Extracted for testability — use with sentRestart.current:
+ *   if (shouldDispatchRestart(status, sent)) { sent=true; dispatch(); }
+ */
+export function shouldDispatchRestart(status: CodexStatus | undefined, alreadySent: boolean): boolean {
+  return status === "complete" && !alreadySent;
+}

--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -703,6 +703,40 @@ export const getTailscalePeers = async (_args: unknown, context: any) => {
 };
 
 // ============================================================
+// Codex OAuth ceremony (#565). Backed by the two ctrl-api routes
+// in packages/ctrl/src/api/routes/hermes_codex_auth.ts (PR #566).
+//   getCodexAuthStatus → GET  /api/v1/hermes/codex-auth/status
+//   startCodexAuth     → POST /api/v1/hermes/codex-auth/start
+//   restartHermes      → POST /api/v1/hermes/restart
+// ============================================================
+
+export const getCodexAuthStatus = async (_args: unknown, context: any) => {
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    path: "/api/v1/hermes/codex-auth/status",
+    timeoutMs: 10_000,
+  });
+};
+
+export const startCodexAuth = async (_args: unknown, context: any) => {
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    method: "POST",
+    path: "/api/v1/hermes/codex-auth/start",
+    timeoutMs: 15_000,
+  });
+};
+
+export const restartHermes = async (_args: unknown, context: any) => {
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, {
+    method: "POST",
+    path: "/api/v1/hermes/restart",
+    timeoutMs: 45_000,
+  });
+};
+
+// ============================================================
 // Lane III — Recall.ai channel on /channels (#113 PR3).
 // ============================================================
 //


### PR DESCRIPTION
## Summary

- Adds `codexAuthCore.ts` — a pure, import-free state-derivation module for the Codex OAuth device-code ceremony. Exports `deriveCodexViewState`, `isTerminal`, and `shouldDispatchRestart`. Follows the `tailscaleCardCore` pattern.
- Adds `codexAuthCore.test.ts` — 12 `node:test` cases covering all five server statuses, the key `awaiting_approval`-without-code transition, distinct `failed`/`timeout` phases, error surfacing, and the restart-idempotency guard.
- Rewrites `HermesAuthBanner.tsx` to use the core module. Removes inline state machine; banner derives view state from `deriveCodexViewState(payload, restarting)`.
- Adds three Wasp operations (`getCodexAuthStatus` query, `startCodexAuth` action, `restartHermes` action) wired through `proxyToTenant` in `operations.ts`.
- Fixes dead CLI fallback: `hermes auth login --provider openai-codex` does not exist on the 0.19.0 wheel. Corrected to `hermes auth add openai-codex --type oauth`.

## Scope note

`scope_limit` raised to 330 — coordinator-authorised. The original 200-line limit forced a choice between the tested pure-logic seam and fitting the number; the coordinator's instruction was that the seam and its tests are the right call, and the coordinator decides on scope raises (not the lane agent). Total PR diff: 305 changed lines.

## Flow

1. Banner appears when `getOnboardingProgress` reports a degraded stage.
2. Operator clicks **Connect from browser** → `startCodexAuth` → `flowActive` goes true → fast poll (2.5 s).
3. Until first response: `displayPhase = "waiting_for_code"` (before payload arrives).
4. When `user_code` + `verification_uri` arrive → `show_code` phase displays them.
5. After operator approves → `complete` → `shouldDispatchRestart` check → `restartHermes` fires once (idempotent via `sentRestart` ref) → `restarting` phase → `done`.
6. `failed`/`timeout` show distinct messages + Retry button. Retry resets `sentRestart.current`.

## Operator steps

After merge CI rebuilds `alfred-web:latest` and `alfred-web-client:latest`. Both containers need redeploying (`web` + `web-client`) — see CLAUDE.md §15.4. Hard browser refresh required.

**A live ceremony pass on `home.alfred.black` is required before #565 can be closed.** The coordinator will run this after deploy.

## Smoke evidence

Local structural smoke:

```
# 1. Gate passed on both commits
commit 71683ba2: lane III (web) gate passed — 173 LOC, 3 files, verify ok
commit 0f5345c6: lane III (web) gate passed — 200 LOC, 3 files, verify ok

# 2. Tests: 12/12 pass
$ tsx --test packages/web/src/dashboard/codexAuthCore.test.ts
# tests 12 / pass 12 / fail 0

# 3. Cases exercised by the tests:
  - awaiting_approval WITHOUT user_code → waiting_for_code  [the key bug]
  - awaiting_approval WITH code → show_code (fields surfaced)
  - complete, failed, timeout → distinct phases
  - error string surfaced; fallback non-empty when absent
  - restarting=true overrides any server status
  - shouldDispatchRestart: complete+false→true, complete+true→false [guard]
  - isTerminal: correct for all 5 statuses

# 4. Wiring: three ops in main.wasp and operations.ts
$ grep -c "getCodexAuthStatus\|startCodexAuth\|restartHermes" packages/web/main.wasp
6
$ grep -c "getCodexAuthStatus\|startCodexAuth\|restartHermes" packages/web/src/dashboard/operations.ts
6

# 5. CLI fix confirmed
$ grep "hermes auth add" packages/web/src/dashboard/HermesAuthBanner.tsx
  "docker exec -it alfred-black-hermes-1 hermes auth add openai-codex --type oauth\n" +
```

Live UI ceremony verification (device-code exchange, restart, banner clearing) **needs a live staging UI pass** after CI builds the images. The coordinator has indicated they will run this on `home.alfred.black` after deploy.

References #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)
