### PR TITLE
fix(learn): drop cli from HUMAN_SOURCES — machine traffic, not principal typing (#584)

### DIFF
--- a/packages/learn/src/activities/nar_data.py
+++ b/packages/learn/src/activities/nar_data.py
@@ -43,10 +43,25 @@ GAP_MS = 10 * 60 * 1000   # 10-minute gap ends a burst
 FLOOR_MS = 2 * 60 * 1000  # 2-minute floor per burst
 
 # Human session sources allowlist (§2 — never use a denylist).
-# `cli` is excluded per §2: "suspect and should be reviewed before being
-# trusted as human."  Add sources here only when we have evidence they
-# represent Sir typing, not a machine process.
-HUMAN_SOURCES: frozenset[str] = frozenset({"web", "telegram", "slack"})
+#
+# Each member must have evidence it represents the principal typing, not a
+# machine process.  Add a new source only when you can answer: "what human
+# authored these messages?"
+#
+#   web      — the Wasp dashboard chat surface; Sir types in the browser.
+#   slack    — the principal's own Slack account; text from Sir's keyboard.
+#   telegram — the principal's Telegram chat with Alfred; confirmed human-authored.
+#
+# Excluded sources (and why):
+#   cli  — inspected in production: first user turn reads like agent-authored
+#           one-shots ("gather…", "Use the vault read tool…").  177 cli sessions
+#           in June 2026, nearly all a single user turn, machine-dispatched.
+#           Any genuine cli work is already counted as autonomous artifact under
+#           §1c; crediting it here would double-count.
+#
+# Rule: if you cannot name the human who typed the session's first user turn,
+# the source does not belong here.
+HUMAN_SOURCES: frozenset[str] = frozenset({"web", "slack", "telegram"})
 
 # Path to the Hermes main profile session store.
 _DEFAULT_HERMES_CONFIG_DIR = "/hermes-state/profiles"

--- a/packages/learn/tests/test_nar_recap.py
+++ b/packages/learn/tests/test_nar_recap.py
@@ -117,13 +117,14 @@ class TestBucketConstants:
         assert SUPPRESSION_RATE_MINUTES == 0.5
 
     def test_human_sources_allowlist(self):
-        # cli is explicitly excluded by the method doc.
+        # cli is machine-authored (agent one-shots); explicitly excluded.
         assert "cli" not in HUMAN_SOURCES
         # api_server and cron are machine sources — must be absent.
         assert "api_server" not in HUMAN_SOURCES
         assert "cron" not in HUMAN_SOURCES
-        # At least one human source must be in the allowlist.
-        assert len(HUMAN_SOURCES) >= 1
+        # The two confirmed human sources must be present.
+        assert "slack" in HUMAN_SOURCES
+        assert "telegram" in HUMAN_SOURCES
 
 
 # ---------------------------------------------------------------------------
@@ -689,6 +690,62 @@ class TestGetHumanSessionsParentage:
         ])
         results = _get_human_sessions(db, self._day())
         assert results == []
