### PR TITLE
feat(web): attention statement core derivations — PR 1/2 (#584)

### DIFF
--- a/packages/web/src/dashboard/attentionCore.test.ts
+++ b/packages/web/src/dashboard/attentionCore.test.ts
@@ -9,7 +9,10 @@ import {
   isEmptyDay, formatHours, formatMinutes,
   deriveChartBars, deriveChartScale, deriveRangeAggregates,
   normalizeAttentionDay, formatScaleSignal, formatItemLabel,
-  type AttentionDayResponse, type InferredItem, type SeriesPoint,
+  formatHeaderDate, formatWholeMinutes,
+  collapseAutonomousRows, deriveLedger, LEDGER_COL_NA,
+  deriveBarGeometry,
+  type AttentionDayResponse, type InferredItem, type SeriesPoint, type AutonomousItem,
 } from "./attentionCore";
 
 const I: InferredItem = { label: "x", bucket: "M", minutes: 20, turns: 10, tools: 5, evidence_kind: "session", evidence_ref: "s", outcome: "delivered" };
@@ -240,4 +243,125 @@ test("formatItemLabel: null label → falls back to evidence_kind", () => {
 test("formatItemLabel: neither label nor evidence_kind → honest placeholder", () => {
   assert.equal(formatItemLabel({ label: null, evidence_kind: null }), "—");
   assert.equal(formatItemLabel({}), "—");
+});
+
+// 11. formatHeaderDate
+test("formatHeaderDate: known date returns full uppercased day/month string", () => {
+  // 2026-08-14 is a Friday (UTC)
+  assert.equal(formatHeaderDate("2026-08-14"), "FRIDAY 14 AUGUST 2026");
+});
+test("formatHeaderDate: Monday", () => {
+  // 2026-08-10 is a Monday
+  assert.equal(formatHeaderDate("2026-08-10"), "MONDAY 10 AUGUST 2026");
+});
+test("formatHeaderDate: malformed input does not throw", () => {
+  const result = formatHeaderDate("not-a-date");
+  assert.ok(typeof result === "string" && result.length > 0);
+});
+
+// 12. formatWholeMinutes
+test("formatWholeMinutes: float rounds to nearest integer", () => {
+  assert.equal(formatWholeMinutes(120.4), "120");
+  assert.equal(formatWholeMinutes(119.6), "120");
+});
+test("formatWholeMinutes: zero", () => {
+  assert.equal(formatWholeMinutes(0), "0");
+});
+
+// 13. collapseAutonomousRows
+const mkAuto = (label: string, minutes: number, bucket = "S"): AutonomousItem => ({ label, bucket, minutes, evidence_kind: "chore_run", evidence_ref: "x" });
+
+test("collapseAutonomousRows: identical labels collapse into one with summed minutes", () => {
+  const items = [mkAuto("Vigilance", 0.01), mkAuto("Vigilance", 0.01), mkAuto("Vigilance", 0.01)];
+  const rows = collapseAutonomousRows(items);
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].count, 3);
+  assert.ok(Math.abs(rows[0].total_minutes - 0.03) < 0.0001);
+});
+test("collapseAutonomousRows: distinct labels preserved separately", () => {
+  const items = [mkAuto("A", 5), mkAuto("B", 10), mkAuto("A", 5)];
+  const rows = collapseAutonomousRows(items);
+  assert.equal(rows.length, 2);
+  const a = rows.find(r => r.label === "A");
+  assert.ok(a && a.count === 2 && Math.abs(a.total_minutes - 10) < 0.0001);
+});
+test("collapseAutonomousRows: sum invariant — collapsed total == input total", () => {
+  const items = [mkAuto("X", 3), mkAuto("X", 7), mkAuto("Y", 4), mkAuto("Y", 1)];
+  const rows = collapseAutonomousRows(items);
+  const collapsedSum = rows.reduce((s, r) => s + r.total_minutes, 0);
+  const rawSum = items.reduce((s, i) => s + i.minutes, 0);
+  assert.ok(Math.abs(collapsedSum - rawSum) < 0.0001);
+});
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+test("collapseAutonomousRows: null-safe → []", () => assert.deepEqual(collapseAutonomousRows(null as any), []));
+
+// 14. deriveLedger
+const mkInferred = (label: string, minutes: number, outcome?: string): InferredItem => ({
+  label, bucket: "M", minutes, evidence_kind: "session", evidence_ref: "s", outcome: outcome ?? "delivered",
+});
+
+test("deriveLedger: group names are CONVERSATIONAL / EXPLICIT / AUTONOMOUS", () => {
+  const vm = deriveLedger(E.displaced);
+  const names = vm.groups.map(g => g.name);
+  assert.deepEqual(names, ["CONVERSATIONAL", "EXPLICIT", "AUTONOMOUS"]);
+});
+test("deriveLedger: group subtotals equal sum of row displaced_min", () => {
+  const displaced = {
+    total_hours: 3,
+    inferred: { hours: 1, items: [mkInferred("X", 30), mkInferred("Y", 30)] },
+    explicit: { hours: 0.5, items: [{ label: "A", count: 1, rate_minutes: 5, minutes: 30 }] },
+    autonomous: { hours: 0.5, items: [mkAuto("Z", 15), mkAuto("Z", 15)] },
+  };
+  const vm = deriveLedger(displaced);
+  for (const g of vm.groups) {
+    const rowSum = g.rows.reduce((s, r) => s + r.displaced_min, 0);
+    assert.ok(Math.abs(rowSum - g.subtotal_displaced_min) < 0.0001,
+      `${g.name}: rowSum=${rowSum} subtotal=${g.subtotal_displaced_min}`);
+  }
+});
+test("deriveLedger: total_displaced_min equals sum of group subtotals", () => {
+  const displaced = {
+    total_hours: 3,
+    inferred: { hours: 1, items: [mkInferred("X", 60)] },
+    explicit: { hours: 0.5, items: [{ label: "A", count: 2, rate_minutes: 5, minutes: 10 }] },
+    autonomous: { hours: 0.5, items: [mkAuto("Z", 20)] },
+  };
+  const vm = deriveLedger(displaced);
+  const groupTotal = vm.groups.reduce((s, g) => s + g.subtotal_displaced_min, 0);
+  assert.ok(Math.abs(groupTotal - vm.total_displaced_min) < 0.0001);
+});
+test("deriveLedger: autonomous rows with same label are collapsed (count > 1)", () => {
+  const displaced = {
+    total_hours: 0, inferred: { hours: 0, items: [] }, explicit: { hours: 0, items: [] },
+    autonomous: { hours: 0, items: [mkAuto("V", 0.01), mkAuto("V", 0.01), mkAuto("V", 0.01)] },
+  };
+  const vm = deriveLedger(displaced);
+  const autoGroup = vm.groups.find(g => g.name === "AUTONOMOUS")!;
+  assert.equal(autoGroup.rows.length, 1);
+  assert.equal(autoGroup.rows[0].count, 3);
+});
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+test("deriveLedger: null displaced → all groups empty, total=0", () => {
+  const vm = deriveLedger(null as any);
+  assert.equal(vm.total_displaced_min, 0);
+  for (const g of vm.groups) assert.equal(g.rows.length, 0);
+  assert.equal(vm.engaged, LEDGER_COL_NA);
+});
+
+// 15. deriveBarGeometry
+test("deriveBarGeometry: displaced is the tallest bar (height_pct=100) when it dominates", () => {
+  const bg = deriveBarGeometry(12, 3, 1.52, 100);
+  assert.equal(bg.displaced.height_pct, 100); // 12 is max
+  assert.ok(bg.mess.height_pct < 100);
+  assert.ok(bg.net.height_pct < 100);
+});
+test("deriveBarGeometry: net value equals displaced minus mess", () => {
+  const bg = deriveBarGeometry(12.03, 3, 1.52, 100);
+  assert.ok(Math.abs(bg.net.value_hours - (12.03 - 3 - 1.52)) < 0.0001);
+});
+test("deriveBarGeometry: all-zero guard — no division by zero", () => {
+  const bg = deriveBarGeometry(0, 0, 0, 100);
+  assert.ok(isFinite(bg.displaced.height_pct));
+  assert.ok(isFinite(bg.mess.height_pct));
+  assert.ok(isFinite(bg.net.height_pct));
 });

--- a/packages/web/src/dashboard/attentionCore.ts
+++ b/packages/web/src/dashboard/attentionCore.ts
@@ -170,6 +170,141 @@ export function normalizeAttentionDay(raw: unknown): AttentionDayViewModel {
   };
 }
 
+// ── Header date format ────────────────────────────────────────────────────────
+
+const _DAYS = ["SUNDAY","MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY","SATURDAY"] as const;
+const _MONTHS = ["JANUARY","FEBRUARY","MARCH","APRIL","MAY","JUNE","JULY","AUGUST","SEPTEMBER","OCTOBER","NOVEMBER","DECEMBER"] as const;
+
+/** Format "2026-08-14" → "THURSDAY 14 AUGUST 2026" (uppercase, UTC-based day-of-week). */
+export function formatHeaderDate(dateStr: string): string {
+  const parts = (dateStr ?? "").split("-").map(Number);
+  if (parts.length < 3 || parts.some(isNaN)) return (dateStr ?? "").toUpperCase();
+  const [y, m, d] = parts;
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  return `${_DAYS[dt.getUTCDay()]} ${d} ${_MONTHS[m - 1]} ${y}`;
+}
+
+// ── Whole-minute formatter (section 03 uses minutes, not hours) ───────────────
+
+/** Round to nearest whole minute and return as a plain string (no unit).
+ *  Section 03 ledger columns use whole minutes; section 01 uses hours. */
+export function formatWholeMinutes(minutes: number): string {
+  return String(Math.round(minutes ?? 0));
+}
+
+// ── Autonomous row collapsing ─────────────────────────────────────────────────
+
+export interface CollapsedAutonomousRow {
+  label: string; bucket: string; count: number; total_minutes: number;
+}
+
+/** Group AutonomousItems with identical labels into one collapsed row.
+ *  Preserves insertion order of first occurrence; adopts that occurrence's bucket.
+ *  Invariant: sum(result[i].total_minutes) == sum(items[i].minutes). */
+export function collapseAutonomousRows(items: AutonomousItem[]): CollapsedAutonomousRow[] {
+  const map = new Map<string, CollapsedAutonomousRow>();
+  for (const it of (items ?? [])) {
+    const row = map.get(it.label);
+    if (row) { row.count += 1; row.total_minutes += it.minutes; }
+    else map.set(it.label, { label: it.label, bucket: it.bucket, count: 1, total_minutes: it.minutes });
+  }
+  return Array.from(map.values());
+}
+
+// ── Ledger view model (section 03) ────────────────────────────────────────────
+
+/** Sentinel: the API does not yet provide per-item engaged or NAR. */
+export const LEDGER_COL_NA = "—" as const;
+export type LedgerColNA = typeof LEDGER_COL_NA;
+
+export interface LedgerItemRow {
+  label: string;
+  displaced_min: number;  // available: from API
+  engaged: LedgerColNA;   // not yet in API
+  nar: LedgerColNA;       // not yet in API
+  count?: number;         // present only on collapsed autonomous rows (count > 1)
+}
+
+export interface LedgerGroup {
+  name: "CONVERSATIONAL" | "EXPLICIT" | "AUTONOMOUS";
+  rows: LedgerItemRow[];
+  subtotal_displaced_min: number; // == sum(rows[i].displaced_min)
+  engaged: LedgerColNA;
+  nar: LedgerColNA;
+}
+
+export interface LedgerViewModel {
+  groups: LedgerGroup[];
+  total_displaced_min: number; // == sum(groups[i].subtotal_displaced_min)
+  engaged: LedgerColNA;
+  nar: LedgerColNA;
+}
+
+/** Build the three-group ledger from the API displaced block.
+ *  Groups: CONVERSATIONAL (inferred) · EXPLICIT (rate-card) · AUTONOMOUS (collapsed).
+ *  Invariants:
+ *    group.subtotal_displaced_min == sum(rows[i].displaced_min)
+ *    total_displaced_min         == sum(groups[i].subtotal_displaced_min) */
+export function deriveLedger(
+  displaced: AttentionDayResponse["displaced"] | null | undefined,
+): LedgerViewModel {
+  const convRows: LedgerItemRow[] = deriveInferredDisplay(displaced?.inferred?.items ?? []).map((it) => ({
+    label: formatItemLabel(it), displaced_min: it.display_minutes,
+    engaged: LEDGER_COL_NA, nar: LEDGER_COL_NA,
+  }));
+  const explRows: LedgerItemRow[] = (displaced?.explicit?.items ?? []).map((it) => ({
+    label: it.label, displaced_min: it.minutes,
+    engaged: LEDGER_COL_NA, nar: LEDGER_COL_NA,
+  }));
+  const autoRows: LedgerItemRow[] = collapseAutonomousRows(displaced?.autonomous?.items ?? []).map((it) => ({
+    label: it.label, displaced_min: it.total_minutes,
+    engaged: LEDGER_COL_NA, nar: LEDGER_COL_NA,
+    ...(it.count > 1 ? { count: it.count } : {}),
+  }));
+  const rowSum = (rows: LedgerItemRow[]) => rows.reduce((s, r) => s + r.displaced_min, 0);
+  const groups: LedgerGroup[] = [
+    { name: "CONVERSATIONAL", rows: convRows, subtotal_displaced_min: rowSum(convRows), engaged: LEDGER_COL_NA, nar: LEDGER_COL_NA },
+    { name: "EXPLICIT",       rows: explRows, subtotal_displaced_min: rowSum(explRows), engaged: LEDGER_COL_NA, nar: LEDGER_COL_NA },
+    { name: "AUTONOMOUS",     rows: autoRows, subtotal_displaced_min: rowSum(autoRows), engaged: LEDGER_COL_NA, nar: LEDGER_COL_NA },
+  ];
+  return { groups, total_displaced_min: groups.reduce((s, g) => s + g.subtotal_displaced_min, 0), engaged: LEDGER_COL_NA, nar: LEDGER_COL_NA };
+}
+
+/** Rendered once below section 03 column headers to explain the em-dash columns. */
+export const LEDGER_PER_ITEM_NOTE = "Per-session engaged and NAR attribution is not yet computed — columns show —." as const;
+
+/** Rendered once in section 02 to explain the em-dash allocation rows. */
+export const ALLOCATION_UNAVAILABLE_NOTE = "Allocation (work / life split) is not yet computed — all rows show —." as const;
+
+// ── Section 01 bar geometry ───────────────────────────────────────────────────
+
+export interface BarGeometry {
+  /** DISPLACED — solid brass, typically the tallest bar. */
+  displaced: { value_hours: number; height_pct: number };
+  /** THE MESS — engaged + interruption; shown labelled as negative. */
+  mess: { value_hours: number; height_pct: number };
+  /** NET — NAR = displaced − mess; solid brass. */
+  net: { value_hours: number; height_pct: number };
+}
+
+/** Compute proportional bar heights (0–barHeight) for the three-bar SVG in section 01.
+ *  All bars share a baseline and grow upward.
+ *  mess.value_hours is the positive magnitude; the label renders it as negative. */
+export function deriveBarGeometry(
+  displaced_hours: number, engaged_hours: number, interruption_hours: number,
+  barHeight = 100,
+): BarGeometry {
+  const d    = displaced_hours ?? 0;
+  const mess = (engaged_hours ?? 0) + (interruption_hours ?? 0);
+  const net  = d - mess;
+  const maxMag = Math.max(d, mess, Math.abs(net), 0.001);
+  return {
+    displaced: { value_hours: d,    height_pct: (d / maxMag) * barHeight },
+    mess:      { value_hours: mess, height_pct: (mess / maxMag) * barHeight },
+    net:       { value_hours: net,  height_pct: (Math.abs(net) / maxMag) * barHeight },
+  };
+}
+
 // ── Range view derivations ────────────────────────────────────────────────────
 
 export interface ChartBar {


### PR DESCRIPTION
## What

Pure derivation additions to attentionCore.ts, zero JSX. PR 1 of 2 for the Attention Statement redesign (#584). Scope limit of 450 authorised by orchestrator.

## New exports

- formatHeaderDate: converts 2026-08-14 to THURSDAY 14 AUGUST 2026 (UTC day-of-week)
- formatWholeMinutes: rounds to whole int, plain string — section 03 uses minutes not hours
- collapseAutonomousRows: groups identical labels into one row with count + summed minutes
- deriveLedger: three-group view model: CONVERSATIONAL / EXPLICIT / AUTONOMOUS
- LEDGER_COL_NA / LedgerColNA: sentinel for per-item engaged + NAR columns not yet in API
- LEDGER_PER_ITEM_NOTE: one-line note rendered once below section 03 headers
- ALLOCATION_UNAVAILABLE_NOTE: one-line note rendered in section 02
- deriveBarGeometry: proportional heights for the three-bar SVG in section 01

## Invariants enforced and tested

- group.subtotal_displaced_min == sum(rows[i].displaced_min) for every group
- total_displaced_min == sum(groups[i].subtotal_displaced_min)
- sum(collapsed[i].total_minutes) == sum(items[i].minutes) (collapsing is lossless)

## Tests

44 to 61 (+17 new tests, all pass).

## Smoke evidence

Local run via the lane VERIFY:

    cd packages/web && npx tsx --test src/dashboard/attentionCore.test.ts
    1..61
    # tests 61
    # pass 61
    # fail 0
    # duration_ms 73.27
    lane III (web) gate passed — 261 LOC, 2 files, verify ok

PR 2 (lane-3/attention-statement-view) will rewrite AttentionPage.tsx consuming these functions.

References #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)