### PR TITLE
fix(ctrl): recompute must start NarDayRecapWorkflow (#584)

### DIFF
--- a/packages/ctrl/src/api/routes/attention.ts
+++ b/packages/ctrl/src/api/routes/attention.ts
@@ -1072,7 +1072,7 @@ export function registerAttentionRoutes(): void {
     let handle: string | null = wfId;
     try {
       const out = await dockerExec("temporal", [
-        "temporal","workflow","start","--type","NarRecapWorkflow",
+        "temporal","workflow","start","--type","NarDayRecapWorkflow",
         "--task-queue","alfred-learn","--workflow-id",wfId,"--input",input,"--output","json",
       ]);
       try { const p = JSON.parse(out.trim()); handle = p?.workflowId ?? p?.workflow_id ?? wfId; } catch { /**/ }


### PR DESCRIPTION
Every triggered recap has been failing silently.

`POST /api/v1/attention/recompute` started `NarRecapWorkflow`. The learn worker registers `NarDayRecapWorkflow`. Temporal accepted the start, reported the workflow **RUNNING**, and the workflow task then failed and retried forever:

```
ApplicationError: NotFoundError: Workflow class NarRecapWorkflow is not
registered on this worker, available workflows: …
pendingWorkflowTask: attempt 12
```

No activity ran, no rows were written, and the only outward symptom was a workflow that stayed RUNNING and did nothing. `pendingActivities: 0` with a climbing workflow-task attempt count is the tell.

## Why it got through

The frozen cross-lane contract for this feature pinned the HTTP endpoint shapes and response bodies, and both lanes honoured it exactly. It never named the workflow. Each lane picked a reasonable name and they differed — the integration point that wasn't written down is the one that broke.

Both sides pass their own tests: ctrl asserts it issues a start command, learn asserts its workflow is registered. Nothing exercised the join until they ran against a live tenant.

## Smoke evidence

```
learn:  @workflow.defn(name="NarDayRecapWorkflow")   registered in worker.py
ctrl:   --type NarRecapWorkflow                      (before)
        --type NarDayRecapWorkflow                   (after)
```

Verified by inspecting both deployed containers on a live tenant. Needs a `ctrl-api` rebuild and redeploy, after which the backfill can run.