### PR TITLE
fix(db): register 0019 in migrate.ts — it shipped as a dead file (#563)

### DIFF
--- a/packages/ctrl/src/db/migrate.ts
+++ b/packages/ctrl/src/db/migrate.ts
@@ -32,6 +32,7 @@ import m0015 from "./migrations/0015_composio_user_defaults.sql";
 import m0016 from "./migrations/0016_files_extraction.sql";
 import m0017 from "./migrations/0017_agent_profiles.sql";
 import m0018 from "./migrations/0018_channel_identity.sql";
+import m0019 from "./migrations/0019_journal_solicited.sql";
 
 interface Migration {
   version: number;
@@ -59,6 +60,7 @@ const MIGRATIONS: Migration[] = [
   { version: 16, name: "files_extraction",    sql: m0016 },
   { version: 17, name: "agent_profiles",      sql: m0017 },
   { version: 18, name: "channel_identity",    sql: m0018 },
+  { version: 19, name: "journal_solicited",   sql: m0019 },
 ];
 
 /**

--- a/packages/ctrl/tests/alfred-journal.test.ts
+++ b/packages/ctrl/tests/alfred-journal.test.ts
@@ -20,6 +20,10 @@ import assert from "node:assert/strict";
 import { DatabaseSync } from "node:sqlite";
 import schema from "../src/db/schema.sql";
 import { runMigrations } from "../src/db/migrate.js";
+import { readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import {
   appendJournal,
   bindPrincipalChannel,
@@ -32,6 +36,20 @@ function makeDb(): DatabaseSync {
   db.exec(schema);
   runMigrations(db);
   return db;
+}
+
+// Latest migration version, derived from the migrations directory rather than
+// hardcoded. A hardcoded number means every new migration breaks an unrelated
+// test and the fix is a bump, which teaches nobody anything. Derived, this
+// still catches a real failure — the runner not reaching the latest registered
+// version — because expected and actual come from independent sources.
+function latestMigrationVersion(): number {
+  const dir = join(dirname(fileURLToPath(import.meta.url)), "..", "src", "db", "migrations");
+  const nums = readdirSync(dir)
+    .filter((f) => f.endsWith(".sql"))
+    .map((f) => Number(f.slice(0, 4)))
+    .filter((n) => Number.isFinite(n));
+  return Math.max(...nums);
 }
 
 function userVersion(db: DatabaseSync): number {
@@ -51,18 +69,10 @@ function tableNames(db: DatabaseSync): string[] {
 
 describe("alfred_journal migration", () => {
   it("bumps user_version to the latest migration", () => {
-    // The runner applies every migration > current version, so the value
-    // naturally tracks the highest registered version. Today: 18
-    // (0001 fix_pack + 0002 alfred_journal + 0003 tailscale_connection
-    // + 0004 channel_tokens + 0005 ha_channel + 0006 files_table
-    // + 0007 recall + 0008 ha_event_subscription
-    // + 0009 ha_registry_vanished + 0010 files_cold_archive
-    // + 0011 ha_tier4 + 0012 ha_integration_ref_removed_at
-    // + 0013 recall_realtime + 0014 tool_disposition
-    // + 0015 composio_user_defaults + 0016 files_extraction
-    // + 0017 agent_profiles + 0018 channel_identity).
+    // Derived from the migrations directory, not hardcoded — see
+    // latestMigrationVersion() above.
     const db = makeDb();
-    assert.equal(userVersion(db), 18);
+    assert.equal(userVersion(db), latestMigrationVersion());
     db.close();
   });
 

--- a/packages/ctrl/tests/migrate.test.ts
+++ b/packages/ctrl/tests/migrate.test.ts
@@ -9,12 +9,30 @@ import assert from "node:assert/strict";
 import { DatabaseSync } from "node:sqlite";
 import schema from "../src/db/schema.sql";
 import { runMigrations } from "../src/db/migrate.js";
+import { readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
 
 function cols(db: DatabaseSync, table: string): string[] {
   return (db.prepare(`PRAGMA table_info(${table})`).all() as { name: string }[]).map(
     (r) => r.name,
   );
 }
+// Latest migration version, derived from the migrations directory rather than
+// hardcoded. A hardcoded number means every new migration breaks an unrelated
+// test and the fix is a bump, which teaches nobody anything. Derived, this
+// still catches a real failure — the runner not reaching the latest registered
+// version — because expected and actual come from independent sources.
+function latestMigrationVersion(): number {
+  const dir = join(dirname(fileURLToPath(import.meta.url)), "..", "src", "db", "migrations");
+  const nums = readdirSync(dir)
+    .filter((f) => f.endsWith(".sql"))
+    .map((f) => Number(f.slice(0, 4)))
+    .filter((n) => Number.isFinite(n));
+  return Math.max(...nums);
+}
+
 function userVersion(db: DatabaseSync): number {
   return (db.prepare("PRAGMA user_version").get() as { user_version: number }).user_version;
 }
@@ -45,8 +63,8 @@ describe("state.db migration runner", () => {
     // + 0013_recall_realtime + 0014_tool_disposition
     // + 0015_composio_user_defaults + 0016_files_extraction
     // + 0017_agent_profiles + 0018_channel_identity).
-    assert.equal(v, 18, "migrated to latest version");
-    assert.equal(userVersion(db), 18);
+    assert.equal(v, latestMigrationVersion(), "migrated to latest version");
+    assert.equal(userVersion(db), latestMigrationVersion());
     assert.ok(cols(db, "observation").includes("processed_at"), "0001: processed_at present after migrate");
     // 0002: alfred_journal + alfred_principal tables present.
     const tables = (
@@ -366,7 +384,7 @@ describe("state.db migration runner", () => {
     db.exec(schema);
     runMigrations(db);
     const v2 = runMigrations(db);
-    assert.equal(v2, 18);
+    assert.equal(v2, latestMigrationVersion());
     assert.equal(
       cols(db, "observation").filter((c) => c === "processed_at").length,
       1,

--- a/packages/ctrl/tests/migrations-registered.test.ts
+++ b/packages/ctrl/tests/migrations-registered.test.ts
@@ -1,0 +1,41 @@
+// Every migrations/*.sql file must be registered in migrate.ts.
+//
+// migrate.ts loads migrations by STATIC IMPORT into an explicit MIGRATIONS
+// array — esbuild inlines each .sql as a text string at build time. A file
+// added to migrations/ but not imported there is therefore never applied,
+// and nothing else catches it: the build succeeds, CI is green, and the
+// column simply never appears. That happened with 0019 (#563 item 2), which
+// merged, built, and deployed as a dead file.
+//
+// This test closes that gap. It is deliberately filesystem-driven rather
+// than a hardcoded count, so it keeps working as migrations are appended.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const migrationsDir = join(here, "..", "src", "db", "migrations");
+const migrateTs = readFileSync(join(here, "..", "src", "db", "migrate.ts"), "utf8");
+
+test("every migration file is imported by migrate.ts", () => {
+  const files = readdirSync(migrationsDir).filter((f) => f.endsWith(".sql")).sort();
+  assert.ok(files.length > 0, "found no migration files — path wrong?");
+  const missing = files.filter((f) => !migrateTs.includes(`./migrations/${f}`));
+  assert.deepEqual(missing, [], `migration files not imported in migrate.ts: ${missing.join(", ")}`);
+});
+
+test("every migration file has a MIGRATIONS array entry", () => {
+  const files = readdirSync(migrationsDir).filter((f) => f.endsWith(".sql")).sort();
+  const missing: string[] = [];
+  for (const f of files) {
+    const n = Number(f.slice(0, 4));
+    // The entry references the import alias mNNNN for this version.
+    const alias = `m${String(n).padStart(4, "0")}`;
+    const entry = new RegExp(`version:\\s*${n}\\b[^}]*sql:\\s*${alias}\\b`);
+    if (!entry.test(migrateTs)) missing.push(f);
+  }
+  assert.deepEqual(missing, [], `migration files with no MIGRATIONS entry: ${missing.join(", ")}`);
+});


### PR DESCRIPTION
#577 added `migrations/0019_journal_solicited.sql` but not the import or the `MIGRATIONS` entry. It merged, built, and deployed to a tenant — and the column does not exist.

```
$ docker exec … node -e '…PRAGMA table_info(alfred_journal)…'
solicited column present: false     # on the image built from #577
```

## Why nothing caught it

`migrate.ts` loads migrations by **static import into an explicit array**; esbuild inlines each `.sql` as a text string at build time. An unregistered migration file is just an unused file — the build succeeds, `test-ctrl` passes, `lane-gate` passes, the image ships, and the schema silently never changes. There was no check that could have failed.

## The guard

Two filesystem-driven tests, so they keep working as migrations are appended rather than encoding a count:

- every `migrations/*.sql` is imported in `migrate.ts`
- every one has a matching `MIGRATIONS` array entry (version number ↔ import alias)

## Smoke evidence

Verified the guard actually fails on the broken state — a test that cannot fail is worse than no test:

```
=== against main's migrate.ts (0019 unregistered) ===
not ok 1 - every migration file is imported by migrate.ts
    migration files not imported in migrate.ts: 0019_journal_solicited.sql
not ok 2 - every migration file has a MIGRATIONS array entry
    migration files with no MIGRATIONS entry: 0019_journal_solicited.sql
# pass 0
# fail 2

=== with the fix ===
# pass 2
# fail 0
```

Needs a `ctrl-api` rebuild and redeploy before the column exists on any tenant.