### PR TITLE
fix(web): deriveLedger consumed the raw shape while the page passed the view model

### DIFF
--- a/packages/web/src/dashboard/attentionCore.test.ts
+++ b/packages/web/src/dashboard/attentionCore.test.ts
@@ -12,7 +12,7 @@ import {
   formatHeaderDate, formatWholeMinutes,
   collapseAutonomousRows, deriveLedger, LEDGER_COL_NA,
   deriveBarGeometry,
-  type AttentionDayResponse, type InferredItem, type SeriesPoint, type AutonomousItem,
+  type AttentionDayResponse, type InferredItem, type InferredDisplayItem, type SeriesPoint, type AutonomousItem,
 } from "./attentionCore";
 
 const I: InferredItem = { label: "x", bucket: "M", minutes: 20, turns: 10, tools: 5, evidence_kind: "session", evidence_ref: "s", outcome: "delivered" };
@@ -296,9 +296,17 @@ test("collapseAutonomousRows: sum invariant — collapsed total == input total",
 test("collapseAutonomousRows: null-safe → []", () => assert.deepEqual(collapseAutonomousRows(null as any), []));
 
 // 14. deriveLedger
-const mkInferred = (label: string, minutes: number, outcome?: string): InferredItem => ({
-  label, bucket: "M", minutes, evidence_kind: "session", evidence_ref: "s", outcome: outcome ?? "delivered",
-});
+// deriveLedger consumes the NORMALISED view model, not the raw response —
+// normalizeAttentionDay has already run deriveInferredDisplay. Fixtures must
+// therefore be display items carrying display_minutes, not raw minutes.
+const mkInferred = (label: string, minutes: number, outcome?: string): InferredDisplayItem => {
+  const failed = outcome !== undefined && outcome !== "delivered";
+  return {
+    label, bucket: "M", claimed_minutes: minutes, display_minutes: failed ? 0 : minutes,
+    evidence_kind: "session", evidence_ref: "s", outcome: outcome ?? "delivered",
+    is_blocked: failed, blocked_reason: failed ? `${outcome} — no displacement credit` : null,
+  };
+};
 
 test("deriveLedger: group names are CONVERSATIONAL / EXPLICIT / AUTONOMOUS", () => {
   const vm = deriveLedger(E.displaced);
@@ -364,4 +372,32 @@ test("deriveBarGeometry: all-zero guard — no division by zero", () => {
   assert.ok(isFinite(bg.displaced.height_pct));
   assert.ok(isFinite(bg.mess.height_pct));
   assert.ok(isFinite(bg.net.height_pct));
+});
+
+// Regression: deriveLedger consumed the RAW response shape while the component
+// passed the NORMALISED view model. deriveInferredDisplay ran twice, the second
+// pass read `it.minutes` (absent on InferredDisplayItem), and every
+// conversational row rendered NaN. wasp build caught the type error; tsx could
+// not, because tsc cannot run pre-codegen in this package.
+test("deriveLedger reads display_minutes from normalised items — never NaN", () => {
+  const vm = {
+    total_hours: 1,
+    explicit: { hours: 0, items: [] },
+    inferred: { hours: 1, items: [
+      { label: "Invoice rebuilt", bucket: "L", claimed_minutes: 60, display_minutes: 60,
+        turns: 6, tools: 57, evidence_kind: "session", evidence_ref: "s1",
+        outcome: "delivered", is_blocked: false, blocked_reason: null },
+      { label: "Failed thing", bucket: "M", claimed_minutes: 20, display_minutes: 0,
+        turns: 2, tools: 3, evidence_kind: "session", evidence_ref: "s2",
+        outcome: "failed", is_blocked: true, blocked_reason: "failed — no displacement credit" },
+    ] },
+    autonomous: { hours: 0, items: [] },
+  };
+  const l = deriveLedger(vm as never);
+  const conv = l.groups.find((g) => g.name === "CONVERSATIONAL")!;
+  for (const r of conv.rows) assert.ok(Number.isFinite(r.displaced_min), `NaN in ${r.label}`);
+  assert.equal(conv.rows[0].displaced_min, 60);
+  assert.equal(conv.rows[1].displaced_min, 0, "blocked row credits zero");
+  assert.equal(conv.subtotal_displaced_min, 60, "subtotal is the sum of displayed rows");
+  assert.equal(l.total_displaced_min, 60);
 });

--- a/packages/web/src/dashboard/attentionCore.ts
+++ b/packages/web/src/dashboard/attentionCore.ts
@@ -246,9 +246,13 @@ export interface LedgerViewModel {
  *    group.subtotal_displaced_min == sum(rows[i].displaced_min)
  *    total_displaced_min         == sum(groups[i].subtotal_displaced_min) */
 export function deriveLedger(
-  displaced: AttentionDayResponse["displaced"] | null | undefined,
+  displaced: AttentionDayViewModel["displaced"] | null | undefined,
 ): LedgerViewModel {
-  const convRows: LedgerItemRow[] = deriveInferredDisplay(displaced?.inferred?.items ?? []).map((it) => ({
+  // Takes the ALREADY-NORMALISED displaced block, not the raw response.
+  // normalizeAttentionDay has run deriveInferredDisplay; running it again here
+  // read `it.minutes`, which does not exist on InferredDisplayItem, so every
+  // conversational row rendered NaN. Consume display_minutes directly.
+  const convRows: LedgerItemRow[] = (displaced?.inferred?.items ?? []).map((it) => ({
     label: formatItemLabel(it), displaced_min: it.display_minutes,
     engaged: LEDGER_COL_NA, nar: LEDGER_COL_NA,
   }));


### PR DESCRIPTION
`build-web` is red on `main`:

```
AttentionPage.tsx(136,31): error TS2345
  Type 'InferredDisplayItem[]' is not assignable to type 'InferredItem[]'.
    Property 'minutes' is missing in type 'InferredDisplayItem'.
```

## The type error is the symptom; the defect is a double derivation

`normalizeAttentionDay` already runs `deriveInferredDisplay`. `deriveLedger` ran it **again** on the output. The second pass reads `it.minutes`, which does not exist on `InferredDisplayItem` — so every conversational row would have rendered `NaN`, and the group subtotals and total with it.

Had the types happened to line up, this would have shipped as a page full of `NaN` rather than a build failure. The compiler caught a logic bug.

`deriveLedger` now takes `AttentionDayViewModel["displaced"]` and consumes `display_minutes` directly.

## Two existing tests updated, not deferred

The sum-invariant tests built their fixture from **raw** items, so they were asserting the old contract. Updated here per CLAUDE.md §11.3 rather than left for a follow-up. The fixture helper now produces display items with the same blocked-row semantics the real normaliser applies — a blocked row carries `display_minutes: 0` while keeping `claimed_minutes`.

## Regression test

Asserts no row is `NaN`, that a blocked row credits zero, and that the subtotal still equals the sum of displayed rows.

## Why local tests could not catch it

`tsc` cannot run pre-codegen in this package, so `tsx` tests pass against a type error and `wasp build` is the only real gate — and it only runs after merge. **Second time this exact gap has bitten** (#571 was the first, an import extension). Worth a follow-up to get type checking into the PR gate for `packages/web`.

## Smoke evidence

```
# tests 62
# pass 62
# fail 0
```