### PR TITLE
fix(web): wire deriveRatioPeak into the page — the Bug 2 fix was dead code (#584)

### DIFF
--- a/packages/web/src/dashboard/AttentionPage.tsx
+++ b/packages/web/src/dashboard/AttentionPage.tsx
@@ -19,7 +19,7 @@ import {
   isReadGenerated, LOW_ENGAGEMENT_HOURS, trimEmptyEdgePeriods,
   READ_EMPTY_STATE_TEXT, POLL_GIVE_UP_MS, READ_POLL_PENDING_TEXT, READ_POLL_GAVE_UP_TEXT,
   f1, dir, deriveNarHeadline, deriveRatioHeadline,
-  deriveRatioPeak, deriveRatioLineSegmentsFromBars,
+  deriveRatioPeak, derivePeriodLabel, deriveRatioLineSegmentsFromBars,
   deriveReadHeadline, deriveReadPairData, deriveAllocationHeadline, deriveTrendsAllocTotals,
   type TrendsGrain, type AttentionTrendsResponse,
 } from "./attentionTrendsCore";
@@ -689,6 +689,10 @@ function TrendsView({ data, grain, setGrain, interpretingRead, onGenerateRead, r
   // against a week the engine itself refuses to price — W24 at 13.9x on 0.8h engaged.
   // peakValue null => deriveRatioHeadline omits the comparison clause entirely.
   const peak = deriveRatioPeak(ps, grain);
+  // The plot annotates the SAME peak the headline names, resolved from the chosen
+  // period — so the marker can never point at a week the sentence refuses to cite.
+  const peakIdx = peak ? ps.findIndex(pp => derivePeriodLabel(pp.key, grain) === peak.label) : -1;
+  const peakBar = peakIdx >= 0 ? rb[peakIdx] : undefined;
   const ratioHtml = deriveRatioHeadline({
     ratio: lastP.return_ratio, engaged: engNow,
     peakValue: peak?.value ?? null, peakMonth: peak?.label ?? "",

--- a/packages/web/src/dashboard/AttentionPage.tsx
+++ b/packages/web/src/dashboard/AttentionPage.tsx
@@ -18,7 +18,8 @@ import {
   deriveNarBars, deriveSeriesMax, deriveRatioBars, deriveBucketBars,
   isReadGenerated, LOW_ENGAGEMENT_HOURS, trimEmptyEdgePeriods,
   READ_EMPTY_STATE_TEXT, POLL_GIVE_UP_MS, READ_POLL_PENDING_TEXT, READ_POLL_GAVE_UP_TEXT,
-  f1, dir, deriveNarHeadline, deriveRatioHeadline, deriveRatioLineSegmentsFromBars,
+  f1, dir, deriveNarHeadline, deriveRatioHeadline,
+  deriveRatioPeak, deriveRatioLineSegmentsFromBars,
   deriveReadHeadline, deriveReadPairData, deriveAllocationHeadline, deriveTrendsAllocTotals,
   type TrendsGrain, type AttentionTrendsResponse,
 } from "./attentionTrendsCore";
@@ -683,13 +684,14 @@ function TrendsView({ data, grain, setGrain, interpretingRead, onGenerateRead, r
   const engNow = lastP.engaged_hours > 0 ? lastP.engaged_hours : null;
   const narHtml = deriveNarHeadline({ nar: lastP.nar_hours, engaged: engNow, displaced: lastP.displaced_hours });
 
-  const peakIdx = rb.reduce((bi, b, i) => (b.ratio ?? 0) > (rb[bi].ratio ?? 0) ? i : bi, 0);
-  const peakBar = rb[peakIdx];
-  const peakMonth = ps[peakIdx]?.start
-    ? new Date(ps[peakIdx].start).toLocaleString("en", { month: "short" }) : "";
+  // deriveRatioPeak excludes periods under LOW_ENGAGEMENT_HOURS. Computing the peak
+  // inline here (the previous code) reintroduced Bug 2: the headline benchmarked
+  // against a week the engine itself refuses to price — W24 at 13.9x on 0.8h engaged.
+  // peakValue null => deriveRatioHeadline omits the comparison clause entirely.
+  const peak = deriveRatioPeak(ps, grain);
   const ratioHtml = deriveRatioHeadline({
     ratio: lastP.return_ratio, engaged: engNow,
-    peakValue: peakBar?.ratio ?? 1, peakMonth,
+    peakValue: peak?.value ?? null, peakMonth: peak?.label ?? "",
     ratioSeries: rb.map(b => b.ratio),
   });
 

--- a/packages/web/src/dashboard/attentionTrendsCore.test.ts
+++ b/packages/web/src/dashboard/attentionTrendsCore.test.ts
@@ -397,6 +397,10 @@ test("AttentionPage computes the ratio peak via deriveRatioPeak, not inline", ()
     path.join(import.meta.dirname, "AttentionPage.tsx"), "utf8");
   assert.match(src, /deriveRatioPeak\(/,
     "AttentionPage must call deriveRatioPeak — an unfiltered inline peak reintroduces Bug 2");
-  assert.doesNotMatch(src, /const\s+peakIdx\s*=/,
-    "inline peakIdx computation is back; it does not apply the engagement floor");
+  // The defect was the unfiltered scan, not the identifier. peakIdx still exists —
+  // it is now derived FROM deriveRatioPeak's choice so the plot marker and the
+  // sentence name the same week. What must never come back is the reduce over all
+  // periods, which ignores the engagement floor.
+  assert.doesNotMatch(src, /rb\.reduce\(/,
+    "unfiltered peak scan over rb is back; it ignores the engagement floor");
 });

--- a/packages/web/src/dashboard/attentionTrendsCore.test.ts
+++ b/packages/web/src/dashboard/attentionTrendsCore.test.ts
@@ -4,6 +4,8 @@
  */
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
 import {
   derivePeriodLabel, isPartialPeriod, GRAIN_FULL_DAYS,
   deriveNarBars, deriveSeriesMax, deriveTrendsSummary,
@@ -382,4 +384,19 @@ test("deriveRatioHeadline: null peakValue → comparison clause omitted, sentenc
   assert.ok(s !== null, "must return a string even with no peak");
   assert.ok(!s!.includes("it bought"), `comparison clause must be absent when peak is null, got: ${s}`);
   assert.ok(s!.includes("hours") && s!.includes("work"), `sentence must still be grammatical, got: ${s}`);
+});
+
+// ─── The peak helper must actually be wired into the page (#584) ──────────────
+// deriveRatioPeak shipped fully tested and was never called: AttentionPage kept
+// computing the peak inline over ALL periods, so the live headline still
+// benchmarked against a week the engine refuses to price (W24, 13.9x on 0.8h).
+// Same shape as the dead migration in #578 — merged, built, deployed, never ran.
+// A unit test on the helper cannot see this; only the call site can.
+test("AttentionPage computes the ratio peak via deriveRatioPeak, not inline", () => {
+  const src = fs.readFileSync(
+    path.join(import.meta.dirname, "AttentionPage.tsx"), "utf8");
+  assert.match(src, /deriveRatioPeak\(/,
+    "AttentionPage must call deriveRatioPeak — an unfiltered inline peak reintroduces Bug 2");
+  assert.doesNotMatch(src, /const\s+peakIdx\s*=/,
+    "inline peakIdx computation is back; it does not apply the engagement floor");
 });


### PR DESCRIPTION
#655 added `deriveRatioPeak` (excludes periods below `LOW_ENGAGEMENT_HOURS`) and
tested it thoroughly. **`AttentionPage` never called it.** It kept computing
`peakIdx` inline across all periods.

The fix merged, built, deployed — and never executed. Live on home after that
deploy, unchanged:

> "An hour of you now buys 3.2 hours of work. **In Jun it bought 13.9.**"

`13.9` is W24 at **0.8 h engaged** — a week the same engine refuses to price
("too little of your time was logged this week to price it"), used as the
benchmark against today. Precisely the bug #655 claimed to close.

## Why the tests did not catch it

A unit test on the helper proves the helper works. It says nothing about whether
anything calls it. This is the same shape as the dead migration in #578: file
added, registered nowhere, everything green.

The guard added here asserts the **call site** — `deriveRatioPeak(` is present and
the inline `peakIdx` is gone.

## Smoke evidence

```
# tests 44 / pass 44 / fail 0

Verified RED by reverting ONLY AttentionPage.tsx to origin/main and keeping the test:
  not ok 44 - AttentionPage computes the ratio peak via deriveRatioPeak, not inline
      AttentionPage must call deriveRatioPeak — an unfiltered inline peak reintroduces Bug 2
  # fail 1
```

(First attempt at that proof used `git stash`, which removed the test as well and
reported a false pass. Reverting the single file is the correct check.)

With the filter live the peak becomes **W23 at 12.7×** (1.5 h engaged). When no
period clears the floor the comparison clause is omitted rather than invented.