### PR TITLE
fix(web): red main — attentionCore test fixture missing engaged_minutes/nar_minutes (#584)

### DIFF
--- a/packages/web/src/dashboard/AttentionPage.tsx
+++ b/packages/web/src/dashboard/AttentionPage.tsx
@@ -208,7 +208,7 @@ function DayView({ day, recomp, running }: { day: AttentionDayViewModel; recomp(
             </div>
             {[fh(bucket?.displaced_hours), fh(bucket?.engaged_hours),
               fh(bucket?.interruption_hours), fh(bucket?.nar_hours)].map((v, ci) => (
-              <span key={ci} className="font-mono text-[9px] tabular-nums text-right" style={{ opacity: bucket != null ? 0.75 : 0.35 }}>{v}</span>
+              <span key={ci} className="font-mono text-[14px] tabular-nums text-right" style={{ opacity: bucket != null ? 0.85 : 0.35 }}>{v}</span>
             ))}
           </div>
         );
@@ -290,7 +290,7 @@ function DayView({ day, recomp, running }: { day: AttentionDayViewModel; recomp(
       {/* Rate card — stay visible so every figure is recomputable by hand */}
       {day.rates != null && (
         <div className="mt-8 pt-4" style={{ borderTop: "1px solid var(--rule)" }}>
-          <p className="font-mono text-[9px] uppercase tracking-[0.22em] mb-1.5" style={{ color: "var(--marginalia)" }}>
+          <p className="font-mono text-[10px] uppercase tracking-[0.22em] mb-1.5" style={{ color: "var(--marginalia)" }}>
             Rate card in force
           </p>
           <div className="flex flex-wrap gap-x-6 gap-y-0.5 font-mono text-[10px]" style={{ color: "var(--marginalia)" }}>
@@ -303,10 +303,10 @@ function DayView({ day, recomp, running }: { day: AttentionDayViewModel; recomp(
 
       {/* FOOTER */}
       <div className="flex justify-between items-center mt-10 pt-2" style={{ borderTop: "1px solid var(--rule)" }}>
-        <span className="font-mono text-[9px] uppercase tracking-[0.22em]" style={{ color: "var(--marginalia)" }}>
+        <span className="font-mono text-[10px] uppercase tracking-[0.22em]" style={{ color: "var(--marginalia)" }}>
           Alfred Black · Attention Statement · {day.date}
         </span>
-        <span className="font-mono text-[9px] uppercase tracking-[0.22em]" style={{ color: "var(--marginalia)" }}>
+        <span className="font-mono text-[10px] uppercase tracking-[0.22em]" style={{ color: "var(--marginalia)" }}>
           Page 1 of 1
         </span>
       </div>
@@ -427,7 +427,7 @@ export default function AttentionPage() {
                 <img src={logoCurrentcolor} alt="" className="h-7 w-auto" />
                 <span className="font-mono text-[11px] uppercase tracking-[0.2em]" style={{ color: "var(--brass)" }}>Alfred Black</span>
               </div>
-              <span className="font-mono text-[9px] uppercase tracking-[0.2em]" style={{ color: "var(--marginalia)" }}>
+              <span className="font-mono text-[10px] uppercase tracking-[0.2em]" style={{ color: "var(--marginalia)" }}>
                 {formatHeaderDate(date)}
               </span>
             </div>

--- a/packages/web/src/dashboard/attentionCore.test.ts
+++ b/packages/web/src/dashboard/attentionCore.test.ts
@@ -299,12 +299,19 @@ test("collapseAutonomousRows: null-safe → []", () => assert.deepEqual(collapse
 // deriveLedger consumes the NORMALISED view model, not the raw response —
 // normalizeAttentionDay has already run deriveInferredDisplay. Fixtures must
 // therefore be display items carrying display_minutes, not raw minutes.
-const mkInferred = (label: string, minutes: number, outcome?: string): InferredDisplayItem => {
+const mkInferred = (
+  label: string, minutes: number, outcome?: string, engaged: number | null = null,
+): InferredDisplayItem => {
   const failed = outcome !== undefined && outcome !== "delivered";
   return {
     label, bucket: "M", claimed_minutes: minutes, display_minutes: failed ? 0 : minutes,
     evidence_kind: "session", evidence_ref: "s", outcome: outcome ?? "delivered",
     is_blocked: failed, blocked_reason: failed ? `${outcome} — no displacement credit` : null,
+    // Default to unmeasured. NAR follows displayed displacement, so a failed
+    // session with measured engagement is correctly negative — it cost
+    // attention and returned none.
+    engaged_minutes: engaged,
+    nar_minutes: engaged === null ? null : (failed ? 0 : minutes) - engaged,
   };
 };
 


### PR DESCRIPTION
`wasp build` is failing on main at `1bd86b5d`:

```
src/dashboard/attentionCore.test.ts(304,3): error TS2739:
  Type '{ ... }' is missing the following properties from
  type 'InferredDisplayItem': engaged_minutes, nar_minutes
```

#624 added the two fields to `InferredDisplayItem` and did not update the
`mkInferred` fixture. The suite stayed 72/72 green because `tsx --test`
strips types instead of checking them — the same gap that produced the two
previous red mains on this feature, tracked as #615.

The fixture now takes an optional engagement argument and derives NAR from
the **displayed** displacement, so a failed session carrying measured
engagement comes out negative rather than positive. Default stays `null`, so
existing cases remain unmeasured rather than quietly becoming zero.

Also in this commit: section 02's allocation figures were left at the 9px
marginalia scale when the ledger moved to 14px. They are the primary numbers
in that block, so they now match the ledger. The genuinely-chrome labels
(rate card heading, footer) go 9px → 10px.

## Smoke evidence

```
# tests 72
# pass 72
# fail 0

tsc --noEmit --strict on attentionCore.ts + attentionCore.test.ts:
  only TS2307 for node:test / node:assert (no @types/node in the ad-hoc
  invocation) — the TS2739 shape error is gone.
```

Real verification is the `build-web` run on the merge commit; this cannot be
proven green locally without a full `wasp build`.