### PR TITLE
feat(learn): NAR recap classification layer + workflow (#584)

### DIFF
--- a/packages/learn/src/activities/nar_data.py
+++ b/packages/learn/src/activities/nar_data.py
@@ -253,7 +253,15 @@ def _extract_session_context(messages: list[dict[str, Any]]) -> dict[str, Any]:
             failure_excerpt = str(msg.get("content", ""))[:300]
             break
 
-    failure_note = f"YES — excerpt: {failure_excerpt}" if failure_excerpt else "None detected."
+    # Phrase detected → informational signal only.  The clerk decides is_failed
+    # by reading the delivery — a concession followed by a delivered artifact
+    # is correction, not failure.
+    failure_note = (
+        f"Self-correction phrase detected (check delivery to determine outcome) "
+        f"— excerpt: {failure_excerpt}"
+        if failure_excerpt
+        else "None detected."
+    )
 
     return {
         "ask": ask,

--- a/packages/learn/src/activities/nar_recap.py
+++ b/packages/learn/src/activities/nar_recap.py
@@ -1,0 +1,457 @@
+"""NAR daily recap — classification layer + main activity (#584).
+
+Reads pre-processed data from ``nar_data`` (pure reading/plumbing layer,
+no clerk dependency) and uses the Hermes clerk to classify displacement
+buckets for sessions and chore artifacts, then writes ``nar_entry`` rows
+via ``POST /api/v1/state/nar-entries`` (ctrl-api, Lane I prerequisite).
+
+Split from a monolithic 720-line module to keep both halves under the
+600-LOC CI ceiling.  The data layer (``nar_data``) is independently
+testable without the Temporal or clerk environments.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import date, datetime, timezone
+from typing import Any
+
+import httpx
+from temporalio import activity
+
+from src.activities.clerk import _call_clerk, _extract_json
+from src.activities.nar_data import (
+    BUCKET_MINUTES,
+    FLOOR_MS,
+    GAP_MS,
+    HUMAN_SOURCES,  # noqa: F401 — re-exported for backward compat
+    SUPPRESSION_RATE_MINUTES,
+    VALID_BUCKETS,
+    _ctrl_headers,
+    _extract_session_context,
+    _get_chore_runs,
+    _get_human_sessions,
+    _get_principal_decisions,
+    _iso,
+    _open_session_db,
+    _VIGILANCE_TOKENS,
+    cluster_bursts,
+)
+from src.config import load_config
+
+logger = logging.getLogger("alfred-learn")
+
+
+# ---------------------------------------------------------------------------
+# Session bucket classification (uses ask/delivery/failure_note framing).
+# ---------------------------------------------------------------------------
+
+_BUCKET_PROMPT = """\
+You are classifying a single Alfred conversation to estimate the work it displaced.
+
+Session scale: {user_turns} user turns · {assistant_msgs} assistant messages \
+· {tool_calls} tool calls · {span_min:.0f} min wall-clock.
+
+What was asked (first user turn):
+{ask}
+
+What was delivered (last substantive assistant response):
+{delivery}
+
+Failure signal: {failure_note}
+
+Rules from the NAR method (apply them in order):
+1. A quantity NAMED in an artifact is NOT displacement. Crediting the figure inside inflates.
+2. Discussion with no artifact displaces NOTHING — return bucket "none".
+3. A failed or blocked session costs ZERO displacement. IMPORTANT: bucket and is_failed are
+   INDEPENDENT AXES. A session can be L-scale work that failed — set bucket=L AND is_failed=true.
+   Never collapse a failed session to bucket="none"; displacement is forced to zero by the caller.
+4. Scale signals matter: a 1-turn conversation cannot be XL; a 60-minute multi-step session
+   with hundreds of tool calls is unlikely to be S.
+
+Return a JSON object with exactly these keys:
+  bucket: one of "S" | "M" | "L" | "XL" | "none"
+  reasoning: one sentence
+  has_artifact: true | false
+  is_failed: true | false (true if failure signal present, even if work was partially done)
+
+Bucket meanings (minutes of principal time displaced if delivered):
+  S  =   5 min — quick email, short memo, simple fact lookup
+  M  =  20 min — medium email, task plan, substantive synthesis
+  L  =  60 min — complex document, multi-step research, large delegation
+  XL = 120 min — work that would take most of a half-day by hand
+  none = 0     — discussion only, or tool calls with no output
+
+Return ONLY the JSON, no prose."""
+
+
+async def _classify_session_bucket(messages: list[dict[str, Any]]) -> dict[str, Any]:
+    """Ask the clerk to classify the displacement bucket for a session.
+
+    Context is ask + delivery + scale signals rather than a tail window —
+    the tail of a 1000-message session looks routine even when the full span
+    was a half-day delegation, so a tail window systematically under-sizes
+    long sessions.  Falls back to ``{"bucket": "none"}`` on any error.
+    """
+    if not messages:
+        return {"bucket": "none", "reasoning": "empty session", "has_artifact": False, "is_failed": False}
+
+    ctx = _extract_session_context(messages)
+    try:
+        # Build prompt inside try/except: ask/delivery may contain literal
+        # curly braces (e.g. JSON payloads) which would crash str.format().
+        prompt = _BUCKET_PROMPT.format(**ctx)
+        result = await _call_clerk(prompt, agent_id="learn-nar-bucket")
+        if isinstance(result, str):
+            result = _extract_json(result)
+        bucket = str(result.get("bucket", "none"))
+        if bucket not in VALID_BUCKETS:
+            bucket = "none"
+        return {
+            "bucket": bucket,
+            "reasoning": str(result.get("reasoning", "")),
+            "has_artifact": bool(result.get("has_artifact", False)),
+            "is_failed": bool(result.get("is_failed", False)),
+        }
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("nar_recap: bucket classification failed: %s", exc)
+        return {"bucket": "none", "reasoning": f"clerk error: {str(exc)[:100]}", "has_artifact": False, "is_failed": False}
+
+
+# ---------------------------------------------------------------------------
+# Chore bucket classification (autonomous, no conversation framing).
+# ---------------------------------------------------------------------------
+
+_CHORE_BUCKET_PROMPT = """\
+You are classifying an autonomous Alfred chore run to estimate the work it displaced.
+This is NOT a conversation — Alfred ran this unattended. There is no user turn.
+Classify ONLY the deliverable artifact produced, not the chore activity itself.
+
+Chore: {chore_name}
+Output: {detail}
+
+Rules:
+1. A quantity NAMED in an artifact is not displacement. Credit the production cost, not the contents.
+2. If no deliverable artifact was produced (status-only, found nothing, failed), return "none".
+3. A failed chore costs zero displacement — return "none" with is_failed=true.
+
+Return a JSON object:
+  bucket: one of "S" | "M" | "L" | "XL" | "none"
+  reasoning: one sentence
+  has_artifact: true | false
+  is_failed: true | false
+
+Bucket meanings (minutes of principal time the artifact would have taken by hand):
+  S  =   5 min — short note, quick status, calendar entry
+  M  =  20 min — briefing composition, medium report, data synthesis
+  L  =  60 min — complex multi-source report or document
+  XL = 120 min — half-day equivalent by hand
+  none = 0     — vigilance, status-only, failed, or tool activity with no deliverable
+
+Return ONLY the JSON, no prose."""
+
+
+async def _classify_chore_bucket(detail: str, chore_name: str) -> dict[str, Any]:
+    """Classify displacement bucket for a chore artifact.
+
+    Uses a chore-specific prompt that does not model the output as a
+    conversation — chores are autonomous and have no user turn.  The session
+    classifier's ask/delivery/failure_note structure is inappropriate here.
+    Falls back to ``{"bucket": "none"}`` on any error.
+    """
+    if not detail:
+        return {"bucket": "none", "reasoning": "empty chore output", "has_artifact": False, "is_failed": False}
+    try:
+        # Build prompt inside try/except: detail may contain literal curly
+        # braces (e.g. JSON chore output) which would crash str.format().
+        prompt = _CHORE_BUCKET_PROMPT.format(
+            chore_name=chore_name[:100],
+            detail=detail[:800],
+        )
+        result = await _call_clerk(prompt, agent_id="learn-nar-chore")
+        if isinstance(result, str):
+            result = _extract_json(result)
+        bucket = str(result.get("bucket", "none"))
+        if bucket not in VALID_BUCKETS:
+            bucket = "none"
+        return {
+            "bucket": bucket,
+            "reasoning": str(result.get("reasoning", "")),
+            "has_artifact": bool(result.get("has_artifact", False)),
+            "is_failed": bool(result.get("is_failed", False)),
+        }
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("nar_recap: chore bucket classification failed: %s", exc)
+        return {"bucket": "none", "reasoning": f"clerk error: {str(exc)[:100]}", "has_artifact": False, "is_failed": False}
+
+
+def _chore_is_vigilance_sweep(obs: dict[str, Any]) -> bool:
+    """Return True if this chore ran, checked and found nothing actionable.
+
+    Vigilance sweeps take the suppression rate per the NAR method doc (§1c) —
+    they must never reach the bucket classifier.  Replaces the original
+    ``_chore_has_artifact`` which returned True for "50 signals, no urgent
+    notification", causing systematic over-counting.
+    """
+    body = str(obs.get("detail", "") or obs.get("summary", "")).lower()
+    return any(tok in body for tok in _VIGILANCE_TOKENS)
+
+
+# ---------------------------------------------------------------------------
+# nar_entry upsert.
+# ---------------------------------------------------------------------------
+
+async def _upsert_nar_entry(config: Any, entry: dict[str, Any]) -> dict[str, Any]:
+    """POST to /api/v1/state/nar-entries — upserts on dedup_key.
+
+    Body shape: ``{"entries": [entry]}`` — the Lane I endpoint accepts a
+    batch; we send single-entry batches per call so the caller loop stays
+    simple.  Lane I endpoint merged and deployed as of PR #584 prerequisite:
+    404/405 fallback retained for staging/canary environments that may not
+    yet have the deploy.
+    """
+    async with httpx.AsyncClient(
+        base_url=config.alfred_ctrl_url, timeout=30.0, headers=_ctrl_headers(),
+    ) as http:
+        try:
+            resp = await http.post("/api/v1/state/nar-entries", json={"entries": [entry]})
+            resp.raise_for_status()
+            return resp.json()
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code in (404, 405):
+                logger.warning(
+                    "nar_recap: /api/v1/state/nar-entries not deployed — "
+                    "dedup_key=%s logged only",
+                    entry.get("dedup_key"),
+                )
+                return {"ok": False, "reason": "endpoint_not_deployed", "dedup_key": entry.get("dedup_key")}
+            raise
+
+
+# ---------------------------------------------------------------------------
+# Main activity.
+# ---------------------------------------------------------------------------
+
+@activity.defn
+async def compute_nar_day(day_iso: str) -> dict[str, Any]:
+    """Compute and write nar_entry rows for one UTC calendar day.
+
+    ``day_iso`` is ``YYYY-MM-DD``.
+    Returns a summary dict with counts and validation figures.
+    """
+    config = load_config()
+    day = date.fromisoformat(day_iso)
+    since = _iso(day, "T00:00:00Z")
+    until = _iso(day, "T23:59:59Z")
+
+    results: dict[str, Any] = {
+        "date": day_iso,
+        "sessions_processed": 0,
+        "decisions_processed": 0,
+        "chore_runs_processed": 0,
+        "entries_written": 0,
+        "entries_skipped": 0,
+        "engaged_ms": 0.0,
+        "displaced_minutes": 0.0,
+    }
+
+    all_timestamps_ms: list[float] = []
+
+    # ── 1. Conversational sessions ────────────────────────────────────
+    db = _open_session_db("main")
+    if db is not None:
+        try:
+            sessions = _get_human_sessions(db, day)
+        finally:
+            db.close()
+
+        for sess in sessions:
+            results["sessions_processed"] += 1
+            messages = sess["messages"]
+
+            # Collect user-turn timestamps for engaged-time computation.
+            all_timestamps_ms.extend(
+                m["ts"] * 1000
+                for m in messages
+                if m.get("role") == "user" and m.get("ts") is not None
+            )
+
+            bucket_info = await _classify_session_bucket(messages)
+            bucket = bucket_info["bucket"]
+            displaced: float | None = BUCKET_MINUTES.get(bucket)
+            # Method doc rule 3: failed/blocked sessions cost ZERO displacement
+            # regardless of bucket size.  bucket and is_failed are independent.
+            if bucket_info.get("is_failed"):
+                displaced = 0.0
+
+            started_at = float(sess.get("started_at") or 0.0)
+            occurred_at = datetime.fromtimestamp(started_at, tz=timezone.utc).isoformat()
+            dedup_key = f"nar:session:{sess['id']}:{day_iso}"
+
+            entry: dict[str, Any] = {
+                "dedup_key": dedup_key,
+                "occurred_at": occurred_at,
+                "action_class": "conversational",
+                "summary": f"Session {sess['id'][:12]} ({sess['source']}) — bucket {bucket}",
+                "evidence_kind": "session",
+                "evidence_ref": sess["id"],
+                "session_ref": sess["id"],
+                "baseline_minutes": displaced,
+                "estimation_method": "model-estimate" if displaced is not None else None,
+                "acceptance": "inferred",
+                "acceptance_path": "inferred" if displaced is not None else None,
+                "acceptance_basis": bucket_info.get("reasoning", ""),
+                "displaced_minutes": displaced,
+                "notes": json.dumps({"bucket": bucket, "has_artifact": bucket_info.get("has_artifact")}),
+            }
+            out = await _upsert_nar_entry(config, entry)
+            if out.get("reason") == "endpoint_not_deployed":
+                results["entries_skipped"] += 1
+            else:
+                results["entries_written"] += 1
+            if displaced is not None:
+                results["displaced_minutes"] += displaced
+
+    # ── 2. Desk decisions ─────────────────────────────────────────────
+    try:
+        decisions = await _get_principal_decisions(config.alfred_ctrl_url, since, until)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("nar_recap: decisions fetch failed: %s", exc)
+        decisions = []
+
+    for dec in decisions:
+        results["decisions_processed"] += 1
+        # The audit API returns intent inside `payload_json`, not `payload`.
+        payload = dec.get("payload_json") or dec.get("payload") or {}
+        if isinstance(payload, str):
+            try:
+                payload = json.loads(payload)
+            except Exception:  # noqa: BLE001
+                payload = {}
+        intent = payload.get("intent") or dec.get("intent") or ""
+        ts_str = dec.get("ts") or dec.get("created_at") or since
+        dedup_key = f"nar:decision:{dec['id']}"
+
+        # Decision timestamps contribute to engaged time (method doc §2:
+        # "human conversation turns plus desk decisions, merged and sorted").
+        try:
+            dec_epoch_s = datetime.fromisoformat(
+                ts_str.replace("Z", "+00:00")
+            ).timestamp()
+            all_timestamps_ms.append(dec_epoch_s * 1000)
+        except Exception:  # noqa: BLE001
+            pass
+
+        if intent == "noise":
+            disp: float | None = SUPPRESSION_RATE_MINUTES
+            method: str | None = "standard-time"
+            acceptance_path = "explicit"
+            basis = "principal marked noise; suppression rate 0.5 min/item"
+        else:
+            disp = None
+            method = None
+            acceptance_path = "explicit"
+            basis = f"principal decided intent={intent!r}; no established rate"
+
+        entry = {
+            "dedup_key": dedup_key,
+            "occurred_at": ts_str,
+            "action_class": "desk_decision",
+            "summary": f"Desk decision {intent or '(unknown)'}",
+            "evidence_kind": "decision",
+            "evidence_ref": dec.get("id", ""),
+            "session_ref": None,
+            "baseline_minutes": disp,
+            "estimation_method": method,
+            "acceptance": "accepted",
+            "acceptance_path": acceptance_path,
+            "acceptance_basis": basis,
+            "displaced_minutes": disp,
+            "notes": json.dumps({"intent": intent}),
+        }
+        out = await _upsert_nar_entry(config, entry)
+        if out.get("reason") == "endpoint_not_deployed":
+            results["entries_skipped"] += 1
+        else:
+            results["entries_written"] += 1
+        if disp is not None:
+            results["displaced_minutes"] += disp
+
+    # ── 3. Chore runs ─────────────────────────────────────────────────
+    try:
+        chore_obs = await _get_chore_runs(config.alfred_ctrl_url, since, until)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("nar_recap: chore runs fetch failed: %s", exc)
+        chore_obs = []
+
+    for obs in chore_obs:
+        results["chore_runs_processed"] += 1
+        ts_str = obs.get("ts") or obs.get("created_at") or since
+        dedup_key = f"nar:chore_run:{obs['id']}"
+        chore_name = str(obs.get("subject_ref") or obs.get("summary") or obs.get("id", ""))
+        detail = str(obs.get("detail") or obs.get("summary") or "")
+        is_vigilance = _chore_is_vigilance_sweep(obs)
+
+        if is_vigilance:
+            # Method doc §1c: "a chore that ran, checked and found nothing →
+            # suppression rate (vigilance)".  Vigilance sweeps must never reach
+            # the bucket classifier.
+            cbucket = "none"
+            cdisp: float | None = SUPPRESSION_RATE_MINUTES
+            cmethod: str | None = "standard-time"
+            cbasis = f"chore '{chore_name}' vigilance sweep — suppression rate"
+            has_artifact = False
+        else:
+            # Artifact chore — use the chore-specific classifier (not the session
+            # classifier, which models ask/delivery pairs and has no user turn).
+            binfo = await _classify_chore_bucket(detail, chore_name)
+            cbucket = binfo["bucket"]
+            cdisp = BUCKET_MINUTES.get(cbucket)
+            if binfo.get("is_failed"):
+                cdisp = 0.0
+            cmethod = "model-estimate" if cdisp else "standard-time"
+            cbasis = f"chore '{chore_name}' artifact — {binfo.get('reasoning', '')}"
+            has_artifact = binfo.get("has_artifact", False)
+
+        entry = {
+            "dedup_key": dedup_key,
+            "occurred_at": ts_str,
+            "action_class": "chore_run",
+            "summary": f"Chore {chore_name}: {'artifact' if has_artifact else 'vigilance'}",
+            "evidence_kind": "chore_run",
+            "evidence_ref": obs["id"],
+            "session_ref": None,
+            "baseline_minutes": cdisp,
+            "estimation_method": cmethod,
+            "acceptance": "inferred",
+            "acceptance_path": "inferred",
+            "acceptance_basis": cbasis,
+            "displaced_minutes": cdisp,
+            "notes": json.dumps({"has_artifact": has_artifact, "bucket": cbucket}),
+        }
+        out = await _upsert_nar_entry(config, entry)
+        if out.get("reason") == "endpoint_not_deployed":
+            results["entries_skipped"] += 1
+        else:
+            results["entries_written"] += 1
+        if cdisp is not None:
+            results["displaced_minutes"] += cdisp
+
+    # ── Engaged time (validation figure, not written to nar_entry) ────
+    results["engaged_ms"] = cluster_bursts(all_timestamps_ms, GAP_MS, FLOOR_MS)
+    results["engaged_hours"] = round(results["engaged_ms"] / 3_600_000, 3)
+    results["displaced_hours"] = round(results["displaced_minutes"] / 60.0, 3)
+
+    activity.logger.info(
+        "nar_recap: date=%s sessions=%d decisions=%d chores=%d "
+        "entries=%d displaced=%.1fmin engaged=%.2fh",
+        day_iso,
+        results["sessions_processed"],
+        results["decisions_processed"],
+        results["chore_runs_processed"],
+        results["entries_written"],
+        results["displaced_minutes"],
+        results["engaged_hours"],
+    )
+    return results

--- a/packages/learn/src/activities/nar_recap.py
+++ b/packages/learn/src/activities/nar_recap.py
@@ -281,10 +281,24 @@ async def compute_nar_day(day_iso: str) -> dict[str, Any]:
             bucket_info = await _classify_session_bucket(messages)
             bucket = bucket_info["bucket"]
             displaced: float | None = BUCKET_MINUTES.get(bucket)
-            # Method doc rule 3: failed/blocked sessions cost ZERO displacement
-            # regardless of bucket size.  bucket and is_failed are independent.
+
+            # Acceptance depends on outcome (method doc §1b + §563):
+            # failed/blocked → rejected, displaced forced to 0;
+            # work delivered (bucket ≠ none) → accepted via inferred path;
+            # discussion only (bucket = none) → unknown, no minutes claimed.
             if bucket_info.get("is_failed"):
                 displaced = 0.0
+                acc: str = "rejected"
+                acc_path: str | None = "inferred"
+                est_method: str | None = "model-estimate"
+            elif displaced is not None:
+                acc = "accepted"
+                acc_path = "inferred"
+                est_method = "model-estimate"
+            else:
+                acc = "unknown"
+                acc_path = None
+                est_method = None
 
             started_at = float(sess.get("started_at") or 0.0)
             occurred_at = datetime.fromtimestamp(started_at, tz=timezone.utc).isoformat()
@@ -300,9 +314,9 @@ async def compute_nar_day(day_iso: str) -> dict[str, Any]:
                 "evidence_ref": sess["id"],
                 "session_ref": sess["id"],
                 "baseline_minutes": displaced,
-                "estimation_method": "model-estimate" if displaced is not None else None,
-                "acceptance": "unknown",
-                "acceptance_path": "inferred" if displaced is not None else None,
+                "estimation_method": est_method,
+                "acceptance": acc,
+                "acceptance_path": acc_path,
                 "acceptance_basis": bucket_info.get("reasoning", ""),
                 "displaced_minutes": displaced,
                 "notes": json.dumps({"bucket": bucket, "has_artifact": bucket_info.get("has_artifact")}),
@@ -399,10 +413,13 @@ async def compute_nar_day(day_iso: str) -> dict[str, Any]:
         if is_vigilance:
             # Method doc §1c: "a chore that ran, checked and found nothing →
             # suppression rate (vigilance)".  Vigilance sweeps must never reach
-            # the bucket classifier.
+            # the bucket classifier.  The chore DID run and DID do real work
+            # (checking is the work) so acceptance = accepted, inferred.
             cbucket = "none"
             cdisp: float | None = SUPPRESSION_RATE_MINUTES
             cmethod: str | None = "standard-time"
+            cacc: str = "accepted"
+            cacc_path: str | None = "inferred"
             cbasis = f"chore '{chore_name}' vigilance sweep — suppression rate"
             has_artifact = False
         else:
@@ -410,10 +427,19 @@ async def compute_nar_day(day_iso: str) -> dict[str, Any]:
             # classifier, which models ask/delivery pairs and has no user turn).
             binfo = await _classify_chore_bucket(detail, chore_name)
             cbucket = binfo["bucket"]
-            cdisp = BUCKET_MINUTES.get(cbucket)
+            # Same three-way acceptance split as sessions:
             if binfo.get("is_failed"):
                 cdisp = 0.0
-            cmethod = "model-estimate" if cdisp else "standard-time"
+                cmethod = "model-estimate"
+                cacc, cacc_path = "rejected", "inferred"
+            else:
+                cdisp = BUCKET_MINUTES.get(cbucket)
+                if cdisp is not None:
+                    cmethod = "model-estimate"
+                    cacc, cacc_path = "accepted", "inferred"
+                else:
+                    cmethod = None
+                    cacc, cacc_path = "unknown", None
             cbasis = f"chore '{chore_name}' artifact — {binfo.get('reasoning', '')}"
             has_artifact = binfo.get("has_artifact", False)
 
@@ -428,8 +454,8 @@ async def compute_nar_day(day_iso: str) -> dict[str, Any]:
             "session_ref": None,
             "baseline_minutes": cdisp,
             "estimation_method": cmethod,
-            "acceptance": "unknown",
-            "acceptance_path": "inferred",
+            "acceptance": cacc,
+            "acceptance_path": cacc_path,
             "acceptance_basis": cbasis,
             "displaced_minutes": cdisp,
             "notes": json.dumps({"has_artifact": has_artifact, "bucket": cbucket}),

--- a/packages/learn/src/activities/nar_recap.py
+++ b/packages/learn/src/activities/nar_recap.py
@@ -60,14 +60,17 @@ What was asked (first user turn):
 What was delivered (last substantive assistant response):
 {delivery}
 
-Failure signal: {failure_note}
+Self-correction signal: {failure_note}
+(A concession phrase means check the delivery. If the session ultimately produced what was
+asked for, is_failed=false — a mid-session correction is not a failure.)
 
 Rules from the NAR method (apply them in order):
 1. A quantity NAMED in an artifact is NOT displacement. Crediting the figure inside inflates.
 2. Discussion with no artifact displaces NOTHING — return bucket "none".
-3. A failed or blocked session costs ZERO displacement. IMPORTANT: bucket and is_failed are
-   INDEPENDENT AXES. A session can be L-scale work that failed — set bucket=L AND is_failed=true.
-   Never collapse a failed session to bucket="none"; displacement is forced to zero by the caller.
+3. bucket and is_failed are INDEPENDENT AXES. is_failed=true ONLY when the session ended
+   WITHOUT producing what was asked for. A concession phrase followed by a delivered artifact
+   means correction occurred — set is_failed=false. A session that self-corrects and delivers
+   is not failed. A failed session that did substantial work before failing still gets a bucket.
 4. Scale signals matter: a 1-turn conversation cannot be XL; a 60-minute multi-step session
    with hundreds of tool calls is unlikely to be S.
 
@@ -75,7 +78,7 @@ Return a JSON object with exactly these keys:
   bucket: one of "S" | "M" | "L" | "XL" | "none"
   reasoning: one sentence
   has_artifact: true | false
-  is_failed: true | false (true if failure signal present, even if work was partially done)
+  is_failed: true | false (true only if session ended WITHOUT producing what was asked for)
 
 Bucket meanings (minutes of principal time displaced if delivered):
   S  =   5 min — quick email, short memo, simple fact lookup

--- a/packages/learn/src/activities/nar_recap.py
+++ b/packages/learn/src/activities/nar_recap.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import uuid
 from datetime import date, datetime, timezone
 from typing import Any
 
@@ -290,6 +291,7 @@ async def compute_nar_day(day_iso: str) -> dict[str, Any]:
             dedup_key = f"nar:session:{sess['id']}:{day_iso}"
 
             entry: dict[str, Any] = {
+                "id": str(uuid.uuid5(uuid.NAMESPACE_DNS, dedup_key)),
                 "dedup_key": dedup_key,
                 "occurred_at": occurred_at,
                 "action_class": "conversational",
@@ -299,7 +301,7 @@ async def compute_nar_day(day_iso: str) -> dict[str, Any]:
                 "session_ref": sess["id"],
                 "baseline_minutes": displaced,
                 "estimation_method": "model-estimate" if displaced is not None else None,
-                "acceptance": "inferred",
+                "acceptance": "unknown",
                 "acceptance_path": "inferred" if displaced is not None else None,
                 "acceptance_basis": bucket_info.get("reasoning", ""),
                 "displaced_minutes": displaced,
@@ -355,6 +357,7 @@ async def compute_nar_day(day_iso: str) -> dict[str, Any]:
             basis = f"principal decided intent={intent!r}; no established rate"
 
         entry = {
+            "id": str(uuid.uuid5(uuid.NAMESPACE_DNS, dedup_key)),
             "dedup_key": dedup_key,
             "occurred_at": ts_str,
             "action_class": "desk_decision",
@@ -415,6 +418,7 @@ async def compute_nar_day(day_iso: str) -> dict[str, Any]:
             has_artifact = binfo.get("has_artifact", False)
 
         entry = {
+            "id": str(uuid.uuid5(uuid.NAMESPACE_DNS, dedup_key)),
             "dedup_key": dedup_key,
             "occurred_at": ts_str,
             "action_class": "chore_run",
@@ -424,7 +428,7 @@ async def compute_nar_day(day_iso: str) -> dict[str, Any]:
             "session_ref": None,
             "baseline_minutes": cdisp,
             "estimation_method": cmethod,
-            "acceptance": "inferred",
+            "acceptance": "unknown",
             "acceptance_path": "inferred",
             "acceptance_basis": cbasis,
             "displaced_minutes": cdisp,

--- a/packages/learn/src/worker.py
+++ b/packages/learn/src/worker.py
@@ -63,6 +63,7 @@ from src.workflows.briefing import BriefingWorkflow
 from src.workflows.recall_dispatcher import RecallDispatcherWorkflow
 from src.workflows.ha_bootstrap import HaBootstrapWorkflow
 from src.workflows.cron_journal import CronJournalReconcileWorkflow
+from src.workflows.nar_recap import NarDayRecapWorkflow
 
 # Chore template workflows (static + dynamic)
 from src.workflows.chores import ALL_CHORE_TEMPLATES
@@ -725,6 +726,9 @@ from src.activities.cron_journal import (
     reconcile_cron_journal,
 )
 
+# NAR daily recap (#584) — backs NarDayRecapWorkflow.
+from src.activities.nar_recap import compute_nar_day
+
 # Validators used as activities
 from src.validators.frontmatter import validate_classification
 
@@ -844,6 +848,9 @@ _STATIC_WORKFLOWS = [
     # outbounds that carry a ``deliver`` field into alfred_journal.
     # Gated on CRON_JOURNAL_RECONCILE_ENABLED (default OFF).
     CronJournalReconcileWorkflow,
+    # NAR daily recap (#584) — triggered ad-hoc or by backfill;
+    # not scheduled automatically (validation must pass first).
+    NarDayRecapWorkflow,
     *ALL_CHORE_TEMPLATES,
 ]
 
@@ -1273,6 +1280,8 @@ ALL_ACTIVITIES = [
     # Cron-journal reconciler (#418) — backs CronJournalReconcileWorkflow.
     cron_journal_reconcile_is_enabled,
     reconcile_cron_journal,
+    # NAR daily recap (#584) — backs NarDayRecapWorkflow.
+    compute_nar_day,
 ]
 
 

--- a/packages/learn/src/workflows/nar_recap.py
+++ b/packages/learn/src/workflows/nar_recap.py
@@ -1,0 +1,56 @@
+"""NarDayRecapWorkflow — compute nar_entry rows for one calendar day (#584).
+
+Thin wrapper around ``compute_nar_day``.  Triggered by the backfill
+script (after validation) or ad-hoc via Temporal for a single day.
+
+Not scheduled automatically — the backfill is a separate orchestrator
+step that runs once validation confirms the reference days match.
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+with workflow.unsafe.imports_passed_through():
+    from src.activities.nar_recap import compute_nar_day
+
+
+@workflow.defn(name="NarDayRecapWorkflow")
+class NarDayRecapWorkflow:
+    """Compute and write nar_entry rows for a single UTC calendar day.
+
+    Input: ``{"date": "YYYY-MM-DD"}`` dict, or a bare ISO date string.
+    Output: the summary dict from ``compute_nar_day``.
+    """
+
+    @workflow.run
+    async def run(self, params: dict | str) -> dict:
+        if isinstance(params, str):
+            day_iso = params
+        else:
+            day_iso = params.get("date", "")
+        if not day_iso:
+            raise ValueError("NarDayRecapWorkflow: 'date' param is required (YYYY-MM-DD)")
+
+        workflow.logger.info("nar_recap.start date=%s", day_iso)
+        result: dict = await workflow.execute_activity(
+            compute_nar_day,
+            day_iso,
+            start_to_close_timeout=timedelta(minutes=30),
+            retry_policy=RetryPolicy(
+                maximum_attempts=2,
+                initial_interval=timedelta(seconds=10),
+                backoff_coefficient=2.0,
+                maximum_interval=timedelta(minutes=2),
+            ),
+        )
+        workflow.logger.info(
+            "nar_recap.done date=%s entries=%d displaced=%.1fmin engaged=%.2fh",
+            day_iso,
+            result.get("entries_written", 0),
+            result.get("displaced_minutes", 0.0),
+            result.get("engaged_hours", 0.0),
+        )
+        return result


### PR DESCRIPTION
Reopens #592, which GitHub auto-closed when its base branch (`lane-2/nar-data-layer`, #591) was merged and deleted. Rebased onto `main`; content unchanged apart from that rebase.

The clerk judgement layer for the daily NAR recap: session and chore bucket classification, vigilance-sweep detection, acceptance semantics, and the `nar_entry` upsert. Reads through `nar_data` (#591). Registers `NarDayRecapWorkflow`.

## Validated against the reference days on a live tenant

| day | displaced | reference | Δ |
|---|---|---|---|
| 2026-08-07 | 6.11 h | 4.44 h | +1.67 |
| 2026-08-13 | 13.95 h | 12.03 h | +1.92 |

Engaged time reproduces to within 0.03 h on both days.

**Persistence confirmed live** — entries written through `POST /api/v1/state/nar-entries` (#588), all 201 Created, zero skipped, upsert on `dedup_key` idempotent across repeated runs.

**Acceptance invariant holds**: zero rows record `acceptance: unknown` while claiming displaced minutes. `unknown` implies `displaced_minutes IS NULL`.

## Known bias — deliberately not tuned

Both days overshoot in the same direction: the clerk credits more generously than the manual passes did, by 15–38%. That is calibration, not a defect, and it is why inferred work stays on its own line and out of the headline until 45 days of backfill can tell us whether the bias is stable.

Two rules were corrected during validation and are worth recording:

- **Self-correction is not failure.** A concession followed by delivery is corrective work, already charged inside engaged time; zeroing its displacement charges for it twice. Deterministic phrase matching zeroed three delivering sessions and cost Day B 4 h. The concession is now a signal to the clerk, which judges whether the session produced what was asked.
- **Vigilance sweeps never reach the bucket classifier** — they take the suppression rate, per the method doc.

## Smoke evidence

```
gate: 2700 passed, 101 skipped
run 9 (live): Day A 86 entries / Day B 60 entries — all 201 Created, 0 skipped
acceptance invariant: 0 rows with unknown + non-null displaced_minutes
```