### PR TITLE
fix(web): route the deriveLedger fixture through the normaliser (#584)

### DIFF
--- a/packages/web/src/dashboard/attentionCore.test.ts
+++ b/packages/web/src/dashboard/attentionCore.test.ts
@@ -309,7 +309,10 @@ const mkInferred = (label: string, minutes: number, outcome?: string): InferredD
 };
 
 test("deriveLedger: group names are CONVERSATIONAL / EXPLICIT / AUTONOMOUS", () => {
-  const vm = deriveLedger(E.displaced);
+  // E is a RAW response; deriveLedger takes the normalised view model, so go
+  // through the real normaliser rather than casting — that is the actual path
+  // the page uses, and casting here is what let the shape drift in the first place.
+  const vm = deriveLedger(normalizeAttentionDay(E).displaced);
   const names = vm.groups.map(g => g.name);
   assert.deepEqual(names, ["CONVERSATIONAL", "EXPLICIT", "AUTONOMOUS"]);
 });


### PR DESCRIPTION
Second type error from the same contract change.

```
attentionCore.test.ts(312,27): error TS2345
  inferred.items: InferredItem[] not assignable to InferredDisplayItem[]
```

The group-names test passed `E.displaced`. `E` is a **raw** `AttentionDayResponse`; `deriveLedger` now takes the normalised view model.

Fixed by calling `normalizeAttentionDay(E).displaced` rather than casting — that is the path the page actually uses, and a cast is exactly what let the two shapes drift apart unnoticed in the first place.

## My mistake

I fixed only the `mkInferred` helper in the previous commit and pushed without checking every `deriveLedger` call site. There are six; one still passed a raw fixture. `tsx` does not typecheck, so the suite stayed green and `build-web` went red a second time.

Audited all six this time:

| line | fixture | status |
|---|---|---|
| 312 | `E.displaced` (raw) | **fixed** — now via `normalizeAttentionDay` |
| 323, 337, 346 | built from `mkInferred` | already display shape |
| 353 | `null` | n/a |
| 396 | regression fixture | already display shape |

## Smoke evidence

```
# tests 62
# pass 62
# fail 0
```

## Follow-up worth filing

`packages/web` has no type checking in the PR gate — `tsc` cannot run pre-codegen and `wasp build` only runs after merge. That gap has now produced three red mains (#571, #613, this). A pre-merge `wasp build` on web-touching PRs would close it.