### PR TITLE
fix(ctrl): exclude agent-spawned sessions from engaged time (#584)

### DIFF
--- a/packages/ctrl/src/api/routes/attention.ts
+++ b/packages/ctrl/src/api/routes/attention.ts
@@ -933,6 +933,7 @@ export function registerAttentionRoutes(): void {
         hermesTs = (hsDb.prepare(
           `SELECT m.timestamp FROM messages m JOIN sessions s ON m.session_id=s.id
            WHERE m.role='user' AND s.source IN ('slack','cli','telegram')
+             AND s.parent_session_id IS NULL
              AND m.timestamp>=? AND m.timestamp<=?`,
         ).all(dayStartEp, dayEndEp) as Array<{ timestamp: number }>).map(r => r.timestamp);
         hsDb.close();

--- a/packages/ctrl/tests/nar-entries.test.ts
+++ b/packages/ctrl/tests/nar-entries.test.ts
@@ -3,18 +3,23 @@
 //         (3) empty day → 200 zeros not 404; (4) unrated populated;
 //         (5) rates echoes the arithmetic table used.
 
-import { describe, it, before, beforeEach } from "node:test";
+import { describe, it, before, after, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { ServerResponse } from "node:http";
+import { DatabaseSync } from "node:sqlite";
 
 const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nar-"));
 process.env.ALFRED_DATA_DIR = tmp;
 process.env.STATE_DB_PATH   = path.join(tmp, "state.db");
 process.env.VAULT_PATH      = path.join(tmp, "vault");
 process.env.SQLITE_VEC_PATH = "";
+// Point HERMES_CONFIG_DIR at the tmp tree so the parentage-filter tests can
+// create a real main/state.db that the route handler finds. Must be set BEFORE
+// registerAttentionRoutes() captures it.
+process.env.HERMES_CONFIG_DIR = path.join(tmp, "hermes-state");
 ["needs_attention", "decision", "event"].forEach((d) =>
   fs.mkdirSync(path.join(tmp, "vault", d), { recursive: true }),
 );
@@ -306,5 +311,67 @@ describe("POST /api/v1/state/nar-entries — mode='replace'", () => {
       "SELECT dedup_key FROM nar_entry WHERE date(occurred_at)='2026-07-15' ORDER BY dedup_key",
     ).all() as any[];
     assert.deepStrictEqual(rows.map((r: any) => r.dedup_key), ["r1", "r4"]);
+  });
+});
+
+// ─── parent_session_id filter (#584) ───────────────────────────────────────
+// The human-turn query in buildDayStatement must exclude agent-spawned
+// sessions (parent_session_id IS NOT NULL) so engaged time matches the recap.
+// HERMES_CONFIG_DIR was pointed at tmp/hermes-state at module level (above)
+// so registerAttentionRoutes() captured it; we just manage the file here.
+describe("GET /api/v1/attention/statement — parent_session_id filter", () => {
+  const hsDir = path.join(tmp, "hermes-state");
+  const hsDbPath = path.join(hsDir, "main", "state.db");
+
+  before(() => {
+    fs.mkdirSync(path.join(hsDir, "main"), { recursive: true });
+    const hdb = new DatabaseSync(hsDbPath);
+    hdb.exec(`
+      CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, parent_session_id TEXT);
+      CREATE TABLE messages (id TEXT PRIMARY KEY, session_id TEXT, role TEXT, timestamp REAL NOT NULL);
+    `);
+    hdb.close();
+  });
+
+  after(() => { fs.rmSync(hsDir, { recursive: true, force: true }); });
+
+  beforeEach(() => {
+    db.prepare("DELETE FROM nar_entry").run();
+    const hdb = new DatabaseSync(hsDbPath);
+    hdb.exec("DELETE FROM messages; DELETE FROM sessions;");
+    hdb.close();
+  });
+
+  it("spawned session (parent IS NOT NULL) contributes no turns to engaged time", async () => {
+    const hdb = new DatabaseSync(hsDbPath);
+    hdb.prepare("INSERT INTO sessions VALUES (?,?,?)").run("s-agent", "slack", "parent-1");
+    hdb.prepare("INSERT INTO messages VALUES (?,?,'user',?)").run(
+      "m-1", "s-agent", new Date("2026-07-15T10:00:00Z").getTime() / 1000,
+    );
+    hdb.close();
+    const { p } = await getStatement("date=2026-07-15");
+    assert.strictEqual(p.engaged.hours, 0, "agent-spawned session must be excluded");
+  });
+
+  it("human session (parent IS NULL) contributes turns to engaged time", async () => {
+    const hdb = new DatabaseSync(hsDbPath);
+    hdb.prepare("INSERT INTO sessions VALUES (?,?,?)").run("s-human", "slack", null);
+    hdb.prepare("INSERT INTO messages VALUES (?,?,'user',?)").run(
+      "m-2", "s-human", new Date("2026-07-15T10:00:00Z").getTime() / 1000,
+    );
+    hdb.close();
+    const { p } = await getStatement("date=2026-07-15");
+    assert.ok(p.engaged.hours > 0, "human session with null parent must contribute");
+  });
+
+  it("unknown-source session excluded even with null parent", async () => {
+    const hdb = new DatabaseSync(hsDbPath);
+    hdb.prepare("INSERT INTO sessions VALUES (?,?,?)").run("s-omi", "omi", null);
+    hdb.prepare("INSERT INTO messages VALUES (?,?,'user',?)").run(
+      "m-3", "s-omi", new Date("2026-07-15T10:00:00Z").getTime() / 1000,
+    );
+    hdb.close();
+    const { p } = await getStatement("date=2026-07-15");
+    assert.strictEqual(p.engaged.hours, 0, "source not in allowlist excluded regardless of parentage");
   });
 });


