### PR TITLE
fix(ctrl): explicit group dropped non-suppression displaced_minutes (#584)

### DIFF
--- a/packages/ctrl/src/api/routes/attention.ts
+++ b/packages/ctrl/src/api/routes/attention.ts
@@ -905,7 +905,12 @@ export function registerAttentionRoutes(): void {
         });
       } else {
         // Explicit or unrated — rate-card actions.
-        const rate = row.action_class === "suppression" ? suppressionRate : null;
+        // Suppression always uses the rate-card value. Other action classes
+        // (e.g. desk_decision noise rows) carry their own displaced_minutes set
+        // by the recap workflow; null displaced_minutes means no agreed rate →
+        // unrated. The prior code hard-coded null for every non-suppression row,
+        // which dropped the desk_decision explicit group entirely (#584).
+        const rate = row.action_class === "suppression" ? suppressionRate : row.displaced_minutes;
         if (rate !== null) {
           const existing = explicitBuckets.get(row.action_class);
           if (existing) {

--- a/packages/ctrl/tests/nar-entries.test.ts
+++ b/packages/ctrl/tests/nar-entries.test.ts
@@ -194,6 +194,65 @@ describe("GET /api/v1/attention/statement", () => {
     assert.ok(Number.isFinite(p.stats.return_ratio), "return_ratio must be finite");
   });
 
+  // ── #584 explicit-group fix ─────────────────────────────────────────────
+  // Non-suppression rows with displaced_minutes must credit explicit, not unrated.
+
+  it("rated desk_decision rows credit explicit; unrated ones appear in unrated — never dropped", async () => {
+    // 3 noise decisions × 0.5 min = 1.5 min; 2 done decisions with no rate.
+    await postEntries({ entries: [
+      entry({ dedup_key: "dd-r1", action_class: "desk_decision", evidence_kind: "decision",
+              displaced_minutes: 0.5, estimation_method: "standard-time",
+              acceptance: "accepted", acceptance_path: "explicit" }),
+      entry({ dedup_key: "dd-r2", action_class: "desk_decision", evidence_kind: "decision",
+              displaced_minutes: 0.5, estimation_method: "standard-time",
+              acceptance: "accepted", acceptance_path: "explicit" }),
+      entry({ dedup_key: "dd-r3", action_class: "desk_decision", evidence_kind: "decision",
+              displaced_minutes: 0.5, estimation_method: "standard-time",
+              acceptance: "accepted", acceptance_path: "explicit" }),
+      entry({ dedup_key: "dd-u1", action_class: "desk_decision", evidence_kind: "decision",
+              displaced_minutes: null, estimation_method: null,
+              acceptance: "accepted", acceptance_path: "explicit" }),
+      entry({ dedup_key: "dd-u2", action_class: "desk_decision", evidence_kind: "decision",
+              displaced_minutes: null, estimation_method: null,
+              acceptance: "accepted", acceptance_path: "explicit" }),
+    ]});
+    const { p } = await getStatement("date=2026-08-14");
+    // Rated entries land in explicit.
+    const ddItem = p.displaced.explicit.items.find((i: any) => i.label === "desk_decision");
+    assert.ok(ddItem, `desk_decision must appear in explicit.items; got ${JSON.stringify(p.displaced.explicit.items)}`);
+    assert.strictEqual(ddItem.count, 3, "3 rated desk_decision rows");
+    assert.strictEqual(ddItem.minutes, 1.5, "3 × 0.5 = 1.5 min");
+    // Unrated entries land in unrated, not silently dropped.
+    const unratedEntry = p.unrated.find((u: any) => u.action_class === "desk_decision");
+    assert.ok(unratedEntry, `desk_decision must appear in unrated; got ${JSON.stringify(p.unrated)}`);
+    assert.strictEqual(unratedEntry.count, 2, "2 unrated desk_decision rows");
+  });
+
+  it("explicit + inferred + autonomous hours sum exactly to displaced.total_hours", async () => {
+    // A mix of all three classification paths ensures no group is silently dropped.
+    // estimation_method must be one of the CHECK-list values.
+    await postEntries({ entries: [
+      entry({ dedup_key: "sup-sum", action_class: "suppression", evidence_kind: "audit",
+              displaced_minutes: 0.5, estimation_method: "standard-time",
+              acceptance: "accepted", acceptance_path: "explicit" }),
+      entry({ dedup_key: "inf-sum", action_class: "conversational", evidence_kind: "session",
+              displaced_minutes: 30, estimation_method: "standard-time",
+              acceptance: "accepted", acceptance_path: "inferred" }),
+      entry({ dedup_key: "aut-sum", action_class: "chore_run", evidence_kind: "chore_run",
+              displaced_minutes: 20, estimation_method: "standard-time",
+              acceptance: "accepted", acceptance_path: "explicit" }),
+    ]});
+    const { p } = await getStatement("date=2026-08-14");
+    const sum = p.displaced.explicit.hours + p.displaced.inferred.hours + p.displaced.autonomous.hours;
+    // Each group is independently rounded to 3 dp before summing; total_hours rounds the
+    // unrounded sum. A 1-unit-last-place (≤0.002 h) discrepancy is normal floating-point
+    // behaviour. The test is that no group is silently dropped — if it were, sum would be
+    // far smaller than total_hours.
+    assert.ok(Math.abs(sum - p.displaced.total_hours) <= 0.002,
+      `explicit+inferred+autonomous must approximate total_hours within 0.002 (got ${sum} vs ${p.displaced.total_hours})`);
+    assert.ok(p.displaced.total_hours > 0, "total must be positive with these entries");
+  });
+
   it("range query returns one object per day with totals", async () => {
     const m = matchRoute("GET", "/api/v1/attention/statement");
     assert.ok(m);


### PR DESCRIPTION
## Summary

- `buildDayStatement` hard-coded `rate = null` for every non-suppression row in the explicit/unrated bucket, so `desk_decision` noise rows (with `displaced_minutes` set by the recap) went to `unratedCounts` instead of `explicitBuckets`.
- The result: `explicit` reported 0 h while the recap log computed 0.225 h — the 0.225 h (13.5 min) discrepancy documented in #584.
- Fix: use `row.displaced_minutes` as the rate for non-suppression rows. A non-null value means the recap established the credit; null means no agreed rate → genuinely unrated. Suppression keeps the rate-card path unchanged.

## Files touched

- `packages/ctrl/src/api/routes/attention.ts` — 1 logical line changed (`rate` computation in `buildDayStatement`)
- `packages/ctrl/tests/nar-entries.test.ts` — 2 new test cases

## Smoke evidence

Local `npm run test:ci` run from the worktree:

```
# tests 1459
# suites 354
# pass 1458
# fail 0
# skipped 1
# duration_ms ~30000
```

The two new tests exercise the exact failure mode:

1. **`rated desk_decision rows credit explicit; unrated ones appear in unrated — never dropped`**
   - 3 noise rows with `displaced_minutes = 0.5` → `explicit.items` gets `desk_decision` with `count=3, minutes=1.5`
   - 2 done rows with `displaced_minutes = null` → `unrated` gets `desk_decision count=2`
   - Before the fix this test would have failed: `ddItem` would be `undefined`

2. **`explicit + inferred + autonomous hours sum exactly to displaced.total_hours`**
   - Mix of all three classification paths — suppression (explicit), session/inferred, chore_run (autonomous)
   - Asserts no group is silently dropped

## Architecture note

The fix is a one-statement change. It preserves:
- Suppression: still uses the rate-card value (`suppressionRate`) regardless of stored `displaced_minutes`
- Non-suppression with `displaced_minutes`: now correctly credits the row's own value
- Non-suppression without `displaced_minutes`: still goes to `unrated` (unchanged)

Closes #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc