### PR TITLE
fix(hermes): a broken auxiliary process must not kill the gateway container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -413,6 +413,11 @@ services:
     environment:
       - HERMES_API_SERVER_KEY=${HERMES_API_SERVER_KEY}
       - HERMES_HOME=/hermes-state
+      # Opt a tenant out of the hermes-relay (:8767) + dashboard (:9119)
+      # block in supervisor.sh. Documented there as the per-tenant switch
+      # since it shipped, but never plumbed through compose — so setting it
+      # in .env silently did nothing (found 2026-08-17). Defaults on.
+      - HERMES_RELAY_ENABLED=${HERMES_RELAY_ENABLED:-true}
       - OPENCLAW_GATEWAY_TOKEN_FILE=/alfred-data/.gateway-token
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}

--- a/packages/hermes/docker/supervisor.sh
+++ b/packages/hermes/docker/supervisor.sh
@@ -968,12 +968,28 @@ while true; do
             RESTARTS["$name"]=$(( ${RESTARTS["$name"]:-0} + 1 ))
             log "process '$name' exited (code ${code}, restart #${RESTARTS[$name]})"
 
-            # Crash-loop guard: after 5 restarts in quick succession the
-            # process is broken — surface it by exiting so compose's
-            # restart policy / an operator can react, rather than spinning.
+            # Crash-loop guard. For a GATEWAY (hermes-*) a persistent crash
+            # loop means the tenant has no working runtime, so exit and let
+            # compose's restart policy / an operator react.
+            #
+            # For anything else (relay, dashboard) it must NOT be fatal: those
+            # are auxiliary, the gateways keep serving without them, and taking
+            # the container down over one is strictly worse than losing the
+            # feature. 2026-08-17: the 0.19 dashboard refuses to bind 0.0.0.0
+            # without an auth provider, exited on a ~10s cycle, hit this guard,
+            # and killed the whole container — on 4 of 6 tenants, ~5000 restarts
+            # each over 10 days, every cycle spamming a shutdown notice to the
+            # tenant's chat surface. The three gateways were healthy the entire
+            # time. Abandon the process instead and keep serving.
             if (( ${RESTARTS[$name]} > 20 )); then
-                log "FATAL: '$name' restarted >20 times — giving up, exiting container"
-                shutdown
+                if [[ "$name" == hermes-* ]]; then
+                    log "FATAL: gateway '$name' restarted >20 times — giving up, exiting container"
+                    shutdown
+                else
+                    log "WARN: auxiliary process '$name' restarted >20 times — abandoning it; gateways stay up"
+                    unset "PIDS[$name]"
+                    continue
+                fi
             fi
 
             sleep "$RESTART_DELAY"


### PR DESCRIPTION
## What

Two small changes, one incident:

1. `packages/hermes/docker/supervisor.sh` — the supervise loop's `>20 restarts` crash-loop guard is now **gateway-only**. A crash-looping `hermes-*` gateway still exits the container; an auxiliary process (relay, dashboard) is abandoned with a WARN and the gateways keep serving.
2. `docker-compose.yaml` — wire `HERMES_RELAY_ENABLED` into the `hermes` service environment (defaults on).

## Why

On **4 of 6 tenants** the hermes container had been restarting **every ~3 minutes for 10 days — ~5,000 restarts each** — while the three AI gateways inside were healthy the entire time. Every cycle emitted a shutdown notice to the tenant's chat surface, so a principal was being spammed continuously and conversations were being killed mid-turn.

**Defect 1 — an auxiliary process could kill everything.** The 0.19 dashboard refuses to bind `0.0.0.0` without an auth provider:

```
Refusing to bind dashboard to 0.0.0.0 — the auth gate engages on non-loopback
binds, but no auth providers are registered.
There is no unauthenticated public-bind option.
```

`--insecure` no longer bypasses that gate. So the dashboard exited on a ~10s cycle, tripped the guard, and called `shutdown()` — taking the whole container down. Docker's `unless-stopped` restarted it and the loop closed. Losing a cosmetic dashboard is fine; losing the tenant's entire AI runtime over it is not.

**Defect 2 — the documented opt-out did nothing.** `supervisor.sh` has advertised `HERMES_RELAY_ENABLED` as the per-tenant switch since it shipped ("DEFAULTS ON — set to 0/false/no/off to opt a tenant out"), but it was never plumbed into compose. The `hermes` service declares an explicit `environment:` list and **no `env_file:`**, so setting it in a tenant's `.env` was silently ignored — verified by inspecting the container env after doing exactly that.

**Not a version issue.** Affected and unaffected tenants both run `hermes-agent 0.19.0` from the same image with identical config and no auth configured. The only difference was whether the supervisor kept respawning the dashboard long enough to reach the guard — on the healthy tenant it stopped after 1 attempt, on the others it reached 21 and self-destructed. Pulling images does not fix this; an earlier hypothesis that it would was wrong.

## Smoke evidence

**Before** — fleet state (hermes container):

| tenant | restarts | dashboard-fatal/20m | gateways |
|---|---|---|---|
| A | 16 | 0 | healthy |
| B | 0 (fresh) | 0 | healthy |
| C | 5,751 | 13 | healthy (killed as collateral) |
| D | 4,639 | 10 | healthy (killed as collateral) |
| E | 5,343 | 12 | healthy (killed as collateral) |
| F | 5,497 | 12 | healthy (killed as collateral) |

Only `dashboard` was ever the failing process — `52 × "process 'dashboard' exited"`, nothing else — while `18789/18790/18791` all returned 200 throughout.

**Mitigation applied live to the 4 looping tenants** (wire the var + set it to 0), which is what this PR lands durably:

```
env: HERMES_RELAY_ENABLED=0
[supervisor] relay/dashboard disabled (HERMES_RELAY_ENABLED!=1 or plugin absent)
dashboard exits since start: 0      (was 52)
restarts=0
gw 18789: 200   gw 18790: 200   gw 18791: 200
```

All four stayed up with zero further restarts, and a tenant carrying a sibling profile kept it healthy (`hermes-cratchit` up, override intact). The sibling was never affected — the relay/dashboard block doesn't match its profile layout.

Confirmed the relay itself is unused before disabling it: **0** Caddyfile references, **0** compose references, **0** established connections on `:8767`.

**Validation:** `bash -n packages/hermes/docker/supervisor.sh` clean; `docker compose config -q` clean; 24 services intact; lane gate passed (lane V, 31 LOC, 2 files).

## Deploy note

`supervisor.sh` is baked into the hermes image, so change 1 needs `build-hermes` + a **`docker compose pull`** on each tenant — and note `deploy-compose` runs `up -d` **without** a pull, so image drift is not corrected automatically. Change 2 (compose) rsyncs on merge. The live mitigation already stops the loop in the meantime, so this can roll at a normal pace.

## Follow-up (deliberately not here)

The dashboard could bind `127.0.0.1` and start cleanly instead of failing 21 times per boot. Nothing references `:9119` in Caddyfile or compose, but the in-file comment says tenants may expose it over a private tailnet as `hermes:9119`, so that trade-off deserves its own decision rather than being smuggled into this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)