### PR TITLE
fix(web): codexAuthCore test import must be extensionless for wasp build (#565)

### DIFF
--- a/packages/web/src/dashboard/codexAuthCore.test.ts
+++ b/packages/web/src/dashboard/codexAuthCore.test.ts
@@ -1,6 +1,6 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
-import { deriveCodexViewState, isTerminal, shouldDispatchRestart } from "./codexAuthCore.ts";
+import { deriveCodexViewState, isTerminal, shouldDispatchRestart } from "./codexAuthCore";
 
 describe("deriveCodexViewState", () => {
   test("null/undefined/not_started → idle", () => {


### PR DESCRIPTION
Main went red on `build-web` immediately after #569.

`import … from "./codexAuthCore.ts"` is accepted by `tsx --test` but rejected by wasp's tsc: `TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled`. The existing `tailscaleCardCore.test.ts` imports extensionless; this matches it.

**Why the gate missed it:** `build-web.yml` is push-to-main and path-filtered, so it never ran on the PR. The lane VERIFY was a grep-based wiring check because `tsc` cannot run pre-codegen in this package — which means `wasp build` in CI is the only real type gate for `packages/web`, and it only fires after merge. Worth remembering before the next web merge.

## Smoke evidence

```
$ npx tsx --test src/dashboard/codexAuthCore.test.ts
# tests 12
# suites 3
# pass 12
# fail 0
```

Unblocks the `alfred-web` / `alfred-web-client` rebuild needed to deploy the Codex auth UI.