### PR TITLE
ci(deploy-compose): add cratchit to the tenant matrix

### DIFF
--- a/.github/workflows/deploy-compose.yml
+++ b/.github/workflows/deploy-compose.yml
@@ -62,6 +62,14 @@ jobs:
           - zsolt.alfred.black
           - miguel.alfred.black
           - rami.alfred.black
+          # cratchit is its own VM, not a profile on joe (the `hermes-cratchit`
+          # container ON joe is a different thing). It was absent from every
+          # workflow until 2026-08-17, so it never received a compose, Caddyfile
+          # or .env.example update and silently fell behind on every merge —
+          # far enough that it was still running the caddy healthcheck #661
+          # removed, and its .env was missing TRUST_PROXY_HOPS, which crash-looped
+          # mcp-server the moment its images were brought current.
+          - cratchit.alfred.black
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## What

`cratchit` is its own VM and appeared in **no workflow at all** — `grep -r cratchit .github/workflows/` returned nothing. So it never received an automated compose, Caddyfile or `.env.example` update, and fell further behind on every merge.

It is easy to miss: a `hermes-cratchit` container also runs **on joe** as a fourth profile. That container is not the tenant.

## How far it had drifted

Found on 2026-08-17 when its images were finally brought current by hand:

| | |
|---|---|
| `docker-compose.yaml` | still carried the caddy healthcheck **#661 removed** — so it has been leaking one PID slot per probe, the failure mode that pins a box at 1024 and makes every fork inside the container fail |
| `.env` | missing `TRUST_PROXY_HOPS`, which the current mcp-server requires in production. Bringing its images current crash-looped mcp-server until the key was added |

Adding it to this job is what stops both classes of drift recurring.

## Verified before adding it

This job overwrites files and then runs `docker compose up -d`, so the risk is that it clobbers cratchit's bespoke setup. Checked, and it does not:

- **Caddyfile** differs from the repo's only in stale comments (leftover `plane` references) — functionally identical.
- **The cdsk route** lives in `caddy/tailscale-snippets/cdsk.caddy`, a host mount this job does not sync, and the Caddyfile's `import /tailscale-snippets/*.caddy` line survives the overwrite.
- **cratchit's extra services** (`composio-sidecar`, `cdsk-mcp`, `paperclip`, `paperclip-init`, `voice-bridge`, `hermes-cratchit`) live in a host-local `docker-compose.override.yaml`, which this job also does not touch.

## Note on fleet size

`rami` was already in the list, is live (SSH OK), and synced successfully in today's run. **The fleet is seven tenants** — home, rj, joe, zsolt, miguel, rami, cratchit — not the five or six it is usually described as.

## Smoke evidence

```
YAML parses; 7 tenants: home, rj, joe, zsolt, miguel, rami, cratchit
```

```
cratchit reachability:  dns=178.156.184.95  ssh=OK
rami     reachability:  dns=178.105.224.71  ssh=OK
last deploy-compose run: 6/6 tenants success (cratchit not yet in matrix)
```

Caddyfile diff, repo vs cratchit — comments only:
```
13c13
< # public IP — `@` (apex), `sure`, `vault`, `mcp`, `sms`, `voice`,
> # public IP — `@` (apex), `plane`, `sure`, `vault`, `mcp`, `sms`, `voice`,
```

**Gate:** phase0 (orchestrator) passed — 8 LOC, 1 file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)