### PR TITLE
docs(design): correct the day A reference figure (#584)

### DIFF
--- a/docs/design/nar-method.md
+++ b/docs/design/nar-method.md
@@ -163,9 +163,27 @@ development tenant within a stated tolerance:
 
 | day | engaged | displaced | NAR |
 |---|---|---|---|
-| A (light) | 2.03 h | 1.85 h | −0.18 h |
+| A (light) | 2.03 h | 2.93 h | +0.90 h |
 | B (heavy) | 4.19 h | 12.03 h | +7.51 h |
 
-Day B includes the autonomous contribution; both were computed by hand before
-any automation existed. An implementation that cannot land near these is
-wrong, however plausible its output looks.
+Both were computed by hand before any automation existed. An implementation
+that cannot land near these is wrong, however plausible its output looks.
+
+**Day A was corrected on first validation, and the correction is instructive.**
+It was originally recorded as 1.85 h displaced / −0.18 h NAR. That figure was
+computed with a draft bucket table (M=15, L=45) before the canonical sizes
+above were settled, and it omitted the autonomous contribution entirely —
+autonomous work was only added to the method while analysing day B. The first
+implementation reproduced 2.933 h, which is what a corrected manual pass
+gives:
+
+```
+sessions  10 + 20 + 60 + 20 + 5  = 115 min
+noise     42 x 0.5               =  21 min
+chores    morning M + evening M  =  40 min
+                                   176 min = 2.93 h
+```
+
+The lesson worth keeping: a reference figure computed before the method was
+settled is not a reference. When an implementation disagrees with a target,
+re-derive the target before touching the code.


### PR DESCRIPTION
The day A acceptance target in `docs/design/nar-method.md` was wrong. The first implementation was right.

## What happened

Day A was recorded as **1.85 h displaced / −0.18 h NAR**. Two errors:

1. computed with a **draft bucket table** (M=15, L=45) before the canonical M=20/L=60 sizes were settled
2. **omitted the autonomous contribution** entirely — autonomous work was only added to the method while analysing day B

The Lane II implementation produced **2.933 h**, which is exactly what a corrected manual pass gives:

```
sessions  10 + 20 + 60 + 20 + 5  = 115 min
noise     42 × 0.5               =  21 min
chores    morning M + evening M  =  40 min
                                   176 min = 2.93 h
```

Corrected targets: **displaced 2.93 h, NAR +0.90 h**. Engaged is unchanged at 2.03 h and was reproduced to within 0.001 h.

## Why the correction stays visible in the doc

Rather than quietly rewriting the number, the doc now records what went wrong, because the failure mode generalises: **a reference figure computed before the method was settled is not a reference.** When an implementation disagrees with a target, re-derive the target before touching the code — otherwise correct code gets "fixed" to match a stale number.

Day B's target is unchanged. Its gap is a genuine implementation bug (the clerk sees only the last 8 turns of a session, so a 1000-message session is judged on its tail) and is being fixed in Lane II.

## Smoke evidence

Documentation only — no code, no schema, no runtime change.