### PR TITLE
feat(web): consume allocation + per-item engaged/nar on /attention (#584)

### DIFF
--- a/packages/web/src/dashboard/AttentionPage.tsx
+++ b/packages/web/src/dashboard/AttentionPage.tsx
@@ -7,8 +7,8 @@ import { Frame } from "../client/components/ab/Frame";
 import logoCurrentcolor from "../client/assets/brand/alfred-logo-currentcolor.svg";
 import {
   normalizeAttentionDay, isEmptyDay, formatHours, formatWholeMinutes,
-  formatHeaderDate, deriveLedger, deriveBarGeometry,
-  LEDGER_PER_ITEM_NOTE, ALLOCATION_UNAVAILABLE_NOTE,
+  formatHeaderDate, deriveLedger, deriveBarGeometry, deriveAllocationBarWidths,
+  LEDGER_PER_ITEM_NOTE,
   deriveChartBars, deriveChartScale, deriveRangeAggregates,
   type AttentionDayViewModel, type AttentionStatsResponse,
   type ChartBar, type ChartScaleResult, type BarGeometry,
@@ -147,6 +147,15 @@ function DayView({ day, recomp, running }: { day: AttentionDayViewModel; recomp(
     day.interruption?.hours ?? 0,
   );
   const NA = "—";
+  // Formatter for nullable hour/minute values: null stays "—", never "0.00".
+  const fh = (v: number | null | undefined) => v != null ? formatHours(v) : NA;
+  const fmtM = (v: number | null) => v !== null ? formatWholeMinutes(v) : NA;
+  const barWidths = deriveAllocationBarWidths(day.allocation ?? undefined);
+  const ALLOC_ROWS = [
+    { label: "Work",        key: "work"        as const },
+    { label: "Life",        key: "life"        as const },
+    { label: "Unallocated", key: "unallocated" as const },
+  ];
 
   return (
     <>
@@ -170,9 +179,6 @@ function DayView({ day, recomp, running }: { day: AttentionDayViewModel; recomp(
 
       {/* ── 02 WHERE IT WENT ───────────────────────────────────────────── */}
       <SL n="02" title="WHERE IT WENT" />
-      <p className="font-mono text-[10px] italic mb-3" style={{ color: "var(--marginalia)" }}>
-        {ALLOCATION_UNAVAILABLE_NOTE}
-      </p>
       {/* Column headers — bar track column header is blank */}
       <div className="grid font-mono text-[11px] uppercase tracking-[0.18em] pb-1 mb-0"
         style={{ gridTemplateColumns: "1fr minmax(160px,300px) repeat(4,78px)", color: "var(--marginalia)", borderBottom: "1px solid var(--rule)", opacity: 0.7 }}>
@@ -182,20 +188,40 @@ function DayView({ day, recomp, running }: { day: AttentionDayViewModel; recomp(
           <span key={c} className="text-right">{c}</span>
         ))}
       </div>
-      {/* Rows: Work / Life / Unallocated — all unavailable.
-          The bar track always draws even with no data — the empty track
-          shows the structure and makes the absence legible. */}
-      {(["Work","Life","Unallocated"] as const).map((row) => (
-        <div key={row} className="grid items-center"
-          style={{ gridTemplateColumns: "1fr minmax(160px,300px) repeat(4,78px)", borderBottom: "1px solid var(--rule)", opacity: 0.65, minHeight: 21 }}>
-          <span className="font-sans italic" style={{ fontSize: 13 }}>{row}</span>
-          {/* horizontal bar track — 10px tall, faint, always drawn */}
-          <div style={{ height: 10, background: "var(--rule)", opacity: 0.18, borderRadius: 1 }} />
-          {[NA, NA, NA, NA].map((v, ci) => (
-            <span key={ci} className="font-mono text-[9px] tabular-nums text-right opacity-40">{v}</span>
-          ))}
-        </div>
-      ))}
+      {/* Rows: Work / Life / Unallocated.
+          Bar track is proportional to each row's displaced hours, scaled
+          to the largest of the three. Empty track always drawn — absence is
+          legible, not invisible. Interruption is structurally zero for work
+          and life (all interruption lands in unallocated by construction). */}
+      {ALLOC_ROWS.map(({ label, key }) => {
+        const bucket = day.allocation?.[key] ?? null;
+        return (
+          <div key={key} className="grid items-center"
+            style={{ gridTemplateColumns: "1fr minmax(160px,300px) repeat(4,78px)", borderBottom: "1px solid var(--rule)", opacity: 0.75, minHeight: 21 }}>
+            <span className="font-sans italic" style={{ fontSize: 13 }}>{label}</span>
+            {/* bar track — faint container, brass fill proportional to displaced */}
+            <div style={{ height: 10, background: "var(--rule)", opacity: 0.18, borderRadius: 1, position: "relative", overflow: "hidden" }}>
+              {bucket != null && bucket.displaced_hours > 0 && (
+                <div style={{ position: "absolute", top: 0, left: 0, height: "100%",
+                  width: `${barWidths[key]}%`, background: "var(--brass)", opacity: 0.65, borderRadius: 1 }} />
+              )}
+            </div>
+            {[fh(bucket?.displaced_hours), fh(bucket?.engaged_hours),
+              fh(bucket?.interruption_hours), fh(bucket?.nar_hours)].map((v, ci) => (
+              <span key={ci} className="font-mono text-[9px] tabular-nums text-right" style={{ opacity: bucket != null ? 0.75 : 0.35 }}>{v}</span>
+            ))}
+          </div>
+        );
+      })}
+      {/* Reconciliation footnote: two honest measures of different scopes — not an error. */}
+      {day.allocation_reconciliation != null && (
+        <p className="font-mono text-[10px] mt-2" style={{ color: "var(--marginalia)" }}>
+          Per-session attributed {formatHours(day.allocation_reconciliation.attributed_engaged_hours)} h engaged
+          · day-level {formatHours(day.allocation_reconciliation.day_engaged_hours)} h
+          · {formatHours(Math.abs(day.allocation_reconciliation.difference_hours))} h difference.
+          {" "}Per-session clustering and whole-day burst clustering measure different scopes and are not expected to match.
+        </p>
+      )}
 
       {/* ── 03 THE LEDGER ──────────────────────────────────────────────── */}
       <SL n="03" title="THE LEDGER" />
@@ -217,8 +243,8 @@ function DayView({ day, recomp, running }: { day: AttentionDayViewModel; recomp(
           <div className="grid items-baseline" style={{ gridTemplateColumns: "1fr repeat(3,68px)", minHeight: 24, paddingTop: 4, paddingBottom: 4 }}>
             <span className="font-mono text-[11px] uppercase tracking-[0.22em]" style={{ color: "var(--brass)" }}>{grp.name}</span>
             <span className="font-mono text-[11px] tabular-nums text-right" style={{ color: "var(--brass)" }}>{formatWholeMinutes(grp.subtotal_displaced_min)}</span>
-            <span className="font-mono text-[11px] tabular-nums text-right" style={{ color: "var(--brass)" }}>{grp.engaged}</span>
-            <span className="font-mono text-[11px] tabular-nums text-right" style={{ color: "var(--brass)" }}>{grp.nar}</span>
+            <span className="font-mono text-[11px] tabular-nums text-right" style={{ color: "var(--brass)" }}>{fmtM(grp.subtotal_engaged_min)}</span>
+            <span className="font-mono text-[11px] tabular-nums text-right" style={{ color: "var(--brass)" }}>{fmtM(grp.subtotal_nar_min)}</span>
           </div>
           {/* Item rows — 14px serif label, 14px mono numbers */}
           {grp.rows.length === 0
@@ -232,8 +258,8 @@ function DayView({ day, recomp, running }: { day: AttentionDayViewModel; recomp(
                       : null}
                   </span>
                   <span className="font-mono tabular-nums text-right" style={{ fontSize: 14 }}>{formatWholeMinutes(row.displaced_min)}</span>
-                  <span className="font-mono tabular-nums text-right opacity-35" style={{ fontSize: 14 }}>{row.engaged}</span>
-                  <span className="font-mono tabular-nums text-right opacity-35" style={{ fontSize: 14 }}>{row.nar}</span>
+                  <span className="font-mono tabular-nums text-right opacity-35" style={{ fontSize: 14 }}>{fmtM(row.engaged_min)}</span>
+                  <span className="font-mono tabular-nums text-right opacity-35" style={{ fontSize: 14 }}>{fmtM(row.nar_min)}</span>
                 </div>
               ))}
         </div>
@@ -242,8 +268,8 @@ function DayView({ day, recomp, running }: { day: AttentionDayViewModel; recomp(
       <div className="grid items-baseline mt-0.5" style={{ gridTemplateColumns: "1fr repeat(3,68px)", borderTop: "2px solid var(--rule)", minHeight: 24, paddingTop: 4, paddingBottom: 4 }}>
         <span className="font-mono text-[11px] uppercase tracking-[0.22em]" style={{ color: "var(--brass)" }}>TOTAL</span>
         <span className="font-mono text-[11px] tabular-nums text-right" style={{ color: "var(--brass)" }}>{formatWholeMinutes(ledger.total_displaced_min)}</span>
-        <span className="font-mono text-[11px] tabular-nums text-right" style={{ color: "var(--brass)" }}>{ledger.engaged}</span>
-        <span className="font-mono text-[11px] tabular-nums text-right" style={{ color: "var(--brass)" }}>{ledger.nar}</span>
+        <span className="font-mono text-[11px] tabular-nums text-right" style={{ color: "var(--brass)" }}>{fmtM(ledger.total_engaged_min)}</span>
+        <span className="font-mono text-[11px] tabular-nums text-right" style={{ color: "var(--brass)" }}>{fmtM(ledger.total_nar_min)}</span>
       </div>
 
       {/* Unrated action classes — zero contribution, must not be omitted */}

--- a/packages/web/src/dashboard/attentionCore.test.ts
+++ b/packages/web/src/dashboard/attentionCore.test.ts
@@ -11,7 +11,7 @@ import {
   normalizeAttentionDay, formatScaleSignal, formatItemLabel,
   formatHeaderDate, formatWholeMinutes,
   collapseAutonomousRows, deriveLedger, LEDGER_COL_NA,
-  deriveBarGeometry,
+  deriveBarGeometry, deriveAllocationBarWidths,
   type AttentionDayResponse, type InferredItem, type InferredDisplayItem, type SeriesPoint, type AutonomousItem,
 } from "./attentionCore";
 
@@ -352,11 +352,12 @@ test("deriveLedger: autonomous rows with same label are collapsed (count > 1)", 
   assert.equal(autoGroup.rows[0].count, 3);
 });
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-test("deriveLedger: null displaced → all groups empty, total=0", () => {
+test("deriveLedger: null displaced → all groups empty, total=0, engaged null", () => {
   const vm = deriveLedger(null as any);
   assert.equal(vm.total_displaced_min, 0);
   for (const g of vm.groups) assert.equal(g.rows.length, 0);
-  assert.equal(vm.engaged, LEDGER_COL_NA);
+  assert.equal(vm.total_engaged_min, null);  // no measured rows → null, never "—"
+  assert.equal(LEDGER_COL_NA, "—");          // sentinel still exported for display layer
 });
 
 // 15. deriveBarGeometry
@@ -405,6 +406,72 @@ test("deriveBarGeometry: negative NAR (mess > displaced) produces non-negative g
   // waterfall invariants still hold with clamped net
   assert.ok(Math.abs((bg.mess.y_offset_pct + bg.mess.height_pct) - bg.displaced.height_pct) < 0.0001);
   assert.ok(Math.abs((bg.net.height_pct    + bg.mess.height_pct) - bg.displaced.height_pct) < 0.0001);
+});
+
+// 16. Ledger engaged/nar columns — null semantics (#584 allocation)
+
+const mkDisp = (items: InferredDisplayItem[]) => ({
+  total_hours: 0, inferred: { hours: 0, items }, explicit: { hours: 0, items: [] }, autonomous: { hours: 0, items: [] },
+});
+const mkIdItem = (label: string, disp: number, eng: number | null, nar: number | null): InferredDisplayItem => ({
+  label, bucket: "M", claimed_minutes: disp, display_minutes: disp, evidence_kind: "session", evidence_ref: "s",
+  outcome: "delivered", is_blocked: false, blocked_reason: null, engaged_minutes: eng, nar_minutes: nar,
+});
+
+test("ledger: item with engaged_minutes null → engaged_min and nar_min are null (not zero)", () => {
+  const vm = deriveLedger(mkDisp([mkIdItem("x", 30, null, null)]));
+  const row = vm.groups.find(g => g.name === "CONVERSATIONAL")!.rows[0];
+  assert.equal(row.engaged_min, null); assert.equal(row.nar_min, null);
+});
+
+test("ledger: all-null group yields null subtotal, never 0", () => {
+  const vm = deriveLedger(mkDisp([mkIdItem("a", 20, null, null), mkIdItem("b", 10, null, null)]));
+  const conv = vm.groups.find(g => g.name === "CONVERSATIONAL")!;
+  assert.equal(conv.subtotal_engaged_min, null); assert.equal(conv.subtotal_nar_min, null);
+  assert.equal(vm.total_engaged_min, null);
+});
+
+test("ledger: mixed group sums only measured rows, skips nulls", () => {
+  const vm = deriveLedger(mkDisp([
+    mkIdItem("a", 60, 15, 45), mkIdItem("b", 20, null, null), mkIdItem("c", 90, 25, 65),
+  ]));
+  const conv = vm.groups.find(g => g.name === "CONVERSATIONAL")!;
+  assert.equal(conv.subtotal_engaged_min, 40); assert.equal(conv.subtotal_nar_min, 110);
+});
+
+// 17. Allocation rows — four figures + bar widths (#584 allocation)
+
+const mkAlloc = (wd: number, ld: number, ud: number, ui: number) => ({
+  work:        { displaced_hours: wd, engaged_hours: 0, interruption_hours: 0,  nar_hours: wd },
+  life:        { displaced_hours: ld, engaged_hours: 0, interruption_hours: 0,  nar_hours: ld },
+  unallocated: { displaced_hours: ud, engaged_hours: 0, interruption_hours: ui, nar_hours: ud - ui },
+});
+
+test("allocation: interruption_hours is non-zero only in unallocated; work and life carry zero", () => {
+  const vm = normalizeAttentionDay({ ...E, allocation: mkAlloc(2, 1, 0.5, 0.1) });
+  assert.equal(vm.allocation!.work.interruption_hours, 0);
+  assert.equal(vm.allocation!.life.interruption_hours, 0);
+  assert.ok(vm.allocation!.unallocated.interruption_hours > 0);
+  assert.equal(vm.allocation!.work.displaced_hours, 2);
+});
+
+test("allocation bar widths: proportional to displaced, largest row gets 100%", () => {
+  const w = deriveAllocationBarWidths(mkAlloc(2, 4, 1, 0));
+  assert.equal(w.life, 100); assert.ok(Math.abs(w.work - 50) < 0.01); assert.ok(Math.abs(w.unallocated - 25) < 0.01);
+});
+
+test("allocation bar widths: all-zero → all widths zero (empty tracks still drawn)", () => {
+  const w = deriveAllocationBarWidths(mkAlloc(0, 0, 0, 0));
+  assert.ok(w.work === 0 && w.life === 0 && w.unallocated === 0);
+});
+
+test("reconciliation: difference_hours is non-zero when the two engaged measures disagree", () => {
+  const vm = normalizeAttentionDay({ ...E, allocation_reconciliation:
+    { attributed_engaged_hours: 2.45, day_engaged_hours: 3.12, difference_hours: 0.67 } });
+  assert.ok(vm.allocation_reconciliation !== null);
+  assert.ok(Math.abs(vm.allocation_reconciliation!.difference_hours) > 0);
+  const r = vm.allocation_reconciliation!;
+  assert.ok(Math.abs(r.day_engaged_hours - r.attributed_engaged_hours - r.difference_hours) < 0.001);
 });
 
 // Regression: deriveLedger consumed the RAW response shape while the component

--- a/packages/web/src/dashboard/attentionCore.ts
+++ b/packages/web/src/dashboard/attentionCore.ts
@@ -6,9 +6,13 @@
 //   4. empty day is identifiable without inspecting items
 
 export interface ExplicitItem { label: string; count: number; rate_minutes: number; minutes: number }
-export interface InferredItem { label: string; bucket: string; minutes: number; turns?: number | null; tools?: number | null; evidence_kind: string; evidence_ref: string; outcome?: string | null }
-export interface AutonomousItem { label: string; bucket: string; minutes: number; evidence_kind: string; evidence_ref: string }
+export interface InferredItem { label: string; bucket: string; minutes: number; turns?: number | null; tools?: number | null; evidence_kind: string; evidence_ref: string; outcome?: string | null; engaged_minutes?: number | null; nar_minutes?: number | null }
+export interface AutonomousItem { label: string; bucket: string; minutes: number; evidence_kind: string; evidence_ref: string; engaged_minutes?: number | null; nar_minutes?: number | null }
 export interface UnratedEntry { action_class: string; count: number }
+
+export interface AllocationBucket { displaced_hours: number; engaged_hours: number; interruption_hours: number; nar_hours: number }
+export interface AllocationBlock { work: AllocationBucket; life: AllocationBucket; unallocated: AllocationBucket }
+export interface AllocationReconciliation { attributed_engaged_hours: number; day_engaged_hours: number; difference_hours: number }
 
 export interface AttentionDayResponse {
   date: string; nar_hours: number;
@@ -18,6 +22,8 @@ export interface AttentionDayResponse {
   stats: { sessions: number; turns: number; self_corrections: number; blocked: number; hard_failures: number; return_ratio: number; autonomous_artifacts: number };
   rates: { suppression_minutes_per_item: number; bucket_minutes: { S: number; M: number; L: number; XL: number }; interruption_minutes: number };
   unrated: UnratedEntry[];
+  allocation?: AllocationBlock | null;
+  allocation_reconciliation?: AllocationReconciliation | null;
 }
 
 export interface SeriesPoint { date: string; nar_hours: number; displaced_hours: number; engaged_hours: number }
@@ -34,6 +40,8 @@ export interface InferredDisplayItem {
   claimed_minutes: number; display_minutes: number; // 0 only for explicit failures — asymmetry is the point
   turns?: number | null; tools?: number | null; evidence_kind: string; evidence_ref: string;
   outcome?: string | null; is_blocked: boolean; blocked_reason: string | null;
+  engaged_minutes: number | null; // null = not measured; never zero-substituted
+  nar_minutes: number | null;     // null when engaged is null
 }
 
 export function deriveUnratedRows(unrated: UnratedEntry[]): UnratedRow[] {
@@ -50,7 +58,8 @@ export function deriveInferredDisplay(items: InferredItem[]): InferredDisplayIte
     const explicitFail = typeof it.outcome === "string" && EXPLICIT_FAILURES.has(it.outcome);
     return { label: it.label, bucket: it.bucket, claimed_minutes: it.minutes, display_minutes: explicitFail ? 0 : it.minutes,
       turns: it.turns, tools: it.tools, evidence_kind: it.evidence_kind, evidence_ref: it.evidence_ref,
-      outcome: it.outcome, is_blocked: explicitFail, blocked_reason: explicitFail ? `outcome: ${it.outcome} — no displacement credit` : null };
+      outcome: it.outcome, is_blocked: explicitFail, blocked_reason: explicitFail ? `outcome: ${it.outcome} — no displacement credit` : null,
+      engaged_minutes: it.engaged_minutes ?? null, nar_minutes: it.nar_minutes ?? null };
   });
 }
 
@@ -133,6 +142,18 @@ export interface AttentionDayViewModel {
   stats: { sessions: number; turns: number; self_corrections: number; blocked: number; hard_failures: number; return_ratio: number; autonomous_artifacts: number } | null;
   rates: { suppression_minutes_per_item: number; bucket_minutes: { S: number; M: number; L: number; XL: number }; interruption_minutes: number } | null;
   unrated: UnratedRow[];
+  allocation: AllocationBlock | null;
+  allocation_reconciliation: AllocationReconciliation | null;
+}
+
+/** Normalise one AllocationBucket — all fields default to 0 when absent. */
+function _normAllocBucket(b: Partial<AllocationBucket> | null | undefined): AllocationBucket {
+  return {
+    displaced_hours:    b?.displaced_hours    ?? 0,
+    engaged_hours:      b?.engaged_hours      ?? 0,
+    interruption_hours: b?.interruption_hours ?? 0,
+    nar_hours:          b?.nar_hours          ?? 0,
+  };
 }
 
 /** Normalise a raw API day response into a fully-typed view model.
@@ -167,6 +188,16 @@ export function normalizeAttentionDay(raw: unknown): AttentionDayViewModel {
       interruption_minutes: r.rates.interruption_minutes ?? 0,
     } : null,
     unrated: deriveUnratedRows(r.unrated ?? []),
+    allocation: r.allocation != null ? {
+      work:        _normAllocBucket(r.allocation.work),
+      life:        _normAllocBucket(r.allocation.life),
+      unallocated: _normAllocBucket(r.allocation.unallocated),
+    } : null,
+    allocation_reconciliation: r.allocation_reconciliation != null ? {
+      attributed_engaged_hours: r.allocation_reconciliation.attributed_engaged_hours ?? 0,
+      day_engaged_hours:        r.allocation_reconciliation.day_engaged_hours        ?? 0,
+      difference_hours:         r.allocation_reconciliation.difference_hours         ?? 0,
+    } : null,
   };
 }
 
@@ -213,38 +244,46 @@ export function collapseAutonomousRows(items: AutonomousItem[]): CollapsedAutono
 
 // ── Ledger view model (section 03) ────────────────────────────────────────────
 
-/** Sentinel: the API does not yet provide per-item engaged or NAR. */
+/** Em-dash sentinel — used as a display constant when a measured column is absent. */
 export const LEDGER_COL_NA = "—" as const;
 export type LedgerColNA = typeof LEDGER_COL_NA;
 
 export interface LedgerItemRow {
   label: string;
-  displaced_min: number;  // available: from API
-  engaged: LedgerColNA;   // not yet in API
-  nar: LedgerColNA;       // not yet in API
-  count?: number;         // present only on collapsed autonomous rows (count > 1)
+  displaced_min: number;        // always available from API
+  engaged_min: number | null;   // null = not measured (chore run, desk decision)
+  nar_min: number | null;       // null when engaged is null — unknown ≠ zero
+  count?: number;               // present only on collapsed autonomous rows (count > 1)
 }
 
 export interface LedgerGroup {
   name: "CONVERSATIONAL" | "EXPLICIT" | "AUTONOMOUS";
   rows: LedgerItemRow[];
-  subtotal_displaced_min: number; // == sum(rows[i].displaced_min)
-  engaged: LedgerColNA;
-  nar: LedgerColNA;
+  subtotal_displaced_min: number;       // == sum(rows[i].displaced_min)
+  subtotal_engaged_min: number | null;  // null when all rows are null; sum of non-null otherwise
+  subtotal_nar_min: number | null;      // same rule
 }
 
 export interface LedgerViewModel {
   groups: LedgerGroup[];
-  total_displaced_min: number; // == sum(groups[i].subtotal_displaced_min)
-  engaged: LedgerColNA;
-  nar: LedgerColNA;
+  total_displaced_min: number;       // == sum(groups[i].subtotal_displaced_min)
+  total_engaged_min: number | null;  // null when no group has a measured row
+  total_nar_min: number | null;      // same rule
 }
 
-/** Build the three-group ledger from the API displaced block.
+/** Sum only the non-null values in an array.
+ *  Returns null when the array is empty or every element is null. */
+function sumNullable(values: (number | null)[]): number | null {
+  const measured = values.filter((v): v is number => v !== null);
+  return measured.length > 0 ? measured.reduce((a, b) => a + b, 0) : null;
+}
+
+/** Build the three-group ledger from the NORMALISED displaced block.
  *  Groups: CONVERSATIONAL (inferred) · EXPLICIT (rate-card) · AUTONOMOUS (collapsed).
  *  Invariants:
  *    group.subtotal_displaced_min == sum(rows[i].displaced_min)
- *    total_displaced_min         == sum(groups[i].subtotal_displaced_min) */
+ *    total_displaced_min         == sum(groups[i].subtotal_displaced_min)
+ *  Null-sum rule: subtotal/total for engaged/nar is null when no measured rows exist. */
 export function deriveLedger(
   displaced: AttentionDayViewModel["displaced"] | null | undefined,
 ): LedgerViewModel {
@@ -254,31 +293,64 @@ export function deriveLedger(
   // conversational row rendered NaN. Consume display_minutes directly.
   const convRows: LedgerItemRow[] = (displaced?.inferred?.items ?? []).map((it) => ({
     label: formatItemLabel(it), displaced_min: it.display_minutes,
-    engaged: LEDGER_COL_NA, nar: LEDGER_COL_NA,
+    engaged_min: it.engaged_minutes, nar_min: it.nar_minutes,
   }));
+  // Explicit (rate-card) and autonomous items carry no per-session engagement measurement.
   const explRows: LedgerItemRow[] = (displaced?.explicit?.items ?? []).map((it) => ({
     label: it.label, displaced_min: it.minutes,
-    engaged: LEDGER_COL_NA, nar: LEDGER_COL_NA,
+    engaged_min: null, nar_min: null,
   }));
   const autoRows: LedgerItemRow[] = collapseAutonomousRows(displaced?.autonomous?.items ?? []).map((it) => ({
     label: it.label, displaced_min: it.total_minutes,
-    engaged: LEDGER_COL_NA, nar: LEDGER_COL_NA,
+    engaged_min: null, nar_min: null,
     ...(it.count > 1 ? { count: it.count } : {}),
   }));
   const rowSum = (rows: LedgerItemRow[]) => rows.reduce((s, r) => s + r.displaced_min, 0);
   const groups: LedgerGroup[] = [
-    { name: "CONVERSATIONAL", rows: convRows, subtotal_displaced_min: rowSum(convRows), engaged: LEDGER_COL_NA, nar: LEDGER_COL_NA },
-    { name: "EXPLICIT",       rows: explRows, subtotal_displaced_min: rowSum(explRows), engaged: LEDGER_COL_NA, nar: LEDGER_COL_NA },
-    { name: "AUTONOMOUS",     rows: autoRows, subtotal_displaced_min: rowSum(autoRows), engaged: LEDGER_COL_NA, nar: LEDGER_COL_NA },
+    { name: "CONVERSATIONAL", rows: convRows, subtotal_displaced_min: rowSum(convRows),
+      subtotal_engaged_min: sumNullable(convRows.map(r => r.engaged_min)),
+      subtotal_nar_min:     sumNullable(convRows.map(r => r.nar_min)) },
+    { name: "EXPLICIT", rows: explRows, subtotal_displaced_min: rowSum(explRows),
+      subtotal_engaged_min: null, subtotal_nar_min: null },
+    { name: "AUTONOMOUS", rows: autoRows, subtotal_displaced_min: rowSum(autoRows),
+      subtotal_engaged_min: null, subtotal_nar_min: null },
   ];
-  return { groups, total_displaced_min: groups.reduce((s, g) => s + g.subtotal_displaced_min, 0), engaged: LEDGER_COL_NA, nar: LEDGER_COL_NA };
+  return {
+    groups,
+    total_displaced_min: groups.reduce((s, g) => s + g.subtotal_displaced_min, 0),
+    total_engaged_min: sumNullable(groups.map(g => g.subtotal_engaged_min)),
+    total_nar_min:     sumNullable(groups.map(g => g.subtotal_nar_min)),
+  };
 }
 
-/** Rendered once below section 03 column headers to explain the em-dash columns. */
-export const LEDGER_PER_ITEM_NOTE = "Per-session engaged and NAR attribution is not yet computed — columns show —." as const;
+/** Note rendered below section 03 column headers: names which row types carry no measurement. */
+export const LEDGER_PER_ITEM_NOTE = "Chore runs and desk decisions carry no per-session engagement measurement — their ENGAGED and NAR columns show —." as const;
 
-/** Rendered once in section 02 to explain the em-dash allocation rows. */
-export const ALLOCATION_UNAVAILABLE_NOTE = "Allocation (work / life split) is not yet computed — all rows show —." as const;
+// ── Section 02 bar geometry ───────────────────────────────────────────────────
+
+export interface AllocationBarWidths { work: number; life: number; unallocated: number }
+
+/** Compute bar-track fill widths (0–100%) for the three allocation rows.
+ *  Each row's width is proportional to its displaced_hours, scaled to the
+ *  largest of the three. An all-zero allocation produces all-zero widths
+ *  (empty tracks) — absence stays legible rather than vanishing.
+ *  Safe to call with null / undefined. */
+export function deriveAllocationBarWidths(
+  allocation: AllocationBlock | null | undefined,
+): AllocationBarWidths {
+  if (!allocation) return { work: 0, life: 0, unallocated: 0 };
+  const maxDisp = Math.max(
+    allocation.work.displaced_hours,
+    allocation.life.displaced_hours,
+    allocation.unallocated.displaced_hours,
+    0.001,
+  );
+  return {
+    work:        (allocation.work.displaced_hours        / maxDisp) * 100,
+    life:        (allocation.life.displaced_hours        / maxDisp) * 100,
+    unallocated: (allocation.unallocated.displaced_hours / maxDisp) * 100,
+  };
+}
 
 // ── Section 01 bar geometry ───────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- **Section 02 (Where It Went):** Replace three hardcoded em-dash rows with real `allocation.{work,life,unallocated}` data. Each row renders `displaced_hours`, `engaged_hours`, `interruption_hours`, and `nar_hours`. The horizontal bar track is proportional to `displaced_hours` relative to the largest bucket; the track draws empty when zero, not hidden. `ALLOCATION_UNAVAILABLE_NOTE` removed. Reconciliation footnote from `allocation_reconciliation` renders when present, with a plain-English note explaining that per-session and whole-day burst clustering measure different scopes.
- **Section 03 (The Ledger):** Replace `LEDGER_COL_NA` sentinels with `engaged_min: number | null` and `nar_min: number | null` per row. `sumNullable` sums only non-null rows; all-null groups produce `null` ("—"), never `0.0`. ENGAGED/NAR subtotals and TOTAL follow the same rule. `LEDGER_PER_ITEM_NOTE` updated to name which rows carry no measurement (chore runs and desk decisions).
- **7 new/fixed tests** in `attentionCore.test.ts` (72/72 pass), covering null-item null propagation, all-null group → null subtotal, mixed-null sum, allocation figure preservation, bar width proportionality, all-zero empty tracks, and reconciliation non-zero difference.

Scope: 277 total LOC changed (221 insertions, 56 deletions) — under the 300 cap.

References #584.

## Smoke evidence

Run locally from worktree `agent-ad378c86007d73711`:

```
cd packages/web && npx tsx --test src/dashboard/attentionCore.test.ts
```

```
TAP version 13
ok 1 - unrated: carries note=no_rate_established on every entry
ok 2 - unrated: empty → []
ok 3 - unrated: null-tolerant
...
ok 65 - ledger: item with engaged_minutes null → engaged_min and nar_min are null (not zero)
ok 66 - ledger: all-null group yields null subtotal, never 0
ok 67 - ledger: mixed group sums only measured rows, skips nulls
ok 68 - allocation: interruption_hours is non-zero only in unallocated; work and life carry zero
ok 69 - allocation bar widths: proportional to displaced, largest row gets 100%
ok 70 - allocation bar widths: all-zero → all widths zero (empty tracks still drawn)
ok 71 - reconciliation: difference_hours is non-zero when the two engaged measures disagree
ok 72 - deriveLedger reads display_minutes from normalised items — never NaN
1..72
# tests 72
# pass 72
# fail 0
# duration_ms 82.023416
```

Gate output: `✓ lane III (web) gate passed — 277 LOC, 3 files, verify ok`

UI smoke: needs a live staging pass. This lane renders data that only flows from the backend when the ctrl-api `/api/v1/attention/:date/statement` route returns populated `allocation` and `allocation_reconciliation` blocks (not yet deployed). Local unit tests cover all derivation logic. A click-through pass on staging once ctrl-api ships the allocation backend will close the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)