### PR TITLE
fix(web): the ledger multiplier rendered as a literal backslash escape (#584)

### DIFF
--- a/packages/web/src/dashboard/AttentionPage.tsx
+++ b/packages/web/src/dashboard/AttentionPage.tsx
@@ -384,7 +384,7 @@ function DayView({ day, date, recomp, running }: {
                       {(row.count ?? 1) > 1 && (
                         <span style={{ fontFamily: "var(--font-mono)", color: "var(--marginalia)",
                           fontSize: 9, marginLeft: 6 }}>
-                          \xd7{row.count}
+                          {"\u00d7"}{row.count}
                         </span>
                       )}
                     </span>
@@ -449,7 +449,7 @@ function DayView({ day, date, recomp, running }: {
               <span style={{ fontFamily: "var(--font-mono)", fontSize: 9,
                 color: "var(--marginalia)" }}>{r.action_class}</span>
               <span style={{ fontFamily: "var(--font-mono)", fontSize: 9,
-                color: "var(--marginalia)" }}>\xd7{r.count}</span>
+                color: "var(--marginalia)" }}>{"\u00d7"}{r.count}</span>
             </div>
           ))}
         </div>

--- a/packages/web/src/dashboard/attentionCore.test.ts
+++ b/packages/web/src/dashboard/attentionCore.test.ts
@@ -4,6 +4,8 @@
  */
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
 import {
   deriveUnratedRows, deriveInferredDisplay, deriveDisplacementGroups,
   isEmptyDay, formatHours, formatMinutes,
@@ -574,4 +576,25 @@ test("deriveLedger reads display_minutes from normalised items — never NaN", (
   assert.equal(conv.rows[1].displaced_min, 0, "blocked row credits zero");
   assert.equal(conv.subtotal_displaced_min, 60, "subtotal is the sum of displayed rows");
   assert.equal(l.total_displaced_min, 60);
+});
+
+// ─── JSX text is not a JS string (#584) ───────────────────────────────────────
+// The day-tab rebuild wrote `\xd7{row.count}` as JSX *text* intending the
+// multiplication sign. Escapes are not interpreted there, so the page rendered
+// the literal characters — "vigilance \xd724" instead of "vigilance ×24" — on
+// every collapsed row. It shipped green: no test reads the component's text, and
+// `wasp build` type-checks but does not evaluate JSX children.
+test("AttentionPage contains no un-evaluated backslash escapes in JSX text", () => {
+  const src = fs.readFileSync(
+    path.join(import.meta.dirname, "AttentionPage.tsx"), "utf8");
+  // Match a backslash escape that is NOT inside a quoted string on the same
+  // token — i.e. sitting bare in JSX children, where it renders literally.
+  const bare = src.split("\n")
+    .map((line, i) => ({ line, n: i + 1 }))
+    .filter(({ line }) => /(^|[>}\s])\\(x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4})/.test(line)
+                          && !/["'`]\\(x|u)/.test(line));
+  assert.deepEqual(
+    bare.map(b => `${b.n}: ${b.line.trim()}`), [],
+    "backslash escape in JSX text renders literally — wrap it as {\"\\u00d7\"}",
+  );
 });


### PR DESCRIPTION
Found by looking at the deployed page, not the diff.

The day-tab rebuild (#646) wrote `\xd7{row.count}` as JSX **text**, intending the
multiplication sign. Escapes are not interpreted in JSX children, so every
collapsed ledger row rendered the literal characters:

```
50 signals, no urgent notification — vigilance  \xd724
```

instead of `×24`. Same in the unrated-action-classes block.

## Why the gate did not catch it

It shipped green through `typecheck-web`. `wasp build` type-checks JSX but does
not evaluate its children, and no test reads the component's rendered text — so
the type gate that has caught real errors all day is **structurally blind to this
whole class of defect**. Anything wrong *inside* JSX text is invisible to it.

The guard added here scans `AttentionPage.tsx` for a backslash escape sitting bare
in JSX text (not inside a quoted string) and fails with the fix in the assertion
message.

## Smoke evidence

```
# tests 77 / pass 77 / fail 0

Verified RED by reintroducing the original expression:
  not ok 77 - AttentionPage contains no un-evaluated backslash escapes in JSX text
      backslash escape in JSX text renders literally — wrap it as {"×"}
  # fail 1

Live evidence, home /attention?date=2026-08-13, before this fix:
  "50 signals, no urgent notification — vigilance  \xd724"
  "0 candidates, below threshold, silent — vigilance  \xd72"
```