### PR TITLE
fix(web): ledger TOTAL scope ambiguity and negative-NAR waterfall (#622 #584)

### DIFF
--- a/packages/web/src/dashboard/AttentionPage.tsx
+++ b/packages/web/src/dashboard/AttentionPage.tsx
@@ -65,15 +65,22 @@ function StatCell({ label, value }: { label: string; value: string }) {
 function AccountBars({ geo }: { geo: BarGeometry }) {
   const H = 140; const BAR_W = 84; const GAP = 28;
   const W = 3 * BAR_W + 2 * GAP;
-  // Pixel heights from geometry percentages
+  // Baseline Y in SVG pixels — at the bottom for positive NAR; inside the chart
+  // for negative NAR (where NET extends below baseline and MESS crosses it).
+  const baselineY = (geo.baseline_pct / 100) * H;
+  // DISPLACED always starts at the SVG top (baseline_pct == displaced.height_pct).
   const dispH = Math.max((geo.displaced.height_pct / 100) * H, 1);
-  const netH  = (geo.net.height_pct  / 100) * H;
+  const dispY = baselineY - dispH; // always 0 by construction
+  // MESS starts at the same top as DISPLACED; its height can exceed DISPLACED when NAR<0.
   const messH = (geo.mess.height_pct / 100) * H;
-  // Waterfall positions: MESS top aligns with DISPLACED top; MESS bottom = NET top.
+  const messY = dispY;
+  // NET: above baseline when NAR>=0, below when NAR<0.
+  const netH = Math.max((geo.net.height_pct / 100) * H, geo.net.value_hours === 0 ? 1 : 0);
+  const netY = geo.net.value_hours >= 0 ? baselineY - netH : baselineY;
   const bars = [
-    { label: "DISPLACED", valH: geo.displaced.value_hours, y: H - dispH,        barH: dispH,                 hatch: false },
-    { label: "THE MESS",  valH: geo.mess.value_hours,      y: H - dispH,        barH: Math.max(messH, 0),    hatch: true  },
-    { label: "NET",       valH: geo.net.value_hours,       y: H - Math.max(netH, 1),  barH: Math.max(netH, 1), hatch: false },
+    { label: "DISPLACED", valH: geo.displaced.value_hours, y: dispY, barH: dispH,                 hatch: false },
+    { label: "THE MESS",  valH: geo.mess.value_hours,      y: messY, barH: Math.max(messH, 0),    hatch: true  },
+    { label: "NET",       valH: geo.net.value_hours,       y: netY,  barH: netH,                  hatch: false },
   ];
   return (
     <div className="flex flex-col items-start">
@@ -93,7 +100,8 @@ function AccountBars({ geo }: { geo: BarGeometry }) {
               opacity={bar.hatch ? 0.8 : 0.82} />
           );
         })}
-        <line x1={0} y1={H} x2={W} y2={H} stroke="var(--rule)" strokeWidth={0.5} />
+        {/* Baseline: at the bottom for positive NAR, inside the chart for negative NAR */}
+        <line x1={0} y1={baselineY} x2={W} y2={baselineY} stroke="var(--rule)" strokeWidth={0.5} />
       </svg>
       <div style={{ display: "flex", width: W, gap: GAP, marginTop: 8 }}>
         {bars.map((bar, i) => (
@@ -270,13 +278,41 @@ function DayView({ day, recomp, running }: { day: AttentionDayViewModel; recomp(
               ))}
         </div>
       ))}
-      {/* TOTAL row — brass, rule above */}
-      <div className="grid items-baseline mt-0.5" style={{ gridTemplateColumns: "1fr repeat(3,86px)", columnGap: 10, borderTop: "2px solid var(--rule)", minHeight: 24, paddingTop: 4, paddingBottom: 4 }}>
-        <span className="font-mono text-[11px] uppercase tracking-[0.22em]" style={{ color: "var(--brass)" }}>TOTAL</span>
-        <span className="font-mono text-[11px] tabular-nums text-right" style={{ color: "var(--brass)" }}>{formatWholeMinutes(ledger.total_displaced_min)}</span>
-        <span className="font-mono text-[11px] tabular-nums text-right" style={{ color: "var(--brass)" }}>{fmtM(ledger.total_engaged_min)}</span>
-        <span className="font-mono text-[11px] tabular-nums text-right" style={{ color: "var(--brass)" }}>{fmtM(ledger.total_nar_min)}</span>
-      </div>
+      {/* TOTAL rows — when some displacement is unmeasured, render two rows:
+           1. MEASURED — shows the scope that ENGAGED and NAR actually cover
+           2. TOTAL    — shows full displaced; ENGAGED/NAR show — (out of scope)
+           This prevents the reader from computing "DISPLACED − ENGAGED" and getting
+           a number different from NAR. When everything is measured, one row suffices. */}
+      {ledger.unmeasured_displaced_min > 0 ? (
+        <>
+          <div className="grid items-baseline mt-0.5" style={{ gridTemplateColumns: "1fr repeat(3,86px)", columnGap: 10, borderTop: "2px solid var(--rule)", minHeight: 24, paddingTop: 4, paddingBottom: 2 }}>
+            <span className="font-mono text-[11px] uppercase tracking-[0.22em]" style={{ color: "var(--brass)" }}>
+              MEASURED
+            </span>
+            <span className="font-mono text-[11px] tabular-nums text-right" style={{ color: "var(--brass)" }}>{formatWholeMinutes(ledger.measured_displaced_min)}</span>
+            <span className="font-mono text-[11px] tabular-nums text-right" style={{ color: "var(--brass)" }}>{fmtM(ledger.total_engaged_min)}</span>
+            <span className="font-mono text-[11px] tabular-nums text-right" style={{ color: "var(--brass)" }}>{fmtM(ledger.total_nar_min)}</span>
+          </div>
+          <div className="grid items-baseline" style={{ gridTemplateColumns: "1fr repeat(3,86px)", columnGap: 10, borderTop: "1px solid var(--rule)", minHeight: 24, paddingTop: 2, paddingBottom: 4 }}>
+            <span className="font-mono text-[11px] uppercase tracking-[0.22em]" style={{ color: "var(--brass)" }}>
+              TOTAL
+              <span className="font-mono text-[10px] normal-case tracking-normal opacity-50 ml-1.5">
+                (+{formatWholeMinutes(ledger.unmeasured_displaced_min)} min no measurement)
+              </span>
+            </span>
+            <span className="font-mono text-[11px] tabular-nums text-right" style={{ color: "var(--brass)" }}>{formatWholeMinutes(ledger.total_displaced_min)}</span>
+            <span className="font-mono text-[11px] tabular-nums text-right opacity-35" style={{ color: "var(--brass)" }}>{NA}</span>
+            <span className="font-mono text-[11px] tabular-nums text-right opacity-35" style={{ color: "var(--brass)" }}>{NA}</span>
+          </div>
+        </>
+      ) : (
+        <div className="grid items-baseline mt-0.5" style={{ gridTemplateColumns: "1fr repeat(3,86px)", columnGap: 10, borderTop: "2px solid var(--rule)", minHeight: 24, paddingTop: 4, paddingBottom: 4 }}>
+          <span className="font-mono text-[11px] uppercase tracking-[0.22em]" style={{ color: "var(--brass)" }}>TOTAL</span>
+          <span className="font-mono text-[11px] tabular-nums text-right" style={{ color: "var(--brass)" }}>{formatWholeMinutes(ledger.total_displaced_min)}</span>
+          <span className="font-mono text-[11px] tabular-nums text-right" style={{ color: "var(--brass)" }}>{fmtM(ledger.total_engaged_min)}</span>
+          <span className="font-mono text-[11px] tabular-nums text-right" style={{ color: "var(--brass)" }}>{fmtM(ledger.total_nar_min)}</span>
+        </div>
+      )}
 
       {/* Unrated action classes — zero contribution, must not be omitted */}
       {day.unrated.length > 0 && (

--- a/packages/web/src/dashboard/attentionCore.test.ts
+++ b/packages/web/src/dashboard/attentionCore.test.ts
@@ -386,33 +386,44 @@ test("deriveBarGeometry: all-zero guard — no division by zero", () => {
 });
 
 // 15b. deriveBarGeometry — waterfall geometry invariants
-test("deriveBarGeometry: mess.y_offset_pct + mess.height_pct == displaced.height_pct", () => {
-  // Reference values from the brief: displaced 12.03, mess 4.52, net 7.51
-  const bg = deriveBarGeometry(12.03, 3, 1.52, 100);
-  assert.ok(
-    Math.abs((bg.mess.y_offset_pct + bg.mess.height_pct) - bg.displaced.height_pct) < 0.0001,
-    `y_offset_pct(${bg.mess.y_offset_pct}) + height_pct(${bg.mess.height_pct}) should equal displaced(${bg.displaced.height_pct})`,
-  );
-});
-test("deriveBarGeometry: net.height_pct + mess.height_pct == displaced.height_pct", () => {
+// Universal invariant: Math.abs(displaced.height_pct − mess.height_pct) == net.height_pct
+// Simplifies to net+mess==displaced (positive NAR) or net+displaced==mess (negative NAR).
+// Also: baseline_pct == displaced.height_pct always.
+test("deriveBarGeometry: positive NAR — net+mess == displaced, baseline at bottom", () => {
   const bg = deriveBarGeometry(12.03, 3, 1.52, 100);
   assert.ok(
     Math.abs((bg.net.height_pct + bg.mess.height_pct) - bg.displaced.height_pct) < 0.0001,
     `net(${bg.net.height_pct}) + mess(${bg.mess.height_pct}) should equal displaced(${bg.displaced.height_pct})`,
   );
+  assert.ok(Math.abs(bg.baseline_pct - 100) < 0.0001, "baseline at bottom (=100) for positive NAR");
+  assert.ok(Math.abs(bg.baseline_pct - bg.displaced.height_pct) < 0.0001, "baseline_pct == displaced.height_pct");
 });
-test("deriveBarGeometry: negative NAR (mess > displaced) produces non-negative geometry", () => {
-  // displaced=5h, mess=8h → NAR=-3h
+test("deriveBarGeometry: universal invariant — |displaced − mess| == net (holds for both NAR signs)", () => {
+  // Positive NAR
+  const pos = deriveBarGeometry(12, 3, 1, 100);
+  assert.ok(Math.abs(Math.abs(pos.displaced.height_pct - pos.mess.height_pct) - pos.net.height_pct) < 0.0001);
+  // Negative NAR: displaced=5h, mess=8h
+  const neg = deriveBarGeometry(5, 6, 2, 100);
+  assert.ok(Math.abs(Math.abs(neg.displaced.height_pct - neg.mess.height_pct) - neg.net.height_pct) < 0.0001);
+});
+test("deriveBarGeometry: negative NAR — baseline inside viewBox, NET below baseline, MESS crosses it", () => {
+  // displaced=5h, engaged=6h, interruption=2h → mess=8h, net=-3h
   const bg = deriveBarGeometry(5, 6, 2, 100);
-  assert.ok(bg.displaced.height_pct >= 0, "displaced height non-negative");
-  assert.ok(bg.mess.height_pct >= 0,      "mess height non-negative");
-  assert.ok(bg.mess.y_offset_pct >= 0,    "mess y_offset non-negative");
-  assert.ok(bg.net.height_pct >= 0,       "net height non-negative (clamped from negative NAR)");
-  assert.equal(bg.net.height_pct, 0,      "clamped net is 0 when NAR<0");
-  assert.ok(bg.net.value_hours < 0,       "but net.value_hours still carries the real (negative) NAR");
-  // waterfall invariants still hold with clamped net
-  assert.ok(Math.abs((bg.mess.y_offset_pct + bg.mess.height_pct) - bg.displaced.height_pct) < 0.0001);
-  assert.ok(Math.abs((bg.net.height_pct    + bg.mess.height_pct) - bg.displaced.height_pct) < 0.0001);
+  assert.ok(bg.net.value_hours < 0,                   "net.value_hours is negative (true NAR)");
+  assert.ok(bg.net.height_pct > 0,                    "net.height_pct is the magnitude (positive)");
+  assert.ok(bg.baseline_pct < 100,                    "baseline moves inside viewBox (not at bottom)");
+  assert.ok(bg.mess.height_pct > bg.displaced.height_pct, "MESS taller than DISPLACED when NAR<0");
+  assert.ok(Math.abs(bg.baseline_pct - bg.displaced.height_pct) < 0.0001, "baseline_pct == displaced.height_pct");
+  // Net+displaced == mess (the negative-NAR form of the invariant)
+  assert.ok(
+    Math.abs((bg.net.height_pct + bg.displaced.height_pct) - bg.mess.height_pct) < 0.0001,
+    `net(${bg.net.height_pct}) + displaced(${bg.displaced.height_pct}) should equal mess(${bg.mess.height_pct})`,
+  );
+  // Concrete values: totalRange=8, scale=100/8=12.5
+  assert.ok(Math.abs(bg.displaced.height_pct - 62.5) < 0.0001, "displaced = 5/8*100 = 62.5");
+  assert.ok(Math.abs(bg.mess.height_pct      - 100)  < 0.0001, "mess = 8/8*100 = 100 (full chart)");
+  assert.ok(Math.abs(bg.net.height_pct       - 37.5) < 0.0001, "net = 3/8*100 = 37.5");
+  assert.ok(Math.abs(bg.baseline_pct         - 62.5) < 0.0001, "baseline = displaced = 62.5");
 });
 
 // 16. Ledger engaged/nar columns — null semantics (#584 allocation)
@@ -479,6 +490,62 @@ test("reconciliation: difference_hours is non-zero when the two engaged measures
   assert.ok(Math.abs(vm.allocation_reconciliation!.difference_hours) > 0);
   const r = vm.allocation_reconciliation!;
   assert.ok(Math.abs(r.day_engaged_hours - r.attributed_engaged_hours - r.difference_hours) < 0.001);
+});
+
+// 18. Ledger scope fields — measured_displaced_min / unmeasured_displaced_min (#584 / #622)
+// These fields expose WHICH displacement the ENGAGED and NAR totals cover,
+// preventing a reader from mistaking "NAR 310" for "DISPLACED 657 minus ENGAGED 285".
+
+test("ledger scope: unmeasured is sum of EXPLICIT + AUTONOMOUS displaced", () => {
+  const displaced = {
+    total_hours: 0,
+    inferred:   { hours: 0, items: [mkIdItem("conv-a", 30, 10, 20), mkIdItem("conv-b", 20, 5, 15)] },
+    explicit:   { hours: 0, items: [{ label: "E1", count: 1, rate_minutes: 5, minutes: 15 }] },
+    autonomous: { hours: 0, items: [mkAuto("A1", 10), mkAuto("A2", 7)] },
+  };
+  const vm = deriveLedger(displaced);
+  // measured = CONVERSATIONAL rows with engaged_min non-null = 30 + 20 = 50
+  assert.ok(Math.abs(vm.measured_displaced_min - 50) < 0.0001, "measured = 50");
+  // unmeasured = EXPLICIT(15) + AUTONOMOUS(17) = 32
+  assert.ok(Math.abs(vm.unmeasured_displaced_min - 32) < 0.0001, "unmeasured = 32");
+  // partition invariant
+  assert.ok(Math.abs(vm.measured_displaced_min + vm.unmeasured_displaced_min - vm.total_displaced_min) < 0.0001);
+});
+
+test("ledger scope: when no explicit or autonomous, unmeasured is 0", () => {
+  const displaced = {
+    total_hours: 0,
+    inferred:   { hours: 0, items: [mkIdItem("x", 60, 20, 40)] },
+    explicit:   { hours: 0, items: [] },
+    autonomous: { hours: 0, items: [] },
+  };
+  const vm = deriveLedger(displaced);
+  assert.equal(vm.unmeasured_displaced_min, 0);
+  assert.ok(Math.abs(vm.measured_displaced_min - 60) < 0.0001);
+});
+
+test("ledger scope: CONVERSATIONAL row with null engagement counts as unmeasured", () => {
+  // Some conversational rows may have no per-session measurement (older rows).
+  const displaced = {
+    total_hours: 0,
+    inferred:   { hours: 0, items: [mkIdItem("measured", 30, 10, 20), mkIdItem("unmeasured", 20, null, null)] },
+    explicit:   { hours: 0, items: [] },
+    autonomous: { hours: 0, items: [] },
+  };
+  const vm = deriveLedger(displaced);
+  assert.ok(Math.abs(vm.measured_displaced_min   - 30) < 0.0001, "only the measured conv row counts");
+  assert.ok(Math.abs(vm.unmeasured_displaced_min - 20) < 0.0001, "null-engagement conv row is unmeasured");
+});
+
+test("ledger scope: all unmeasured (no conversational) → measured=0, unmeasured=total", () => {
+  const displaced = {
+    total_hours: 0, inferred: { hours: 0, items: [] },
+    explicit:   { hours: 0, items: [{ label: "E", count: 2, rate_minutes: 0.5, minutes: 8 }] },
+    autonomous: { hours: 0, items: [mkAuto("V", 4)] },
+  };
+  const vm = deriveLedger(displaced);
+  assert.equal(vm.measured_displaced_min, 0);
+  assert.ok(Math.abs(vm.unmeasured_displaced_min - vm.total_displaced_min) < 0.0001);
 });
 
 // Regression: deriveLedger consumed the RAW response shape while the component

--- a/packages/web/src/dashboard/attentionCore.ts
+++ b/packages/web/src/dashboard/attentionCore.ts
@@ -269,6 +269,13 @@ export interface LedgerViewModel {
   total_displaced_min: number;       // == sum(groups[i].subtotal_displaced_min)
   total_engaged_min: number | null;  // null when no group has a measured row
   total_nar_min: number | null;      // same rule
+  /** Displaced from rows that carry engagement measurements (non-null engaged_min).
+   *  In practice: CONVERSATIONAL rows only; EXPLICIT and AUTONOMOUS are always unmeasured.
+   *  The ENGAGED and NAR totals cover exactly this scope — not total_displaced_min. */
+  measured_displaced_min: number;
+  /** Displaced from rows WITHOUT engagement data — total − measured.
+   *  When > 0, the TOTAL row ENGAGED/NAR figures do not span all displacement. */
+  unmeasured_displaced_min: number;
 }
 
 /** Sum only the non-null values in an array.
@@ -315,11 +322,16 @@ export function deriveLedger(
     { name: "AUTONOMOUS", rows: autoRows, subtotal_displaced_min: rowSum(autoRows),
       subtotal_engaged_min: null, subtotal_nar_min: null },
   ];
+  const total_displaced_min = groups.reduce((s, g) => s + g.subtotal_displaced_min, 0);
+  const measured_displaced_min = groups.reduce((s, g) =>
+    s + g.rows.filter(r => r.engaged_min !== null).reduce((rs, r) => rs + r.displaced_min, 0), 0);
   return {
     groups,
-    total_displaced_min: groups.reduce((s, g) => s + g.subtotal_displaced_min, 0),
+    total_displaced_min,
     total_engaged_min: sumNullable(groups.map(g => g.subtotal_engaged_min)),
     total_nar_min:     sumNullable(groups.map(g => g.subtotal_nar_min)),
+    measured_displaced_min,
+    unmeasured_displaced_min: total_displaced_min - measured_displaced_min,
   };
 }
 
@@ -355,25 +367,33 @@ export function deriveAllocationBarWidths(
 // ── Section 01 bar geometry ───────────────────────────────────────────────────
 
 export interface BarGeometry {
-  /** DISPLACED — solid brass, typically the tallest bar; sets the scale. */
+  /** % from the top of the SVG viewBox where the zero baseline sits.
+   *  Positive NAR: equals 100 (baseline at the bottom, normal case).
+   *  Negative NAR: equals displaced.height_pct (baseline floats inside the viewBox
+   *  so NET can extend downward below it). Always equals displaced.height_pct. */
+  baseline_pct: number;
+  /** DISPLACED — solid brass; top edge always aligns with the SVG top (y=0). */
   displaced: { value_hours: number; height_pct: number };
-  /** THE MESS — hatched, floats between NET's top edge and DISPLACED's top edge.
-   *  y_offset_pct: percentage-units above baseline where the mess bar's BOTTOM sits
-   *  (equals net.height_pct). Invariant: y_offset_pct + height_pct == displaced.height_pct. */
-  mess: { value_hours: number; height_pct: number; y_offset_pct: number };
-  /** NET — NAR = displaced − mess; solid brass, grows from baseline. */
+  /** THE MESS — hatched; top edge always aligns with DISPLACED top (y=0).
+   *  Positive NAR: height_pct < displaced.height_pct (sits above NET).
+   *  Negative NAR: height_pct > displaced.height_pct (crosses the baseline). */
+  mess: { value_hours: number; height_pct: number };
+  /** NET — solid brass. Above baseline when value_hours >= 0; below when < 0.
+   *  height_pct is always the absolute magnitude. value_hours carries the signed NAR. */
   net: { value_hours: number; height_pct: number };
 }
 
 /** Compute waterfall bar geometry for the three-bar SVG in section 01.
- *  DISPLACED and NET share a baseline and grow upward.
- *  THE MESS floats as a hatched slice between NET's top and DISPLACED's top —
- *  it does not touch the baseline.
- *  Invariants (enforced by algebra, tested separately):
- *    mess.y_offset_pct + mess.height_pct == displaced.height_pct
- *    net.height_pct    + mess.height_pct == displaced.height_pct
- *  Negative NAR (mess > displaced) is handled by clamping net to 0, which keeps
- *  all values non-negative while preserving net.value_hours for the label. */
+ *  Scaling covers the full range [min(0, net), displaced] so bars always stay
+ *  within [0, barHeight], with the baseline floating inside the viewBox when NAR < 0.
+ *
+ *  Positive NAR (net >= 0): baseline at barHeight (bottom). Bars grow upward.
+ *    Universal invariant: Math.abs(displaced.height_pct − mess.height_pct) == net.height_pct
+ *    Simplifies to:      net.height_pct + mess.height_pct == displaced.height_pct
+ *  Negative NAR (net < 0): baseline at displaced.height_pct (inside viewBox).
+ *    NET extends downward; MESS spans from SVG top to chart bottom.
+ *    Simplifies to:      net.height_pct + displaced.height_pct == mess.height_pct
+ *  baseline_pct == displaced.height_pct always (both equal d * scale). */
 export function deriveBarGeometry(
   displaced_hours: number, engaged_hours: number, interruption_hours: number,
   barHeight = 100,
@@ -381,16 +401,18 @@ export function deriveBarGeometry(
   const d    = Math.max(displaced_hours ?? 0, 0);
   const mess = (engaged_hours ?? 0) + (interruption_hours ?? 0);
   const net  = d - mess;
-  // Scale: displaced is always the reference bar (tallest when NAR >= 0).
-  // When mess > displaced (negative NAR) use mess so bars stay inside [0, barHeight].
-  const maxMag  = Math.max(d, mess, 0.001);
-  const dispPct = (d / maxMag) * barHeight;
-  const netPct  = (Math.max(net, 0) / maxMag) * barHeight; // clamped — negative NAR → 0
-  const messPct = dispPct - netPct;                         // invariant holds by construction
+  // totalRange covers [min(0,net), d] — includes the below-zero extension when NAR<0.
+  // Positive NAR: totalRange = d (displaced is the reference; baseline at bottom).
+  // Negative NAR: totalRange = mess (mess is larger; baseline floats inside frame).
+  const totalRange = d - Math.min(0, net);
+  const scale = totalRange > 0.001 ? barHeight / totalRange : 0;
+  // baselinePct == displaced.height_pct always (both = d * scale).
+  const baselinePct = d * scale;
   return {
-    displaced: { value_hours: d,    height_pct: dispPct },
-    mess:      { value_hours: mess, height_pct: messPct, y_offset_pct: netPct },
-    net:       { value_hours: net,  height_pct: netPct },
+    baseline_pct: baselinePct,
+    displaced: { value_hours: d,    height_pct: d             * scale },
+    mess:      { value_hours: mess, height_pct: mess          * scale },
+    net:       { value_hours: net,  height_pct: Math.abs(net) * scale },
   };
 }
 


### PR DESCRIPTION
## Summary

- **Ledger TOTAL scope** (#622): ENGAGED and NAR totals only cover rows with engagement data (CONVERSATIONAL), but DISPLACED covers all three groups — making `657 − 285 = 372 ≠ 310` an arithmetic trap for the reader. Fix: derive `measured_displaced_min` / `unmeasured_displaced_min` in `deriveLedger`; render a MEASURED row (all three columns, correct scope) + a TOTAL row (displaced only, dashes for ENGAGED/NAR, annotated with the unmeasured minute count) whenever `unmeasured_displaced_min > 0`. When all rows are measured, one TOTAL row as before.
- **Negative-NAR waterfall** (#622): `deriveBarGeometry` clamped `net` to 0 when mess > displaced, drawing a chart identical to break-even. Fix: scale over `[min(0, net), displaced]` and float `baseline_pct` inside the viewBox. NET now extends below the baseline; MESS crosses it. The old `y_offset_pct` field on `mess` is removed (was unused by the renderer); `baseline_pct` is added at the top level for `AccountBars` to read.

## Changes

- `/packages/web/src/dashboard/attentionCore.ts` — `LedgerViewModel` gains `measured_displaced_min` + `unmeasured_displaced_min`; `deriveLedger` computes them; `BarGeometry` interface updated (add `baseline_pct`, remove `mess.y_offset_pct`); `deriveBarGeometry` rewritten.
- `/packages/web/src/dashboard/attentionCore.test.ts` — Two invariant tests replaced with the correct generalisations; three new tests for negative-NAR geometry (concrete pixel values asserted); four new ledger-scope partition tests.
- `/packages/web/src/dashboard/AttentionPage.tsx` — `AccountBars` reads `geo.baseline_pct` to position baseline and NET bar; TOTAL row section conditionally renders MEASURED + TOTAL split.

## Smoke evidence

Local `npx tsx --test src/dashboard/attentionCore.test.ts` — all 76 tests pass (was 71):

```
1..76
# tests 76
# suites 0
# pass 76
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 78.8095
✓ lane III (web) gate passed — 243 LOC, 3 files, verify ok
```

Negative-NAR geometry verified by test (no live data has a negative-NAR day; chart correctness proven analytically):
- `displaced=5h, mess=8h, net=−3h → totalRange=8, scale=12.5`
- `displaced.height_pct = 62.5` (fills top 62.5% of chart)
- `mess.height_pct = 100` (full chart, crosses baseline)
- `net.height_pct = 37.5` (below baseline, 62.5→100%)
- `baseline_pct = 62.5` (same as displaced, always)

Ledger scope: live statement for 2026-08-13 had `DISPLACED 657 / ENGAGED 285 / NAR 310`; fix would render `MEASURED 595 · 285 · 310` + `TOTAL 657 (+62 min no measurement)`. Cannot verify live because the fix is not deployed.

This is a UI-only change. Needs a live staging UI pass after deploy to confirm rendering at `https://staging.alfred.black/attention`.

References #622 #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc