### PR TITLE
fix(web/instincts): pass ?instinct= so WHAT I'VE SEEN counts correctly

### DIFF
--- a/packages/web/src/intuition/InstinctsPage.tsx
+++ b/packages/web/src/intuition/InstinctsPage.tsx
@@ -27,7 +27,7 @@
 // The discretion bar is still shown — as progress toward the next
 // promotion, not as the thing that names the stage.
 // (`deprecated` still collapses the row out of the index.)
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import {
   useQuery,
   getIntuitionInstincts,
@@ -236,14 +236,7 @@ export default function InstinctsPage() {
     undefined,
     { refetchInterval: 60_000, retry: false },
   );
-  const { data: observationsData } = useQuery(getObservations, undefined, {
-    refetchInterval: 60_000,
-    retry: false,
-  });
-
   const instincts = (instinctsData?.items ?? []) as any[];
-  // State DB response: { observations: [...], results: [...] (alias), count, total }
-  const observations = ((observationsData as any)?.observations ?? []) as any[];
 
   const [open, setOpen] = useState<string | null>(null);
   const [toggling, setToggling] = useState(false);
@@ -292,23 +285,16 @@ export default function InstinctsPage() {
     }
   }
 
-  // Group observations by which instinct they reference.
-  // State DB rows: o.instinct_ref  (vault path like "instinct/foo-bar.md")
-  // Legacy vault rows: o.frontmatter.instinct or o.frontmatter.matched_instinct
-  const observationsByInstinct = useMemo(() => {
-    const map: Record<string, any[]> = {};
-    for (const o of observations) {
-      const ref = String(
-        o?.instinct_ref ??
-        o?.frontmatter?.instinct ??
-        o?.frontmatter?.matched_instinct ??
-        "",
-      );
-      if (!ref) continue;
-      (map[ref] ??= []).push(o);
-    }
-    return map;
-  }, [observations]);
+  // Fetch observations for the currently expanded instinct card (#584).
+  // Fires once per open; ?instinct=<path> filters ctrl-api to that
+  // instinct_ref so the panel shows the full per-instinct slice, not a
+  // truncated global top-20 that may not include older rows.
+  const { data: openObsData } = useQuery(
+    getObservations,
+    { instinct: open ?? "" },
+    { retry: false, enabled: !!open },
+  );
+  const openObs = ((openObsData as any)?.observations ?? []) as any[];
 
   const visible = instincts.filter((i: any) => {
     const status = String(i?.status ?? i?.frontmatter?.status ?? "");
@@ -364,7 +350,7 @@ export default function InstinctsPage() {
             {visible.map((p) => {
               const path = String(p?.path ?? p?.id ?? p?.name ?? "");
               const isOpen = open === path;
-              const obs = observationsByInstinct[path] ?? [];
+              const obs = isOpen ? openObs : [];
               // Two distinct counts deliberately separated:
               //
               //   firedCount  — actual firings the runtime has recorded

--- a/packages/web/src/intuition/IntuitionPage.tsx
+++ b/packages/web/src/intuition/IntuitionPage.tsx
@@ -68,7 +68,7 @@ export function LearningContent() {
   const {
     data: observations,
     isLoading: observationsLoading,
-  } = useQuery(getObservations, undefined, {
+  } = useQuery(getObservations, {}, {
     refetchInterval: 30_000,
     retry: false,
     enabled: !statusError,
@@ -678,7 +678,7 @@ function LegacyIntuitionPage() {
   const {
     data: observations,
     isLoading: observationsLoading,
-  } = useQuery(getObservations, undefined, {
+  } = useQuery(getObservations, {}, {
     refetchInterval: 30_000,
     retry: false,
     enabled: !statusError,

--- a/packages/web/src/intuition/instinctOpsCore.test.ts
+++ b/packages/web/src/intuition/instinctOpsCore.test.ts
@@ -5,7 +5,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
-import { deriveInstinctSlug, observationProseFromRow, OBSERVATION_PATH } from "./instinctOpsCore.js";
+import { buildObservationQuery, deriveInstinctSlug, observationProseFromRow, OBSERVATION_PATH } from "./instinctOpsCore.js";
 
 // ── 1. slug derivation ────────────────────────────────────────────────────────
 
@@ -84,4 +84,59 @@ test("InstinctsPage.tsx has no Patterns JSX label or toggle", () => {
   const src = fs.readFileSync(path.join(import.meta.dirname, "./InstinctsPage.tsx"), "utf8");
   assert.ok(!/>\s*Patterns\s*</.test(src), "still renders >Patterns< JSX label");
   assert.ok(!src.includes('"Patterns:'), 'still has "Patterns:" toggle label');
+});
+
+// ── 5. buildObservationQuery — query object sent to ctrl-api ──────────────────
+
+test("query: instinct key is present when a slug is provided", () => {
+  const q = buildObservationQuery("foo-bar");
+  assert.equal(q.instinct, "foo-bar");
+});
+
+test("query: no instinct key when slug is absent", () => {
+  const q = buildObservationQuery();
+  assert.ok(!("instinct" in q), "instinct key must be absent with no slug");
+});
+
+test("query: no instinct key when slug is undefined", () => {
+  const q = buildObservationQuery(undefined);
+  assert.ok(!("instinct" in q));
+});
+
+test("query: default limit is 20", () => {
+  const q = buildObservationQuery();
+  assert.equal(q.limit, "20");
+});
+
+test("query: custom limit is honoured", () => {
+  const q = buildObservationQuery("foo", 50);
+  assert.equal(q.limit, "50");
+});
+
+test("query: slug with a dot survives unmangled", () => {
+  // ctrl normalises the value; we pass the canonical vault-path form
+  // including any dots so it reaches the endpoint intact.
+  const q = buildObservationQuery("instinct/foo.bar.md");
+  assert.equal(q.instinct, "instinct/foo.bar.md");
+});
+
+test("operations.ts calls buildObservationQuery and forwards args.instinct", () => {
+  const src = fs.readFileSync(path.join(import.meta.dirname, "./operations.ts"), "utf8");
+  assert.ok(src.includes("buildObservationQuery"), "must call buildObservationQuery");
+  // The previous fix passed its tests while the parameter was omitted (#584).
+  // Assert the arg is actually forwarded — not just that the function exists.
+  assert.ok(
+    src.includes("args?.instinct") || src.includes("args.instinct"),
+    "must forward args.instinct to buildObservationQuery",
+  );
+});
+
+test("InstinctsPage passes the open card path as instinct to getObservations", () => {
+  const src = fs.readFileSync(path.join(import.meta.dirname, "./InstinctsPage.tsx"), "utf8");
+  // The per-open query must include the open card's path as the instinct
+  // filter so ctrl-api returns only that instinct's rows (#584).
+  assert.ok(
+    src.includes("instinct: open") || src.includes("instinct:open"),
+    "InstinctsPage must pass { instinct: open } to getObservations",
+  );
 });

--- a/packages/web/src/intuition/instinctOpsCore.ts
+++ b/packages/web/src/intuition/instinctOpsCore.ts
@@ -45,3 +45,24 @@ export function observationProseFromRow(o: unknown): string {
   if (fact) return fact;
   return "";
 }
+
+/**
+ * Build the query-string object for GET /api/v1/state/observations.
+ *
+ * When `instinct` is present the ?instinct= filter is included so
+ * ctrl-api returns only rows linked to that instinct_ref.  ctrl normalises
+ * the value (bare slug, path-without-.md, or full canonical path all work),
+ * so pass whichever form you have — but do so consistently.
+ *
+ * When absent the filter is omitted (no `instinct` key in the returned
+ * object) and the endpoint returns the global top-N, preserving the
+ * existing behaviour for callers that pass no slug.
+ */
+export function buildObservationQuery(
+  instinct?: string,
+  limit = 20,
+): Record<string, string> {
+  const q: Record<string, string> = { limit: String(limit) };
+  if (instinct) q.instinct = instinct;
+  return q;
+}

--- a/packages/web/src/intuition/operations.ts
+++ b/packages/web/src/intuition/operations.ts
@@ -12,7 +12,7 @@ import type {
   ResolveInstinctPromotion,
 } from "wasp/server/operations";
 import { getUserInstance, proxyToTenant } from "../server/tenantProxy";
-import { deriveInstinctSlug, OBSERVATION_PATH } from "./instinctOpsCore";
+import { buildObservationQuery, deriveInstinctSlug, OBSERVATION_PATH } from "./instinctOpsCore";
 
 export const getIntuitionStatus: GetIntuitionStatus<void, any> = async (_args, context) => {
   const instance = await getUserInstance(context);
@@ -44,15 +44,17 @@ export const disableIntuition: DisableIntuition<void, any> = async (_args, conte
   return proxyToTenant(instance, { method: "POST", path: "/api/v1/learning/disable" });
 };
 
-export const getObservations: GetObservations<void, any> = async (_args, context) => {
+export const getObservations: GetObservations<{ instinct?: string; limit?: number }, any> = async (args, context) => {
   const instance = await getUserInstance(context);
   // Observations are a demoted type (§5.1) — they live in alfred-state.db,
   // not in vault/observation/. The vault directory is empty on live tenants.
   // Frozen contract (Lane I parallel): GET /api/v1/state/observations?instinct=<slug>&limit=20
+  // When args.instinct is present the endpoint filters on instinct_ref; when
+  // absent the filter is omitted and global top-N is returned (IntuitionPage).
   const data = await proxyToTenant(instance, {
     method: "GET",
     path: OBSERVATION_PATH,
-    query: { limit: "20" },
+    query: buildObservationQuery(args?.instinct, args?.limit),
   });
   // Normalise: add `results` alias so legacy callers (IntuitionPage) still
   // find their array at data.results while InstinctsPage reads data.observations.


### PR DESCRIPTION
## Problem

`InstinctsPage` showed **WHAT I'VE SEEN (0)** on every instinct that had stored observations. Verified live: `GET /api/v1/state/observations?instinct=close-stale-and-duplicate-attention-cards&limit=50` returns 19 rows — the data was there; nothing asked for it.

Root cause: two compounding omissions.

1. `getObservations` was typed `GetObservations<void, any>` — no args could reach it. The query always sent `{ limit: "20" }` and omitted `instinct`.
2. `InstinctsPage` fetched a global top-20 and grouped client-side via `observationsByInstinct`. The target instinct's 19 observations were older than that global window, so its bucket was always empty.

The comment in `operations.ts` literally quoted the frozen contract (`GET /api/v1/state/observations?instinct=<slug>&limit=20`) and the code ignored it.

## Fix

**`instinctOpsCore.ts`** — adds `buildObservationQuery(instinct?, limit?)`. The pure testable seam that constructs the query object. When `instinct` is present the key is included; when absent the key is omitted entirely (no regression for callers that pass no slug — `IntuitionPage`).

**`operations.ts`** — changes the signature from `GetObservations<void, any>` to `GetObservations<{ instinct?: string; limit?: number }, any>` and calls `buildObservationQuery(args?.instinct, args?.limit)`. The parameter now actually reaches ctrl-api.

**`InstinctsPage.tsx`** — replaces the global top-20 fetch + client-side grouping with a single top-level query gated on the `open` state variable:

```ts
const { data: openObsData } = useQuery(
  getObservations,
  { instinct: open ?? "" },
  { retry: false, enabled: !!open },
);
const openObs = ((openObsData as any)?.observations ?? []) as any[];
```

One request fires per expanded card; it fetches exactly that card's full slice from ctrl-api. `obs = isOpen ? openObs : []` so closed cards see an empty array and the open card sees the real data.

**`IntuitionPage.tsx`** — two `useQuery(getObservations, undefined)` call sites updated to `{}` because the arg type is now an object, not void. No behaviour change — passing no `instinct` returns the global top-N unchanged.

## Tests — 22/22 pass

8 new tests in `instinctOpsCore.test.ts`:

| # | Assertion |
|---|-----------|
| 15 | `buildObservationQuery("foo-bar")` returns object with `instinct: "foo-bar"` |
| 16-17 | absent/undefined slug produces no `instinct` key in the object |
| 18 | default limit is `"20"` |
| 19 | custom limit is honoured |
| 20 | slug with a dot (`instinct/foo.bar.md`) survives unmangled |
| 21 | `operations.ts` calls `buildObservationQuery` and forwards `args?.instinct` |
| 22 | `InstinctsPage` passes `{ instinct: open }` to `getObservations` |

All 14 pre-existing tests still pass.

## Smoke evidence

Local test run (the seam under test is the pure query-builder + file-read assertions that prove the wiring):

```
TAP version 13
ok 1 - slug: vault path with directory
ok 2 - slug: bare .md slug
ok 3 - slug: bare slug no extension
ok 4 - slug: mid-string dots preserved
ok 5 - slug: double-.md bug is fixed — idempotent
ok 6 - OBSERVATION_PATH is the state endpoint
ok 7 - operations.ts uses state endpoint, not vault/list/observation
ok 8 - prose: empty / null / undefined row -> empty string
ok 9 - prose: state DB summary returned
ok 10 - prose: whitespace-only summary -> empty string (no stray bullet)
ok 11 - prose: falls back to frontmatter.fact for legacy vault rows
ok 12 - prose: summary takes priority over frontmatter.fact
ok 13 - Frame.tsx nav label is "Instincts"
ok 14 - InstinctsPage.tsx has no Patterns JSX label or toggle
ok 15 - query: instinct key is present when a slug is provided
ok 16 - query: no instinct key when slug is absent
ok 17 - query: no instinct key when slug is undefined
ok 18 - query: default limit is 20
ok 19 - query: custom limit is honoured
ok 20 - query: slug with a dot survives unmangled
ok 21 - operations.ts calls buildObservationQuery and forwards args.instinct
ok 22 - InstinctsPage passes the open card path as instinct to getObservations
1..22
# tests 22
# pass  22
# fail  0
lane III (web) gate passed -- 128 LOC, 5 files, verify ok
```

The live click-through (expand a card on `/instincts`, verify the count matches `frontmatter.observation_count`) needs a staging UI pass — this lane agent has no GUI. Tagged **"needs live staging UI pass"**.

Closes #459 #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01YXT3pvDEzLCjMcgChAXTHc
