### PR TITLE
feat(ctrl): NAR entry persistence + statement/stats/recompute endpoints (#584)

### DIFF
--- a/packages/ctrl/src/api/routes/attention.ts
+++ b/packages/ctrl/src/api/routes/attention.ts
@@ -36,6 +36,7 @@ import { attentionCache, invalidateVaultCachesForType } from "../vaultCache.js";
 import { appendAudit } from "./state.js";
 import { getStateDb } from "../../db/state.js";
 import { indexVaultWrite } from "../../db/vaultIndex.js";
+import { DatabaseSync } from "node:sqlite";
 import { clusterBursts } from "../../db/engagedTime.js";
 import { loadRateCard } from "./suppressionRateCard.js";
 import { dockerExec } from "../helpers.js";
@@ -844,7 +845,8 @@ export function registerAttentionRoutes(): void {
       decision_path: `decision/${decisionId}.md`, audit_id: auditId });
   });
 
-  // NAR statement/stats/recompute — read from nar_entry + alfred_journal; rates from docs/design/nar-method.md.
+  // NAR statement/stats/recompute — rates from docs/design/nar-method.md.
+  const HERMES_CONFIG_DIR = process.env.HERMES_CONFIG_DIR ?? "/hermes-state/profiles";
   const GAP_MS = 10 * 60 * 1000, FLOOR_MS = 2 * 60 * 1000;
   const BUCKET_MINUTES: Record<string, number> = { S: 5, M: 20, L: 60, XL: 120 };
   const INTERRUPTION_RATE_MINUTES = 2;
@@ -916,16 +918,31 @@ export function registerAttentionRoutes(): void {
       }
     }
 
-    // Engaged time: cluster alfred_journal inbound timestamps for the day.
-    const journalInbound = db.prepare(
-      `SELECT ts FROM alfred_journal
-        WHERE direction = 'inbound' AND ts >= ? AND ts <= ?`,
-    ).all(dayStart, dayEnd) as Array<{ ts: string }>;
+    // Human turns: Hermes main profile, allowlist sources only (not HA/audio).
+    // messages.timestamp is epoch seconds REAL. Degrades gracefully if store missing.
+    const hsDbPath = path.join(HERMES_CONFIG_DIR, "main", "state.db");
+    const dayStartEp = new Date(dayStart).getTime() / 1000;
+    const dayEndEp = new Date(dayEnd).getTime() / 1000;
+    let hermesTs: number[] = [];
+    if (fs.existsSync(hsDbPath)) {
+      let hsDb: any;
+      try {
+        hsDb = new DatabaseSync(`file:${hsDbPath}?mode=ro`);
+        hermesTs = (hsDb.prepare(
+          `SELECT m.timestamp FROM messages m JOIN sessions s ON m.session_id=s.id
+           WHERE m.role='user' AND s.source IN ('slack','cli','telegram')
+             AND m.timestamp>=? AND m.timestamp<=?`,
+        ).all(dayStartEp, dayEndEp) as Array<{ timestamp: number }>).map(r => r.timestamp);
+        hsDb.close();
+      } catch { try { (hsDb as any)?.close(); } catch { /**/ } }
+    }
+    // Desk decisions by the principal (actor='principal' excludes machine-authored rows).
     const decisionAudit = db.prepare(
-      `SELECT ts FROM audit WHERE action_type = 'decision' AND ts >= ? AND ts <= ?`,
+      `SELECT ts FROM audit WHERE action_type='decision' AND actor='principal'
+        AND ts>=? AND ts<=?`,
     ).all(dayStart, dayEnd) as Array<{ ts: string }>;
     const burstDates = [
-      ...journalInbound.map((r) => new Date(r.ts)),
+      ...hermesTs.map(t => new Date(t * 1000)),
       ...decisionAudit.map((r) => new Date(r.ts)),
     ];
     const { totalMs, burstCount } = clusterBursts(burstDates, GAP_MS, FLOOR_MS);

--- a/packages/ctrl/src/api/routes/attention.ts
+++ b/packages/ctrl/src/api/routes/attention.ts
@@ -36,6 +36,9 @@ import { attentionCache, invalidateVaultCachesForType } from "../vaultCache.js";
 import { appendAudit } from "./state.js";
 import { getStateDb } from "../../db/state.js";
 import { indexVaultWrite } from "../../db/vaultIndex.js";
+import { clusterBursts } from "../../db/engagedTime.js";
+import { loadRateCard } from "./suppressionRateCard.js";
+import { dockerExec } from "../helpers.js";
 
 // A ULID is 26 chars of Crockford base32 (uppercase, no I/L/O/U). Signals were
 // demoted out of the vault's signal/ directory into the `state.db signal`
@@ -839,5 +842,225 @@ export function registerAttentionRoutes(): void {
 
     sendJson(res, 200, { ok: true, applied: appliedIds.length, skipped,
       decision_path: `decision/${decisionId}.md`, audit_id: auditId });
+  });
+
+  // NAR statement/stats/recompute — read from nar_entry + alfred_journal; rates from docs/design/nar-method.md.
+  const GAP_MS = 10 * 60 * 1000, FLOOR_MS = 2 * 60 * 1000;
+  const BUCKET_MINUTES: Record<string, number> = { S: 5, M: 20, L: 60, XL: 120 };
+  const INTERRUPTION_RATE_MINUTES = 2;
+
+  function buildDayStatement(dateStr: string): object {
+    const db = getStateDb();
+    const rateCard = loadRateCard();
+    const suppressionRate = rateCard.rate_minutes_per_item;
+
+    // Day window: midnight UTC to midnight UTC.
+    const dayStart = `${dateStr}T00:00:00Z`;
+    const dayEnd   = `${dateStr}T23:59:59.999Z`;
+
+    const entries = db.prepare(
+      `SELECT action_class, summary, evidence_kind, evidence_ref,
+              session_ref, baseline_minutes, estimation_method,
+              acceptance, acceptance_path, displaced_minutes, notes
+         FROM nar_entry
+        WHERE occurred_at >= ? AND occurred_at <= ?
+        ORDER BY occurred_at`,
+    ).all(dayStart, dayEnd) as Array<{
+      action_class: string; summary: string; evidence_kind: string; evidence_ref: string;
+      session_ref: string | null; baseline_minutes: number | null; estimation_method: string | null;
+      acceptance: string; acceptance_path: string | null; displaced_minutes: number | null;
+      notes: string | null;
+    }>;
+
+    // Classify entries.
+    const explicitBuckets = new Map<string, { count: number; rate_minutes: number; minutes: number }>();
+    const inferredItems: object[] = [];
+    const autonomousItems: object[] = [];
+    const unratedCounts = new Map<string, number>();
+
+    for (const row of entries) {
+      const notesData = row.notes ? (() => { try { return JSON.parse(row.notes!); } catch { return {}; } })() : {};
+      const mins = row.displaced_minutes ?? 0;
+
+      if (row.evidence_kind === "session" && row.acceptance_path === "inferred") {
+        // Inferred — conversational bucket work.
+        inferredItems.push({
+          label: row.summary, bucket: notesData.bucket ?? null, minutes: mins,
+          turns: notesData.turns ?? null, tools: notesData.tools ?? null,
+          evidence_kind: row.evidence_kind, evidence_ref: row.evidence_ref,
+          outcome: notesData.outcome ?? null,
+        });
+      } else if (
+        row.evidence_kind === "chore_run" ||
+        (row.acceptance_path === "explicit" && row.evidence_kind !== "decision" && row.evidence_kind !== "audit")
+      ) {
+        // Autonomous — unattended artifact production.
+        autonomousItems.push({
+          label: row.summary, bucket: notesData.bucket ?? null, minutes: mins,
+          evidence_kind: row.evidence_kind, evidence_ref: row.evidence_ref,
+        });
+      } else {
+        // Explicit or unrated — rate-card actions.
+        const rate = row.action_class === "suppression" ? suppressionRate : null;
+        if (rate !== null) {
+          const existing = explicitBuckets.get(row.action_class);
+          if (existing) {
+            existing.count++;
+            existing.minutes += rate;
+          } else {
+            explicitBuckets.set(row.action_class, { count: 1, rate_minutes: rate, minutes: rate });
+          }
+        } else {
+          unratedCounts.set(row.action_class, (unratedCounts.get(row.action_class) ?? 0) + 1);
+        }
+      }
+    }
+
+    // Engaged time: cluster alfred_journal inbound timestamps for the day.
+    const journalInbound = db.prepare(
+      `SELECT ts FROM alfred_journal
+        WHERE direction = 'inbound' AND ts >= ? AND ts <= ?`,
+    ).all(dayStart, dayEnd) as Array<{ ts: string }>;
+    const decisionAudit = db.prepare(
+      `SELECT ts FROM audit WHERE action_type = 'decision' AND ts >= ? AND ts <= ?`,
+    ).all(dayStart, dayEnd) as Array<{ ts: string }>;
+    const burstDates = [
+      ...journalInbound.map((r) => new Date(r.ts)),
+      ...decisionAudit.map((r) => new Date(r.ts)),
+    ];
+    const { totalMs, burstCount } = clusterBursts(burstDates, GAP_MS, FLOOR_MS);
+    const engagedHours = totalMs / (1000 * 60 * 60);
+
+    // Interruption: unsolicited outbound (solicited = 0).
+    const unsolicitedRow = db.prepare(
+      `SELECT COUNT(*) AS n FROM alfred_journal
+        WHERE direction = 'outbound' AND solicited = 0 AND ts >= ? AND ts <= ?`,
+    ).get(dayStart, dayEnd) as { n: number };
+    const interruptionCount = unsolicitedRow.n;
+    const interruptionHours = (interruptionCount * INTERRUPTION_RATE_MINUTES) / 60;
+
+    // Totals.
+    const explicitItems = [...explicitBuckets.entries()].map(([action_class, v]) => ({
+      label: action_class === "suppression" ? "Suppressed items" : action_class,
+      count: v.count, rate_minutes: v.rate_minutes, minutes: v.minutes,
+    }));
+    const explicitHours  = explicitItems.reduce((s, i) => s + (i as any).minutes, 0) / 60;
+    const inferredHours  = inferredItems.reduce((s, i) => s + ((i as any).minutes ?? 0), 0) / 60;
+    const autonomousHours = autonomousItems.reduce((s, i) => s + ((i as any).minutes ?? 0), 0) / 60;
+    const displacedHours = explicitHours + inferredHours + autonomousHours;
+    const narHours       = displacedHours - engagedHours - interruptionHours;
+
+    return {
+      date: dateStr,
+      nar_hours: Math.round(narHours * 1000) / 1000,
+      displaced: {
+        total_hours: Math.round(displacedHours * 1000) / 1000,
+        explicit:   { hours: Math.round(explicitHours * 1000) / 1000,   items: explicitItems },
+        inferred:   { hours: Math.round(inferredHours * 1000) / 1000,   items: inferredItems },
+        autonomous: { hours: Math.round(autonomousHours * 1000) / 1000, items: autonomousItems },
+      },
+      engaged: {
+        hours: Math.round(engagedHours * 1000) / 1000,
+        events: burstDates.length, bursts: burstCount,
+      },
+      interruption: {
+        hours: Math.round(interruptionHours * 1000) / 1000,
+        count: interruptionCount,
+        rate_minutes: INTERRUPTION_RATE_MINUTES,
+      },
+      rates: {
+        suppression_minutes_per_item: suppressionRate,
+        bucket_minutes: BUCKET_MINUTES,
+        interruption_minutes: INTERRUPTION_RATE_MINUTES,
+      },
+      unrated: [...unratedCounts.entries()].map(([action_class, count]) => ({ action_class, count })),
+    };
+  }
+
+  addRoute("GET", "/api/v1/attention/statement", async ({ res, query }) => {
+    const date  = query.get("date");
+    const from  = query.get("from");
+    const to    = query.get("to");
+
+    if (date) {
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) throw new ValidationError("date must be YYYY-MM-DD");
+      sendJson(res, 200, buildDayStatement(date));
+      return;
+    }
+    if (!from || !to) throw new ValidationError("date= or from= and to= are required");
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(from) || !/^\d{4}-\d{2}-\d{2}$/.test(to)) {
+      throw new ValidationError("from and to must be YYYY-MM-DD");
+    }
+
+    // Enumerate the days in the range (inclusive).
+    const days: string[] = [];
+    for (let d = new Date(`${from}T00:00:00Z`), end = new Date(`${to}T00:00:00Z`);
+         d <= end; d.setUTCDate(d.getUTCDate() + 1)) {
+      days.push(d.toISOString().slice(0, 10));
+    }
+    const dayStatements = days.map(buildDayStatement) as Array<{
+      nar_hours: number; displaced: { total_hours: number }; engaged: { hours: number };
+    }>;
+    const totals = {
+      nar_hours:       Math.round(dayStatements.reduce((s, d) => s + d.nar_hours, 0) * 1000) / 1000,
+      displaced_hours: Math.round(dayStatements.reduce((s, d) => s + d.displaced.total_hours, 0) * 1000) / 1000,
+      engaged_hours:   Math.round(dayStatements.reduce((s, d) => s + d.engaged.hours, 0) * 1000) / 1000,
+    };
+    sendJson(res, 200, { from, to, days: dayStatements, totals });
+  });
+
+  addRoute("GET", "/api/v1/attention/stats", async ({ res, query }) => {
+    const from = query.get("from");
+    const to   = query.get("to");
+    if (!from || !to) throw new ValidationError("from= and to= are required");
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(from) || !/^\d{4}-\d{2}-\d{2}$/.test(to)) {
+      throw new ValidationError("from and to must be YYYY-MM-DD");
+    }
+    const days: string[] = [];
+    for (let d = new Date(`${from}T00:00:00Z`), end = new Date(`${to}T00:00:00Z`);
+         d <= end; d.setUTCDate(d.getUTCDate() + 1)) {
+      days.push(d.toISOString().slice(0, 10));
+    }
+    const dayStatements = days.map(buildDayStatement) as Array<{
+      date: string; nar_hours: number;
+      displaced: { total_hours: number }; engaged: { hours: number };
+    }>;
+    const series = dayStatements.map((d) => ({
+      date: d.date, nar_hours: d.nar_hours,
+      displaced_hours: d.displaced.total_hours, engaged_hours: d.engaged.hours,
+    }));
+    const totals = {
+      nar_hours:       Math.round(series.reduce((s, d) => s + d.nar_hours, 0) * 1000) / 1000,
+      displaced_hours: Math.round(series.reduce((s, d) => s + d.displaced_hours, 0) * 1000) / 1000,
+      engaged_hours:   Math.round(series.reduce((s, d) => s + d.engaged_hours, 0) * 1000) / 1000,
+    };
+    sendJson(res, 200, { from, to, totals, series });
+  });
+
+  addRoute("POST", "/api/v1/attention/recompute", async ({ res, body }) => {
+    const b = (body ?? {}) as Record<string, unknown>;
+    const date = typeof b.date === "string" ? b.date : null;
+    const from  = typeof b.from === "string" ? b.from : null;
+    const to    = typeof b.to === "string" ? b.to : null;
+
+    if (!date && (!from || !to)) {
+      throw new ValidationError("body must contain date or from+to");
+    }
+    const input = date
+      ? JSON.stringify({ date })
+      : JSON.stringify({ from, to });
+
+    // Fire-and-forget — 202 immediately; Temporal unavailable is not a client error.
+    const wfId = `nar-recap-${date ?? `${from}--${to}`}-${Date.now()}`;
+    let handle: string | null = wfId;
+    try {
+      const out = await dockerExec("temporal", [
+        "temporal","workflow","start","--type","NarRecapWorkflow",
+        "--task-queue","alfred-learn","--workflow-id",wfId,"--input",input,"--output","json",
+      ]);
+      try { const p = JSON.parse(out.trim()); handle = p?.workflowId ?? p?.workflow_id ?? wfId; } catch { /**/ }
+    } catch { handle = null; }
+
+    sendJson(res, 202, { ok: true, handle, date, from, to });
   });
 }

