### PR TITLE
fix(learn): guard trend read against partial-period calendar artifact and narrow materiality rule (#584)

### DIFF
--- a/packages/learn/src/activities/attention_trend_read.py
+++ b/packages/learn/src/activities/attention_trend_read.py
@@ -1,7 +1,7 @@
 """Attention trend read — fetch, clerk-read, write observation (#584)."""
 from __future__ import annotations
 import json, logging
-from datetime import datetime, timezone
+from datetime import date as _date, datetime, timezone
 from typing import Any
 import httpx
 from temporalio import activity
@@ -20,6 +20,17 @@ async def _fetch_trends(ctrl_url: str, grain: str, from_: str, to: str) -> dict[
         return r.json()
 
 
+def _full_period_days(period: dict[str, Any]) -> int:
+    """Days from period['start'] to period['end'] inclusive — the canonical full-period length.
+
+    Works for any grain: week (always 7), month (28–31), quarter (89–92).
+    The period's start/end are the canonical ISO boundaries returned by ctrl-api.
+    """
+    start = _date.fromisoformat(period["start"][:10])
+    end = _date.fromisoformat(period["end"][:10])
+    return (end - start).days + 1
+
+
 def _build_prompt(payload: dict[str, Any]) -> str:
     periods = payload.get("periods", [])
     grain = payload.get("grain", "week")
@@ -31,12 +42,46 @@ def _build_prompt(payload: dict[str, Any]) -> str:
         "Do NOT describe or compare them.  Omit interruption entirely.\n\n"
         if unmeasured else ""
     )
+
+    # Annotate each period so the model can distinguish complete from partial windows.
+    annotated: list[dict[str, Any]] = []
+    partial_keys: list[str] = []
+    for p in periods:
+        try:
+            full = _full_period_days(p)
+        except (ValueError, TypeError, KeyError):
+            full = None
+        days = p.get("days", 0)
+        if full is not None and days < full:
+            status = f"PARTIAL ({days}/{full} days)"
+            partial_keys.append(p.get("key", "?"))
+        elif full is not None:
+            status = f"full ({days} days)"
+        else:
+            status = f"({days} days)"
+        annotated.append({**p, "_status": status})
+
+    partial_rule = (
+        f"PARTIAL PERIOD RULE: periods {partial_keys} are incomplete windows.  "
+        "Do NOT use a partial period as one endpoint of a 'rose/fell/increased/decreased' "
+        "comparison against a full period.  Either (a) normalise to a per-day rate and "
+        "state that you are doing so, or (b) describe the partial period standalone "
+        "without directional comparison to a full period.\n\n"
+        if partial_keys else ""
+    )
     return (
         f"You are reading Alfred's attention trend data for the principal.\n\n"
-        f"{guard}DATA:\n{json.dumps({'grain': grain, 'periods': periods}, indent=2)}\n\n"
+        f"{guard}"
+        f"{partial_rule}"
+        f"DATA:\n{json.dumps({'grain': grain, 'periods': annotated}, indent=2)}\n\n"
         "Produce 3–5 observations (fewer if data doesn't support 3).  Rules:\n"
         "- Cite the specific number supporting each observation.\n"
-        "- Only flag displaced_hours changes >10 % (drift is single-digit %).\n"
+        "- Materiality: flag changes >10 % for displaced_hours, return_ratio, nar_hours, "
+        "and per-class/per-bucket displaced figures — all are derived from displacement, "
+        "which drifts ±single-digit % run-to-run, so smaller moves are noise.  Engaged "
+        "and interruption counts are directly measured (not displacement-derived) and may "
+        "be noted at a lower threshold — but omit interruption entirely if it is not "
+        "instrumented for a period.\n"
         "- No praise, no encouragement.\n"
         "- If interruption_instrumented is false for a period, omit interruption.\n\n"
         "Useful shapes: return_ratio falling; class handed over more/less than prior period;\n"

--- a/packages/learn/tests/test_attention_trend_read.py
+++ b/packages/learn/tests/test_attention_trend_read.py
@@ -124,3 +124,77 @@ class TestReplaceSemantics:
     def test_subject_encodes_grain_range(self):
         s = "attention_trend:month:2026-07-01:2026-07-31"
         assert "month" in s and "2026-07-01" in s and s != "attention_trend:month:2026-06-01:2026-06-30"
+
+
+class TestPartialPeriodAnnotation:
+    """Periods with days < the canonical window length must be labelled PARTIAL in the prompt."""
+
+    def _period(self, start: str, end: str, days: int, key: str = "T") -> dict:
+        return {"key": key, "start": start, "end": end, "days": days}
+
+    def _prompt(self, periods, grain="week") -> str:
+        from src.activities.attention_trend_read import _build_prompt
+        return _build_prompt({"grain": grain, "periods": periods, "coverage": {}})
+
+    def test_incomplete_week_marked_partial(self):
+        # W33 has 6 of 7 days in the window → PARTIAL
+        p = self._period("2026-08-10", "2026-08-16", 6, key="2026-W33")
+        prompt = self._prompt([p])
+        assert "PARTIAL" in prompt
+        assert "PARTIAL PERIOD RULE" in prompt
+
+    def test_complete_week_not_partial(self):
+        # W32 has all 7 days → full, no rule emitted
+        p = self._period("2026-08-03", "2026-08-09", 7, key="2026-W32")
+        prompt = self._prompt([p])
+        assert "PARTIAL PERIOD RULE" not in prompt
+        assert "full (7 days)" in prompt
+
+    def test_complete_february_not_partial(self):
+        # Feb 2026 has 28 days; all 28 present → full (28-day window is complete)
+        p = self._period("2026-02-01", "2026-02-28", 28, key="2026-02")
+        prompt = self._prompt([p], grain="month")
+        assert "PARTIAL PERIOD RULE" not in prompt
+        assert "full (28 days)" in prompt
+
+    def test_incomplete_august_partial(self):
+        # Aug 2026 has 31 days; only 15 present → PARTIAL
+        p = self._period("2026-08-01", "2026-08-31", 15, key="2026-08")
+        prompt = self._prompt([p], grain="month")
+        assert "PARTIAL" in prompt
+        assert "PARTIAL PERIOD RULE" in prompt
+
+    def test_incomplete_quarter_marked_partial(self):
+        # Q3 2026 (2026-07-01 to 2026-09-30) = 92 days; 50 present → PARTIAL
+        p = self._period("2026-07-01", "2026-09-30", 50, key="2026-Q3")
+        prompt = self._prompt([p], grain="quarter")
+        assert "PARTIAL" in prompt
+        assert "PARTIAL PERIOD RULE" in prompt
+
+    def test_complete_quarter_not_partial(self):
+        # Q3 2026 = 92 days; all 92 present → full
+        p = self._period("2026-07-01", "2026-09-30", 92, key="2026-Q3")
+        prompt = self._prompt([p], grain="quarter")
+        assert "PARTIAL PERIOD RULE" not in prompt
+
+
+class TestMaterialityRuleExtension:
+    """The >10 % rule must cover return_ratio and nar_hours, not just displaced_hours."""
+
+    def _prompt(self) -> str:
+        from src.activities.attention_trend_read import _build_prompt
+        return _build_prompt({"grain": "week", "periods": [], "coverage": {}})
+
+    def test_return_ratio_in_materiality_rule(self):
+        assert "return_ratio" in self._prompt()
+
+    def test_nar_hours_in_materiality_rule(self):
+        assert "nar_hours" in self._prompt()
+
+    def test_displaced_hours_still_covered(self):
+        assert "displaced_hours" in self._prompt()
+
+    def test_engaged_counts_distinguished(self):
+        # Engaged/interruption counts are described as measured, not displacement-derived
+        p = self._prompt()
+        assert "directly measured" in p or "Engaged" in p


### PR DESCRIPTION
## Problem

The first live run of `AttentionTrendReadWorkflow` (week / 2026-05-23 / 2026-08-15) produced misleading observations because the prompt had no concept of partial periods:

> **Autonomous displacement contracted sharply** — "Autonomous displaced hours fell 22.7%, from 6.401 in W32 to 4.949 in W33."

> **Large and long buckets gained share** — "XL displacement increased from 6 hours in W32 to 8 in W33, while L increased from 5 to 7…"

**W33 has `days: 6`. W32 has `days: 7`.** W33 is the current, incomplete week. A 22.7% fall against a 14% shorter window is mostly calendar shrinkage, not a real trend. XL "gaining" is a raw-total comparison that has not been normalised either.

Additionally:

> **Return ratio reached a new low** — "declined from 3.595 in W32 to 3.515 in W33"

A 2.2% move on a displacement-derived quantity. The >10% materiality guard applied only to `displaced_hours`, so `return_ratio` slipped through unchecked.

## Changes

**`packages/learn/src/activities/attention_trend_read.py`**

- `_full_period_days(period)` — derives the canonical window length from `period["start"]` and `period["end"]` using `date.fromisoformat`. Works for week (7), month (28–31), and quarter (89–92) without hardcoding grain rules.
- `_build_prompt` now annotates every period with `_status: "PARTIAL (N/M days)"` or `"full (N days)"` so the LLM sees completeness inline in the data.
- When any partial period is present the prompt emits a **PARTIAL PERIOD RULE**: the partial period may not be an endpoint of a "rose/fell" comparison against a full period. It may either be normalised to per-day rate (stated explicitly) or described standalone.
- Materiality rule extended from `displaced_hours` only to `displaced_hours`, `return_ratio`, `nar_hours`, and per-class/per-bucket displaced figures (all are displacement-derived; single-digit % run-to-run drift is noise, not signal). Engaged and interruption counts are distinguished as directly measured, with a lower threshold allowed — but with the existing interruption guard still applied when `interruption_instrumented` is false.

**`packages/learn/tests/test_attention_trend_read.py`**

10 new tests in two classes:

- `TestPartialPeriodAnnotation` — W33 (6/7) marked PARTIAL, W32 (7/7) not; Feb 2026 with 28/28 days full; Aug 2026 with 15/31 days PARTIAL; Q3 with 50/92 PARTIAL, Q3 with 92/92 full.
- `TestMaterialityRuleExtension` — prompt text contains `return_ratio`, `nar_hours`, `displaced_hours`, and "directly measured".

All 13 original tests still pass; 23/23 total.

## Smoke evidence

Motivation is the misleading live output from the first real workflow run — quoted verbatim:

```
Autonomous displacement contracted sharply — "Autonomous displaced hours fell 22.7%,
from 6.401 in W32 to 4.949 in W33."

Large and long buckets gained share — "XL displacement increased from 6 hours in W32
to 8 in W33, while L increased from 5 to 7…"

Return ratio reached a new low — "declined from 3.595 in W32 to 3.515 in W33"
```

W33 had `days: 6` (current, incomplete week). W32 had `days: 7` (full week). The
22.7% fall and the XL gain are both raw-total comparisons against a 14% shorter
window. The 2.2% return_ratio move is below the materiality bar.

Local test smoke: 23/23 tests pass, lane gate cleared (125 LOC, verify ok).

Closes #584 (partial — this fixes the prompt; the data pipeline was previously merged).

References #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)