### PR TITLE
feat(design-system): add the canonical Attention Trends report template

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -6,9 +6,12 @@
 #   * shellcheck         — scripts/bootstrap.sh
 #
 # Runs on every PR and on push to main. Does NOT build or deploy images
-# (that is the build-*.yml workflows' job). The Wasp web app is type-checked
-# by build-web.yml's `wasp build` — bare `tsc` cannot resolve the generated
-# `wasp/*` modules without Wasp codegen, so it is not checked here.
+# (that is the build-*.yml workflows' job). The Wasp web app is not checked
+# here — bare `tsc` cannot resolve the generated `wasp/*` modules without
+# Wasp codegen. It is type-checked on PRs by typecheck-web.yml, which runs
+# the real `wasp build`. Until #615 that check lived only in build-web.yml,
+# i.e. after the merge, so a type error could not be caught before it broke
+# main.
 name: ci-check
 
 on:

--- a/.github/workflows/typecheck-web.yml
+++ b/.github/workflows/typecheck-web.yml
@@ -1,0 +1,59 @@
+# Type-check the Wasp web app on pull requests.
+#
+# WHY THIS EXISTS (#615). `packages/web` had no type gate before merge. The
+# unit suites run under `tsx --test`, which STRIPS types rather than checking
+# them, so a file that cannot compile still reports every test green. The only
+# real type check was `wasp build` inside build-web.yml — and that runs on
+# PUSH TO MAIN, i.e. after the merge. The failure mode is therefore:
+#
+#   PR is green  →  merge  →  main goes red  →  no image is published
+#
+# which happened three times in one afternoon on a single feature (#584),
+# each time costing a build-and-deploy cycle and leaving main unable to ship.
+#
+# Bare `tsc --noEmit` is NOT a substitute: it cannot resolve the generated
+# `wasp/*` modules without Wasp codegen, which is exactly why ci-check.yml
+# skips web. `wasp build` is the only thing that type-checks this package, so
+# this workflow runs it — the same command, moved to where it can still
+# prevent the merge.
+#
+# It duplicates work build-web.yml does later. That is deliberate: a few
+# minutes of runner time per web PR is cheaper than a red main.
+#
+# To make this binding, add `typecheck-web` to the branch-protection required
+# checks for main. Without that it reports but does not block.
+name: typecheck-web
+
+on:
+  pull_request:
+    paths:
+      - "packages/web/**"
+      - ".github/workflows/typecheck-web.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: typecheck-web-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck-web:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install Wasp
+        # Keep this version pinned to the one build-web.yml uses. A drift here
+        # means the gate checks against a different compiler than the one that
+        # publishes the image, which would let the same class of error through.
+        run: curl -sSL https://get.wasp.sh/installer.sh | sh -s -- -v 0.19.0
+
+      - name: wasp build (type check)
+        working-directory: packages/web
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          wasp build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ alfred-black/
 │   ├── FIX-CONTRACTS.md     frozen cross-lane interfaces (Cn…)
 │   ├── design/ specs/       design rationale + per-issue specs
 │   └── operators/           ops runbooks
+├── design-system/           the Alfred Black brand system — tokens, rules, templates (§19)
 ├── deploy/                  ops runbooks
 ├── debug/                   ignored — investigation outputs land here
 └── CLAUDE.md                this file
@@ -669,7 +670,7 @@ For mapping unknown breakage (e.g. a sweep over the live product):
    | **II**·learn | `lane-2/` | `packages/learn/**` | Temporal activities, the intelligence layer, scoring |
    | **III**·web | `lane-3/` | `packages/web/**` | Wasp app, dashboard pages, operations.ts |
    | **IV**·alfred-vault | `lane-4/` | `packages/alfred-vault/**` | The Python vault daemon (separate package `alfred-vault` 1.0+) |
-   | **V**·edges/infra | `lane-5/` | `packages/{hermes,mcp-server,vault-init,setup}/**`, `scripts/**`, `caddy/**`, `docker-compose.yaml`, `.env.example`, `Makefile`, `docs/**` | All non-package config |
+   | **V**·edges/infra | `lane-5/` | `packages/{hermes,mcp-server,vault-init,setup}/**`, `scripts/**`, `caddy/**`, `docker-compose.yaml`, `.env.example`, `Makefile`, `docs/**`, `design-system/**` | All non-package config + the brand system |
    | **VI**·voice-bridge | `lane-6/` | `packages/voice-bridge/**` | Twilio/telephony bridge |
    | **VII**·paperclip | `lane-7/` | `packages/paperclip/**` | Paperclip adapter |
 
@@ -1085,6 +1086,75 @@ containers.
   is that human decisions on /desk become observations become tier
   promotions. If observations aren't landing in `state.db`, the system
   isn't learning — and that's a bug to fix urgently, not a "we'll iterate" item.
+
+---
+
+---
+
+## 19. The design system — read this before touching any surface
+
+`design-system/` holds the **Alfred Black brand system**. It is not decoration and it
+is not optional: every principal-facing surface is expected to be derived from it.
+
+**`design-system/readme.md` is the authoritative document.** Read it before designing
+anything. `design-system/IMPORTED.md` records where the snapshot came from, what was
+left out, and the one place the older `_brandpack/` layer contradicts the readme.
+
+### The identity in one paragraph
+
+**Letterpress meets terminal.** Ivory paper `#F4EFE6`, wool black `#0B0B0B`, ink
+`#1A1A1A`, and **one** antique-brass accent `#A8843A`. Playfair Display (Didone) for
+display, frequently italic. EB Garamond for running text, oldstyle numerals. JetBrains
+Mono for everything machine — labels, ledgers, marginalia — uppercase, 0.18–0.32em
+tracking. The product is a *private command room*, not a SaaS dashboard.
+
+### Non-negotiables
+
+- **One brass accent per screen.** No second accent, ever. Brass is punctuation: it
+  marks the single most important thing, then falls silent. If a chart needs a second
+  series colour, use tints of brass or the marginalia grey — **not a new hue**.
+- **`--radius: 0`.** Corners are sharp. Only tiny chips earn 2px.
+- **Hairline rules, not cards.** Structure is drawn with `--ab-rule`; there are no
+  filled cards, no drop shadows, no glassmorphism, no blur. Print does not float.
+- **Serif for what Alfred says; mono for machine truth.** Prose in EB Garamond, signed
+  *"— Alfred."* Labels, statuses and ledger figures in mono caps.
+- **No emoji. Ever.** The only non-icon glyphs are `● → ↓ · ✕` and roman numerals.
+- **No ASCII / dot-matrix art.** The engraved icon set carries the whole iconographic
+  load, including empty states. (`_brandpack/` says otherwise; it is the older layer —
+  see `IMPORTED.md`.)
+- **Calm copy.** No hype, no exclamation marks, no "Oops!". *"No urgent action is
+  required."* is the register.
+
+### Where things live
+
+| path | what |
+|---|---|
+| `design-system/readme.md` | **authoritative** — voice, palette, type, surfaces, iconography |
+| `design-system/styles.css` | single entry point; `@import`s the tokens in order |
+| `design-system/tokens/` | `colors` · `typography` · `spacing` · `surfaces` · `fonts` |
+| `design-system/templates/attention-statement/` | the canonical statement layout |
+| `design-system/SKILL.md` | portable Agent-Skill wrapper |
+
+### The token values are the product's, not a mockup's
+
+`design-system/tokens/*.css` is lifted verbatim from `packages/web/src/client/Main.css`.
+That file remains the source of truth for the running app. If the two ever drift,
+**the product theme wins and the snapshot is stale** — re-import rather than editing
+`Main.css` to match a mockup.
+
+### Snapshot, not sync
+
+This is a point-in-time copy of a Claude Design project (id in `IMPORTED.md`). Editing
+files here does not change the design project. The React components, the 17 engraved
+SVG icons, brand marks and textures are **not yet imported** — `readme.md` describes
+assets that this directory does not yet contain.
+
+### Never commit the source project's `uploads/`
+
+The design project carries client PDFs, a competitive-landscape report and personal
+travel documents. **This repository is public.** Sample data in the templates has also
+carried real client names — scrub before committing, and never put a real name in a
+commit message, PR body or comment.
 
 ---
 

--- a/design-system/IMPORTED.md
+++ b/design-system/IMPORTED.md
@@ -30,6 +30,7 @@ The **buildable core** — everything needed to write in-brand CSS and markup:
 | `tokens/surfaces.css` | `.paper` `.wool` `.rule` `.gilt` `.press`, the button family |
 | `templates/attention-statement/AttentionStatement.dc.html` | canonical statement — **light**, A4 client-facing |
 | `templates/attention-statement/AttentionStatementDark.html` | canonical statement — **dark**, the in-app treatment |
+| `templates/attention-trends/AttentionTrends.html` | canonical **trends report** — sentence-led panels, mirrored chart, ratio plot |
 | `_brandpack/prompts/UI_RULES.md` | the ten UI rules (older layer) |
 | `_brandpack/ui-kit/components/COMPONENT_RULES.md` | panels, buttons, inputs, tables (older layer) |
 
@@ -58,6 +59,21 @@ Any future import must repeat both checks before committing — the design proje
 private, this repository is not.
 
 ---
+
+## The trends template carries logic, not just layout
+
+`templates/attention-trends/AttentionTrends.html` ships an inline `<script>` that
+**computes its own headlines** from a JSON feed. That script is part of the design,
+not scaffolding: the sentence it picks is how the report stays honest.
+
+- engaged is null → *"your time wasn't measured"* rather than a ratio
+- engaged < 1h → *"Too little of your time was logged this week to price it."*
+- NAR ≤ 0 → *"Nothing came back this week"*
+- a `null` in `ratio_series` is drawn as a faint dashed segment — a gap, never interpolated
+- the read picks from eight templates on the direction triple (ratio / XL hours / failures)
+
+Port those rules faithfully when implementing. Dropping them turns an honest report
+into a confident one.
 
 ## The one contradiction, and which side wins
 

--- a/design-system/IMPORTED.md
+++ b/design-system/IMPORTED.md
@@ -28,7 +28,8 @@ The **buildable core** — everything needed to write in-brand CSS and markup:
 | `tokens/typography.css` | display/body/mono scales, tracking, leading |
 | `tokens/spacing.css` | `--radius: 0`, 4px scale, hairlines, layout widths |
 | `tokens/surfaces.css` | `.paper` `.wool` `.rule` `.gilt` `.press`, the button family |
-| `templates/attention-statement/` | the canonical Attention Statement layout |
+| `templates/attention-statement/AttentionStatement.dc.html` | canonical statement — **light**, A4 client-facing |
+| `templates/attention-statement/AttentionStatementDark.html` | canonical statement — **dark**, the in-app treatment |
 | `_brandpack/prompts/UI_RULES.md` | the ten UI rules (older layer) |
 | `_brandpack/ui-kit/components/COMPONENT_RULES.md` | panels, buttons, inputs, tables (older layer) |
 
@@ -46,10 +47,15 @@ The **buildable core** — everything needed to write in-brand CSS and markup:
 
 ## Sample data was scrubbed
 
-`templates/attention-statement/AttentionStatement.dc.html` shipped with a real client
-company name in its standfirst and is a client-facing document. The name has been
-replaced with the fictional **Northwind & Co**. Any future import must repeat this
-check before committing — the design project is private, this repository is not.
+`AttentionStatement.dc.html` (light) shipped with a real client company name in its
+standfirst; replaced with the fictional **Northwind & Co**.
+
+`AttentionStatementDark.html` shipped with the principal's full name in its `<title>`;
+removed. Its ledger line items are generic by nature ("Client invoice rebuilt") and were
+kept — they demonstrate the register the ledger should be written in.
+
+Any future import must repeat both checks before committing — the design project is
+private, this repository is not.
 
 ---
 

--- a/design-system/IMPORTED.md
+++ b/design-system/IMPORTED.md
@@ -1,0 +1,72 @@
+# Imported — provenance, scope, and one contradiction
+
+**Source:** Claude Design project `e1a3afca-fdb4-4a71-95fd-163c4cd0653c`
+("Alfred Black Design System").
+**Snapshot date:** 2026-08-15.
+
+This is a **point-in-time snapshot, not a live sync.** Editing files here does not
+change the design project, and changes made there do not appear here until someone
+re-imports.
+
+**To re-sync:** use the `DesignSync` tool with the project id above —
+`list_files`, then `get_file` per path. Read methods only; do not push repo state back
+into the design project.
+
+---
+
+## What this snapshot contains
+
+The **buildable core** — everything needed to write in-brand CSS and markup:
+
+| path | what |
+|---|---|
+| `readme.md` | **the authoritative system document** — voice, palette, type, surfaces, iconography |
+| `SKILL.md` | portable Agent-Skill wrapper |
+| `styles.css` | single entry point; `@import`s every token file in order |
+| `tokens/fonts.css` | Playfair Display · EB Garamond · JetBrains Mono |
+| `tokens/colors.css` | material + semantic + `.dark` scope |
+| `tokens/typography.css` | display/body/mono scales, tracking, leading |
+| `tokens/spacing.css` | `--radius: 0`, 4px scale, hairlines, layout widths |
+| `tokens/surfaces.css` | `.paper` `.wool` `.rule` `.gilt` `.press`, the button family |
+| `templates/attention-statement/` | the canonical Attention Statement layout |
+| `_brandpack/prompts/UI_RULES.md` | the ten UI rules (older layer) |
+| `_brandpack/ui-kit/components/COMPONENT_RULES.md` | panels, buttons, inputs, tables (older layer) |
+
+## What is deliberately NOT here
+
+- **`uploads/`** — client PDFs, a competitive-landscape report, and personal travel
+  documents. **This repository is public.** These must never be committed.
+- **`screenshots/`, `_brandpack/references/`** — large PNG renders with no build value.
+- **Root one-off documents** — landing pages, decks, ebooks, thesis inserts. They are
+  outputs of the system, not the system.
+- **`components/`, `assets/`, `icons/`, `guidelines/cards/`** — the React primitives,
+  the 17 engraved SVG icons, brand marks and textures. **Not yet imported.** They are
+  wanted; they were left out of this pass to keep it reviewable. Until they land,
+  `readme.md`'s iconography section describes assets that are not in this directory.
+
+## Sample data was scrubbed
+
+`templates/attention-statement/AttentionStatement.dc.html` shipped with a real client
+company name in its standfirst and is a client-facing document. The name has been
+replaced with the fictional **Northwind & Co**. Any future import must repeat this
+check before committing — the design project is private, this repository is not.
+
+---
+
+## The one contradiction, and which side wins
+
+`readme.md` and the older `_brandpack/` layer disagree about ASCII art:
+
+- **`readme.md`** (newer, authoritative): *"No ASCII / dot-matrix art. The engraved
+  icon set carries the whole iconographic load — including empty states, where a
+  single icon is set large in brass."*
+- **`_brandpack/prompts/UI_RULES.md`** rule 4: *"Use ASCII/dot-matrix as atmosphere,
+  not decoration spam."*
+- **`_brandpack/ui-kit/components/COMPONENT_RULES.md`**, Empty States: *"Use ASCII
+  object engravings: top hat, watch, key, monocle, bow tie."*
+
+**`readme.md` wins.** `SKILL.md` names it as the full system, and it is the later
+document. `_brandpack/` is retained for its assets, type system and copy rules — not
+as a source of layout law. Both conflicting files carry an inline note pointing here.
+
+If you are about to add ASCII art to an Alfred surface, you are following the dead rule.

--- a/design-system/SKILL.md
+++ b/design-system/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: alfred-black-design
+description: Use this skill to generate well-branded interfaces and assets for Alfred Black, the agentic butler — either for production or throwaway prototypes/mocks/decks. Contains essential design guidelines, colours, type, fonts, the engraved icon set, brand marks, and UI-kit components for prototyping.
+user-invocable: true
+---
+
+# Alfred Black — Design Skill
+
+Alfred Black is an **agentic butler**: a private, self-hosted AI that handles the
+details and surfaces only what needs your judgment. The brand is **letterpress meets
+terminal** — ivory paper, wool black, one brass accent, Didone display, Garamond body,
+mono machine-voice, sharp corners, hairline rules.
+
+Read **`readme.md`** in this skill for the full system (content fundamentals, visual
+foundations, iconography, manifest), then explore the other files.
+
+## Where things are
+- `styles.css` — link this one file; it `@import`s every token + font + surface utility.
+- `tokens/` — colour, type, spacing, surfaces (`.paper`, `.wool`, `.rule`, `.gilt`, `btn-*`).
+- `components/` — React primitives (Button, Pill, Rule, Icon, Seal, CommandField, TextField, Panel, LedgerRow).
+- `ui_kits/marketing` & `ui_kits/app` — full-screen recreations to copy from.
+- `assets/` — brand marks, the 17 engraved icons, textures.
+- `guidelines/cards/` — foundation specimens.
+
+## How to work
+- **Visual artifacts (slides, mocks, throwaway prototypes):** copy the assets you need
+  out of `assets/`, link `styles.css`, and build self-contained static HTML. Use the
+  utility classes and inline the engraved icons from `assets/icons/`. The `ui_kits/`
+  files are the best starting points — clone and adapt them.
+- **Production code:** copy assets and read the rules here to design fluently in-brand;
+  the token values match the shipping product (`ssdavidai/alfred`).
+
+## Non-negotiables
+- One brass accent per screen. No second accent, ever. No emoji. Corners stay sharp
+  (`--radius: 0`). Serif for what Alfred *says*; mono for machine truth (labels, ledgers).
+  Calm, composed copy — never hype. Sign Alfred's prose with *"— Alfred."*
+
+If invoked without guidance, ask what the user wants to build, ask a few focused
+questions, then act as an expert Alfred Black designer who outputs HTML artifacts *or*
+production code, depending on the need.

--- a/design-system/_brandpack/prompts/UI_RULES.md
+++ b/design-system/_brandpack/prompts/UI_RULES.md
@@ -1,0 +1,16 @@
+# UI Rules
+
+1. Command first.
+2. Surface judgment, not noise.
+3. Human layer in serif, machine layer in mono.
+4. Use ASCII/dot-matrix as atmosphere, not decoration spam.
+5. Brass is punctuation.
+6. Privacy is visible and auditable.
+7. No dashboard clutter.
+8. Mobile is capture, approval, and brief only.
+9. Use Alfred's silhouette as signature, not mascot.
+10. Make stillness feel powerful.
+
+> **Superseded on rule 4.** `../../readme.md` is the authoritative layer and states
+> "No ASCII / dot-matrix art. The engraved icon set carries the whole iconographic
+> load — including empty states." See `../../IMPORTED.md`.

--- a/design-system/_brandpack/ui-kit/components/COMPONENT_RULES.md
+++ b/design-system/_brandpack/ui-kit/components/COMPONENT_RULES.md
@@ -1,0 +1,28 @@
+# Component Rules
+
+## Panels
+- Use thin brass hairlines, not heavy borders.
+- Background should be almost black with slight warmth.
+- No large cards unless the content is a real case file.
+
+## Buttons
+- Primary button: brass fill, black text, uppercase mono.
+- Secondary button: transparent, brass hairline.
+- Destructive action: keep quiet; never bright red except in safety-critical errors.
+
+## Inputs
+- Command input is the hero component.
+- Placeholder voice: "What shall Alfred handle?" or "alfred.black >".
+- Use a block cursor for terminal moments.
+
+## Tables
+- Ledgers, not spreadsheets.
+- Show time, subject, state, and next action.
+- Never use zebra stripes.
+
+## Empty States
+- Use ASCII object engravings: top hat, watch, key, monocle, bow tie.
+- Copy should reassure: "No urgent action is required."
+
+> **Superseded on Empty States.** `../../../readme.md` is authoritative and specifies a
+> single engraved icon set large in brass — not ASCII. See `../../../IMPORTED.md`.

--- a/design-system/readme.md
+++ b/design-system/readme.md
@@ -1,0 +1,144 @@
+# Alfred Black — Design System
+
+> *"Not an app you use. A person you employ."*
+
+Alfred Black is an **agentic butler** — a single-VM, self-hosted AI that reads the
+correspondence, drafts the replies, holds the calendar, and keeps the ledger, then
+surfaces only what needs your judgment. The product is a *private command room*, not
+a SaaS dashboard. This design system encodes its visual and verbal identity so any
+new interface, deck, or asset reads as unmistakably Alfred.
+
+The aesthetic is **letterpress meets terminal**: ivory paper, wool black, a single
+brass accent, Didone display type set large and italic, Garamond running text, and a
+mono machine-voice for labels and ledgers. Sharp corners. Hairline rules. One gilt
+line per page. Serif for human presence; mono for machine truth.
+
+---
+
+## Content fundamentals — how Alfred speaks
+
+Alfred is a butler: **calm, composed, concise, precise.** He never hypes, jokes, or
+over-explains. He addresses the principal directly ("you", occasionally "Sir") and
+signs his work. The register is formal but warm — Jeeves with a terminal.
+
+**Voice in three registers**
+- **Serif (human presence)** — the things Alfred says to you. Full sentences, an
+  em-dash, a closing signature: *"The matter is under control. — Alfred."*
+- **Mono (machine truth)** — labels, status, audit. Uppercase, wide-tracked, terse:
+  `APPROVAL REQUIRED BEFORE EXECUTION`, `DISCRETION MODE ACTIVE`.
+- **Italic display** — emphasis and manifesto: *"A person you employ."*
+
+**Casing & punctuation.** Sentence case for prose; UPPERCASE only for mono labels.
+Brass `·` interpunct in the wordmark (Alfred·Black). Roman numerals for dates of
+record (*Est. MMXXVI*). Oldstyle numerals in body text. No exclamation marks.
+
+**Do say** — Everything important is in hand. · I have prepared this for review. ·
+Approval is required before execution. · Discretion mode is active. · No urgent action
+is required. · The rest is settled, quietly, by the time you ask.
+
+**Never say** — Boost your productivity. · Next-gen AI workflows. · Oops! · Your AI
+super-assistant. · Hey there! · 🎉 / any emoji.
+
+**Taglines** — *Service is the standard. · Your life, attended to. · Classical service.
+Terminal precision. · Private by design. Precise by nature.*
+
+**Terminal prompts** — `alfred.black > brief me` · `alfred.black > prepare my week` ·
+`alfred.black > review open matters` · `alfred.black > audit last 24h`.
+
+---
+
+## Visual foundations
+
+**Palette.** Wool black `#0B0B0B`, ivory paper `#F4EFE6`, ink `#1A1A1A`, and **one**
+antique-brass accent `#A8843A`. *No second accent — ever.* Brass is punctuation: it
+marks the single most important thing on a screen (a CTA, an active state, the gilt
+rule) then falls silent. State colours (oxblood / billiard-green / amber) are
+desaturated and rare; destructive is never fire-red except in safety-critical errors.
+Paper is the default surface; **wool is always dark** and never theme-swaps. A dark
+mode inverts ink and paper while brass holds.
+
+**Type.** Three families. *Playfair Display* (Didone) for display — set large, tracked
+tight (−0.02em), frequently **italic** for emphasis and the wordmark's `Black.`
+*EB Garamond* for running text, with oldstyle numerals and generous 1.6 leading.
+*JetBrains Mono* for everything machine — labels, nav, marginalia, ledgers — always
+uppercase with 0.18–0.32em tracking. Never a bubbly or playful face.
+
+**Corners & borders.** `--radius: 0`. Everything is square; only tiny chips earn 2px.
+Structure is drawn with **hairline rules** (`--ab-rule`, ~0.55 alpha ink), never heavy
+borders or large filled cards. The one flourish is the **gilt** line — a 1px brass rule
+with a soft glow, used *once per page* where the eye should rest.
+
+**Surfaces & texture.** `.paper` and `.wool` carry a fine SVG fractal-noise grain (4px
+speckle + 240px turbulence) so backgrounds feel like stock, not screen. No gradients
+as decoration; the only gradient is the faint radial brass glow behind a hero. No
+glassmorphism, no blur.
+
+**Elevation.** Almost none. Print does not float. Panels sit flat inside hairline
+frames; the only shadow is a 1px letterpress impression (`.press`) on display type
+over wool, and a heavy scrim shadow on modals. No drop-shadow card stacks.
+
+**Imagery & motifs.** The signature is **Alfred's silhouette** — a monocled gentleman
+in bow tie — used as a mark, not a mascot. Empty states use a **single engraved icon**
+(pocket watch, key, top hat) in brass with reassuring copy — *"No urgent action is
+required."* The **Seal** (a pressed italic "A" in a double ring) signs surfaces
+at ~7% opacity in the lower-right gutter. Photography, where used, is warm,
+low-key, and grainy — candlelit, never bright stock.
+
+**Motion.** Restrained and cinematic. Entrances are slow blur-and-rise
+(`cubic-bezier(0.16, 1, 0.3, 1)`, 0.7–0.95s) and rules "draw" from `originX:0`.
+Hover is a 160ms colour/opacity shift toward brass — never a bounce or a scale-pop.
+The terminal caret blinks (1s steps). No infinite decorative loops. Respect
+`prefers-reduced-motion`.
+
+**Hover / press states.** Links and ghost actions shift to brass on hover; the brass
+CTA *fills* with brass and flips its text to paper. Ledger rows wash to 6% brass and
+their hairline brasses. Focus-visible is a 1px brass outline at 3px offset. There is
+no distinct "pressed/shrink" state — the brand prefers stillness.
+
+---
+
+## Iconography
+
+Alfred ships its **own engraved icon set** — 17 monoline marks at a 32px viewBox,
+1.1px stroke, round caps, drawn in `currentColor` so they inherit text colour. They
+read as small *engravings*, not UI furniture: `top_hat`, `bow_tie`, `pocket_watch`,
+`monocle`, `skeleton_key`, `calling_card`, `envelope`, `calendar`, `matter`,
+`approval`, `shield`, `lock`, `globe`, `voice`, `terminal`, `user`, `settings`.
+
+- Use them small (12–20px) and tint via `style={{ color }}` — brass for the one
+  accent, ink/marginalia otherwise. Never recolour them with fills or use them as
+  large hero illustration.
+- **Emoji are never used.** Unicode `●`, `→`, `↓`, `·`, `✕` and roman numerals are the
+  only non-icon glyphs in the vocabulary.
+- **No ASCII / dot-matrix art.** The engraved icon set carries the whole iconographic
+  load — including empty states, where a single icon is set large in brass.
+
+If you need an icon outside the set, draw it to match: single monoline stroke ~1.1px,
+round caps/joins, 32px box, no fills.
+
+---
+
+## Using it
+
+Link the one stylesheet and opt a surface into the base:
+
+```html
+<link rel="stylesheet" href="styles.css">
+<body class="ab-base paper">…</body>   <!-- or class="ab-base wool" for the dark room -->
+```
+
+Then reach for utility classes (`btn-brass`, `pill-brass`, `rule`, `gilt`, `font-display`),
+keep one brass note per screen, set the human voice in serif and the machine voice in
+mono, and leave the corners sharp.
+
+---
+
+## Provenance
+
+The token values, surfaces, and button family here are **lifted verbatim from the
+shipping product theme** at `packages/web/src/client/Main.css`. That file is the source
+of truth, above any mockup. When recreating a product surface, read the component code
+first; the mockups are a high-level guide only.
+
+See `IMPORTED.md` for what this snapshot contains, what was deliberately left out, and
+the one place the older `_brandpack/` layer contradicts this document.

--- a/design-system/styles.css
+++ b/design-system/styles.css
@@ -1,0 +1,13 @@
+/* ════════════════════════════════════════════════════════════
+   ALFRED BLACK — Design System
+   "Not an app you use. A person you employ."
+
+   Global entry point. Consumers link THIS file only.
+   Import order: fonts → colour → type → spacing → surfaces.
+   ════════════════════════════════════════════════════════════ */
+
+@import url("./tokens/fonts.css");
+@import url("./tokens/colors.css");
+@import url("./tokens/typography.css");
+@import url("./tokens/spacing.css");
+@import url("./tokens/surfaces.css");

--- a/design-system/templates/attention-statement/AttentionStatement.dc.html
+++ b/design-system/templates/attention-statement/AttentionStatement.dc.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<!-- @template name="Attention Statement" description="Monthly client-facing statement — accepted work displaced, the mess bill, Net Attention Returned. A4 print-ready." -->
+<helmet>
+<script src="./ds-base.js"></script>
+<style>body{margin:0;background:oklch(0.18 0.006 60)}@media print{body{background:none}}</style>
+</helmet>
+<div style="font-family:var(--font-body,Georgia,serif);color:oklch(0.24 0.012 60)">
+<div style="width:794px;min-height:1123px;box-sizing:border-box;margin:36px auto;background:oklch(0.96 0.01 85);padding:56px 62px 48px;position:relative;box-shadow:0 30px 80px rgba(0,0,0,.5)">
+
+<div style="display:flex;align-items:flex-start;justify-content:space-between;gap:24px">
+<div style="display:flex;align-items:center;gap:14px">
+<img src="../../brand/alfred-logo-black.svg" alt="Alfred Black" style="height:44px;width:auto;display:block">
+<div>
+<div style="font-family:var(--font-mono,monospace);font-weight:800;font-size:12px;letter-spacing:0.32em;color:oklch(0.24 0.012 60)">ALFRED&nbsp;BLACK</div>
+<div style="font-family:var(--font-mono,monospace);font-weight:700;font-size:9px;letter-spacing:0.26em;color:oklch(0.52 0.09 75);margin-top:5px">EMPLOYMENT, NOT TOOLING</div>
+</div>
+</div>
+<div style="text-align:right;font-family:var(--font-mono,monospace);font-weight:700;font-size:10px;letter-spacing:0.2em;color:oklch(0.45 0.015 60);line-height:2">STATEMENT Nº 002<br>PERIOD MAY 01 — MAY 31<br>RECONCILED · WEEKLY ×4</div>
+</div>
+
+<div style="border-top:1px solid oklch(0.24 0.012 60);border-bottom:1px solid oklch(0.24 0.012 60);height:5px;margin:26px 0 34px"></div>
+
+<div style="font-family:var(--font-mono,monospace);font-weight:800;font-size:10.5px;letter-spacing:0.3em;color:oklch(0.52 0.09 75)">MONTHLY PERFORMANCE REVIEW · MONTH 02</div>
+<h1 style="font-family:var(--font-display,Georgia,serif);font-weight:600;font-size:44px;letter-spacing:-0.015em;line-height:1.05;margin:14px 0 10px">Attention Statement.</h1>
+<div style="font-size:16px;font-style:italic;color:oklch(0.45 0.015 60)">Prepared for <span style="color:oklch(0.24 0.012 60);font-style:normal;font-weight:600">Northwind &amp; Co</span> — every minute honestly counted.</div>
+
+<sc-if value="{{ checkpoint }}" hint-placeholder-val="{{ false }}">
+<div style="margin-top:26px;border:1px solid oklch(0.52 0.09 75);background:oklch(0.52 0.09 75 / 0.07);padding:16px 22px;display:flex;justify-content:space-between;align-items:center;gap:18px">
+<span style="font-family:var(--font-mono,monospace);font-weight:800;font-size:10.5px;letter-spacing:0.24em;color:oklch(0.52 0.09 75)">DAY-55 CHECKPOINT</span>
+<span style="font-size:14px;font-style:italic;color:oklch(0.35 0.014 60)">Your day-60 exit decision is due by June 9. Continue, or written notice in the agreed channel.</span>
+</div>
+</sc-if>
+
+<div style="margin-top:40px;display:flex;align-items:baseline;gap:16px">
+<span style="font-family:var(--font-mono,monospace);font-weight:800;font-size:10.5px;letter-spacing:0.28em;color:oklch(0.52 0.09 75)">01 · THE ACCOUNT</span>
+<span style="flex:1;border-top:1px solid oklch(0.24 0.012 60 / 0.15)"></span>
+</div>
+
+<div style="margin-top:20px;font-family:var(--font-mono,monospace);font-weight:700;font-size:13.5px;letter-spacing:0.03em">
+<div style="display:flex;align-items:baseline;gap:12px;padding:9px 0">
+<span>Accepted work displaced</span><span style="flex:1;border-bottom:1px dotted oklch(0.24 0.012 60 / 0.35);transform:translateY(-4px)"></span><span style="font-weight:800">24.0 h</span>
+</div>
+<div style="display:flex;align-items:baseline;gap:12px;padding:7px 0;color:oklch(0.45 0.015 60)">
+<span style="width:14px">−</span><span>Prompting</span><span style="flex:1;border-bottom:1px dotted oklch(0.24 0.012 60 / 0.22);transform:translateY(-4px)"></span><span>2.1 h</span>
+</div>
+<div style="display:flex;align-items:baseline;gap:12px;padding:7px 0;color:oklch(0.45 0.015 60)">
+<span style="width:14px">−</span><span>Review</span><span style="flex:1;border-bottom:1px dotted oklch(0.24 0.012 60 / 0.22);transform:translateY(-4px)"></span><span>1.8 h</span>
+</div>
+<div style="display:flex;align-items:baseline;gap:12px;padding:7px 0;color:oklch(0.45 0.015 60)">
+<span style="width:14px">−</span><span>Correction</span><span style="flex:1;border-bottom:1px dotted oklch(0.24 0.012 60 / 0.22);transform:translateY(-4px)"></span><span>1.2 h</span>
+</div>
+<div style="display:flex;align-items:baseline;gap:12px;padding:7px 0;color:oklch(0.45 0.015 60)">
+<span style="width:14px">−</span><span>Repair of failed work</span><span style="flex:1;border-bottom:1px dotted oklch(0.24 0.012 60 / 0.22);transform:translateY(-4px)"></span><span>0.9 h</span>
+</div>
+<div style="display:flex;align-items:baseline;gap:12px;padding:7px 0;color:oklch(0.45 0.015 60)">
+<span style="width:14px">−</span><span>Alfred-caused interruptions</span><span style="flex:1;border-bottom:1px dotted oklch(0.24 0.012 60 / 0.22);transform:translateY(-4px)"></span><span>0.5 h</span>
+</div>
+<div style="display:flex;align-items:baseline;gap:12px;padding:14px 0 6px;margin-top:8px;border-top:2px solid oklch(0.52 0.09 75);color:oklch(0.52 0.09 75)">
+<span style="font-size:15px;font-weight:800;letter-spacing:0.06em">NET ATTENTION RETURNED</span><span style="flex:1"></span><span style="font-family:var(--font-display,Georgia,serif);font-size:34px;font-weight:600;letter-spacing:-0.01em">17.5 h</span>
+</div>
+</div>
+
+<div style="margin-top:18px">
+<div style="height:20px;border:1px solid oklch(0.24 0.012 60 / 0.35);box-sizing:border-box;display:flex">
+<div style="width:72.9%;background:oklch(0.52 0.09 75)"></div>
+<div style="width:27.1%;background:repeating-linear-gradient(-45deg,oklch(0.24 0.012 60 / 0.18) 0 3px,transparent 3px 7px)"></div>
+</div>
+<div style="display:flex;justify-content:space-between;margin-top:8px;font-family:var(--font-mono,monospace);font-weight:700;font-size:9.5px;letter-spacing:0.2em;color:oklch(0.45 0.015 60)">
+<span style="color:oklch(0.52 0.09 75)">NET RETURNED · 17.5 H</span><span>THE MESS BILL · −6.5 H</span>
+</div>
+</div>
+
+<div style="margin-top:38px;display:flex;align-items:baseline;gap:16px">
+<span style="font-family:var(--font-mono,monospace);font-weight:800;font-size:10.5px;letter-spacing:0.28em;color:oklch(0.52 0.09 75)">02 · WHERE IT WENT</span>
+<span style="flex:1;border-top:1px solid oklch(0.24 0.012 60 / 0.15)"></span>
+</div>
+
+<div style="margin-top:20px;display:grid;grid-template-columns:150px 1fr 58px;gap:12px 16px;align-items:center;font-family:var(--font-mono,monospace);font-weight:700;font-size:12px;letter-spacing:0.06em">
+<span>Client work</span><div style="height:12px;background:oklch(0.24 0.012 60 / 0.06)"><div style="width:54.3%;height:100%;background:oklch(0.52 0.09 75)"></div></div><span style="text-align:right">9.5 h</span>
+<span>Product</span><div style="height:12px;background:oklch(0.24 0.012 60 / 0.06)"><div style="width:22.9%;height:100%;background:oklch(0.52 0.09 75 / 0.75)"></div></div><span style="text-align:right">4.0 h</span>
+<span>Life</span><div style="height:12px;background:oklch(0.24 0.012 60 / 0.06)"><div style="width:18.3%;height:100%;background:oklch(0.52 0.09 75 / 0.5)"></div></div><span style="text-align:right">3.2 h</span>
+<span style="color:oklch(0.45 0.015 60)">Unallocated</span><div style="height:12px;background:oklch(0.24 0.012 60 / 0.06)"><div style="width:4.6%;height:100%;background:oklch(0.24 0.012 60 / 0.3)"></div></div><span style="text-align:right;color:oklch(0.45 0.015 60)">0.8 h</span>
+</div>
+
+<div style="margin-top:38px;display:flex;align-items:baseline;gap:16px">
+<span style="font-family:var(--font-mono,monospace);font-weight:800;font-size:10.5px;letter-spacing:0.28em;color:oklch(0.52 0.09 75)">03 · THE RECORD</span>
+<span style="flex:1;border-top:1px solid oklch(0.24 0.012 60 / 0.15)"></span>
+</div>
+
+<div style="margin-top:20px;display:grid;grid-template-columns:repeat(3,1fr);border:1px solid oklch(0.24 0.012 60 / 0.2)">
+<div style="padding:16px 18px;border-right:1px solid oklch(0.24 0.012 60 / 0.12);border-bottom:1px solid oklch(0.24 0.012 60 / 0.12)">
+<div style="font-family:var(--font-display,Georgia,serif);font-weight:600;font-size:26px">92%</div>
+<div style="font-family:var(--font-mono,monospace);font-weight:700;font-size:8.5px;letter-spacing:0.2em;color:oklch(0.45 0.015 60);margin-top:6px">ACCEPTED WITHOUT REVISION</div>
+</div>
+<div style="padding:16px 18px;border-right:1px solid oklch(0.24 0.012 60 / 0.12);border-bottom:1px solid oklch(0.24 0.012 60 / 0.12)">
+<div style="font-family:var(--font-display,Georgia,serif);font-weight:600;font-size:26px">31</div>
+<div style="font-family:var(--font-mono,monospace);font-weight:700;font-size:8.5px;letter-spacing:0.2em;color:oklch(0.45 0.015 60);margin-top:6px">QUALIFIED OUTPUTS</div>
+</div>
+<div style="padding:16px 18px;border-bottom:1px solid oklch(0.24 0.012 60 / 0.12)">
+<div style="font-family:var(--font-display,Georgia,serif);font-weight:600;font-size:26px;color:oklch(0.52 0.09 75)">0</div>
+<div style="font-family:var(--font-mono,monospace);font-weight:700;font-size:8.5px;letter-spacing:0.2em;color:oklch(0.45 0.015 60);margin-top:6px">HARD FAILURES</div>
+</div>
+<div style="padding:16px 18px;border-right:1px solid oklch(0.24 0.012 60 / 0.12)">
+<div style="font-family:var(--font-display,Georgia,serif);font-weight:600;font-size:26px">L3</div>
+<div style="font-family:var(--font-mono,monospace);font-weight:700;font-size:8.5px;letter-spacing:0.2em;color:oklch(0.45 0.015 60);margin-top:6px">HIGHEST TRUST CLASS · ACT WITH APPROVAL</div>
+</div>
+<div style="padding:16px 18px;border-right:1px solid oklch(0.24 0.012 60 / 0.12)">
+<div style="font-family:var(--font-display,Georgia,serif);font-weight:600;font-size:26px">$212</div>
+<div style="font-family:var(--font-mono,monospace);font-weight:700;font-size:8.5px;letter-spacing:0.2em;color:oklch(0.45 0.015 60);margin-top:6px">PROVIDER &amp; COMPUTE SPEND</div>
+</div>
+<div style="padding:16px 18px">
+<div style="font-family:var(--font-display,Georgia,serif);font-weight:600;font-size:26px">1.2 h</div>
+<div style="font-family:var(--font-mono,monospace);font-weight:700;font-size:8.5px;letter-spacing:0.2em;color:oklch(0.45 0.015 60);margin-top:6px">MANAGEMENT TIME · OURS, NOT YOURS</div>
+</div>
+</div>
+
+<div style="margin-top:16px;font-size:14.5px;font-style:italic;color:oklch(0.35 0.014 60)"><span style="font-family:var(--font-mono,monospace);font-weight:800;font-style:normal;font-size:9.5px;letter-spacing:0.22em;color:oklch(0.52 0.09 75);margin-right:10px">NEXT RESPONSIBILITY CONSIDERED</span>Post-meeting continuity for the two largest accounts — proposed at L2, pending your word.</div>
+
+<div style="margin-top:40px;display:flex;justify-content:space-between;align-items:flex-end;gap:24px">
+<div style="max-width:390px;font-size:12.5px;line-height:1.65;font-style:italic;color:oklch(0.45 0.015 60)">Rejected work scores zero. Failed work subtracts the repair. Reconciled weekly against your own confirmation — dispute any line and it comes off the bill.</div>
+<div style="text-align:right;position:relative;padding-right:8px">
+<div style="font-size:15px;font-style:italic;color:oklch(0.45 0.015 60)">Yours in service,</div>
+<div style="font-family:var(--font-display,Georgia,serif);font-style:italic;font-weight:600;font-size:38px;line-height:1.1;margin-top:2px">Alfred</div>
+<sc-if value="{{ sealStamp }}" hint-placeholder-val="{{ true }}">
+<img src="../../brand/alfred-brand-seal.svg" alt="" style="position:absolute;right:-18px;top:-34px;width:86px;height:86px;opacity:0.5;transform:rotate(-9deg)">
+</sc-if>
+</div>
+</div>
+
+<div style="position:absolute;left:62px;right:62px;bottom:30px;display:flex;justify-content:space-between;border-top:1px solid oklch(0.24 0.012 60 / 0.15);padding-top:12px;font-family:var(--font-mono,monospace);font-weight:700;font-size:8.5px;letter-spacing:0.24em;color:oklch(0.45 0.015 60)">
+<span>ALFRED BLACK · ATTENTION STATEMENT</span><span>PRIVATE BY DESIGN</span><span>PAGE 1 OF 1</span>
+</div>
+
+</div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/design-system/templates/attention-statement/AttentionStatementDark.html
+++ b/design-system/templates/attention-statement/AttentionStatementDark.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Attention Statement (Dark) — 13 August 2026</title>
+<link rel="icon" href="../../brand/alfred-logo-brass.svg">
+<link rel="stylesheet" href="../../styles.css">
+<style>
+doc-page:not(:defined){visibility:hidden}
+:root{--ink:oklch(0.94 0.012 80);--dim:oklch(0.68 0.01 80);--brass:oklch(0.62 0.09 75);--hair:oklch(0.94 0.012 80 / 0.16);--hair2:oklch(0.94 0.012 80 / 0.24);--fd:var(--font-display,Georgia,serif);--fm:var(--font-mono,monospace);--fb:var(--font-body,Georgia,serif)}
+.page{box-sizing:border-box;padding:36px 58px 30px;background:oklch(0.18 0.006 60);color:var(--ink);font-family:var(--fb);position:relative;display:flex;flex-direction:column}
+a{color:var(--ink)}a:hover{color:var(--brass)}
+.mono{font-family:var(--fm);font-weight:800;letter-spacing:0.28em;font-size:10px;text-transform:uppercase}
+.k{color:var(--brass)}
+.sechead{display:flex;align-items:baseline;gap:14px}
+.sechead span:last-child{flex:1;border-top:1px solid var(--hair)}
+.num{text-align:right}
+.tbl{display:grid;grid-template-columns:1fr 82px 82px 82px;font-family:var(--fm);font-weight:700;font-size:11px;letter-spacing:0}
+.tbl>span{padding:2.5px 0;border-bottom:1px solid oklch(0.94 0.012 80 / 0.09)}
+.tbl .h{font-size:7.5px;font-weight:800;letter-spacing:0.16em;color:var(--dim);border-bottom:1px solid var(--hair2);padding-bottom:5px}
+.tbl .g{border-bottom:none;padding:9px 0 2px;font-size:8px;font-weight:800;letter-spacing:0.24em;color:var(--brass)}
+.tbl .n{text-align:right}
+.tbl .t{border-bottom:none;border-top:2px solid var(--brass);margin-top:5px;padding:7px 0 0;color:var(--brass);font-weight:800;font-size:9.5px;letter-spacing:0.06em}
+.hatch{background:repeating-linear-gradient(-45deg,oklch(0.94 0.012 80 / 0.3) 0 2.5px,transparent 2.5px 6px)}
+.foot{position:absolute;left:58px;right:58px;bottom:18px;display:flex;justify-content:space-between;border-top:1px solid var(--hair);padding-top:9px;font-family:var(--fm);font-weight:700;font-size:8px;letter-spacing:0.22em;color:var(--dim)}
+</style>
+</head>
+<body>
+<doc-page size="a4">
+
+<section class="page" id="p1">
+<div style="display:flex;align-items:center;justify-content:space-between;gap:24px">
+<div style="display:flex;align-items:center;gap:13px">
+<img src="../../brand/alfred-logo-white.svg" alt="Alfred Black" style="height:34px;width:auto;display:block">
+<div class="mono" style="font-size:11.5px;letter-spacing:0.32em">ALFRED&nbsp;BLACK</div>
+</div>
+<div style="text-align:right;font-family:var(--fm);font-weight:700;font-size:9.5px;letter-spacing:0.2em;color:var(--dim);line-height:1.9">THURSDAY 13 AUGUST 2026</div>
+</div>
+
+<div style="border-top:1px solid var(--ink);border-bottom:1px solid var(--ink);height:4px;margin:14px 0 20px"></div>
+
+<h1 style="font-family:var(--fd);font-weight:600;font-size:30px;letter-spacing:-0.015em;line-height:1.05;margin:0">Attention Statement.</h1>
+
+<div class="sechead" style="margin-top:24px"><span class="mono k">01 · THE ACCOUNT</span><span></span></div>
+<div style="margin-top:16px;display:flex;align-items:flex-end;justify-content:space-between;gap:44px">
+<div>
+<div style="font-family:var(--fd);font-weight:600;font-size:76px;letter-spacing:-0.02em;line-height:1;color:var(--brass);margin:0 0 12px">7.51 h</div>
+<div class="mono k" style="font-size:8.5px;letter-spacing:0.26em">NET ATTENTION RETURNED</div>
+</div>
+<div style="display:flex;flex-direction:column;align-items:flex-end">
+<div style="display:flex;align-items:flex-end;gap:26px;height:104px">
+<div style="display:flex;flex-direction:column;justify-content:flex-end;height:104px;width:66px"><div style="height:11px;background:oklch(0.62 0.09 75 / 0.45)"></div><div style="height:1px;background:oklch(0.18 0.006 60)"></div><div style="height:92px;background:var(--brass)"></div></div>
+<div style="height:104px;width:66px"><div style="height:39px" class="hatch"></div></div>
+<div style="display:flex;flex-direction:column;justify-content:flex-end;height:104px;width:66px"><div style="height:65px;background:var(--brass)"></div></div>
+</div>
+<div style="display:flex;gap:26px;margin-top:8px;font-family:var(--fm);font-weight:800;font-size:7.5px;letter-spacing:0.14em;color:var(--dim);text-align:center">
+<span style="width:66px">DISPLACED<br><span style="font-size:9.5px;color:var(--ink)">12.03</span></span>
+<span style="width:66px">THE MESS<br><span style="font-size:9.5px">−4.52</span></span>
+<span style="width:66px;color:var(--brass)">NET<br><span style="font-size:9.5px">7.51</span></span>
+</div>
+</div>
+</div>
+
+<div class="sechead" style="margin-top:26px"><span class="mono k">02 · WHERE IT WENT</span><span></span></div>
+<div style="margin-top:10px;display:grid;grid-template-columns:96px 1fr 62px 58px 62px 64px;gap:7px 12px;align-items:center;font-family:var(--fm);font-weight:700;font-size:9px;letter-spacing:0.06em">
+<span></span><span></span><span class="num" style="font-size:7.5px;letter-spacing:0.18em;color:var(--dim)">DISPLACED</span><span class="num" style="font-size:7.5px;letter-spacing:0.18em;color:var(--dim)">ENGAGED</span><span class="num" style="font-size:7.5px;letter-spacing:0.18em;color:var(--dim)">INTERRUPT</span><span class="num" style="font-size:7.5px;letter-spacing:0.18em;color:var(--brass)">NET</span>
+<span style="font-family:var(--fd);font-style:italic;font-size:11.5px;letter-spacing:0.02em">Work</span><div style="height:8px;background:oklch(0.94 0.012 80 / 0.08)"><div style="width:95.8%;height:100%;display:flex"><div style="width:62.4%;background:var(--brass)"></div><div style="width:37.6%" class="hatch"></div></div></div><span class="num">11.53</span><span class="num" style="color:var(--dim)">− 4.02</span><span class="num" style="color:var(--dim)">− 0.32</span><span class="num" style="color:var(--brass)">7.19 h</span>
+<span style="font-family:var(--fd);font-style:italic;font-size:11.5px;letter-spacing:0.02em">Life</span><div style="height:8px;background:oklch(0.94 0.012 80 / 0.08)"><div style="width:4.2%;height:100%;display:flex"><div style="width:64%;background:var(--brass)"></div><div style="width:36%" class="hatch"></div></div></div><span class="num">0.50</span><span class="num" style="color:var(--dim)">− 0.17</span><span class="num" style="color:var(--dim)">− 0.01</span><span class="num" style="color:var(--brass)">0.32 h</span>
+<span style="font-family:var(--fd);font-style:italic;font-size:11.5px;letter-spacing:0.02em;color:var(--dim)">Unallocated</span><div style="height:8px;background:oklch(0.94 0.012 80 / 0.08)"></div><span class="num" style="color:var(--dim)">0</span><span class="num" style="color:var(--dim)">—</span><span class="num" style="color:var(--dim)">—</span><span class="num" style="color:var(--dim)">0 h</span>
+</div>
+
+<div class="sechead" style="margin-top:26px"><span class="mono k">03 · THE LEDGER</span><span></span></div>
+<div class="tbl" style="margin-top:10px">
+<span class="h">WORK</span><span class="h n">DISPLACED</span><span class="h n">ENGAGED</span><span class="h n" style="color:var(--brass)">NAR</span>
+
+<span class="g" style="padding-top:7px">CONVERSATIONAL</span><span class="g n">640</span><span class="g n" style="color:var(--dim)">251</span><span class="g n k">389</span>
+<span>Launch collateral restructured into the vault</span><span class="n">120</span><span class="n" style="color:var(--dim)">14</span><span class="n k">106</span>
+<span>Service research, guide, candidate collection</span><span class="n">120</span><span class="n" style="color:var(--dim)">111</span><span class="n k">9</span>
+<span>Adapter plan traced &amp; verified against live source</span><span class="n">120</span><span class="n" style="color:var(--dim)">60</span><span class="n k">60</span>
+<span>Client invoice rebuilt, margin-locked</span><span class="n">60</span><span class="n" style="color:var(--dim)">8</span><span class="n k">52</span>
+<span>Prospect sheet extended, append-only</span><span class="n">60</span><span class="n" style="color:var(--dim)">34</span><span class="n k">26</span>
+<span>Two weeks of messages, DMs, mail, transcripts gathered</span><span class="n">60</span><span class="n" style="color:var(--dim)">6</span><span class="n k">54</span>
+<span>Invoice billing address corrected &amp; verified</span><span class="n">20</span><span class="n" style="color:var(--dim)">3</span><span class="n k">17</span>
+<span>Device purchase researched to a verdict</span><span class="n">20</span><span class="n" style="color:var(--dim)">5</span><span class="n k">15</span>
+<span>Project brief reconstructed from transcripts</span><span class="n">20</span><span class="n" style="color:var(--dim)">2</span><span class="n k">18</span>
+<span>Retailer shortlist — sandals (life)</span><span class="n">15</span><span class="n" style="color:var(--dim)">1</span><span class="n k">14</span>
+<span>Retailer shortlist — barefoot (life)</span><span class="n">15</span><span class="n" style="color:var(--dim)">1</span><span class="n k">14</span>
+<span>Recurring morning reminder set</span><span class="n">5</span><span class="n" style="color:var(--dim)">1</span><span class="n k">4</span>
+<span>Calendar invite with meeting link sent</span><span class="n">5</span><span class="n" style="color:var(--dim)">4</span><span class="n k">1</span>
+
+<span class="g">EXPLICIT</span><span class="g n">8</span><span class="g n" style="color:var(--dim)">—</span><span class="g n k">8</span>
+<span>Suppressed items</span><span class="n">8</span><span class="n" style="color:var(--dim)">—</span><span class="n k">8</span>
+
+<span class="g">AUTONOMOUS</span><span class="g n">74</span><span class="g n" style="color:var(--dim)">—</span><span class="g n k">74</span>
+<span>Morning briefing composed (19 matters)</span><span class="n">30</span><span class="n" style="color:var(--dim)">—</span><span class="n k">30</span>
+<span>Evening briefing composed (21 matters)</span><span class="n">30</span><span class="n" style="color:var(--dim)">—</span><span class="n k">30</span>
+<span>Vigilance runs — checked, nothing to raise</span><span class="n">14</span><span class="n" style="color:var(--dim)">—</span><span class="n k">14</span>
+<span class="t">TOTAL</span><span class="t n">722</span><span class="t n">251</span><span class="t n">471</span>
+</div>
+
+<div class="foot"><span>ALFRED BLACK · ATTENTION STATEMENT · 2026-08-13</span><span>PAGE 1 OF 1</span></div>
+</section>
+
+</doc-page>
+</body>
+</html>

--- a/design-system/templates/attention-trends/AttentionTrends.html
+++ b/design-system/templates/attention-trends/AttentionTrends.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Attention — Usage over time</title>
+<link rel="icon" href="brand/alfred-logo-brass.svg">
+<link rel="stylesheet" href="styles.css">
+<style>
+:root{--bg:oklch(0.16 0.005 60);--bg2:oklch(0.19 0.006 60);--ink:oklch(0.94 0.012 80);--dim:oklch(0.68 0.01 80);--brass:oklch(0.62 0.09 75);--hair:oklch(0.94 0.012 80 / 0.14);--hair2:oklch(0.94 0.012 80 / 0.22);--fd:var(--font-display,Georgia,serif);--fm:var(--font-mono,monospace);--fb:var(--font-body,Georgia,serif)}
+body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--fb);-webkit-font-smoothing:antialiased}
+a{color:var(--ink);text-decoration:none}a:hover{color:var(--brass)}
+::selection{background:var(--brass);color:var(--bg)}
+.mono{font-family:var(--fm);font-weight:800;letter-spacing:0.26em;font-size:10px;text-transform:uppercase}
+.k{color:var(--brass)}
+.wrap{max-width:1080px;margin:0 auto;padding:0 36px 70px}
+.topbar{display:flex;align-items:center;justify-content:space-between;padding:22px 0;border-bottom:1px solid var(--hair)}
+.hero{display:flex;align-items:flex-end;justify-content:space-between;gap:30px;padding:40px 0 6px;flex-wrap:wrap}
+h1{font-family:var(--fd);font-weight:600;font-size:36px;letter-spacing:-0.015em;margin:10px 0 0}
+.tabs{display:flex;border:1px solid var(--hair2)}
+.tabs a{font-family:var(--fm);font-weight:800;font-size:9px;letter-spacing:0.2em;text-transform:uppercase;color:var(--dim);padding:10px 16px;border-right:1px solid var(--hair)}
+.tabs a:last-child{border-right:none}
+.tabs a.on{color:var(--brass);background:oklch(0.62 0.09 75 / 0.09)}
+.panel{border-top:1px solid var(--hair);padding:44px 0 8px;margin-top:26px}
+h2{font-family:var(--fd);font-weight:600;font-size:27px;letter-spacing:-0.012em;line-height:1.3;margin:0}
+h2 em{font-style:italic;color:var(--brass)}
+.when{font-family:var(--fm);font-weight:700;font-size:9px;letter-spacing:0.2em;color:var(--dim);text-transform:uppercase;margin:10px 0 0}
+.fig{margin-top:34px}
+.lab{font-family:var(--fm);font-weight:700;font-size:9px;letter-spacing:0.14em;color:var(--dim);text-align:center}
+.gut{display:flex;gap:20px}
+.gut .names{display:flex;flex-direction:column;flex-shrink:0;width:86px;text-align:right}
+.gut .names span{font-family:var(--fm);font-weight:800;font-size:8px;letter-spacing:0.16em;color:var(--dim)}
+.chart{display:grid;grid-template-columns:repeat(13,1fr);gap:12px;flex:1}
+.chart .cell{display:flex;flex-direction:column;align-items:center;min-width:0}
+.up{height:96px;display:flex;align-items:flex-end;width:100%;justify-content:center}
+.dn{height:36px;width:100%;display:flex;justify-content:center;border-top:1px solid var(--hair2)}
+.up i,.dn i{width:100%;max-width:46px;display:block}
+.hatch{background:repeating-linear-gradient(-45deg,oklch(0.94 0.012 80 / 0.3) 0 2.5px,transparent 2.5px 6px)}
+.dashed{outline:1.5px dashed var(--brass);outline-offset:2px}
+.dimmed{opacity:0.42}
+.xlabels{display:grid;grid-template-columns:repeat(13,1fr);margin-top:10px}
+svg.plot{width:100%;height:auto;display:block}
+svg.plot text{font-family:var(--fm);font-weight:700;letter-spacing:0.06em}
+.pairs{display:grid;grid-template-columns:1fr 1fr 1fr;gap:2px;margin-top:34px;border:1px solid var(--hair)}
+.pair{background:var(--bg2);padding:26px 28px 24px}
+.pair .v{font-family:var(--fd);font-weight:600;font-size:38px;letter-spacing:-0.015em;line-height:1;margin:0 0 12px}
+.pair .v .arr{color:var(--brass);font-size:26px}
+.pair .n{font-family:var(--fm);font-weight:800;font-size:8.5px;letter-spacing:0.2em;color:var(--dim);text-transform:uppercase;line-height:1.8}
+.strip{display:flex;height:16px;border:1px solid var(--hair2);margin-top:30px}
+.footline{display:flex;gap:26px;flex-wrap:wrap;margin-top:12px;font-family:var(--fm);font-weight:700;font-size:9px;letter-spacing:0.18em;color:var(--dim);text-transform:uppercase}
+.foot{display:flex;justify-content:space-between;border-top:1px solid var(--hair);margin-top:60px;padding-top:14px;font-family:var(--fm);font-weight:700;font-size:8.5px;letter-spacing:0.22em;color:var(--dim);text-transform:uppercase}
+@media(max-width:820px){.pairs{grid-template-columns:1fr}.gut .names{width:60px}}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<div class="topbar">
+<div style="display:flex;align-items:center;gap:12px">
+<img src="brand/alfred-logo-white.svg" alt="" style="height:24px;width:auto;display:block">
+<span class="mono" style="font-size:11px;letter-spacing:0.3em">ALFRED&nbsp;BLACK</span>
+</div>
+<span class="mono" style="font-size:9px;color:var(--dim)">/ ATTENTION · <span data-slot="as_of">AS OF THU 14 AUG, 21:40</span></span>
+</div>
+
+<div class="hero">
+<div>
+<h1>Usage over time.</h1>
+</div>
+<div style="display:flex;gap:14px;flex-wrap:wrap">
+<div class="tabs"><a href="#">Day</a><a href="#">Range</a><a href="#" class="on">Trends</a></div>
+<div class="tabs"><a href="#" class="on">Weekly</a><a href="#">Monthly</a><a href="#">Quarterly</a></div>
+</div>
+</div>
+
+<div class="panel" style="border-top:none">
+<div class="mono k" style="font-size:8.5px;margin-bottom:14px">NET RETURNED · <span data-slot="period_label">W33, DAY 6 OF 7</span></div>
+<h2 data-slot="nar_headline"><em><span data-slot="nar_week">15.3</span> hours came back this week,</em> for the <span data-slot="engaged_week">6.5</span> you put in.</h2>
+<div class="fig gut">
+<div class="names"><span style="height:96px;display:flex;align-items:center;justify-content:flex-end">GIVEN BACK</span><span style="height:36px;display:flex;align-items:center;justify-content:flex-end">YOUR TIME</span></div>
+<div style="flex:1;min-width:0">
+<div class="chart">
+<div class="cell dimmed"><div class="up"><i style="height:5px;background:var(--brass)"></i></div><div class="dn"></div></div>
+<div class="cell"><div class="up"><i style="height:54px;background:var(--brass)"></i></div><div class="dn"><i class="hatch" style="height:19px"></i></div></div>
+<div class="cell"><div class="up"><i style="height:62px;background:var(--brass)"></i></div><div class="dn"><i class="hatch" style="height:23px"></i></div></div>
+<div class="cell"><div class="up"><i style="height:34px;background:var(--brass)"></i></div><div class="dn"><i class="hatch" style="height:17px"></i></div></div>
+<div class="cell"><div class="up"><i style="height:57px;background:var(--brass)"></i></div><div class="dn"><i class="hatch" style="height:21px"></i></div></div>
+<div class="cell"><div class="up"><i style="height:27px;background:var(--brass)"></i></div><div class="dn"><i class="hatch" style="height:15px"></i></div></div>
+<div class="cell"><div class="up"><i style="height:55px;background:var(--brass)"></i></div><div class="dn"><i class="hatch" style="height:22px"></i></div></div>
+<div class="cell"><div class="up"><i style="height:28px;background:var(--brass)"></i></div><div class="dn"><i class="hatch" style="height:4px"></i></div></div>
+<div class="cell"><div class="up"><i style="height:89px;background:var(--brass)"></i></div><div class="dn"><i class="hatch" style="height:28px"></i></div></div>
+<div class="cell"><div class="up"><i style="height:69px;background:var(--brass)"></i></div><div class="dn"><i class="hatch" style="height:20px"></i></div></div>
+<div class="cell"><div class="up"><i style="height:84px;background:var(--brass)"></i></div><div class="dn"><i class="hatch" style="height:18px"></i></div></div>
+<div class="cell"><div class="up"><i style="height:78px;background:var(--brass)"></i></div><div class="dn"><i class="hatch" style="height:31px"></i></div></div>
+<div class="cell"><div class="up"><i class="dashed" style="height:70px;background:var(--brass)"></i></div><div class="dn"><i class="hatch" style="height:30px"></i></div></div>
+</div>
+<div class="xlabels"><span class="lab">MAY</span><span></span><span></span><span></span><span class="lab">JUN</span><span></span><span></span><span></span><span class="lab">JUL</span><span></span><span></span><span></span><span class="lab k">NOW</span></div>
+</div>
+</div>
+</div>
+
+<div class="panel">
+<div class="mono k" style="font-size:8.5px;margin-bottom:14px">RETURN RATIO</div>
+<h2 data-slot="ratio_headline">An hour of you now buys <em><span data-slot="ratio_now">3.5</span> hours</em> of work. In <span data-slot="ratio_peak_month">July</span> it bought <span data-slot="ratio_peak">5.9</span>.</h2>
+<div class="fig">
+<svg class="plot" viewBox="0 0 1040 208">
+<line x1="20" y1="175" x2="1020" y2="175" stroke="var(--dim)" stroke-width="1" stroke-dasharray="2 6" opacity="0.6"></line>
+<text x="24" y="163" font-size="15" fill="var(--dim)" opacity="0.8">BREAK-EVEN</text>
+<polyline points="120,114 200,117 280,132 360,116 440,137 520,121" fill="none" stroke="var(--brass)" stroke-width="2.5"></polyline>
+<polyline points="520,121 600,28 680,107" fill="none" stroke="var(--brass)" stroke-width="1.5" stroke-dasharray="4 5" opacity="0.35"></polyline>
+<polyline points="680,107 760,100 840,73 920,120" fill="none" stroke="var(--brass)" stroke-width="2.5"></polyline>
+<polyline points="920,120 1000,123" fill="none" stroke="var(--brass)" stroke-width="2.5" stroke-dasharray="4 5"></polyline>
+<circle cx="600" cy="28" r="4.5" fill="var(--bg)" stroke="var(--brass)" stroke-width="1.5" opacity="0.45"></circle>
+<circle cx="840" cy="73" r="5" fill="var(--brass)"></circle>
+<text x="840" y="50" text-anchor="middle" font-size="19" fill="var(--brass)">5.9×</text>
+<circle cx="1000" cy="123" r="5" fill="var(--bg)" stroke="var(--brass)" stroke-width="2"></circle>
+<text x="1000" y="100" text-anchor="middle" font-size="19" fill="var(--brass)">3.5×</text>
+</svg>
+<div class="xlabels"><span class="lab">MAY</span><span></span><span></span><span></span><span class="lab">JUN</span><span></span><span></span><span></span><span class="lab">JUL</span><span></span><span></span><span></span><span class="lab k">NOW</span></div>
+</div>
+</div>
+
+<div class="panel">
+<div class="mono k" style="font-size:8.5px;margin-bottom:14px">ALFRED'S READ · GENERATED <span data-slot="read_window">FROM W31 → W32</span></div>
+<h2 data-slot="read_headline">Why the rate fell: <em>the work got bigger</em> — not worse.</h2>
+<div class="when">LAST TWO FULL WEEKS</div>
+<div class="pairs">
+<div class="pair">
+<div class="v" data-slot="pair_xl">4 <span class="arr">→</span> 10 h <span class="arr">▲</span></div>
+<div class="n">HOURS IN THE BIGGEST TASKS</div>
+</div>
+<div class="pair">
+<div class="v" data-slot="pair_failures">26 <span class="arr">→</span> 18 <span class="arr">▼</span></div>
+<div class="n">FAILED TASKS</div>
+</div>
+<div class="pair">
+<div class="v" data-slot="pair_finished">27 <span class="arr">→</span> 26</div>
+<div class="n">FINISHED TASKS</div>
+</div>
+</div>
+</div>
+
+<div class="panel">
+<div class="mono k" style="font-size:8.5px;margin-bottom:14px">ALLOCATION · <span data-slot="alloc_window">SINCE MAY</span></div>
+<h2 data-slot="alloc_headline"><em><span data-slot="total_returned">217</span> returned hours</em> have gone almost entirely to work.</h2>
+<div class="strip">
+<div style="width:88.8%;background:var(--brass)"></div>
+<div style="width:8%;background:oklch(0.62 0.09 75 / 0.4)"></div>
+<div style="width:3.2%;background:oklch(0.94 0.012 80 / 0.2)"></div>
+</div>
+<div class="footline"><span class="k">WORK · 89%</span><span>LIFE · 8%</span><span>NOT YET ASSIGNED · 3%</span></div>
+</div>
+
+<div class="foot"><span>ALFRED BLACK · THE ATTENTION REPORT</span><span data-slot="range_label">W21 – W33 · 2026</span></div>
+
+</div>
+
+<script type="application/json" id="attention-feed">
+{
+"as_of_display":"AS OF THU 14 AUG, 21:40",
+"range":{"from":"W21","to":"W33","year":2026},
+"current":{"week":"W33","days_recorded":6,"days_total":7,"nar":15.3,"engaged":6.5,"displaced":22.5},
+"prior":{"week":"W31","ratio":5.85,"xl_hours":4,"failures":26,"finished":27,"engaged":3.97},
+"latest":{"week":"W32","ratio":3.595,"xl_hours":10,"failures":18,"finished":26,"engaged":6.84},
+"ratio_now":3.46,
+"ratio_series":[null,3.93,3.75,3.05,3.83,2.82,3.55,null,4.26,4.55,5.85,3.6,3.46],
+"ratio_peak":{"value":5.85,"week":"W31","month":"July"},
+"alloc":{"window_label":"SINCE MAY","total":217,"work":0.888,"life":0.08,"unassigned":0.032}
+}
+</script>
+<script>
+(function(){
+const feed=JSON.parse(document.getElementById('attention-feed').textContent);
+const $=s=>document.querySelector('[data-slot="'+s+'"]');
+const set=(s,v)=>{const el=$(s);if(el)el.innerHTML=v;};
+const f1=n=>{const v=Math.round(n*10)/10;return v%1===0?String(Math.round(v)):v.toFixed(1)};
+const hrs=n=>f1(n)+(Math.abs(n-1)<1e-9?' hour':' hours');
+const dir=(a,b)=>{if(a===0)return b>0?'up':'flat';const p=(b-a)/Math.abs(a);return p<=-0.10?'down':(p>=0.10?'up':'flat')};
+const pct=(a,b)=>Math.abs(Math.round(((b-a)/Math.abs(a))*1000)/10);
+// chrome
+set('as_of',feed.as_of_display);
+set('range_label',feed.range.from+' – '+feed.range.to+' · '+feed.range.year);
+set('period_label',feed.current.week+', DAY '+feed.current.days_recorded+' OF '+feed.current.days_total);
+// panel 1 — net returned
+const c=feed.current;
+if(c.engaged==null)set('nar_headline','<em>'+f1(c.nar)+' hours came back this week;</em> your time wasn\u2019t measured.');
+else if(c.nar<=0)set('nar_headline','<em>Nothing came back this week:</em> '+f1(c.engaged)+' hours in, '+f1(c.displaced)+' out.');
+else set('nar_headline','<em>'+f1(c.nar)+' hours came back this week,</em> for the '+f1(c.engaged)+' you put in.');
+// panel 2 — ratio
+const rs=feed.ratio_series.filter(v=>v!=null);
+let streak=1;for(let i=rs.length-1;i>0;i--){if(Math.abs(rs[i]-rs[i-1])/rs[i-1]<0.05)streak++;else break;}
+if(c.engaged!=null&&c.engaged<1)set('ratio_headline','Too little of your time was logged this week to price it.');
+else if(feed.ratio_now>=feed.ratio_peak.value)set('ratio_headline','An hour of you now buys <em>'+f1(feed.ratio_now)+' hours</em> of work — the best yet.');
+else if(streak>=3)set('ratio_headline','An hour of you buys <em>'+f1(feed.ratio_now)+' hours</em> of work — steady for '+streak+' weeks.');
+else set('ratio_headline','An hour of you now buys <em>'+f1(feed.ratio_now)+' hours</em> of work. In '+feed.ratio_peak.month+' it bought '+f1(feed.ratio_peak.value)+'.');
+// panel 3 — read
+const a=feed.prior,b=feed.latest;
+const dR=dir(a.ratio,b.ratio),dX=dir(a.xl_hours,b.xl_hours),dF=dir(a.failures,b.failures);
+let read;
+if(dR==='down'&&dX==='up'&&dF!=='up')read='Why the rate fell: <em>the work got bigger</em> — not worse.';
+else if(dR==='down'&&dX==='up')read='The rate fell: <em>bigger work,</em> and more of it failed.';
+else if(dR==='down'&&dF==='up')read='The rate fell where quality slipped: <em>failures rose '+a.failures+' → '+b.failures+'.</em>';
+else if(dR==='down')read='The rate fell on your side of the desk: <em>your time rose '+f1(a.engaged)+' → '+f1(b.engaged)+' hours.</em>';
+else if(dR==='up'&&dF==='down')read='The rate improved: <em>less of your time, fewer failures.</em>';
+else if(dR==='up')read='The rate improved <em>even as the work got bigger.</em>';
+else if(dR==='flat')read='The rate held at <em>'+f1(b.ratio)+'×</em> across both weeks.';
+else read='Return ratio moved '+pct(a.ratio,b.ratio)+'% from '+a.week+' to '+b.week+'.';
+set('read_headline',read);
+set('read_window','FROM '+a.week+' → '+b.week);
+const arrow=d=>d==='up'?' <span class="arr">▲</span>':(d==='down'?' <span class="arr">▼</span>':'');
+set('pair_xl',f1(a.xl_hours)+' <span class="arr">→</span> '+f1(b.xl_hours)+' h'+arrow(dX));
+set('pair_failures',a.failures+' <span class="arr">→</span> '+b.failures+arrow(dF));
+set('pair_finished',a.finished+' <span class="arr">→</span> '+b.finished+arrow(dir(a.finished,b.finished)));
+// panel 4 — allocation
+const al=feed.alloc;
+let phrase=al.work>=0.85?'almost entirely to work':(al.work>=0.60?'mostly to work':(al.work>=0.40?'to work and life evenly':'mostly to life'));
+let tail=al.unassigned>0.25?' — '+Math.round(al.unassigned*100)+'% still unassigned':'';
+set('alloc_headline','<em>'+al.total+' returned hours</em> have gone '+phrase+'.'+tail);
+set('alloc_window',al.window_label);
+})();
+</script>
+</body>
+</html>

--- a/design-system/tokens/colors.css
+++ b/design-system/tokens/colors.css
@@ -1,0 +1,76 @@
+/* Alfred Black — Colour
+ * Material: wool black, ivory paper, ink, a SINGLE brass accent. No second accent. Ever.
+ * Values lifted verbatim from the product theme (packages/web/src/client/Main.css).
+ * Paper (light) is the default mode; .dark inverts ink/paper while brass holds. */
+
+:root {
+  /* ── Material (raw) ─────────────────────────────── */
+  --ab-paper:      oklch(0.953 0.018 80);   /* #F4EFE6 ivory page          */
+  --ab-wool:       oklch(0.16 0.005 60);    /* #0B0B0B wool black surface   */
+  --ab-ink:        oklch(0.22 0.004 60);    /* #1A1A1A type                 */
+  --ab-brass:      oklch(0.62 0.09 75);     /* #A8843A the one accent       */
+  --ab-marginalia: oklch(0.40 0.005 60);    /* muted ink — notes in margin  */
+  --ab-rule:       oklch(0.22 0.004 60 / 0.55); /* hairline rules           */
+
+  /* ── Semantic — paper mode is default ───────────── */
+  --background: var(--ab-paper);
+  --foreground: var(--ab-ink);
+
+  --card: var(--ab-paper);
+  --card-foreground: var(--ab-ink);
+  --popover: var(--ab-paper);
+  --popover-foreground: var(--ab-ink);
+
+  --primary: var(--ab-ink);
+  --primary-foreground: var(--ab-paper);
+  --secondary: oklch(0.92 0.014 80);
+  --secondary-foreground: var(--ab-ink);
+  --muted: oklch(0.92 0.014 80);
+  --muted-foreground: var(--ab-marginalia);
+  --accent: var(--ab-brass);
+  --accent-foreground: var(--ab-paper);
+
+  /* States — brass is punctuation; these stay quiet, never neon */
+  --destructive: oklch(0.42 0.12 30);      /* deep oxblood, not fire-red */
+  --destructive-foreground: var(--ab-paper);
+  --success: oklch(0.55 0.13 150);          /* muted billiard green       */
+  --success-foreground: var(--ab-paper);
+  --warning: oklch(0.72 0.14 75);           /* amber, brass-adjacent      */
+  --warning-foreground: var(--ab-wool);
+
+  --border: oklch(0.22 0.004 60 / 0.18);
+  --input:  oklch(0.22 0.004 60 / 0.25);
+  --ring:   var(--ab-brass);
+
+  /* Convenience aliases used across cards/components */
+  --text-body:    var(--ab-ink);
+  --text-muted:   var(--ab-marginalia);
+  --text-on-wool: var(--ab-paper);
+  --surface-page: var(--ab-paper);
+  --surface-wool: var(--ab-wool);
+}
+
+/* Dark / wool mode — material inverts, brass is unchanged. */
+.dark,
+.ab-dark {
+  --ab-paper: oklch(0.16 0.005 60);         /* wool becomes the page */
+  --ab-ink:   oklch(0.94 0.012 80);         /* ivory becomes the type */
+  --ab-marginalia: oklch(0.70 0.008 80);
+  --ab-rule:  oklch(0.94 0.012 80 / 0.22);
+
+  --background: var(--ab-paper);
+  --foreground: var(--ab-ink);
+  --card: oklch(0.20 0.005 60);
+  --card-foreground: var(--ab-ink);
+  --popover: oklch(0.20 0.005 60);
+  --popover-foreground: var(--ab-ink);
+  --secondary: oklch(0.22 0.005 60);
+  --muted: oklch(0.22 0.005 60);
+  --muted-foreground: var(--ab-marginalia);
+  --border: oklch(0.94 0.012 80 / 0.18);
+  --input:  oklch(0.94 0.012 80 / 0.25);
+
+  --text-body: var(--ab-ink);
+  --text-muted: var(--ab-marginalia);
+  --surface-page: var(--ab-paper);
+}

--- a/design-system/tokens/fonts.css
+++ b/design-system/tokens/fonts.css
@@ -1,0 +1,6 @@
+/* Alfred Black — Webfonts
+ * Display : Playfair Display (Didone) — headlines, often italic for emphasis
+ * Body    : EB Garamond — running text, oldstyle numerals
+ * Mono    : JetBrains Mono — labels, marginalia, nav, ledgers
+ * The real product uses the same three families (see packages/web Main.css). */
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,600;0,700;0,800;0,900;1,400;1,500;1,600;1,700;1,900&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600&family=JetBrains+Mono:wght@400;500;600;700;800&display=swap');

--- a/design-system/tokens/spacing.css
+++ b/design-system/tokens/spacing.css
@@ -1,0 +1,37 @@
+/* Alfred Black — Spacing, radius, shadow, layout
+ * Corners are SHARP. --radius is 0 by design; this is a letterpress, not a SaaS.
+ * Elevation is hairline rules and the faintest paper-grain shadow, never glow. */
+
+:root {
+  /* Radius — zero. The single exception (2px) exists only for tiny chips. */
+  --radius: 0px;
+  --radius-chip: 2px;
+
+  /* Spacing scale (4px base) */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 48px;
+  --space-8: 64px;
+  --space-9: 96px;
+  --space-10: 128px;
+
+  /* Borders — everything is a hairline */
+  --hairline: 1px solid var(--ab-rule);
+  --hairline-brass: 1px solid var(--ab-brass);
+
+  /* Elevation — used sparingly. Print does not float. */
+  --shadow-rest: none;
+  --shadow-raise: 0 1px 0 color-mix(in oklab, var(--ab-ink) 8%, transparent);
+  --shadow-modal: 0 24px 80px rgba(0, 0, 0, 0.45);
+
+  /* Layout */
+  --measure: 64ch;          /* max reading width      */
+  --container: 1280px;      /* framed page max-width  */
+  --container-narrow: 860px;/* door / manifesto       */
+  --gutter: 32px;           /* page side padding      */
+  --header-h: 88px;
+}

--- a/design-system/tokens/surfaces.css
+++ b/design-system/tokens/surfaces.css
@@ -1,0 +1,199 @@
+/* Alfred Black — Surfaces & utilities
+ * The tactile layer: paper grain, wool grain, letterpress hairlines, the single
+ * gilt rule, and the button family. Ported from the product theme so consuming
+ * designs look identical to the shipping app. Class-based (not tokens) but
+ * reachable from styles.css, so it ships to every consumer. */
+
+/* ── Base ───────────────────────────────────────────── */
+body.ab-base {
+  background: var(--background);
+  color: var(--foreground);
+  font-family: var(--font-body);
+  font-feature-settings: var(--font-features-body);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+::selection { background: var(--ab-brass); color: var(--ab-paper); }
+
+/* ── Family helpers ─────────────────────────────────── */
+.font-display { font-family: var(--font-display); font-feature-settings: "kern","liga"; }
+.font-body    { font-family: var(--font-body); }
+.font-mono    { font-family: var(--font-mono); }
+
+/* ── Paper & wool surfaces (SVG grain, never raster) ── */
+.paper {
+  background-color: var(--ab-paper);
+  background-image:
+    radial-gradient(oklch(0.22 0.004 60 / 0.025) 1px, transparent 1px),
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='240' height='240'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' seed='3'/><feColorMatrix values='0 0 0 0 0.10  0 0 0 0 0.10  0 0 0 0 0.10  0 0 0 0.10 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+  background-size: 4px 4px, 240px 240px;
+}
+.dark .paper {
+  background-image:
+    radial-gradient(oklch(0.94 0.012 80 / 0.04) 1px, transparent 1px),
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='240' height='240'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' seed='3'/><feColorMatrix values='0 0 0 0 1  0 0 0 0 1  0 0 0 0 1  0 0 0 0.06 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+  background-size: 4px 4px, 240px 240px;
+}
+/* Wool is ALWAYS dark by design — it does not theme-swap. */
+.wool {
+  background-color: oklch(0.16 0.005 60);
+  color: oklch(0.953 0.018 80);
+  background-image:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='240' height='240'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='1.2' numOctaves='2' seed='7'/><feColorMatrix values='0 0 0 0 1  0 0 0 0 1  0 0 0 0 1  0 0 0 0.05 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+}
+
+/* ── Letterpress rules ──────────────────────────────── */
+.rule { border: 0; border-top: 1px solid var(--ab-rule); margin: 0; }
+.rule-double {
+  border: 0;
+  border-top: 1px solid var(--ab-rule);
+  border-bottom: 1px solid var(--ab-rule);
+  height: 4px;
+}
+/* Gilt — hairline brass rule with a soft glow. Use ONCE per page. */
+.gilt {
+  height: 1px;
+  background: var(--ab-brass);
+  box-shadow: 0 0 6px color-mix(in oklab, var(--ab-brass) 35%, transparent);
+  border: 0;
+}
+
+/* ── Cinematic type effects ─────────────────────────── */
+.press {
+  text-shadow:
+    0 1px 0 color-mix(in oklab, var(--ab-wool) 70%, transparent),
+    0 -1px 0 color-mix(in oklab, var(--ab-paper) 12%, transparent);
+}
+.smallcaps { font-variant-caps: all-small-caps; letter-spacing: 0.12em; }
+.tabular   { font-variant-numeric: tabular-nums lining-nums; }
+.struck    { text-decoration: line-through; text-decoration-thickness: 1px; color: var(--ab-marginalia); }
+.marginalia {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  line-height: 1.45;
+  color: var(--ab-marginalia);
+  letter-spacing: 0.01em;
+}
+
+/* ── Terminal caret (blinking block) ────────────────── */
+@keyframes ab-caret { 0%,49% { opacity: 1 } 50%,100% { opacity: 0 } }
+.caret::after {
+  content: "";
+  display: inline-block;
+  width: 0.5ch;
+  height: 1em;
+  background: currentColor;
+  margin-left: 2px;
+  vertical-align: -0.12em;
+  animation: ab-caret 1s steps(1) infinite;
+}
+
+/* ── Buttons ────────────────────────────────────────── */
+/* Primary CTA — brass border, fills with brass on hover. Italic display face. */
+.btn-brass {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 1.5rem;
+  line-height: 1;
+  padding: 0.55em 1.1em;
+  border: 1px solid var(--ab-brass);
+  background: transparent;
+  color: var(--ab-ink);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6em;
+  cursor: pointer;
+  transition: background-color 160ms ease, color 160ms ease, box-shadow 160ms ease;
+}
+.btn-brass:hover, .btn-brass:hover * {
+  background: var(--ab-brass);
+  color: var(--ab-paper);
+  box-shadow: 0 1px 0 var(--ab-brass);
+}
+.btn-brass:disabled { opacity: 0.35; cursor: not-allowed; }
+.wool .btn-brass { color: oklch(0.953 0.018 80); }
+.wool .btn-brass:hover, .wool .btn-brass:hover * { background: var(--ab-brass); color: oklch(0.16 0.005 60); }
+
+/* Small ghost action — uppercase mono, brass on hover */
+.btn-ghost {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  font-weight: 800;
+  padding: 6px 10px;
+  border: 1px solid var(--ab-rule);
+  background: transparent;
+  color: var(--ab-ink);
+  cursor: pointer;
+  transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease;
+}
+.btn-ghost:hover {
+  background: color-mix(in oklab, var(--ab-brass) 12%, transparent);
+  border-color: var(--ab-brass);
+  color: var(--ab-brass);
+}
+.wool .btn-ghost { color: var(--ab-paper); border-color: color-mix(in oklab, var(--ab-paper) 25%, transparent); }
+.wool .btn-ghost:hover { color: var(--ab-brass); border-color: var(--ab-brass); }
+
+/* Underlined text action — minimal, no border */
+.btn-link {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 800;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  padding: 6px 0;
+  background: transparent;
+  color: var(--ab-ink);
+  border: 0;
+  border-bottom: 1px solid transparent;
+  cursor: pointer;
+  transition: color 160ms ease, border-color 160ms ease;
+}
+.btn-link:hover { color: var(--ab-brass); border-bottom-color: var(--ab-brass); }
+.wool .btn-link { color: var(--ab-paper); }
+.wool .btn-link:hover { color: var(--ab-brass); border-bottom-color: var(--ab-brass); }
+
+/* Italic display action — Delegate · Defer · Delete · Do */
+.btn-instruction {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 26px;
+  line-height: 1;
+  background: transparent;
+  border: 0;
+  padding: 4px 2px;
+  color: var(--ab-ink);
+  cursor: pointer;
+  transition: color 200ms ease;
+}
+.btn-instruction:hover { color: var(--ab-brass); }
+.wool .btn-instruction { color: var(--ab-paper); }
+.wool .btn-instruction:hover { color: var(--ab-brass); }
+
+/* Pill — brass status chip */
+.pill-brass {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  font-weight: 800;
+  padding: 3px 8px;
+  background: var(--ab-brass);
+  color: var(--ab-paper);
+  white-space: nowrap;
+}
+
+/* Linkable card / ledger row */
+.card-hover { transition: background-color 160ms ease, border-color 160ms ease; }
+.card-hover:hover {
+  background: color-mix(in oklab, var(--ab-brass) 6%, transparent);
+  border-color: var(--ab-brass);
+}
+
+/* Focus ring — brass, keyboard users only */
+:focus-visible { outline: 1px solid var(--ab-brass); outline-offset: 3px; }

--- a/design-system/tokens/typography.css
+++ b/design-system/tokens/typography.css
@@ -1,0 +1,48 @@
+/* Alfred Black — Typography tokens
+ * "Serif for human presence, mono for machine truth." Display is set big and
+ * frequently italic; mono is always uppercase with wide tracking for labels. */
+
+:root {
+  /* Families */
+  --font-display: 'Playfair Display', 'Didot', 'Bodoni 72', Georgia, serif;
+  --font-body:    'EB Garamond', Garamond, Georgia, serif;
+  --font-mono:    'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+
+  /* Display scale (Playfair) — editorial, tight leading */
+  --text-hero:    clamp(80px, 14vw, 180px); /* the Door            */
+  --text-display: 64px;                     /* page titles         */
+  --text-h1:      48px;
+  --text-h2:      36px;
+  --text-h3:      28px;
+
+  /* Body scale (EB Garamond) */
+  --text-lede:    21px;   /* page lede / standfirst */
+  --text-body-lg: 19px;   /* brief & long-form body */
+  --text-body:    17px;
+  --text-small:   15px;
+
+  /* Mono scale (JetBrains) — labels & marginalia */
+  --text-label:   10px;   /* uppercase nav / kicker / pill */
+  --text-meta:    11px;
+  --text-mono-sm: 13px;
+
+  /* Weights */
+  --weight-body: 400;
+  --weight-medium: 500;
+  --weight-display: 700;
+  --weight-display-black: 900;  /* the wordmark "Alfred Black." */
+  --weight-mono-bold: 800;      /* nav & pills                 */
+
+  /* Tracking — mono labels are wide, display is tight */
+  --tracking-display: -0.02em;
+  --tracking-label:   0.22em;   /* default uppercase mono       */
+  --tracking-kicker:  0.32em;   /* widest — section eyebrows    */
+  --tracking-nav:     0.18em;
+
+  /* Leading */
+  --leading-display: 1.02;
+  --leading-body:    1.6;
+
+  /* Body font-feature-settings: kerning, ligatures, oldstyle numerals */
+  --font-features-body: "kern", "liga", "onum";
+}

--- a/scripts/hooks/lanes.json
+++ b/scripts/hooks/lanes.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Lane definitions for the Alfred fix fan-out. Enforced by check_lane.py at pre-commit AND replayed server-side by .github/workflows/lane-gate.yml on every PR from a lane-N/* branch. forbidden_zone is Phase-0-owned and off-limits to every lane (except phase0). A staged file must match >=1 of its lane's `allowed` globs and 0 forbidden_zone globs. Glob rules: `a/b/**` = prefix match; `**/x` = suffix match; otherwise fnmatch; exact path = equality. `verify` is the regression gate (overridable per-task via .lane). scope_limit is net changed LOC. Branch naming: lane-<arabic>/<issue>-<slug> maps to the roman lane id (lane-1=I .. lane-7=VII). v2 2026-07-15: added lanes VI (voice-bridge) + VII (paperclip), setup joined lane V — every package now has exactly one owning lane; .github/** and docs/lane-protocol.md joined the forbidden zone.",
+  "_comment": "Lane definitions for the Alfred fix fan-out. Enforced by check_lane.py at pre-commit AND replayed server-side by .github/workflows/lane-gate.yml on every PR from a lane-N/* branch. forbidden_zone is Phase-0-owned and off-limits to every lane (except phase0). A staged file must match >=1 of its lane's `allowed` globs and 0 forbidden_zone globs. Glob rules: `a/b/**` = prefix match; `**/x` = suffix match; otherwise fnmatch; exact path = equality. `verify` is the regression gate (overridable per-task via .lane). scope_limit is net changed LOC. Branch naming: lane-<arabic>/<issue>-<slug> maps to the roman lane id (lane-1=I .. lane-7=VII). v2 2026-07-15: added lanes VI (voice-bridge) + VII (paperclip), setup joined lane V — every package now has exactly one owning lane; .github/** and docs/lane-protocol.md joined the forbidden zone. v3 2026-08-15: design-system/** joined lane V — the imported Alfred Black brand system (tokens, components, templates) is shipped in-repo so a fresh clone can build in-brand.",
   "forbidden_zone": [
     "packages/ctrl/src/db/schema.sql",
     "packages/ctrl/src/db/migrations/**",
@@ -17,25 +17,33 @@
   "lanes": {
     "I": {
       "name": "ctrl-api",
-      "allowed": ["packages/ctrl/**"],
+      "allowed": [
+        "packages/ctrl/**"
+      ],
       "verify": "cd packages/ctrl && npm run build",
       "scope_limit": 200
     },
     "II": {
       "name": "learn",
-      "allowed": ["packages/learn/**"],
+      "allowed": [
+        "packages/learn/**"
+      ],
       "verify": "cd packages/learn && python3 -m pytest -q",
       "scope_limit": 200
     },
     "III": {
       "name": "web",
-      "allowed": ["packages/web/**"],
+      "allowed": [
+        "packages/web/**"
+      ],
       "verify": "cd packages/web && npx tsc --noEmit",
       "scope_limit": 200
     },
     "IV": {
       "name": "alfred-vault",
-      "allowed": ["packages/alfred-vault/**"],
+      "allowed": [
+        "packages/alfred-vault/**"
+      ],
       "verify": "cd packages/alfred-vault && python3 -m pytest -q",
       "scope_limit": 200
     },
@@ -51,26 +59,33 @@
         "docker-compose.yaml",
         ".env.example",
         "Makefile",
-        "docs/**"
+        "docs/**",
+        "design-system/**"
       ],
       "verify": "docker compose config -q",
       "scope_limit": 200
     },
     "VI": {
       "name": "voice-bridge",
-      "allowed": ["packages/voice-bridge/**"],
+      "allowed": [
+        "packages/voice-bridge/**"
+      ],
       "verify": "cd packages/voice-bridge && npm test",
       "scope_limit": 200
     },
     "VII": {
       "name": "paperclip",
-      "allowed": ["packages/paperclip/**"],
+      "allowed": [
+        "packages/paperclip/**"
+      ],
       "verify": "cd packages/paperclip/adapter && npm run typecheck && npm test",
       "scope_limit": 200
     },
     "phase0": {
       "name": "orchestrator",
-      "allowed": ["**"],
+      "allowed": [
+        "**"
+      ],
       "verify": "true",
       "scope_limit": 100000
     }


### PR DESCRIPTION
The trends tab I built was a chart dump with labels. This is the actual design.

Four panels, each led by a **full sentence** in display serif with the figure set in
brass italic:

> *15.3 hours came back this week,* for the 6.5 you put in.
> An hour of you now buys *3.5 hours* of work. In July it bought 5.9.
> Why the rate fell: *the work got bigger* — not worse.
> *217 returned hours* have gone almost entirely to work.

And English instead of jargon at every label — GIVEN BACK / YOUR TIME rather than
NAR / engaged, HOURS IN THE BIGGEST TASKS rather than XL bucket, NOT YET ASSIGNED
rather than unallocated, FINISHED rather than delivered.

## The script is part of the design

The inline `<script>` computes each headline from a JSON feed, and the honesty
rules live **in the sentence** rather than in a footnote underneath a chart:

| condition | what it says |
|---|---|
| engaged is null | *your time wasn't measured* — no ratio claimed |
| engaged < 1h | *Too little of your time was logged this week to price it.* |
| NAR <= 0 | *Nothing came back this week* |
| `null` in `ratio_series` | drawn as a faint dashed segment — a gap, never interpolated |
| the read | eight templates chosen on the direction triple (ratio / XL / failures) |

That is a better answer than the footnotes I had been bolting under charts. It also
handles the low-engagement trap I special-cased by hand: a ratio built on near-zero
engagement does not get de-emphasised, it does not get stated at all.

Recorded in `IMPORTED.md` so an implementer treats the script as spec, not scaffolding.

## Smoke evidence

```
gate: lane phase0 (orchestrator) — 239 LOC, 2 files, verify ok
grep for personal/client strings in the template → 0 hits
```