### PR TITLE
fix(learn): the observation table is a shared bus — its readers must filter (#584)

### DIFF
--- a/packages/learn/src/activities/pattern_detection.py
+++ b/packages/learn/src/activities/pattern_detection.py
@@ -468,14 +468,19 @@ async def detect_pattern_proposals() -> dict[str, Any]:
         # the clusterer expects.
         from datetime import timedelta as _td
 
-        from src.utils.signal_state import list_observation_records
+        from src.utils.signal_state import (
+            INTUITION_OBS_KINDS, list_observation_records,
+        )
 
         since_iso = (
             datetime.now(timezone.utc) - _td(days=WINDOW_DAYS)
         ).isoformat()
         try:
+            # Shared-bus filter — see INTUITION_OBS_KINDS. Feeding a
+            # reporting kind to pattern discovery would let a statement about
+            # the system shape a proposed instinct about the world.
             observations = await list_observation_records(
-                since=since_iso, limit=20_000,
+                since=since_iso, limit=20_000, kinds=INTUITION_OBS_KINDS,
             )
         except httpx.HTTPError as exc:
             counters["errors"] += 1

--- a/packages/learn/src/activities/vault.py
+++ b/packages/learn/src/activities/vault.py
@@ -627,9 +627,17 @@ async def collect_living_brief_data() -> dict[str, Any]:
         # state.db rows now — query ctrl-api's /api/v1/state/observations
         # instead of walking vault/observation/.
         try:
-            from src.utils.signal_state import list_observation_records
+            from src.utils.signal_state import (
+                INTUITION_OBS_KINDS, list_observation_records,
+            )
 
-            observations = await list_observation_records(limit=20)
+            # The observation table is a shared bus and this is a
+            # principal-facing surface: filter to the kinds that describe the
+            # world. Unfiltered, any derived/reporting kind written by another
+            # workflow surfaces in Sir's brief dressed as an intuition note.
+            observations = await list_observation_records(
+                limit=20, kinds=INTUITION_OBS_KINDS,
+            )
         except Exception:  # noqa: BLE001
             observations = []
         quiet_notes: list[dict[str, Any]] = []

--- a/packages/learn/src/utils/signal_state.py
+++ b/packages/learn/src/utils/signal_state.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import json
 import logging
 from datetime import datetime, timezone
+from collections.abc import Collection
 from typing import Any
 
 from src.config import Config, load_config
@@ -419,9 +420,25 @@ def observation_row_to_record(row: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+# The kinds that describe the world — what the intuition layer learns from and
+# what the brief may show Sir. The observation table is a SHARED BUS and its
+# readers historically filtered nothing, so any new derived/reporting kind
+# written into it silently appeared in the daily brief and in pattern
+# discovery. Consumers of those two surfaces must pass this set.
+#
+# Reporting kinds (e.g. attention_read) are deliberately absent: they are
+# statements about the system, not observations about the world, and feeding
+# them to pattern discovery would let a dashboard shape proposed instincts.
+INTUITION_OBS_KINDS: frozenset[str] = frozenset({
+    "chore_run", "decision", "signal", "constraint",
+    "synthesis", "assumption", "contradiction", "system",
+})
+
+
 async def list_observation_records(
     *,
     kind: str | None = None,
+    kinds: Collection[str] | None = None,
     since: str | None = None,
     limit: int | None = None,
     config: Config | None = None,
@@ -430,10 +447,21 @@ async def list_observation_records(
 
     Replaces ``GET /api/v1/vault/list/observation`` for the pattern
     detector — observations are Store 2 rows now.
+
+    ``kinds`` filters to a SET of kinds (``kind`` filters to one, server-side).
+    The filter is applied to the RAW ROW, before rehydration, deliberately:
+    ``observation_row_to_record`` does not carry ``kind`` at the top level — it
+    folds the column into ``frontmatter["source_kind"]`` via ``setdefault``, so
+    a payload that already carries ``source_kind`` keeps its own value and the
+    column is lost. Filtering the rehydrated record would therefore drop rows
+    it should keep and keep rows it should drop.
     """
     cfg = config or load_config()
     async with StateClient(cfg) as sc:
         rows = await sc.list_observations(kind=kind, since=since, limit=limit)
+    if kinds is not None:
+        allowed = set(kinds)
+        rows = [r for r in rows if r.get("kind") in allowed]
     return [observation_row_to_record(r) for r in rows]
 
 

--- a/packages/learn/tests/test_observation_bus_filter.py
+++ b/packages/learn/tests/test_observation_bus_filter.py
@@ -1,0 +1,88 @@
+"""The observation table is a shared bus — its readers must filter by kind.
+
+Written after `attention_read` (#584) was about to be added as a new kind:
+neither the daily brief's Quiet Notes nor pattern discovery filtered anything,
+so a reporting kind would have surfaced in Sir's brief as an intuition note and
+been fed to pattern discovery as an observation about the world.
+"""
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.utils.signal_state import (
+    INTUITION_OBS_KINDS,
+    list_observation_records,
+    observation_row_to_record,
+)
+
+
+def _row(obs_id: str, kind: str, payload: dict | None = None) -> dict:
+    return {
+        "id": obs_id, "kind": kind, "subject": f"s-{obs_id}",
+        "summary": f"summary {obs_id}", "ts": "2026-08-15T00:00:00Z",
+        "payload": payload or {},
+    }
+
+
+class TestKindIsNotOnTheRehydratedRecord:
+    """Why the filter must run on the raw row, not the record."""
+
+    def test_record_has_no_top_level_kind(self):
+        rec = observation_row_to_record(_row("a", "signal"))
+        assert "kind" not in rec, (
+            "if this ever gains a top-level kind, the raw-row filter can be "
+            "simplified — until then, filtering the record silently matches nothing"
+        )
+
+    def test_payload_source_kind_wins_over_the_column(self):
+        # setdefault: a payload carrying source_kind keeps its own value and the
+        # kind column is lost. Filtering on frontmatter["source_kind"] would
+        # therefore misclassify this row.
+        rec = observation_row_to_record(
+            _row("b", "attention_read", {"source_kind": "signal"}),
+        )
+        assert rec["frontmatter"]["source_kind"] == "signal"
+
+
+class TestKindsFilter:
+    @pytest.mark.asyncio
+    async def test_reporting_kind_excluded_intuition_kinds_kept(self):
+        rows = [
+            _row("1", "signal"), _row("2", "decision"),
+            _row("3", "attention_read"), _row("4", "chore_run"),
+        ]
+        with patch("src.utils.signal_state.StateClient") as sc:
+            sc.return_value.__aenter__.return_value.list_observations = AsyncMock(
+                return_value=rows,
+            )
+            out = await list_observation_records(limit=20, kinds=INTUITION_OBS_KINDS)
+        assert [r["id"] for r in out] == ["1", "2", "4"]
+
+    @pytest.mark.asyncio
+    async def test_no_kinds_argument_filters_nothing(self):
+        # Existing callers that pass no `kinds` must keep their behaviour.
+        rows = [_row("1", "signal"), _row("2", "attention_read")]
+        with patch("src.utils.signal_state.StateClient") as sc:
+            sc.return_value.__aenter__.return_value.list_observations = AsyncMock(
+                return_value=rows,
+            )
+            out = await list_observation_records(limit=20)
+        assert [r["id"] for r in out] == ["1", "2"]
+
+    def test_attention_read_is_not_an_intuition_kind(self):
+        assert "attention_read" not in INTUITION_OBS_KINDS
+        for k in ("signal", "decision", "chore_run"):
+            assert k in INTUITION_OBS_KINDS
+
+
+class TestBothConsumersPassTheFilter:
+    """Guards the call sites, not just the helper — the helper defaults to
+    filtering nothing, so a consumer that forgets the argument is the bug."""
+
+    def test_brief_quiet_notes_passes_kinds(self):
+        src = open("src/activities/vault.py").read()
+        assert "kinds=INTUITION_OBS_KINDS" in src
+
+    def test_pattern_detection_passes_kinds(self):
+        src = open("src/activities/pattern_detection.py").read()
+        assert "kinds=INTUITION_OBS_KINDS" in src


### PR DESCRIPTION
Blocks #633.

## The hazard

`observation` is a shared bus. Two consumers read it with **no kind filter**:

| consumer | filters? | consequence |
|---|---|---|
| `vault.py:632` — daily brief "Quiet Notes" | no | a derived kind appears in Sir's brief dressed as an intuition note |
| `pattern_detection.py:477` — pattern discovery | no | a derived kind is fed in as an observation about the world, shaping proposed instincts |
| `vault.py:789` — Reflection | `status='unprocessed'` | **safe**, but only because ctrl defaults new rows to `open` |

#633 adds `attention_read` — a statement about the *system*, not the world. It
would have leaked into both unfiltered surfaces. Reflection, the one that feeds
the instinct ladder, escapes by an accident of a default value elsewhere in the
stack; nothing was enforcing it.

## The fix

`INTUITION_OBS_KINDS` plus a `kinds=` argument on `list_observation_records`,
passed at both sites. An **allowlist of the kinds that describe the world**,
not an exclusion list — whoever adds the next reporting kind will not know to
add themselves to an exclusion list.

`kinds=None` filters nothing, so every existing caller is unchanged.

## Why the filter runs on the raw row

`observation_row_to_record` carries **no top-level `kind`**. It folds the column
into `frontmatter["source_kind"]` via `setdefault` — so a payload that already
carries `source_kind` keeps its own value and the column is lost.

Filtering the rehydrated record is the obvious implementation and it is wrong
in both directions: it drops rows it should keep, and keeps rows it should
drop. Two tests pin that so the filter is not "simplified" later.

## Smoke evidence

```
tests/test_observation_bus_filter.py .......      7 passed

Red against the unfixed consumers (call sites reverted to origin/main):
  FAILED ...::test_brief_quiet_notes_passes_kinds
  FAILED ...::test_pattern_detection_passes_kinds
  2 failed, 5 passed

Full learn suite: 4 failed, 2809 passed, 101 skipped
  — the 4 are pre-existing test_file_extraction env gaps (pdf/openpyxl),
    plus 2 pre-existing collection errors (no fastapi). Unrelated; present
    on main.
```

The two call-site tests were run against reverted consumers to confirm they
actually fail — a guard that has never been seen red is not a guard.