### PR TITLE
feat(ctrl): mode=replace on nar-entries — fix stale-row accumulation on recap re-runs (#584)

### DIFF
--- a/packages/ctrl/src/api/routes/state.ts
+++ b/packages/ctrl/src/api/routes/state.ts
@@ -758,18 +758,40 @@ export function registerStateRoutes(): void {
   });
 
   // nar_entry — per-action displacement atom for NAR (#563, migration 0020).
-  // POST /api/v1/state/nar-entries { entries:[...] } — upserts on dedup_key.
-  // CHECK constraints are validated client-side so violations return 400, not 500.
+  // POST /api/v1/state/nar-entries { mode?, date?, entries:[...] }
+  //   mode="upsert" (default) — upserts on dedup_key; existing callers unaffected.
+  //   mode="replace" — in one transaction: delete rows for `date` whose dedup_key
+  //     is NOT in the submitted set, then upsert the submitted entries (#584).
+  //     `date` (YYYY-MM-DD) is required for replace. Empty entries clears the day.
+  // CHECK constraints validated client-side so violations return 400, not 500.
   addRoute("POST", "/api/v1/state/nar-entries", async ({ res, body }) => {
     const b = asObj(body);
+    const rawMode = typeof b.mode === "string" ? b.mode : "upsert";
+    if (rawMode !== "upsert" && rawMode !== "replace") {
+      throw new ValidationError("mode must be 'upsert' or 'replace'");
+    }
+    const mode = rawMode as "upsert" | "replace";
+    const date = optStr(b, "date");
+    if (mode === "replace") {
+      if (!date) throw new ValidationError("date (YYYY-MM-DD) is required when mode='replace'");
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) throw new ValidationError("date must be YYYY-MM-DD");
+    }
     const entries = b.entries;
-    if (!Array.isArray(entries) || entries.length === 0) {
+    // replace allows empty entries (clears the day); upsert requires non-empty.
+    if (!Array.isArray(entries) || (mode === "upsert" && entries.length === 0)) {
       throw new ValidationError("entries must be a non-empty array");
     }
     const VA = new Set(["accepted", "rejected", "unknown"]);
     const VAP = new Set(["explicit", "inferred"]);
     const VEM = new Set(["standard-time","timed-sample","observed-history","model-estimate","client-estimate"]);
-    let upserted = 0, updated = 0;
+    // Validate all entries before any writes — prevents partial state on replace.
+    type Ent = { id: string; dedup_key: string; occurred_at: string; action_class: string;
+                 summary: string; evidence_kind: string; evidence_ref: string;
+                 session_ref: string|null; baseline_minutes: number|null;
+                 estimation_method: string|null; acceptance: string;
+                 acceptance_path: string|null; acceptance_basis: string|null;
+                 displaced_minutes: number|null; notes: string|null };
+    const parsed: Ent[] = [];
     for (const raw of entries) {
       const e = asObj(raw as unknown);
       const id = reqStr(e, "id"), dedup_key = reqStr(e, "dedup_key");
@@ -789,27 +811,56 @@ export function registerStateRoutes(): void {
         throw new ValidationError(`estimation_method must be one of: ${[...VEM].join(", ")}`);
       if (displaced_minutes !== null && estimation_method === null)
         throw new ValidationError("displaced_minutes requires estimation_method — no method, no claim");
-      if (db().prepare("SELECT id FROM nar_entry WHERE dedup_key = ?").get(dedup_key)) {
-        db().prepare(
-          `UPDATE nar_entry SET occurred_at=?,action_class=?,summary=?,evidence_kind=?,evidence_ref=?,
-           session_ref=?,baseline_minutes=?,estimation_method=?,acceptance=?,acceptance_path=?,
-           acceptance_basis=?,displaced_minutes=?,notes=? WHERE dedup_key=?`,
-        ).run(occurred_at,action_class,summary,evidence_kind,evidence_ref,
-              session_ref,baseline_minutes,estimation_method,acceptance,acceptance_path,
-              acceptance_basis,displaced_minutes,notes,dedup_key);
-        updated++;
-      } else {
-        db().prepare(
-          `INSERT INTO nar_entry(id,dedup_key,occurred_at,action_class,summary,evidence_kind,evidence_ref,
-           session_ref,baseline_minutes,estimation_method,acceptance,acceptance_path,acceptance_basis,
-           displaced_minutes,notes) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
-        ).run(id,dedup_key,occurred_at,action_class,summary,evidence_kind,evidence_ref,
-              session_ref,baseline_minutes,estimation_method,acceptance,acceptance_path,
-              acceptance_basis,displaced_minutes,notes);
-        upserted++;
-      }
+      parsed.push({ id, dedup_key, occurred_at, action_class, summary, evidence_kind, evidence_ref,
+                    session_ref, baseline_minutes, estimation_method, acceptance, acceptance_path,
+                    acceptance_basis, displaced_minutes, notes });
     }
-    sendJson(res, 201, { ok: true, upserted, updated });
+    const writeEntries = (list: Ent[]): { upserted: number; updated: number } => {
+      let upserted = 0, updated = 0;
+      for (const v of list) {
+        if (db().prepare("SELECT id FROM nar_entry WHERE dedup_key = ?").get(v.dedup_key)) {
+          db().prepare(
+            `UPDATE nar_entry SET occurred_at=?,action_class=?,summary=?,evidence_kind=?,evidence_ref=?,
+             session_ref=?,baseline_minutes=?,estimation_method=?,acceptance=?,acceptance_path=?,
+             acceptance_basis=?,displaced_minutes=?,notes=? WHERE dedup_key=?`,
+          ).run(v.occurred_at,v.action_class,v.summary,v.evidence_kind,v.evidence_ref,
+                v.session_ref,v.baseline_minutes,v.estimation_method,v.acceptance,v.acceptance_path,
+                v.acceptance_basis,v.displaced_minutes,v.notes,v.dedup_key);
+          updated++;
+        } else {
+          db().prepare(
+            `INSERT INTO nar_entry(id,dedup_key,occurred_at,action_class,summary,evidence_kind,evidence_ref,
+             session_ref,baseline_minutes,estimation_method,acceptance,acceptance_path,acceptance_basis,
+             displaced_minutes,notes) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+          ).run(v.id,v.dedup_key,v.occurred_at,v.action_class,v.summary,v.evidence_kind,v.evidence_ref,
+                v.session_ref,v.baseline_minutes,v.estimation_method,v.acceptance,v.acceptance_path,
+                v.acceptance_basis,v.displaced_minutes,v.notes);
+          upserted++;
+        }
+      }
+      return { upserted, updated };
+    };
+    let upserted = 0, updated = 0, deleted = 0;
+    if (mode === "replace") {
+      const r = runInTx(db(), () => {
+        const keys = parsed.map(v => v.dedup_key);
+        let del: number;
+        if (keys.length === 0) {
+          del = db().prepare(`DELETE FROM nar_entry WHERE date(occurred_at) = ?`).run(date!).changes;
+        } else {
+          const ph = keys.map(() => "?").join(",");
+          del = db().prepare(
+            `DELETE FROM nar_entry WHERE date(occurred_at) = ? AND dedup_key NOT IN (${ph})`,
+          ).run(date!, ...keys).changes;
+        }
+        const w = writeEntries(parsed);
+        return { del, ins: w.upserted, upd: w.updated };
+      });
+      deleted = r.del; upserted = r.ins; updated = r.upd;
+    } else {
+      ({ upserted, updated } = writeEntries(parsed));
+    }
+    sendJson(res, 201, { ok: true, upserted, updated, deleted });
   });
 }
 

--- a/packages/ctrl/tests/nar-entries.test.ts
+++ b/packages/ctrl/tests/nar-entries.test.ts
@@ -206,3 +206,105 @@ describe("GET /api/v1/attention/statement", () => {
     assert.ok(p.totals, "totals must be present");
   });
 });
+
+// mode='replace' — atomic day-replace (#584)
+describe("POST /api/v1/state/nar-entries — mode='replace'", () => {
+  before(() => db);
+  beforeEach(() => db.prepare("DELETE FROM nar_entry").run());
+
+  it("replace removes rows for that date absent from the payload", async () => {
+    await postEntries({ entries: [
+      entry({ dedup_key: "keep",  occurred_at: "2026-07-15T09:00:00Z" }),
+      entry({ dedup_key: "stale", occurred_at: "2026-07-15T10:00:00Z" }),
+    ]});
+    const { status, p } = await postEntries({
+      mode: "replace",
+      date: "2026-07-15",
+      entries: [entry({ dedup_key: "keep", occurred_at: "2026-07-15T09:00:00Z" })],
+    });
+    assert.strictEqual(status, 201);
+    assert.strictEqual(p.deleted, 1, "stale row must be deleted");
+    assert.strictEqual(p.updated, 1, "'keep' row already exists → updated");
+    assert.strictEqual(p.upserted, 0);
+    const rows = db.prepare("SELECT dedup_key FROM nar_entry WHERE date(occurred_at)='2026-07-15'").all() as any[];
+    assert.deepStrictEqual(rows.map((r: any) => r.dedup_key), ["keep"]);
+  });
+
+  it("replace leaves rows for OTHER dates untouched", async () => {
+    await postEntries({ entries: [
+      entry({ dedup_key: "day-a-1", occurred_at: "2026-07-14T09:00:00Z" }),
+      entry({ dedup_key: "day-b-1", occurred_at: "2026-07-15T09:00:00Z" }),
+      entry({ dedup_key: "day-b-2", occurred_at: "2026-07-15T10:00:00Z" }),
+    ]});
+    const { status, p } = await postEntries({
+      mode: "replace",
+      date: "2026-07-15",
+      entries: [entry({ dedup_key: "day-b-new", occurred_at: "2026-07-15T11:00:00Z" })],
+    });
+    assert.strictEqual(status, 201);
+    assert.strictEqual(p.deleted, 2, "both 2026-07-15 rows absent from payload deleted");
+    const day14 = db.prepare("SELECT COUNT(*) AS n FROM nar_entry WHERE date(occurred_at)='2026-07-14'").get() as any;
+    assert.strictEqual(day14.n, 1, "row on other date must survive");
+    const day15 = db.prepare("SELECT dedup_key FROM nar_entry WHERE date(occurred_at)='2026-07-15'").all() as any[];
+    assert.deepStrictEqual(day15.map((r: any) => r.dedup_key), ["day-b-new"]);
+  });
+
+  it("replace with empty entries clears exactly that day, nothing else", async () => {
+    await postEntries({ entries: [
+      entry({ dedup_key: "target",   occurred_at: "2026-07-15T09:00:00Z" }),
+      entry({ dedup_key: "survivor", occurred_at: "2026-07-14T09:00:00Z" }),
+    ]});
+    const { status, p } = await postEntries({ mode: "replace", date: "2026-07-15", entries: [] });
+    assert.strictEqual(status, 201);
+    assert.strictEqual(p.deleted, 1, "target row must be deleted");
+    assert.deepStrictEqual({ upserted: p.upserted, updated: p.updated }, { upserted: 0, updated: 0 });
+    const total = db.prepare("SELECT COUNT(*) AS n FROM nar_entry").get() as any;
+    assert.strictEqual(total.n, 1, "only the survivor on other date remains");
+    const rem = db.prepare("SELECT dedup_key FROM nar_entry").all() as any[];
+    assert.strictEqual(rem[0].dedup_key, "survivor");
+  });
+
+  it("replace without date returns 400", async () => {
+    const { status, p } = await postEntries({
+      mode: "replace",
+      entries: [entry({ occurred_at: "2026-07-15T09:00:00Z" })],
+    });
+    assert.strictEqual(status, 400);
+    assert.ok(String(p.error).toLowerCase().includes("date"), "error must mention 'date'");
+  });
+
+  it("upsert mode (default) does not delete any rows", async () => {
+    await postEntries({ entries: [entry({ dedup_key: "existing", occurred_at: "2026-07-15T09:00:00Z" })] });
+    const { status, p } = await postEntries({
+      entries: [entry({ dedup_key: "new-entry", occurred_at: "2026-07-15T10:00:00Z" })],
+    });
+    assert.strictEqual(status, 201);
+    assert.strictEqual(p.deleted, 0, "upsert must never delete rows");
+    assert.strictEqual((db.prepare("SELECT COUNT(*) AS n FROM nar_entry").get() as any).n, 2);
+  });
+
+  it("response counts match what actually changed", async () => {
+    await postEntries({ entries: [
+      entry({ dedup_key: "r1", occurred_at: "2026-07-15T08:00:00Z" }),
+      entry({ dedup_key: "r2", occurred_at: "2026-07-15T09:00:00Z" }),
+      entry({ dedup_key: "r3", occurred_at: "2026-07-15T10:00:00Z" }),
+      entry({ dedup_key: "other", occurred_at: "2026-07-14T09:00:00Z" }),
+    ]});
+    // Replace 2026-07-15: r1 (update), r4 (insert); r2+r3 should be deleted.
+    const { p } = await postEntries({
+      mode: "replace",
+      date: "2026-07-15",
+      entries: [
+        entry({ dedup_key: "r1", occurred_at: "2026-07-15T08:00:00Z" }),
+        entry({ dedup_key: "r4", occurred_at: "2026-07-15T11:00:00Z" }),
+      ],
+    });
+    assert.strictEqual(p.deleted, 2, "r2 and r3 deleted");
+    assert.strictEqual(p.updated, 1, "r1 updated (pre-existing)");
+    assert.strictEqual(p.upserted, 1, "r4 inserted (new)");
+    const rows = db.prepare(
+      "SELECT dedup_key FROM nar_entry WHERE date(occurred_at)='2026-07-15' ORDER BY dedup_key",
+    ).all() as any[];
+    assert.deepStrictEqual(rows.map((r: any) => r.dedup_key), ["r1", "r4"]);
+  });
+});


### PR DESCRIPTION
## Problem

`POST /api/v1/state/nar-entries` upserts on `dedup_key` and never deletes. When a NAR recap is re-run and produces **fewer** entries, the surplus rows remain forever.

Measured live: a contaminated run wrote 183 rows on 2026-07-15. After a filter fix the recap correctly computed 113 entries — but the day still reported **38.16 h displaced** because the 70 stale rows survived. The recap log confirmed the right answer was computed:

```
nar_recap: date=2026-07-15 sessions=16 entries=113 displaced=343.0min engaged=1.11h
```

The computation was right; the stored result was wrong. A 45-day backfill re-run would have compounded this across every corrected day.

## Solution

Add `mode` to the endpoint:

```
POST /api/v1/state/nar-entries
{
  "date":    "YYYY-MM-DD",          // required when mode="replace"
  "mode":    "upsert" | "replace",  // default "upsert" — existing callers unaffected
  "entries": [ ... ]
}
```

`mode="replace"` executes in **one transaction**:
1. `DELETE FROM nar_entry WHERE date(occurred_at) = ? AND dedup_key NOT IN (submitted set)`
2. Upsert the submitted entries

Rules honoured per the Lane II contract brief:
- `mode` defaults to `"upsert"` — existing callers that omit it are unchanged
- `mode="replace"` without `date` → 400
- `mode="replace"` with empty `entries` → clears the day (deliberate, not accidental)
- Response now includes `deleted` (0 for upsert mode)

