### PR TITLE
fix(compose): remove caddy healthcheck — it leaked one PID slot per probe

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -73,22 +73,57 @@ services:
       # no-op because the glob matches zero files.
       - ./caddy/tailscale-certs:/tailscale-certs
       - ./caddy/tailscale-snippets:/tailscale-snippets
-    healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:80/ >/dev/null 2>&1 || exit 0"]
-      interval: 30s
-      timeout: 5s
-      retries: 3
-      start_period: 10s
+    # NO healthcheck — deliberate. Do not re-add one here.
+    #
+    # Removed 2026-08-17. It was:
+    #   test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:80/ >/dev/null 2>&1 || exit 0"]
+    #   interval: 30s
+    #
+    # Two problems, either one fatal:
+    #
+    # 1. It could never fail. The trailing `|| exit 0` swallowed every
+    #    non-zero exit, so the probe reported success unconditionally —
+    #    including when caddy was down. Zero diagnostic value, ever.
+    #    (`wget` to :80 gets a 308 redirect to https and exits non-zero on
+    #    this image, so the `|| exit 0` was masking a broken probe.)
+    #
+    # 2. It leaked exactly one PID slot per run, permanently — an ACCOUNTING
+    #    leak, not a process leak. `pids.current` climbs by 1 per probe while
+    #    `cgroup.threads` stays flat at ~16, with zero descendant cgroups and
+    #    zero zombies. (So `init: true` does NOT fix this: there is nothing
+    #    to reap. The charge is simply never released on task exit.) After
+    #    ~8.4h the 1024 ceiling is reached and *every* fork inside the
+    #    container fails: `docker exec` returns `procReady not received`,
+    #    `caddy reload` returns `failed to create new OS thread; errno=11`
+    #    (EAGAIN), and the probe itself can no longer run — so the container
+    #    reports `unhealthy` forever while still serving traffic perfectly
+    #    (Go needs no fork per request; ACME renewal is in-process).
+    #
+    # Measured on a live tenant 2026-08-17, 13 min after a clean recreate:
+    #   caddy        pids= 42/1024  threads=16  -> +26 phantom, ~26 probes
+    #   web-client   pids= 17/256   threads=17  -> 0   (same wget probe, 15s)
+    #   vaultwarden  pids= 42/256   threads=42  -> 0   (10s)
+    #   temporal     pids= 24/1024  threads=24  -> 0   (10s)
+    # i.e. 1 leaked slot per probe, 1:1, and ONLY on caddy. Every other
+    # service has pids == threads exactly, so this is NOT a blanket
+    # docker/containerd healthcheck bug and the other 13 probes are fine
+    # (they are deliberately left in place). Why caddy specifically is
+    # undetermined — the trigger is unambiguous, so the trigger is what we
+    # remove. All six tenants were found pinned at ~1023/1024 with ~20 live
+    # threads, i.e. every tenant re-saturates within ~8.4h of any restart.
+    #
+    # This is also the true cause of the 2026-05-29 incident that prompted
+    # the pids_limit 256 -> 1024 bump below: that raised the ceiling, which
+    # only delayed saturation from ~2h to ~8.4h. Removing the probe removes
+    # the leak's only trigger. If a real healthcheck is ever wanted here it
+    # must not exec per-interval until the runtime bug is fixed upstream.
     mem_limit: 256m
-    # Bumped 256 -> 1024 on 2026-05-29. Caddy's runtime is small but every
-    # operator `caddy validate` / `caddy reload` (e.g. ctrl-api's tailscale
-    # cert route, an interactive shell-out during incident response, or the
-    # deploy-compose.yml graceful-reload step) forks a fresh Go runtime —
-    # which spawns ~30-50 OS threads per invocation. On home.alfred.black
-    # the cap was hit live during HA wiring: `caddy reload` returned
-    # `runtime: failed to create new OS thread; errno=11` (EAGAIN) and
-    # every shell-out inside the container failed. 1024 is well clear of
-    # the steady-state ~80-100 threads + room for concurrent reloads.
+    # Bumped 256 -> 1024 on 2026-05-29. Caddy's steady state is ~16-20
+    # threads; the headroom is for operator `caddy validate` / `caddy reload`
+    # (ctrl-api's tailscale cert route, an interactive shell-out during
+    # incident response, the deploy-compose.yml graceful-reload step), each
+    # of which forks a fresh Go runtime spawning ~30-50 OS threads. Kept at
+    # 1024 as a safety margin now that the per-interval leak above is gone.
     pids_limit: 1024
 
   # ── web-db — Postgres for the Wasp web app (auth, ApiKey, OAuth) ────


### PR DESCRIPTION
## What

Deletes the `caddy` healthcheck from `docker-compose.yaml`. No other service is touched — the other 13 probes stay exactly as they are.

## Why

The probe was doing two things, both bad.

**1. It could never fail.** It was:

```
test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:80/ >/dev/null 2>&1 || exit 0"]
```

The trailing `|| exit 0` swallows every non-zero exit, so it reported success unconditionally — including when caddy was down. It has never once reported anything true. (`wget` to `:80` gets a 308 redirect to https and exits non-zero on this image, so the `|| exit 0` was masking a probe that never worked.)

**2. It leaked exactly one PID slot per run, permanently.** `pids_limit` (1024) is exhausted in ~8.4h, after which *every* fork inside the container fails:

- `docker exec` → `procReady not received`
- `caddy reload` → `failed to create new OS thread; errno=11` (EAGAIN)
- the probe itself can no longer run, so the container reports `unhealthy` **forever**

Caddy keeps serving traffic perfectly throughout — Go forks nothing per request and ACME renewal is in-process — which is why this sat unnoticed for a week on every tenant.

This is an **accounting** leak, not a process leak: `pids.current` climbs by 1 per probe while `cgroup.threads` stays flat, with **zero** descendant cgroups and **zero** zombies. So `init: true` would not help — there is nothing to reap.

It is also the true cause of the 2026-05-29 incident that prompted the `pids_limit` 256 → 1024 bump. That raised the ceiling, delaying saturation from ~2h to ~8.4h rather than fixing it. `pids_limit` stays at 1024 as headroom for operator `caddy reload` shell-outs.

## Smoke evidence

**Fleet audit — every tenant was pinned at the ceiling** with only ~20 live threads:

| tenant | pids.current/max | real threads | denied forks | health |
|---|---|---|---|---|
| A | 1023/1024 | 18 | 20,938 | unhealthy/1825 |
| B | 1023/1024 | 21 | 307,640 | unhealthy/7855 |
| C | 1022/1024 | 20 | 380,059 | unhealthy/184 |
| D | 1024/1024 | 21 | 379,041 | unhealthy/14183 |
| E | 1022/1024 | 21 | 374,809 | unhealthy/191 |
| F | 1022/1024 | 19 | 24,673 | healthy/0 (lagging) |

**Recreating caddy on the canary tenant cleared it and restored forking:**

```
pids.current:  1024/1024 -> 17        (16 real threads — now consistent)
denied forks:  379,041   -> 0
docker exec:   procReady not received -> EXEC-OK
health:        unhealthy/14183        -> healthy/0
volumes kept:  caddy_data + caddy_config  (cert unchanged, no re-issue)
ingress:       all vhosts responding normally
```

**Leak reproduced 1:1, and isolated to caddy.** 13 min after that clean recreate, same host, same moment:

```
caddy        pids= 42/1024  threads=16   -> +26 phantom, ~26 probes elapsed (30s)
web-client   pids= 17/256   threads=17   -> 0   (near-identical wget probe, 15s)
vaultwarden  pids= 42/256   threads=42   -> 0   (10s)
temporal     pids= 24/1024  threads=24   -> 0   (10s)
```

One leaked slot per probe, exactly, and **only** on caddy — every other service has `pids == threads`. So this is not a blanket docker/containerd healthcheck bug, which is why the other probes are deliberately left in place. Why caddy specifically is undetermined; the trigger is unambiguous, so the trigger is what we remove.

Ruled out as causes: no OOM kills, no `dmesg` fork failures, no docker-daemon errors; host at 2.3k threads against a 250k limit and 7GB/30GB RAM.

**Validation:** `docker-compose.yaml` parses; `caddy` retains `ports`, `volumes` (5), `mem_limit`, `pids_limit`, `depends_on`; 24 services intact; 14 other healthchecks untouched. Lane gate passed (phase0, 1 file).

## Deploy plan

`deploy-compose.yml` rsyncs the compose file on merge, but the running container must be **recreated** for it to take effect (a plain restart does not release the leaked charge). Canary one tenant first — verify `pids.current` stops climbing and stays == `threads` — then roll the rest.

## Not in scope

Whether this caused the unrelated incident on 2026-08-17 05:00–06:18 UTC (vault writes failing with `pthread_create failed: Resource temporarily unavailable` while reads worked). Almost certainly **not**: caddy's cgroup is isolated from ctrl-api's, and the leak is uniform across all tenants while only one broke. That root cause is unproven — a subsequent deploy recreated ctrl-api/hermes and took the evidence with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)