### PR TITLE
fix(learn): compute_nar_day sends mode=replace so re-runs clear stale rows (#584)

### DIFF
--- a/packages/learn/src/activities/nar_recap.py
+++ b/packages/learn/src/activities/nar_recap.py
@@ -233,6 +233,55 @@ async def _upsert_nar_entry(config: Any, entry: dict[str, Any]) -> dict[str, Any
             raise
 
 
+async def _replace_nar_entries(
+    config: Any, day_iso: str, entries: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """POST to /api/v1/state/nar-entries with mode='replace' for one calendar day.
+
+    Sends the complete entry set for ``day_iso`` in a single transaction.
+    ctrl-api deletes every existing nar_entry on that date whose dedup_key
+    is not in the submitted set, then upserts the submitted entries.  An
+    empty list is valid — a day with nothing must still clear any earlier
+    rows rather than silently keeping them.
+
+    Graceful degradation:
+      400 → older ctrl-api without mode support.  Logged clearly as a
+            replace failure; the day was NOT replaced.  Returns
+            ``{"ok": False, "reason": "replace_not_supported"}``.  The
+            caller must not treat this as success.
+      404/405 → endpoint not deployed at all.  Same log-and-continue
+                behaviour as before.
+    """
+    async with httpx.AsyncClient(
+        base_url=config.alfred_ctrl_url, timeout=30.0, headers=_ctrl_headers(),
+    ) as http:
+        try:
+            resp = await http.post(
+                "/api/v1/state/nar-entries",
+                json={"date": day_iso, "mode": "replace", "entries": entries},
+            )
+            resp.raise_for_status()
+            return resp.json()
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
+            if status == 400:
+                logger.warning(
+                    "nar_recap: replace mode rejected (400) for date=%s — "
+                    "ctrl-api may be running an older build without mode support; "
+                    "day was NOT replaced",
+                    day_iso,
+                )
+                return {"ok": False, "reason": "replace_not_supported", "date": day_iso}
+            if status in (404, 405):
+                logger.warning(
+                    "nar_recap: /api/v1/state/nar-entries not deployed — "
+                    "date=%s logged only",
+                    day_iso,
+                )
+                return {"ok": False, "reason": "endpoint_not_deployed", "date": day_iso}
+            raise
+
+
 # ---------------------------------------------------------------------------
 # Main activity.
 # ---------------------------------------------------------------------------
@@ -261,6 +310,7 @@ async def compute_nar_day(day_iso: str) -> dict[str, Any]:
     }
 
     all_timestamps_ms: list[float] = []
+    entries_list: list[dict[str, Any]] = []
 
     # ── 1. Conversational sessions ────────────────────────────────────
     db = _open_session_db("main")
@@ -324,11 +374,7 @@ async def compute_nar_day(day_iso: str) -> dict[str, Any]:
                 "displaced_minutes": displaced,
                 "notes": json.dumps({"bucket": bucket, "has_artifact": bucket_info.get("has_artifact")}),
             }
-            out = await _upsert_nar_entry(config, entry)
-            if out.get("reason") == "endpoint_not_deployed":
-                results["entries_skipped"] += 1
-            else:
-                results["entries_written"] += 1
+            entries_list.append(entry)
             if displaced is not None:
                 results["displaced_minutes"] += displaced
 
@@ -390,11 +436,7 @@ async def compute_nar_day(day_iso: str) -> dict[str, Any]:
             "displaced_minutes": disp,
             "notes": json.dumps({"intent": intent}),
         }
-        out = await _upsert_nar_entry(config, entry)
-        if out.get("reason") == "endpoint_not_deployed":
-            results["entries_skipped"] += 1
-        else:
-            results["entries_written"] += 1
+        entries_list.append(entry)
         if disp is not None:
             results["displaced_minutes"] += disp
 
@@ -463,13 +505,20 @@ async def compute_nar_day(day_iso: str) -> dict[str, Any]:
             "displaced_minutes": cdisp,
             "notes": json.dumps({"has_artifact": has_artifact, "bucket": cbucket}),
         }
-        out = await _upsert_nar_entry(config, entry)
-        if out.get("reason") == "endpoint_not_deployed":
-            results["entries_skipped"] += 1
-        else:
-            results["entries_written"] += 1
+        entries_list.append(entry)
         if cdisp is not None:
             results["displaced_minutes"] += cdisp
+
+    # ── 4. Write the day's entries atomically (replace mode) ─────────
+    # compute_nar_day produces a complete picture of a day and is
+    # authoritative for that date — every run is a full recomputation.
+    # mode=replace deletes stale rows (dedup_key not in the submitted set)
+    # before upserting; an empty list still clears any earlier debris.
+    out = await _replace_nar_entries(config, day_iso, entries_list)
+    if out.get("reason") in ("endpoint_not_deployed", "replace_not_supported"):
+        results["entries_skipped"] = len(entries_list)
+    else:
+        results["entries_written"] = len(entries_list)
 
     # ── Engaged time (validation figure, not written to nar_entry) ────
     results["engaged_ms"] = cluster_bursts(all_timestamps_ms, GAP_MS, FLOOR_MS)

--- a/packages/learn/tests/test_nar_recap.py
+++ b/packages/learn/tests/test_nar_recap.py
@@ -689,3 +689,65 @@ class TestGetHumanSessionsParentage:
         ])
         results = _get_human_sessions(db, self._day())
         assert results == []
+
+
+# ---------------------------------------------------------------------------
+# _replace_nar_entries — batch replace writer (#584 stale-row fix)
+# ---------------------------------------------------------------------------
+
+class TestReplaceNarEntries:
+    """_replace_nar_entries posts mode='replace' + date; 400 is a replace failure."""
+
+    def _mock_http(self, status: int = 200):
+        """Return (mock_client_cls, mock_client, mock_resp) for httpx.AsyncClient."""
+        mc = AsyncMock()
+        mc.__aenter__ = AsyncMock(return_value=mc)
+        mc.__aexit__ = AsyncMock(return_value=False)
+        mr = MagicMock()
+        mr.status_code = status
+        mr.raise_for_status = MagicMock()
+        mr.json = MagicMock(return_value={"ok": True})
+        mc.post = AsyncMock(return_value=mr)
+        return MagicMock(return_value=mc), mc, mr
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("entries", [
+        [{"dedup_key": "nar:decision:01TEST", "occurred_at": "2026-07-15T10:00:00Z"}],
+        [],
+    ], ids=["with-entries", "empty"])
+    async def test_payload_carries_mode_replace_and_date(self, entries):
+        """POST body must carry mode='replace' and the ISO date; empty list included."""
+        from src.activities.nar_recap import _replace_nar_entries
+
+        config = MagicMock()
+        config.alfred_ctrl_url = "http://localhost:3100"
+        mock_cls, mock_client, _ = self._mock_http()
+
+        with patch("httpx.AsyncClient", mock_cls):
+            await _replace_nar_entries(config, "2026-07-15", entries)
+
+        body = mock_client.post.call_args.kwargs["json"]
+        assert body["mode"] == "replace"
+        assert body["date"] == "2026-07-15"
+        assert body["entries"] == entries
+
+    @pytest.mark.asyncio
+    async def test_400_is_replace_failure_not_success(self):
+        """400 from ctrl-api must surface as replace_not_supported, not success."""
+        from src.activities.nar_recap import _replace_nar_entries
+        import httpx
+
+        config = MagicMock()
+        config.alfred_ctrl_url = "http://localhost:3100"
+        mock_cls, _, mock_resp = self._mock_http(status=400)
+        mock_resp.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                "Bad Request", request=MagicMock(), response=mock_resp
+            )
+        )
+
+        with patch("httpx.AsyncClient", mock_cls):
+            out = await _replace_nar_entries(config, "2026-07-15", [])
+
+        assert out.get("ok") is False
+        assert out["reason"] == "replace_not_supported"


### PR DESCRIPTION
## Problem

`compute_nar_day` is authoritative for a calendar day, but it was calling `_upsert_nar_entry` once per entry. Upsert never removes rows, so a re-run that produces fewer entries leaves the surplus behind forever.

Measured: the 2026-07-15 contaminated run wrote 183 rows. After the spawned-session filter (#599), the recap correctly computes **113** entries — but the day still reports **38.16 h displaced** because the 70 stale rows remain. The computation was right; the stored result was wrong. This blocks the 45-day backfill.

## Change

Adds `_replace_nar_entries(config, day_iso, entries)` in `packages/learn/src/activities/nar_recap.py`:

- POSTs `{"date": "YYYY-MM-DD", "mode": "replace", "entries": [...]}` to `POST /api/v1/state/nar-entries` in one call after all three source sections (sessions, decisions, chores) have been collected.
- ctrl-api (Lane I, #584) deletes every existing `nar_entry` on that date whose `dedup_key` is not in the submitted set, then upserts.
- An empty entry list is still sent — a day that genuinely has nothing must clear any earlier rows.
- `400` response (older ctrl-api build without `mode` support): logged clearly as a replace failure, counted as `entries_skipped`, NOT reported as success.
- `404`/`405`: same log-and-continue as before.

The three per-entry upsert calls inside `compute_nar_day` are replaced with `entries_list.append(entry)`, then the single batch call at the end.

## Tests

Three new tests in `TestReplaceNarEntries`:

- `test_payload_carries_mode_replace_and_date` — parametrized with entries and empty: verifies `mode`, `date`, and `entries` are in the POST body for both cases.
- `test_400_is_replace_failure_not_success` — 400 response returns `ok=False, reason=replace_not_supported`.

Gate: `2750 passed, 101 skipped`, 141 LOC, lane II verify green.

## Smoke evidence

**Local — mocked HTTP (no deployed ctrl-api required):**

```
cd packages/learn && python3 -m pytest tests/test_nar_recap.py -v
...
tests/test_nar_recap.py::TestReplaceNarEntries::test_payload_carries_mode_replace_and_date[with-entries] PASSED
tests/test_nar_recap.py::TestReplaceNarEntries::test_payload_carries_mode_replace_and_date[empty] PASSED
tests/test_nar_recap.py::TestReplaceNarEntries::test_400_is_replace_failure_not_success PASSED
...
50 passed in 0.12s
```

Full suite (excluding 3 pre-existing missing-dep failures — `fastapi`, `pypdf` not installed in this env):
```
2750 passed, 101 skipped in 21.21s
```

Gate output: `✓ lane II (learn) gate passed — 141 LOC, 2 files, verify ok`

**Post-merge live verification (needs Lane I endpoint):** re-run `compute_nar_day("2026-07-15")` once Lane I's `mode=replace` endpoint is deployed; expect `entries_written=113`, displaced matching reference C (4.30 h), stale rows gone. Sir to confirm 38 h → ~4 h on that date.

## Lane I prerequisite

`POST /api/v1/state/nar-entries` with `mode` and `date` support must land and deploy **before** this PR's first live run. Merge order: Lane I (#584) → this PR → backfill.

References #584.

🤖 Generated with [Claude Code](https://claude.com/claude-code)