### PR TITLE
fix(ctrl): add missing stats block to attention day statement

### DIFF
--- a/packages/ctrl/src/api/routes/attention.ts
+++ b/packages/ctrl/src/api/routes/attention.ts
@@ -879,9 +879,11 @@ export function registerAttentionRoutes(): void {
     const inferredItems: object[] = [];
     const autonomousItems: object[] = [];
     const unratedCounts = new Map<string, number>();
+    let selfCorrections = 0;
 
     for (const row of entries) {
       const notesData = row.notes ? (() => { try { return JSON.parse(row.notes!); } catch { return {}; } })() : {};
+      if (notesData.outcome === "corrective") selfCorrections++;
       const mins = row.displaced_minutes ?? 0;
 
       if (row.evidence_kind === "session" && row.acceptance_path === "inferred") {
@@ -967,6 +969,20 @@ export function registerAttentionRoutes(): void {
     const displacedHours = explicitHours + inferredHours + autonomousHours;
     const narHours       = displacedHours - engagedHours - interruptionHours;
 
+    // Stats block — quality counters derived from the same day's data.
+    // hard_failures: no dedicated field in nar_entry schema; always 0 until a
+    // source signal is introduced. self_corrections: requires notes.outcome="corrective"
+    // written by the recap workflow; zero when the field is absent.
+    const statsSessions   = new Set(
+      entries.map((e) => e.session_ref).filter((s): s is string => s !== null),
+    ).size;
+    const statsBlocked    = entries.filter((e) => e.acceptance === "rejected").length;
+    const statsArtifacts  = autonomousItems.filter(
+      (i) => ((i as any).minutes ?? 0) > suppressionRate,
+    ).length;
+    const statsDenom      = engagedHours + interruptionHours;
+    const statsRatio      = statsDenom === 0 ? 0 : Math.round((displacedHours / statsDenom) * 1000) / 1000;
+
     return {
       date: dateStr,
       nar_hours: Math.round(narHours * 1000) / 1000,
@@ -991,6 +1007,15 @@ export function registerAttentionRoutes(): void {
         interruption_minutes: INTERRUPTION_RATE_MINUTES,
       },
       unrated: [...unratedCounts.entries()].map(([action_class, count]) => ({ action_class, count })),
+      stats: {
+        sessions: statsSessions,
+        turns: burstDates.length,
+        self_corrections: selfCorrections,
+        blocked: statsBlocked,
+        hard_failures: 0,
+        return_ratio: statsRatio,
+        autonomous_artifacts: statsArtifacts,
+      },
     };
   }
 

--- a/packages/ctrl/tests/nar-entries.test.ts
+++ b/packages/ctrl/tests/nar-entries.test.ts
@@ -147,6 +147,53 @@ describe("GET /api/v1/attention/statement", () => {
     assert.strictEqual(p.rates.suppression_minutes_per_item, sup.rate_minutes);
   });
 
+  it("empty day → stats block present with all-zero values, never undefined", async () => {
+    const { status, p } = await getStatement("date=2026-08-02");
+    assert.strictEqual(status, 200);
+    assert.ok(p.stats !== undefined, "stats must be present even for an empty day");
+    assert.strictEqual(p.stats.sessions, 0);
+    assert.strictEqual(p.stats.turns, 0);
+    assert.strictEqual(p.stats.self_corrections, 0);
+    assert.strictEqual(p.stats.blocked, 0);
+    assert.strictEqual(p.stats.hard_failures, 0);
+    assert.strictEqual(p.stats.return_ratio, 0);
+    assert.strictEqual(p.stats.autonomous_artifacts, 0);
+  });
+
+  it("day with entries → stats block has every required key with non-negative integers", async () => {
+    await postEntries({ entries: [
+      entry({ dedup_key: "e1", session_ref: "sess-a", occurred_at: "2026-08-14T08:00:00Z" }),
+      entry({ dedup_key: "e2", session_ref: "sess-a", occurred_at: "2026-08-14T08:01:00Z" }),
+      entry({ dedup_key: "e3", session_ref: "sess-b", occurred_at: "2026-08-14T09:00:00Z",
+               acceptance: "rejected" }),
+    ]});
+    const { status, p } = await getStatement("date=2026-08-14");
+    assert.strictEqual(status, 200);
+    const s = p.stats;
+    assert.ok(s !== undefined, "stats must be present");
+    // Every key present
+    for (const k of ["sessions","turns","self_corrections","blocked","hard_failures",
+                      "return_ratio","autonomous_artifacts"]) {
+      assert.ok(k in s, `stats.${k} must be present`);
+    }
+    // Derivable values
+    assert.strictEqual(s.sessions, 2, "two distinct session_refs");
+    assert.strictEqual(s.blocked, 1, "one rejected entry");
+    assert.ok(Number.isFinite(s.return_ratio), "return_ratio must be finite");
+    assert.ok(s.return_ratio >= 0, "return_ratio must be non-negative");
+  });
+
+  it("return_ratio is 0 (not NaN/Infinity) when engaged and interruption are both zero", async () => {
+    // Insert a single entry on a date with no Hermes sessions and no audit decisions.
+    await postEntries({ entries: [
+      entry({ dedup_key: "rr-zero", occurred_at: "2026-08-03T10:00:00Z",
+               displaced_minutes: 5, estimation_method: "standard-time" }),
+    ]});
+    const { p } = await getStatement("date=2026-08-03");
+    assert.strictEqual(p.stats.return_ratio, 0, "return_ratio must be 0 when denominator is zero");
+    assert.ok(Number.isFinite(p.stats.return_ratio), "return_ratio must be finite");
+  });
+
   it("range query returns one object per day with totals", async () => {
     const m = matchRoute("GET", "/api/v1/attention/statement");
     assert.ok(m);


### PR DESCRIPTION
## Problem

GET /api/v1/attention/statement?date=YYYY-MM-DD returned every top-level key (date, nar_hours, displaced, engaged, interruption, rates, unrated) except stats. The dashboard reads stats.sessions immediately on render, producing:

  TypeError: Cannot read properties of undefined (reading 'sessions')

This blanked the entire Attention page in production.

## Fix

Populate stats in buildDayStatement (packages/ctrl/src/api/routes/attention.ts) derived from the same nar_entry rows and sources the rest of the statement already reads.

### What each field derives from

| Field | Source | Notes |
|---|---|---|
| sessions | Distinct non-null session_ref values in that day's nar_entry rows | |
| turns | burstDates.length — same principal-event count used for engaged time | |
| self_corrections | entries where notes.outcome === 'corrective' | Returns 0 until recap workflow writes this field. No schema change needed. |
| blocked | entries where acceptance === 'rejected' | Zero displacement, full engaged cost. |
| hard_failures | Always 0 | No dedicated signal in nar_entry schema. Stated here rather than invented. |
| return_ratio | displacedHours / (engagedHours + interruptionHours) | Guarded against divide-by-zero. |
| autonomous_artifacts | Autonomous items with displaced_minutes > suppressionRate | Excludes vigilance sweeps. |

The stats key is now always present on every day object — including empty days — so the dashboard can destructure it unconditionally.

## Tests added (nar-entries.test.ts)

1. Empty day -> stats block present with all-zero values, never undefined — direct regression guard for the crash.
2. Day with entries -> every required key present — checks sessions, blocked, return_ratio correct.
3. return_ratio is 0 (not NaN/Infinity) when denominator is zero — explicit guard for divide-by-zero.

All 1450 tests pass (1 pre-existing skip, 0 failures).

## Smoke evidence

Local run, worktree agent-ad168945af7f60b39, branch lane-1/attention-stats-block:

  cd packages/ctrl && npm run test:ci

  # tests 1451
  # suites 353
  # pass 1450
  # fail 0
  # cancelled 0
  # skipped 1
  # duration_ms 14908.649125
  lane I (ctrl-api) gate passed — 72 LOC, 2 files, verify ok

The three new test names confirm coverage:

  ok 5 - empty day -> stats block present with all-zero values, never undefined
  ok 6 - day with entries -> stats block has every required key with non-negative integers
  ok 7 - return_ratio is 0 (not NaN/Infinity) when engaged and interruption are both zero

## Files touched

- packages/ctrl/src/api/routes/attention.ts (+25 lines) — selfCorrections counter in classification loop + stats variable block + stats field on return object
- packages/ctrl/tests/nar-entries.test.ts (+47 lines) — three new tests

## Known zeros (honest partial)

- hard_failures is always 0 — no field in nar_entry represents this. A future recap pass writing notes.hard_failure would activate it without a schema change.
- self_corrections is 0 until the NAR recap workflow writes notes.outcome = 'corrective'. The detection logic is already live.

References #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)