### PR TITLE
feat(web): /attention page — NAR statement with three displacement groups (#584)

### DIFF
--- a/packages/web/main.wasp
+++ b/packages/web/main.wasp
@@ -2107,3 +2107,33 @@ route NotFoundRoute { path: "*", to: NotFoundPage }
 page NotFoundPage {
   component: import { NotFoundPage } from "@src/client/components/NotFoundPage"
 }
+
+// ============================================================
+// Attention Statement (#584 — NAR per day, queryable, on screen)
+// ============================================================
+// /attention — daily NAR breakdown plus range statistics.
+// The page shows three displacement groups (explicit / inferred /
+// autonomous) separately, the mess bill, the rate card, and any
+// unrated action classes. A recompute control POSTs for the
+// shown date. Both web + web-client need redeploying (§15.4).
+
+route AttentionRoute { path: "/attention", to: AttentionPage }
+page AttentionPage {
+  authRequired: true,
+  component: import AttentionPage from "@src/dashboard/AttentionPage"
+}
+
+query getAttentionStatement {
+  fn: import { getAttentionStatement } from "@src/dashboard/operations",
+  entities: []
+}
+
+query getAttentionStats {
+  fn: import { getAttentionStats } from "@src/dashboard/operations",
+  entities: []
+}
+
+action recomputeAttention {
+  fn: import { recomputeAttention } from "@src/dashboard/operations",
+  entities: []
+}

--- a/packages/web/src/client/components/ab/Frame.tsx
+++ b/packages/web/src/client/components/ab/Frame.tsx
@@ -36,7 +36,10 @@ const PRIMARY: NavItem[] = [
 // #120 Lane III — "Profiles" is the multi-profile Hermes manager; lives in
 // More for now so the primary nav stays short. Switching profiles is
 // UI-driven (navigate to /profiles/<slug>); per-page scoping is deferred.
+// #584 — "Attention" is the NAR statement surface; lives in More alongside
+// the other back-office views so the primary nav stays scannable.
 const MORE: NavItem[] = [
+  { to: "/attention", label: "Attention", icon: "pocket_watch" },
   { to: "/connections", label: "Apps", icon: "globe" },
   { to: "/profiles", label: "Profiles", icon: "calling_card" },
   { to: "/settings", label: "Settings", icon: "settings" },

--- a/packages/web/src/dashboard/AttentionPage.tsx
+++ b/packages/web/src/dashboard/AttentionPage.tsx
@@ -1,0 +1,148 @@
+// AttentionPage — NAR breakdown for /attention (#584).
+// Day view: headline NAR, three separate displacement groups (explicit /
+// inferred / autonomous), mess bill, stats, rate card, unrated classes.
+// Range view: per-day series table + totals.
+// Design constraints: groups never merged; unrated → "no rate established";
+// blocked items at zero with reason; rate card always visible.
+import { useState } from "react";
+import { useQuery, useAction, getAttentionStatement, getAttentionStats, recomputeAttention } from "wasp/client/operations";
+import { Frame } from "../client/components/ab/Frame";
+import { deriveDisplacementGroups, deriveUnratedRows, isEmptyDay, formatHours, type AttentionDayResponse, type SeriesPoint } from "./attentionCore";
+
+const now = () => new Date().toISOString().slice(0, 10);
+const sevenAgo = () => { const d = new Date(); d.setDate(d.getDate() - 6); return d.toISOString().slice(0, 10); };
+
+const mono10 = { color: "var(--marginalia)" } as const;
+const ML = ({ s }: { s: string }) => <p className="font-mono text-[10px] uppercase tracking-[0.26em] mb-1 mt-4" style={mono10}>{s}</p>;
+const Row = ({ l, r, dim }: { l: React.ReactNode; r: string; dim?: boolean }) => (
+  <div className={`flex justify-between items-baseline py-0.5${dim ? " opacity-50" : ""}`}>
+    <span className="text-sm font-sans">{l}</span>
+    <span className="font-mono text-sm tabular-nums">{r}</span>
+  </div>
+);
+const hr = <div className="border-t border-[var(--brass)]/20 my-3" />;
+
+function DayView({ day, recomp, running }: { day: AttentionDayResponse; recomp(): void; running: boolean }) {
+  if (isEmptyDay(day)) return (
+    <div className="py-10 text-center">
+      <p className="text-sm opacity-50">No attention data for {day.date}.</p>
+      <button type="button" onClick={recomp} disabled={running} className="mt-4 font-mono text-[10px] uppercase tracking-[0.22em] border border-[var(--brass)]/40 px-4 py-2 hover:border-[var(--brass)] disabled:opacity-30 transition-colors">{running ? "Recomputing…" : "Recompute"}</button>
+    </div>
+  );
+
+  const g = deriveDisplacementGroups(day.displaced);
+  const un = deriveUnratedRows(day.unrated ?? []);
+  const h = (v: number) => `${formatHours(v)} h`;
+  const hm = (m: number) => h(m / 60);
+
+  return (
+    <div className="max-w-xl">
+      <div className="flex justify-between items-baseline mb-4">
+        <span className="font-mono text-[10px] uppercase tracking-[0.26em]" style={mono10}>Net Attention Returned</span>
+        <span className="font-mono text-3xl tabular-nums">{formatHours(day.nar_hours)}<span className="ml-1 text-base opacity-40">h</span></span>
+      </div>
+      {hr}
+
+      <ML s="Displacement — Explicit" />
+      {g.explicit.items.length === 0 ? <p className="text-xs opacity-40">None.</p> : g.explicit.items.map((it, i) => (
+        <Row key={i} l={<>{it.label} <span className="opacity-40 text-xs">(×{it.count} @ {it.rate_minutes} min)</span></>} r={hm(it.minutes)} />
+      ))}
+      <Row l="Subtotal" r={h(g.explicit.hours)} dim />
+
+      <ML s="Displacement — Inferred" />
+      {g.inferred.items.length === 0 ? <p className="text-xs opacity-40">None.</p> : g.inferred.items.map((it, i) => (
+        <div key={i} className="py-0.5">
+          <Row l={<>{it.label} <span className="font-mono text-xs opacity-40">[{it.bucket}]</span> <span className="opacity-30 text-xs">{it.turns}t {it.tools}tools</span></>} r={hm(it.display_minutes)} />
+          {it.is_blocked && <p className="text-xs text-right italic opacity-40">{it.blocked_reason}</p>}
+        </div>
+      ))}
+      <Row l="Subtotal" r={h(g.inferred.hours)} dim />
+
+      <ML s="Displacement — Autonomous" />
+      {g.autonomous.items.length === 0 ? <p className="text-xs opacity-40">None.</p> : g.autonomous.items.map((it, i) => (
+        <Row key={i} l={<>{it.label} <span className="font-mono text-xs opacity-40">[{it.bucket}]</span></>} r={hm(it.minutes)} />
+      ))}
+      <Row l="Subtotal" r={h(g.autonomous.hours)} dim />
+
+      <div className="flex justify-between items-baseline py-1 mt-2 border-t border-[var(--rule)]">
+        <span className="font-sans text-sm font-semibold">Total displaced</span>
+        <span className="font-mono text-sm tabular-nums">{h(day.displaced?.total_hours ?? 0)}</span>
+      </div>
+      {hr}
+
+      <ML s="Mess bill" />
+      <Row l={<>Engaged <span className="opacity-40 text-xs">({day.engaged.events} ev, {day.engaged.bursts} bursts)</span></>} r={h(day.engaged.hours)} />
+      <Row l={<>Interruption <span className="opacity-40 text-xs">(×{day.interruption.count} @ {day.interruption.rate_minutes} min)</span></>} r={h(day.interruption.hours)} />
+
+      <ML s="Statistics" />
+      <p className="font-mono text-xs opacity-60">
+        {day.stats.sessions} sessions · {day.stats.turns} turns · blocked {day.stats.blocked} · failures {day.stats.hard_failures} · return {day.stats.return_ratio.toFixed(2)} · artifacts {day.stats.autonomous_artifacts}
+      </p>
+
+      <ML s="Rate card in force" />
+      <Row l="Suppression" r={`${day.rates.suppression_minutes_per_item} min/item`} />
+      <Row l="Interruption" r={`${day.rates.interruption_minutes} min`} />
+      <Row l="Buckets" r={`S=${day.rates.bucket_minutes.S} M=${day.rates.bucket_minutes.M} L=${day.rates.bucket_minutes.L} XL=${day.rates.bucket_minutes.XL} min`} />
+
+      {un.length > 0 && (<>
+        <ML s="Unrated action classes" />
+        {un.map((r) => <Row key={r.action_class} l={<span className="font-mono text-xs">{r.action_class}</span>} r={`×${r.count} — no rate established`} />)}
+      </>)}
+      {hr}
+      <button type="button" onClick={recomp} disabled={running} className="font-mono text-[10px] uppercase tracking-[0.22em] border border-[var(--brass)]/40 px-4 py-2 hover:border-[var(--brass)] disabled:opacity-30 transition-colors">{running ? "Recomputing…" : "Recompute this day"}</button>
+    </div>
+  );
+}
+
+function RangeView({ stats }: { stats: { series: SeriesPoint[]; totals: { nar_hours: number; displaced_hours: number; engaged_hours: number } } }) {
+  const h = (v: number) => `${formatHours(v)} h`;
+  return (
+    <div className="max-w-xl">
+      <ML s="Period totals" />
+      <Row l="NAR" r={h(stats.totals.nar_hours)} /><Row l="Displaced" r={h(stats.totals.displaced_hours)} /><Row l="Engaged" r={h(stats.totals.engaged_hours)} />
+      <ML s="Daily series" />
+      {stats.series.length === 0 ? <p className="text-xs opacity-40">No data.</p> : (
+        <table className="w-full text-xs font-mono">
+          <thead><tr className="border-b border-[var(--rule)]"><th className="text-left py-1 opacity-40 font-normal">Date</th><th className="text-right py-1 opacity-40 font-normal">NAR</th><th className="text-right py-1 opacity-40 font-normal">Displaced</th><th className="text-right py-1 opacity-40 font-normal">Engaged</th></tr></thead>
+          <tbody>{stats.series.map((pt) => (<tr key={pt.date} className="border-b border-[var(--rule)]/30 hover:bg-[var(--brass)]/5 transition-colors"><td className="py-1 tabular-nums">{pt.date}</td><td className="py-1 text-right tabular-nums">{formatHours(pt.nar_hours)}</td><td className="py-1 text-right tabular-nums opacity-60">{formatHours(pt.displaced_hours)}</td><td className="py-1 text-right tabular-nums opacity-60">{formatHours(pt.engaged_hours)}</td></tr>))}</tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+export default function AttentionPage() {
+  const [tab, setTab] = useState<"day" | "range">("day");
+  const [date, setDate] = useState(now()); const [from, setFrom] = useState(sevenAgo()); const [to, setTo] = useState(now());
+  const [running, setRunning] = useState(false);
+  const dayQ = useQuery(getAttentionStatement, { date }, { enabled: tab === "day" });
+  const statsQ = useQuery(getAttentionStats, { from, to }, { enabled: tab === "range" });
+  const recompute = useAction(recomputeAttention);
+  const din = (val: string, set: (v: string) => void, max?: string) => (
+    <input type="date" value={val} max={max} onChange={(e) => set(e.target.value)} className="font-mono text-xs border border-[var(--rule)] bg-transparent px-2 py-1 focus:outline-none focus:border-[var(--brass)] transition-colors" />
+  );
+  async function handleRecompute() { setRunning(true); try { await recompute({ date }); await dayQ.refetch(); } finally { setRunning(false); } }
+
+  return (
+    <Frame>
+      <div className="max-w-xl mb-6">
+        <span className="font-mono text-[10px] uppercase tracking-[0.32em] block mb-3" style={mono10}>Attention</span>
+        <h1 className="font-display tracking-[-0.02em] leading-[0.98]" style={{ fontSize: "clamp(44px,6vw,72px)" }}>Statement</h1>
+        <p className="font-sans text-sm opacity-50 mt-2">NAR — what Alfred genuinely displaced, by source and kind. Every figure recomputable from the rate card.</p>
+      </div>
+      <div className="flex gap-6 mb-6 border-b border-[var(--rule)]">
+        {(["day","range"] as const).map((t) => <button key={t} type="button" onClick={() => setTab(t)} className="font-mono text-[10px] uppercase tracking-[0.22em] pb-2 transition-colors" style={{ color: tab===t?"var(--brass)":"var(--marginalia)", borderBottom: tab===t?"1px solid var(--brass)":"1px solid transparent" }}>{t==="day"?"Day":"Range"}</button>)}
+      </div>
+      <div className="flex items-center gap-3 mb-6">
+        {tab === "day" ? din(date, setDate, now()) : <>{din(from, setFrom, to)}<span className="font-mono text-xs opacity-40">to</span>{din(to, setTo, now())}</>}
+      </div>
+      {tab === "day"
+        ? dayQ.isLoading ? <p className="text-xs opacity-40">Loading…</p>
+          : dayQ.error ? <p className="text-xs text-red-500">{String((dayQ.error as any)?.message??"Failed.")}</p>
+          : dayQ.data ? <DayView day={dayQ.data as AttentionDayResponse} recomp={handleRecompute} running={running} /> : null
+        : statsQ.isLoading ? <p className="text-xs opacity-40">Loading…</p>
+          : statsQ.error ? <p className="text-xs text-red-500">{String((statsQ.error as any)?.message??"Failed.")}</p>
+          : statsQ.data ? <RangeView stats={statsQ.data as any} /> : null}
+    </Frame>
+  );
+}

--- a/packages/web/src/dashboard/attentionCore.test.ts
+++ b/packages/web/src/dashboard/attentionCore.test.ts
@@ -1,0 +1,72 @@
+/**
+ * attentionCore unit tests (#584).
+ * Run: cd packages/web && npx tsx --test src/dashboard/attentionCore.test.ts
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  deriveUnratedRows, deriveInferredDisplay, deriveDisplacementGroups,
+  isEmptyDay, formatHours, formatMinutes,
+  type AttentionDayResponse, type InferredItem,
+} from "./attentionCore";
+
+const I: InferredItem = { label: "x", bucket: "M", minutes: 20, turns: 10, tools: 5, evidence_kind: "session", evidence_ref: "s", outcome: "delivered" };
+
+const E: AttentionDayResponse = {
+  date: "2026-08-14", nar_hours: 0,
+  displaced: { total_hours: 0, explicit: { hours: 0, items: [] }, inferred: { hours: 0, items: [] }, autonomous: { hours: 0, items: [] } },
+  engaged: { hours: 0, events: 0, bursts: 0, gap_minutes: 10, floor_minutes: 2 },
+  interruption: { hours: 0, count: 0, rate_minutes: 2 },
+  stats: { sessions: 0, turns: 0, self_corrections: 0, blocked: 0, hard_failures: 0, return_ratio: 0, autonomous_artifacts: 0 },
+  rates: { suppression_minutes_per_item: 0.5, bucket_minutes: { S: 5, M: 20, L: 60, XL: 120 }, interruption_minutes: 2 },
+  unrated: [],
+};
+
+// 1. Unrated → note="no_rate_established"
+test("unrated: carries note=no_rate_established on every entry", () => {
+  const rows = deriveUnratedRows([{ action_class: "desk_decision_done", count: 1 }, { action_class: "chore_run", count: 3 }]);
+  assert.equal(rows.length, 2);
+  for (const r of rows) assert.equal(r.note, "no_rate_established");
+  assert.equal(rows[0].action_class, "desk_decision_done");
+});
+test("unrated: empty → []", () => assert.deepEqual(deriveUnratedRows([]), []));
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+test("unrated: null-tolerant", () => assert.deepEqual(deriveUnratedRows(null as any), []));
+
+// 2. Blocked / non-delivered → display_minutes=0
+test("inferred: delivered passes at full minutes, no reason", () => {
+  const [d] = deriveInferredDisplay([I]);
+  assert.equal(d.display_minutes, 20); assert.equal(d.is_blocked, false); assert.equal(d.blocked_reason, null);
+});
+test("inferred: non-delivered → zero with reason (asymmetry visible via claimed_minutes)", () => {
+  const [d] = deriveInferredDisplay([{ ...I, outcome: "aborted" }]);
+  assert.equal(d.display_minutes, 0); assert.equal(d.claimed_minutes, 20);
+  assert.equal(d.is_blocked, true); assert.match(d.blocked_reason ?? "", /aborted/);
+  assert.match(d.blocked_reason ?? "", /no displacement credit/);
+});
+test("inferred: 'blocked' outcome → zero", () => {
+  const [d] = deriveInferredDisplay([{ ...I, outcome: "blocked" }]);
+  assert.equal(d.display_minutes, 0); assert.equal(d.is_blocked, true);
+});
+
+// 3. Empty day detection
+test("isEmptyDay: all-zero → true", () => assert.equal(isEmptyDay(E), true));
+test("isEmptyDay: nar_hours>0 → false", () => assert.equal(isEmptyDay({ ...E, nar_hours: 7.51 }), false));
+test("isEmptyDay: unrated entries → false", () => assert.equal(isEmptyDay({ ...E, unrated: [{ action_class: "x", count: 1 }] }), false));
+
+// 4. Three distinct groups, never merged
+test("deriveDisplacementGroups: three keys; inferred has display_minutes, explicit does not", () => {
+  const g = deriveDisplacementGroups({
+    total_hours: 12, explicit: { hours: 0.13, items: [{ label: "S", count: 1, rate_minutes: 0.5, minutes: 8 }] },
+    inferred: { hours: 10, items: [I] }, autonomous: { hours: 1, items: [{ label: "B", bucket: "M", minutes: 30, evidence_kind: "chore_run", evidence_ref: "y" }] },
+  });
+  assert.ok("explicit" in g && "inferred" in g && "autonomous" in g);
+  assert.equal(g.explicit.items.length, 1); assert.equal(g.inferred.items.length, 1); assert.equal(g.autonomous.items.length, 1);
+  assert.ok("display_minutes" in g.inferred.items[0]); assert.ok(!("display_minutes" in g.explicit.items[0]));
+});
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+test("deriveDisplacementGroups: null safe", () => { const g = deriveDisplacementGroups(null as any); assert.equal(g.explicit.items.length, 0); });
+
+// Formatters
+test("formatHours: 2dp", () => { assert.equal(formatHours(7.51), "7.51"); assert.equal(formatHours(0), "0.00"); });
+test("formatMinutes: 1dp", () => { assert.equal(formatMinutes(0.5), "0.5"); assert.equal(formatMinutes(120), "120.0"); });

--- a/packages/web/src/dashboard/attentionCore.ts
+++ b/packages/web/src/dashboard/attentionCore.ts
@@ -1,0 +1,67 @@
+// attentionCore — pure response→view-model derivation for /attention (#584).
+// Import-free; node:test-able. Four invariants enforced:
+//   1. three displacement groups (explicit/inferred/autonomous) stay separate
+//   2. unrated classes carry note="no_rate_established", never zero
+//   3. non-delivered inferred → display_minutes=0 + blocked_reason
+//   4. empty day is identifiable without inspecting items
+
+export interface ExplicitItem { label: string; count: number; rate_minutes: number; minutes: number }
+export interface InferredItem { label: string; bucket: string; minutes: number; turns: number; tools: number; evidence_kind: string; evidence_ref: string; outcome: string }
+export interface AutonomousItem { label: string; bucket: string; minutes: number; evidence_kind: string; evidence_ref: string }
+export interface UnratedEntry { action_class: string; count: number }
+
+export interface AttentionDayResponse {
+  date: string; nar_hours: number;
+  displaced: { total_hours: number; explicit: { hours: number; items: ExplicitItem[] }; inferred: { hours: number; items: InferredItem[] }; autonomous: { hours: number; items: AutonomousItem[] } };
+  engaged: { hours: number; events: number; bursts: number; gap_minutes: number; floor_minutes: number };
+  interruption: { hours: number; count: number; rate_minutes: number };
+  stats: { sessions: number; turns: number; self_corrections: number; blocked: number; hard_failures: number; return_ratio: number; autonomous_artifacts: number };
+  rates: { suppression_minutes_per_item: number; bucket_minutes: { S: number; M: number; L: number; XL: number }; interruption_minutes: number };
+  unrated: UnratedEntry[];
+}
+
+export interface SeriesPoint { date: string; nar_hours: number; displaced_hours: number; engaged_hours: number }
+export interface AttentionStatsResponse { from: string; to: string; series: SeriesPoint[]; totals: { nar_hours: number; displaced_hours: number; engaged_hours: number } }
+
+export interface UnratedRow { action_class: string; count: number; note: "no_rate_established" }
+export interface InferredDisplayItem {
+  label: string; bucket: string;
+  claimed_minutes: number; display_minutes: number; // 0 when not delivered — asymmetry is the point
+  turns: number; tools: number; evidence_kind: string; evidence_ref: string;
+  outcome: string; is_blocked: boolean; blocked_reason: string | null;
+}
+
+export function deriveUnratedRows(unrated: UnratedEntry[]): UnratedRow[] {
+  return (unrated ?? []).map((u) => ({ ...u, note: "no_rate_established" as const }));
+}
+
+export function deriveInferredDisplay(items: InferredItem[]): InferredDisplayItem[] {
+  return (items ?? []).map((it) => {
+    const ok = it.outcome === "delivered";
+    return { label: it.label, bucket: it.bucket, claimed_minutes: it.minutes, display_minutes: ok ? it.minutes : 0,
+      turns: it.turns, tools: it.tools, evidence_kind: it.evidence_kind, evidence_ref: it.evidence_ref,
+      outcome: it.outcome, is_blocked: !ok, blocked_reason: ok ? null : `outcome: ${it.outcome} — no displacement credit` };
+  });
+}
+
+export function isEmptyDay(day: AttentionDayResponse): boolean {
+  if (!day || day.nar_hours > 0) return !day;
+  const d = day.displaced;
+  return !d || (d.explicit.items.length === 0 && d.inferred.items.length === 0 &&
+    d.autonomous.items.length === 0 && (day.unrated ?? []).length === 0);
+}
+
+export function deriveDisplacementGroups(displaced: AttentionDayResponse["displaced"]): {
+  explicit: { hours: number; items: ExplicitItem[] };
+  inferred: { hours: number; items: InferredDisplayItem[] };
+  autonomous: { hours: number; items: AutonomousItem[] };
+} {
+  return {
+    explicit: { hours: displaced?.explicit?.hours ?? 0, items: displaced?.explicit?.items ?? [] },
+    inferred: { hours: displaced?.inferred?.hours ?? 0, items: deriveInferredDisplay(displaced?.inferred?.items ?? []) },
+    autonomous: { hours: displaced?.autonomous?.hours ?? 0, items: displaced?.autonomous?.items ?? [] },
+  };
+}
+
+export const formatHours = (h: number) => (h ?? 0).toFixed(2);
+export const formatMinutes = (m: number) => (m ?? 0).toFixed(1);

--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -4439,3 +4439,24 @@ function mintDecisionRef(): string {
   }
   return timeChars + randChars;
 }
+
+// Attention Statement (#584) — thin proxies to /api/v1/attention/*.
+export const getAttentionStatement = async (args: { date?: string; from?: string; to?: string } | void, context: any): Promise<any> => {
+  const instance = await getUserInstance(context);
+  const q: Record<string, string> = {};
+  if (args && typeof args === "object") { if (args.date) q.date = args.date; if (args.from) q.from = args.from; if (args.to) q.to = args.to; }
+  return proxyToTenant(instance, { method: "GET", path: "/api/v1/attention/statement", query: Object.keys(q).length ? q : undefined });
+};
+
+export const getAttentionStats = async (args: { from: string; to: string } | void, context: any): Promise<any> => {
+  const instance = await getUserInstance(context);
+  const q: Record<string, string> = {};
+  if (args && typeof args === "object") { if (args.from) q.from = args.from; if (args.to) q.to = args.to; }
+  return proxyToTenant(instance, { method: "GET", path: "/api/v1/attention/stats", query: Object.keys(q).length ? q : undefined });
+};
+
+export const recomputeAttention = async (args: { date: string }, context: any): Promise<any> => {
+  if (!args?.date) throw new HttpError(400, "date required");
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, { method: "POST", path: "/api/v1/attention/recompute", body: { date: args.date } });
+};


### PR DESCRIPTION
## Summary

- Adds `/attention` page to the dashboard (reachable via the More nav). Day view shows the NAR headline, then three **visually distinct groups** — Explicit, Inferred, Autonomous — never merged. Each inferred/autonomous item shows its bucket and scale signals (turns, tools). Mess bill (engaged + interruption), statistics, rate card, and unrated classes follow.
- Range view shows per-day series table plus period totals.
- A recompute button POSTs for the shown date and shows a running state.
- Pure derivation lives in `attentionCore.ts` (import-free); 13/13 `node:test` pass locally.
- `scope_limit: 400` — authorised by orchestrator for this task. 341 net LOC.

## Design invariants honoured (from `docs/design/nar-method.md`)

- Unrated classes render as "×N — no rate established", never as zero and never omitted.
- Rate card always visible so every figure is recomputable by hand from the page.
- Non-delivered/blocked inferred items: `display_minutes=0` with the reason shown inline; `claimed_minutes` still visible so the asymmetry (full engagement cost, zero credit) reads clearly.
- Three displacement groups always separate — the type system makes merging them a compile error.
- Empty day renders explicitly, not as an error.

## Verify

`tsc --noEmit` is not runnable in this worktree (no `node_modules` — pre-codegen expected failure, documented in the lane brief). Gate fallback: `node:test` 13/13 PASS. `wasp build` in CI is the real type gate.

## Operator steps

**Both `web` and `web-client` containers need redeploying** after merge (CLAUDE.md §15.4). The API endpoints (`GET /api/v1/attention/statement`, `GET /api/v1/attention/stats`, `POST /api/v1/attention/recompute`) are being implemented in parallel in Lane I. The page degrades to a loading/error state until those routes land.

## Smoke evidence

The parallel Lane I routes are not yet deployed. Local smoke verified on the pure module:

```
cd packages/web && npx tsx --test src/dashboard/attentionCore.test.ts

TAP version 13
ok 1 - unrated: carries note=no_rate_established on every entry
ok 2 - unrated: empty → []
ok 3 - unrated: null-tolerant
ok 4 - inferred: delivered passes at full minutes, no reason
ok 5 - inferred: non-delivered → zero with reason (asymmetry visible via claimed_minutes)
ok 6 - inferred: 'blocked' outcome → zero
ok 7 - isEmptyDay: all-zero → true
ok 8 - isEmptyDay: nar_hours>0 → false
ok 9 - isEmptyDay: unrated entries → false
ok 10 - deriveDisplacementGroups: three keys; inferred has display_minutes, explicit does not
ok 11 - deriveDisplacementGroups: null safe
ok 12 - formatHours: 2dp
ok 13 - formatMinutes: 1dp
1..13
# tests 13 / pass 13 / fail 0
```

Gate output: `✓ lane III (web) gate passed — 341 LOC, 6 files, verify ok`

Wiring checks (grep):
- `getAttentionStatement`, `getAttentionStats`, `recomputeAttention` declared in `main.wasp` and exported from `operations.ts`
- Route `/attention` → `AttentionPage` registered in `main.wasp`
- `Frame.tsx` MORE nav entry `{ to: "/attention", label: "Attention", icon: "pocket_watch" }`
- Import from `"./attentionCore"` (extensionless — the Wasp build `.ts` import gotcha is avoided)

Full UI smoke (page rendering, tab switching, recompute flow) needs a live staging pass once the Lane I API lands. Tagged **"needs live staging UI pass"** per the smoke-as-truth protocol.

References #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc