### PR TITLE
fix(ctrl): count historical cron/system outbounds as interruption with disclosure (#580)

### DIFF
--- a/packages/ctrl/src/api/routes/attention.ts
+++ b/packages/ctrl/src/api/routes/attention.ts
@@ -956,13 +956,29 @@ export function registerAttentionRoutes(): void {
     const { totalMs, burstCount } = clusterBursts(burstDates, GAP_MS, FLOOR_MS);
     const engagedHours = totalMs / (1000 * 60 * 60);
 
-    // Interruption: unsolicited outbound (solicited = 0).
-    const unsolicitedRow = db.prepare(
+    // Interruption: unsolicited outbound.
+    // Two sub-counts kept separate for disclosure in the response.
+    //   from_flag:        solicited = 0  (authoritative — the writer said so)
+    //   from_source_kind: solicited IS NULL AND source_kind IN ('cron','system')
+    //                     (historical fallback — both are machine-initiated by
+    //                      definition; safe to classify without guessing)
+    // solicited = 1 is never counted. NULL with any other source_kind stays
+    // unknown and is not counted.
+    const flagRow = db.prepare(
       `SELECT COUNT(*) AS n FROM alfred_journal
-        WHERE direction = 'outbound' AND solicited = 0 AND ts >= ? AND ts <= ?`,
+         WHERE direction = 'outbound' AND solicited = 0 AND ts >= ? AND ts <= ?`,
     ).get(dayStart, dayEnd) as { n: number };
-    const interruptionCount = unsolicitedRow.n;
-    const interruptionHours = (interruptionCount * INTERRUPTION_RATE_MINUTES) / 60;
+    const sourceKindRow = db.prepare(
+      `SELECT COUNT(*) AS n FROM alfred_journal
+         WHERE direction = 'outbound'
+           AND solicited IS NULL
+           AND source_kind IN ('cron', 'system')
+           AND ts >= ? AND ts <= ?`,
+    ).get(dayStart, dayEnd) as { n: number };
+    const interruptionFromFlag       = flagRow.n;
+    const interruptionFromSourceKind = sourceKindRow.n;
+    const interruptionCount          = interruptionFromFlag + interruptionFromSourceKind;
+    const interruptionHours          = (interruptionCount * INTERRUPTION_RATE_MINUTES) / 60;
 
     // Totals.
     const explicitItems = [...explicitBuckets.entries()].map(([action_class, v]) => ({
@@ -1005,6 +1021,8 @@ export function registerAttentionRoutes(): void {
       interruption: {
         hours: Math.round(interruptionHours * 1000) / 1000,
         count: interruptionCount,
+        from_flag:        interruptionFromFlag,
+        from_source_kind: interruptionFromSourceKind,
         rate_minutes: INTERRUPTION_RATE_MINUTES,
       },
       rates: {

--- a/packages/ctrl/tests/nar-entries.test.ts
+++ b/packages/ctrl/tests/nar-entries.test.ts
@@ -434,3 +434,93 @@ describe("GET /api/v1/attention/statement — parent_session_id filter", () => {
     assert.strictEqual(p.engaged.hours, 0, "source not in allowlist excluded regardless of parentage");
   });
 });
+
+// ─── interruption fallback (#580) ────────────────────────────────────────────
+// The interruption count has two sub-terms:
+//   from_flag:        solicited = 0  (authoritative)
+//   from_source_kind: solicited IS NULL + source_kind IN ('cron','system')
+//                     (historical fallback — machine-initiated by definition)
+// These tests prove each inclusion and exclusion rule, and that the totals
+// add up (disclosure integrity).
+describe("GET /api/v1/attention/statement — interruption fallback (#580)", () => {
+  let jSeq = 0;
+  function insertJournal(params: {
+    ts: string; direction: string; source_kind?: string | null; solicited?: number | null;
+  }): void {
+    jSeq++;
+    db.prepare(
+      `INSERT INTO alfred_journal
+         (id, ts, channel, chat_id, direction, message, source_kind, solicited)
+       VALUES (?, ?, 'slack', 'C-INT-580', ?, 'test', ?, ?)`,
+    ).run(`01INT${String(jSeq).padStart(10, "0")}`, params.ts, params.direction,
+          params.source_kind ?? null, params.solicited ?? null);
+  }
+
+  beforeEach(() => {
+    db.prepare("DELETE FROM alfred_journal WHERE chat_id = 'C-INT-580'").run();
+  });
+
+  it("solicited=0 → counted in from_flag", async () => {
+    insertJournal({ ts: "2026-06-01T10:00:00Z", direction: "outbound", source_kind: "slack", solicited: 0 });
+    const { p } = await getStatement("date=2026-06-01");
+    assert.strictEqual(p.interruption.count, 1);
+    assert.strictEqual(p.interruption.from_flag, 1);
+    assert.strictEqual(p.interruption.from_source_kind, 0);
+  });
+
+  it("solicited=1 → never counted regardless of source_kind", async () => {
+    insertJournal({ ts: "2026-06-02T10:00:00Z", direction: "outbound", source_kind: "cron", solicited: 1 });
+    const { p } = await getStatement("date=2026-06-02");
+    assert.strictEqual(p.interruption.count, 0);
+    assert.strictEqual(p.interruption.from_flag, 0);
+    assert.strictEqual(p.interruption.from_source_kind, 0);
+  });
+
+  it("solicited IS NULL + source_kind='cron' → counted in from_source_kind", async () => {
+    insertJournal({ ts: "2026-06-03T10:00:00Z", direction: "outbound", source_kind: "cron", solicited: null });
+    const { p } = await getStatement("date=2026-06-03");
+    assert.strictEqual(p.interruption.count, 1);
+    assert.strictEqual(p.interruption.from_flag, 0);
+    assert.strictEqual(p.interruption.from_source_kind, 1);
+  });
+
+  it("solicited IS NULL + source_kind='system' → counted in from_source_kind", async () => {
+    insertJournal({ ts: "2026-06-04T10:00:00Z", direction: "outbound", source_kind: "system", solicited: null });
+    const { p } = await getStatement("date=2026-06-04");
+    assert.strictEqual(p.interruption.count, 1);
+    assert.strictEqual(p.interruption.from_flag, 0);
+    assert.strictEqual(p.interruption.from_source_kind, 1);
+  });
+
+  it("solicited IS NULL + source_kind='ha-conversation-reply' → NOT counted", async () => {
+    insertJournal({ ts: "2026-06-05T10:00:00Z", direction: "outbound", source_kind: "ha-conversation-reply", solicited: null });
+    const { p } = await getStatement("date=2026-06-05");
+    assert.strictEqual(p.interruption.count, 0, "ha-conversation-reply is solicited; must not count even when flag absent");
+    assert.strictEqual(p.interruption.from_source_kind, 0);
+  });
+
+  it("solicited IS NULL + source_kind IS NULL → NOT counted", async () => {
+    insertJournal({ ts: "2026-06-06T10:00:00Z", direction: "outbound", source_kind: null, solicited: null });
+    const { p } = await getStatement("date=2026-06-06");
+    assert.strictEqual(p.interruption.count, 0, "genuinely unknown provenance must not be counted");
+    assert.strictEqual(p.interruption.from_source_kind, 0);
+  });
+
+  it("from_flag + from_source_kind === count (disclosure adds up to total)", async () => {
+    // 2 via flag + 3 via source_kind, plus 2 that must be excluded.
+    insertJournal({ ts: "2026-06-07T08:00:00Z", direction: "outbound", source_kind: "slack",  solicited: 0 });
+    insertJournal({ ts: "2026-06-07T08:01:00Z", direction: "outbound", source_kind: "slack",  solicited: 0 });
+    insertJournal({ ts: "2026-06-07T09:00:00Z", direction: "outbound", source_kind: "cron",   solicited: null });
+    insertJournal({ ts: "2026-06-07T09:01:00Z", direction: "outbound", source_kind: "cron",   solicited: null });
+    insertJournal({ ts: "2026-06-07T09:02:00Z", direction: "outbound", source_kind: "system", solicited: null });
+    // Must NOT count: solicited=1 overrides cron classification, and NULL source.
+    insertJournal({ ts: "2026-06-07T10:00:00Z", direction: "outbound", source_kind: "cron",   solicited: 1 });
+    insertJournal({ ts: "2026-06-07T10:01:00Z", direction: "outbound", source_kind: null,     solicited: null });
+    const { p } = await getStatement("date=2026-06-07");
+    assert.strictEqual(p.interruption.from_flag, 2,       "two solicited=0 rows");
+    assert.strictEqual(p.interruption.from_source_kind, 3,"three NULL+cron/system rows");
+    assert.strictEqual(p.interruption.count, 5,           "total = 2 + 3");
+    assert.strictEqual(p.interruption.from_flag + p.interruption.from_source_kind,
+                       p.interruption.count, "disclosure sub-counts must sum to total");
+  });
+});


### PR DESCRIPTION
## Summary

- Extends the interruption query in `buildDayStatement` to count `alfred_journal` rows where `solicited IS NULL AND source_kind IN ('cron', 'system')` as unsolicited — a historical fallback for rows written before the `solicited` flag existed
- Adds `from_flag` / `from_source_kind` sub-fields to the `interruption` response block so callers can see exactly how many rows came from the authoritative flag versus the provenance fallback
- `solicited = 1` is never counted regardless of `source_kind`; `solicited IS NULL` with any other `source_kind` (including `ha-conversation-reply` and NULL) remains uncounted

## Why the fallback is safe

`cron` and `system` are machine-initiated by definition — this is a known mapping from the transport label, not an inference about intent. `ha-conversation-reply` outnumbers unsolicited by ~100:1 on the live tenant and is intentionally excluded. NULL `source_kind` is genuinely ambiguous and stays uncounted.

## Disclosure

The new `from_flag` / `from_source_kind` sub-fields make the two-tier computation visible to any reader. A reader checking 2026-08-07 (no cron/system outbounds) should see both sub-counts at 0; a reader checking 2026-08-13 (10 cron outbounds) should see `from_source_kind: 10`.

## Files touched

- `packages/ctrl/src/api/routes/attention.ts` — split one query into two, expose `from_flag` / `from_source_kind` in response
- `packages/ctrl/tests/nar-entries.test.ts` — 7 new tests in `describe("interruption fallback (#580)")`

## Smoke evidence

Local: `cd packages/ctrl && npm run test:ci`

```
# tests 1469
# suites 356
# pass 1468
# fail 0
# cancelled 0
# skipped 1
# duration_ms 12701
```

Gate report: `✓ lane I (ctrl-api) gate passed — 118 LOC, 2 files, verify ok`

New tests covering all inclusion/exclusion cases:

```
ok 1 - solicited=0 → counted in from_flag
ok 2 - solicited=1 → never counted regardless of source_kind
ok 3 - solicited IS NULL + source_kind='cron' → counted in from_source_kind
ok 4 - solicited IS NULL + source_kind='system' → counted in from_source_kind
ok 5 - solicited IS NULL + source_kind='ha-conversation-reply' → NOT counted
ok 6 - solicited IS NULL + source_kind IS NULL → NOT counted
ok 7 - from_flag + from_source_kind === count (disclosure adds up to total)
```

References #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)