## Files touched

- `packages/ctrl/src/api/routes/state.ts` — handler rewrite (mode parsing, validate-all-upfront, replace branch, `writeEntries` inner helper, `runInTx` wrapping the delete + upserts)
- `packages/ctrl/tests/nar-entries.test.ts` — 6 new tests in a new `describe` block

## Smoke evidence

Local route-level smoke via the test suite (real SQLite + real in-process route handler):

```
node --experimental-sqlite ... --test tests/nar-entries.test.ts

# POST /api/v1/state/nar-entries — mode='replace'
    ok 1 - replace removes rows for that date absent from the payload
    ok 2 - replace leaves rows for OTHER dates untouched
    ok 3 - replace with empty entries clears exactly that day, nothing else
    ok 4 - replace without date returns 400
    ok 5 - upsert mode (default) does not delete any rows
    ok 6 - response counts match what actually changed

# tests 18
# suites 3
# pass 18
# fail 0
# duration_ms 209ms
```

Full suite (all 367 test files):

```
# tests 1456
# pass 1456
# fail 0
# duration_ms 12689ms
```

Key isolation assertion (test 2): seeded entries on 2026-07-14 and 2026-07-15; replaced only 2026-07-15 → 2026-07-14 row untouched (n=1 confirmed). This is the test that matters most — a date-scoping bug here silently destroys the whole table.

References #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)
