### PR TITLE
feat(learn): stamp solicited=0 on proactive delivery paths (#580)

### DIFF
--- a/packages/learn/src/activities/chore_actions.py
+++ b/packages/learn/src/activities/chore_actions.py
@@ -450,7 +450,7 @@ async def send_chore_notification(
 
     async with httpx.AsyncClient(timeout=30.0) as http:
         resp = await http.post(
-            f"{config.alfred_ctrl_url}/api/v1/alfred-deliver",
+            f"{config.alfred_ctrl_url}/api/v1/notifications",
             json=body,
             headers=headers,
         )
@@ -1283,8 +1283,9 @@ Write the briefing now. Plain prose. Your output is the message Sir sees."""
         return {"mode": "preview", "path": path, "delivered": False, "briefing": briefing}
 
     # Live delivery: first render the briefing text via a workers subagent
-    # (same as preview mode), then POST the rendered text directly to
-    # /api/v1/alfred-deliver.  solicited=0: this is Alfred-initiated (#580).
+    # (same as preview mode), then POST the rendered text to ctrl-api's
+    # /api/v1/notifications, which pushes it outbound via openclaw's
+    # `message.send` tool → Slack/Telegram/etc.  solicited=0: Alfred-initiated (#580).
     briefing = await _workers_spawn_subagent(
         agent_id="learn-clerk",
         prompt=prompt,
@@ -1297,7 +1298,7 @@ Write the briefing now. Plain prose. Your output is the message Sir sees."""
     )
     config = load_config()
     api_key = os.environ.get("AAS_API_KEY", "")
-    url = f"{config.alfred_ctrl_url}/api/v1/alfred-deliver"
+    url = f"{config.alfred_ctrl_url}/api/v1/notifications"
     headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
     async with httpx.AsyncClient(timeout=60.0) as http:
         resp = await http.post(
@@ -1305,6 +1306,7 @@ Write the briefing now. Plain prose. Your output is the message Sir sees."""
             json={
                 "message": briefing,
                 "urgency": "normal",
+                "session_id": session_id,
                 "solicited": 0,
             },
             headers=headers,

--- a/packages/learn/src/activities/chore_actions.py
+++ b/packages/learn/src/activities/chore_actions.py
@@ -436,9 +436,11 @@ async def send_chore_notification(
     # 3. Build POST body; split channel (platform enum) and to (recipient id)
     #    per alfredDeliver.ts:35.  Omit both when no explicit destination so
     #    ctrl-api's home-channel default is the sole fallback.
+    #    solicited=0: chore notifications are Alfred-initiated (#580).
     body: dict[str, Any] = {
         "message": f"[Chore: {chore_slug}]\n\n{message}",
         "urgency": "normal",
+        "solicited": 0,
     }
     if parsed:
         body["channel"] = parsed[0]  # platform enum: "slack"|"telegram"|"email"
@@ -448,7 +450,7 @@ async def send_chore_notification(
 
     async with httpx.AsyncClient(timeout=30.0) as http:
         resp = await http.post(
-            f"{config.alfred_ctrl_url}/api/v1/notifications",
+            f"{config.alfred_ctrl_url}/api/v1/alfred-deliver",
             json=body,
             headers=headers,
         )
@@ -1281,10 +1283,8 @@ Write the briefing now. Plain prose. Your output is the message Sir sees."""
         return {"mode": "preview", "path": path, "delivered": False, "briefing": briefing}
 
     # Live delivery: first render the briefing text via a workers subagent
-    # (same as preview mode), then POST the rendered text to ctrl-api's
-    # /api/v1/notifications, which pushes it outbound via openclaw's
-    # `message.send` tool → Slack/Telegram/etc. The notifications route
-    # handles channel + recipient resolution from the tenant's config.
+    # (same as preview mode), then POST the rendered text directly to
+    # /api/v1/alfred-deliver.  solicited=0: this is Alfred-initiated (#580).
     briefing = await _workers_spawn_subagent(
         agent_id="learn-clerk",
         prompt=prompt,
@@ -1297,7 +1297,7 @@ Write the briefing now. Plain prose. Your output is the message Sir sees."""
     )
     config = load_config()
     api_key = os.environ.get("AAS_API_KEY", "")
-    url = f"{config.alfred_ctrl_url}/api/v1/notifications"
+    url = f"{config.alfred_ctrl_url}/api/v1/alfred-deliver"
     headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
     async with httpx.AsyncClient(timeout=60.0) as http:
         resp = await http.post(
@@ -1305,8 +1305,7 @@ Write the briefing now. Plain prose. Your output is the message Sir sees."""
             json={
                 "message": briefing,
                 "urgency": "normal",
-                "session_id": session_id,
-                # agent_id defaults to "main" server-side
+                "solicited": 0,
             },
             headers=headers,
         )

--- a/packages/learn/src/activities/flywheel_telemetry.py
+++ b/packages/learn/src/activities/flywheel_telemetry.py
@@ -212,7 +212,7 @@ async def send_flywheel_digest() -> dict[str, Any]:
 
     client = VaultClient(config)
     try:
-        await client.notify("flywheel/weekly", text)
+        await client.notify("flywheel/weekly", text, solicited=0)
     finally:
         await client.close()
     return {"sent": True, "days": len(days), "flat_arms": flat_arms}

--- a/packages/learn/src/activities/notify.py
+++ b/packages/learn/src/activities/notify.py
@@ -17,7 +17,7 @@ async def notify_digest_ready(path: str, summary: str) -> None:
     config = load_config()
     client = VaultClient(config)
     try:
-        await client.notify(path, summary)
+        await client.notify(path, summary, solicited=0)
     finally:
         await client.close()
 
@@ -71,6 +71,6 @@ async def escalate_to_user(
 
         summary = f"Needs your judgment: {title}.{score_info}"
         path = input_event.get("path", input_event.get("id", ""))
-        await client.notify(path, summary)
+        await client.notify(path, summary, solicited=0)
     finally:
         await client.close()

--- a/packages/learn/src/utils/vault_client.py
+++ b/packages/learn/src/utils/vault_client.py
@@ -272,19 +272,24 @@ class VaultClient:
     async def notify(
         self, path: str, summary: str, *, solicited: int | None = None
     ) -> None:
-        """Send a proactive notification to Sir via the alfred-deliver surface.
+        """Send a notification to the main Alfred agent.
 
-        ``solicited`` must be 0 (Alfred-initiated, e.g. briefings, weekly
-        digests, escalations) or omitted (ambiguous — stays NULL in the DB).
-        Never pass 1 here; that value is for principal-reply paths only.
-        The column feeds the NAR interruption term (#580).
+        Pass ``solicited=0`` when Alfred is the initiator (briefings, digests,
+        escalations) so alfred_journal.solicited lands as 0 rather than NULL.
+        The column feeds the NAR interruption term (#580).  Omit the kwarg when
+        direction is unknown — NULL is the honest default.
+        Never pass 1; that value is for principal-reply paths only.
         """
         message = f"Alfred Learn: {summary}\nPath: {path}"
-        body: dict[str, Any] = {"message": message, "urgency": "normal"}
+        body: dict[str, Any] = {
+            "message": message,
+            "urgency": "normal",
+            "session_id": "main",
+        }
         # Only stamp 0; any other value is left out so it stays NULL.
         if solicited == 0:
             body["solicited"] = 0
-        resp = await self._client.post("/api/v1/alfred-deliver", json=body)
+        resp = await self._client.post("/api/v1/notifications", json=body)
         # Best-effort — don't raise on failure
         if resp.status_code >= 500:
             resp.raise_for_status()

--- a/packages/learn/src/utils/vault_client.py
+++ b/packages/learn/src/utils/vault_client.py
@@ -269,13 +269,22 @@ class VaultClient:
         resp.raise_for_status()
         return resp.json().get("decisions", [])
 
-    async def notify(self, path: str, summary: str) -> None:
-        """Send a notification to the main Alfred agent."""
+    async def notify(
+        self, path: str, summary: str, *, solicited: int | None = None
+    ) -> None:
+        """Send a proactive notification to Sir via the alfred-deliver surface.
+
+        ``solicited`` must be 0 (Alfred-initiated, e.g. briefings, weekly
+        digests, escalations) or omitted (ambiguous — stays NULL in the DB).
+        Never pass 1 here; that value is for principal-reply paths only.
+        The column feeds the NAR interruption term (#580).
+        """
         message = f"Alfred Learn: {summary}\nPath: {path}"
-        resp = await self._client.post(
-            "/api/v1/notifications",
-            json={"message": message, "urgency": "normal", "session_id": "main"},
-        )
+        body: dict[str, Any] = {"message": message, "urgency": "normal"}
+        # Only stamp 0; any other value is left out so it stays NULL.
+        if solicited == 0:
+            body["solicited"] = 0
+        resp = await self._client.post("/api/v1/alfred-deliver", json=body)
         # Best-effort — don't raise on failure
         if resp.status_code >= 500:
             resp.raise_for_status()

--- a/packages/learn/tests/test_chore_notify_channel.py
+++ b/packages/learn/tests/test_chore_notify_channel.py
@@ -35,7 +35,7 @@ def _mock_httpx_response(status_code: int = 200) -> MagicMock:
     resp = MagicMock(spec=httpx.Response)
     resp.status_code = status_code
     if status_code >= 400:
-        req = httpx.Request("POST", "http://ctrl-api/api/v1/notifications")
+        req = httpx.Request("POST", "http://ctrl-api/api/v1/alfred-deliver")
         resp.raise_for_status.side_effect = httpx.HTTPStatusError(
             f"HTTP {status_code}", request=req, response=resp
         )
@@ -93,6 +93,7 @@ class TestValidChannelFieldSplit:
         body = _posted_body(http_mock)
         assert body.get("channel") == "slack"
         assert body.get("to") == "C0123456789"
+        assert body.get("solicited") == 0, "chore notify must stamp solicited=0 (#580)"
         assert result["delivered"] is True
         assert result["destination"] == "slack:C0123456789"
 
@@ -108,6 +109,7 @@ class TestValidChannelFieldSplit:
         body = _posted_body(http_mock)
         assert body.get("channel") == "telegram"
         assert body.get("to") == "-1001234567"
+        assert body.get("solicited") == 0, "chore notify must stamp solicited=0 (#580)"
         assert result["destination"] == "telegram:-1001234567"
 
     def test_email_channel_splits_correctly(self) -> None:
@@ -122,6 +124,7 @@ class TestValidChannelFieldSplit:
         body = _posted_body(http_mock)
         assert body.get("channel") == "email"
         assert body.get("to") == "user@example.com"
+        assert body.get("solicited") == 0, "chore notify must stamp solicited=0 (#580)"
 
     def test_session_id_never_forwarded(self) -> None:
         """The dead session_id param must NOT appear in the POST body."""
@@ -153,6 +156,7 @@ class TestNoChannelConfigured:
         body = _posted_body(http_mock)
         assert "channel" not in body
         assert "to" not in body
+        assert body.get("solicited") == 0, "chore notify must stamp solicited=0 (#580)"
         assert result["destination"] == "auto"
         assert result["delivered"] is True
 

--- a/packages/learn/tests/test_chore_notify_channel.py
+++ b/packages/learn/tests/test_chore_notify_channel.py
@@ -35,7 +35,7 @@ def _mock_httpx_response(status_code: int = 200) -> MagicMock:
     resp = MagicMock(spec=httpx.Response)
     resp.status_code = status_code
     if status_code >= 400:
-        req = httpx.Request("POST", "http://ctrl-api/api/v1/alfred-deliver")
+        req = httpx.Request("POST", "http://ctrl-api/api/v1/notifications")
         resp.raise_for_status.side_effect = httpx.HTTPStatusError(
             f"HTTP {status_code}", request=req, response=resp
         )

--- a/packages/learn/tests/test_ctrl_contract.py
+++ b/packages/learn/tests/test_ctrl_contract.py
@@ -430,18 +430,20 @@ class TestNotify:
     """POST /api/v1/notifications"""
 
     def test_calls_correct_endpoint(self, vc):
+        """notify() must target alfred-deliver directly; /notifications does not
+        forward solicited so using it would silently drop the NAR stamp (#580)."""
         client, http = vc
-        http.post.return_value = make_response(200, {"status": "sent"})
+        http.post.return_value = make_response(200, {"ok": True})
 
         asyncio.run(client.notify("observation/test.md", "New observation"))
 
         http.post.assert_called_once()
-        assert http.post.call_args.args[0] == "/api/v1/notifications"
+        assert http.post.call_args.args[0] == "/api/v1/alfred-deliver"
 
     def test_payload_has_required_message_field(self, vc):
         """ctrl validates that 'message' is present and is a string."""
         client, http = vc
-        http.post.return_value = make_response(200, {"status": "sent"})
+        http.post.return_value = make_response(200, {"ok": True})
 
         asyncio.run(client.notify("observation/test.md", "summary text"))
 
@@ -452,22 +454,26 @@ class TestNotify:
     def test_payload_has_urgency_field(self, vc):
         """ctrl accepts an 'urgency' field; VaultClient hardcodes 'normal'."""
         client, http = vc
-        http.post.return_value = make_response(200, {"status": "sent"})
+        http.post.return_value = make_response(200, {"ok": True})
 
         asyncio.run(client.notify("observation/test.md", "summary"))
 
         payload = http.post.call_args.kwargs["json"]
         assert payload.get("urgency") == "normal"
 
-    def test_payload_has_session_id_field(self, vc):
-        """ctrl routes to a session; VaultClient hardcodes 'main'."""
+    def test_payload_session_id_removed(self, vc):
+        """session_id was a dead parameter; it must NOT appear in the body.
+
+        alfred-deliver does not recognise session_id and the old notifications
+        route was its sole consumer. Sending it now would be noise (#580).
+        """
         client, http = vc
-        http.post.return_value = make_response(200, {"status": "sent"})
+        http.post.return_value = make_response(200, {"ok": True})
 
         asyncio.run(client.notify("observation/test.md", "summary"))
 
         payload = http.post.call_args.kwargs["json"]
-        assert payload.get("session_id") == "main"
+        assert "session_id" not in payload
 
     def test_message_contains_path_and_summary(self, vc):
         """The message body must embed both the vault path and the summary text."""

--- a/packages/learn/tests/test_ctrl_contract.py
+++ b/packages/learn/tests/test_ctrl_contract.py
@@ -430,20 +430,18 @@ class TestNotify:
     """POST /api/v1/notifications"""
 
     def test_calls_correct_endpoint(self, vc):
-        """notify() must target alfred-deliver directly; /notifications does not
-        forward solicited so using it would silently drop the NAR stamp (#580)."""
         client, http = vc
-        http.post.return_value = make_response(200, {"ok": True})
+        http.post.return_value = make_response(200, {"status": "sent"})
 
         asyncio.run(client.notify("observation/test.md", "New observation"))
 
         http.post.assert_called_once()
-        assert http.post.call_args.args[0] == "/api/v1/alfred-deliver"
+        assert http.post.call_args.args[0] == "/api/v1/notifications"
 
     def test_payload_has_required_message_field(self, vc):
         """ctrl validates that 'message' is present and is a string."""
         client, http = vc
-        http.post.return_value = make_response(200, {"ok": True})
+        http.post.return_value = make_response(200, {"status": "sent"})
 
         asyncio.run(client.notify("observation/test.md", "summary text"))
 
@@ -454,26 +452,22 @@ class TestNotify:
     def test_payload_has_urgency_field(self, vc):
         """ctrl accepts an 'urgency' field; VaultClient hardcodes 'normal'."""
         client, http = vc
-        http.post.return_value = make_response(200, {"ok": True})
+        http.post.return_value = make_response(200, {"status": "sent"})
 
         asyncio.run(client.notify("observation/test.md", "summary"))
 
         payload = http.post.call_args.kwargs["json"]
         assert payload.get("urgency") == "normal"
 
-    def test_payload_session_id_removed(self, vc):
-        """session_id was a dead parameter; it must NOT appear in the body.
-
-        alfred-deliver does not recognise session_id and the old notifications
-        route was its sole consumer. Sending it now would be noise (#580).
-        """
+    def test_payload_has_session_id_field(self, vc):
+        """ctrl routes to a session; VaultClient hardcodes 'main'."""
         client, http = vc
-        http.post.return_value = make_response(200, {"ok": True})
+        http.post.return_value = make_response(200, {"status": "sent"})
 
         asyncio.run(client.notify("observation/test.md", "summary"))
 
         payload = http.post.call_args.kwargs["json"]
-        assert "session_id" not in payload
+        assert payload.get("session_id") == "main"
 
     def test_message_contains_path_and_summary(self, vc):
         """The message body must embed both the vault path and the summary text."""

--- a/packages/learn/tests/test_flywheel_telemetry_332.py
+++ b/packages/learn/tests/test_flywheel_telemetry_332.py
@@ -51,7 +51,7 @@ class _VC:
                     {"frontmatter": {"as_of": "2026-06-01T00:00:00Z"}}]
         return [{"frontmatter": {"parent_matter": "matter/x.md"}},
                 {"frontmatter": {}}]
-    async def notify(self, path, summary):
+    async def notify(self, path, summary, **kwargs):
         self.notified = (path, summary)
     async def close(self): return None
 

--- a/packages/learn/tests/test_proactive_delivery_solicited.py
+++ b/packages/learn/tests/test_proactive_delivery_solicited.py
@@ -67,22 +67,6 @@ def test_vault_client_notify_omits_solicited_key_when_not_passed() -> None:
     assert "solicited" not in body
 
 
-def test_vault_client_notify_routes_to_alfred_deliver() -> None:
-    """/notifications does not forward solicited; must bypass it (#580)."""
-    from src.utils.vault_client import VaultClient
-    resp = MagicMock()
-    resp.status_code = 200
-    resp.raise_for_status.return_value = None
-    inner = AsyncMock()
-    inner.post = AsyncMock(return_value=resp)
-    vc = object.__new__(VaultClient)
-    vc._client = inner  # type: ignore[attr-defined]
-    asyncio.run(vc.notify("p", "s", solicited=0))
-    url = inner.post.call_args.args[0] if inner.post.call_args.args else ""
-    assert "alfred-deliver" in url
-    assert "notifications" not in url
-
-
 def test_observe_execute_instructions_notify_solicited_absent() -> None:
     """Vault-instruction notify is direction-unknown; solicited must be absent."""
     vc = MagicMock()

--- a/packages/learn/tests/test_proactive_delivery_solicited.py
+++ b/packages/learn/tests/test_proactive_delivery_solicited.py
@@ -1,0 +1,104 @@
+"""solicited=0 stamping on Alfred's proactive delivery paths (#580).
+
+Five learn-owned senders must stamp solicited=0; the ambiguous observe path
+must leave the key absent so the journal row stays NULL.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from temporalio.testing import ActivityEnvironment
+
+from src.activities.notify import escalate_to_user, notify_digest_ready
+from src.activities.observe import execute_alfred_instructions
+
+
+def _run(fn: Any, *args: Any) -> Any:
+    return asyncio.run(ActivityEnvironment().run(fn, *args))
+
+
+def _vc() -> tuple[Any, MagicMock]:
+    vc = MagicMock()
+    vc.notify = AsyncMock(return_value=None)
+    vc.close = AsyncMock(return_value=None)
+    return (lambda _cfg: vc), vc
+
+
+def test_notify_digest_ready_stamps_solicited_zero() -> None:
+    factory, vc = _vc()
+    with patch("src.activities.notify.VaultClient", factory):
+        _run(notify_digest_ready, "digest.md", "ready")
+    _, kw = vc.notify.call_args
+    assert kw.get("solicited") == 0
+
+
+def test_escalate_to_user_stamps_solicited_zero() -> None:
+    factory, vc = _vc()
+    with patch("src.activities.notify.VaultClient", factory):
+        _run(escalate_to_user, {"title": "x"}, None)
+    _, kw = vc.notify.call_args
+    assert kw.get("solicited") == 0
+
+
+def test_no_proactive_sender_stamps_solicited_one() -> None:
+    """learn never stamps 1 — only principal-reply paths may use that value."""
+    factory, vc = _vc()
+    with patch("src.activities.notify.VaultClient", factory):
+        _run(notify_digest_ready, "d.md", "s")
+    _, kw = vc.notify.call_args
+    assert kw.get("solicited") != 1
+
+
+# VaultClient.notify() — key absent when solicited not passed
+def test_vault_client_notify_omits_solicited_key_when_not_passed() -> None:
+    """Omitting solicited must leave the key absent (not None) so the DB stays NULL."""
+    from src.utils.vault_client import VaultClient
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status.return_value = None
+    inner = AsyncMock()
+    inner.post = AsyncMock(return_value=resp)
+    vc = object.__new__(VaultClient)
+    vc._client = inner  # type: ignore[attr-defined]
+    asyncio.run(vc.notify("p", "s"))
+    body = inner.post.call_args.kwargs.get("json", {})
+    assert "solicited" not in body
+
+
+def test_vault_client_notify_routes_to_alfred_deliver() -> None:
+    """/notifications does not forward solicited; must bypass it (#580)."""
+    from src.utils.vault_client import VaultClient
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status.return_value = None
+    inner = AsyncMock()
+    inner.post = AsyncMock(return_value=resp)
+    vc = object.__new__(VaultClient)
+    vc._client = inner  # type: ignore[attr-defined]
+    asyncio.run(vc.notify("p", "s", solicited=0))
+    url = inner.post.call_args.args[0] if inner.post.call_args.args else ""
+    assert "alfred-deliver" in url
+    assert "notifications" not in url
+
+
+def test_observe_execute_instructions_notify_solicited_absent() -> None:
+    """Vault-instruction notify is direction-unknown; solicited must be absent."""
+    vc = MagicMock()
+    vc.read_record = AsyncMock(return_value={"content": "", "frontmatter": {}, "body": ""})
+    vc.notify = AsyncMock(return_value=None)
+    vc.update_record = AsyncMock(return_value=None)
+    vc.close = AsyncMock(return_value=None)
+    clerk_plan = {
+        "understood": True,
+        "actions": [{"type": "notify", "target": "p.md", "details": "msg"}],
+    }
+    with patch("src.activities.observe.VaultClient", lambda _cfg: vc):
+        with patch(
+            "src.activities.clerk.clerk_execute_instructions",
+            AsyncMock(return_value=clerk_plan),
+        ):
+            _run(execute_alfred_instructions, {"path": "p.md", "target": "p.md", "details": "msg"})
+    _, kw = vc.notify.call_args
+    assert "solicited" not in kw


### PR DESCRIPTION
## Summary

Stamps `solicited: 0` on alfred-learn's five genuinely Alfred-initiated delivery paths so `alfred_journal.solicited` lands as 0 rather than NULL. This feeds the NAR interruption term (#580) which was near-empty because learn never stamped the field.

**Root cause found:** `notifications.ts` builds an explicit `forwardBody` whitelist and `solicited` was never added to it when migration 0019 shipped in #579. Every caller going through `/api/v1/notifications` had `solicited` silently dropped in transit even if passed in the request body.

**Fix split across two lanes:**
- **Lane I PR #609** (must land first): adds `solicited` to the `forwardBody` whitelist in `notifications.ts` so the field actually reaches `alfred-deliver` and gets written to `alfred_journal.solicited`.
- **This PR #608** (Lane II): adds the `solicited` kwarg to `VaultClient.notify()` and has the five proactive senders pass `solicited=0`.

**Do NOT merge this PR before #609.** The stamp will be silently dropped in transit until #609 merges.

### What changed

- `VaultClient.notify()` now accepts `solicited: int | None = None`; stamps `0` in the body when passed; omits the key otherwise (DB stays NULL — honest default).
- Five confirmed Alfred-initiated call sites stamped with `solicited=0`:
  1. `notify.py:notify_digest_ready` — Alfred pushes a digest
  2. `notify.py:escalate_to_user` — Alfred escalates a signal
  3. `flywheel_telemetry.py:send_flywheel_digest` — weekly flywheel summary
  4. `chore_actions.py:send_chore_notification` — chore run result
  5. `chore_actions.py:build_daily_briefing_v2` — daily briefing delivery
- `observe.py:execute_alfred_instructions` notify action left **without** `solicited` — direction is unknown at that call site; NULL is the honest value.
- `solicited: 1` is never stamped by learn (principal-reply paths only).
- No backfill of historical rows.
- No blanket defaults.

## Smoke evidence

Local VERIFY: `cd packages/learn && python3 -m pytest tests/ -x -q --ignore=tests/test_composio_server.py --ignore=tests/test_composio_server_defaults.py --ignore=tests/test_file_extraction.py`

```
2763 passed, 101 skipped in 21.59s
```

Gate: 133 LOC net from main (scope_limit 180). Both commits passed the local lane gate (`✓ lane II (learn) gate passed`).

Key tests that verify the stamps:
- `test_proactive_delivery_solicited.py::test_notify_digest_ready_stamps_solicited_zero` — escalate + digest both pass `solicited=0`
- `test_proactive_delivery_solicited.py::test_vault_client_notify_omits_solicited_key_when_not_passed` — key absent when kwarg omitted
- `test_proactive_delivery_solicited.py::test_observe_execute_instructions_notify_solicited_absent` — observe path leaves key absent
- `test_chore_notify_channel.py` — solicited=0 asserted in all delivery body checks

## Files touched

- `packages/learn/src/utils/vault_client.py` — `notify()` kwarg + endpoint stays on `/api/v1/notifications`
- `packages/learn/src/activities/notify.py` — `notify_digest_ready` + `escalate_to_user` stamp `solicited=0`
- `packages/learn/src/activities/flywheel_telemetry.py` — `send_flywheel_digest` stamps `solicited=0`
- `packages/learn/src/activities/chore_actions.py` — `send_chore_notification` + `build_daily_briefing_v2` stamp `solicited=0`
- `packages/learn/tests/test_proactive_delivery_solicited.py` — new test file (5 tests)
- `packages/learn/tests/test_chore_notify_channel.py` — solicited=0 assertions added
- `packages/learn/tests/test_ctrl_contract.py` — `TestNotify` updated to match reverted shape
- `packages/learn/tests/test_flywheel_telemetry_332.py` — `_VC.notify` mock accepts `**kwargs`

## Operator steps

None. No migration, no env var, no deploy step beyond the normal `alfred-learn` image build.

Reference: #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)