### PR TITLE
fix(web/instincts): slug double-.md, empty observations panel, stale nav label

### DIFF
--- a/packages/web/src/client/components/ab/Frame.tsx
+++ b/packages/web/src/client/components/ab/Frame.tsx
@@ -27,7 +27,7 @@ const PRIMARY: NavItem[] = [
   { to: "/files", label: "Files", icon: "envelope" },
   { to: "/channels", label: "Channels", icon: "voice" },
   { to: "/chores", label: "Chores", icon: "pocket_watch" },
-  { to: "/instincts", label: "Patterns", icon: "monocle" },
+  { to: "/instincts", label: "Instincts", icon: "monocle" },
 ];
 
 // Everything else, behind a "More" menu.

--- a/packages/web/src/intuition/InstinctsPage.tsx
+++ b/packages/web/src/intuition/InstinctsPage.tsx
@@ -51,6 +51,7 @@ import {
   tierCaption,
   type Stage,
 } from "./instinctTierCore";
+import { observationProseFromRow } from "./instinctOpsCore";
 
 // The stage is read straight off `frontmatter.tier` (#447). The old
 // derivation — `classifyStage` / `earnedCeiling` / a local
@@ -159,34 +160,28 @@ function fmtRelativeDay(value: unknown): string {
 }
 
 function observationProse(o: any): string {
-  // Each observation carries a human-readable `fact` written by
-  // extract_observation_from_decision / extract_obs_from_signal. That
-  // is the line we want on the page — the body content
-  // ("Extracted from signal `signal/...`" boilerplate) is junk for the
-  // principal. Fall back through name → "—" only if the writer was
-  // broken when this record was created.
-  const fm = o?.frontmatter ?? {};
-  const fact = String(fm.fact ?? "").trim();
-  if (fact) return fact;
-  const name = String(fm.name ?? o?.name ?? "").trim();
-  if (name && !/^\d{4}-\d{2}-\d{2}T/.test(name)) return name;
-  return "—";
+  // Delegate to the testable core. State DB rows carry `summary`; legacy
+  // vault records carry `frontmatter.fact`. Returns "" (not "—") when the
+  // row has no text — ObservationRow uses this to suppress the row entirely.
+  return observationProseFromRow(o);
 }
 
 function ObservationRow({ obs }: { obs: any }) {
-  const fm = obs?.frontmatter ?? {};
-  const when = fmtRelativeDay(fm.created);
   const prose = observationProse(obs);
+  // Empty prose → render nothing. "A row whose text field is missing must
+  // render as nothing, not as `undefined` or an empty bullet." (#459)
+  if (!prose) return null;
+
+  // State DB rows: created_at / ts  (vault rows: frontmatter.created)
+  const fm = obs?.frontmatter ?? {};
+  const when = fmtRelativeDay(obs?.created_at ?? obs?.ts ?? fm.created);
+  // State DB rows: kind is the tag pill (pattern_proposal, signal, decision…)
+  // Vault rows: source_kind=decision → intent; else source_type.
+  const tag = obs?.kind
+    ?? (String(fm.source_kind ?? "") === "decision" && String(fm.intent ?? "").trim()
+        ? String(fm.intent ?? "").trim()
+        : String(fm.source_type ?? ""));
   const sender = String(fm.sender ?? "").trim();
-  const intent = String(fm.intent ?? "").trim();
-  // For decision-sourced observations, the intent IS the gesture
-  // ("delegate", "noise", etc.). For signal-sourced ones the gesture
-  // is "received" — already implied in the fact. Keep the metadata
-  // pill thin: source-type if signal, intent if decision.
-  const tag =
-    String(fm.source_kind ?? "") === "decision" && intent
-      ? intent
-      : String(fm.source_type ?? "");
   return (
     <li className="py-3 grid grid-cols-[100px_1fr_100px] gap-4 items-baseline">
       <span
@@ -247,7 +242,8 @@ export default function InstinctsPage() {
   });
 
   const instincts = (instinctsData?.items ?? []) as any[];
-  const observations = (observationsData?.results ?? []) as any[];
+  // State DB response: { observations: [...], results: [...] (alias), count, total }
+  const observations = ((observationsData as any)?.observations ?? []) as any[];
 
   const [open, setOpen] = useState<string | null>(null);
   const [toggling, setToggling] = useState(false);
@@ -296,13 +292,17 @@ export default function InstinctsPage() {
     }
   }
 
-  // Group observations by which instinct they reference. Observations
-  // carry frontmatter.instinct (path) when matched.
+  // Group observations by which instinct they reference.
+  // State DB rows: o.instinct_ref  (vault path like "instinct/foo-bar.md")
+  // Legacy vault rows: o.frontmatter.instinct or o.frontmatter.matched_instinct
   const observationsByInstinct = useMemo(() => {
     const map: Record<string, any[]> = {};
     for (const o of observations) {
       const ref = String(
-        o?.frontmatter?.instinct ?? o?.frontmatter?.matched_instinct ?? "",
+        o?.instinct_ref ??
+        o?.frontmatter?.instinct ??
+        o?.frontmatter?.matched_instinct ??
+        "",
       );
       if (!ref) continue;
       (map[ref] ??= []).push(o);
@@ -324,10 +324,10 @@ export default function InstinctsPage() {
               className="font-mono text-[10px] uppercase tracking-[0.28em]"
               style={{ color: "var(--brass)" }}
             >
-              Patterns
+              Instincts
             </div>
             <h1 className="font-display text-5xl tracking-tight">
-              Patterns Alfred has learned.
+              Instincts Alfred has formed.
             </h1>
           </div>
           <button
@@ -339,8 +339,8 @@ export default function InstinctsPage() {
             {toggling
               ? "…"
               : enabled
-                ? "Patterns: on"
-                : "Patterns: off"}
+                ? "Instincts: on"
+                : "Instincts: off"}
           </button>
         </div>
         <p

--- a/packages/web/src/intuition/instinctOpsCore.test.ts
+++ b/packages/web/src/intuition/instinctOpsCore.test.ts
@@ -1,0 +1,87 @@
+// Unit tests for instinctOpsCore.ts (#459, #584).
+// Run: cd packages/web && npx tsx --test src/intuition/instinctOpsCore.test.ts
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { deriveInstinctSlug, observationProseFromRow, OBSERVATION_PATH } from "./instinctOpsCore.js";
+
+// ── 1. slug derivation ────────────────────────────────────────────────────────
+
+test("slug: vault path with directory", () => {
+  assert.equal(deriveInstinctSlug("instinct/foo-bar.md"), "foo-bar");
+});
+test("slug: bare .md slug", () => {
+  assert.equal(deriveInstinctSlug("foo-bar.md"), "foo-bar");
+});
+test("slug: bare slug no extension", () => {
+  assert.equal(deriveInstinctSlug("foo-bar"), "foo-bar");
+});
+test("slug: mid-string dots preserved", () => {
+  assert.equal(deriveInstinctSlug("instinct/foo.bar.baz"), "foo.bar.baz");
+  assert.equal(deriveInstinctSlug("foo.bar.baz"), "foo.bar.baz");
+});
+test("slug: double-.md bug is fixed — idempotent", () => {
+  // The original bug: split("/").pop() on "instinct/foo.md" → "foo.md" (not "foo").
+  assert.equal(deriveInstinctSlug("instinct/close-stale-cards.md"), "close-stale-cards");
+  assert.equal(
+    deriveInstinctSlug(deriveInstinctSlug("instinct/close-stale-cards.md")),
+    "close-stale-cards",
+  );
+});
+
+// ── 2. observations endpoint path ────────────────────────────────────────────
+
+test("OBSERVATION_PATH is the state endpoint", () => {
+  assert.equal(OBSERVATION_PATH, "/api/v1/state/observations");
+  assert.ok(!OBSERVATION_PATH.includes("vault"));
+});
+test("operations.ts uses state endpoint, not vault/list/observation", () => {
+  const src = fs.readFileSync(path.join(import.meta.dirname, "./operations.ts"), "utf8");
+  assert.ok(src.includes("/api/v1/state/observations"), "must reference state endpoint");
+  assert.ok(!src.includes("/api/v1/vault/list/observation"), "must not reference empty vault dir");
+});
+
+// ── 3. observation row prose — missing text renders nothing ───────────────────
+
+test("prose: empty / null / undefined row → empty string", () => {
+  assert.equal(observationProseFromRow({}), "");
+  assert.equal(observationProseFromRow(null), "");
+  assert.equal(observationProseFromRow(undefined), "");
+  assert.equal(observationProseFromRow({ kind: "pattern_proposal" }), "");
+});
+test("prose: state DB summary returned", () => {
+  assert.equal(observationProseFromRow({ summary: "Alfred noticed billing" }), "Alfred noticed billing");
+});
+test("prose: whitespace-only summary → empty string (no stray bullet)", () => {
+  assert.equal(observationProseFromRow({ summary: "   " }), "");
+});
+test("prose: falls back to frontmatter.fact for legacy vault rows", () => {
+  assert.equal(
+    observationProseFromRow({ frontmatter: { fact: "vault fact" } }),
+    "vault fact",
+  );
+});
+test("prose: summary takes priority over frontmatter.fact", () => {
+  assert.equal(
+    observationProseFromRow({ summary: "state summary", frontmatter: { fact: "vault fact" } }),
+    "state summary",
+  );
+});
+
+// ── 4. no user-facing "Patterns" label ───────────────────────────────────────
+
+test('Frame.tsx nav label is "Instincts"', () => {
+  const src = fs.readFileSync(
+    path.join(import.meta.dirname, "../client/components/ab/Frame.tsx"),
+    "utf8",
+  );
+  assert.ok(!src.includes('label: "Patterns"'), 'Frame.tsx still has label: "Patterns"');
+  assert.ok(src.includes('label: "Instincts"'), 'Frame.tsx missing label: "Instincts"');
+});
+test("InstinctsPage.tsx has no Patterns JSX label or toggle", () => {
+  const src = fs.readFileSync(path.join(import.meta.dirname, "./InstinctsPage.tsx"), "utf8");
+  assert.ok(!/>\s*Patterns\s*</.test(src), "still renders >Patterns< JSX label");
+  assert.ok(!src.includes('"Patterns:'), 'still has "Patterns:" toggle label');
+});

--- a/packages/web/src/intuition/instinctOpsCore.ts
+++ b/packages/web/src/intuition/instinctOpsCore.ts
@@ -1,0 +1,47 @@
+// instinctOpsCore — pure, testable helpers for the /instincts surface.
+//
+// Extracted so the slug-derivation, observation-endpoint path, and row-prose
+// logic can be unit-tested independently of Wasp's server scaffold.
+
+/** State-store endpoint for observations (demoted type, §5.1).
+ * Observations live in alfred-state.db, NOT in vault/observation/.
+ * The vault directory holds 0 files on live tenants; all 5,900+ records
+ * are in state.db.observation. */
+export const OBSERVATION_PATH = "/api/v1/state/observations";
+
+/**
+ * Derive the API slug from a vault path string.
+ *
+ *   instinct/foo-bar.md   → foo-bar
+ *   foo-bar.md            → foo-bar
+ *   foo-bar               → foo-bar
+ *   instinct/foo.bar.baz  → foo.bar.baz   (mid-string dots preserved)
+ */
+export function deriveInstinctSlug(path: string): string {
+  const base = String(path).split("/").pop() ?? path;
+  // Only strip a trailing ".md" — do not touch dots elsewhere in the name.
+  return base.replace(/\.md$/, "");
+}
+
+/**
+ * Extract display prose from a state DB observation row or a legacy vault
+ * record.  Returns "" (empty string — never "—") when no text is present,
+ * so callers can suppress the row entirely instead of rendering a stray bullet.
+ *
+ * State DB shape:  o.summary  (TEXT NOT NULL in schema)
+ * Legacy vault shape: o.frontmatter.fact
+ */
+export function observationProseFromRow(o: unknown): string {
+  if (!o || typeof o !== "object") return "";
+  const row = o as Record<string, unknown>;
+  // State DB: summary is the canonical text field.
+  const summary = String(row.summary ?? "").trim();
+  if (summary) return summary;
+  // Legacy vault-record fallback: fact written by extract_observation_from_decision.
+  const fm = (typeof row.frontmatter === "object" && row.frontmatter !== null
+    ? row.frontmatter
+    : {}) as Record<string, unknown>;
+  const fact = String(fm.fact ?? "").trim();
+  if (fact) return fact;
+  return "";
+}

--- a/packages/web/src/intuition/operations.ts
+++ b/packages/web/src/intuition/operations.ts
@@ -12,6 +12,7 @@ import type {
   ResolveInstinctPromotion,
 } from "wasp/server/operations";
 import { getUserInstance, proxyToTenant } from "../server/tenantProxy";
+import { deriveInstinctSlug, OBSERVATION_PATH } from "./instinctOpsCore";
 
 export const getIntuitionStatus: GetIntuitionStatus<void, any> = async (_args, context) => {
   const instance = await getUserInstance(context);
@@ -45,20 +46,28 @@ export const disableIntuition: DisableIntuition<void, any> = async (_args, conte
 
 export const getObservations: GetObservations<void, any> = async (_args, context) => {
   const instance = await getUserInstance(context);
-  return proxyToTenant(instance, {
+  // Observations are a demoted type (§5.1) — they live in alfred-state.db,
+  // not in vault/observation/. The vault directory is empty on live tenants.
+  // Frozen contract (Lane I parallel): GET /api/v1/state/observations?instinct=<slug>&limit=20
+  const data = await proxyToTenant(instance, {
     method: "GET",
-    path: "/api/v1/vault/list/observation",
-    query: { limit: "10", sort: "date_desc" },
+    path: OBSERVATION_PATH,
+    query: { limit: "20" },
   });
+  // Normalise: add `results` alias so legacy callers (IntuitionPage) still
+  // find their array at data.results while InstinctsPage reads data.observations.
+  return { ...data, results: (data as any)?.observations ?? [] };
 };
 
 export const getRecentJudgments: GetRecentJudgments<void, any> = async (_args, context) => {
   const instance = await getUserInstance(context);
-  return proxyToTenant(instance, {
+  // Same demoted-type fix as getObservations — state DB, not the empty vault dir.
+  const data = await proxyToTenant(instance, {
     method: "GET",
-    path: "/api/v1/vault/list/observation",
-    query: { limit: "20", sort: "date_desc" },
+    path: OBSERVATION_PATH,
+    query: { limit: "20" },
   });
+  return { ...data, results: (data as any)?.observations ?? [] };
 };
 
 export const getSessions: GetSessions<void, any> = async (_args, context) => {
@@ -86,7 +95,10 @@ export const resolveInstinctPromotion: ResolveInstinctPromotion<
   any
 > = async (args, context) => {
   const instance = await getUserInstance(context);
-  const slug = args.path.split("/").pop() ?? args.path;
+  // deriveInstinctSlug strips the directory prefix AND the trailing ".md" so
+  // "instinct/close-stale-cards.md" → "close-stale-cards" rather than the
+  // double-extension "close-stale-cards.md" that caused 404s (#459).
+  const slug = deriveInstinctSlug(args.path);
   return proxyToTenant(instance, {
     method: "POST",
     path: `/api/v1/learning/instincts/${encodeURIComponent(slug)}/promotion`,


### PR DESCRIPTION
## Summary

Three defects on `/instincts`, all diagnosed against the live tenant.

- **Defect 1 — Approve button 404**: `resolveInstinctPromotion` called `split("/").pop()` on the vault path to get the slug, but `.pop()` yields `close-stale-cards.md` — extension included. ctrl-api then constructs `instinct/close-stale-cards.md.md` → 404. Fixed: `deriveInstinctSlug()` strips the directory prefix AND the trailing `.md` suffix.

- **Defect 2 — "WHAT I'VE SEEN (0)"**: `getObservations` and `getRecentJudgments` both queried `GET /api/v1/vault/list/observation`. That vault directory holds 0 files on live tenants — all 5,900+ observations live in `alfred-state.db` (demoted type, §5.1). Redirected to `GET /api/v1/state/observations` per the frozen Lane I contract. `ObservationRow` now reads state DB fields (`summary`, `created_at`, `ts`, `kind`, `instinct_ref`). Rows with no `summary` return `null` from `ObservationRow` — no stray bullet. `observationsByInstinct` groups by `o.instinct_ref`.

- **Defect 3 — Stale label**: Route is `/instincts`; nav item, page kicker, h1, and toggle buttons all said "Patterns". Changed to "Instincts".

## Files changed

- `packages/web/src/intuition/instinctOpsCore.ts` (new) — `deriveInstinctSlug`, `observationProseFromRow`, `OBSERVATION_PATH`
- `packages/web/src/intuition/instinctOpsCore.test.ts` (new) — 14 tests
- `packages/web/src/intuition/operations.ts` — slug fix + state endpoint
- `packages/web/src/intuition/InstinctsPage.tsx` — field names, grouping, labels
- `packages/web/src/client/components/ab/Frame.tsx` — nav label

## Smoke evidence

Local test run — 77 attentionCore + 14 instinctOpsCore, 0 failures:

```
✓ lane III (web) gate passed — 224 LOC, 5 files, verify ok
# tests 77, pass 77, fail 0  (attentionCore)
# tests 14, pass 14, fail 0  (instinctOpsCore)
```

Slug fix verified by test:
```
slug: double-.md bug is fixed — idempotent
  deriveInstinctSlug("instinct/close-stale-cards.md") === "close-stale-cards"  ✓
```

Endpoint fix verified by test:
```
operations.ts uses state endpoint, not vault/list/observation  ✓
  src includes "/api/v1/state/observations"
  src does not include "/api/v1/vault/list/observation"
```

Nav label verified by test:
```
Frame.tsx nav label is "Instincts"  ✓
InstinctsPage.tsx has no Patterns JSX label or toggle  ✓
```

The Approve button path (Defect 1) requires a live tenant with an instinct carrying `pending_promotion: Acting` — that is the post-merge verification Sir will perform without promoting anything.

Closes #459
References #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)