### PR TITLE
feat(ctrl): populate alfred_journal.solicited at write time (#563 item 2)

### DIFF
--- a/packages/ctrl/src/api/routes/alfredDeliver.ts
+++ b/packages/ctrl/src/api/routes/alfredDeliver.ts
@@ -355,6 +355,13 @@ export function registerAlfredDeliverRoutes(): void {
     // profile's .env and journal entries scope to THAT profile.
     const profileCtx = resolveProfileContextForChannel(db, channel, to);
 
+    // solicited: the caller must pass 0 or 1 explicitly when it knows.
+    // Callers that cannot determine provenance omit the field → null (unknown).
+    // We only accept 0/1 integers to guard against truthy-string inflation.
+    const solicitedRaw = b.solicited;
+    const solicited =
+      solicitedRaw === 0 ? 0 : solicitedRaw === 1 ? 1 : null;
+
     const pending = appendJournal(db, {
       channel,
       chat_id: to,
@@ -364,6 +371,7 @@ export function registerAlfredDeliverRoutes(): void {
       source_kind: typeof b.source_kind === "string" ? b.source_kind : null,
       source_ref: typeof b.source_ref === "string" ? b.source_ref : null,
       hermes_profile: profileCtx.journal_scope_key,
+      solicited,
       metadata: {
         urgency,
         principal_note:
@@ -465,6 +473,10 @@ export function registerAlfredDeliverRoutes(): void {
       principal_note: principalNote,
       source_headline: sourceHeadline,
       summary,
+      // Delegate outcomes: Sir explicitly asked for a Sir-facing result when
+      // delegating (principal_note is set — the check above guards this path).
+      // The delivery is a reply to Sir's original delegation turn → solicited.
+      solicited: 1,
     };
     let resp: Response;
     try {

--- a/packages/ctrl/src/api/routes/alfredJournal.ts
+++ b/packages/ctrl/src/api/routes/alfredJournal.ts
@@ -87,6 +87,12 @@ export function registerAlfredJournalRoutes(): void {
       metadata = b.metadata as Record<string, unknown>;
     }
 
+    // solicited: accept 0 or 1 from callers that know provenance.
+    // Any other value (including omitted) → null (honest unknown).
+    const solicitedRaw = b.solicited;
+    const solicited =
+      solicitedRaw === 0 ? 0 : solicitedRaw === 1 ? 1 : null;
+
     const db = getStateDb();
     const entry = appendJournal(db, {
       channel,
@@ -101,6 +107,7 @@ export function registerAlfredJournalRoutes(): void {
       delivery_error: asOptionalString(b.delivery_error),
       metadata,
       principal_id: asOptionalString(b.principal_id),
+      solicited,
     });
 
     sendJson(res, 201, entry);

--- a/packages/ctrl/src/api/routes/channels_ha.ts
+++ b/packages/ctrl/src/api/routes/channels_ha.ts
@@ -327,6 +327,7 @@ function journalOut(
       status,
       delivery_error: deliveryError,
       metadata,
+      solicited: 1, // reply to a turn the principal initiated via HA.
     });
   } catch (e) {
     console.warn(

--- a/packages/ctrl/src/api/routes/channels_paperclip.ts
+++ b/packages/ctrl/src/api/routes/channels_paperclip.ts
@@ -471,6 +471,10 @@ function journalOut(
       hermes_profile: ctx.journal_scope_key,
       status,
       delivery_error: deliveryError,
+      // Paperclip heartbeats originate from the Paperclip platform, not from
+      // the principal. Alfred is responding to the platform, not to Sir.
+      // NAR interruption requires a turn Sir initiated → null (not applicable).
+      solicited: null,
     });
   } catch (e) {
     console.warn(

--- a/packages/ctrl/src/api/routes/phone.ts
+++ b/packages/ctrl/src/api/routes/phone.ts
@@ -1246,6 +1246,11 @@ export function registerPhoneRoutes(): void {
           duration_seconds: durationSeconds(startedAt, endedAt),
           turn_count: transcript.length,
         },
+        // This endpoint receives transcripts for both inbound calls (Sir called
+        // Alfred) and outbound calls (Alfred called Sir). The transcript body
+        // carries no direction marker that distinguishes the two cases, so we
+        // cannot honestly classify solicited/unsolicited at write time.
+        solicited: null,
       });
     } catch (err) {
       // Log and continue — the transcript is already in the stream log.

--- a/packages/ctrl/src/db/alfredJournal.ts
+++ b/packages/ctrl/src/db/alfredJournal.ts
@@ -35,6 +35,11 @@ export interface JournalEntry {
   status: Status;
   delivery_error: string | null;
   metadata: Record<string, unknown> | null;
+  /** NAR column (migration 0019). Only meaningful for direction='outbound'.
+   *  1 = solicited (reply to a principal-initiated turn).
+   *  0 = unsolicited (cron, proactive notification, instinct fire).
+   * null = unknown — writer could not determine provenance at write time. */
+  solicited: number | null;
   created_at: string;
   updated_at: string;
 }
@@ -54,6 +59,7 @@ interface RawJournalRow {
   status: string;
   delivery_error: string | null;
   metadata: string | null;
+  solicited: number | null;
   created_at: string;
   updated_at: string;
 }
@@ -83,6 +89,7 @@ function rowToEntry(r: RawJournalRow): JournalEntry {
     status: r.status as Status,
     delivery_error: r.delivery_error,
     metadata,
+    solicited: r.solicited ?? null,
     created_at: r.created_at,
     updated_at: r.updated_at,
   };
@@ -148,6 +155,11 @@ export function appendJournal(
     delivery_error?: string | null;
     metadata?: Record<string, unknown> | null;
     principal_id?: string | null;
+    /** NAR solicited flag (migration 0019). Only set for direction='outbound'.
+     *  1 = reply to a principal-initiated turn.
+     *  0 = Alfred-initiated (cron, proactive, instinct fire).
+     * null = writer cannot determine — the honest default. */
+    solicited?: number | null;
   },
 ): JournalEntry {
   const id = ulid();
@@ -155,13 +167,17 @@ export function appendJournal(
   const principalId =
     fields.principal_id ?? resolvePrincipal(db, fields.channel, fields.chat_id);
   const metadataJson = fields.metadata ? JSON.stringify(fields.metadata) : null;
+  // Normalise: only accept 0 or 1; anything else collapses to null so a
+  // stale caller passing a truthy string cannot silently inflate the term.
+  const solicited =
+    fields.solicited === 0 ? 0 : fields.solicited === 1 ? 1 : null;
 
   db.prepare(
     `INSERT INTO alfred_journal
        (id, ts, principal_id, channel, chat_id, direction, message,
         source_kind, source_ref, hermes_session_id, hermes_profile,
-        status, delivery_error, metadata, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        status, delivery_error, metadata, solicited, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     id,
     ts,
@@ -177,6 +193,7 @@ export function appendJournal(
     fields.status ?? "delivered",
     fields.delivery_error ?? null,
     metadataJson,
+    solicited,
     ts,
     ts,
   );

--- a/packages/ctrl/src/db/hermesCronJournal.ts
+++ b/packages/ctrl/src/db/hermesCronJournal.ts
@@ -102,6 +102,7 @@ export function reconcileCronOutbounds(
       source_kind: "cron", source_ref: job.name,
       hermes_session_id: sid, hermes_profile: profile,
       status: "delivered", metadata: { cron_job_id: jobId, cron_job_name: job.name },
+      solicited: 0, // cron-fired: Alfred initiated this exchange.
     });
     result.journaled++;
   }

--- a/packages/ctrl/tests/journal-solicited.test.ts
+++ b/packages/ctrl/tests/journal-solicited.test.ts
@@ -1,0 +1,136 @@
+// journal-solicited.test.ts — migration 0019 writers (#563 item 2).
+// Verifies solicited column values: cron→0, HA reply→1, Paperclip/phone→null,
+// inbound→null, explicit null→null (not 0), truthy non-int→null, omitted→null.
+//
+// NOTE: migrate.ts does not yet register 0019 (orchestrator must add the
+// import + MIGRATIONS entry — migrate.ts is forbidden-zone for Lane I).
+// makeDb() applies the migration SQL directly in the interim; after
+// migrate.ts registration the try/catch absorbs the duplicate-column error.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import schema from "../src/db/schema.sql";
+import migration0019 from "../src/db/migrations/0019_journal_solicited.sql";
+import { runMigrations } from "../src/db/migrate.js";
+import { appendJournal } from "../src/db/alfredJournal.js";
+
+function makeDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  db.exec(schema);
+  runMigrations(db);
+  try { db.exec(migration0019); } catch { /* already applied after migrate.ts registers 0019 */ }
+  return db;
+}
+
+function getSolicited(db: DatabaseSync, id: string): number | null {
+  const r = db.prepare("SELECT solicited FROM alfred_journal WHERE id = ?")
+    .get(id) as { solicited: number | null } | undefined;
+  return r?.solicited ?? null;
+}
+
+describe("solicited — cron outbound → 0", () => {
+  it("cron outbound records solicited=0 (Alfred initiated)", () => {
+    const db = makeDb();
+    const e = appendJournal(db, {
+      channel: "slack", chat_id: "C0CRON", direction: "outbound",
+      message: "briefing", source_kind: "cron", solicited: 0,
+    });
+    assert.strictEqual(getSolicited(db, e.id), 0);
+    assert.strictEqual(e.solicited, 0, "round-trip");
+    db.close();
+  });
+});
+
+describe("solicited — HA outbound → 1", () => {
+  it("HA reply records solicited=1 (reply to principal turn)", () => {
+    const db = makeDb();
+    const e = appendJournal(db, {
+      channel: "ha-conversation", chat_id: "ha-install-1", direction: "outbound",
+      message: "Good morning, Sir.", source_kind: "ha-conversation-reply",
+      hermes_profile: "main", solicited: 1,
+    });
+    assert.strictEqual(getSolicited(db, e.id), 1);
+    assert.strictEqual(e.solicited, 1, "round-trip");
+    db.close();
+  });
+});
+
+describe("solicited — Paperclip outbound → null", () => {
+  it("Paperclip reply records solicited=null (platform-initiated, not principal)", () => {
+    const db = makeDb();
+    const e = appendJournal(db, {
+      channel: "paperclip", chat_id: "paperclip-agent-001", direction: "outbound",
+      message: "Task acknowledged.", source_kind: "paperclip-reply", solicited: null,
+    });
+    assert.strictEqual(getSolicited(db, e.id), null);
+    assert.strictEqual(e.solicited, null, "round-trip");
+    db.close();
+  });
+});
+
+describe("solicited — phone transcript → null", () => {
+  it("phone transcript records solicited=null (call direction unknown at write time)", () => {
+    const db = makeDb();
+    const e = appendJournal(db, {
+      channel: "voice", chat_id: "+15551234567", direction: "outbound",
+      message: "Call summary.", source_kind: "voice-call-transcript", solicited: null,
+    });
+    assert.strictEqual(getSolicited(db, e.id), null);
+    db.close();
+  });
+});
+
+describe("solicited — inbound rows", () => {
+  it("inbound rows store null when solicited is omitted", () => {
+    const db = makeDb();
+    const e = appendJournal(db, {
+      channel: "ha-conversation", chat_id: "ha-install-1", direction: "inbound",
+      message: "What's on my brief?", source_kind: "ha-conversation-turn",
+    });
+    assert.strictEqual(getSolicited(db, e.id), null);
+    db.close();
+  });
+});
+
+describe("solicited — null integrity (guards silent default-to-0 regression)", () => {
+  it("explicit null stores null — NOT 0 (a 0 default inflates the interruption term)", () => {
+    // This test must break if any future refactor defaults solicited to 0.
+    // Wrong 0 inflates NAR's AI-caused-interruption subtraction term silently.
+    const db = makeDb();
+    const e = appendJournal(db, {
+      channel: "slack", chat_id: "U-OWNER", direction: "outbound",
+      message: "unknown provenance", source_kind: "system", solicited: null,
+    });
+    assert.strictEqual(getSolicited(db, e.id), null,
+      "explicit null must store null, never 0");
+    assert.strictEqual(e.solicited, null,
+      "returned entry must carry null, not 0");
+    db.close();
+  });
+
+  it("truthy non-integer collapses to null (normalisation)", () => {
+    const db = makeDb();
+    const e = appendJournal(db, {
+      channel: "slack", chat_id: "U-OWNER", direction: "outbound",
+      message: "test", solicited: ("yes" as unknown) as number,
+    });
+    assert.strictEqual(getSolicited(db, e.id), null,
+      "truthy non-integer must collapse to null, not 1");
+    db.close();
+  });
+
+  it("omitting solicited stores null — NOT 0", () => {
+    const db = makeDb();
+    const e = appendJournal(db, {
+      channel: "telegram", chat_id: "100000000", direction: "outbound",
+      message: "notification",
+      // solicited deliberately omitted
+    });
+    assert.strictEqual(getSolicited(db, e.id), null,
+      "omitting solicited must default to null, never 0");
+    assert.strictEqual(e.solicited, null,
+      "returned entry must carry null, not 0");
+    db.close();
+  });
+});


### PR DESCRIPTION
## Summary

- Stamps `alfred_journal.solicited` (0/1/null) at write time for all seven `appendJournal` call sites, eliminating the need to re-derive solicited/unsolicited from `source_kind` post-hoc for NAR computation.
- Classification: `cron→0` (Alfred initiated), `HA reply→1` (principal turn), `delegate-outcomes→1` (Sir asked for callback), `Paperclip/phone/unknown→null`.
- Normalisation guard in `appendJournal`: only exact integers 0 or 1 accepted; anything else (omitted, truthy string, other number) collapses to `null`, preventing silent inflation of the NAR interruption term.

## Known gap — Lane II (tracked, not fixed here)

`alfredDeliver.ts` accepts `solicited` from the request body, so any caller that does not pass it produces `null`. The main proactive sender is `alfred-learn`, which does not pass `solicited` today. That means the largest genuinely-unsolicited category (learn-driven proactive delivers) stays `null` rather than `0` — the NAR interruption term has nothing to count from that path.

`null` is the correct and honest value here: guessing `0` would contradict the normalisation guard this PR ships. The fix belongs in Lane II (`packages/learn/**`) — learn's dispatch code must pass `solicited: 0` when firing proactively. Tracked as a follow-up to #563.

## Smoke evidence

Local run — `cd packages/ctrl && npm run build && npm run test:ci` after rebasing onto main (post-#578):

```
tests 1429
suites 352
pass  1428
fail  0
cancelled 0
skipped 1
```

The skipped test is a pre-existing flake in the quarantine list. The previously-failing `channels_ha_turn` and `channels_paperclip` journal-row tests now pass — the `solicited` column is available because #578 registered migration 0019 in `migrate.ts`.

Specific writer tests (`tests/journal-solicited.test.ts` — 8 tests):

```
solicited — cron outbound → 0                                          ok
solicited — HA outbound → 1                                            ok
solicited — Paperclip outbound → null                                  ok
solicited — phone transcript → null                                    ok
solicited — inbound rows                                               ok
solicited — null integrity (guards silent default-to-0 regression)     ok (3 sub-tests)
```

References #563 (item 2 of sequence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)