### PR DESCRIPTION
## Summary

- `buildDayStatement` in `attention.ts` was counting Hermes sessions
  whose `source IN ('slack','cli','telegram')` without checking whether
  the session was started by the principal or spawned by an agent.
- On 2026-07-15, 71 of 87 Slack sessions were agent-spawned children
  (`parent_session_id IS NOT NULL`), inflating the endpoint's engaged
  figure to **2.977 h** vs the recap's correct **1.11 h** — a 3x
  overcount on the same day and same store.
- Fix: add `AND s.parent_session_id IS NULL` to the human-turn query,
  matching the filter `#599` added to the recap's own copy.

## Known debt (do not fix here)

Engaged time is computed **twice** — once in `buildDayStatement`
(ctrl-api endpoint) and once in the NAR recap (alfred-learn). This
duplication caused today's drift on the first day that mattered. The
durable fix is the recap computing it once into a day-level record that
the endpoint reads, eliminating the divergence structurally. That
requires a state.db migration (Phase 0 + Lane II) and is tracked in
#584. This PR is the minimal correct fix that stops the overcount now.

## Smoke evidence

Local test suite — 1460 tests, 0 failures, 1 pre-existing skip.
Gate verdict: lane I (ctrl-api) — 70 LOC, 2 files, verify ok.

```
# tests 1460
# suites 355
# pass 1459
# fail 0
# cancelled 0
# skipped 1
✓ lane I (ctrl-api) gate passed — 70 LOC, 2 files, verify ok
```

Three new tests added to `nar-entries.test.ts` exercise the filter
directly via a real in-process Hermes state.db:

1. spawned session (`parent_session_id = 'parent-1'`) → `engaged.hours === 0`
2. human session (`parent_session_id = null`) → `engaged.hours > 0`
3. unknown-source session (`source = 'omi'`, null parent) → `engaged.hours === 0`

Test 1 would have failed before the fix (the query returned the turn
from the spawned session, making engaged non-zero).

The endpoint result for 2026-07-15 will need a live comparison against
the recap log after deploy — Sir requested that comparison in the brief.
Reference figures: recap log `1.11 h`, hand-derived `1.04 h`; endpoint
should drop from `2.977 h` to that range.

Closes #584 (ctrl side only; learn/recap verified separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)