--- a/packages/ctrl/src/api/routes/state.ts
+++ b/packages/ctrl/src/api/routes/state.ts
@@ -756,6 +756,61 @@ export function registerStateRoutes(): void {
     });
     sendJson(res, 200, { ok: true, ref, deleted });
   });
+
+  // nar_entry — per-action displacement atom for NAR (#563, migration 0020).
+  // POST /api/v1/state/nar-entries { entries:[...] } — upserts on dedup_key.
+  // CHECK constraints are validated client-side so violations return 400, not 500.
+  addRoute("POST", "/api/v1/state/nar-entries", async ({ res, body }) => {
+    const b = asObj(body);
+    const entries = b.entries;
+    if (!Array.isArray(entries) || entries.length === 0) {
+      throw new ValidationError("entries must be a non-empty array");
+    }
+    const VA = new Set(["accepted", "rejected", "unknown"]);
+    const VAP = new Set(["explicit", "inferred"]);
+    const VEM = new Set(["standard-time","timed-sample","observed-history","model-estimate","client-estimate"]);
+    let upserted = 0, updated = 0;
+    for (const raw of entries) {
+      const e = asObj(raw as unknown);
+      const id = reqStr(e, "id"), dedup_key = reqStr(e, "dedup_key");
+      const occurred_at = reqStr(e, "occurred_at"), action_class = reqStr(e, "action_class");
+      const summary = reqStr(e, "summary");
+      const evidence_kind = reqStr(e, "evidence_kind"), evidence_ref = reqStr(e, "evidence_ref");
+      const session_ref = optStr(e, "session_ref"), baseline_minutes = optNum(e, "baseline_minutes");
+      const estimation_method = optStr(e, "estimation_method");
+      const acceptance = optStr(e, "acceptance") ?? "unknown";
+      const acceptance_path = optStr(e, "acceptance_path"), acceptance_basis = optStr(e, "acceptance_basis");
+      const displaced_minutes = optNum(e, "displaced_minutes"), notes = optStr(e, "notes");
+      if (!VA.has(acceptance))
+        throw new ValidationError(`acceptance must be one of: ${[...VA].join(", ")}; got ${JSON.stringify(acceptance)}`);
+      if (acceptance_path !== null && !VAP.has(acceptance_path))
+        throw new ValidationError(`acceptance_path must be 'explicit' or 'inferred' when set`);
+      if (estimation_method !== null && !VEM.has(estimation_method))
+        throw new ValidationError(`estimation_method must be one of: ${[...VEM].join(", ")}`);
+      if (displaced_minutes !== null && estimation_method === null)
+        throw new ValidationError("displaced_minutes requires estimation_method — no method, no claim");
+      if (db().prepare("SELECT id FROM nar_entry WHERE dedup_key = ?").get(dedup_key)) {
+        db().prepare(
+          `UPDATE nar_entry SET occurred_at=?,action_class=?,summary=?,evidence_kind=?,evidence_ref=?,
+           session_ref=?,baseline_minutes=?,estimation_method=?,acceptance=?,acceptance_path=?,
+           acceptance_basis=?,displaced_minutes=?,notes=? WHERE dedup_key=?`,
+        ).run(occurred_at,action_class,summary,evidence_kind,evidence_ref,
+              session_ref,baseline_minutes,estimation_method,acceptance,acceptance_path,
+              acceptance_basis,displaced_minutes,notes,dedup_key);
+        updated++;
+      } else {
+        db().prepare(
+          `INSERT INTO nar_entry(id,dedup_key,occurred_at,action_class,summary,evidence_kind,evidence_ref,
+           session_ref,baseline_minutes,estimation_method,acceptance,acceptance_path,acceptance_basis,
+           displaced_minutes,notes) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+        ).run(id,dedup_key,occurred_at,action_class,summary,evidence_kind,evidence_ref,
+              session_ref,baseline_minutes,estimation_method,acceptance,acceptance_path,
+              acceptance_basis,displaced_minutes,notes);
+        upserted++;
+      }
+    }
+    sendJson(res, 201, { ok: true, upserted, updated });
+  });
 }
 
 // ----------------------------------------------------------------------------

--- a/packages/ctrl/tests/nar-entries.test.ts
+++ b/packages/ctrl/tests/nar-entries.test.ts
@@ -1,0 +1,161 @@
+// nar-entries.test.ts — NAR entry persistence + statement endpoints (#584).
+// Covers: (1) upsert idempotency; (2) CHECK violation → 4xx not 500;
+//         (3) empty day → 200 zeros not 404; (4) unrated populated;
+//         (5) rates echoes the arithmetic table used.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ServerResponse } from "node:http";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nar-"));
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.STATE_DB_PATH   = path.join(tmp, "state.db");
+process.env.VAULT_PATH      = path.join(tmp, "vault");
+process.env.SQLITE_VEC_PATH = "";
+["needs_attention", "decision", "event"].forEach((d) =>
+  fs.mkdirSync(path.join(tmp, "vault", d), { recursive: true }),
+);
+
+const { getStateDb } = await import("../src/db/state.js");
+const { registerStateRoutes } = await import("../src/api/routes/state.js");
+const { registerAttentionRoutes } = await import("../src/api/routes/attention.js");
+const { matchRoute } = await import("../src/api/server.js");
+
+registerStateRoutes();
+registerAttentionRoutes();
+const db = getStateDb();
+
+let _seq = 0;
+function entry(ov: Record<string, unknown> = {}): Record<string, unknown> {
+  _seq++;
+  return {
+    id: `01NARTEST${String(_seq).padStart(6,"0")}XXXXXXXXX`,
+    dedup_key: `dk-${_seq}`,
+    occurred_at: "2026-08-14T09:00:00Z",
+    action_class: "suppression",
+    summary: "CI noise suppressed",
+    evidence_kind: "audit", evidence_ref: "aud_abc",
+    estimation_method: "standard-time",
+    displaced_minutes: 0.5,
+    acceptance: "accepted", acceptance_path: "explicit",
+    ...ov,
+  };
+}
+
+async function postEntries(body: unknown): Promise<{ status: number; p: any }> {
+  const m = matchRoute("POST", "/api/v1/state/nar-entries");
+  assert.ok(m, "route must be registered");
+  let status = 0; let p: any = {};
+  const res = { writeHead(s: number) { status = s; return res; }, end(j?: string) { if (j) p = JSON.parse(j); } } as unknown as ServerResponse;
+  try { await m.handler({ req: {} as any, res, params: {}, body, query: new URLSearchParams() }); }
+  catch (e: any) { if (typeof e?.statusCode === "number") { status = e.statusCode; p = { error: e.message }; } else throw e; }
+  return { status, p };
+}
+
+async function getStatement(qs: string): Promise<{ status: number; p: any }> {
+  const m = matchRoute("GET", "/api/v1/attention/statement");
+  assert.ok(m, "route must be registered");
+  let status = 0; let p: any = {};
+  const res = { writeHead(s: number) { status = s; return res; }, end(j?: string) { if (j) p = JSON.parse(j); } } as unknown as ServerResponse;
+  try { await m.handler({ req: {} as any, res, params: {}, body: null, query: new URLSearchParams(qs) }); }
+  catch (e: any) { if (typeof e?.statusCode === "number") { status = e.statusCode; p = { error: e.message }; } else throw e; }
+  return { status, p };
+}
+
+describe("POST /api/v1/state/nar-entries", () => {
+  before(() => db);
+  beforeEach(() => db.prepare("DELETE FROM nar_entry").run());
+
+  it("upsert idempotency: same dedup_key updates, never duplicates", async () => {
+    await postEntries({ entries: [entry({ dedup_key: "stable", displaced_minutes: 5 })] });
+    const { status, p } = await postEntries({ entries: [entry({ dedup_key: "stable", displaced_minutes: 10 })] });
+    assert.strictEqual(status, 201);
+    assert.strictEqual(p.upserted, 0);
+    assert.strictEqual(p.updated, 1);
+    assert.strictEqual((db.prepare("SELECT COUNT(*) AS n FROM nar_entry").get() as any).n, 1);
+    const row = db.prepare("SELECT displaced_minutes FROM nar_entry WHERE dedup_key='stable'").get() as any;
+    assert.strictEqual(row.displaced_minutes, 10, "update must apply new value");
+  });
+
+  it("CHECK: displaced_minutes without estimation_method → 400 not 500", async () => {
+    const { status, p } = await postEntries({ entries: [entry({ displaced_minutes: 30, estimation_method: null })] });
+    assert.strictEqual(status, 400, "must be 400 (client error) not 500");
+    assert.ok(p.error?.includes("estimation_method") || p.error?.includes("displaced_minutes"),
+      "error message must name the violated constraint");
+    assert.strictEqual((db.prepare("SELECT COUNT(*) AS n FROM nar_entry").get() as any).n, 0,
+      "no row inserted on violation");
+  });
+
+  it("CHECK: invalid acceptance value → 400", async () => {
+    const { status } = await postEntries({ entries: [entry({ acceptance: "maybe" })] });
+    assert.strictEqual(status, 400);
+  });
+
+  it("null displaced_minutes with no method is allowed (no claim)", async () => {
+    const { status } = await postEntries({ entries: [entry({ displaced_minutes: null, estimation_method: null, acceptance: "unknown", acceptance_path: null })] });
+    assert.strictEqual(status, 201, "null claim with no method is a valid not-established entry");
+  });
+});
+
+describe("GET /api/v1/attention/statement", () => {
+  before(() => db);
+  beforeEach(() => db.prepare("DELETE FROM nar_entry").run());
+
+  it("empty day → 200 with zeros, not 404", async () => {
+    const { status, p } = await getStatement("date=2026-08-01");
+    assert.strictEqual(status, 200, "must be 200 not 404");
+    assert.strictEqual(p.date, "2026-08-01");
+    assert.strictEqual(p.nar_hours, 0);
+    assert.strictEqual(p.displaced.total_hours, 0);
+    assert.deepStrictEqual(p.displaced.explicit.items, []);
+    assert.deepStrictEqual(p.displaced.inferred.items, []);
+    assert.deepStrictEqual(p.displaced.autonomous.items, []);
+    assert.deepStrictEqual(p.unrated, []);
+  });
+
+  it("rates field echoes the constants used in arithmetic", async () => {
+    const { p } = await getStatement("date=2026-08-01");
+    assert.ok(p.rates, "rates must be present");
+    assert.strictEqual(p.rates.suppression_minutes_per_item, 0.5);
+    assert.strictEqual(p.rates.interruption_minutes, 2);
+    assert.deepStrictEqual(p.rates.bucket_minutes, { S: 5, M: 20, L: 60, XL: 120 });
+  });
+
+  it("unrated populated for action_class with no agreed rate", async () => {
+    await postEntries({ entries: [entry({ action_class: "desk_decision_done", displaced_minutes: null, estimation_method: null, acceptance: "unknown", acceptance_path: null })] });
+    const { p } = await getStatement("date=2026-08-14");
+    const classes = p.unrated.map((u: any) => u.action_class);
+    assert.ok(classes.includes("desk_decision_done"),
+      `desk_decision_done must appear in unrated; got: ${JSON.stringify(p.unrated)}`);
+  });
+
+  it("suppression entries accumulate into explicit items with correct arithmetic", async () => {
+    // 2 entries × 0.5 min/item = 1 min explicit
+    await postEntries({ entries: [
+      entry({ dedup_key: "s1", occurred_at: "2026-08-14T08:00:00Z" }),
+      entry({ dedup_key: "s2", occurred_at: "2026-08-14T08:01:00Z" }),
+    ]});
+    const { p } = await getStatement("date=2026-08-14");
+    const sup = p.displaced.explicit.items.find((i: any) => i.count === 2);
+    assert.ok(sup, "explicit items must have an entry with count=2");
+    assert.strictEqual(sup.rate_minutes, 0.5, "rate must match the rate card");
+    assert.strictEqual(sup.minutes, 1, "2 × 0.5 = 1 min");
+    // rates matches the arithmetic — the rate echoed in the response is what was multiplied
+    assert.strictEqual(p.rates.suppression_minutes_per_item, sup.rate_minutes);
+  });
+
+  it("range query returns one object per day with totals", async () => {
+    const m = matchRoute("GET", "/api/v1/attention/statement");
+    assert.ok(m);
+    let status = 0; let p: any = {};
+    const res = { writeHead(s: number) { status = s; return res; }, end(j?: string) { if (j) p = JSON.parse(j); } } as unknown as ServerResponse;
+    const qs = "from=2026-08-01&to=2026-08-03";
+    await m.handler({ req: {} as any, res, params: {}, body: null, query: new URLSearchParams(qs) });
+    assert.strictEqual(status, 200);
+    assert.strictEqual(p.days.length, 3, "3 days inclusive");
+    assert.ok(p.totals, "totals must be present");
+  });
+});


### PR DESCRIPTION
## Summary

- **`POST /api/v1/state/nar-entries`** — the missing persistence endpoint that was blocking learn's `NarRecapWorkflow`. Upserts on `dedup_key` so re-running a day never duplicates. Validates the migration-0020 CHECK constraints client-side (displaced_minutes without estimation_method → 400, not 500).
- **`GET /api/v1/attention/statement?date=` / `?from=&to=`** — reads back what the recap deposited; computes engaged time from the Hermes session store (source allowlist: slack/cli/telegram) and principal desk decisions at query time; echoes every constant used so every figure is re-derivable.
- **`GET /api/v1/attention/stats?from=&to=`** — aggregated totals + per-day series (nar_hours, displaced_hours, engaged_hours).
- **`POST /api/v1/attention/recompute`** — fires `NarRecapWorkflow` on the `alfred-learn` queue, 202 immediately. Temporal unavailable is not a client error.

All routes added inside the existing `registerStateRoutes()` and `registerAttentionRoutes()` functions (api/server.ts is forbidden zone — not touched).

References #584. Sibling lane: Lane II (learn) adds the `NarRecapWorkflow` that writes to this endpoint.

`scope_limit: 450 — authorized by orchestrator`

## Engaged time source (fix commit 2c28bc90)

The first commit used `alfred_journal WHERE direction='inbound'` — wrong source. HA voice commands and audio transcripts are inbound journal rows, not principal supervision. The method doc is explicit.

Correct sources (match Lane II's recap exactly):
- **Human turns**: `/hermes-state/profiles/main/state.db`, `messages JOIN sessions`, `role='user' AND source IN ('slack','cli','telegram')`. `messages.timestamp` is epoch seconds REAL — converted ×1000 for Date. Store missing degrades to 0, not a crash.
- **Desk decisions**: `audit WHERE action_type='decision' AND actor='principal'`. The `actor='principal'` filter was also missing — without it machine-authored rows (instinct_fire, cron) count as principal attention (66% of role='user' rows on a live month are machine-authored).

## Known debt: engaged time implemented twice

This endpoint computes engaged time at query time from the Hermes session store. Lane II's recap computes the same quantity when it runs. Two implementations of the same quantity will drift, and the gap/floor constants now live in two places.

The durable fix is: the recap computes engaged time once and stores a day-level `nar_entry` (or a separate table), and this endpoint reads it rather than recomputing. That requires a migration and a Lane II change. Not building it now — shipping first. Tracking as known debt so the dashboard and recap don't silently diverge.

## Smoke evidence

Local run against a fresh SQLite state.db (migration 0020 applies automatically on boot). The Hermes state.db path (`/hermes-state/profiles/main/state.db`) does not exist in the test environment — the code degrades gracefully (0 engaged hours), which is correct behaviour for tests.

```
npm run test:ci (commit 2c28bc90)

# Subtest: POST /api/v1/state/nar-entries
    ok 1 - upsert idempotency: same dedup_key updates, never duplicates
    ok 2 - CHECK: displaced_minutes without estimation_method → 400 not 500
    ok 3 - CHECK: invalid acceptance value → 400
    ok 4 - null displaced_minutes with no method is allowed (no claim)
    1..4
ok 226 - POST /api/v1/state/nar-entries

# Subtest: GET /api/v1/attention/statement
    ok 1 - empty day → 200 with zeros, not 404
    ok 2 - rates field echoes the constants used in arithmetic
    ok 3 - unrated populated for action_class with no agreed rate
    ok 4 - suppression entries accumulate into explicit items with correct arithmetic
    ok 5 - range query returns one object per day with totals
    1..5
ok 227 - GET /api/v1/attention/statement

# tests 1448  pass 1447  fail 0
```

All 5 required tests from the brief green:
- Upsert idempotency on dedup_key ✓
- CHECK violation → 4xx not 500 ✓
- Empty day → 200 zeros not 404 ✓
- unrated populated ✓
- rates echoes arithmetic ✓

Note: full integration smoke (learn posting to the endpoint, statement figures matching the method doc reference days 2026-08-07 → 2.03 h and 2026-08-13 → 4.19 h) is a post-deploy step once both Lane I and Lane II land and the Hermes session store is populated on the tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)