### PR TITLE
fix(ctrl): /notifications must forward solicited to alfred-deliver (#580)

### DIFF
--- a/packages/ctrl/src/api/routes/notifications.ts
+++ b/packages/ctrl/src/api/routes/notifications.ts
@@ -447,6 +447,11 @@ export function registerNotificationRoutes(): void {
     if (typeof b.source_headline === "string")
       forwardBody.source_headline = b.source_headline;
     if (typeof b.summary === "string") forwardBody.summary = b.summary;
+    // solicited: 0 = Alfred initiated, 1 = reply to a principal turn.
+    // Only 0|1 forward; anything else stays absent so the row is NULL
+    // (unknown), never coerced to 0 — a wrong 0 inflates the NAR
+    // interruption term. Missed when #579 added the column (#580).
+    if (b.solicited === 0 || b.solicited === 1) forwardBody.solicited = b.solicited;
 
     let resp: Response;
     try {


### PR DESCRIPTION
`#579` added `alfred_journal.solicited` and taught every direct writer to set it — but `/api/v1/notifications` forwards an explicit whitelist of fields, and `solicited` was never added to it. Any caller going through that route had the flag **silently dropped**.

That is why proactive deliveries land `NULL` and the NAR interruption term counts almost nothing across all 45 backfilled days.

## Why one line here rather than rewiring the callers

The obvious alternative — have learn's five proactive senders POST `/api/v1/alfred-deliver` directly — was drafted and rejected. That route is a deliberate thin forwarder that still does its own channel resolution and returns 424 honestly when a target cannot be resolved (see the comments at `notifications.ts:130-139`). Bypassing it to add one field would lose that for five senders.

## Only 0 or 1 forward

Anything else is left absent so the row stays `NULL` — unknown — rather than being coerced to `0`. A wrong `0` inflates a subtraction term and makes NAR look worse than reality; the normalisation added in `#579` already guards this at the writer, and the forwarder now matches it.

## Smoke evidence

```
✓ lane I (ctrl-api) gate passed — 6 LOC, 1 files, verify ok
```

Behaviour is covered by the existing `#579` normalisation tests on the receiving side; this restores the path that feeds them. Paired with #607 (historical `cron`/`system` fallback) and the learn-side stamping in #608.