### PR TITLE
feat(ctrl): POST /api/v1/attention/trends/interpret — trigger Alfred's read (#584)

### DIFF
--- a/packages/ctrl/src/api/routes/attention.ts
+++ b/packages/ctrl/src/api/routes/attention.ts
@@ -1204,6 +1204,37 @@ export function registerAttentionRoutes(): void {
     sendJson(res, 200, { from, to, totals, series });
   });
 
+  // Trigger Alfred's read of a trends window. Same fire-and-forget shape as
+  // /recompute. There is no Temporal SCHEDULE for AttentionTrendReadWorkflow —
+  // without this route the read only ever exists if someone starts the workflow
+  // by hand, so the Trends tab would show "not generated yet" forever.
+  addRoute("POST", "/api/v1/attention/trends/interpret", async ({ res, body }) => {
+    const b = (body ?? {}) as Record<string, unknown>;
+    const grain = typeof b.grain === "string" ? b.grain : null;
+    const from  = typeof b.from  === "string" ? b.from  : null;
+    const to    = typeof b.to    === "string" ? b.to    : null;
+    if (!grain || !from || !to) {
+      throw new ValidationError("body must contain grain, from and to");
+    }
+    if (!["week", "month", "quarter"].includes(grain)) {
+      throw new ValidationError("grain must be week, month or quarter");
+    }
+    // The workflow id is NOT derived from the window alone — re-reading the same
+    // window is a legitimate repeat action (the underlying data moves), and a
+    // stable id would collide with the completed run and silently no-op.
+    const wfId = `attn-read-${grain}-${from}--${to}-${Date.now()}`;
+    let handle: string | null = wfId;
+    try {
+      const out = await dockerExec("temporal", [
+        "temporal","workflow","start","--type","AttentionTrendReadWorkflow",
+        "--task-queue","alfred-learn","--workflow-id",wfId,
+        "--input",JSON.stringify({ grain, from, to }),"--output","json",
+      ]);
+      try { const p = JSON.parse(out.trim()); handle = p?.workflowId ?? p?.workflow_id ?? wfId; } catch { /**/ }
+    } catch { handle = null; }
+    sendJson(res, 202, { ok: true, handle, grain, from, to });
+  });
+
   addRoute("POST", "/api/v1/attention/recompute", async ({ res, body }) => {
     const b = (body ?? {}) as Record<string, unknown>;
     const date = typeof b.date === "string" ? b.date : null;

--- a/packages/ctrl/tests/attention-trends.test.ts
+++ b/packages/ctrl/tests/attention-trends.test.ts
@@ -218,3 +218,49 @@ describe("by_bucket and unbucketed",()=>{
       `bkt(${bktTotal})+unbucketed(${per.unbucketed.displaced_hours})=${total} ≠ displaced(${per.displaced_hours})`);
   });
 });
+
+// ─── POST /api/v1/attention/trends/interpret (#584) ──────────────────────────
+async function postInterpret(body:unknown):Promise<{status:number;p:any}> {
+  const m=matchRoute("POST","/api/v1/attention/trends/interpret"); assert.ok(m);
+  let status=0; let p:any={};
+  const res={writeHead(s:number){status=s;return res;},end(j?:string){if(j)p=JSON.parse(j);}} as unknown as ServerResponse;
+  try { await m.handler({req:{}as any,res,params:{},body,query:new URLSearchParams("")}); }
+  catch(e:any){if(typeof e?.statusCode==="number"){status=e.statusCode;p={error:e.message};}else throw e;}
+  return {status,p};
+}
+
+describe("POST /api/v1/attention/trends/interpret", () => {
+  // The workflow TYPE string is the fragile part: ctrl starts a Temporal
+  // workflow by name and learn registers it by name, in a different language,
+  // with no shared constant. A mismatch does not error — Temporal accepts the
+  // start, reports RUNNING, and the workflow task fails and retries forever.
+  // That exact failure already cost this feature one silent debugging cycle.
+  it("starts the workflow name learn actually registers", () => {
+    const routeSrc = fs.readFileSync(
+      path.join(import.meta.dirname, "..", "src", "api", "routes", "attention.ts"), "utf8");
+    // Slice from the interpret route so the NarDayRecapWorkflow start below
+    // cannot satisfy this match; the source wraps lines, so match the type alone.
+    const m = /"--type","([A-Za-z]+)"/.exec(
+      routeSrc.slice(routeSrc.indexOf("trends/interpret")));
+    assert.ok(m, "could not find the interpret route's workflow-start invocation");
+
+    const wfSrc = fs.readFileSync(
+      path.join(import.meta.dirname, "..", "..", "learn", "src", "workflows",
+                "attention_trend_read.py"), "utf8");
+    const reg = /@workflow\.defn\(name="([A-Za-z]+)"\)/.exec(wfSrc);
+    assert.ok(reg, "could not find @workflow.defn in attention_trend_read.py");
+
+    assert.strictEqual(m![1], reg![1],
+      `ctrl starts "${m![1]}" but learn registers "${reg![1]}" — a mismatch retries forever, silently`);
+  });
+
+  it("rejects a bad grain", async () => {
+    const r = await postInterpret({grain:"fortnight",from:"2026-08-01",to:"2026-08-15"});
+    assert.strictEqual(r.status, 400);
+  });
+
+  it("rejects a missing range", async () => {
+    const r = await postInterpret({grain:"week",from:"2026-08-01"});
+    assert.strictEqual(r.status, 400);
+  });
+});


### PR DESCRIPTION
`AttentionTrendReadWorkflow` has **no Temporal schedule**, and nothing in
ctrl started it. The read only existed if someone ran the workflow by hand, so
the Trends tab would have shown "not generated yet" forever — a button with
nothing behind it.

Same fire-and-forget shape as `/attention/recompute`: 202 immediately;
Temporal being unavailable is not a client error.

The workflow id carries a timestamp rather than deriving from the window alone.
Re-reading a window is a legitimate repeat action — the underlying data moves —
and a stable id would collide with the completed run and silently no-op.

## The guard test

ctrl starts a Temporal workflow **by name**; learn registers it **by name**, in
a different language, with no shared constant. A mismatch does not error:
Temporal accepts the start and reports `RUNNING` while the workflow task fails
and retries forever, `pendingActivities: 0`. That exact failure already cost
this feature one silent debugging cycle earlier in the epic.

The test reads the type string out of this route and the
`@workflow.defn(name=…)` out of `packages/learn/src/workflows/attention_trend_read.py`
and asserts they are equal.

## Smoke evidence

```
attention-trends.test.ts:  # tests 23 / pass 23 / fail 0
full ctrl suite:           # fail 0 / skipped 1

Guard verified RED by renaming one side:
  ctrl starts "AttentionTrendReadWorkflowX" but learn registers
  "AttentionTrendReadWorkflow" — a mismatch retries forever, silently
  # fail 1
```

A guard that has never been seen failing is not a guard, so it was made to
fail before being trusted.