### PR TITLE
feat(learn): weekly Temporal schedule for AttentionTrendReadWorkflow (#584)

### DIFF
--- a/packages/learn/scripts/register_schedules.py
+++ b/packages/learn/scripts/register_schedules.py
@@ -437,18 +437,19 @@ CALENDAR_SCHEDULES = [
         ),
     },
     {
-        # #584 — pre-compute the trailing-7-day attention trend so the
-        # Range tab on /attention is populated without a manual Recompute.
+        # #584 — pre-compute the weekly attention trend so the TRENDS tab
+        # on /attention shows a read without requiring the Generate button.
         #
-        # The UI's default window is sevenAgo()→now() (today − 6 days to
-        # today, computed at render time in AttentionPage.tsx), so the
-        # window cannot be encoded as a fixed string in the schedule.  The
-        # workflow derives from/to at run time; only the grain is passed.
+        # AttentionPage.tsx line 32/694:
+        #   const thirteenWeeksAgo = () => { d.setDate(d.getDate()-91) }
+        #   const [trendsFrom] = useState(thirteenWeeksAgo);   // today−91d
+        #   const [trendsTo]   = useState(now);
+        # The window is fixed at 91 days regardless of grain.  A hardcoded
+        # date in the schedule would be stale by next Monday, so only the
+        # grain is passed and the workflow derives from/to at run time.
         #
-        # Monday 04:00 LOCAL: nightly-maintenance (03:00) has settled and
-        # the morning briefing (05:00) hasn't fired yet, so a full week of
-        # fresh nar_entry data is ready when Sir opens /attention Monday
-        # morning.  day_of_week=1 is Monday (0=Sunday).
+        # Monday 04:00 LOCAL: nightly-maintenance (03:00) has settled, one
+        # hour before the morning briefing (05:00).  day_of_week=1=Monday.
         "id": "al-attention-trend-read",
         "workflow": "AttentionTrendReadWorkflow",
         "args": [{"grain": "week"}],

--- a/packages/learn/scripts/register_schedules.py
+++ b/packages/learn/scripts/register_schedules.py
@@ -436,6 +436,28 @@ CALENDAR_SCHEDULES = [
             minute=[ScheduleRange(start=0)],
         ),
     },
+    {
+        # #584 — pre-compute the trailing-7-day attention trend so the
+        # Range tab on /attention is populated without a manual Recompute.
+        #
+        # The UI's default window is sevenAgo()→now() (today − 6 days to
+        # today, computed at render time in AttentionPage.tsx), so the
+        # window cannot be encoded as a fixed string in the schedule.  The
+        # workflow derives from/to at run time; only the grain is passed.
+        #
+        # Monday 04:00 LOCAL: nightly-maintenance (03:00) has settled and
+        # the morning briefing (05:00) hasn't fired yet, so a full week of
+        # fresh nar_entry data is ready when Sir opens /attention Monday
+        # morning.  day_of_week=1 is Monday (0=Sunday).
+        "id": "al-attention-trend-read",
+        "workflow": "AttentionTrendReadWorkflow",
+        "args": [{"grain": "week"}],
+        "calendar": ScheduleCalendarSpec(
+            day_of_week=[ScheduleRange(start=1, end=1)],
+            hour=[ScheduleRange(start=4)],
+            minute=[ScheduleRange(start=0)],
+        ),
+    },
 ]
 
 

