### PR TITLE
feat(ctrl): GET /api/v1/attention/trends — weekly/monthly/quarterly NAR rollups

### DIFF
--- a/packages/ctrl/src/api/routes/attention.ts
+++ b/packages/ctrl/src/api/routes/attention.ts
@@ -513,6 +513,31 @@ export async function dispatchSignalToAgent(
   return { outcome_signal_path: sourceSignal, error: null };
 }
 
+/** Subset of buildDayStatement return read by the trends aggregator. */
+interface DayStatement {
+  nar_hours: number;
+  displaced: { total_hours: number; explicit: { hours: number; items: Array<{ count: number; minutes: number }> }; inferred: { hours: number; items: Array<{ bucket: string|null; minutes: number; outcome: string|null; engaged_minutes: number|null }> }; autonomous: { hours: number; items: Array<{ bucket: string|null; minutes: number }> } };
+  engaged: { hours: number }; interruption: { hours: number };
+  allocation: { work: {displaced_hours:number;engaged_hours:number}; life: {displaced_hours:number;engaged_hours:number}; unallocated: {displaced_hours:number;engaged_hours:number} };
+  stats: { sessions: number };
+}
+
+/** Period key + canonical ISO start/end for a grain+date string. Exported for tests. */
+export function periodKeyBounds(grain: "week"|"month"|"quarter", dateStr: string): {key:string;start:string;end:string} {
+  if (grain === "week") {
+    const d=new Date(`${dateStr}T00:00:00Z`), dow=d.getUTCDay()||7; // Mon=1…Sun=7
+    const mon=new Date(d); mon.setUTCDate(d.getUTCDate()-dow+1);
+    const sun=new Date(mon); sun.setUTCDate(mon.getUTCDate()+6);
+    const thu=new Date(d); thu.setUTCDate(d.getUTCDate()-dow+4); // Thursday = ISO week anchor
+    const wn=Math.ceil(((thu.getTime()-Date.UTC(thu.getUTCFullYear(),0,1))/86400000+1)/7);
+    return {key:`${thu.getUTCFullYear()}-W${String(wn).padStart(2,"0")}`,start:mon.toISOString().slice(0,10),end:sun.toISOString().slice(0,10)};
+  }
+  const [y,mo]=dateStr.slice(0,7).split("-").map(Number);
+  if (grain === "month") return {key:dateStr.slice(0,7),start:`${y}-${String(mo).padStart(2,"0")}-01`,end:new Date(Date.UTC(y,mo,0)).toISOString().slice(0,10)};
+  const q=Math.ceil(mo/3), qm1=(q-1)*3+1;
+  return {key:`${y}-Q${q}`,start:`${y}-${String(qm1).padStart(2,"0")}-01`,end:new Date(Date.UTC(y,q*3,0)).toISOString().slice(0,10)};
+}
+
 export function registerAttentionRoutes(): void {
   // GET /api/v1/admin/needs-attention — list pending records (status=pending)
   // Optional query: ?include=all (return done/dispatched/skipped too — for the
@@ -1204,5 +1229,79 @@ export function registerAttentionRoutes(): void {
     } catch { handle = null; }
 
     sendJson(res, 202, { ok: true, handle, date, from, to });
+  });
+
+  // GET /api/v1/attention/trends — weekly/monthly/quarterly NAR rollups (#584).
+  // Reuses buildDayStatement per day; does NOT reimplement displacement/engaged logic.
+  addRoute("GET", "/api/v1/attention/trends", async ({ res, query }) => {
+    const grain=(query.get("grain")??"") as "week"|"month"|"quarter";
+    const from=query.get("from")??"", to=query.get("to")??"";
+    if (!["week","month","quarter"].includes(grain)) throw new ValidationError("grain must be week|month|quarter");
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(from)||!/^\d{4}-\d{2}-\d{2}$/.test(to)) throw new ValidationError("from and to must be YYYY-MM-DD");
+    const fromD=new Date(`${from}T00:00:00Z`), toD=new Date(`${to}T00:00:00Z`);
+    if (isNaN(fromD.getTime())||isNaN(toD.getTime())||fromD>toD) throw new ValidationError("from must be ≤ to");
+    const total=Math.round((toD.getTime()-fromD.getTime())/86400000)+1;
+    if (total>400) throw new ValidationError(`range ${total} days exceeds 400-day cap`);
+
+    const dates:string[]=[];
+    for (let d=new Date(fromD);d<=toD;d.setUTCDate(d.getUTCDate()+1)) dates.push(d.toISOString().slice(0,10));
+    const dayResults=dates.map(buildDayStatement) as DayStatement[];
+    const r3=(v:number)=>Math.round(v*1000)/1000;
+    type PG={key:string;start:string;end:string;indices:number[]};
+    const pm=new Map<string,PG>();
+    for (let i=0;i<dates.length;i++) {
+      const {key,start,end}=periodKeyBounds(grain,dates[i]);
+      if (!pm.has(key)) pm.set(key,{key,start,end,indices:[]});
+      pm.get(key)!.indices.push(i);
+    }
+
+    const db=getStateDb();
+    const cf=`${from}T00:00:00Z`, ct=`${to}T23:59:59.999Z`;
+    const firstJ=(db.prepare(`SELECT MIN(DATE(ts)) AS d FROM alfred_journal WHERE direction='outbound' AND ts>=? AND ts<=?`).get(cf,ct) as {d:string|null}).d;
+    const daysData=(db.prepare(`SELECT COUNT(DISTINCT DATE(occurred_at)) AS n FROM nar_entry WHERE occurred_at>=? AND occurred_at<=?`).get(cf,ct) as {n:number}).n;
+
+    const periods=[];
+    for (const pg of pm.values()) {
+      const drs=pg.indices.map(i=>dayResults[i]);
+      let nar=0,disp=0,eng=0,intr=0,sess=0;
+      const al:Record<"work"|"life"|"unallocated",{d:number;e:number}>={work:{d:0,e:0},life:{d:0,e:0},unallocated:{d:0,e:0}};
+      let cDisp=0,cEng=0,cCnt=0,aDisp=0,aCnt=0,eDisp=0,eCnt=0;
+      const bkt:Record<string,{count:number;displaced_hours:number}>={};
+      const oc={delivered:0,failed:0,unknown:0};
+      for (const dr of drs) {
+        nar+=dr.nar_hours; disp+=dr.displaced.total_hours;
+        // engaged_hours per period = SUM of daily burst-clustered values.
+        // Daily clustering is the defined measure; summing days is the only
+        // aggregation consistent with it — re-clustering would merge sessions.
+        eng+=dr.engaged.hours; intr+=dr.interruption.hours; sess+=dr.stats.sessions;
+        for (const a of (["work","life","unallocated"] as const)) { al[a].d+=dr.allocation[a].displaced_hours; al[a].e+=dr.allocation[a].engaged_hours; }
+        cDisp+=dr.displaced.inferred.hours; cCnt+=dr.displaced.inferred.items.length;
+        for (const it of dr.displaced.inferred.items) {
+          cEng+=(it.engaged_minutes??0)/60;
+          if (it.bucket) { bkt[it.bucket]??={count:0,displaced_hours:0}; bkt[it.bucket].count++; bkt[it.bucket].displaced_hours+=it.minutes/60; }
+          const o=it.outcome??null;
+          if (o==="delivered") oc.delivered++; else if (o==="failed") oc.failed++; else oc.unknown++;
+        }
+        aDisp+=dr.displaced.autonomous.hours; aCnt+=dr.displaced.autonomous.items.length;
+        for (const it of dr.displaced.autonomous.items)
+          if (it.bucket) { bkt[it.bucket]??={count:0,displaced_hours:0}; bkt[it.bucket].count++; bkt[it.bucket].displaced_hours+=it.minutes/60; }
+        eDisp+=dr.displaced.explicit.hours; eCnt+=dr.displaced.explicit.items.reduce((s,x)=>s+x.count,0);
+      }
+      // interruption_instrumented false = "nothing recorded" not "no interruptions occurred"
+      const pS=`${dates[pg.indices[0]]}T00:00:00Z`, pE=`${dates[pg.indices[pg.indices.length-1]]}T23:59:59.999Z`;
+      const jn=(db.prepare(`SELECT COUNT(*) AS n FROM alfred_journal WHERE direction='outbound' AND ts>=? AND ts<=?`).get(pS,pE) as {n:number}).n;
+      periods.push({
+        key:pg.key,start:pg.start,end:pg.end,days:pg.indices.length,
+        nar_hours:r3(nar),displaced_hours:r3(disp),engaged_hours:r3(eng),interruption_hours:r3(intr),
+        interruption_instrumented:jn>0,return_ratio:eng===0?null:r3(disp/eng),
+        allocation:{work:{displaced_hours:r3(al.work.d),engaged_hours:r3(al.work.e)},life:{displaced_hours:r3(al.life.d),engaged_hours:r3(al.life.e)},unallocated:{displaced_hours:r3(al.unallocated.d),engaged_hours:r3(al.unallocated.e)}},
+        by_class:{conversational:{displaced_hours:r3(cDisp),engaged_hours:r3(cEng),count:cCnt},autonomous:{displaced_hours:r3(aDisp),engaged_hours:0,count:aCnt},explicit:{displaced_hours:r3(eDisp),engaged_hours:0,count:eCnt}},
+        by_bucket:Object.fromEntries(Object.entries(bkt).map(([k,v])=>[k,{count:v.count,displaced_hours:r3(v.displaced_hours)}])),
+        outcomes:oc,sessions:sess,
+      });
+    }
+    sendJson(res,200,{grain,from,to,
+      coverage:{interruption_instrumented_from:firstJ??null,days_total:dates.length,days_with_data:daysData},
+      periods});
   });
 }

--- a/packages/ctrl/tests/attention-trends.test.ts
+++ b/packages/ctrl/tests/attention-trends.test.ts
@@ -1,0 +1,144 @@
+// attention-trends.test.ts — GET /api/v1/attention/trends (#584).
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ServerResponse } from "node:http";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "atrends-"));
+process.env.ALFRED_DATA_DIR   = tmp;
+process.env.STATE_DB_PATH     = path.join(tmp, "state.db");
+process.env.VAULT_PATH        = path.join(tmp, "vault");
+process.env.SQLITE_VEC_PATH   = "";
+process.env.HERMES_CONFIG_DIR = path.join(tmp, "hermes-state");
+["needs_attention","decision","event"].forEach(d=>fs.mkdirSync(path.join(tmp,"vault",d),{recursive:true}));
+
+const { getStateDb }          = await import("../src/db/state.js");
+const { registerStateRoutes } = await import("../src/api/routes/state.js");
+const { registerAttentionRoutes, periodKeyBounds } = await import("../src/api/routes/attention.js");
+const { matchRoute }          = await import("../src/api/server.js");
+
+registerStateRoutes();
+registerAttentionRoutes();
+const db = getStateDb();
+
+async function getTrends(qs:string):Promise<{status:number;p:any}> {
+  const m=matchRoute("GET","/api/v1/attention/trends"); assert.ok(m);
+  let status=0; let p:any={};
+  const res={writeHead(s:number){status=s;return res;},end(j?:string){if(j)p=JSON.parse(j);}} as unknown as ServerResponse;
+  try { await m.handler({req:{}as any,res,params:{},body:null,query:new URLSearchParams(qs)}); }
+  catch(e:any){if(typeof e?.statusCode==="number"){status=e.statusCode;p={error:e.message};}else throw e;}
+  return {status,p};
+}
+
+let _seq=0;
+function nar(ov:Record<string,unknown>={}) {
+  _seq++;
+  db.prepare(`INSERT OR REPLACE INTO nar_entry(id,dedup_key,occurred_at,action_class,summary,evidence_kind,evidence_ref,estimation_method,displaced_minutes,acceptance,acceptance_path,notes)VALUES(?,?,?,?,?,?,?,?,?,?,?,?)`)
+    .run(`01TRN${String(_seq).padStart(21,"0")}`,`trn-${_seq}`,ov.occurred_at??"2026-08-10T10:00:00Z",
+      ov.action_class??"conversational","test",ov.evidence_kind??"session",`ref-${_seq}`,
+      "standard-time",ov.displaced_minutes??10,"accepted","inferred",ov.notes??null);
+}
+function jrn(ts:string,dir="outbound"){
+  db.prepare(`INSERT INTO alfred_journal(id,ts,channel,chat_id,direction,message)VALUES(?,?,?,?,?,?)`)
+    .run(`jrn-${++_seq}`,ts,"telegram","test",dir,"msg");
+}
+function clear(){db.prepare("DELETE FROM nar_entry").run();db.prepare("DELETE FROM alfred_journal").run();}
+
+// 1. periodKeyBounds helper — keys and boundaries for all three grains
+describe("periodKeyBounds",()=>{
+  it("week 2026-08-10 (Monday) → W33, Mon 08-10 – Sun 08-16",()=>{
+    const b=periodKeyBounds("week","2026-08-10");
+    assert.strictEqual(b.key,"2026-W33");assert.strictEqual(b.start,"2026-08-10");assert.strictEqual(b.end,"2026-08-16");
+  });
+  it("month 2026-08-15 → 2026-08, 01–31; Feb 2026 ends 28 (non-leap)",()=>{
+    const m=periodKeyBounds("month","2026-08-15");
+    assert.strictEqual(m.key,"2026-08");assert.strictEqual(m.start,"2026-08-01");assert.strictEqual(m.end,"2026-08-31");
+    assert.strictEqual(periodKeyBounds("month","2026-02-15").end,"2026-02-28");
+  });
+  it("quarter 2026-08-01 → Q3, 07-01–09-30",()=>{
+    const q=periodKeyBounds("quarter","2026-08-01");
+    assert.strictEqual(q.key,"2026-Q3");assert.strictEqual(q.start,"2026-07-01");assert.strictEqual(q.end,"2026-09-30");
+  });
+});
+
+// 2. Partial periods — real days count, canonical boundaries preserved
+describe("partial period",()=>{
+  beforeEach(clear);
+  it("month 5 days in Aug → days=5, canonical start/end",async()=>{
+    const {status,p}=await getTrends("grain=month&from=2026-08-25&to=2026-08-29");
+    assert.strictEqual(status,200);assert.strictEqual(p.periods[0].days,5);
+    assert.strictEqual(p.periods[0].start,"2026-08-01");assert.strictEqual(p.periods[0].end,"2026-08-31");
+  });
+  it("quarter Jun28-Jul03 → Q2(3d)+Q3(3d)",async()=>{
+    const {status,p}=await getTrends("grain=quarter&from=2026-06-28&to=2026-07-03");
+    assert.strictEqual(status,200);assert.strictEqual(p.periods.length,2);
+    assert.strictEqual(p.periods[0].key,"2026-Q2");assert.strictEqual(p.periods[0].days,3);
+    assert.strictEqual(p.periods[1].key,"2026-Q3");assert.strictEqual(p.periods[1].days,3);
+  });
+});
+
+// 3. return_ratio null when engaged=0
+describe("return_ratio",()=>{
+  beforeEach(clear);
+  it("null (not Infinity) when engaged_hours=0",async()=>{
+    const {p}=await getTrends("grain=week&from=2026-08-10&to=2026-08-10");
+    assert.strictEqual(p.periods[0].engaged_hours,0);
+    assert.strictEqual(p.periods[0].return_ratio,null);
+  });
+});
+
+// 4. interruption_instrumented
+describe("interruption_instrumented",()=>{
+  beforeEach(clear);
+  it("false when only inbound journal rows exist",async()=>{
+    jrn("2026-08-12T14:00:00Z","inbound");
+    const {p}=await getTrends("grain=week&from=2026-08-10&to=2026-08-16");
+    assert.strictEqual(p.periods[0].interruption_instrumented,false);
+  });
+  it("true when at least one outbound row exists",async()=>{
+    jrn("2026-08-12T14:00:00Z","outbound");
+    const {p}=await getTrends("grain=week&from=2026-08-10&to=2026-08-16");
+    assert.strictEqual(p.periods[0].interruption_instrumented,true);
+  });
+});
+
+// 5. allocation + by_class displaced sums equal period.displaced_hours
+describe("sum consistency",()=>{
+  beforeEach(clear);
+  it("alloc work+life+unallocated == displaced_hours; class sums too",async()=>{
+    nar({occurred_at:"2026-08-10T09:00:00Z",displaced_minutes:30,notes:JSON.stringify({allocation:"work"})});
+    nar({occurred_at:"2026-08-11T09:00:00Z",displaced_minutes:20,notes:JSON.stringify({allocation:"life"})});
+    const {p}=await getTrends("grain=week&from=2026-08-10&to=2026-08-16");
+    const per=p.periods[0];
+    const allocSum=per.allocation.work.displaced_hours+per.allocation.life.displaced_hours+per.allocation.unallocated.displaced_hours;
+    assert.ok(Math.abs(allocSum-per.displaced_hours)<0.001,`alloc ${allocSum}≠${per.displaced_hours}`);
+    const classSum=per.by_class.conversational.displaced_hours+per.by_class.autonomous.displaced_hours+per.by_class.explicit.displaced_hours;
+    assert.ok(Math.abs(classSum-per.displaced_hours)<0.001,`class ${classSum}≠${per.displaced_hours}`);
+  });
+});
+
+// 6. absent notes.outcome → unknown, not failed
+describe("outcome classification",()=>{
+  beforeEach(clear);
+  it("delivered/failed/absent-null each count correctly; absent is unknown",async()=>{
+    nar({occurred_at:"2026-08-10T09:00:00Z",notes:JSON.stringify({outcome:"delivered"})});
+    nar({occurred_at:"2026-08-10T10:00:00Z",notes:JSON.stringify({outcome:"failed"})});
+    nar({occurred_at:"2026-08-10T11:00:00Z",notes:null});
+    const {p}=await getTrends("grain=week&from=2026-08-10&to=2026-08-10");
+    assert.deepStrictEqual(p.periods[0].outcomes,{delivered:1,failed:1,unknown:1});
+  });
+});
+
+// 7. 400-day range cap
+describe("400-day cap",()=>{
+  it("401 days → 400",async()=>{
+    const {status}=await getTrends("grain=month&from=2025-01-01&to=2026-02-05");
+    assert.strictEqual(status,400);
+  });
+  it("400 days → 200",async()=>{
+    const {status}=await getTrends("grain=month&from=2025-01-01&to=2026-02-04");
+    assert.strictEqual(status,200);
+  });
+});