+
+    def test_cli_session_excluded_by_query(self):
+        """cli sessions must not appear in the human-session results.
+
+        cli is machine-authored traffic — agent one-shots dispatched by cron or
+        subagents, not the principal at a keyboard.  Even with parent_session_id
+        IS NULL the source filter must reject them.
+        """
+        db = _make_session_db([
+            {"id": "s_cli", "source": "cli", "started_at": self._ts(10),
+             "ended_at": self._ts(10) + 30, "parent_session_id": None},
+        ])
+        results = _get_human_sessions(db, self._day())
+        assert results == [], (
+            "cli session with parent_session_id=NULL must be excluded by the "
+            "source allowlist — cli is machine traffic, not the principal typing"
+        )
+
+    def test_mixed_cli_and_slack_returns_only_slack(self):
+        """A day with both cli and slack sessions returns only the slack session.
+
+        This is the exact production pattern being fixed (#584): cli sessions
+        were inflating the recap by counting autonomous agent dispatches as
+        principal conversational work.
+        """
+        db = _make_session_db(
+            sessions=[
+                {"id": "s_slack", "source": "slack", "started_at": self._ts(10),
+                 "parent_session_id": None},
+                {"id": "s_cli_1", "source": "cli", "started_at": self._ts(9),
+                 "parent_session_id": None},
+                {"id": "s_cli_2", "source": "cli", "started_at": self._ts(11),
+                 "parent_session_id": None},
+            ],
+            messages=[
+                {"session_id": "s_slack", "role": "user", "content": "hello", "timestamp": self._ts(10) * 1000},
+                {"session_id": "s_cli_1", "role": "user",
+                 "content": "[Your active task list was preserved] - [>] gather...",
+                 "timestamp": self._ts(9) * 1000},
+                {"session_id": "s_cli_2", "role": "user",
+                 "content": "Use the vault read tool to read task/abc.md and return the body",
+                 "timestamp": self._ts(11) * 1000},
+            ],
+        )
+        results = _get_human_sessions(db, self._day())
+        assert len(results) == 1, (
+            f"expected 1 session (slack only), got {len(results)}: "
+            f"{[r['id'] for r in results]}"
+        )
+        assert results[0]["id"] == "s_slack"
+        assert results[0]["source"] == "slack"
+        # Verify the cli turn content is absent from the returned messages.
+        all_content = [m["content"] for r in results for m in r["messages"]]
+        assert not any("vault read tool" in c for c in all_content), (
+            "cli session message content must not appear in human-session results"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`nar_data.py` selects human sessions for the NAR recap from a named module-level constant `HUMAN_SOURCES`. The constant already excluded `cli` from the query, but the comment only said it was "suspect pending review" — no evidence, no per-member justification, and the four test cases the brief requires were missing.

This PR:
1. Replaces the vague `cli` comment with explicit evidence (177 sessions June 2026, all agent one-shots), explains why double-counting is the risk, and records per-member justification for `web`, `slack`, and `telegram`.
2. Adds two new query-level tests that prove the exclusion holds at the SQLite layer, not just at the constant.
3. Strengthens the existing allowlist test to assert `slack` and `telegram` are present, not just that bad sources are absent.

## Why cli is excluded

cli sessions are machine-dispatched agent one-shots. Production evidence:
- First user turn reads like `[Your active task list was preserved across context compression] - [>] gather...` or `Use the vault read tool to read task/<id>.md and return the exact body text...`
- 177 such sessions in June 2026, nearly all a single user turn
- Any work they represent is already counted as autonomous artifact under §1c of the method doc — crediting cli here would double-count

## Files changed

- `packages/learn/src/activities/nar_data.py` — enhanced `HUMAN_SOURCES` comment with per-member justification and explicit cli exclusion rationale
- `packages/learn/tests/test_nar_recap.py` — added `test_cli_session_excluded_by_query`, `test_mixed_cli_and_slack_returns_only_slack`; strengthened `test_human_sources_allowlist`

## Smoke evidence

Local run — all tests green:

```
packages/learn $ python3 -m pytest tests/test_nar_recap.py -v 2>&1 | tail -5
...
68 passed in 0.51s

packages/learn $ python3 -m pytest tests/ -x -q \
  --ignore=tests/test_composio_server.py \
  --ignore=tests/test_composio_server_defaults.py \
  --ignore=tests/test_file_extraction.py 2>&1 | tail -3
2773 passed, 101 skipped in 21.05s
```

Gate output:
```
✓ lane II (learn) gate passed — 86 LOC, 2 files, verify ok
```

The 3 ignored test files fail on `ModuleNotFoundError: No module named 'fastapi'` / `openpyxl` — both pre-existing, not caused by this change (verified on main before branching).

New tests passing:
- `TestGetHumanSessionsParentage::test_cli_session_excluded_by_query` PASSED
- `TestGetHumanSessionsParentage::test_mixed_cli_and_slack_returns_only_slack` PASSED
- `TestBucketConstants::test_human_sources_allowlist` PASSED (strengthened)

References #584.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc