### PR TITLE
fix(web): TRENDS tab visual pass — chart scale, empty-edge trim, generate-read button, palette (#584)

### DIFF
--- a/packages/web/main.wasp
+++ b/packages/web/main.wasp
@@ -2142,3 +2142,8 @@ query getAttentionTrends {
   fn: import { getAttentionTrends } from "@src/dashboard/operations",
   entities: []
 }
+
+action interpretAttentionTrends {
+  fn: import { interpretAttentionTrends } from "@src/dashboard/operations",
+  entities: []
+}

--- a/packages/web/src/dashboard/AttentionPage.tsx
+++ b/packages/web/src/dashboard/AttentionPage.tsx
@@ -1,8 +1,8 @@
 // AttentionPage — Attention Statement redesign for /attention (#584).
 // Day view: canonical statement (header → 01 The Account → 02 Where It Went →
 // 03 The Ledger → rate card → footer). Range tab: unchanged.
-import { useState } from "react";
-import { useQuery, useAction, getAttentionStatement, getAttentionStats, recomputeAttention, getAttentionTrends } from "wasp/client/operations";
+import { useState, useEffect } from "react";
+import { useQuery, useAction, getAttentionStatement, getAttentionStats, recomputeAttention, getAttentionTrends, interpretAttentionTrends } from "wasp/client/operations";
 import { Frame } from "../client/components/ab/Frame";
 import logoCurrentcolor from "../client/assets/brand/alfred-logo-currentcolor.svg";
 import {
@@ -17,6 +17,7 @@ import {
   deriveNarBars, deriveSeriesMax, deriveTrendsSummary,
   deriveAllocationBars, deriveRatioBars, deriveBucketBars, deriveOutcomesBars,
   isReadGenerated, BUCKET_KEYS, LOW_ENGAGEMENT_HOURS,
+  trimEmptyEdgePeriods, READ_EMPTY_STATE_TEXT,
   type TrendsGrain, type AttentionTrendsResponse,
 } from "./attentionTrendsCore";
 
@@ -443,22 +444,42 @@ function RangeView({ stats }: { stats: AttentionStatsResponse }) {
 
 // ── Trends view (#584 — TRENDS tab) ──────────────────────────────────────────
 
-function TrendsView({ data, grain, setGrain }: { data: AttentionTrendsResponse; grain: TrendsGrain; setGrain: (g: TrendsGrain) => void }) {
-  const ps = data.periods ?? [];
+function TrendsView({ data, grain, setGrain, interpretingRead, onGenerateRead }: {
+  data: AttentionTrendsResponse;
+  grain: TrendsGrain;
+  setGrain: (g: TrendsGrain) => void;
+  interpretingRead: boolean;
+  onGenerateRead: () => void;
+}) {
+  // Trim leading/trailing empty periods (range padding — e.g. a week that predates
+  // any data on the tenant). Mid-series zeros are kept — a quiet week is data.
+  const ps = trimEmptyEdgePeriods(data.periods ?? []);
   if (!ps.length) return <p className="font-mono text-xs opacity-40 mt-12">No data for this period.</p>;
+
   const nb = deriveNarBars(ps, grain); const ab = deriveAllocationBars(ps, grain);
   const rb = deriveRatioBars(ps, grain); const bb = deriveBucketBars(ps, grain);
   const ob = deriveOutcomesBars(ps, grain); const sum = deriveTrendsSummary(ps);
-  const BW = 24; const GP = 5; const H = 80; const CW = ps.length * (BW + GP) - GP;
+
+  // Chart sizing: scale bars to fill ~600px at the target column width, capped so
+  // a small series doesn't get absurdly wide bars. GP=4px gap; BW min 12px, max 60px.
+  const N = ps.length;
+  const GP = 4;
+  const BW = Math.min(Math.max(Math.round((600 - Math.max(N - 1, 0) * GP) / Math.max(N, 1)), 12), 60);
+  const CW = N * BW + Math.max(N - 1, 0) * GP;
+  // Section 02 is the hero chart — give it real vertical presence.
+  const H_NAR = 230;
+  // Sections 04 and 05 are secondary — less height.
+  const H_SUB = 150;
+
   const xi = (i: number) => i * (BW + GP);
-  const bar = (v: number, max: number) => Math.round(Math.max(v, 0) / max * H);
+  const barPx = (v: number, max: number, h: number) => Math.max(Math.round(Math.max(v, 0) / max * h), 0);
   const maxDisp = deriveSeriesMax(nb.map(b => b.displaced_hours));
-  const maxAlloc = deriveSeriesMax(ab.map(b => b.total));
   const maxOut = deriveSeriesMax(ob.map(b => b.total));
   const validR = rb.filter(b => b.ratio != null && !b.low_engagement).map(b => b.ratio!);
   const maxRatio = deriveSeriesMax(validR.length ? validR : rb.filter(b => b.ratio != null).map(b => b.ratio!));
   const fh = (v: number | null, d = 1) => v == null ? "—" : v.toFixed(d);
   const totalUnbucketed = bb.reduce((s, b) => s + b.unbucketed_count, 0);
+
   return (
     <div className="mt-4">
       {/* Grain selector */}
@@ -494,17 +515,22 @@ function TrendsView({ data, grain, setGrain }: { data: AttentionTrendsResponse; 
         </div>
       </div>
 
-      {/* 02 NAR chart — displaced (total) bars with engaged overlay; partial=dashed; uninstrumented=dim */}
+      {/* 02 NAR chart — hero; displaced (total) bars with engaged overlay.
+           partial=dashed outline; uninstrumented=dimmed. Full-width at ~600px. */}
       <div className="mb-12">
         <SL n="02" title="NAR by period" />
-        <svg width={CW} height={H + 16} className="overflow-visible mt-4" role="img" aria-label="NAR by period chart">
+        <svg width={CW} height={H_NAR + 20} style={{ display: "block", maxWidth: "100%", overflow: "visible" }}
+          role="img" aria-label="NAR by period chart">
           {nb.map((b, i) => {
-            const disp = bar(b.displaced_hours, maxDisp); const eng = bar(b.engaged_hours, maxDisp);
+            const disp = barPx(b.displaced_hours, maxDisp, H_NAR);
+            const eng = barPx(b.engaged_hours, maxDisp, H_NAR);
             return (
               <g key={b.key} opacity={b.uninstrumented ? 0.4 : 1}>
-                <rect x={xi(i)} y={H - disp} width={BW} height={disp} fill="var(--rule)" rx={1} stroke={b.partial ? "var(--brass)" : "none"} strokeWidth={b.partial ? 1 : 0} strokeDasharray={b.partial ? "3 2" : undefined} />
-                <rect x={xi(i)} y={H - eng} width={BW} height={eng} fill="var(--brass)" rx={1} opacity={0.6} />
-                <text x={xi(i) + BW / 2} y={H + 12} textAnchor="middle" fontSize={8} fontFamily="monospace" fill="var(--marginalia)">{b.label}</text>
+                <rect x={xi(i)} y={H_NAR - disp} width={BW} height={Math.max(disp, 1)} fill="var(--rule)" rx={1}
+                  stroke={b.partial ? "var(--brass)" : "none"} strokeWidth={b.partial ? 1 : 0}
+                  strokeDasharray={b.partial ? "3 2" : undefined} />
+                {eng > 0 && <rect x={xi(i)} y={H_NAR - eng} width={BW} height={eng} fill="var(--brass)" rx={1} opacity={0.6} />}
+                <text x={xi(i) + BW / 2} y={H_NAR + 14} textAnchor="middle" fontSize={9} fontFamily="monospace" fill="var(--marginalia)">{b.label}</text>
               </g>
             );
           })}
@@ -517,7 +543,9 @@ function TrendsView({ data, grain, setGrain }: { data: AttentionTrendsResponse; 
         </p>
       </div>
 
-      {/* 03 Allocation — proportional bars: work / life / unallocated */}
+      {/* 03 Allocation — proportional bars: work / life / unallocated.
+           Palette: brass for work, marginalia-grey for life, rule for unallocated.
+           No teal — the whole view uses this two-tone palette. */}
       <div className="mb-12">
         <SL n="03" title="Where it went" />
         <div className="flex flex-col gap-2 mt-4">
@@ -527,7 +555,8 @@ function TrendsView({ data, grain, setGrain }: { data: AttentionTrendsResponse; 
               <div className="flex-1 flex h-4 gap-px overflow-hidden rounded-sm">
                 {(["work", "life", "unallocated"] as const).map(k => {
                   const v = b[k]; const pct = v / b.total * 100;
-                  return pct > 0.5 ? <div key={k} style={{ width: `${pct}%`, background: k === "work" ? "var(--brass)" : k === "life" ? "oklch(0.62 0.09 200)" : "var(--rule)", opacity: k === "unallocated" ? 0.4 : 0.8 }} /> : null;
+                  const bg = k === "work" ? "var(--brass)" : k === "life" ? "var(--marginalia)" : "var(--rule)";
+                  return pct > 0.5 ? <div key={k} style={{ width: `${pct}%`, background: bg, opacity: k === "unallocated" ? 0.35 : k === "life" ? 0.6 : 0.8 }} /> : null;
                 })}
               </div>
               <span className="font-mono text-[9px] w-10 shrink-0" style={{ color: "var(--marginalia)" }}>{b.total.toFixed(1)}h</span>
@@ -535,30 +564,34 @@ function TrendsView({ data, grain, setGrain }: { data: AttentionTrendsResponse; 
           ))}
         </div>
         <div className="flex gap-4 mt-2">
-          {(["work", "life", "unallocated"] as const).map(k => (
-            <span key={k} className="font-mono text-[9px] flex items-center gap-1" style={{ color: "var(--marginalia)" }}>
-              <span className="inline-block w-2 h-2" style={{ background: k === "work" ? "var(--brass)" : k === "life" ? "oklch(0.62 0.09 200)" : "var(--rule)" }} /> {k}
-            </span>
-          ))}
+          {(["work", "life", "unallocated"] as const).map(k => {
+            const bg = k === "work" ? "var(--brass)" : k === "life" ? "var(--marginalia)" : "var(--rule)";
+            return (
+              <span key={k} className="font-mono text-[9px] flex items-center gap-1" style={{ color: "var(--marginalia)" }}>
+                <span className="inline-block w-2 h-2" style={{ background: bg, opacity: k === "life" ? 0.6 : 1 }} /> {k}
+              </span>
+            );
+          })}
         </div>
       </div>
 
       {/* 04 Return ratio — null preserved as em-dash; low-engagement dimmed */}
       <div className="mb-12">
         <SL n="04" title="Return ratio" />
-        <svg width={CW} height={H + 16} className="overflow-visible mt-4" role="img" aria-label="Return ratio chart">
+        <svg width={CW} height={H_SUB + 20} style={{ display: "block", maxWidth: "100%", overflow: "visible" }}
+          role="img" aria-label="Return ratio chart">
           {rb.map((b, i) => {
             if (b.ratio == null) return (
               <g key={b.key}>
-                <text x={xi(i) + BW / 2} y={H / 2} textAnchor="middle" fontSize={11} fontFamily="monospace" fill="var(--marginalia)" dominantBaseline="middle">—</text>
-                <text x={xi(i) + BW / 2} y={H + 12} textAnchor="middle" fontSize={8} fontFamily="monospace" fill="var(--marginalia)">{b.label}</text>
+                <text x={xi(i) + BW / 2} y={H_SUB / 2} textAnchor="middle" fontSize={11} fontFamily="monospace" fill="var(--marginalia)" dominantBaseline="middle">—</text>
+                <text x={xi(i) + BW / 2} y={H_SUB + 14} textAnchor="middle" fontSize={9} fontFamily="monospace" fill="var(--marginalia)">{b.label}</text>
               </g>
             );
-            const h = bar(b.ratio, maxRatio);
+            const h = barPx(b.ratio, maxRatio, H_SUB);
             return (
               <g key={b.key} opacity={b.low_engagement ? 0.3 : 1}>
-                <rect x={xi(i)} y={H - h} width={BW} height={h} fill="var(--brass)" rx={1} />
-                <text x={xi(i) + BW / 2} y={H + 12} textAnchor="middle" fontSize={8} fontFamily="monospace" fill="var(--marginalia)">{b.label}</text>
+                <rect x={xi(i)} y={H_SUB - h} width={BW} height={Math.max(h, 1)} fill="var(--brass)" rx={1} />
+                <text x={xi(i) + BW / 2} y={H_SUB + 14} textAnchor="middle" fontSize={9} fontFamily="monospace" fill="var(--marginalia)">{b.label}</text>
               </g>
             );
           })}
@@ -571,15 +604,18 @@ function TrendsView({ data, grain, setGrain }: { data: AttentionTrendsResponse; 
       {/* 05 Outcomes — delivered/failed/unknown; failures in destructive red */}
       <div className="mb-12">
         <SL n="05" title="Outcomes" />
-        <svg width={CW} height={H + 16} className="overflow-visible mt-4" role="img" aria-label="Outcomes chart">
+        <svg width={CW} height={H_SUB + 20} style={{ display: "block", maxWidth: "100%", overflow: "visible" }}
+          role="img" aria-label="Outcomes chart">
           {ob.map((b, i) => {
-            const tot = bar(b.total, maxOut); const del = bar(b.delivered, maxOut); const fail = bar(b.failed, maxOut);
+            const tot = barPx(b.total, maxOut, H_SUB);
+            const del = barPx(b.delivered, maxOut, H_SUB);
+            const fail = barPx(b.failed, maxOut, H_SUB);
             return (
               <g key={b.key}>
-                <rect x={xi(i)} y={H - tot} width={BW} height={tot} fill="var(--rule)" rx={1} />
-                <rect x={xi(i)} y={H - del} width={BW} height={del} fill="var(--brass)" rx={1} opacity={0.75} />
-                {fail > 0 && <rect x={xi(i)} y={H - fail} width={BW / 2} height={fail} fill="oklch(0.42 0.12 30)" rx={1} />}
-                <text x={xi(i) + BW / 2} y={H + 12} textAnchor="middle" fontSize={8} fontFamily="monospace" fill="var(--marginalia)">{b.label}</text>
+                <rect x={xi(i)} y={H_SUB - tot} width={BW} height={Math.max(tot, 1)} fill="var(--rule)" rx={1} />
+                {del > 0 && <rect x={xi(i)} y={H_SUB - del} width={BW} height={del} fill="var(--brass)" rx={1} opacity={0.75} />}
+                {fail > 0 && <rect x={xi(i)} y={H_SUB - fail} width={Math.ceil(BW / 2)} height={fail} fill="oklch(0.42 0.12 30)" rx={1} />}
+                <text x={xi(i) + BW / 2} y={H_SUB + 14} textAnchor="middle" fontSize={9} fontFamily="monospace" fill="var(--marginalia)">{b.label}</text>
               </g>
             );
           })}
@@ -611,7 +647,8 @@ function TrendsView({ data, grain, setGrain }: { data: AttentionTrendsResponse; 
         {totalUnbucketed > 0 && <p className="font-mono text-[9px] mt-2" style={{ color: "var(--marginalia)" }}>+ {totalUnbucketed} vigilance sweeps (unbucketed — not shown)</p>}
       </div>
 
-      {/* 07 Alfred's read — null = not yet generated; never fabricate observations */}
+      {/* 07 Alfred's read — null = not yet generated; never fabricate observations.
+           There is no nightly schedule — the read must be explicitly triggered. */}
       <div className="mb-10">
         <SL n="07" title="Alfred's read" />
         {isReadGenerated(data.read) ? (
@@ -628,8 +665,16 @@ function TrendsView({ data, grain, setGrain }: { data: AttentionTrendsResponse; 
                   </div>
                 ))}
               </div>
+        ) : interpretingRead ? (
+          <p className="font-mono text-xs mt-4 opacity-50">Generating Alfred's read — this takes a minute or two. The page will update automatically.</p>
         ) : (
-          <p className="font-mono text-xs mt-4 opacity-50">Alfred hasn't generated a read for this period yet — it runs automatically after the nightly workflow.</p>
+          <div className="mt-4">
+            <p className="font-mono text-xs opacity-50">{READ_EMPTY_STATE_TEXT}</p>
+            <button type="button" onClick={onGenerateRead}
+              className="mt-4 font-mono text-[10px] uppercase tracking-[0.22em] border border-[var(--rule)] px-5 py-2 hover:border-[var(--brass)] transition-colors">
+              Generate Alfred's read
+            </button>
+          </div>
         )}
       </div>
     </div>
@@ -648,14 +693,36 @@ export default function AttentionPage() {
   const [grain, setGrain] = useState<TrendsGrain>("week");
   const [trendsFrom] = useState(thirteenWeeksAgo);
   const [trendsTo] = useState(now);
+  const [interpretingRead, setInterpretingRead] = useState(false);
   const dayQ = useQuery(getAttentionStatement, { date }, { enabled: tab === "day" });
   const statsQ = useQuery(getAttentionStats, { from, to }, { enabled: tab === "range" });
   const trendsQ = useQuery(getAttentionTrends, { grain, from: trendsFrom, to: trendsTo }, { enabled: tab === "trends" });
   const recompute = useAction(recomputeAttention);
+  const interpretTrends = useAction(interpretAttentionTrends);
+
+  // Poll for the read every 15 s while it is being generated.
+  useEffect(() => {
+    if (!interpretingRead) return;
+    const id = setInterval(() => { trendsQ.refetch(); }, 15_000);
+    return () => clearInterval(id);
+  }, [interpretingRead]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Stop polling once the read appears in the data.
+  useEffect(() => {
+    if (interpretingRead && (trendsQ.data as AttentionTrendsResponse | undefined)?.read != null) {
+      setInterpretingRead(false);
+    }
+  }, [interpretingRead, trendsQ.data]);
 
   async function handleRecompute() {
     setRunning(true);
     try { await recompute({ date }); await dayQ.refetch(); } finally { setRunning(false); }
+  }
+
+  async function handleGenerateRead() {
+    setInterpretingRead(true);
+    try { await interpretTrends({ grain, from: trendsFrom, to: trendsTo }); }
+    catch { setInterpretingRead(false); }
   }
 
   const din = (val: string, set: (v: string) => void, max?: string) => (
@@ -741,7 +808,7 @@ export default function AttentionPage() {
               : statsQ.data ? <RangeView stats={statsQ.data as AttentionStatsResponse} /> : null
             : trendsQ.isLoading ? <p className="font-mono text-xs opacity-40">Loading…</p>
               : trendsQ.error ? <p className="font-mono text-xs" style={{ color: "oklch(0.42 0.12 30)" }}>{String((trendsQ.error as any)?.message ?? "Failed.")}</p>
-              : trendsQ.data ? <TrendsView data={trendsQ.data as AttentionTrendsResponse} grain={grain} setGrain={setGrain} /> : null}
+              : trendsQ.data ? <TrendsView data={trendsQ.data as AttentionTrendsResponse} grain={grain} setGrain={setGrain} interpretingRead={interpretingRead} onGenerateRead={handleGenerateRead} /> : null}
 
       </section>
     </Frame>

--- a/packages/web/src/dashboard/attentionTrendsCore.test.ts
+++ b/packages/web/src/dashboard/attentionTrendsCore.test.ts
@@ -9,6 +9,7 @@ import {
   deriveNarBars, deriveSeriesMax, deriveTrendsSummary,
   deriveAllocationBars, deriveRatioBars, deriveBucketBars, deriveOutcomesBars,
   isReadGenerated, BUCKET_KEYS, LOW_ENGAGEMENT_HOURS,
+  trimEmptyEdgePeriods, READ_EMPTY_STATE_TEXT,
   type TrendsPeriod,
 } from "./attentionTrendsCore";
 
@@ -138,4 +139,46 @@ test("isReadGenerated: null/undefined → false; object (even empty) → true", 
   assert.equal(isReadGenerated(null), false); assert.equal(isReadGenerated(undefined), false);
   assert.equal(isReadGenerated({ generated_at: "2026-08-10", observations: [] }), true);
   assert.equal(isReadGenerated({ generated_at: "2026-08-10", observations: [{ headline:"h",detail:"d",evidence:"e" }] }), true);
+});
+
+// ── 11. Empty-edge trimming ───────────────────────────────────────────────────
+
+const EMPTY_P = mkP("2026-W20", 7, 0, 0, 0, null); // no displacement, no engagement, zero NAR
+
+test("trimEmptyEdgePeriods: leading and trailing empty periods are removed; mid-series zero is kept", () => {
+  // A genuinely quiet week (mid-series) must NOT be removed — absence in the middle
+  // is data; absence at the edge is only range padding (e.g. W20 predating deployment).
+  const midZero = mkP("2026-W25", 7, 0, 0, 0, null); // zero activity between two live weeks
+  const series = [EMPTY_P, W22, midZero, W32, EMPTY_P];
+  const trimmed = trimEmptyEdgePeriods(series);
+  assert.equal(trimmed.length, 3, "leading and trailing W20 empties removed");
+  assert.equal(trimmed[0].key, "2026-W22", "first kept period is W22");
+  assert.equal(trimmed[1].key, "2026-W25", "mid-series zero is preserved");
+  assert.equal(trimmed[2].key, "2026-W32", "last kept period is W32");
+
+  // Leading only
+  const leadOnly = [EMPTY_P, W32, W33];
+  const tl = trimEmptyEdgePeriods(leadOnly);
+  assert.equal(tl.length, 2); assert.equal(tl[0].key, "2026-W32");
+
+  // All-empty series collapses to []
+  assert.deepEqual(trimEmptyEdgePeriods([EMPTY_P, EMPTY_P]), []);
+
+  // No empties → unchanged
+  const noEmp = trimEmptyEdgePeriods([W22, W32]);
+  assert.equal(noEmp.length, 2);
+
+  // Null-safe
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  assert.deepEqual(trimEmptyEdgePeriods(null as any), []);
+});
+
+// ── 12. Empty-state text honesty ──────────────────────────────────────────────
+
+test("READ_EMPTY_STATE_TEXT: no claim of automatic or scheduled generation", () => {
+  const t = READ_EMPTY_STATE_TEXT.toLowerCase();
+  assert.ok(!t.includes("automatic"), "must not say 'automatic'");
+  assert.ok(!t.includes("scheduled"), "must not say 'scheduled'");
+  assert.ok(!t.includes("nightly"), "must not say 'nightly'");
+  assert.ok(t.length > 10, "must be a real sentence, not empty");
 });

--- a/packages/web/src/dashboard/attentionTrendsCore.ts
+++ b/packages/web/src/dashboard/attentionTrendsCore.ts
@@ -142,3 +142,28 @@ export function deriveOutcomesBars(periods: TrendsPeriod[], grain: TrendsGrain):
 export function isReadGenerated(read: TrendsRead | null | undefined): read is TrendsRead {
   return read != null && Array.isArray(read.observations);
 }
+
+// ── Empty-state text (exported so the test can assert honesty) ─────────────────
+
+/** Displayed when no read has been generated for the current window.
+ *  Must NOT claim automatic or scheduled generation — there is no nightly job for this. */
+export const READ_EMPTY_STATE_TEXT = "No read has been generated for this window.";
+
+// ── Empty-edge trimming ────────────────────────────────────────────────────────
+
+/** A period is data-empty when all key fields are zero — no displacement, no engagement, no NAR.
+ *  This distinguishes "system not yet deployed" padding from a genuine quiet week. */
+export function isEmptyPeriod(p: TrendsPeriod): boolean {
+  return (p.nar_hours ?? 0) === 0 && (p.displaced_hours ?? 0) === 0 && (p.engaged_hours ?? 0) === 0;
+}
+
+/** Remove leading and trailing periods that contain no data at all.
+ *  A zero-activity period in the MIDDLE of the series is preserved — a quiet week
+ *  that falls between active weeks reads correctly as a quiet week, not as padding. */
+export function trimEmptyEdgePeriods(periods: TrendsPeriod[]): TrendsPeriod[] {
+  if (!periods?.length) return [];
+  let s = 0, e = periods.length - 1;
+  while (s <= e && isEmptyPeriod(periods[s])) s++;
+  while (e >= s && isEmptyPeriod(periods[e])) e--;
+  return periods.slice(s, e + 1);
+}

--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -4471,3 +4471,9 @@ export const getAttentionTrends = async (args: { grain?: string; from?: string; 
   }
   return proxyToTenant(instance, { method: "GET", path: "/api/v1/attention/trends", query: Object.keys(q).length ? q : undefined });
 };
+
+export const interpretAttentionTrends = async (args: { grain: string; from: string; to: string }, context: any): Promise<any> => {
+  if (!args?.grain || !args?.from || !args?.to) throw new HttpError(400, "grain, from, to required");
+  const instance = await getUserInstance(context);
+  return proxyToTenant(instance, { method: "POST", path: "/api/v1/attention/trends/interpret", body: { grain: args.grain, from: args.from, to: args.to } });
+};


### PR DESCRIPTION
## Summary

Four defects on the live TRENDS tab, all fixed in one commit.

**1. Charts far too small (the main one)**
Sections 02, 04, 05 were rendering at ~372×80 px in a ~660 px column. Bar width now scales dynamically to fill ~600 px (`BW` 24 → 43 px for 13 bars). Section 02 (NAR by period) gets a 230 px hero height; sections 04 and 05 get 150 px. `style={{ maxWidth: "100%" }}` keeps them within the column on narrow views. Section 03 and 06 already used full-width flex and are unchanged.

**2. Leading empty period drawn as real data**
A period with `nar_hours = displaced_hours = engaged_hours = 0` at the edge of the range is range padding, not a genuine quiet week. `trimEmptyEdgePeriods()` (new export in `attentionTrendsCore.ts`) removes leading and trailing such periods before any derivation. Mid-series zero-activity periods are preserved — absence between two active weeks is signal.

**3. Alfred's read: false empty-state text + no trigger button**
The old empty-state said "it runs automatically after the nightly workflow" — there is no such workflow. Replaced with `READ_EMPTY_STATE_TEXT` ("No read has been generated for this window.") + a "Generate Alfred's read" button. The button fires `interpretAttentionTrends` (new Wasp action) POSTing `{grain, from, to}` — exactly the range currently displayed, not a hardcoded default. A 15-second poll loop via `useEffect` watches for the read to appear and clears the pending state when it does.

**4. Section 03 teal not in palette**
`oklch(0.62 0.09 200)` (stray teal for `life`) replaced with `var(--marginalia)` at 0.6 opacity. All three series in section 03 now use the brass/marginalia/rule palette that the rest of the view uses. Updated in both the bars and the legend swatch.

## Files touched

- `packages/web/src/dashboard/attentionTrendsCore.ts` — `trimEmptyEdgePeriods`, `isEmptyPeriod`, `READ_EMPTY_STATE_TEXT` exports
- `packages/web/src/dashboard/attentionTrendsCore.test.ts` — tests 11 (edge trimming) and 12 (text honesty), 12/12 pass
- `packages/web/src/dashboard/AttentionPage.tsx` — all four visual fixes + generate-read wiring
- `packages/web/src/dashboard/operations.ts` — `interpretAttentionTrends` operation
- `packages/web/main.wasp` — `interpretAttentionTrends` action declaration

## Smoke evidence

Local VERIFY (lane gate, runs on commit):

```
▶ lane III verify: cd packages/web && npx tsx --test src/dashboard/attentionTrendsCore.test.ts
ok 1 - label: renders for all three grains and falls through on unknown key
ok 2 - isPartialPeriod: W21 (2d) and W33 (6d) are partial; full weeks are not
ok 3 - deriveNarBars: partial and uninstrumented flags; values preserved; null-safe
ok 4 - deriveSeriesMax: handles real home range (no clipping) and all-zero period
ok 5 - deriveTrendsSummary: null ratio stays null (never 0); delta; direction; empty
ok 6 - deriveAllocationBars: work/life values correct; total guard prevents div-by-zero
ok 7 - deriveRatioBars: null ratio preserved; low-engagement and uninstrumented flags
ok 8 - deriveBucketBars: S/M/L/XL from by_bucket; unbucketed is footnote-only and excluded from sum
ok 9 - deriveOutcomesBars: W32 18 failures survive derivation; total consistent
ok 10 - isReadGenerated: null/undefined → false; object (even empty) → true
ok 11 - trimEmptyEdgePeriods: leading and trailing empty periods are removed; mid-series zero is kept
ok 12 - READ_EMPTY_STATE_TEXT: no claim of automatic or scheduled generation
1..12
# tests 12 / pass 12 / fail 0
✓ lane III (web) gate passed — 216 LOC, 5 files, verify ok
```

UI verification needs a live staging pass — the charts, button, and palette are visual and not covered by the core unit tests. Tag: **needs live staging UI pass**.

References #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc