### PR TITLE
fix(web): section-02 numeric columns must fit INTERRUPT (#584)

### DIFF
--- a/packages/web/src/dashboard/AttentionPage.tsx
+++ b/packages/web/src/dashboard/AttentionPage.tsx
@@ -169,7 +169,7 @@ function DayView({ day, recomp, running }: { day: AttentionDayViewModel; recomp(
       </p>
       {/* Column headers — bar track column header is blank */}
       <div className="grid font-mono text-[9px] uppercase tracking-[0.18em] pb-1 mb-0"
-        style={{ gridTemplateColumns: "1fr 300px repeat(4,62px)", color: "var(--marginalia)", borderBottom: "1px solid var(--rule)", opacity: 0.7 }}>
+        style={{ gridTemplateColumns: "1fr minmax(160px,300px) repeat(4,78px)", color: "var(--marginalia)", borderBottom: "1px solid var(--rule)", opacity: 0.7 }}>
         <span />
         <span />
         {(["DISPLACED","ENGAGED","INTERRUPT","NET"] as const).map(c => (
@@ -181,7 +181,7 @@ function DayView({ day, recomp, running }: { day: AttentionDayViewModel; recomp(
           shows the structure and makes the absence legible. */}
       {(["Work","Life","Unallocated"] as const).map((row) => (
         <div key={row} className="grid items-center"
-          style={{ gridTemplateColumns: "1fr 300px repeat(4,62px)", borderBottom: "1px solid var(--rule)", opacity: 0.65, minHeight: 21 }}>
+          style={{ gridTemplateColumns: "1fr minmax(160px,300px) repeat(4,78px)", borderBottom: "1px solid var(--rule)", opacity: 0.65, minHeight: 21 }}>
           <span className="font-sans italic" style={{ fontSize: 13 }}>{row}</span>
           {/* horizontal bar track — 10px tall, faint, always drawn */}
           <div style={{ height: 10, background: "var(--rule)", opacity: 0.18, borderRadius: 1 }} />


### PR DESCRIPTION
The section-02 header renders as `DISPLACED ENGAGEDINTERRUPT NET`.

Matching the reference proportions narrowed the numeric columns from 96px to 62px, which is too tight for the widest label — `INTERRUPT` at 9px mono with 0.18em tracking overflows and collides with its neighbour.

**78px** clears it with the tracking intact. The bar-track column becomes `minmax(160px,300px)` so it yields first on narrow viewports rather than the numeric columns crushing again.

## Second occurrence

This header collided once before; that fix widened to 96px, and matching the reference re-narrowed it. Sizing to the widest label rather than to a round number is what stops it coming back a third time.

## Smoke evidence

```
# tests 62
# pass 62
# fail 0
```

Verified in a browser at 1440px: the empty bar tracks in section 02 do render (faint, by design — no allocation data exists), and section 01 now balances the figure against the bar group as the reference does.