### PR TITLE
feat(web): port TRENDS sentence engine to attentionTrendsCore.ts (#584)

### DIFF
--- a/packages/web/src/dashboard/attentionTrendsCore.test.ts
+++ b/packages/web/src/dashboard/attentionTrendsCore.test.ts
@@ -11,7 +11,9 @@ import {
   isReadGenerated, BUCKET_KEYS, LOW_ENGAGEMENT_HOURS,
   trimEmptyEdgePeriods, READ_EMPTY_STATE_TEXT,
   POLL_GIVE_UP_MS, READ_POLL_PENDING_TEXT, READ_POLL_GAVE_UP_TEXT,
-  type TrendsPeriod,
+  f1, dir, deriveNarHeadline, deriveRatioHeadline,
+  deriveRatioLineSegmentsFromBars, deriveReadHeadline, deriveAllocationHeadline,
+  type TrendsPeriod, type ReadHeadlineParams, type RatioBar,
 } from "./attentionTrendsCore";
 
 // ── Fixture factory ───────────────────────────────────────────────────────────
@@ -205,4 +207,117 @@ test("READ_POLL_GAVE_UP_TEXT and READ_POLL_PENDING_TEXT are distinct non-empty s
     "gave-up and pending messages must be distinct — they signal different states");
   assert.ok(READ_POLL_PENDING_TEXT.length > 10, "pending text must be a real sentence");
   assert.ok(READ_POLL_GAVE_UP_TEXT.length > 10, "gave-up text must be a real sentence");
+});
+
+// ── Sentence engine ───────────────────────────────────────────────────────────
+
+// — deriveNarHeadline —
+test("deriveNarHeadline: engaged null → wasn’t measured, no ratio claimed", () => {
+  const s = deriveNarHeadline({ nar: 5, engaged: null, displaced: 10 });
+  assert.ok(s.includes("wasn’t measured"), `got: ${s}`);
+  assert.ok(!s.includes("you put in"), `must not claim ratio when unmeasured, got: ${s}`);
+});
+test("deriveNarHeadline: NAR ≤ 0 → nothing came back", () => {
+  const s = deriveNarHeadline({ nar: 0, engaged: 4, displaced: 7 });
+  assert.ok(s.includes("Nothing came back"), `got: ${s}`);
+  const s2 = deriveNarHeadline({ nar: -2, engaged: 6, displaced: 8 });
+  assert.ok(s2.includes("Nothing came back"), `got: ${s2}`);
+});
+test("deriveNarHeadline: positive NAR with engagement → came back … you put in", () => {
+  const s = deriveNarHeadline({ nar: 12.5, engaged: 6, displaced: 18.5 });
+  assert.ok(s.includes("came back this week"), `got: ${s}`);
+  assert.ok(s.includes("you put in"), `got: ${s}`);
+});
+
+// — deriveRatioHeadline —
+test("deriveRatioHeadline: engaged null → null (no ratio claimed)", () => {
+  assert.strictEqual(deriveRatioHeadline({ ratio: 4, engaged: null, peakValue: 5, peakMonth: "Jun", ratioSeries: [4] }), null);
+});
+test("deriveRatioHeadline: engaged 0.5h → too little of your time", () => {
+  const s = deriveRatioHeadline({ ratio: 3.5, engaged: 0.5, peakValue: 5, peakMonth: "Jun", ratioSeries: [3.5] });
+  assert.ok(s?.includes("Too little of your time"), `got: ${s}`);
+});
+test("deriveRatioHeadline: ratio at peak → the best yet; 3 flat periods → steady for N weeks", () => {
+  const sBest = deriveRatioHeadline({ ratio: 5.9, engaged: 6, peakValue: 5.85, peakMonth: "Jul", ratioSeries: [3, 4, 5.9] });
+  assert.ok(sBest?.includes("the best yet"), `got: ${sBest}`);
+  const sFlat = deriveRatioHeadline({ ratio: 3.5, engaged: 4, peakValue: 6, peakMonth: "Jul", ratioSeries: [3.5, 3.48, 3.52] });
+  assert.ok(sFlat?.includes("steady for") && sFlat.includes("weeks"), `got: ${sFlat}`);
+});
+
+// — deriveRatioLineSegmentsFromBars: null produces gap segment, never interpolated point —
+const mkRBars = (ratios: (number | null)[]): RatioBar[] =>
+  ratios.map((r, i) => ({ key: `W${i}`, label: `W${i}`, ratio: r, low_engagement: false, uninstrumented: false }));
+
+test("deriveRatioLineSegmentsFromBars: null in series → isGap=true; adjacent non-null → isGap=false", () => {
+  const gap = deriveRatioLineSegmentsFromBars(mkRBars([3.5, null, 4.0]));
+  assert.strictEqual(gap.length, 1); assert.strictEqual(gap[0].isGap, true);
+  assert.strictEqual(gap[0].from, 0); assert.strictEqual(gap[0].to, 2);
+  const solid = deriveRatioLineSegmentsFromBars(mkRBars([3, 4, 5]));
+  assert.ok(solid.every(s => !s.isGap), "all solid when no nulls");
+});
+
+// — deriveReadHeadline (8 templates) —
+const rh = (dR: string, dX: string, dF: string, extra: Partial<ReadHeadlineParams> = {}): string =>
+  deriveReadHeadline({
+    dR: dR as any, dX: dX as any, dF: dF as any,
+    priorKey: "W1", latestKey: "W2",
+    priorRatio: 4, latestRatio: 3,
+    priorFailures: 5, latestFailures: 8,
+    priorEngaged: 4, latestEngaged: 5,
+    priorXLHours: 2, latestXLHours: 6,
+    ...extra,
+  });
+
+test("read template 1: down+up+!up → work got bigger, not worse", () => {
+  const s = rh("down", "up", "flat");
+  assert.ok(s.includes("work got bigger"), `got: ${s}`);
+  assert.ok(s.includes("not worse"), `got: ${s}`);
+});
+test("read template 2: down+up+up → bigger work and more failed", () => {
+  const s = rh("down", "up", "up");
+  assert.ok(s.includes("bigger work"), `got: ${s}`);
+  assert.ok(s.includes("failed"), `got: ${s}`);
+});
+test("read template 3: down+flat+up → quality slipped, failures rose", () => {
+  const s = rh("down", "flat", "up");
+  assert.ok(s.includes("quality slipped"), `got: ${s}`);
+  assert.ok(s.includes("failures rose"), `got: ${s}`);
+});
+test("read template 4: down+flat+flat → your side of the desk", () => {
+  const s = rh("down", "flat", "flat");
+  assert.ok(s.includes("your side of the desk"), `got: ${s}`);
+  assert.ok(s.includes("your time rose"), `got: ${s}`);
+});
+test("read template 5: up+flat+down → fewer failures", () =>
+  assert.ok(rh("up", "flat", "down").includes("fewer failures")));
+test("read template 6: up+up+flat → improved even as the work", () =>
+  assert.ok(rh("up", "up", "flat").includes("even as the work")));
+test("read template 7: flat → held at X× across both weeks", () => {
+  const s = rh("flat", "flat", "flat", { latestRatio: 3.5 });
+  assert.ok(s.includes("held at"), `got: ${s}`);
+  assert.ok(s.includes("across both weeks"), `got: ${s}`);
+  assert.ok(s.includes("×") || s.includes("×"), `must include × char, got: ${s}`);
+});
+
+// — deriveAllocationHeadline —
+test("allocation headline: workFrac ≥ 0.85 → almost entirely to work", () => {
+  const s = deriveAllocationHeadline({ totalNar: 40, workFrac: 0.88, lifeFrac: 0.09, unassignedFrac: 0.03 });
+  assert.ok(s.includes("almost entirely to work"), `got: ${s}`);
+});
+test("allocation headline: 0.60 ≤ workFrac < 0.85 → mostly to work", () => {
+  const s = deriveAllocationHeadline({ totalNar: 30, workFrac: 0.70, lifeFrac: 0.25, unassignedFrac: 0.05 });
+  assert.ok(s.includes("mostly to work"), `got: ${s}`);
+});
+test("allocation headline: 0.40 ≤ workFrac < 0.60 → to work and life evenly", () => {
+  const s = deriveAllocationHeadline({ totalNar: 20, workFrac: 0.50, lifeFrac: 0.45, unassignedFrac: 0.05 });
+  assert.ok(s.includes("to work and life evenly"), `got: ${s}`);
+});
+test("allocation headline: workFrac < 0.40 → mostly to life", () => {
+  const s = deriveAllocationHeadline({ totalNar: 15, workFrac: 0.30, lifeFrac: 0.65, unassignedFrac: 0.05 });
+  assert.ok(s.includes("mostly to life"), `got: ${s}`);
+});
+test("allocation headline: unassigned > 25% → tail clause appended", () => {
+  const s = deriveAllocationHeadline({ totalNar: 20, workFrac: 0.55, lifeFrac: 0.15, unassignedFrac: 0.30 });
+  assert.ok(s.includes("still unassigned"), `tail clause expected, got: ${s}`);
+  assert.ok(s.includes("30%"), `must include pct, got: ${s}`);
 });

--- a/packages/web/src/dashboard/attentionTrendsCore.ts
+++ b/packages/web/src/dashboard/attentionTrendsCore.ts
@@ -180,3 +180,159 @@ export function trimEmptyEdgePeriods(periods: TrendsPeriod[]): TrendsPeriod[] {
   while (e >= s && isEmptyPeriod(periods[e])) e--;
   return periods.slice(s, e + 1);
 }
+
+// ── Sentence engine ───────────────────────────────────────────────────────────
+// Port of the AttentionTrends.html inline <script>. Pure functions; zero deps.
+// JSX text rule: always \u escapes in strings — \x escapes render literally in JSX children.
+
+/** Round to 1 dp, drop trailing zero for whole values. */
+export function f1(n: number): string {
+  const v = Math.round(n * 10) / 10;
+  return v % 1 === 0 ? String(Math.round(v)) : v.toFixed(1);
+}
+
+export type Direction = "up" | "down" | "flat";
+/** Direction at ±10% threshold. Zero base: up when b > 0, flat otherwise. */
+export function dir(a: number, b: number): Direction {
+  if (a === 0) return b > 0 ? "up" : "flat";
+  const p = (b - a) / Math.abs(a);
+  return p <= -0.10 ? "down" : p >= 0.10 ? "up" : "flat";
+}
+
+// Panel 1 — NET RETURNED
+
+export interface NarHeadlineParams { nar: number; engaged: number | null; displaced: number }
+/** HTML string for the NET RETURNED h2.
+ *  When engaged is null no ratio is claimed (instrumentation was absent). */
+export function deriveNarHeadline(p: NarHeadlineParams): string {
+  const { nar, engaged, displaced } = p;
+  if (engaged == null)
+    return `<em>${f1(nar)} hours came back this week;</em> your time wasn’t measured.`;
+  if (nar <= 0)
+    return `<em>Nothing came back this week:</em> ${f1(engaged)} hours in, ${f1(displaced)} out.`;
+  return `<em>${f1(nar)} hours came back this week,</em> for the ${f1(engaged)} you put in.`;
+}
+
+// Panel 2 — RETURN RATIO
+
+export interface RatioHeadlineParams {
+  ratio: number | null; engaged: number | null;
+  peakValue: number; peakMonth: string;
+  ratioSeries: (number | null)[];
+}
+/** HTML string for the RETURN RATIO h2.
+ *  Returns null when engaged is null — no ratio claimed. */
+export function deriveRatioHeadline(p: RatioHeadlineParams): string | null {
+  if (p.engaged == null) return null;
+  if (p.engaged < 1) return "Too little of your time was logged this week to price it.";
+  if (p.ratio == null) return "No engagement data this week — return ratio unavailable.";
+  const rs = (p.ratioSeries ?? []).filter((v): v is number => v != null);
+  let streak = 1;
+  for (let i = rs.length - 1; i > 0; i--) {
+    if (rs[i - 1] > 0 && Math.abs(rs[i] - rs[i - 1]) / rs[i - 1] < 0.05) streak++;
+    else break;
+  }
+  if (p.ratio >= p.peakValue)
+    return `An hour of you now buys <em>${f1(p.ratio)} hours</em> of work — the best yet.`;
+  if (streak >= 3)
+    return `An hour of you buys <em>${f1(p.ratio)} hours</em> of work — steady for ${streak} weeks.`;
+  return `An hour of you now buys <em>${f1(p.ratio)} hours</em> of work. In ${p.peakMonth} it bought ${f1(p.peakValue)}.`;
+}
+
+/** Split ratio bars into solid (adjacent non-null) and gap (crossing-null) segments.
+ *  A null produces a gap segment — never an interpolated point. */
+export interface LineSegment { from: number; to: number; isGap: boolean }
+export function deriveRatioLineSegmentsFromBars(bars: RatioBar[]): LineSegment[] {
+  const segs: LineSegment[] = [];
+  let last = -1;
+  for (let i = 0; i < (bars ?? []).length; i++) {
+    if (bars[i].ratio != null) {
+      if (last >= 0) segs.push({ from: last, to: i, isGap: i > last + 1 });
+      last = i;
+    }
+  }
+  return segs;
+}
+
+// Panel 3 — ALFRED'S READ
+
+export interface ReadHeadlineParams {
+  dR: Direction; dX: Direction; dF: Direction;
+  priorKey: string; latestKey: string; priorRatio: number; latestRatio: number;
+  priorFailures: number; latestFailures: number; priorEngaged: number; latestEngaged: number;
+  priorXLHours: number; latestXLHours: number;
+}
+/** HTML string chosen from 8 templates by direction triple (dR × dX × dF). */
+export function deriveReadHeadline(p: ReadHeadlineParams): string {
+  const { dR, dX, dF, priorFailures: af, latestFailures: bf,
+    priorEngaged: ae, latestEngaged: be, priorRatio: ar, latestRatio: br,
+    priorKey, latestKey } = p;
+  const pct = (a: number, b: number) =>
+    Math.abs(Math.round(((b - a) / Math.abs(a || 1)) * 1000) / 10);
+  if (dR === "down" && dX === "up" && dF !== "up")
+    return "Why the rate fell: <em>the work got bigger</em> — not worse.";
+  if (dR === "down" && dX === "up")
+    return "The rate fell: <em>bigger work,</em> and more of it failed.";
+  if (dR === "down" && dF === "up")
+    return `The rate fell where quality slipped: <em>failures rose ${af} → ${bf}.</em>`;
+  if (dR === "down")
+    return `The rate fell on your side of the desk: <em>your time rose ${f1(ae)} → ${f1(be)} hours.</em>`;
+  if (dR === "up" && dF === "down")
+    return "The rate improved: <em>less of your time, fewer failures.</em>";
+  if (dR === "up")
+    return "The rate improved <em>even as the work got bigger.</em>";
+  if (dR === "flat")
+    return `The rate held at <em>${f1(br)}×</em> across both weeks.`;
+  return `Return ratio moved ${pct(ar, br)}% from ${priorKey} to ${latestKey}.`;
+}
+
+/** Last two full non-partial periods with non-null ratio — read panel source. */
+export interface ReadPairData {
+  priorKey: string; latestKey: string; priorRatio: number; latestRatio: number;
+  priorXLHours: number; latestXLHours: number; priorFailures: number; latestFailures: number;
+  priorFinished: number; latestFinished: number; priorEngaged: number; latestEngaged: number;
+}
+export function deriveReadPairData(periods: TrendsPeriod[], grain: TrendsGrain): ReadPairData | null {
+  const full = (periods ?? []).filter(p => !isPartialPeriod(p, grain) && p.return_ratio != null);
+  if (full.length < 2) return null;
+  const pr = full[full.length - 2], la = full[full.length - 1];
+  return {
+    priorKey: pr.key, latestKey: la.key,
+    priorRatio: pr.return_ratio!, latestRatio: la.return_ratio!,
+    priorXLHours: pr.by_bucket?.XL?.displaced_hours ?? 0,
+    latestXLHours: la.by_bucket?.XL?.displaced_hours ?? 0,
+    priorFailures: pr.outcomes?.failed ?? 0, latestFailures: la.outcomes?.failed ?? 0,
+    priorFinished: pr.outcomes?.delivered ?? 0, latestFinished: la.outcomes?.delivered ?? 0,
+    priorEngaged: pr.engaged_hours, latestEngaged: la.engaged_hours,
+  };
+}
+
+// Panel 4 — ALLOCATION
+
+export interface AllocationHeadlineParams {
+  totalNar: number; workFrac: number; lifeFrac: number; unassignedFrac: number;
+}
+/** HTML string for the ALLOCATION h2.
+ *  Banded at 0.85/0.60/0.40; tail clause when unassigned > 25%. */
+export function deriveAllocationHeadline(p: AllocationHeadlineParams): string {
+  const phrase = p.workFrac >= 0.85 ? "almost entirely to work"
+    : p.workFrac >= 0.60 ? "mostly to work"
+    : p.workFrac >= 0.40 ? "to work and life evenly"
+    : "mostly to life";
+  const tail = p.unassignedFrac > 0.25
+    ? ` — ${Math.round(p.unassignedFrac * 100)}% still unassigned` : "";
+  return `<em>${f1(p.totalNar)} returned hours</em> have gone ${phrase}.${tail}`;
+}
+
+/** Cumulative allocation totals across all periods in the window. */
+export interface TrendsAllocTotals {
+  totalNar: number; workFrac: number; lifeFrac: number; unassignedFrac: number;
+}
+export function deriveTrendsAllocTotals(periods: TrendsPeriod[]): TrendsAllocTotals {
+  const totalNar = (periods ?? []).reduce((s, p) => s + (p.nar_hours ?? 0), 0);
+  const tw = (periods ?? []).reduce((s, p) => s + (p.allocation?.work?.displaced_hours ?? 0), 0);
+  const tl = (periods ?? []).reduce((s, p) => s + (p.allocation?.life?.displaced_hours ?? 0), 0);
+  const tu = (periods ?? []).reduce((s, p) => s + (p.allocation?.unallocated?.displaced_hours ?? 0), 0);
+  const tot = Math.max(tw + tl + tu, 0.001);
+  return { totalNar: Math.round(totalNar * 10) / 10, workFrac: tw / tot, lifeFrac: tl / tot, unassignedFrac: tu / tot };
+}


### PR DESCRIPTION
## Summary

- Ports the inline `<script>` from `design-system/templates/attention-trends/AttentionTrends.html` into `attentionTrendsCore.ts` as pure, zero-dep, tree-shakeable exports
- Covers all four panel headlines (NET RETURNED · RETURN RATIO · ALFRED'S READ · ALLOCATION) plus the line-segment splitter for the SVG ratio plot
- Standalone: no renderer changes in this PR — the view rebuild follows in the companion PR `lane-3/trends-report-view` which must merge second

## New exports

| Function | Rule |
|---|---|
| `f1(n)` | Round to 1 dp, drop trailing zero |
| `dir(a, b)` | ±10% threshold → up/down/flat |
| `deriveNarHeadline` | 3 branches: engaged=null → "wasn't measured, no ratio claimed"; NAR≤0 → "nothing came back"; default |
| `deriveRatioHeadline` | Returns null when engaged=null (no ratio claim); <1h → "too little"; peak / streak≥3 / default |
| `deriveRatioLineSegmentsFromBars` | null in series → isGap=true gap segment, never interpolated — enforced by structure |
| `deriveReadHeadline` | 7 reachable templates from direction triple dR×dX×dF; 8th else is TypeScript-unreachable safety net |
| `deriveReadPairData` | Last two full non-partial periods with non-null ratio |
| `deriveAllocationHeadline` | Banded at 0.85/0.60/0.40; tail clause when unassigned > 25% |
| `deriveTrendsAllocTotals` | Cumulative work/life/unassigned fractions across the full window |

## Smoke evidence

`cd packages/web && npx tsx --test src/dashboard/attentionTrendsCore.test.ts`:

```
1..34
# tests 34  pass 34  fail 0
# duration_ms 97ms
✓ lane III (web) gate passed — 273 LOC, 2 files, verify ok
```

15 existing tests retained (no regressions). 19 new tests cover every honesty rule from the spec.

References #584. Companion view PR must merge after this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc
