### PR TITLE
fix(web): absent outcome must credit, not zero — scale signal + label (#584)

### DIFF
--- a/packages/web/src/dashboard/AttentionPage.tsx
+++ b/packages/web/src/dashboard/AttentionPage.tsx
@@ -8,6 +8,7 @@ import { Frame } from "../client/components/ab/Frame";
 import {
   normalizeAttentionDay, isEmptyDay, formatHours,
   deriveChartBars, deriveChartScale, deriveRangeAggregates,
+  formatScaleSignal, formatItemLabel,
   type AttentionDayViewModel, type AttentionStatsResponse, type ChartBar, type ChartScaleResult,
 } from "./attentionCore";
 
@@ -127,12 +128,12 @@ function DayView({ day, recomp, running }: { day: AttentionDayViewModel; recomp(
       <p className="font-mono text-[10px] uppercase tracking-[0.18em] mb-2 opacity-40">Estimated — model heuristic, not measured</p>
       {inferred.items.length === 0 ? <p className="text-xs opacity-40">None.</p> : inferred.items.map((it, i) => (
         <div key={i}>
-          <TR l={<><Pill s={it.bucket} />{it.label}</>}
+          <TR l={<><Pill s={it.bucket} />{formatItemLabel(it)}</>}
             r={it.is_blocked
               ? <><span className="line-through opacity-40 mr-1.5">{hm(it.claimed_minutes)}</span><span>0.00 h</span></>
               : hm(it.display_minutes)} />
           <p className="text-right font-mono text-[10px] opacity-40 mb-0.5">
-            {it.turns}t · {it.tools} tools{it.is_blocked ? ` · ${it.blocked_reason}` : ""}
+            {[formatScaleSignal(it), it.is_blocked ? it.blocked_reason : null].filter(Boolean).join(" · ")}
           </p>
         </div>
       ))}

--- a/packages/web/src/dashboard/attentionCore.test.ts
+++ b/packages/web/src/dashboard/attentionCore.test.ts
@@ -8,7 +8,7 @@ import {
   deriveUnratedRows, deriveInferredDisplay, deriveDisplacementGroups,
   isEmptyDay, formatHours, formatMinutes,
   deriveChartBars, deriveChartScale, deriveRangeAggregates,
-  normalizeAttentionDay,
+  normalizeAttentionDay, formatScaleSignal, formatItemLabel,
   type AttentionDayResponse, type InferredItem, type SeriesPoint,
 } from "./attentionCore";
 
@@ -35,20 +35,54 @@ test("unrated: empty → []", () => assert.deepEqual(deriveUnratedRows([]), []))
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 test("unrated: null-tolerant", () => assert.deepEqual(deriveUnratedRows(null as any), []));
 
-// 2. Blocked / non-delivered → display_minutes=0
+// 2. Outcome gate — only explicit failures zero credit; absent ≠ failed
 test("inferred: delivered passes at full minutes, no reason", () => {
   const [d] = deriveInferredDisplay([I]);
   assert.equal(d.display_minutes, 20); assert.equal(d.is_blocked, false); assert.equal(d.blocked_reason, null);
 });
-test("inferred: non-delivered → zero with reason (asymmetry visible via claimed_minutes)", () => {
+test("inferred: outcome null → full credit, not blocked (absent ≠ failed)", () => {
+  const [d] = deriveInferredDisplay([{ ...I, outcome: null }]);
+  assert.equal(d.display_minutes, 20);
+  assert.equal(d.is_blocked, false);
+  assert.equal(d.blocked_reason, null);
+});
+test("inferred: outcome undefined (key absent) → full credit, not blocked", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const [d] = deriveInferredDisplay([{ ...I, outcome: undefined as any }]);
+  assert.equal(d.display_minutes, 20);
+  assert.equal(d.is_blocked, false);
+  assert.equal(d.blocked_reason, null);
+});
+test("inferred: explicit 'aborted' → zero with reason (asymmetry visible via claimed_minutes)", () => {
   const [d] = deriveInferredDisplay([{ ...I, outcome: "aborted" }]);
   assert.equal(d.display_minutes, 0); assert.equal(d.claimed_minutes, 20);
   assert.equal(d.is_blocked, true); assert.match(d.blocked_reason ?? "", /aborted/);
   assert.match(d.blocked_reason ?? "", /no displacement credit/);
 });
-test("inferred: 'blocked' outcome → zero", () => {
+test("inferred: explicit 'failed' → zero, reason present, claimed_minutes preserved", () => {
+  const [d] = deriveInferredDisplay([{ ...I, minutes: 45, outcome: "failed" }]);
+  assert.equal(d.display_minutes, 0);
+  assert.equal(d.claimed_minutes, 45);
+  assert.equal(d.is_blocked, true);
+  assert.match(d.blocked_reason ?? "", /no displacement credit/);
+});
+test("inferred: explicit 'blocked' outcome → zero", () => {
   const [d] = deriveInferredDisplay([{ ...I, outcome: "blocked" }]);
   assert.equal(d.display_minutes, 0); assert.equal(d.is_blocked, true);
+});
+// Sum invariant: rows must sum to section total (the key correctness property).
+// Mix: delivered=30, null-outcome=20, aborted=15. Non-failed sum=50; aborted=0.
+test("inferred: sum of display_minutes equals non-failed total (rows consistent with section total)", () => {
+  const items = deriveInferredDisplay([
+    { ...I, minutes: 30, outcome: "delivered" },
+    { ...I, minutes: 20, outcome: null },
+    { ...I, minutes: 15, outcome: "aborted" },
+  ]);
+  const displaySum = items.reduce((s, it) => s + it.display_minutes, 0);
+  // 30 (delivered) + 20 (null-outcome credited) + 0 (aborted) = 50
+  assert.equal(displaySum, 50);
+  // The API's inferred.hours for these items = 50 / 60; rows and total agree.
+  assert.ok(Math.abs(displaySum / 60 - 50 / 60) < 0.001);
 });
 
 // 3. Empty day detection
@@ -167,4 +201,43 @@ test("normalizeAttentionDay: full response → no section null, values preserved
   const vm = normalizeAttentionDay(E);
   assert.equal(vm.date, E.date); assert.ok(vm.stats !== null); assert.equal(vm.stats?.sessions, 0);
   assert.ok(vm.displaced !== null); assert.ok(vm.engaged !== null); assert.ok(vm.rates !== null);
+});
+
+// 9. formatScaleSignal — scale signal must carry the numbers, not bare unit labels
+test("formatScaleSignal: both counts → 'N turns · N tools'", () => {
+  assert.equal(formatScaleSignal({ turns: 12, tools: 85 }), "12 turns · 85 tools");
+});
+test("formatScaleSignal: only turns present → 'N turns', no bare · tools", () => {
+  assert.equal(formatScaleSignal({ turns: 3, tools: null }), "3 turns");
+  assert.equal(formatScaleSignal({ turns: 3 }), "3 turns");
+});
+test("formatScaleSignal: only tools present → 'N tools', no bare turns ·", () => {
+  assert.equal(formatScaleSignal({ turns: null, tools: 7 }), "7 tools");
+  assert.equal(formatScaleSignal({ tools: 7 }), "7 tools");
+});
+test("formatScaleSignal: neither present → empty string", () => {
+  assert.equal(formatScaleSignal({}), "");
+  assert.equal(formatScaleSignal({ turns: null, tools: undefined }), "");
+});
+test("formatScaleSignal: zero is a valid count, not omitted", () => {
+  assert.equal(formatScaleSignal({ turns: 0, tools: 0 }), "0 turns · 0 tools");
+});
+
+// 10. formatItemLabel — degrade gracefully from bare session IDs
+test("formatItemLabel: descriptive label → returned as-is", () => {
+  assert.equal(formatItemLabel({ label: "Email thread: Q3 planning", evidence_kind: "session" }), "Email thread: Q3 planning");
+});
+test("formatItemLabel: label with channel annotation → not bare, returned as-is", () => {
+  // "Session 20260715_113 (slack)" has readable info beyond the ID
+  assert.equal(formatItemLabel({ label: "Session 20260715_113 (slack)", evidence_kind: "session" }), "Session 20260715_113 (slack)");
+});
+test("formatItemLabel: bare session ID → falls back to evidence_kind", () => {
+  assert.equal(formatItemLabel({ label: "Session 20260715_113", evidence_kind: "session" }), "session");
+});
+test("formatItemLabel: null label → falls back to evidence_kind", () => {
+  assert.equal(formatItemLabel({ label: null, evidence_kind: "chore_run" }), "chore_run");
+});
+test("formatItemLabel: neither label nor evidence_kind → honest placeholder", () => {
+  assert.equal(formatItemLabel({ label: null, evidence_kind: null }), "—");
+  assert.equal(formatItemLabel({}), "—");
 });

--- a/packages/web/src/dashboard/attentionCore.ts
+++ b/packages/web/src/dashboard/attentionCore.ts
@@ -2,11 +2,11 @@
 // Import-free; node:test-able. Four invariants enforced:
 //   1. three displacement groups (explicit/inferred/autonomous) stay separate
 //   2. unrated classes carry note="no_rate_established", never zero
-//   3. non-delivered inferred → display_minutes=0 + blocked_reason
+//   3. only explicitly failed/blocked/aborted inferred → display_minutes=0; absent outcome credits at full rate
 //   4. empty day is identifiable without inspecting items
 
 export interface ExplicitItem { label: string; count: number; rate_minutes: number; minutes: number }
-export interface InferredItem { label: string; bucket: string; minutes: number; turns: number; tools: number; evidence_kind: string; evidence_ref: string; outcome: string }
+export interface InferredItem { label: string; bucket: string; minutes: number; turns?: number | null; tools?: number | null; evidence_kind: string; evidence_ref: string; outcome?: string | null }
 export interface AutonomousItem { label: string; bucket: string; minutes: number; evidence_kind: string; evidence_ref: string }
 export interface UnratedEntry { action_class: string; count: number }
 
@@ -31,22 +31,59 @@ export interface AttentionStatsResponse {
 export interface UnratedRow { action_class: string; count: number; note: "no_rate_established" }
 export interface InferredDisplayItem {
   label: string; bucket: string;
-  claimed_minutes: number; display_minutes: number; // 0 when not delivered — asymmetry is the point
-  turns: number; tools: number; evidence_kind: string; evidence_ref: string;
-  outcome: string; is_blocked: boolean; blocked_reason: string | null;
+  claimed_minutes: number; display_minutes: number; // 0 only for explicit failures — asymmetry is the point
+  turns?: number | null; tools?: number | null; evidence_kind: string; evidence_ref: string;
+  outcome?: string | null; is_blocked: boolean; blocked_reason: string | null;
 }
 
 export function deriveUnratedRows(unrated: UnratedEntry[]): UnratedRow[] {
   return (unrated ?? []).map((u) => ({ ...u, note: "no_rate_established" as const }));
 }
 
+// Outcomes that earn zero displacement credit. Absent / null is NOT failure —
+// many older rows never had outcome written; silently zeroing them makes the
+// statement contradict itself (total says one thing, every row says zero).
+const EXPLICIT_FAILURES: ReadonlySet<string> = new Set(["failed", "blocked", "aborted"]);
+
 export function deriveInferredDisplay(items: InferredItem[]): InferredDisplayItem[] {
   return (items ?? []).map((it) => {
-    const ok = it.outcome === "delivered";
-    return { label: it.label, bucket: it.bucket, claimed_minutes: it.minutes, display_minutes: ok ? it.minutes : 0,
+    const explicitFail = typeof it.outcome === "string" && EXPLICIT_FAILURES.has(it.outcome);
+    return { label: it.label, bucket: it.bucket, claimed_minutes: it.minutes, display_minutes: explicitFail ? 0 : it.minutes,
       turns: it.turns, tools: it.tools, evidence_kind: it.evidence_kind, evidence_ref: it.evidence_ref,
-      outcome: it.outcome, is_blocked: !ok, blocked_reason: ok ? null : `outcome: ${it.outcome} — no displacement credit` };
+      outcome: it.outcome, is_blocked: explicitFail, blocked_reason: explicitFail ? `outcome: ${it.outcome} — no displacement credit` : null };
   });
+}
+
+// ── Presentational helpers ────────────────────────────────────────────────────
+
+/** Build the "N turns · N tools" scale signal for a session row.
+ *  Omits a component cleanly when its count is absent (null / undefined) —
+ *  never leaves a bare unit label without a number.
+ *  Examples:
+ *    formatScaleSignal({turns:12,tools:85}) → "12 turns · 85 tools"
+ *    formatScaleSignal({turns:3,tools:null}) → "3 turns"
+ *    formatScaleSignal({}) → "" */
+export function formatScaleSignal(item: { turns?: number | null; tools?: number | null }): string {
+  const parts: string[] = [];
+  if (item.turns != null) parts.push(`${item.turns} turns`);
+  if (item.tools != null) parts.push(`${item.tools} tools`);
+  return parts.join(" · ");
+}
+
+// Bare session identifier: only digits, underscores, hyphens, optionally
+// prefixed with "Session " — carries no human-readable information beyond the ID.
+const BARE_SESSION_RE = /^(?:[Ss]ession\s+)?[\d_-]+$/;
+
+/** Return a readable label for an inferred item.
+ *  Prefers `label` when present and not a bare session ID.
+ *  Falls back to `evidence_kind` (type hint) when label is absent or raw.
+ *  Returns "—" as last-resort placeholder; never invents a description. */
+export function formatItemLabel(item: { label?: string | null; evidence_kind?: string | null }): string {
+  const label = (item.label ?? "").trim();
+  if (label && !BARE_SESSION_RE.test(label)) return label;
+  const kind = (item.evidence_kind ?? "").trim();
+  if (kind) return kind;
+  return label || "—";
 }
 
 // Minimal structural shape accepted by isEmptyDay — satisfied by both


### PR DESCRIPTION
## What

Three rendering defects on the `/attention` statement made it contradict itself — the headline total said one thing while every displayed row said zero.

### Defect 1 — absent outcome zeroed credit (`deriveInferredDisplay`)

`const ok = it.outcome === "delivered"` treated `null`, `undefined`, and any unrecognised value identically to `"aborted"`, zeroing the `display_minutes` for every row that hadn't had an outcome written yet (the majority on a real day).

Fix: introduce `EXPLICIT_FAILURES = {failed, blocked, aborted}`. Only those three string values earn zero credit. A null or absent outcome credits at full rate with no `blocked_reason` — absent is not failed.

### Defect 2 — scale signal rendered as `t · tools`

`{it.turns}t · {it.tools} tools` in JSX: when `turns` / `tools` are `undefined` on the wire (the API omits them on older rows), React renders nothing for the expression, leaving the literal text `t · tools` with no numbers.

Fix: add `formatScaleSignal({turns, tools})` to `attentionCore.ts` that joins only the present components into `"12 turns · 85 tools"`, `"3 turns"`, `"7 tools"`, or `""`. `AttentionPage.tsx` now uses it.

### Defect 3 — bare session IDs in label column

When the API `label` field contains a raw identifier like `Session 20260715_113` (no channel annotation, no human-readable context), the label column shows the raw ID.

Fix: add `formatItemLabel({label, evidence_kind})` that:
- passes descriptive labels through unchanged (`"Session 20260715_113 (slack)"` → unchanged)
- falls back to `evidence_kind` for bare IDs (`"Session 20260715_113"` → `"session"`)
- returns `"—"` when neither is available

## Tests

44/44 pass (`npx tsx --test src/dashboard/attentionCore.test.ts`). 10 new tests added:

- `outcome: null` → full credit, not blocked
- `outcome: undefined` → full credit, not blocked
- `outcome: "failed"` → zero, `claimed_minutes` preserved, reason present
- **sum invariant**: `display_minutes` sum over a mixed delivered/absent/failed set equals the section total (the key correctness property — a statement whose lines contradict its total is worse than no statement)
- `formatScaleSignal`: both counts, turns-only, tools-only, neither, zero
- `formatItemLabel`: descriptive label, label-with-channel, bare ID, null label, no fields

## Smoke evidence

Local — the only place this code runs (it is not deployed yet):

```
$ cd packages/web && npx tsx --test src/dashboard/attentionCore.test.ts
TAP version 13
...
1..44
# tests 44
# pass 44
# fail 0
# duration_ms 141.2
```

Gate: `✓ lane III (web) gate passed — 139 LOC, 3 files, verify ok`

Note: this is a pure logic + rendering fix; the UI is not live until CI builds and both `web` and `web-client` are redeployed (CLAUDE.md §15.4). A live browser pass against `https://home.alfred.black/attention` after deploy will confirm the three defects are gone.

## Files touched

- `/packages/web/src/dashboard/attentionCore.ts` — `EXPLICIT_FAILURES` set, fixed `deriveInferredDisplay`, new `formatScaleSignal`, new `formatItemLabel`, updated `InferredItem`/`InferredDisplayItem` types to mark `turns`/`tools`/`outcome` optional
- `/packages/web/src/dashboard/attentionCore.test.ts` — 10 new tests
- `/packages/web/src/dashboard/AttentionPage.tsx` — import `formatScaleSignal`/`formatItemLabel`, use both in `DayView`

References #584.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc