### PR TITLE
fix(ctrl): exclude cli sessions from NAR engaged calculation (#584)

### DIFF
--- a/packages/ctrl/src/api/routes/attention.ts
+++ b/packages/ctrl/src/api/routes/attention.ts
@@ -48,6 +48,22 @@ import { dockerExec } from "../helpers.js";
 // right store.
 const ULID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
 
+// Human-authored Hermes session sources counted as principal attention in NAR.
+// Authorship rationale per docs/design/nar-method.md §2:
+//   slack    — messages arrive via the Slack channel integration; Sir typed them.
+//   telegram — messages arrive via the Telegram bot; Sir typed them.
+//   cli      — EXCLUDED: cli sessions are agent-driven one-shots (context-compressed
+//              task lists, vault reads, "gather…" instructions). Live data shows 177
+//              such sessions in June 2026, nearly all with a single user turn. Because
+//              clusterBursts applies a 2-minute floor per burst, isolated one-shot agent
+//              calls each became their own burst — inflating engaged by hours per month
+//              and pushing NAR down. Confirmed machine traffic; removed here.
+// Adding a new source requires confirming it is human-authored, not machine traffic.
+export const HUMAN_SESSION_SOURCES = ["slack", "telegram"] as const;
+
+// Precomputed IN-clause fragment — these are static string literals, safe to interpolate.
+const HUMAN_SOURCES_SQL = HUMAN_SESSION_SOURCES.map((s) => `'${s}'`).join(",");
+
 const NEEDS_ATTENTION_DIR = path.join(VAULT_PATH, "needs_attention");
 const EVENTS_DIR = path.join(VAULT_PATH, "event");
 
@@ -954,7 +970,7 @@ export function registerAttentionRoutes(): void {
         hsDb = new DatabaseSync(`file:${hsDbPath}?mode=ro`);
         hermesTs = (hsDb.prepare(
           `SELECT m.timestamp FROM messages m JOIN sessions s ON m.session_id=s.id
-           WHERE m.role='user' AND s.source IN ('slack','cli','telegram')
+           WHERE m.role='user' AND s.source IN (${HUMAN_SOURCES_SQL})
              AND s.parent_session_id IS NULL
              AND m.timestamp>=? AND m.timestamp<=?`,
         ).all(dayStartEp, dayEndEp) as Array<{ timestamp: number }>).map(r => r.timestamp);

--- a/packages/ctrl/tests/nar-entries.test.ts
+++ b/packages/ctrl/tests/nar-entries.test.ts
@@ -26,7 +26,7 @@ process.env.HERMES_CONFIG_DIR = path.join(tmp, "hermes-state");
 
 const { getStateDb } = await import("../src/db/state.js");
 const { registerStateRoutes } = await import("../src/api/routes/state.js");
-const { registerAttentionRoutes } = await import("../src/api/routes/attention.js");
+const { registerAttentionRoutes, HUMAN_SESSION_SOURCES } = await import("../src/api/routes/attention.js");
 const { matchRoute } = await import("../src/api/server.js");
 
 registerStateRoutes();
@@ -522,5 +522,98 @@ describe("GET /api/v1/attention/statement — interruption fallback (#580)", () 
     assert.strictEqual(p.interruption.count, 5,           "total = 2 + 3");
     assert.strictEqual(p.interruption.from_flag + p.interruption.from_source_kind,
                        p.interruption.count, "disclosure sub-counts must sum to total");
+  });
+});
+
+// ─── HUMAN_SESSION_SOURCES allowlist — cli removed (#584) ───────────────────
+// cli sessions are agent-driven one-shots, not principal attention.
+// These tests cover: (a) the constant shape; (b) cli-only day = zero engaged;
+// (c) mixed slack+cli day = only slack turns count.
+// The Hermes state.db fixture reuses the tmp dir from the parent_session_id
+// describe block above but in a fresh before() that re-creates the directory
+// (which that block's after() deletes).
+describe("HUMAN_SESSION_SOURCES allowlist — cli excluded (#584)", () => {
+  // Re-create the same hermes-state path that the parent_session_id block's
+  // after() cleaned up, so the route handler's fs.existsSync check passes.
+  const hsDir2 = path.join(tmp, "hermes-state");
+  const hsDbPath2 = path.join(hsDir2, "main", "state.db");
+
+  before(() => {
+    fs.mkdirSync(path.join(hsDir2, "main"), { recursive: true });
+    const hdb = new DatabaseSync(hsDbPath2);
+    hdb.exec(`
+      CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, parent_session_id TEXT);
+      CREATE TABLE messages (id TEXT PRIMARY KEY, session_id TEXT, role TEXT, timestamp REAL NOT NULL);
+    `);
+    hdb.close();
+  });
+
+  after(() => { fs.rmSync(hsDir2, { recursive: true, force: true }); });
+
+  beforeEach(() => {
+    db.prepare("DELETE FROM nar_entry").run();
+    const hdb = new DatabaseSync(hsDbPath2);
+    hdb.exec("DELETE FROM messages; DELETE FROM sessions;");
+    hdb.close();
+  });
+
+  it("constant contains slack and telegram and does NOT contain cli", () => {
+    assert.ok(
+      (HUMAN_SESSION_SOURCES as readonly string[]).includes("slack"),
+      "slack must be in HUMAN_SESSION_SOURCES",
+    );
+    assert.ok(
+      (HUMAN_SESSION_SOURCES as readonly string[]).includes("telegram"),
+      "telegram must be in HUMAN_SESSION_SOURCES",
+    );
+    assert.ok(
+      !(HUMAN_SESSION_SOURCES as readonly string[]).includes("cli"),
+      "cli must NOT be in HUMAN_SESSION_SOURCES — it is machine traffic",
+    );
+  });
+
+  it("cli-only sessions (parent IS NULL) yield zero engaged time", async () => {
+    const hdb = new DatabaseSync(hsDbPath2);
+    hdb.prepare("INSERT INTO sessions VALUES (?,?,?)").run("s-cli-1", "cli", null);
+    hdb.prepare("INSERT INTO messages VALUES (?,?,'user',?)").run(
+      "m-cli-1", "s-cli-1", new Date("2026-08-10T09:00:00Z").getTime() / 1000,
+    );
+    hdb.prepare("INSERT INTO sessions VALUES (?,?,?)").run("s-cli-2", "cli", null);
+    hdb.prepare("INSERT INTO messages VALUES (?,?,'user',?)").run(
+      "m-cli-2", "s-cli-2", new Date("2026-08-10T09:01:00Z").getTime() / 1000,
+    );
+    hdb.close();
+    const { p } = await getStatement("date=2026-08-10");
+    assert.strictEqual(p.engaged.hours, 0,
+      "cli sessions must not contribute to engaged — they are machine traffic");
+  });
+
+  it("mixed slack+cli day counts only the slack turns", async () => {
+    const hdb = new DatabaseSync(hsDbPath2);
+    // One human slack session.
+    hdb.prepare("INSERT INTO sessions VALUES (?,?,?)").run("s-slack-1", "slack", null);
+    hdb.prepare("INSERT INTO messages VALUES (?,?,'user',?)").run(
+      "m-slack-1", "s-slack-1", new Date("2026-08-11T10:00:00Z").getTime() / 1000,
+    );
+    // One agent cli session — same day.
+    hdb.prepare("INSERT INTO sessions VALUES (?,?,?)").run("s-cli-3", "cli", null);
+    hdb.prepare("INSERT INTO messages VALUES (?,?,'user',?)").run(
+      "m-cli-3", "s-cli-3", new Date("2026-08-11T10:30:00Z").getTime() / 1000,
+    );
+    hdb.close();
+    // The slack session contributes ≥ the 2-min floor; cli contributes 0.
+    // If cli were included the burst would be ~32 min; slack-only = 2 min floor.
+    const { p } = await getStatement("date=2026-08-11");
+    // The two timestamps are 30 min apart — two separate bursts if both counted.
+    // With cli excluded, only the slack turn remains → single burst at the floor.
+    assert.ok(p.engaged.hours > 0, "slack turn must be counted");
+    // 30-min gap > GAP_MS (10 min) → two bursts if both sources counted.
+    // Verify the cli turn did NOT add a second burst by checking hours < 2 × floor.
+    // floor = 2 min, so two bursts would yield ≥ 4 min = 0.0667 h.
+    // One burst (slack only) = 2 min = 0.0333 h.
+    assert.ok(
+      p.engaged.hours < 0.05,
+      `only the slack turn must be counted; expected < 0.05h but got ${p.engaged.hours}`,
+    );
   });
 });


### PR DESCRIPTION
## Summary

- `cli` sessions in the Hermes main profile session store are agent-driven one-shots (context-compressed task lists, vault reads, `gather…` instructions), not principal attention.
- 177 such sessions in June 2026, nearly all single-turn, each scored at the 2-minute burst floor by `clusterBursts` → engaged inflated by hours per month, NAR depressed accordingly.
- `docs/design/nar-method.md §2` already flagged `cli` as suspect; it has been reviewed and confirmed as machine traffic.

**Changes:**

- `packages/ctrl/src/api/routes/attention.ts`: export `HUMAN_SESSION_SOURCES = ["slack","telegram"]` at module level, with authorship rationale and the `cli` exclusion recorded in the constant comment. Derive `HUMAN_SOURCES_SQL` from it. Replace the one `IN ('slack','cli','telegram')` clause in `buildDayStatement` with `IN (${HUMAN_SOURCES_SQL})`.
- `packages/ctrl/tests/nar-entries.test.ts`: three new tests in a new describe block `HUMAN_SESSION_SOURCES allowlist — cli excluded (#584)`:
  1. constant shape: `slack` in, `telegram` in, `cli` NOT in
  2. cli-only sessions (parent IS NULL) yield zero engaged time
  3. mixed slack+cli day counts only the slack turns

No other filters changed (gap, floor, `parent_session_id IS NULL`, `role='user'`).

Historical NAR figures will differ after re-backfill; that is the intended outcome. The NAR method doc flagged this as a known issue.

## Smoke evidence

Local VERIFY run (pre-commit hook):

```
▶ lane I verify: cd packages/ctrl && npm run build && npm run test:ci

Build complete — dist/api.mjs

# tests 1479
# suites 359
# pass 1478
# fail 0
# cancelled 0
# skipped 1
# duration_ms ~13s
```

New describe block confirmed passing:

```
# Subtest: HUMAN_SESSION_SOURCES allowlist — cli excluded (#584)
    ok 1 - constant contains slack and telegram and does NOT contain cli
    ok 2 - cli-only sessions (parent IS NULL) yield zero engaged time
    ok 3 - mixed slack+cli day counts only the slack turns
ok 6 - HUMAN_SESSION_SOURCES allowlist — cli excluded (#584)

# tests 33
# pass 33
# fail 0
```

No new failures. The 1 skip is a pre-existing quarantine entry unchanged by this PR.

References #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc