### PR TITLE
fix(learn): nar_entry summary human-readable; outcome written to notes (#584)

### DIFF
--- a/packages/learn/src/activities/nar_recap.py
+++ b/packages/learn/src/activities/nar_recap.py
@@ -76,9 +76,10 @@ Rules from the NAR method (apply them in order):
 
 Return a JSON object with exactly these keys:
   bucket: one of "S" | "M" | "L" | "XL" | "none"
-  reasoning: one sentence
+  reasoning: one sentence explaining the classification
   has_artifact: true | false
   is_failed: true | false (true only if session ended WITHOUT producing what was asked for)
+  work_summary: 4-10 words describing what was done (e.g. "Invoice drafted for client", "Two weeks of messages gathered") — no bucket letter, no session id; use an empty string when bucket is "none"
 
 Bucket meanings (minutes of principal time displaced if delivered):
   S  =   5 min — quick email, short memo, simple fact lookup
@@ -99,7 +100,7 @@ async def _classify_session_bucket(messages: list[dict[str, Any]]) -> dict[str, 
     long sessions.  Falls back to ``{"bucket": "none"}`` on any error.
     """
     if not messages:
-        return {"bucket": "none", "reasoning": "empty session", "has_artifact": False, "is_failed": False}
+        return {"bucket": "none", "reasoning": "empty session", "has_artifact": False, "is_failed": False, "work_summary": ""}
 
     ctx = _extract_session_context(messages)
     try:
@@ -117,10 +118,11 @@ async def _classify_session_bucket(messages: list[dict[str, Any]]) -> dict[str, 
             "reasoning": str(result.get("reasoning", "")),
             "has_artifact": bool(result.get("has_artifact", False)),
             "is_failed": bool(result.get("is_failed", False)),
+            "work_summary": str(result.get("work_summary", "")),
         }
     except Exception as exc:  # noqa: BLE001
         logger.warning("nar_recap: bucket classification failed: %s", exc)
-        return {"bucket": "none", "reasoning": f"clerk error: {str(exc)[:100]}", "has_artifact": False, "is_failed": False}
+        return {"bucket": "none", "reasoning": f"clerk error: {str(exc)[:100]}", "has_artifact": False, "is_failed": False, "work_summary": ""}
 
 
 # ---------------------------------------------------------------------------
@@ -142,9 +144,10 @@ Rules:
 
 Return a JSON object:
   bucket: one of "S" | "M" | "L" | "XL" | "none"
-  reasoning: one sentence
+  reasoning: one sentence explaining the classification
   has_artifact: true | false
   is_failed: true | false
+  work_summary: 4-10 words describing the artifact produced (e.g. "Morning briefing composed and sent") — use an empty string when bucket is "none"
 
 Bucket meanings (minutes of principal time the artifact would have taken by hand):
   S  =   5 min — short note, quick status, calendar entry
@@ -165,7 +168,7 @@ async def _classify_chore_bucket(detail: str, chore_name: str) -> dict[str, Any]
     Falls back to ``{"bucket": "none"}`` on any error.
     """
     if not detail:
-        return {"bucket": "none", "reasoning": "empty chore output", "has_artifact": False, "is_failed": False}
+        return {"bucket": "none", "reasoning": "empty chore output", "has_artifact": False, "is_failed": False, "work_summary": ""}
     try:
         # Build prompt inside try/except: detail may contain literal curly
         # braces (e.g. JSON chore output) which would crash str.format().
@@ -184,10 +187,11 @@ async def _classify_chore_bucket(detail: str, chore_name: str) -> dict[str, Any]
             "reasoning": str(result.get("reasoning", "")),
             "has_artifact": bool(result.get("has_artifact", False)),
             "is_failed": bool(result.get("is_failed", False)),
+            "work_summary": str(result.get("work_summary", "")),
         }
     except Exception as exc:  # noqa: BLE001
         logger.warning("nar_recap: chore bucket classification failed: %s", exc)
-        return {"bucket": "none", "reasoning": f"clerk error: {str(exc)[:100]}", "has_artifact": False, "is_failed": False}
+        return {"bucket": "none", "reasoning": f"clerk error: {str(exc)[:100]}", "has_artifact": False, "is_failed": False, "work_summary": ""}
 
 
 def _chore_is_vigilance_sweep(obs: dict[str, Any]) -> bool:
@@ -357,12 +361,26 @@ async def compute_nar_day(day_iso: str) -> dict[str, Any]:
             occurred_at = datetime.fromtimestamp(started_at, tz=timezone.utc).isoformat()
             dedup_key = f"nar:session:{sess['id']}:{day_iso}"
 
+            # outcome: ctrl reads notes.outcome to render credit per line.
+            # "delivered" when work was produced; "failed" when session ended without
+            # delivering; None for bucket:none (discussion-only — distinct from failed).
+            if bucket_info.get("is_failed"):
+                _sess_outcome: str | None = "failed"
+            elif bucket != "none":
+                _sess_outcome = "delivered"
+            else:
+                _sess_outcome = None
+            _sess_notes: dict[str, Any] = {"bucket": bucket, "has_artifact": bucket_info.get("has_artifact")}
+            if _sess_outcome is not None:
+                _sess_notes["outcome"] = _sess_outcome
+            _sess_work_summary = bucket_info.get("work_summary") or ""
+
             entry: dict[str, Any] = {
                 "id": str(uuid.uuid5(uuid.NAMESPACE_DNS, dedup_key)),
                 "dedup_key": dedup_key,
                 "occurred_at": occurred_at,
                 "action_class": "conversational",
-                "summary": f"Session {sess['id'][:12]} ({sess['source']}) — bucket {bucket}",
+                "summary": _sess_work_summary if _sess_work_summary else f"{sess['source']} session",
                 "evidence_kind": "session",
                 "evidence_ref": sess["id"],
                 "session_ref": sess["id"],
@@ -372,7 +390,7 @@ async def compute_nar_day(day_iso: str) -> dict[str, Any]:
                 "acceptance_path": acc_path,
                 "acceptance_basis": bucket_info.get("reasoning", ""),
                 "displaced_minutes": displaced,
-                "notes": json.dumps({"bucket": bucket, "has_artifact": bucket_info.get("has_artifact")}),
+                "notes": json.dumps(_sess_notes),
             }
             entries_list.append(entry)
             if displaced is not None:
@@ -455,6 +473,8 @@ async def compute_nar_day(day_iso: str) -> dict[str, Any]:
         detail = str(obs.get("detail") or obs.get("summary") or "")
         is_vigilance = _chore_is_vigilance_sweep(obs)
 
+        _chore_outcome: str | None = None
+        _chore_work_summary = ""
         if is_vigilance:
             # Method doc §1c: "a chore that ran, checked and found nothing →
             # suppression rate (vigilance)".  Vigilance sweeps must never reach
@@ -487,13 +507,25 @@ async def compute_nar_day(day_iso: str) -> dict[str, Any]:
                     cacc, cacc_path = "unknown", None
             cbasis = f"chore '{chore_name}' artifact — {binfo.get('reasoning', '')}"
             has_artifact = binfo.get("has_artifact", False)
+            if binfo.get("is_failed"):
+                _chore_outcome = "failed"
+            elif cbucket != "none":
+                _chore_outcome = "delivered"
+            _chore_work_summary = binfo.get("work_summary") or ""
 
+        _chore_notes: dict[str, Any] = {"has_artifact": has_artifact, "bucket": cbucket}
+        if _chore_outcome is not None:
+            _chore_notes["outcome"] = _chore_outcome
+        _chore_summary = (
+            _chore_work_summary if _chore_work_summary
+            else (chore_name if has_artifact else f"{chore_name} — vigilance")
+        )
         entry = {
             "id": str(uuid.uuid5(uuid.NAMESPACE_DNS, dedup_key)),
             "dedup_key": dedup_key,
             "occurred_at": ts_str,
             "action_class": "chore_run",
-            "summary": f"Chore {chore_name}: {'artifact' if has_artifact else 'vigilance'}",
+            "summary": _chore_summary,
             "evidence_kind": "chore_run",
             "evidence_ref": obs["id"],
             "session_ref": None,
@@ -503,7 +535,7 @@ async def compute_nar_day(day_iso: str) -> dict[str, Any]:
             "acceptance_path": cacc_path,
             "acceptance_basis": cbasis,
             "displaced_minutes": cdisp,
-            "notes": json.dumps({"has_artifact": has_artifact, "bucket": cbucket}),
+            "notes": json.dumps(_chore_notes),
         }
         entries_list.append(entry)
         if cdisp is not None:

--- a/packages/learn/tests/test_nar_recap.py
+++ b/packages/learn/tests/test_nar_recap.py
@@ -751,3 +751,135 @@ class TestReplaceNarEntries:
 
         assert out.get("ok") is False
         assert out["reason"] == "replace_not_supported"
+
+
+# ---------------------------------------------------------------------------
+# Defect 1 — summary must be human-readable (not a machine label)
+# Defect 2 — outcome must be written to notes for ctrl to read
+# ---------------------------------------------------------------------------
+
+class TestOutcomeWrittenToNotes:
+    """ctrl reads notes.outcome per inferred item; None renders as 'no displacement credit'.
+
+    The logic below mirrors what compute_nar_day does — tested in isolation
+    so the outcome-building contract is locked independently of the HTTP stack.
+    """
+
+    def _build_sess_notes(self, bucket: str, is_failed: bool) -> dict:
+        """Mirror the outcome logic from compute_nar_day sessions section."""
+        if is_failed:
+            outcome: str | None = "failed"
+        elif bucket != "none":
+            outcome = "delivered"
+        else:
+            outcome = None
+        obj: dict = {"bucket": bucket, "has_artifact": True}
+        if outcome is not None:
+            obj["outcome"] = outcome
+        return json.loads(json.dumps(obj))
+
+    def test_delivered_session_outcome_is_delivered(self):
+        for bucket in ("S", "M", "L", "XL"):
+            notes = self._build_sess_notes(bucket, is_failed=False)
+            assert notes.get("outcome") == "delivered", f"bucket={bucket}"
+
+    def test_failed_session_outcome_is_not_delivered(self):
+        notes = self._build_sess_notes("S", is_failed=True)
+        assert notes.get("outcome") != "delivered"
+        # A specific non-None value must be present (the failed value).
+        assert notes.get("outcome") is not None
+
+    def test_bucket_none_not_failed_not_marked_failed(self):
+        """bucket='none', not failed → outcome absent (discussion-only ≠ failure)."""
+        notes = self._build_sess_notes("none", is_failed=False)
+        assert notes.get("outcome") != "failed", (
+            "bucket:none without failure must not be labelled failed"
+        )
+
+    @pytest.mark.asyncio
+    async def test_classify_session_bucket_exposes_work_summary(self):
+        """_classify_session_bucket must return work_summary so compute_nar_day can use it."""
+        from src.activities.nar_recap import _classify_session_bucket
+
+        messages = [{"role": "user", "content": "Draft the invoice.", "ts": 1.0}]
+        with patch("src.activities.nar_recap._call_clerk", new_callable=AsyncMock) as mock_clerk:
+            mock_clerk.return_value = {
+                "bucket": "S",
+                "reasoning": "short invoice task",
+                "has_artifact": True,
+                "is_failed": False,
+                "work_summary": "Invoice drafted for client",
+            }
+            result = await _classify_session_bucket(messages)
+        assert "work_summary" in result
+        assert result["work_summary"] == "Invoice drafted for client"
+
+
+
+class TestWorkSummaryShape:
+    """summary must describe the work done, not the session metadata.
+
+    Migration 0020 defines summary as 'one line, human readable — this is what
+    the principal reads'.  The old format (Session <id12> (slack) — bucket L)
+    told the principal nothing.
+    """
+
+    def test_summary_not_session_id_or_bucket_label(self):
+        """When work_summary is present it replaces the machine label."""
+        session_id = "sess_deadbeef1234"
+        source = "slack"
+        bucket = "L"
+        work_summary = "Two weeks of messages, DMs and mail gathered"
+
+        # New logic: summary = work_summary when non-empty.
+        summary = work_summary if work_summary else f"{source} session"
+
+        assert session_id[:12] not in summary, "session id must not appear in summary"
+        assert f"— bucket {bucket}" not in summary, "bucket label must not appear in summary"
+        assert f"bucket {bucket}" not in summary
+
+    def test_fallback_summary_has_no_session_id(self):
+        """When clerk returns empty work_summary, fallback is source-only (no id)."""
+        session_id = "sess_deadbeef1234"
+        source = "slack"
+        work_summary = ""
+
+        summary = work_summary if work_summary else f"{source} session"
+
+        assert session_id[:12] not in summary
+        assert "bucket" not in summary.lower()
+
+    @pytest.mark.asyncio
+    async def test_clerk_error_fallback_work_summary_empty(self):
+        """On clerk error, work_summary is '' — the machine fallback summary is used."""
+        from src.activities.nar_recap import _classify_session_bucket
+
+        messages = [{"role": "user", "content": "hello", "ts": 1.0}]
+        with patch("src.activities.nar_recap._call_clerk", new_callable=AsyncMock) as mock_clerk:
+            mock_clerk.side_effect = RuntimeError("gateway timeout")
+            result = await _classify_session_bucket(messages)
+        assert result.get("work_summary") == ""
+
+    @pytest.mark.asyncio
+    async def test_chore_work_summary_used_as_summary(self):
+        """Artifact chore summary comes from work_summary, not the machine label."""
+        from src.activities.nar_recap import _classify_chore_bucket
+
+        chore_name = "morning-brief"
+        with patch("src.activities.nar_recap._call_clerk", new_callable=AsyncMock) as mock_clerk:
+            mock_clerk.return_value = {
+                "bucket": "M",
+                "reasoning": "briefing composed",
+                "has_artifact": True,
+                "is_failed": False,
+                "work_summary": "Morning briefing composed and delivered",
+            }
+            binfo = await _classify_chore_bucket("composed briefing.md", chore_name)
+
+        work_summary = binfo.get("work_summary") or ""
+        summary = (
+            work_summary if work_summary
+            else (chore_name if binfo.get("has_artifact") else f"{chore_name} — vigilance")
+        )
+        assert "artifact" not in summary
+        assert summary == "Morning briefing composed and delivered"


### PR DESCRIPTION
## What

Fixes two defects in the NAR recap that caused every statement line to render as `outcome: null — no displacement credit` even when the total showed tens of hours.

### Defect 1 — summary was a machine label

`nar_entry.summary` was set by string-formatting session metadata:
```
Session 20260715_113 (slack) — bucket L
```
This tells the principal nothing. Migration 0020 defines it as _"one line, human readable — this is what the principal reads"_.

The clerk already reads the ask and delivery to assign a bucket. The session prompt now also requests a `work_summary` (4–10 words, no bucket letter, no session id):
```
Invoice drafted for client
Two weeks of messages, DMs and mail gathered
```
`compute_nar_day` uses this as `entry["summary"]`. Fallback when clerk returns empty: `"{source} session"`. Same change applied to chore entries via `_classify_chore_bucket`.

### Defect 2 — `outcome` never written to notes

`attention.ts` line 895 reads `notesData.outcome` per inferred item. When `null`, the UI renders "no displacement credit" even though `displaced_minutes` is non-zero (the total is computed directly from the DB; the per-line display is the only thing broken).

`outcome` is now written into the `notes` JSON:
- `"delivered"` — session produced what was asked (not failed, bucket ≠ none)
- `"failed"` — session ended without delivering (is_failed=True)
- absent — bucket:none, not failed (discussion-only — distinct from failure, must not be conflated)

## Files touched

- `packages/learn/src/activities/nar_recap.py` — prompts updated, `work_summary` added to all return paths, `outcome` + `_sess_work_summary` computed before entry dict in sessions and chores sections
- `packages/learn/tests/test_nar_recap.py` — `TestOutcomeWrittenToNotes`, `TestWorkSummaryShape` (58 tests green)

## Smoke evidence

Local verify gate:
```
cd packages/learn && python3 -m pytest tests/ -x -q \
  --ignore=tests/test_composio_server.py \
  --ignore=tests/test_composio_server_defaults.py \
  --ignore=tests/test_file_extraction.py

2758 passed, 101 skipped in 21.20s
✓ lane II (learn) gate passed — 186 LOC, 2 files, verify ok
```

The 3 ignored test files fail due to missing optional dependencies in the local Mac env (`fastapi`, `pypdf`, `python-docx`, `openpyxl`) — these are pre-existing failures unrelated to this PR; CI container has all three installed.

Target verification: after deploying `alfred-learn:latest`, trigger a NAR day recompute and check `/attention` — individual lines should show a human description and non-null outcome (rendering credit per line matching the day total).

References #584.

🤖 Generated with [Claude Code](https://claude.com/claude-code)