### PR TITLE
fix(ctrl): add read field to trends response and move none-bucket to unbucketed (#584)

### DIFF
--- a/packages/ctrl/src/api/routes/attention.ts
+++ b/packages/ctrl/src/api/routes/attention.ts
@@ -1267,6 +1267,10 @@ export function registerAttentionRoutes(): void {
       const al:Record<"work"|"life"|"unallocated",{d:number;e:number}>={work:{d:0,e:0},life:{d:0,e:0},unallocated:{d:0,e:0}};
       let cDisp=0,cEng=0,cCnt=0,aDisp=0,aCnt=0,eDisp=0,eCnt=0;
       const bkt:Record<string,{count:number;displaced_hours:number}>={};
+      // Items with bucket=null/undefined/"none" land in unbucketed, not by_bucket.
+      // "none" is a sentinel written by vigilance chore sweeps; it must not appear
+      // as a size tier beside S/M/L/XL — it would skew any size comparison.
+      let ubCnt=0,ubDisp=0;
       const oc={delivered:0,failed:0,unknown:0};
       for (const dr of drs) {
         nar+=dr.nar_hours; disp+=dr.displaced.total_hours;
@@ -1278,13 +1282,15 @@ export function registerAttentionRoutes(): void {
         cDisp+=dr.displaced.inferred.hours; cCnt+=dr.displaced.inferred.items.length;
         for (const it of dr.displaced.inferred.items) {
           cEng+=(it.engaged_minutes??0)/60;
-          if (it.bucket) { bkt[it.bucket]??={count:0,displaced_hours:0}; bkt[it.bucket].count++; bkt[it.bucket].displaced_hours+=it.minutes/60; }
+          if (it.bucket && it.bucket!=="none") { bkt[it.bucket]??={count:0,displaced_hours:0}; bkt[it.bucket].count++; bkt[it.bucket].displaced_hours+=it.minutes/60; }
+          else { ubCnt++; ubDisp+=it.minutes/60; }
           const o=it.outcome??null;
           if (o==="delivered") oc.delivered++; else if (o==="failed") oc.failed++; else oc.unknown++;
         }
         aDisp+=dr.displaced.autonomous.hours; aCnt+=dr.displaced.autonomous.items.length;
         for (const it of dr.displaced.autonomous.items)
-          if (it.bucket) { bkt[it.bucket]??={count:0,displaced_hours:0}; bkt[it.bucket].count++; bkt[it.bucket].displaced_hours+=it.minutes/60; }
+          if (it.bucket && it.bucket!=="none") { bkt[it.bucket]??={count:0,displaced_hours:0}; bkt[it.bucket].count++; bkt[it.bucket].displaced_hours+=it.minutes/60; }
+          else { ubCnt++; ubDisp+=it.minutes/60; }
         eDisp+=dr.displaced.explicit.hours; eCnt+=dr.displaced.explicit.items.reduce((s,x)=>s+x.count,0);
       }
       // interruption_instrumented false = "nothing recorded" not "no interruptions occurred"
@@ -1297,11 +1303,26 @@ export function registerAttentionRoutes(): void {
         allocation:{work:{displaced_hours:r3(al.work.d),engaged_hours:r3(al.work.e)},life:{displaced_hours:r3(al.life.d),engaged_hours:r3(al.life.e)},unallocated:{displaced_hours:r3(al.unallocated.d),engaged_hours:r3(al.unallocated.e)}},
         by_class:{conversational:{displaced_hours:r3(cDisp),engaged_hours:r3(cEng),count:cCnt},autonomous:{displaced_hours:r3(aDisp),engaged_hours:0,count:aCnt},explicit:{displaced_hours:r3(eDisp),engaged_hours:0,count:eCnt}},
         by_bucket:Object.fromEntries(Object.entries(bkt).map(([k,v])=>[k,{count:v.count,displaced_hours:r3(v.displaced_hours)}])),
+        unbucketed:{count:ubCnt,displaced_hours:r3(ubDisp)},
         outcomes:oc,sessions:sess,
       });
     }
+    // Join the clerk-written interpretation for this exact window.
+    // kind='attention_read', subject='attention_trend:{grain}:{from}:{to}'.
+    // null = workflow has not run for this window yet (normal until first run).
+    // {generated_at, observations:[]} = ran but found nothing to say (show, not null).
+    const obsRow=(db.prepare(
+      `SELECT payload_json FROM observation WHERE kind='attention_read' AND subject=? ORDER BY ts DESC LIMIT 1`
+    ).get(`attention_trend:${grain}:${from}:${to}`) as {payload_json:string}|undefined);
+    let read:{generated_at:string;observations:unknown[]}|null=null;
+    if (obsRow?.payload_json) {
+      try {
+        const p=JSON.parse(obsRow.payload_json);
+        read={generated_at:p.generated_at??null,observations:Array.isArray(p.observations)?p.observations:[]};
+      } catch { /* malformed payload — treat as not generated */ }
+    }
     sendJson(res,200,{grain,from,to,
       coverage:{interruption_instrumented_from:firstJ??null,days_total:dates.length,days_with_data:daysData},
-      periods});
+      periods,read});
   });
 }

--- a/packages/ctrl/tests/attention-trends.test.ts
+++ b/packages/ctrl/tests/attention-trends.test.ts
@@ -44,7 +44,19 @@ function jrn(ts:string,dir="outbound"){
   db.prepare(`INSERT INTO alfred_journal(id,ts,channel,chat_id,direction,message)VALUES(?,?,?,?,?,?)`)
     .run(`jrn-${++_seq}`,ts,"telegram","test",dir,"msg");
 }
-function clear(){db.prepare("DELETE FROM nar_entry").run();db.prepare("DELETE FROM alfred_journal").run();}
+function clear(){
+  db.prepare("DELETE FROM nar_entry").run();
+  db.prepare("DELETE FROM alfred_journal").run();
+  db.prepare("DELETE FROM observation").run();
+}
+/** Insert a fake attention_read observation for the given window. */
+function obs(grain:string,from:string,to:string,observations:unknown[]=[],generated_at="2026-08-10T00:00:00.000000+00:00"){
+  _seq++;
+  db.prepare(`INSERT INTO observation(id,ts,subject,kind,summary,confidence,status,payload_json)VALUES(?,?,?,?,?,?,?,?)`)
+    .run(`01OBS${String(_seq).padStart(21,"0")}`,generated_at,
+      `attention_trend:${grain}:${from}:${to}`,"attention_read","summary",1.0,"open",
+      JSON.stringify({grain,from,to,observations,generated_at,period_count:0}));
+}
 
 // 1. periodKeyBounds helper — keys and boundaries for all three grains
 describe("periodKeyBounds",()=>{
@@ -140,5 +152,69 @@ describe("400-day cap",()=>{
   it("400 days → 200",async()=>{
     const {status}=await getTrends("grain=month&from=2025-01-01&to=2026-02-04");
     assert.strictEqual(status,200);
+  });
+});
+
+// 8. read field — joins attention_read observation for the exact window
+describe("read field",()=>{
+  beforeEach(clear);
+  it("null when no observation exists for this window",async()=>{
+    const {p}=await getTrends("grain=week&from=2026-08-10&to=2026-08-16");
+    assert.strictEqual(p.read,null);
+  });
+  it("returns generated_at + observations array when a matching obs exists",async()=>{
+    const obsList=[{headline:"Return ratio fell",detail:"From 1.4 to 0.9.",evidence:"return_ratio=0.9"}];
+    obs("week","2026-08-10","2026-08-16",obsList,"2026-08-11T02:00:00.000000+00:00");
+    const {p}=await getTrends("grain=week&from=2026-08-10&to=2026-08-16");
+    assert.ok(p.read,"read should not be null");
+    assert.strictEqual(p.read.generated_at,"2026-08-11T02:00:00.000000+00:00");
+    assert.deepStrictEqual(p.read.observations,obsList);
+  });
+  it("returns [] (not null) when a matching obs exists with empty observations",async()=>{
+    obs("week","2026-08-10","2026-08-16",[],"2026-08-11T02:00:00.000000+00:00");
+    const {p}=await getTrends("grain=week&from=2026-08-10&to=2026-08-16");
+    assert.ok(p.read!==null,"read must not be null — workflow ran, found nothing");
+    assert.deepStrictEqual(p.read.observations,[]);
+  });
+  it("null when obs exists for different grain (month vs week)",async()=>{
+    obs("month","2026-08-01","2026-08-31",[{headline:"H"}]);
+    const {p}=await getTrends("grain=week&from=2026-08-01&to=2026-08-07");
+    assert.strictEqual(p.read,null);
+  });
+  it("null when obs exists for different date range",async()=>{
+    obs("week","2026-08-03","2026-08-09",[{headline:"H"}]);
+    const {p}=await getTrends("grain=week&from=2026-08-10&to=2026-08-16");
+    assert.strictEqual(p.read,null);
+  });
+});
+
+// 9. by_bucket / unbucketed — "none" must not appear as a size tier
+describe("by_bucket and unbucketed",()=>{
+  beforeEach(clear);
+  it("items with bucket='none' land in unbucketed, not by_bucket",async()=>{
+    nar({occurred_at:"2026-08-10T09:00:00Z",displaced_minutes:12,notes:JSON.stringify({bucket:"none"})});
+    const {p}=await getTrends("grain=week&from=2026-08-10&to=2026-08-10");
+    const per=p.periods[0];
+    assert.ok(!("none" in per.by_bucket),"by_bucket must not contain 'none'");
+    assert.strictEqual(per.unbucketed.count,1);
+    assert.ok(per.unbucketed.displaced_hours>0);
+  });
+  it("items with no bucket also land in unbucketed",async()=>{
+    nar({occurred_at:"2026-08-10T09:00:00Z",displaced_minutes:6,notes:JSON.stringify({allocation:"work"})});
+    const {p}=await getTrends("grain=week&from=2026-08-10&to=2026-08-10");
+    const per=p.periods[0];
+    assert.ok(!("none" in per.by_bucket));
+    assert.strictEqual(per.unbucketed.count,1);
+  });
+  it("by_bucket displaced + unbucketed displaced equals total displaced",async()=>{
+    nar({occurred_at:"2026-08-10T09:00:00Z",displaced_minutes:30,notes:JSON.stringify({bucket:"S"})});
+    nar({occurred_at:"2026-08-10T10:00:00Z",displaced_minutes:20,notes:JSON.stringify({bucket:"none"})});
+    nar({occurred_at:"2026-08-10T11:00:00Z",displaced_minutes:10,notes:null});
+    const {p}=await getTrends("grain=week&from=2026-08-10&to=2026-08-10");
+    const per=p.periods[0];
+    const bktTotal=Object.values(per.by_bucket as Record<string,{displaced_hours:number}>).reduce((s,v)=>s+v.displaced_hours,0);
+    const total=bktTotal+per.unbucketed.displaced_hours;
+    assert.ok(Math.abs(total-per.displaced_hours)<0.001,
+      `bkt(${bktTotal})+unbucketed(${per.unbucketed.displaced_hours})=${total} ≠ displaced(${per.displaced_hours})`);
   });
 });


### PR DESCRIPTION
## Summary

- `GET /api/v1/attention/trends` now returns a top-level `read` field containing the clerk-written interpretation that `AttentionTrendReadWorkflow` (Lane II, merged #633) stores as an `observation` with `kind=attention_read`, `subject=attention_trend:{grain}:{from}:{to}`. The field is `null` when the workflow has not run for this window yet — which is the normal state until the first scheduled execution. An existing read with zero observations returns `{generated_at, observations: []}`, not `null`, so the page can distinguish "not yet generated" from "generated and found nothing interesting".

- Items with `bucket="none"` (vigilance chore sweeps) are moved out of `by_bucket` into a new sibling field `unbucketed: {count, displaced_hours}`. The `"none"` string was silently treated as a size tier alongside S/M/L/XL. Items with a `null`/absent bucket were already absent from `by_bucket`; they now also land in `unbucketed`. Conservation property: `by_bucket` total displaced + `unbucketed` displaced = total displaced for all-inferred periods.

References #584.

## Files touched

- `packages/ctrl/src/api/routes/attention.ts` — trends endpoint: observation join + unbucketed field
- `packages/ctrl/tests/attention-trends.test.ts` — 8 new tests

## Smoke evidence

Local run, worktree `lane-1/trends-join-read`:

```
npm run build   → Build complete — dist/api.mjs

npm run test:ci →
  # tests 1500
  # suites 368
  # pass 1499
  # fail 0
  # cancelled 0
  # skipped 1
  # duration_ms 12995

read field tests:
  ok 1 - null when no observation exists for this window
  ok 2 - returns generated_at + observations array when a matching obs exists
  ok 3 - returns [] (not null) when a matching obs exists with empty observations
  ok 4 - null when obs exists for different grain (month vs week)
  ok 5 - null when obs exists for different date range

by_bucket and unbucketed tests:
  ok 1 - items with bucket='none' land in unbucketed, not by_bucket
  ok 2 - items with no bucket also land in unbucketed
  ok 3 - by_bucket displaced + unbucketed displaced equals total displaced
```

Net LOC: +101 / -4 = 97 net (within 200 limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)