### PR TITLE
ci: type-check the web app on PRs, not after the merge (#615)

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -6,9 +6,12 @@
 #   * shellcheck         — scripts/bootstrap.sh
 #
 # Runs on every PR and on push to main. Does NOT build or deploy images
-# (that is the build-*.yml workflows' job). The Wasp web app is type-checked
-# by build-web.yml's `wasp build` — bare `tsc` cannot resolve the generated
-# `wasp/*` modules without Wasp codegen, so it is not checked here.
+# (that is the build-*.yml workflows' job). The Wasp web app is not checked
+# here — bare `tsc` cannot resolve the generated `wasp/*` modules without
+# Wasp codegen. It is type-checked on PRs by typecheck-web.yml, which runs
+# the real `wasp build`. Until #615 that check lived only in build-web.yml,
+# i.e. after the merge, so a type error could not be caught before it broke
+# main.
 name: ci-check
 
 on:

--- a/.github/workflows/typecheck-web.yml
+++ b/.github/workflows/typecheck-web.yml
@@ -1,0 +1,59 @@
+# Type-check the Wasp web app on pull requests.
+#
+# WHY THIS EXISTS (#615). `packages/web` had no type gate before merge. The
+# unit suites run under `tsx --test`, which STRIPS types rather than checking
+# them, so a file that cannot compile still reports every test green. The only
+# real type check was `wasp build` inside build-web.yml — and that runs on
+# PUSH TO MAIN, i.e. after the merge. The failure mode is therefore:
+#
+#   PR is green  →  merge  →  main goes red  →  no image is published
+#
+# which happened three times in one afternoon on a single feature (#584),
+# each time costing a build-and-deploy cycle and leaving main unable to ship.
+#
+# Bare `tsc --noEmit` is NOT a substitute: it cannot resolve the generated
+# `wasp/*` modules without Wasp codegen, which is exactly why ci-check.yml
+# skips web. `wasp build` is the only thing that type-checks this package, so
+# this workflow runs it — the same command, moved to where it can still
+# prevent the merge.
+#
+# It duplicates work build-web.yml does later. That is deliberate: a few
+# minutes of runner time per web PR is cheaper than a red main.
+#
+# To make this binding, add `typecheck-web` to the branch-protection required
+# checks for main. Without that it reports but does not block.
+name: typecheck-web
+
+on:
+  pull_request:
+    paths:
+      - "packages/web/**"
+      - ".github/workflows/typecheck-web.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: typecheck-web-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck-web:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install Wasp
+        # Keep this version pinned to the one build-web.yml uses. A drift here
+        # means the gate checks against a different compiler than the one that
+        # publishes the image, which would let the same class of error through.
+        run: curl -sSL https://get.wasp.sh/installer.sh | sh -s -- -v 0.19.0
+
+      - name: wasp build (type check)
+        working-directory: packages/web
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          wasp build


### PR DESCRIPTION
Closes #615.

## The gap

`packages/web` has no type gate before merge:

- its unit suites run under `tsx --test`, which **strips** types rather than
  checking them — a file that cannot compile still reports every test green;
- `ci-check.yml` deliberately skips web, because bare `tsc` cannot resolve the
  generated `wasp/*` modules without codegen;
- the only real type check is `wasp build` in `build-web.yml`, which triggers
  on **push to main**.

So: PR green → merge → main red → no image published.

Three times in one afternoon on #584 (#613, #614, and the fixture error that
followed #624). Each cost a build-and-deploy cycle and left main unable to
ship. I also reviewed two of those diffs by eye before merging and missed one,
which is the argument for a gate rather than more care.

## The change

`typecheck-web.yml` runs `wasp build` on PRs touching `packages/web`. Same
command as the publish path, moved to where it can still prevent the merge.
The Wasp version is pinned to build-web.yml's — drift would mean gating
against a different compiler than the one that ships.

It duplicates work build-web.yml does later, deliberately. A few minutes of
runner time per web PR is cheaper than a red main.

Also corrects `ci-check.yml`'s header, which stated the web app "is
type-checked by build-web.yml's `wasp build`" — true, but it read as a
considered arrangement rather than a hole, which is part of why it survived.

## Smoke evidence

```
python3 -c "import yaml; yaml.safe_load(open(...))"  → both workflows parse
```

The workflow itself is exercised by this PR only if it touches
`packages/web`, which it does not — so it will first run on the next web PR.
I have not faked evidence of it firing.

**Operator step:** add `typecheck-web` to the branch-protection required
checks for `main`. Until then it reports but does not block.