### PR TITLE
fix(ctrl): ctrl and learn must list the same human sources (#584)

### DIFF
--- a/packages/ctrl/src/api/routes/attention.ts
+++ b/packages/ctrl/src/api/routes/attention.ts
@@ -52,6 +52,7 @@ const ULID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
 // Authorship rationale per docs/design/nar-method.md §2:
 //   slack    — messages arrive via the Slack channel integration; Sir typed them.
 //   telegram — messages arrive via the Telegram bot; Sir typed them.
+//   web      — the dashboard chat surface; Sir typed them in the browser.
 //   cli      — EXCLUDED: cli sessions are agent-driven one-shots (context-compressed
 //              task lists, vault reads, "gather…" instructions). Live data shows 177
 //              such sessions in June 2026, nearly all with a single user turn. Because
@@ -59,7 +60,12 @@ const ULID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
 //              calls each became their own burst — inflating engaged by hours per month
 //              and pushing NAR down. Confirmed machine traffic; removed here.
 // Adding a new source requires confirming it is human-authored, not machine traffic.
-export const HUMAN_SESSION_SOURCES = ["slack", "telegram"] as const;
+// MUST stay identical to HUMAN_SOURCES in packages/learn/src/activities/nar_data.py.
+// The two are read by different halves of the same formula — learn decides which
+// sessions become displacement, ctrl decides which turns become engaged. A source
+// present in one and absent from the other credits work with no attention cost
+// against it (or the reverse), and the divergence is invisible on the statement.
+export const HUMAN_SESSION_SOURCES = ["slack", "telegram", "web"] as const;
 
 // Precomputed IN-clause fragment — these are static string literals, safe to interpolate.
 const HUMAN_SOURCES_SQL = HUMAN_SESSION_SOURCES.map((s) => `'${s}'`).join(",");

--- a/packages/ctrl/tests/nar-entries.test.ts
+++ b/packages/ctrl/tests/nar-entries.test.ts
@@ -557,6 +557,27 @@ describe("HUMAN_SESSION_SOURCES allowlist — cli excluded (#584)", () => {
     hdb.close();
   });
 
+  // Parity guard. ctrl decides which turns become ENGAGED; learn decides which
+  // sessions become DISPLACED. They read separate copies of the same allowlist,
+  // so a source present in one and absent from the other credits work with no
+  // attention cost against it (or the reverse) — and nothing on the statement
+  // shows the divergence. This test failed to exist when ctrl carried
+  // [slack, telegram] against learn's [web, slack, telegram].
+  it("allowlist matches learn's HUMAN_SOURCES exactly", () => {
+    const pyPath = path.join(
+      import.meta.dirname, "..", "..", "learn", "src", "activities", "nar_data.py",
+    );
+    const py = fs.readFileSync(pyPath, "utf8");
+    const m = py.match(/HUMAN_SOURCES:\s*frozenset\[str\]\s*=\s*frozenset\(\{([^}]*)\}\)/);
+    assert.ok(m, "could not find HUMAN_SOURCES in nar_data.py — has it moved?");
+    const learnSources = [...m![1].matchAll(/"([a-z_]+)"/g)].map((x) => x[1]).sort();
+    const ctrlSources = [...HUMAN_SESSION_SOURCES].sort();
+    assert.deepEqual(
+      ctrlSources, learnSources,
+      `ctrl [${ctrlSources}] and learn [${learnSources}] must list the same human sources`,
+    );
+  });
+
   it("constant contains slack and telegram and does NOT contain cli", () => {
     assert.ok(
       (HUMAN_SESSION_SOURCES as readonly string[]).includes("slack"),

--- a/packages/ctrl/tests/suppression-rate-card.test.ts
+++ b/packages/ctrl/tests/suppression-rate-card.test.ts
@@ -75,7 +75,15 @@ describe("suppression rate card", () => {
   it("audit payload carries rate, source, hash, previous_hash=null on init", () => {
     getRateCard({ dataDir: tmp });
     const row = getStateDb()
-      .prepare("SELECT payload_json FROM audit WHERE action_type='suppression_rate_card_change' ORDER BY created_at DESC LIMIT 1")
+      // The INIT row specifically — id is a ULID, so ASC is insertion order.
+      // This used to read `ORDER BY created_at DESC LIMIT 1`, but created_at has
+      // one-second resolution: when the whole file runs inside a single second
+      // the ordering is a tie and SQLite may return either row. The preceding
+      // test deliberately leaves a 0.75 override in place, so the tie resolved
+      // to that row and the assertion saw 0.75 instead of 0.5. It passed only by
+      // timing luck and broke as soon as an unrelated test file shifted the
+      // schedule across a second boundary.
+      .prepare("SELECT payload_json FROM audit WHERE action_type='suppression_rate_card_change' ORDER BY id ASC LIMIT 1")
       .get() as { payload_json: string };
     const p = JSON.parse(row.payload_json);
     assert.strictEqual(p.rate_minutes_per_item, 0.5);


### PR DESCRIPTION
Follow-up to #630 / #631.

## The divergence

#630 set ctrl's `HUMAN_SESSION_SOURCES` to `[slack, telegram]`. learn's
`HUMAN_SOURCES` is `{web, slack, telegram}`.

These are two hand-maintained copies of the same allowlist, read by different
halves of the same formula:

- **learn** decides which sessions become **displaced**
- **ctrl** decides which turns become **engaged**

A source in one and not the other credits work with no attention cost against
it — inflating NAR — or the reverse. Nothing on the statement would reveal it.

No `web` sessions exist on the live tenant today, so this is latent, not
active. Adding `web` to ctrl aligns them, and a new test reads learn's
constant out of `nar_data.py` and asserts set equality. The comment says the
two must stay identical; the test is what makes that true.

## A latent flake this exposed

Adding one test to `nar-entries.test.ts` turned the full ctrl suite red in
`suppression-rate-card.test.ts` — a file my change does not touch.

`"audit payload carries rate, source, hash, previous_hash=null on init"`
selected `ORDER BY created_at DESC LIMIT 1`. `created_at` has one-second
resolution, so when the file runs inside a single second the ordering is a
**tie**. The preceding test deliberately leaves a `0.75` override in place, so
the tie could resolve to that row — the assertion then saw `0.75` against an
expected `0.5`.

It passed on main by timing luck. Shifting the schedule across a second
boundary was enough to break it. It now selects the init row explicitly by
ULID order, which is what "on init" meant.

## Smoke evidence

```
clean main:            # tests 1479 / pass 1478 / fail 0 / skipped 1
this branch, pre-fix:  # tests 1480 / pass 1478 / fail 1   ← suppression-rate-card
this branch, fixed:    # tests 1480 / pass 1479 / fail 0 / skipped 1

parity test alone:  ok 1 - allowlist matches learn's HUMAN_SOURCES exactly
nar-entries.test.ts: # tests 34 / pass 34 / fail 0
```