### PR DESCRIPTION
Closes #584

## Summary

- Adds `GET /api/v1/attention/trends?grain=week|month|quarter&from=YYYY-MM-DD&to=YYYY-MM-DD` to ctrl-api
- Reuses `buildDayStatement` per day and aggregates — does not reimplement the displacement or engaged-time logic
- Exports `periodKeyBounds()` for independent grain-bucketing unit tests

## Design choices

- **engaged_hours per period = sum of daily burst-clustered values.** Daily clustering is the defined measure; re-clustering across the period would merge independent sessions and inflate the figure.
- **`interruption_instrumented=false`** means "zero outbound `alfred_journal` rows in this window" (nothing recorded), not "no interruptions occurred".
- **`return_ratio` is `null` when `engaged=0`**, never `Infinity`.
- **Absent `notes.outcome` → `unknown`**, not `failed`.
- **400-day cap**: rejects ranges over 400 days with HTTP 400 to prevent accidental full-table scans.

## Files touched

- `packages/ctrl/src/api/routes/attention.ts` — `DayStatement` interface, `periodKeyBounds()` helper, and the trends route (99 net LOC added)
- `packages/ctrl/tests/attention-trends.test.ts` — 12 tests covering all required cases (144 LOC, new file)

## Smoke evidence

**Baseline (deployed home, pre-merge):**
```
GET /api/v1/attention/trends → {"error":{"code":"NOT_FOUND","message":"No route: GET /api/v1/attention/trends"}}
```
Route does not exist on current `:latest` image — expected.

**Local run (branch code, `dist/api.mjs`):**

```
# Week grain — full week, empty data
GET /api/v1/attention/trends?grain=week&from=2026-08-10&to=2026-08-16
→ {"grain":"week","from":"2026-08-10","to":"2026-08-16","coverage":{"interruption_instrumented_from":null,"days_total":7,"days_with_data":0},"periods":[{"key":"2026-W33","start":"2026-08-10","end":"2026-08-16","days":7,"nar_hours":0,"displaced_hours":0,"engaged_hours":0,"interruption_hours":0,"interruption_instrumented":false,"return_ratio":null,...}]}

# Month grain — 3 periods, last is partial (15 days)
GET /api/v1/attention/trends?grain=month&from=2026-06-01&to=2026-08-15
→ periods: 2026-06 (days=30), 2026-07 (days=31), 2026-08 (days=15, partial)

# Quarter grain — span Q2+Q3 partial
GET /api/v1/attention/trends?grain=quarter&from=2026-06-28&to=2026-07-03
→ 2026-Q2: days=3 | 2026-Q3: days=3

# 400-day range cap
GET /api/v1/attention/trends?grain=month&from=2025-01-01&to=2026-02-05
→ {"error":{"code":"VALIDATION_ERROR",...}}

# Bad grain
GET /api/v1/attention/trends?grain=day&from=2026-08-10&to=2026-08-16
→ {"error":{"code":"VALIDATION_ERROR",...}}
```

**Test suite (12 tests, all pass):**
```
# tests 1492 | pass 1491 | fail 0 | skip 1 (pre-existing)
  ok 1 - periodKeyBounds
  ok 2 - partial period
  ok 3 - return_ratio
  ok 4 - interruption_instrumented
  ok 5 - sum consistency
  ok 6 - outcome classification
  ok 7 - 400-day cap
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc