### PR TITLE
feat(ctrl): clusterBursts — engaged-time derivation primitive (#563 item 1)

### DIFF
--- a/packages/ctrl/src/api/routes/decisions.ts
+++ b/packages/ctrl/src/api/routes/decisions.ts
@@ -239,7 +239,9 @@ export function registerDecisionRoutes(): void {
   //
   // Creates a new decision record. Required body fields: source,
   // source_record, intent. Optional: note, matter_ref, task_ref,
-  // source_headline, time_to_decision_ms.
+  // source_headline, time_to_decision_ms (client-reported card-shown →
+  // card-clicked span in ms; NOT engaged time — populated on ~8% of rows;
+  // the server never derives this value; see #563 for the correct approach).
   //
   // Returns the created record (id, path, frontmatter). The
   // DecisionRouterWorkflow will pick it up within ~60s and fan out the
@@ -296,6 +298,8 @@ export function registerDecisionRoutes(): void {
     let taskRef = typeof b.task_ref === "string" ? b.task_ref.trim() : "";
     const sourceHeadline =
       typeof b.source_headline === "string" ? b.source_headline.trim() : "";
+    // Client-reported span (card-shown → card-clicked), not engaged time.
+    // Populated on ~8% of decisions. Never server-computed. See #563.
     const ttd =
       typeof b.time_to_decision_ms === "number" ? b.time_to_decision_ms : null;
 

--- a/packages/ctrl/src/db/engagedTime.ts
+++ b/packages/ctrl/src/db/engagedTime.ts
@@ -1,0 +1,70 @@
+// ============================================================================
+// engagedTime.ts — derive principal engaged time from event timestamps.
+// Issue #563 sequence item 1.
+//
+// Engaged time is a property of a *period*, not of a single decision.
+// Twelve clicks inside six minutes is six minutes of attention, not twelve
+// separate durations. This module provides the derivation primitive.
+//
+// The consumer is the nightly recap workflow (Lane II, #563 item 4).
+// Shipping the derivation without the consumer is intentional — once the
+// recap workflow lands it will import clusterBursts from here.
+// ============================================================================
+
+/** Result of clustering timestamps into interaction bursts. */
+export interface BurstResult {
+  /** Total engaged milliseconds — burst spans each floored at floorMs. */
+  totalMs: number;
+  /** Number of distinct bursts detected. */
+  burstCount: number;
+}
+
+/**
+ * Cluster timestamps into interaction bursts and return total engaged ms.
+ *
+ * Algorithm
+ * ---------
+ * - Input is sorted internally (a copy — the caller's array is not mutated).
+ *   Accepting unsorted input is the safer contract: an unsorted array would
+ *   silently produce wrong results, so sorting once here costs O(n log n)
+ *   but eliminates the silent-wrong-answer class of bugs.
+ * - Consecutive events separated by ≤ gapMs belong to one burst.
+ * - Each burst contributes max(span, floorMs) to the total, so an isolated
+ *   event is not scored as zero.
+ *
+ * @param ts      Event timestamps (order does not matter — sorted internally).
+ * @param gapMs   Gap threshold in ms; a gap larger than this ends a burst.
+ * @param floorMs Minimum contribution per burst in ms.
+ */
+export function clusterBursts(
+  ts: Date[],
+  gapMs: number,
+  floorMs: number,
+): BurstResult {
+  if (ts.length === 0) return { totalMs: 0, burstCount: 0 };
+
+  // Sort a copy so we never mutate the caller's array.
+  const sorted = ts.slice().sort((a, b) => a.getTime() - b.getTime());
+
+  let totalMs = 0;
+  let burstCount = 0;
+  let start = sorted[0];
+  let end = sorted[0];
+
+  for (let i = 1; i < sorted.length; i++) {
+    const gap = sorted[i].getTime() - end.getTime();
+    if (gap <= gapMs) {
+      end = sorted[i]; // extend the current burst
+    } else {
+      totalMs += Math.max(end.getTime() - start.getTime(), floorMs);
+      burstCount++;
+      start = sorted[i];
+      end = sorted[i];
+    }
+  }
+  // Close the final burst.
+  totalMs += Math.max(end.getTime() - start.getTime(), floorMs);
+  burstCount++;
+
+  return { totalMs, burstCount };
+}

--- a/packages/ctrl/tests/engaged-time.test.ts
+++ b/packages/ctrl/tests/engaged-time.test.ts
@@ -1,0 +1,104 @@
+// engaged-time.test.ts — unit tests for clusterBursts (#563 item 1).
+//
+// All expected values are computed by hand from the fixture inputs.
+// The function sorts its input internally; the unsorted-input test
+// verifies that contract.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { clusterBursts } from "../src/db/engagedTime.js";
+
+const MIN = 60_000; // one minute in milliseconds
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function d(isoStr: string): Date { return new Date(isoStr); }
+
+// ─── tests ──────────────────────────────────────────────────────────────────
+
+test("empty input returns zero and does not throw", () => {
+  const result = clusterBursts([], 5 * MIN, 2 * MIN);
+  assert.equal(result.totalMs, 0);
+  assert.equal(result.burstCount, 0);
+});
+
+test("two events inside the gap threshold form one burst", () => {
+  // t0 and t1 are 3 min apart; gap threshold is 5 min → same burst.
+  // Span = 3 min > floor 2 min, so contribution = 3 min.
+  const t0 = d("2026-08-01T09:00:00Z");
+  const t1 = d("2026-08-01T09:03:00Z");
+  const { totalMs, burstCount } = clusterBursts([t0, t1], 5 * MIN, 2 * MIN);
+  assert.equal(burstCount, 1);
+  assert.equal(totalMs, 3 * MIN);
+});
+
+test("two events outside the gap threshold form two bursts", () => {
+  // t0 and t1 are 10 min apart; gap threshold is 5 min → separate bursts.
+  // Each is an isolated event (span 0), floored at 2 min each → total 4 min.
+  const t0 = d("2026-08-01T09:00:00Z");
+  const t1 = d("2026-08-01T09:10:00Z");
+  const { totalMs, burstCount } = clusterBursts([t0, t1], 5 * MIN, 2 * MIN);
+  assert.equal(burstCount, 2);
+  assert.equal(totalMs, 4 * MIN);
+});
+
+test("isolated single event contributes the floor, not zero", () => {
+  // A single timestamp has span 0; the floor applies.
+  const t0 = d("2026-08-01T10:00:00Z");
+  const { totalMs, burstCount } = clusterBursts([t0], 5 * MIN, 2 * MIN);
+  assert.equal(burstCount, 1);
+  assert.equal(totalMs, 2 * MIN);
+});
+
+test("unsorted input produces the same result as sorted input", () => {
+  // t0, t1 are 2 min apart (same burst); t2 is 18 min after t1 (new burst).
+  // Sorted:   burst 1 = [t0, t1] span 2 min; burst 2 = [t2] span 0 → floor 2 min.
+  //           totalMs = 2+2 = 4 min, burstCount = 2.
+  // Unsorted: [t2, t0, t1] — must produce identical result.
+  const t0 = d("2026-08-01T09:00:00Z");
+  const t1 = d("2026-08-01T09:02:00Z");
+  const t2 = d("2026-08-01T09:20:00Z");
+
+  const fromSorted   = clusterBursts([t0, t1, t2], 5 * MIN, 2 * MIN);
+  const fromUnsorted = clusterBursts([t2, t0, t1], 5 * MIN, 2 * MIN);
+
+  assert.equal(fromUnsorted.totalMs,    fromSorted.totalMs);
+  assert.equal(fromUnsorted.burstCount, fromSorted.burstCount);
+
+  // Sanity-check the expected values (derived by hand above).
+  assert.equal(fromSorted.totalMs, 4 * MIN);
+  assert.equal(fromSorted.burstCount, 2);
+});
+
+test("floor sensitivity: different floor values produce different totals", () => {
+  // A single isolated event has span 0, so total = floor exactly.
+  // floor=2min → totalMs=2min; floor=5min → totalMs=5min.
+  const t0 = d("2026-08-01T10:00:00Z");
+  const r2 = clusterBursts([t0], 5 * MIN, 2 * MIN);
+  const r5 = clusterBursts([t0], 5 * MIN, 5 * MIN);
+  assert.equal(r2.totalMs, 2 * MIN);
+  assert.equal(r5.totalMs, 5 * MIN);
+  assert.notEqual(r2.totalMs, r5.totalMs); // the parameter cannot be a no-op
+});
+
+test("floor does not apply when burst span exceeds it", () => {
+  // t0 and t1 are 10 min apart within a 15 min gap threshold → one burst.
+  // Span = 10 min > floor 2 min, so contribution = 10 min (not 2 min).
+  const t0 = d("2026-08-01T09:00:00Z");
+  const t1 = d("2026-08-01T09:10:00Z");
+  const { totalMs, burstCount } = clusterBursts([t0, t1], 15 * MIN, 2 * MIN);
+  assert.equal(burstCount, 1);
+  assert.equal(totalMs, 10 * MIN);
+});
+
+test("three events spanning two bursts — mixed span and floor", () => {
+  // t0+t1 are 3 min apart (same burst, span 3 min > floor 2 min).
+  // t1→t2 gap is 8 min > 5 min threshold → new burst; t2 is isolated, floor applies.
+  // Burst 1: 3 min. Burst 2: 2 min (floor). Total: 5 min.
+  const t0 = d("2026-08-01T09:00:00Z");
+  const t1 = d("2026-08-01T09:03:00Z");
+  const t2 = d("2026-08-01T09:11:00Z");
+  const { totalMs, burstCount } = clusterBursts([t0, t1, t2], 5 * MIN, 2 * MIN);
+  assert.equal(burstCount, 2);
+  assert.equal(totalMs, 5 * MIN);
+});


### PR DESCRIPTION
## What

`clusterBursts(ts, gapMs, floorMs)` — a pure, exported function in
`packages/ctrl/src/db/engagedTime.ts` that clusters event timestamps into
interaction bursts and returns total engaged milliseconds + a burst count.

This is #563 sequence item 1. The consumer is the nightly recap workflow
(Lane II, item 4). Shipping the derivation without its consumer is
intentional — the function is ready to import once the recap lands.

## Design decisions

**Sorts internally.** An unsorted array passed to the previous implementation
would have silently produced wrong results. The function now sorts a copy of
the input so unsorted timestamps produce the correct answer. Parameter renamed
from `sortedTs` to `ts` to reflect this.

**`time_to_decision_ms` — kept but labelled.** Removing the field would break
existing clients (the web sends it on ~8% of decisions) and orphan vault
records that carry it. The field name is kept; two comments in `decisions.ts`
now make explicit that it is a client-reported card-shown → card-clicked span,
not engaged time, and is never server-derived. #563 item 4 (the nightly recap)
is where the server-side derivation actually happens.

**From the reverted commit.** `clusterBursts` was written in #573 and reverted
in #575 because the surrounding statement endpoint was built to the wrong spec.
This PR takes only the function and its types; the rate table, statement shape,
and NAR arithmetic stay reverted.

## Tests (8)

All expected values are hand-computed from the fixture inputs.

| Test | Contract verified |
|---|---|
| Empty input | returns 0, does not throw |
| Two events inside gap threshold | one burst, span wins over floor |
| Two events outside gap threshold | two bursts, floor applied twice |
| Isolated single event | floor applied, not zero |
| Unsorted input | same result as sorted input |
| Floor sensitivity | different floor → different total, cannot be a no-op |
| Span beats floor | when span > floor, span is used |
| Mixed two-burst | burst with span + isolated burst with floor |

## Smoke evidence

The function is a pure computation module — no I/O, no database, no HTTP.
The smoke is the test suite.

```
TAP version 13
ok 1 - empty input returns zero and does not throw
ok 2 - two events inside the gap threshold form one burst
ok 3 - two events outside the gap threshold form two bursts
ok 4 - isolated single event contributes the floor, not zero
ok 5 - unsorted input produces the same result as sorted input
ok 6 - floor sensitivity: different floor values produce different totals
ok 7 - floor does not apply when burst span exceeds it
ok 8 - three events spanning two bursts — mixed span and floor
1..8
# tests 8
# suites 0
# pass 8
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 166.80975
✓ lane I (ctrl-api) gate passed — 180 LOC, 3 files, verify ok
```

Local node_modules symlink is circular (pre-existing — `alfred-merged/packages/ctrl/node_modules` self-references). Build and full test suite require `npm ci` (which CI's `test-ctrl` runs). Local VERIFY was updated to run the new test file directly via tsx.

References #563.

🤖 Generated with [Claude Code](https://claude.com/claude-code)