--- a/packages/learn/scripts/register_schedules.py
+++ b/packages/learn/scripts/register_schedules.py
@@ -437,24 +437,27 @@ CALENDAR_SCHEDULES = [
         ),
     },
     {
-        # #584 — pre-compute the weekly attention trend so the TRENDS tab
-        # on /attention shows a read without requiring the Generate button.
+        # #584 — pre-compute the TRENDS tab attention read so it appears
+        # without the Generate button.
+        #
+        # The schedule MUST be DAILY, not weekly.  Reason: trendsTo is
+        # `now` (AttentionPage.tsx:695), so the subject key the UI looks
+        # up is "attention_trend:week:<from>:<today>".  A weekly schedule
+        # would write a key anchored to Monday's date; any visit on Tue–Sun
+        # would find nothing and show "not generated yet".  Daily ensures
+        # the stored key always matches the current day's window.
         #
         # AttentionPage.tsx line 32/694:
         #   const thirteenWeeksAgo = () => { d.setDate(d.getDate()-91) }
         #   const [trendsFrom] = useState(thirteenWeeksAgo);   // today−91d
-        #   const [trendsTo]   = useState(now);
-        # The window is fixed at 91 days regardless of grain.  A hardcoded
-        # date in the schedule would be stale by next Monday, so only the
-        # grain is passed and the workflow derives from/to at run time.
+        #   const [trendsTo]   = useState(now);               // today
         #
-        # Monday 04:00 LOCAL: nightly-maintenance (03:00) has settled, one
-        # hour before the morning briefing (05:00).  day_of_week=1=Monday.
+        # 04:00 LOCAL: nightly-maintenance (03:00) has settled, one hour
+        # before the morning briefing (05:00).
         "id": "al-attention-trend-read",
         "workflow": "AttentionTrendReadWorkflow",
         "args": [{"grain": "week"}],
         "calendar": ScheduleCalendarSpec(
-            day_of_week=[ScheduleRange(start=1, end=1)],
             hour=[ScheduleRange(start=4)],
             minute=[ScheduleRange(start=0)],
         ),

--- a/packages/learn/src/workflows/attention_trend_read.py
+++ b/packages/learn/src/workflows/attention_trend_read.py
@@ -1,36 +1,67 @@
-"""AttentionTrendReadWorkflow — fetch trend data and produce a clerk read (#584).
+"""AttentionTrendReadWorkflow — weekly pre-compute of the trailing-7-day
+attention trend so the Range tab on /attention is always populated (#584).
 
-Input: ``{"grain": "week"|"month"|"quarter", "from": "YYYY-MM-DD", "to": "YYYY-MM-DD"}``
-Output: summary dict (``observation_id``, ``observations_count``, ``replaced``).
+The UI's default Range window is sevenAgo()→now() (today − 6 days to today,
+computed at render time in AttentionPage.tsx).  The window must be derived at
+workflow-run time; the schedule passes only the grain ({"grain": "week"}).
 """
 from __future__ import annotations
-from datetime import timedelta
+
+import datetime
+from typing import Any
+
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 
 with workflow.unsafe.imports_passed_through():
     from src.activities.attention_trend_read import read_attention_trends
 
+# Days in a full trailing window per grain.  week = 7-day = sevenAgo()→now().
+_GRAIN_DAYS: dict[str, int] = {"week": 7, "month": 30, "quarter": 91}
+
+
+def _window_for_grain(grain: str, ref: datetime.date) -> tuple[datetime.date, datetime.date]:
+    """Return (from_date, to_date) matching the UI default for the given grain.
+
+    ``week`` → ref − 6 days to ref (7-day inclusive, same as sevenAgo()→now()).
+    """
+    n = _GRAIN_DAYS.get(grain, 7)
+    return ref - datetime.timedelta(days=n - 1), ref
+
 
 @workflow.defn(name="AttentionTrendReadWorkflow")
 class AttentionTrendReadWorkflow:
+    """Pre-compute the attention trend observation for the trailing window.
+
+    Input: ``{"grain": "week"}`` — workflow derives from/to at run time.
+    """
+
     @workflow.run
-    async def run(self, params: dict) -> dict:
-        grain = params.get("grain", "week")
-        from_ = params.get("from", "")
-        to = params.get("to", "")
-        if not from_ or not to:
-            raise ValueError("AttentionTrendReadWorkflow: 'from' and 'to' params are required")
-        workflow.logger.info("attention_trend_read.start grain=%s from=%s to=%s", grain, from_, to)
-        result: dict = await workflow.execute_activity(
-            read_attention_trends,
-            {"grain": grain, "from": from_, "to": to},
-            start_to_close_timeout=timedelta(minutes=15),
-            retry_policy=RetryPolicy(maximum_attempts=2,
-                                     initial_interval=timedelta(seconds=10),
-                                     backoff_coefficient=2.0,
-                                     maximum_interval=timedelta(minutes=2)),
+    async def run(self, params: dict[str, Any] | str | None = None) -> dict[str, Any]:
+        grain = "week"
+        if isinstance(params, dict):
+            grain = str(params.get("grain", "week"))
+
+        today = workflow.now().date()
+        from_date, to_date = _window_for_grain(grain, today)
+
+        workflow.logger.info(
+            "attention_trend_read.start grain=%s from=%s to=%s",
+            grain, from_date.isoformat(), to_date.isoformat(),
         )
-        workflow.logger.info("attention_trend_read.done grain=%s obs=%d replaced=%s",
-                             grain, result.get("observations_count", 0), result.get("replaced"))
+        result: dict[str, Any] = await workflow.execute_activity(
+            read_attention_trends,
+            {"grain": grain, "from": from_date.isoformat(), "to": to_date.isoformat()},
+            start_to_close_timeout=datetime.timedelta(minutes=10),
+            retry_policy=RetryPolicy(
+                maximum_attempts=2,
+                initial_interval=datetime.timedelta(seconds=30),
+                backoff_coefficient=2.0,
+                maximum_interval=datetime.timedelta(minutes=3),
+            ),
+        )
+        workflow.logger.info(
+            "attention_trend_read.done grain=%s obs=%d replaced=%s",
+            grain, result.get("observations_count", 0), result.get("replaced", False),
+        )
         return result

--- a/packages/learn/src/workflows/attention_trend_read.py
+++ b/packages/learn/src/workflows/attention_trend_read.py
@@ -1,9 +1,27 @@
-"""AttentionTrendReadWorkflow — weekly pre-compute of the trailing-7-day
-attention trend so the Range tab on /attention is always populated (#584).
+"""AttentionTrendReadWorkflow — fetch trend data and produce a clerk read (#584).
 
-The UI's default Range window is sevenAgo()→now() (today − 6 days to today,
-computed at render time in AttentionPage.tsx).  The window must be derived at
-workflow-run time; the schedule passes only the grain ({"grain": "week"}).
+Input (two shapes):
+
+  Explicit (button / ctrl-api):
+    {"grain": "week"|"month"|"quarter", "from": "YYYY-MM-DD", "to": "YYYY-MM-DD"}
+
+  Schedule (grain only — workflow derives from/to at run time):
+    {"grain": "week"}
+
+The TRENDS tab in AttentionPage.tsx fixes its window at page-load:
+
+    const thirteenWeeksAgo = () => {
+      const d = new Date(); d.setDate(d.getDate() - 91); ...
+    };
+    const [trendsFrom] = useState(thirteenWeeksAgo);  // today − 91 days
+    const [trendsTo]   = useState(now);               // today
+
+Grain only controls how periods are bucketed inside this fixed window.
+When the schedule fires (no explicit from/to), _window_for_grain derives
+from = today − 91, to = today — exactly matching thirteenWeeksAgo()→now()
+so the pre-computed observation key matches what the UI requests on page load.
+
+Output: summary dict (``observation_id``, ``observations_count``, ``replaced``).
 """
 from __future__ import annotations
 
@@ -16,52 +34,61 @@ from temporalio.common import RetryPolicy
 with workflow.unsafe.imports_passed_through():
     from src.activities.attention_trend_read import read_attention_trends
 
-# Days in a full trailing window per grain.  week = 7-day = sevenAgo()→now().
-_GRAIN_DAYS: dict[str, int] = {"week": 7, "month": 30, "quarter": 91}
+# 91 days = thirteenWeeksAgo() in JS (d.setDate(d.getDate() − 91)).
+# Grain only changes period bucketing, not the window.
+_TRENDS_WINDOW_DAYS = 91
 
 
 def _window_for_grain(grain: str, ref: datetime.date) -> tuple[datetime.date, datetime.date]:
-    """Return (from_date, to_date) matching the UI default for the given grain.
+    """Return (from_date, to_date) matching the UI's thirteenWeeksAgo()→now() default.
 
-    ``week`` → ref − 6 days to ref (7-day inclusive, same as sevenAgo()→now()).
+    AttentionPage.tsx line 32: ``d.setDate(d.getDate() - 91)`` for any grain.
     """
-    n = _GRAIN_DAYS.get(grain, 7)
-    return ref - datetime.timedelta(days=n - 1), ref
+    return ref - datetime.timedelta(days=_TRENDS_WINDOW_DAYS), ref
 
 
 @workflow.defn(name="AttentionTrendReadWorkflow")
 class AttentionTrendReadWorkflow:
-    """Pre-compute the attention trend observation for the trailing window.
+    """Fetch attention trends, ask the clerk for observations, persist the read.
 
-    Input: ``{"grain": "week"}`` — workflow derives from/to at run time.
+    Accepts explicit from/to (button path) or derives them from grain alone
+    (schedule path). Explicit from/to always win when both are supplied.
     """
 
     @workflow.run
-    async def run(self, params: dict[str, Any] | str | None = None) -> dict[str, Any]:
-        grain = "week"
-        if isinstance(params, dict):
-            grain = str(params.get("grain", "week"))
+    async def run(self, params: dict[str, Any]) -> dict[str, Any]:
+        grain = params.get("grain", "week")
+        from_ = params.get("from", "")
+        to = params.get("to", "")
 
-        today = workflow.now().date()
-        from_date, to_date = _window_for_grain(grain, today)
+        if bool(from_) != bool(to):
+            raise ValueError(
+                "AttentionTrendReadWorkflow: supply both 'from' and 'to', or neither"
+            )
+
+        if not from_:
+            # Schedule path — derive the 91-day trailing window at run time.
+            today = workflow.now().date()
+            from_date, to_date = _window_for_grain(grain, today)
+            from_ = from_date.isoformat()
+            to = to_date.isoformat()
 
         workflow.logger.info(
-            "attention_trend_read.start grain=%s from=%s to=%s",
-            grain, from_date.isoformat(), to_date.isoformat(),
+            "attention_trend_read.start grain=%s from=%s to=%s", grain, from_, to
         )
         result: dict[str, Any] = await workflow.execute_activity(
             read_attention_trends,
-            {"grain": grain, "from": from_date.isoformat(), "to": to_date.isoformat()},
-            start_to_close_timeout=datetime.timedelta(minutes=10),
+            {"grain": grain, "from": from_, "to": to},
+            start_to_close_timeout=datetime.timedelta(minutes=15),
             retry_policy=RetryPolicy(
                 maximum_attempts=2,
-                initial_interval=datetime.timedelta(seconds=30),
+                initial_interval=datetime.timedelta(seconds=10),
                 backoff_coefficient=2.0,
-                maximum_interval=datetime.timedelta(minutes=3),
+                maximum_interval=datetime.timedelta(minutes=2),
             ),
         )
         workflow.logger.info(
             "attention_trend_read.done grain=%s obs=%d replaced=%s",
-            grain, result.get("observations_count", 0), result.get("replaced", False),
+            grain, result.get("observations_count", 0), result.get("replaced"),
         )
         return result

--- a/packages/learn/tests/test_attention_trend_read.py
+++ b/packages/learn/tests/test_attention_trend_read.py
@@ -248,22 +248,31 @@ class TestScheduleEntry:
 
 
 class TestWindowComputation:
-    """_window_for_grain must match the UI's sevenAgo()→now() default (#584)."""
+    """_window_for_grain must match the UI's thirteenWeeksAgo()→now() default.
+
+    AttentionPage.tsx line 32:
+        const thirteenWeeksAgo = () => {
+            const d = new Date(); d.setDate(d.getDate() - 91); ...
+        };
+        const [trendsFrom] = useState(thirteenWeeksAgo);  // today − 91 days
+        const [trendsTo]   = useState(now);
+
+    Grain changes period bucketing but NOT the window. Any grain maps to 91 days.
+    """
 
     def _w(self, ref: _dt.date) -> tuple[_dt.date, _dt.date]:
         from src.workflows.attention_trend_read import _window_for_grain
         return _window_for_grain("week", ref)
 
-    def test_week_shape_matches_seven_ago(self):
-        """from = ref − 6 (JS setDate(d.getDate()−6)), to = ref, span = 7 days."""
-        ref = _dt.date(2026, 8, 17)
+    def test_window_is_91_days_back(self):
+        """from = ref − 91 days (JS d.setDate(d.getDate() − 91)), to = ref."""
+        ref = _dt.date(2026, 8, 15)
         from_d, to_d = self._w(ref)
         assert to_d == ref
-        assert from_d == ref - _dt.timedelta(days=6)
-        assert (to_d - from_d).days + 1 == 7
+        assert from_d == ref - _dt.timedelta(days=91)
 
     def test_iso_serialisation(self):
-        """Dates are YYYY-MM-DD strings matching the UI's .toISOString().slice(0,10)."""
-        from_d, to_d = self._w(_dt.date(2026, 8, 10))
-        assert from_d.isoformat() == "2026-08-04"
-        assert to_d.isoformat() == "2026-08-10"
+        """from=2026-05-16 when ref=2026-08-15 (91-day JS arithmetic)."""
+        from_d, to_d = self._w(_dt.date(2026, 8, 15))
+        assert to_d.isoformat() == "2026-08-15"
+        assert from_d.isoformat() == "2026-05-16"

--- a/packages/learn/tests/test_attention_trend_read.py
+++ b/packages/learn/tests/test_attention_trend_read.py
@@ -198,3 +198,72 @@ class TestMaterialityRuleExtension:
         # Engaged/interruption counts are described as measured, not displacement-derived
         p = self._prompt()
         assert "directly measured" in p or "Engaged" in p
+
+
+# ---------------------------------------------------------------------------
+# Schedule registration (#584) — weekly al-attention-trend-read entry.
+# ---------------------------------------------------------------------------
+
+import datetime as _dt
+import scripts.register_schedules as _reg
+
+
+def _schedule_entry() -> dict:
+    entries = _reg._build_schedule_entries("UTC")
+    found = [e for e in entries if e.get("id") == "al-attention-trend-read"]
+    assert len(found) == 1, f"expected 1 entry, got {len(found)}"
+    return found[0]
+
+
+class TestScheduleEntry:
+    def test_id_and_workflow_name(self):
+        """Schedule id exists and workflow name matches @workflow.defn(name=...)."""
+        from src.workflows.attention_trend_read import AttentionTrendReadWorkflow
+        defn = getattr(AttentionTrendReadWorkflow, "__temporal_workflow_definition", None)
+        assert defn is not None
+        e = _schedule_entry()
+        assert e["id"] == "al-attention-trend-read"
+        assert e["workflow"] == defn.name
+
+    def test_no_duplicates(self):
+        """Re-calling _build_schedule_entries returns exactly one entry."""
+        ids = [e["id"] for e in _reg._build_schedule_entries("UTC")
+               if e["id"] == "al-attention-trend-read"]
+        assert ids == ["al-attention-trend-read"]
+
+    def test_calendar_monday_04_00_local(self):
+        """Monday 04:00 LOCAL: after nightly-maintenance, before morning briefing."""
+        cal = _schedule_entry()["spec"].calendars[0]
+        assert cal.day_of_week[0].start == 1  # 1=Monday, 0=Sunday
+        assert cal.hour[0].start == 4
+
+    def test_timezone_propagated(self):
+        entries = _reg._build_schedule_entries("America/New_York")
+        e = next(x for x in entries if x["id"] == "al-attention-trend-read")
+        assert e["spec"].time_zone_name == "America/New_York"
+
+    def test_args_grain_only(self):
+        """grain is the only schedule arg; from/to are derived at run time."""
+        assert _schedule_entry().get("args") == [{"grain": "week"}]
+
+
+class TestWindowComputation:
+    """_window_for_grain must match the UI's sevenAgo()→now() default (#584)."""
+
+    def _w(self, ref: _dt.date) -> tuple[_dt.date, _dt.date]:
+        from src.workflows.attention_trend_read import _window_for_grain
+        return _window_for_grain("week", ref)
+
+    def test_week_shape_matches_seven_ago(self):
+        """from = ref − 6 (JS setDate(d.getDate()−6)), to = ref, span = 7 days."""
+        ref = _dt.date(2026, 8, 17)
+        from_d, to_d = self._w(ref)
+        assert to_d == ref
+        assert from_d == ref - _dt.timedelta(days=6)
+        assert (to_d - from_d).days + 1 == 7
+
+    def test_iso_serialisation(self):
+        """Dates are YYYY-MM-DD strings matching the UI's .toISOString().slice(0,10)."""
+        from_d, to_d = self._w(_dt.date(2026, 8, 10))
+        assert from_d.isoformat() == "2026-08-04"
+        assert to_d.isoformat() == "2026-08-10"

--- a/packages/learn/tests/test_attention_trend_read.py
+++ b/packages/learn/tests/test_attention_trend_read.py
@@ -231,11 +231,30 @@ class TestScheduleEntry:
                if e["id"] == "al-attention-trend-read"]
         assert ids == ["al-attention-trend-read"]
 
-    def test_calendar_monday_04_00_local(self):
-        """Monday 04:00 LOCAL: after nightly-maintenance, before morning briefing."""
+    def test_calendar_daily_04_00_local(self):
+        """Schedule must fire DAILY, not weekly.
+
+        trendsTo = now (AttentionPage.tsx:695), so the subject key the UI
+        requests is attention_trend:week:<from>:<today>.  A weekly schedule
+        anchors the key to one fixed day; any other day finds nothing.
+        Daily means the stored key always matches the current day's window.
+
+        The Temporal SDK fills day_of_week with ScheduleRange(0, 6) (all days)
+        when no DOW restriction is set.  A single-day restriction would be
+        ScheduleRange(start=N, end=N) with start==end.  We assert that all
+        7 days are covered so nobody "optimises" this back to weekly.
+        """
         cal = _schedule_entry()["spec"].calendars[0]
-        assert cal.day_of_week[0].start == 1  # 1=Monday, 0=Sunday
         assert cal.hour[0].start == 4
+        # All 7 days must be covered (SDK default: start=0, end=6, step=1).
+        # A weekly-only restriction has start==end (e.g. start=1, end=1 for Monday).
+        dow = cal.day_of_week
+        assert dow, "day_of_week must be present"
+        assert not any(r.start == r.end for r in dow), (
+            "schedule must cover all 7 days (daily); "
+            "found single-day restriction — see comment: trendsTo=now means "
+            "the observation key changes every day"
+        )
 
     def test_timezone_propagated(self):
         entries = _reg._build_schedule_entries("America/New_York")


### PR DESCRIPTION
## Summary

- Adds `al-attention-trend-read` to `CALENDAR_SCHEDULES` — **daily 04:00 LOCAL** (no day-of-week restriction).
- `AttentionTrendReadWorkflow` derives from/to at run time when not supplied (schedule path); explicit from/to win when both are present (button/ctrl-api path).
- Adds schedule + window tests to `test_attention_trend_read.py` (30 total green).

## Window — derived from the TRENDS tab source

`AttentionPage.tsx` lines 32, 694–695:

```typescript
const thirteenWeeksAgo = () => { const d = new Date(); d.setDate(d.getDate() - 91); ... };
const [trendsFrom] = useState(thirteenWeeksAgo);  // today − 91 days
const [trendsTo]   = useState(now);               // today
const trendsQ = useQuery(getAttentionTrends, { grain, from: trendsFrom, to: trendsTo }, ...);
```

The window is **91 days regardless of grain** — grain only changes period bucketing. The schedule passes only `{"grain": "week"}` and the workflow derives `from = today − 91`, `to = today` at run time.

## Why daily, not weekly

`trendsTo = now` (line 695). The UI constructs the observation subject key as `attention_trend:week:<from>:<today>`. A weekly schedule would write a key anchored to Monday's date; any visit on Tue–Sun would find nothing. Daily ensures the stored key always matches the current day's window.

The test `test_calendar_daily_04_00_local` asserts all 7 days are covered and names this reason in its docstring so the constraint cannot be quietly removed.

## Explicit from/to preserved

`POST /api/v1/attention/trends/interpret` and the Generate Read button (AttentionPage.tsx:724) supply `{grain, from: trendsFrom, to: trendsTo}` explicitly. The workflow passes them through unchanged when both are present. Only when neither is supplied (the schedule case) does it derive the window.

## Smoke evidence

```
$ cd packages/learn && python3 -m pytest tests/test_attention_trend_read.py -q
..............................
30 passed in 0.36s
```

Key assertions:
- `test_id_and_workflow_name` — id `al-attention-trend-read`, workflow = `"AttentionTrendReadWorkflow"`.
- `test_no_duplicates` — exactly one entry, idempotent to re-register.
- `test_calendar_daily_04_00_local` — no single-day DOW restriction (fires every day); `hour[0].start == 4`. Docstring names why weekly would be wrong.
- `test_timezone_propagated` — `spec.time_zone_name` honours the tenant timezone.
- `test_args_grain_only` — `args == [{"grain": "week"}]`; no dates.
- `test_window_is_91_days_back` — `from = ref − 91 days`, `to = ref`. Matches `d.setDate(d.getDate() − 91)`.
- `test_iso_serialisation` — `ref=2026-08-15` → `from=2026-05-16`, `to=2026-08-15`.

Gate: 46 LOC (cadence fix commit), lane II verify 30/30 green.

References #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc