### PR TITLE
fix(learn): exclude agent-spawned sessions from human conversational work (#584)

### DIFF
--- a/packages/learn/src/activities/nar_data.py
+++ b/packages/learn/src/activities/nar_data.py
@@ -127,6 +127,7 @@ def _get_human_sessions(db: sqlite3.Connection, day: date) -> list[dict[str, Any
             WHERE source IN ({placeholders})
               AND started_at >= ?
               AND started_at <= ?
+              AND parent_session_id IS NULL
             ORDER BY started_at ASC
             """.format(placeholders=",".join("?" * len(HUMAN_SOURCES))),
             (*HUMAN_SOURCES, start_s, end_s),

--- a/packages/learn/tests/test_nar_recap.py
+++ b/packages/learn/tests/test_nar_recap.py
@@ -13,6 +13,7 @@ Non-negotiables validated here (from the method doc):
 from __future__ import annotations
 
 import json
+import sqlite3
 from datetime import date, datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -26,6 +27,7 @@ from src.activities.nar_data import (
     SUPPRESSION_RATE_MINUTES,
     VALID_BUCKETS,
     _day_epoch_window,
+    _get_human_sessions,
     _iso,
     cluster_bursts,
 )
@@ -574,3 +576,116 @@ class TestClassifyChoreeBucket:
         result = await _classify_chore_bucket("", "test-chore")
         assert result["bucket"] == "none"
         assert result["has_artifact"] is False
+
+
+# ---------------------------------------------------------------------------
+# _get_human_sessions — parent_session_id IS NULL filter (#584)
+# ---------------------------------------------------------------------------
+
+def _make_session_db(
+    sessions: list[dict],
+    messages: list[dict] | None = None,
+) -> sqlite3.Connection:
+    """In-memory Hermes session store with the exact columns _get_human_sessions reads."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript("""
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT,
+            started_at REAL,
+            ended_at REAL,
+            parent_session_id TEXT
+        );
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT,
+            role TEXT,
+            content TEXT,
+            timestamp REAL
+        );
+    """)
+    for s in sessions:
+        conn.execute(
+            "INSERT INTO sessions VALUES (?, ?, ?, ?, ?)",
+            (s["id"], s["source"], s["started_at"],
+             s.get("ended_at"), s.get("parent_session_id")),
+        )
+    for m in (messages or []):
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+            (m["session_id"], m["role"], m["content"], m["timestamp"]),
+        )
+    conn.commit()
+    return conn
+
+
+class TestGetHumanSessionsParentage:
+    """_get_human_sessions must exclude agent-spawned sessions (#584).
+
+    sessions.parent_session_id IS NULL is the structural discriminator:
+    the principal's sessions have no parent; agent-spawned ones do.
+    """
+
+    def _day(self) -> date:
+        return date(2026, 7, 15)
+
+    def _ts(self, hour: int = 10) -> float:
+        """Epoch-seconds for 2026-07-15 HH:00:00 UTC."""
+        return datetime(2026, 7, 15, hour, 0, 0, tzinfo=timezone.utc).timestamp()
+
+    def test_null_parent_slack_session_included(self):
+        """A slack session with parent_session_id=NULL is a human session."""
+        db = _make_session_db([
+            {"id": "s1", "source": "slack", "started_at": self._ts(10),
+             "ended_at": self._ts(11), "parent_session_id": None},
+        ])
+        results = _get_human_sessions(db, self._day())
+        assert len(results) == 1
+        assert results[0]["id"] == "s1"
+
+    def test_nonnull_parent_slack_session_excluded(self):
+        """A slack session with a non-null parent_session_id is agent-spawned
+        and must NOT appear in the human session list."""
+        db = _make_session_db([
+            {"id": "s_spawned", "source": "slack", "started_at": self._ts(10),
+             "ended_at": self._ts(10) + 300, "parent_session_id": "parent_abc"},
+        ])
+        results = _get_human_sessions(db, self._day())
+        assert results == []
+
+    def test_spawned_session_turns_absent_from_results(self):
+        """Turns belonging to an agent-spawned session must not appear in the
+        returned session list, so their timestamps cannot reach cluster_bursts."""
+        spawned_ts = self._ts(9)
+        human_ts = self._ts(10)
+        db = _make_session_db(
+            sessions=[
+                {"id": "s_human", "source": "slack", "started_at": human_ts,
+                 "parent_session_id": None},
+                {"id": "s_spawned", "source": "slack", "started_at": spawned_ts,
+                 "parent_session_id": "some_parent"},
+            ],
+            messages=[
+                {"session_id": "s_human", "role": "user", "content": "hi", "timestamp": human_ts * 1000},
+                {"session_id": "s_spawned", "role": "user", "content": "agent task", "timestamp": spawned_ts * 1000},
+            ],
+        )
+        results = _get_human_sessions(db, self._day())
+        assert len(results) == 1
+        assert results[0]["id"] == "s_human"
+        all_ts = [m["ts"] for s in results for m in s["messages"]]
+        # spawned session's turn must not be in the timestamp set
+        assert spawned_ts * 1000 not in all_ts
+        assert human_ts * 1000 in all_ts
+
+    def test_unknown_source_excluded_regardless_of_parent(self):
+        """The source allowlist is maintained independently of the parentage
+        filter.  An api_server session with parent_session_id=NULL is still
+        machine traffic and must be excluded."""
+        db = _make_session_db([
+            {"id": "s_api", "source": "api_server", "started_at": self._ts(10),
+             "parent_session_id": None},
+        ])
+        results = _get_human_sessions(db, self._day())
+        assert results == []


### PR DESCRIPTION
## Summary

- `_get_human_sessions` previously filtered only by `source IN ('slack','telegram','web')`. Agent-spawned tasks that deliver into Slack carry `source='slack'` and were incorrectly counted as displaced conversational time.
- `parent_session_id IS NULL` is the structural discriminator already in the Hermes session store. The principal's own sessions have no parent; an agent-spawned session does.
- Both conditions are now required: `source IN (allowlist) AND parent_session_id IS NULL`.

References #584. Does not close it — Sir will re-derive the affected day (2026-07-15) by hand before trusting the new numbers.

## Root cause

On 2026-07-15 the tenant had 87 Slack sessions, 71 agent-spawned (`Google Drive Interview Transcription #27–#36`, `WHOOP Daily Brief Integration #2`, etc.). The day reported 38.16 h displaced / 2.98 h engaged — physically impossible. The two reference days used for validation had zero spawned sessions, so this never showed up during development.

## What changed

`packages/learn/src/activities/nar_data.py` — one line added to the SQL WHERE clause in `_get_human_sessions`:

```sql
AND parent_session_id IS NULL
```

`packages/learn/tests/test_nar_recap.py` — 4 new tests exercising `_get_human_sessions` with in-memory SQLite fixtures:
1. Slack session + `parent_session_id=NULL` → included
2. Slack session + `parent_session_id='parent_abc'` → excluded
3. Spawned session's turns absent from the timestamp set fed to `cluster_bursts`
4. Unknown source (`api_server`) excluded regardless of parent (allowlist invariant preserved)

## What was NOT done

Agent-spawned sessions are not dropped from the picture entirely — they belong in the autonomous-work bucket counted by artifact. Routing them there is outside the scope of this fix; a clear TODO is implied by the method doc and can be a follow-up.

## Smoke evidence

Local run, in-process, on an in-memory SQLite fixture that mirrors the exact schema of the Hermes session store:

```
python3 -m pytest tests/test_nar_recap.py -v -k "Parentage" 2>&1

tests/test_nar_recap.py::TestGetHumanSessionsParentage::test_null_parent_slack_session_included PASSED
tests/test_nar_recap.py::TestGetHumanSessionsParentage::test_nonnull_parent_slack_session_excluded PASSED
tests/test_nar_recap.py::TestGetHumanSessionsParentage::test_spawned_session_turns_absent_from_results PASSED
tests/test_nar_recap.py::TestGetHumanSessionsParentage::test_unknown_source_excluded_regardless_of_parent PASSED

4 passed in 0.01s
```

Full suite (3 files excluded for missing local deps `fastapi`/`pypdf` — both ARE in `requirements.txt` and will be present in CI):

```
2747 passed, 101 skipped in 21.30s
```

Lane gate: ✓ 116 LOC, 2 files, verify ok

Live tenant smoke (home.alfred.black) is not feasible pre-merge for this change — the NAR workflow runs nightly and the session store is on the tenant's Hermes profile. Sir will re-derive 2026-07-15 after the fix deploys by running `NarDayRecapWorkflow` for that date and comparing the engaged/displaced split to the expected ~2.98 h engaged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc