### PR TITLE
feat(web): TRENDS tab on /attention — TrendsView component wired to /api/v1/attention/trends (#584)

### DIFF
--- a/packages/web/main.wasp
+++ b/packages/web/main.wasp
@@ -2137,3 +2137,8 @@ action recomputeAttention {
   fn: import { recomputeAttention } from "@src/dashboard/operations",
   entities: []
 }
+
+query getAttentionTrends {
+  fn: import { getAttentionTrends } from "@src/dashboard/operations",
+  entities: []
+}

--- a/packages/web/src/dashboard/AttentionPage.tsx
+++ b/packages/web/src/dashboard/AttentionPage.tsx
@@ -2,7 +2,7 @@
 // Day view: canonical statement (header → 01 The Account → 02 Where It Went →
 // 03 The Ledger → rate card → footer). Range tab: unchanged.
 import { useState } from "react";
-import { useQuery, useAction, getAttentionStatement, getAttentionStats, recomputeAttention } from "wasp/client/operations";
+import { useQuery, useAction, getAttentionStatement, getAttentionStats, recomputeAttention, getAttentionTrends } from "wasp/client/operations";
 import { Frame } from "../client/components/ab/Frame";
 import logoCurrentcolor from "../client/assets/brand/alfred-logo-currentcolor.svg";
 import {
@@ -13,6 +13,12 @@ import {
   type AttentionDayViewModel, type AttentionStatsResponse,
   type ChartBar, type ChartScaleResult, type BarGeometry,
 } from "./attentionCore";
+import {
+  deriveNarBars, deriveSeriesMax, deriveTrendsSummary,
+  deriveAllocationBars, deriveRatioBars, deriveBucketBars, deriveOutcomesBars,
+  isReadGenerated, BUCKET_KEYS, LOW_ENGAGEMENT_HOURS,
+  type TrendsGrain, type AttentionTrendsResponse,
+} from "./attentionTrendsCore";
 
 const now = () => new Date().toISOString().slice(0, 10);
 /** Read an ISO date from the query string; fall back when absent or malformed. */
@@ -22,6 +28,7 @@ const dateParam = (key: string, fallback: string): string => {
   return v !== null && /^\d{4}-\d{2}-\d{2}$/.test(v) ? v : fallback;
 };
 const sevenAgo = () => { const d = new Date(); d.setDate(d.getDate() - 6); return d.toISOString().slice(0, 10); };
+const thirteenWeeksAgo = () => { const d = new Date(); d.setDate(d.getDate() - 91); return d.toISOString().slice(0, 10); };
 
 // ── Shared primitives ─────────────────────────────────────────────────────────
 
@@ -434,17 +441,216 @@ function RangeView({ stats }: { stats: AttentionStatsResponse }) {
   );
 }
 
+// ── Trends view (#584 — TRENDS tab) ──────────────────────────────────────────
+
+function TrendsView({ data, grain, setGrain }: { data: AttentionTrendsResponse; grain: TrendsGrain; setGrain: (g: TrendsGrain) => void }) {
+  const ps = data.periods ?? [];
+  if (!ps.length) return <p className="font-mono text-xs opacity-40 mt-12">No data for this period.</p>;
+  const nb = deriveNarBars(ps, grain); const ab = deriveAllocationBars(ps, grain);
+  const rb = deriveRatioBars(ps, grain); const bb = deriveBucketBars(ps, grain);
+  const ob = deriveOutcomesBars(ps, grain); const sum = deriveTrendsSummary(ps);
+  const BW = 24; const GP = 5; const H = 80; const CW = ps.length * (BW + GP) - GP;
+  const xi = (i: number) => i * (BW + GP);
+  const bar = (v: number, max: number) => Math.round(Math.max(v, 0) / max * H);
+  const maxDisp = deriveSeriesMax(nb.map(b => b.displaced_hours));
+  const maxAlloc = deriveSeriesMax(ab.map(b => b.total));
+  const maxOut = deriveSeriesMax(ob.map(b => b.total));
+  const validR = rb.filter(b => b.ratio != null && !b.low_engagement).map(b => b.ratio!);
+  const maxRatio = deriveSeriesMax(validR.length ? validR : rb.filter(b => b.ratio != null).map(b => b.ratio!));
+  const fh = (v: number | null, d = 1) => v == null ? "—" : v.toFixed(d);
+  const totalUnbucketed = bb.reduce((s, b) => s + b.unbucketed_count, 0);
+  return (
+    <div className="mt-4">
+      {/* Grain selector */}
+      <div className="flex gap-4 mb-10">
+        {(["week", "month", "quarter"] as TrendsGrain[]).map(g => (
+          <button key={g} type="button" onClick={() => setGrain(g)}
+            className="font-mono text-[10px] uppercase tracking-[0.22em] pb-1 transition-colors"
+            style={{ color: grain === g ? "var(--brass)" : "var(--marginalia)", borderBottom: grain === g ? "1px solid var(--brass)" : "1px solid transparent" }}>
+            {g === "week" ? "Weekly" : g === "month" ? "Monthly" : "Quarterly"}
+          </button>
+        ))}
+      </div>
+
+      {/* 01 Headline pair */}
+      <div className="grid grid-cols-2 gap-8 mb-12">
+        <div>
+          <p className="font-mono text-[10px] uppercase tracking-[0.22em] mb-2" style={{ color: "var(--marginalia)" }}>NAR this {grain}</p>
+          <p className="font-display" style={{ fontSize: 48, lineHeight: 1 }}>{fh(sum.latest_nar)}<span className="font-mono text-base ml-2 opacity-50">h</span></p>
+          {sum.nar_delta != null && (
+            <p className="font-mono text-[11px] mt-1" style={{ color: sum.nar_delta >= 0 ? "var(--brass)" : "oklch(0.42 0.12 30)" }}>
+              {sum.nar_delta >= 0 ? "+" : ""}{fh(sum.nar_delta)}h vs prior {grain}
+            </p>
+          )}
+        </div>
+        <div>
+          <p className="font-mono text-[10px] uppercase tracking-[0.22em] mb-2" style={{ color: "var(--marginalia)" }}>Return ratio</p>
+          <p className="font-display" style={{ fontSize: 48, lineHeight: 1 }}>{fh(sum.latest_ratio)}{sum.latest_ratio != null && <span className="font-mono text-base ml-1 opacity-50">×</span>}</p>
+          {sum.ratio_direction && (
+            <p className="font-mono text-[11px] mt-1" style={{ color: sum.ratio_direction === "up" ? "var(--brass)" : sum.ratio_direction === "down" ? "oklch(0.42 0.12 30)" : "var(--marginalia)" }}>
+              {sum.ratio_direction === "up" ? "↑ improving" : sum.ratio_direction === "down" ? "↓ declining" : "→ flat"}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* 02 NAR chart — displaced (total) bars with engaged overlay; partial=dashed; uninstrumented=dim */}
+      <div className="mb-12">
+        <SL n="02" title="NAR by period" />
+        <svg width={CW} height={H + 16} className="overflow-visible mt-4" role="img" aria-label="NAR by period chart">
+          {nb.map((b, i) => {
+            const disp = bar(b.displaced_hours, maxDisp); const eng = bar(b.engaged_hours, maxDisp);
+            return (
+              <g key={b.key} opacity={b.uninstrumented ? 0.4 : 1}>
+                <rect x={xi(i)} y={H - disp} width={BW} height={disp} fill="var(--rule)" rx={1} stroke={b.partial ? "var(--brass)" : "none"} strokeWidth={b.partial ? 1 : 0} strokeDasharray={b.partial ? "3 2" : undefined} />
+                <rect x={xi(i)} y={H - eng} width={BW} height={eng} fill="var(--brass)" rx={1} opacity={0.6} />
+                <text x={xi(i) + BW / 2} y={H + 12} textAnchor="middle" fontSize={8} fontFamily="monospace" fill="var(--marginalia)">{b.label}</text>
+              </g>
+            );
+          })}
+        </svg>
+        <p className="font-mono text-[9px] mt-2" style={{ color: "var(--marginalia)" }}>
+          <span className="inline-block w-2 h-2 mr-1 align-middle" style={{ background: "var(--brass)", opacity: 0.6 }} /> engaged
+          &nbsp;<span className="inline-block w-2 h-2 mr-1 align-middle" style={{ background: "var(--rule)" }} /> NAR
+          {nb.some(b => b.partial) && <>&nbsp; · dashed outline = partial period</>}
+          {nb.some(b => b.uninstrumented) && <>&nbsp; · dim = interruptions unmeasured</>}
+        </p>
+      </div>
+
+      {/* 03 Allocation — proportional bars: work / life / unallocated */}
+      <div className="mb-12">
+        <SL n="03" title="Where it went" />
+        <div className="flex flex-col gap-2 mt-4">
+          {ab.map(b => (
+            <div key={b.key} className="flex items-center gap-3">
+              <span className="font-mono text-[9px] w-8 shrink-0 text-right" style={{ color: "var(--marginalia)" }}>{b.label}</span>
+              <div className="flex-1 flex h-4 gap-px overflow-hidden rounded-sm">
+                {(["work", "life", "unallocated"] as const).map(k => {
+                  const v = b[k]; const pct = v / b.total * 100;
+                  return pct > 0.5 ? <div key={k} style={{ width: `${pct}%`, background: k === "work" ? "var(--brass)" : k === "life" ? "oklch(0.62 0.09 200)" : "var(--rule)", opacity: k === "unallocated" ? 0.4 : 0.8 }} /> : null;
+                })}
+              </div>
+              <span className="font-mono text-[9px] w-10 shrink-0" style={{ color: "var(--marginalia)" }}>{b.total.toFixed(1)}h</span>
+            </div>
+          ))}
+        </div>
+        <div className="flex gap-4 mt-2">
+          {(["work", "life", "unallocated"] as const).map(k => (
+            <span key={k} className="font-mono text-[9px] flex items-center gap-1" style={{ color: "var(--marginalia)" }}>
+              <span className="inline-block w-2 h-2" style={{ background: k === "work" ? "var(--brass)" : k === "life" ? "oklch(0.62 0.09 200)" : "var(--rule)" }} /> {k}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* 04 Return ratio — null preserved as em-dash; low-engagement dimmed */}
+      <div className="mb-12">
+        <SL n="04" title="Return ratio" />
+        <svg width={CW} height={H + 16} className="overflow-visible mt-4" role="img" aria-label="Return ratio chart">
+          {rb.map((b, i) => {
+            if (b.ratio == null) return (
+              <g key={b.key}>
+                <text x={xi(i) + BW / 2} y={H / 2} textAnchor="middle" fontSize={11} fontFamily="monospace" fill="var(--marginalia)" dominantBaseline="middle">—</text>
+                <text x={xi(i) + BW / 2} y={H + 12} textAnchor="middle" fontSize={8} fontFamily="monospace" fill="var(--marginalia)">{b.label}</text>
+              </g>
+            );
+            const h = bar(b.ratio, maxRatio);
+            return (
+              <g key={b.key} opacity={b.low_engagement ? 0.3 : 1}>
+                <rect x={xi(i)} y={H - h} width={BW} height={h} fill="var(--brass)" rx={1} />
+                <text x={xi(i) + BW / 2} y={H + 12} textAnchor="middle" fontSize={8} fontFamily="monospace" fill="var(--marginalia)">{b.label}</text>
+              </g>
+            );
+          })}
+        </svg>
+        <p className="font-mono text-[9px] mt-2" style={{ color: "var(--marginalia)" }}>
+          — = no engagement data · dim bars = engaged &lt; {LOW_ENGAGEMENT_HOURS}h (ratio unreliable)
+        </p>
+      </div>
+
+      {/* 05 Outcomes — delivered/failed/unknown; failures in destructive red */}
+      <div className="mb-12">
+        <SL n="05" title="Outcomes" />
+        <svg width={CW} height={H + 16} className="overflow-visible mt-4" role="img" aria-label="Outcomes chart">
+          {ob.map((b, i) => {
+            const tot = bar(b.total, maxOut); const del = bar(b.delivered, maxOut); const fail = bar(b.failed, maxOut);
+            return (
+              <g key={b.key}>
+                <rect x={xi(i)} y={H - tot} width={BW} height={tot} fill="var(--rule)" rx={1} />
+                <rect x={xi(i)} y={H - del} width={BW} height={del} fill="var(--brass)" rx={1} opacity={0.75} />
+                {fail > 0 && <rect x={xi(i)} y={H - fail} width={BW / 2} height={fail} fill="oklch(0.42 0.12 30)" rx={1} />}
+                <text x={xi(i) + BW / 2} y={H + 12} textAnchor="middle" fontSize={8} fontFamily="monospace" fill="var(--marginalia)">{b.label}</text>
+              </g>
+            );
+          })}
+        </svg>
+        {ob.some(b => b.failed > 0) && (
+          <p className="font-mono text-[10px] font-semibold mt-2" style={{ color: "oklch(0.42 0.12 30)" }}>
+            {ob.reduce((s, b) => s + b.failed, 0)} failed · {ob.reduce((s, b) => s + b.delivered, 0)} delivered
+          </p>
+        )}
+      </div>
+
+      {/* 06 Task size mix — S/M/L/XL stacked; unbucketed is footnote only */}
+      <div className="mb-12">
+        <SL n="06" title="Task size mix" />
+        <div className="flex flex-col gap-2 mt-4">
+          {bb.map(b => {
+            const tot = b.S + b.M + b.L + b.XL || 1;
+            return (
+              <div key={b.key} className="flex items-center gap-3">
+                <span className="font-mono text-[9px] w-8 shrink-0 text-right" style={{ color: "var(--marginalia)" }}>{b.label}</span>
+                <div className="flex-1 flex h-4 gap-px overflow-hidden rounded-sm">
+                  {BUCKET_KEYS.map((k, ki) => { const v = b[k]; const pct = v / tot * 100; return pct > 0.5 ? <div key={k} style={{ width: `${pct}%`, background: `oklch(${0.52 + ki * 0.07} 0.08 75)` }} /> : null; })}
+                </div>
+                <span className="font-mono text-[9px] w-10 shrink-0" style={{ color: "var(--marginalia)" }}>{tot}</span>
+              </div>
+            );
+          })}
+        </div>
+        {totalUnbucketed > 0 && <p className="font-mono text-[9px] mt-2" style={{ color: "var(--marginalia)" }}>+ {totalUnbucketed} vigilance sweeps (unbucketed — not shown)</p>}
+      </div>
+
+      {/* 07 Alfred's read — null = not yet generated; never fabricate observations */}
+      <div className="mb-10">
+        <SL n="07" title="Alfred's read" />
+        {isReadGenerated(data.read) ? (
+          data.read!.observations.length === 0
+            ? <p className="font-mono text-xs mt-4 opacity-40">Alfred ran the analysis but found no patterns to surface for this period.</p>
+            : <div className="mt-4 flex flex-col gap-6">
+                {data.read!.observations.map((obs, i) => (
+                  <div key={i} className="grid grid-cols-[1fr_2fr] gap-6 pb-6 border-b border-[var(--rule)] last:border-0">
+                    <p className="font-display text-lg leading-snug">{obs.headline}</p>
+                    <div>
+                      <p className="font-mono text-sm mb-2">{obs.detail}</p>
+                      <p className="font-mono text-[10px] opacity-50">{obs.evidence}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+        ) : (
+          <p className="font-mono text-xs mt-4 opacity-50">Alfred hasn't generated a read for this period yet — it runs automatically after the nightly workflow.</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
 // ── Page shell ────────────────────────────────────────────────────────────────
 
 export default function AttentionPage() {
-  const [tab, setTab] = useState<"day" | "range">(
+  const [tab, setTab] = useState<"day" | "range" | "trends">(
     dateParam("from", "") !== "" ? "range" : "day");
   const [date, setDate] = useState(dateParam("date", now()));
   const [from, setFrom] = useState(dateParam("from", sevenAgo()));
   const [to, setTo] = useState(dateParam("to", now()));
   const [running, setRunning] = useState(false);
+  const [grain, setGrain] = useState<TrendsGrain>("week");
+  const [trendsFrom] = useState(thirteenWeeksAgo);
+  const [trendsTo] = useState(now);
   const dayQ = useQuery(getAttentionStatement, { date }, { enabled: tab === "day" });
   const statsQ = useQuery(getAttentionStats, { from, to }, { enabled: tab === "range" });
+  const trendsQ = useQuery(getAttentionTrends, { grain, from: trendsFrom, to: trendsTo }, { enabled: tab === "trends" });
   const recompute = useAction(recomputeAttention);
 
   async function handleRecompute() {
@@ -482,7 +688,7 @@ export default function AttentionPage() {
           </>
         )}
 
-        {/* Page-level header — shown on range tab; day tab has its own statement header */}
+        {/* Page-level header — shown on range/trends tabs; day tab has its own statement header */}
         {tab === "range" && (
           <div className="mb-10">
             <p className="font-mono text-[10px] uppercase tracking-[0.32em] mb-3" style={{ color: "var(--marginalia)" }}>
@@ -493,33 +699,49 @@ export default function AttentionPage() {
             </h1>
           </div>
         )}
+        {tab === "trends" && (
+          <div className="mb-10">
+            <p className="font-mono text-[10px] uppercase tracking-[0.32em] mb-3" style={{ color: "var(--marginalia)" }}>
+              Alfred Black · Attention Trends
+            </p>
+            <h1 className="font-display tracking-[-0.02em] leading-[0.98]" style={{ fontSize: "clamp(44px,6vw,72px)" }}>
+              Usage over time.
+            </h1>
+          </div>
+        )}
 
         {/* Tab bar */}
         <div className="flex gap-6 mb-6 border-b border-[var(--rule)]">
-          {(["day", "range"] as const).map((t) => (
+          {(["day", "range", "trends"] as const).map((t) => (
             <button key={t} type="button" onClick={() => setTab(t)}
               className="font-mono text-[10px] uppercase tracking-[0.22em] pb-2 transition-colors"
               style={{ color: tab === t ? "var(--brass)" : "var(--marginalia)", borderBottom: tab === t ? "1px solid var(--brass)" : "1px solid transparent" }}>
-              {t === "day" ? "Day" : "Range"}
+              {t === "day" ? "Day" : t === "range" ? "Range" : "Trends"}
             </button>
           ))}
         </div>
 
-        {/* Date controls */}
-        <div className="flex items-center gap-3 mb-8">
-          {tab === "day"
-            ? din(date, setDate, now())
-            : <>{din(from, setFrom, to)}<span className="font-mono text-xs opacity-40">to</span>{din(to, setTo, now())}</>}
-        </div>
+        {/* Date controls — Trends uses internal grain selector; no date pickers */}
+        {tab !== "trends" && (
+          <div className="flex items-center gap-3 mb-8">
+            {tab === "day"
+              ? din(date, setDate, now())
+              : <>{din(from, setFrom, to)}<span className="font-mono text-xs opacity-40">to</span>{din(to, setTo, now())}</>}
+          </div>
+        )}
 
         {/* Content */}
         {tab === "day"
           ? dayQ.isLoading ? <p className="font-mono text-xs opacity-40">Loading…</p>
             : dayQ.error ? <p className="font-mono text-xs" style={{ color: "oklch(0.42 0.12 30)" }}>{String((dayQ.error as any)?.message ?? "Failed.")}</p>
             : dayQ.data ? <DayView day={normalizeAttentionDay(dayQ.data)} recomp={handleRecompute} running={running} /> : null
-          : statsQ.isLoading ? <p className="font-mono text-xs opacity-40">Loading…</p>
-            : statsQ.error ? <p className="font-mono text-xs" style={{ color: "oklch(0.42 0.12 30)" }}>{String((statsQ.error as any)?.message ?? "Failed.")}</p>
-            : statsQ.data ? <RangeView stats={statsQ.data as AttentionStatsResponse} /> : null}
+          : tab === "range"
+            ? statsQ.isLoading ? <p className="font-mono text-xs opacity-40">Loading…</p>
+              : statsQ.error ? <p className="font-mono text-xs" style={{ color: "oklch(0.42 0.12 30)" }}>{String((statsQ.error as any)?.message ?? "Failed.")}</p>
+              : statsQ.data ? <RangeView stats={statsQ.data as AttentionStatsResponse} /> : null
+            : trendsQ.isLoading ? <p className="font-mono text-xs opacity-40">Loading…</p>
+              : trendsQ.error ? <p className="font-mono text-xs" style={{ color: "oklch(0.42 0.12 30)" }}>{String((trendsQ.error as any)?.message ?? "Failed.")}</p>
+              : trendsQ.data ? <TrendsView data={trendsQ.data as AttentionTrendsResponse} grain={grain} setGrain={setGrain} /> : null}
 
       </section>
     </Frame>

--- a/packages/web/src/dashboard/attentionTrendsCore.test.ts
+++ b/packages/web/src/dashboard/attentionTrendsCore.test.ts
@@ -1,0 +1,141 @@
+/**
+ * attentionTrendsCore unit tests (#584 TRENDS tab).
+ * Run: cd packages/web && npx tsx --test src/dashboard/attentionTrendsCore.test.ts
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  derivePeriodLabel, isPartialPeriod, GRAIN_FULL_DAYS,
+  deriveNarBars, deriveSeriesMax, deriveTrendsSummary,
+  deriveAllocationBars, deriveRatioBars, deriveBucketBars, deriveOutcomesBars,
+  isReadGenerated, BUCKET_KEYS, LOW_ENGAGEMENT_HOURS,
+  type TrendsPeriod,
+} from "./attentionTrendsCore";
+
+// ── Fixture factory ───────────────────────────────────────────────────────────
+
+const mkP = (key: string, days: number, disp: number, eng: number, nar: number, ratio: number | null, ins = true, work = 0, life = 0): TrendsPeriod => ({
+  key, start: key, end: key, days,
+  nar_hours: nar, displaced_hours: disp, engaged_hours: eng, interruption_hours: 0, interruption_instrumented: ins,
+  return_ratio: ratio,
+  allocation: { work:{displaced_hours:work,engaged_hours:0}, life:{displaced_hours:life,engaged_hours:0}, unallocated:{displaced_hours:Math.max(disp-work-life,0),engaged_hours:eng} },
+  by_class: { conversational:{displaced_hours:0,engaged_hours:0,count:0}, autonomous:{displaced_hours:0,engaged_hours:0,count:0}, explicit:{displaced_hours:0,engaged_hours:0,count:0} },
+  by_bucket: { S:{count:14,displaced_hours:1}, M:{count:25,displaced_hours:3}, L:{count:10,displaced_hours:4}, XL:{count:6,displaced_hours:5} },
+  unbucketed: { count: 216, displaced_hours: 0.1 },
+  outcomes: { delivered: 26, failed: 18, unknown: 0 },
+  sessions: 5,
+});
+
+// Real home data from the brief
+const W21 = mkP("2026-W21", 2, 1.2, 0, 1.2, null, false);              // 2-day partial, uninstrumented
+const W22 = mkP("2026-W22", 7, 16.5, 3.7, 12.7, 4.4, true, 3.3, 4.8);
+const W32 = mkP("2026-W32", 7, 24.6, 6.8, 17.8, 3.6, true, 14.8, 2.5);
+const W33 = mkP("2026-W33", 6, 22.5, 6.4, 15.4, 3.5, true, 14.0, 2.6); // 6-day partial
+const W24 = mkP("2026-W24", 7, 11.6, 0.8, 10.8, 13.9, false);          // high ratio, low engagement
+
+// ── 1. Period labels — all three grains ───────────────────────────────────────
+
+test("label: renders for all three grains and falls through on unknown key", () => {
+  assert.equal(derivePeriodLabel("2026-W22", "week"), "W22");
+  assert.equal(derivePeriodLabel("2026-W9",  "week"), "W9");
+  assert.equal(derivePeriodLabel("2026-05", "month"), "May");
+  assert.equal(derivePeriodLabel("2026-01", "month"), "Jan");
+  assert.equal(derivePeriodLabel("2026-12", "month"), "Dec");
+  assert.equal(derivePeriodLabel("2026-Q2", "quarter"), "Q2");
+  assert.equal(derivePeriodLabel("2026-Q4", "quarter"), "Q4");
+  assert.equal(derivePeriodLabel("unknown", "week"), "unknown");
+});
+
+// ── 2. Partial period detection ────────────────────────────────────────────────
+
+test("isPartialPeriod: W21 (2d) and W33 (6d) are partial; full weeks are not", () => {
+  assert.equal(isPartialPeriod({ days: 7 }, "week"), false);
+  assert.equal(isPartialPeriod({ days: 2 }, "week"), true,  "W21 (2d) must be flagged partial");
+  assert.equal(isPartialPeriod({ days: 6 }, "week"), true,  "W33 (6d < 7) must be flagged partial");
+  assert.equal(isPartialPeriod({ days: 28 }, "month"), false);
+  assert.equal(isPartialPeriod({ days: 20 }, "month"), true);
+  assert.ok(GRAIN_FULL_DAYS.week === 7 && GRAIN_FULL_DAYS.month > 0 && GRAIN_FULL_DAYS.quarter > 0);
+});
+
+// ── 3. NarBars — partial and uninstrumented flags ──────────────────────────────
+
+test("deriveNarBars: partial and uninstrumented flags; values preserved; null-safe", () => {
+  const bars = deriveNarBars([W21, W22, W32, W33], "week");
+  assert.equal(bars[0].partial, true);  assert.equal(bars[0].uninstrumented, true,  "W21 uninstrumented");
+  assert.equal(bars[1].partial, false); assert.equal(bars[1].uninstrumented, false, "W22 instrumented");
+  assert.equal(bars[3].partial, true,  "W33 (6d) partial"); assert.equal(bars[3].uninstrumented, false);
+  const [b32] = deriveNarBars([W32], "week");
+  assert.equal(b32.displaced_hours, 24.6); assert.equal(b32.nar_hours, 17.8); assert.equal(b32.label, "W32");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  assert.deepEqual(deriveNarBars(null as any, "week"), []);
+});
+
+// ── 4. Chart scaling — real range + all-zero guard ────────────────────────────
+
+test("deriveSeriesMax: handles real home range (no clipping) and all-zero period", () => {
+  const max = deriveSeriesMax([W21,W22,W32,W33].map(p => p.nar_hours));
+  assert.ok(max >= 17.8, `max ${max} >= 17.8 — real range must not clip`);
+  assert.equal(deriveSeriesMax([0, 0, 0]), 1, "all-zero → 1 guard");
+  assert.equal(deriveSeriesMax([]), 1, "empty → 1 guard");
+});
+
+// ── 5. Summary — null ratio preserved; direction; delta ───────────────────────
+
+test("deriveTrendsSummary: null ratio stays null (never 0); delta; direction; empty", () => {
+  assert.deepEqual(deriveTrendsSummary([]), { latest_nar: null, nar_delta: null, latest_ratio: null, ratio_direction: null });
+  const s1 = deriveTrendsSummary([W21]);
+  assert.equal(s1.latest_ratio, null, "W21 return_ratio=null must remain null — em-dash in view");
+  assert.equal(s1.nar_delta, null);
+  const s2 = deriveTrendsSummary([W32, W33]);
+  assert.equal(s2.ratio_direction, "down", "3.6→3.5 is down");
+  assert.ok(Math.abs((s2.nar_delta ?? 0) - (15.4 - 17.8)) < 0.01);
+  assert.equal(deriveTrendsSummary([W21, W32]).ratio_direction, null, "prev ratio null → direction null");
+});
+
+// ── 6. Allocation bars ────────────────────────────────────────────────────────
+
+test("deriveAllocationBars: work/life values correct; total guard prevents div-by-zero", () => {
+  const [bar] = deriveAllocationBars([W22], "week");
+  assert.ok(Math.abs(bar.work - 3.3) < 0.01); assert.ok(Math.abs(bar.life - 4.8) < 0.01);
+  const [z] = deriveAllocationBars([{ ...W21, allocation:{work:{displaced_hours:0,engaged_hours:0},life:{displaced_hours:0,engaged_hours:0},unallocated:{displaced_hours:0,engaged_hours:0}} }], "week");
+  assert.ok(z.total > 0, "total guard: never 0 (would cause div-by-zero in chart)");
+});
+
+// ── 7. Ratio bars — honesty rules ─────────────────────────────────────────────
+
+test("deriveRatioBars: null ratio preserved; low-engagement and uninstrumented flags", () => {
+  const bars = deriveRatioBars([W21, W24, W32], "week");
+  assert.equal(bars[0].ratio, null, "W21 null ratio — never coerced to 0");
+  assert.equal(bars[1].low_engagement, true,  "W24 (0.8h < threshold) is low-engagement");
+  assert.equal(bars[2].low_engagement, false, "W32 (6.8h) is not low-engagement");
+  assert.equal(bars[0].uninstrumented, true); assert.equal(bars[2].uninstrumented, false);
+  assert.ok(LOW_ENGAGEMENT_HOURS > 0);
+});
+
+// ── 8. Bucket bars — unbucketed NEVER among S/M/L/XL ─────────────────────────
+
+test("deriveBucketBars: S/M/L/XL from by_bucket; unbucketed is footnote-only and excluded from sum", () => {
+  const [bar] = deriveBucketBars([W32], "week");
+  assert.equal(bar.S, 14); assert.equal(bar.M, 25); assert.equal(bar.L, 10); assert.equal(bar.XL, 6);
+  assert.equal(bar.unbucketed_count, 216);
+  assert.ok(bar.S + bar.M + bar.L + bar.XL < 300, "named sum must not include 216 unbucketed");
+  assert.deepEqual(BUCKET_KEYS as readonly string[], ["S","M","L","XL"]);
+  assert.ok(!(BUCKET_KEYS as readonly string[]).includes("unbucketed"));
+});
+
+// ── 9. Outcomes bars — W32 failure count preserved ────────────────────────────
+
+test("deriveOutcomesBars: W32 18 failures survive derivation; total consistent", () => {
+  const [bar] = deriveOutcomesBars([W32], "week");
+  assert.equal(bar.failed, 18, "18 failures must reach the view unchanged");
+  assert.equal(bar.delivered, 26);
+  assert.equal(bar.total, bar.delivered + bar.failed + bar.unknown);
+});
+
+// ── 10. Read presence guard ───────────────────────────────────────────────────
+
+test("isReadGenerated: null/undefined → false; object (even empty) → true", () => {
+  assert.equal(isReadGenerated(null), false); assert.equal(isReadGenerated(undefined), false);
+  assert.equal(isReadGenerated({ generated_at: "2026-08-10", observations: [] }), true);
+  assert.equal(isReadGenerated({ generated_at: "2026-08-10", observations: [{ headline:"h",detail:"d",evidence:"e" }] }), true);
+});

--- a/packages/web/src/dashboard/attentionTrendsCore.ts
+++ b/packages/web/src/dashboard/attentionTrendsCore.ts
@@ -1,0 +1,144 @@
+// attentionTrendsCore.ts — pure derivations for the TRENDS tab (#584).
+// No imports; node:test-able. Hand-rolled SVG only — no charting library added.
+
+export type TrendsGrain = "week" | "month" | "quarter";
+export interface AllocationSlice { displaced_hours: number; engaged_hours: number }
+export interface ClassSlice { displaced_hours: number; engaged_hours: number; count: number }
+export interface SizeSlice { count: number; displaced_hours: number }
+export interface TrendsPeriod {
+  key: string; start: string; end: string; days: number;
+  nar_hours: number; displaced_hours: number; engaged_hours: number;
+  interruption_hours: number; interruption_instrumented: boolean;
+  return_ratio: number | null;  // null when engaged_hours === 0
+  allocation: { work: AllocationSlice; life: AllocationSlice; unallocated: AllocationSlice };
+  by_class: { conversational: ClassSlice; autonomous: ClassSlice; explicit: ClassSlice };
+  by_bucket: { S: SizeSlice; M: SizeSlice; L: SizeSlice; XL: SizeSlice };
+  unbucketed: { count: number; displaced_hours: number };
+  outcomes: { delivered: number; failed: number; unknown: number };
+  sessions: number;
+}
+export interface TrendsCoverage { interruption_instrumented_from: string | null; days_total: number; days_with_data: number }
+export interface TrendsObservation { headline: string; detail: string; evidence: string }
+export interface TrendsRead { generated_at: string; observations: TrendsObservation[] }
+export interface AttentionTrendsResponse {
+  grain: TrendsGrain; from: string; to: string;
+  coverage: TrendsCoverage; periods: TrendsPeriod[]; read: TrendsRead | null;
+}
+
+// ── Period label ───────────────────────────────────────────────────────────────
+
+const MONTH_ABBR = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"] as const;
+/** "2026-W22" → "W22"; "2026-05" → "May"; "2026-Q2" → "Q2". */
+export function derivePeriodLabel(key: string, grain: TrendsGrain): string {
+  if (grain === "week")  { const m = /W(\d{1,2})$/.exec(key); return m ? `W${m[1]}` : key; }
+  if (grain === "month") { const m = /^(\d{4})-(\d{2})$/.exec(key); if (m) return MONTH_ABBR[parseInt(m[2],10)-1] ?? key; return key; }
+  const m = /Q(\d)$/.exec(key); return m ? `Q${m[1]}` : key;
+}
+
+// ── Partial period ─────────────────────────────────────────────────────────────
+
+/** Minimum day count for a full period per grain. Partials must be visually marked — not treated as low-NAR weeks. */
+export const GRAIN_FULL_DAYS: Record<TrendsGrain, number> = { week: 7, month: 28, quarter: 84 };
+export function isPartialPeriod(period: Pick<TrendsPeriod, "days">, grain: TrendsGrain): boolean {
+  return (period.days ?? 0) < GRAIN_FULL_DAYS[grain];
+}
+
+// ── NAR chart ─────────────────────────────────────────────────────────────────
+
+export interface NarBar {
+  key: string; label: string; nar_hours: number; displaced_hours: number; engaged_hours: number;
+  partial: boolean;        // partial period — must be visually distinguished
+  uninstrumented: boolean; // interruption_instrumented=false — cost is unmeasured, not zero
+}
+export function deriveNarBars(periods: TrendsPeriod[], grain: TrendsGrain): NarBar[] {
+  return (periods ?? []).map((p) => ({
+    key: p.key, label: derivePeriodLabel(p.key, grain),
+    nar_hours: p.nar_hours, displaced_hours: p.displaced_hours, engaged_hours: p.engaged_hours,
+    partial: isPartialPeriod(p, grain), uninstrumented: !p.interruption_instrumented,
+  }));
+}
+/** Largest absolute value in the series; returns 1 when all zero (no div-by-zero). */
+export function deriveSeriesMax(values: number[]): number {
+  return Math.max(...(values ?? []).map((v) => Math.abs(v ?? 0)), 1);
+}
+
+// ── Summary headline pair ──────────────────────────────────────────────────────
+
+export interface TrendsSummary {
+  latest_nar: number | null; nar_delta: number | null;
+  latest_ratio: number | null; ratio_direction: "up" | "down" | "flat" | null;
+}
+export function deriveTrendsSummary(periods: TrendsPeriod[]): TrendsSummary {
+  const ps = periods ?? [];
+  if (!ps.length) return { latest_nar: null, nar_delta: null, latest_ratio: null, ratio_direction: null };
+  const last = ps[ps.length - 1]; const prev = ps.length > 1 ? ps[ps.length - 2] : null;
+  const ratio_direction: TrendsSummary["ratio_direction"] =
+    last.return_ratio == null || prev?.return_ratio == null ? null
+    : last.return_ratio > prev.return_ratio + 0.05 ? "up"
+    : last.return_ratio < prev.return_ratio - 0.05 ? "down" : "flat";
+  return { latest_nar: last.nar_hours, nar_delta: prev != null ? last.nar_hours - prev.nar_hours : null, latest_ratio: last.return_ratio, ratio_direction };
+}
+
+// ── Allocation trend ───────────────────────────────────────────────────────────
+
+export interface AllocationBar { key: string; label: string; work: number; life: number; unallocated: number; total: number }
+export function deriveAllocationBars(periods: TrendsPeriod[], grain: TrendsGrain): AllocationBar[] {
+  return (periods ?? []).map((p) => {
+    const w = p.allocation?.work?.displaced_hours ?? 0;
+    const l = p.allocation?.life?.displaced_hours ?? 0;
+    const u = p.allocation?.unallocated?.displaced_hours ?? 0;
+    return { key: p.key, label: derivePeriodLabel(p.key, grain), work: w, life: l, unallocated: u, total: Math.max(w+l+u, 0.001) };
+  });
+}
+
+// ── Return-ratio trend ─────────────────────────────────────────────────────────
+
+/** Periods where engaged < this threshold have a misleading ratio — de-emphasise them. */
+export const LOW_ENGAGEMENT_HOURS = 1;
+export interface RatioBar {
+  key: string; label: string;
+  ratio: number | null; // null preserved from API — display renders "—", never 0
+  low_engagement: boolean; uninstrumented: boolean;
+}
+export function deriveRatioBars(periods: TrendsPeriod[], grain: TrendsGrain): RatioBar[] {
+  return (periods ?? []).map((p) => ({
+    key: p.key, label: derivePeriodLabel(p.key, grain),
+    ratio: p.return_ratio, // null never coerced to 0
+    low_engagement: (p.engaged_hours ?? 0) < LOW_ENGAGEMENT_HOURS,
+    uninstrumented: !p.interruption_instrumented,
+  }));
+}
+
+// ── Bucket distribution (S/M/L/XL only — unbucketed is NOT a size) ────────────
+
+export type BucketKey = "S" | "M" | "L" | "XL";
+export const BUCKET_KEYS: readonly BucketKey[] = ["S", "M", "L", "XL"] as const;
+export interface BucketBar {
+  key: string; label: string; S: number; M: number; L: number; XL: number;
+  unbucketed_count: number; // footnote only — never a bar
+}
+export function deriveBucketBars(periods: TrendsPeriod[], grain: TrendsGrain): BucketBar[] {
+  return (periods ?? []).map((p) => ({
+    key: p.key, label: derivePeriodLabel(p.key, grain),
+    S: p.by_bucket?.S?.count ?? 0, M: p.by_bucket?.M?.count ?? 0,
+    L: p.by_bucket?.L?.count ?? 0, XL: p.by_bucket?.XL?.count ?? 0,
+    unbucketed_count: p.unbucketed?.count ?? 0,
+  }));
+}
+
+// ── Outcomes trend ─────────────────────────────────────────────────────────────
+
+export interface OutcomesBar { key: string; label: string; delivered: number; failed: number; unknown: number; total: number }
+export function deriveOutcomesBars(periods: TrendsPeriod[], grain: TrendsGrain): OutcomesBar[] {
+  return (periods ?? []).map((p) => {
+    const d = p.outcomes?.delivered ?? 0; const f = p.outcomes?.failed ?? 0; const u = p.outcomes?.unknown ?? 0;
+    return { key: p.key, label: derivePeriodLabel(p.key, grain), delivered: d, failed: f, unknown: u, total: d+f+u };
+  });
+}
+
+// ── Read presence guard ────────────────────────────────────────────────────────
+
+/** True when Alfred's read has been generated (observations may be empty). */
+export function isReadGenerated(read: TrendsRead | null | undefined): read is TrendsRead {
+  return read != null && Array.isArray(read.observations);
+}

--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -4460,3 +4460,14 @@ export const recomputeAttention = async (args: { date: string }, context: any): 
   const instance = await getUserInstance(context);
   return proxyToTenant(instance, { method: "POST", path: "/api/v1/attention/recompute", body: { date: args.date } });
 };
+
+export const getAttentionTrends = async (args: { grain?: string; from?: string; to?: string } | void, context: any): Promise<any> => {
+  const instance = await getUserInstance(context);
+  const q: Record<string, string> = {};
+  if (args && typeof args === "object") {
+    if (args.grain) q.grain = args.grain;
+    if (args.from) q.from = args.from;
+    if (args.to) q.to = args.to;
+  }
+  return proxyToTenant(instance, { method: "GET", path: "/api/v1/attention/trends", query: Object.keys(q).length ? q : undefined });
+};


### PR DESCRIPTION
## Summary

- Adds `getAttentionTrends` wasp query declaration (`main.wasp`) + thin proxy to `GET /api/v1/attention/trends` in `operations.ts`.
- Extends `AttentionPage.tsx` with a third **TRENDS** tab alongside DAY and RANGE:
  - Grain selector: WEEKLY / MONTHLY / QUARTERLY (state in page shell; controls the query arg).
  - `TrendsView` component: 7 sections built on the derivation layer from PR1 (#637):
    - **01** Headline pair: latest NAR with delta arrow + return ratio with trend direction.
    - **02** NAR chart (SVG): displaced bars with engaged overlay; partial periods = dashed outline; uninstrumented = 0.4 opacity.
    - **03** Allocation proportional bars: work / life / unallocated.
    - **04** Return ratio chart (SVG): null ratio renders as em-dash (never 0 or omitted); low-engagement bars dimmed to 0.3 opacity so W24's misleading 13.9× doesn't look like a success.
    - **05** Outcomes chart (SVG): delivered (brass), failed (destructive red, left half of bar). W32's 18 failures impossible to miss.
    - **06** Task size mix: S/M/L/XL proportional bars; unbucketed is footnote text only, never a bar.
    - **07** Alfred's read: `read=null` → "hasn't generated yet" message (no fabricated observations); `read={observations:[]}` → "ran, found nothing"; observations rendered headline/detail/evidence.
- 86/86 tests passing (inherited from PR1 derivation layer); gate: 266 LOC.

Depends on PR1 #637 (merge that first — this branch is based on `lane-3/attention-trends-core`). After #637 merges, this PR's base should be rebased to `main`.

References #584.

## Smoke evidence

Gate VERIFY (86/86 tests, same command as PR1):

```
# tests 86
# suites 0
# pass 86
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 75.04875
```

Gate output: `✓ lane III (web) gate passed — 266 LOC, 3 files, verify ok`

**Needs live staging UI pass.** The view layer renders hand-rolled SVG charts and proportional-bar HTML — visual fidelity (chart sizing, colour tokens, partial-period hatching, em-dash rendering for null ratios) requires a browser session on staging logged in as Alfred. Cannot be proved headless. Tag this as "needs live staging UI pass" before merging to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)