### PR TITLE
feat(ctrl): suppression rate card — fixed 0.5 min/item for NAR #563

### DIFF
--- a/packages/ctrl/src/api/routes/suppressionRateCard.ts
+++ b/packages/ctrl/src/api/routes/suppressionRateCard.ts
@@ -1,0 +1,93 @@
+// Suppression rate card — fixed per-item rate for NAR accounting (#563, item 5).
+// Placed in Lane I: ctrl owns the audit table where rate changes are logged.
+// DEFAULT = 0.5 min/item (30 s). Deliberately low — a defensible small number
+// beats an impressive one. 307 items × 5 min (model guess) = 25 h invented;
+// 307 × 0.5 = 2.5 h, arguable in one sentence. To raise it, argue with this
+// comment first, then explain the rationale in the commit message.
+// SCOPE: suppression only. CONSUMERS: nightly recap + Attention Statement (future).
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { appendAudit } from "./state.js";
+
+export const DEFAULT_RATE_MINUTES_PER_ITEM = 0.5;
+const OVERRIDE_FILE = "suppression-rate-card.json";
+const STATE_FILE    = "suppression-rate-card-state.json";
+
+export interface LoadedRateCard {
+  rate_minutes_per_item: number;
+  source: "default" | "override";
+  override_path: string | null;
+}
+
+function dataDir(opts?: { dataDir?: string }): string {
+  return opts?.dataDir ?? (process.env.ALFRED_DATA_DIR ?? "/alfred-data");
+}
+
+/**
+ * Load the effective rate card.
+ * An absent override file is normal. A malformed or invalid one THROWS —
+ * silently ignoring it means someone believes a rate is in effect that is not.
+ */
+export function loadRateCard(opts?: { dataDir?: string }): LoadedRateCard {
+  const d = dataDir(opts);
+  const op = path.join(d, OVERRIDE_FILE);
+  if (!fs.existsSync(op)) {
+    return { rate_minutes_per_item: DEFAULT_RATE_MINUTES_PER_ITEM, source: "default", override_path: null };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(op, "utf-8"));
+  } catch (err) {
+    throw new Error(`[suppression-rate-card] override at ${op} is not valid JSON: ${err}`);
+  }
+  if (!parsed || typeof parsed !== "object" || !("minutes_per_item" in parsed)) {
+    throw new Error(`[suppression-rate-card] override must be a JSON object with a "minutes_per_item" key`);
+  }
+  const rate = (parsed as Record<string, unknown>).minutes_per_item;
+  if (typeof rate !== "number" || !isFinite(rate) || rate < 0) {
+    throw new Error(`[suppression-rate-card] minutes_per_item must be a non-negative finite number; got ${JSON.stringify(rate)}`);
+  }
+  return { rate_minutes_per_item: rate, source: "override", override_path: op };
+}
+
+export function hashRateCard(c: LoadedRateCard): string {
+  return crypto.createHash("sha256")
+    .update(JSON.stringify({ rate: c.rate_minutes_per_item, source: c.source }))
+    .digest("hex").slice(0, 16);
+}
+
+function readHash(d: string): string | null {
+  try { const p = JSON.parse(fs.readFileSync(path.join(d, STATE_FILE), "utf-8")); return typeof p?.hash === "string" ? p.hash : null; } catch { return null; }
+}
+
+function writeHash(d: string, hash: string): void {
+  fs.mkdirSync(d, { recursive: true });
+  const p = path.join(d, STATE_FILE), tmp = p + ".tmp";
+  fs.writeFileSync(tmp, JSON.stringify({ hash, recorded_at: new Date().toISOString() }, null, 2) + "\n", "utf-8");
+  fs.renameSync(tmp, p);
+}
+
+/**
+ * Load the rate card and write an audit row when the rate has changed since
+ * the last persisted state. Idempotent on unchanged repeat calls.
+ */
+export function getRateCard(opts?: { dataDir?: string }): LoadedRateCard {
+  const d = dataDir(opts);
+  const loaded = loadRateCard({ dataDir: d });
+  const hash = hashRateCard(loaded);
+  const prev = readHash(d);
+  if (hash !== prev) {
+    appendAudit({
+      action_type: "suppression_rate_card_change",
+      actor: "alfred",
+      source: "suppression_rate_card",
+      summary: prev === null
+        ? `suppression rate card initialised: ${loaded.rate_minutes_per_item} min/item (${loaded.source})`
+        : `suppression rate card changed to ${loaded.rate_minutes_per_item} min/item (${loaded.source})`,
+      payload: { rate_minutes_per_item: loaded.rate_minutes_per_item, source: loaded.source, hash, previous_hash: prev },
+    });
+    writeHash(d, hash);
+  }
+  return loaded;
+}

--- a/packages/ctrl/tests/suppression-rate-card.test.ts
+++ b/packages/ctrl/tests/suppression-rate-card.test.ts
@@ -1,0 +1,96 @@
+// Suppression rate card tests (#563). Fixtures are raw JSON — not derived from loader.
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "suppression-rc-"));
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.STATE_DB_PATH   = path.join(tmp, "state.db");
+process.env.VAULT_PATH      = path.join(tmp, "vault");
+process.env.SQLITE_VEC_PATH = "";
+fs.mkdirSync(process.env.VAULT_PATH!, { recursive: true });
+
+const { loadRateCard, getRateCard, DEFAULT_RATE_MINUTES_PER_ITEM } =
+  await import("../src/api/routes/suppressionRateCard.js");
+const { getStateDb } = await import("../src/db/state.js");
+
+const OVERRIDE = path.join(tmp, "suppression-rate-card.json");
+const STATE    = path.join(tmp, "suppression-rate-card-state.json");
+const clear = () => { for (const f of [OVERRIDE, STATE]) { try { fs.unlinkSync(f); } catch { /**/ } } };
+const auditCount = () => (getStateDb().prepare("SELECT COUNT(*) AS n FROM audit WHERE action_type='suppression_rate_card_change'").get() as { n: number }).n;
+
+describe("suppression rate card", () => {
+  before(() => getStateDb());
+  beforeEach(clear);
+
+  // 1. Default loads when no override exists
+  it("loads default 0.5 min/item when no override file exists", () => {
+    const c = loadRateCard({ dataDir: tmp });
+    assert.strictEqual(c.rate_minutes_per_item, 0.5);
+    assert.strictEqual(DEFAULT_RATE_MINUTES_PER_ITEM, 0.5);
+    assert.strictEqual(c.source, "default");
+    assert.strictEqual(c.override_path, null);
+  });
+
+  // 2. Override overlays default
+  it("override file overlays the default", () => {
+    fs.writeFileSync(OVERRIDE, JSON.stringify({ minutes_per_item: 1.5 }), "utf-8");
+    const c = loadRateCard({ dataDir: tmp });
+    assert.strictEqual(c.rate_minutes_per_item, 1.5);
+    assert.strictEqual(c.source, "override");
+    assert.strictEqual(c.override_path, OVERRIDE);
+  });
+
+  // 3. Malformed / invalid override throws — never silently falls back
+  it("malformed JSON in override throws (not silent fallback)", () => {
+    fs.writeFileSync(OVERRIDE, "{not valid json", "utf-8");
+    assert.throws(() => loadRateCard({ dataDir: tmp }), /not valid JSON/);
+  });
+  it("override missing minutes_per_item key throws", () => {
+    fs.writeFileSync(OVERRIDE, JSON.stringify({ wrong: 1 }), "utf-8");
+    assert.throws(() => loadRateCard({ dataDir: tmp }), /minutes_per_item/);
+  });
+
+  // 4. Rate-change audit fires on hash change; not on unchanged repeat
+  it("audit row written on first getRateCard call (initialise)", () => {
+    const before = auditCount();
+    getRateCard({ dataDir: tmp });
+    assert.strictEqual(auditCount(), before + 1);
+  });
+  it("no audit row on unchanged repeat call", () => {
+    getRateCard({ dataDir: tmp });
+    const after1 = auditCount();
+    getRateCard({ dataDir: tmp });
+    assert.strictEqual(auditCount(), after1);
+  });
+  it("audit row written when rate changes", () => {
+    getRateCard({ dataDir: tmp });
+    const mid = auditCount();
+    fs.writeFileSync(OVERRIDE, JSON.stringify({ minutes_per_item: 0.75 }), "utf-8");
+    getRateCard({ dataDir: tmp });
+    assert.strictEqual(auditCount(), mid + 1);
+  });
+  it("audit payload carries rate, source, hash, previous_hash=null on init", () => {
+    getRateCard({ dataDir: tmp });
+    const row = getStateDb()
+      .prepare("SELECT payload_json FROM audit WHERE action_type='suppression_rate_card_change' ORDER BY created_at DESC LIMIT 1")
+      .get() as { payload_json: string };
+    const p = JSON.parse(row.payload_json);
+    assert.strictEqual(p.rate_minutes_per_item, 0.5);
+    assert.strictEqual(p.source, "default");
+    assert.ok(p.hash.length > 0);
+    assert.strictEqual(p.previous_hash, null);
+  });
+
+  // 5. Invalid rates rejected
+  it("negative rate rejected", () => {
+    fs.writeFileSync(OVERRIDE, JSON.stringify({ minutes_per_item: -1 }), "utf-8");
+    assert.throws(() => loadRateCard({ dataDir: tmp }), /non-negative/);
+  });
+  it("non-numeric rate rejected", () => {
+    fs.writeFileSync(OVERRIDE, JSON.stringify({ minutes_per_item: "fast" }), "utf-8");
+    assert.throws(() => loadRateCard({ dataDir: tmp }), /non-negative finite number/);
+  });
+});


### PR DESCRIPTION
## Summary

- Ships `suppressionRateCard.ts` in Lane I (not II as listed in #563) because ctrl owns the audit table where rate changes are logged and will compute the statement.
- Fixed default: **0.5 min/item** (30 s). Deliberately low — a defensible small number beats an impressive one.
- Per-tenant override at `ALFRED_DATA_DIR/suppression-rate-card.json`; an absent file is normal, a malformed one throws (never silently ignored).
- `getRateCard()` hashes the effective rate; writes an `suppression_rate_card_change` audit row to `alfred-state.db` only when the hash differs from the last persisted state. Idempotent on unchanged repeat calls.
- Scope: suppression only. No rates for `done`/`delegate`/`defer` — those classes are not yet characterised by a manual recap run.
- Ships without a consumer intentionally — nightly recap (item 4) and Attention Statement (item 6) are the consumers; those come next.

References #563.

## Smoke evidence

Local: `npm run test:ci` via the Lane I pre-commit VERIFY gate.

```
10 tests / 10 pass / 0 fail
```

Tests exercise all 5 required behaviours:
1. Default loads (0.5) when no override file exists.
2. Override file overlays the default.
3. Malformed override throws — no silent fallback.
4. Audit row fires on first call; not on unchanged repeat; fires again on rate change.
5. Negative and non-numeric rates are rejected.

Full test suite (`npm run test:ci`, 1,480 non-quarantined tests) passed with 0 new failures. The 10 failures in the run are all in the pre-existing quarantine list (`ha_ws_client`, `channels_ha_hacs`, `agent-profiles-channel-context`, `voice-routes-lane-vb`, `phone-outbound-call`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)