### PR TITLE
fix(hermes): bake the hand-installed deps and match the canonical display config

### DIFF
--- a/packages/hermes/Dockerfile
+++ b/packages/hermes/Dockerfile
@@ -188,6 +188,23 @@ RUN pip install --no-cache-dir \
         "boto3==1.42.89" \
     && python3 -c "import faster_whisper, playwright, segno, fitz, pytesseract, docx, openpyxl, boto3; print('extra relay/voice/doc deps OK')"
 
+# -----------------------------------------------------------------------------
+# SVG rasterisation + ElevenLabs TTS. Same story as the block above: these were
+# hand-`pip install`ed on home (into /root/.local, so `--force-recreate` would
+# have silently dropped them) and never baked. Two shipped things import them:
+#   cairosvg ..... hermes-agent's own tools/vision_tools.py
+#   elevenlabs ... the shipped alfred-channel-delivery skill's voice-note path
+# Without these a fresh deploy ships the skill and the tool but not the import,
+# so both fail at first use rather than at build time. libcairo is already in
+# the base layer (verified: `ldconfig -p | grep libcairo` → 2 entries), so this
+# is pip-only. Pinned to the versions home runs.
+RUN pip install --no-cache-dir \
+        "cairosvg==2.9.0" "cairocffi==1.7.1" "cffi==2.1.1" "pycparser==3.0" \
+        "cssselect2==0.9.0" "tinycss2==1.5.1" "webencodings==0.6.1" \
+        "defusedxml==0.7.1" \
+        "elevenlabs==1.59.0" \
+    && python3 -c "import cairosvg, cairocffi, cssselect2, tinycss2, defusedxml, elevenlabs; print('svg/tts deps OK')"
+
 # =============================================================================
 # (removed 2026-08-05) The HTML-attachment patch (patch_upstream_hermes.py) is
 # obsolete as of Hermes 0.19.0: upstream now ships .html/.htm in base.py's

--- a/packages/hermes/hermes-config.yaml.njk
+++ b/packages/hermes/hermes-config.yaml.njk
@@ -869,8 +869,11 @@ context:
 # =============================================================================
 display:
   compact: false
-  tool_progress: {% if is_main %}all{% else %}new{% endif %}
+  # 'off' must stay quoted: bare `off` is a YAML boolean, not the string.
+  # main shows the final answer only (no tool-call stream); background
+  # profiles keep `new` so their progress is still greppable in logs.
+  tool_progress: {% if is_main %}'off'{% else %}new{% endif %}
 
-  interim_assistant_messages: {% if is_main %}true{% else %}false{% endif %}
+  interim_assistant_messages: false
 
   streaming: true


### PR DESCRIPTION
## What

`git clone && docker compose up -d` did not reproduce the canonical deployment's Hermes. Two hand-edits that only ever existed on the live box are written back.

| # | Gap | Effect on a fresh deploy |
|---|---|---|
| 1 | `cairosvg cairocffi cssselect2 tinycss2 defusedxml webencodings elevenlabs` pip-installed by hand into `/root/.local`, never baked | Shipped image cannot import any of them. `hermes-agent/tools/vision_tools.py` needs `cairosvg`; the shipped `alfred-channel-delivery` voice-note path needs `elevenlabs`. Fails at first use, not at build |
| 2 | Template rendered `tool_progress: all` + `interim_assistant_messages: true` for the main profile | Fresh deploys got back the tool-call stream that was deliberately turned off |

## Why it matters beyond fresh deploys

The libs in (1) live in `/root/.local`, not the image — so the canonical box is itself one `docker compose up -d --force-recreate` away from losing them silently. Baking them removes that trapdoor.

## Split on purpose

The `.env.example` half of this work is a **follow-up PR, deliberately not merged with this one**. `.env.example` is in `deploy-compose.yml`'s trigger list, and that workflow SSHes every tenant and runs `docker compose up -d`. It must not land until this image build has published, so a recreate cannot catch a box in the window between losing `/root/.local` and gaining the baked layer.

## Notes

- **`'off'` is quoted on purpose.** Bare `off` is a YAML boolean; unquoted it becomes `False`, a different setting. Asserted below.
- **No behaviour change for existing tenants.** `config.yaml` is seed-once, so (2) reaches new deploys only; (1) reaches a tenant when it next pulls the image.
- Non-main profiles already matched and are untouched.

## Smoke evidence

**All 9 pins resolve on PyPI** (a typo here would fail the image build):
```
OK cairosvg==2.9.0   OK cairocffi==1.7.1     OK cffi==2.1.1
OK pycparser==3.0    OK cssselect2==0.9.0    OK tinycss2==1.5.1
OK webencodings==0.6.1  OK defusedxml==0.7.1  OK elevenlabs==1.59.0
```

**Shipped image genuinely lacks them** (before this change):
```
$ docker run --rm --entrypoint python3 <hermes:latest> -c "import cairosvg"
  MISSING cairosvg -> ModuleNotFoundError
  MISSING cairocffi, elevenlabs, tinycss2, cssselect2
$ ldconfig -p | grep -c libcairo    # same image
  2                                 # OS lib already there -> pip-only fix
```

**Rendered YAML asserted for both template branches:**
```
OK is_main=True   tool_progress              -> 'off' (str)
OK is_main=True   interim_assistant_messages -> False (bool)
OK is_main=False  tool_progress              -> 'new' (str)
OK is_main=False  interim_assistant_messages -> False (bool)

bare off -> False    # why the quotes are load-bearing
```

**Gate:** lane V passed, verify ok.
**Verified in sync and deliberately left alone:** compose file, Caddyfile, web-client bundle, and the ctrl-api / learn / worker / web / mcp-server / vault-init images are byte-identical to registry `:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)