### PR TITLE
fix(ctrl): reap healthcheck zombies with tini; add a host watchdog

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -591,6 +591,17 @@ services:
 
   # ── ctrl-api — the dashboard backend / tenant API (:3100) ───────────
   ctrl-api:
+    # tini as PID 1 so orphaned processes get reaped. Docker execs the
+    # healthcheck into the container; when it exits its parent is outside
+    # this PID namespace, so it reparents to PID 1 — and `node` has no
+    # reason to reap a child it never spawned. Each corpse holds a PID slot.
+    # 2026-08-17: found 14 zombie `curl` processes here and rising; the same
+    # accumulation had filled the 1024 budget for 2.5 days, at which point
+    # ctrl-api could no longer fork — so vault WRITES (which shell out to the
+    # vault daemon) failed while READS (in-process) kept working. Silent, and
+    # the only outward sign was Alfred quietly not recording things.
+    # hermes already runs tini for this reason; this brings ctrl-api in line.
+    init: true
     logging: *default-logging
     image: ssdavidai00/alfred-ctrl-api:latest
     depends_on:

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -247,6 +247,29 @@ if [[ -z "${existing_prefix}" ]]; then
 	fi
 fi
 
+# ── host watchdog cron ───────────────────────────────────────────────────────
+# Installs scripts/ops/alfred-watchdog.sh on a 5-minute cron. It records
+# pids.current vs live threads per container (the number that diagnoses a PID
+# exhaustion) and restarts containers Docker has flagged unhealthy.
+#
+# Why: on 2026-08-17 ctrl-api filled its 1024-PID budget with unreaped
+# healthcheck zombies. Docker flagged it `unhealthy` for 2.5 days and did
+# nothing, while vault WRITES silently degraded (writes fork a helper; reads do
+# not) — ~50/day down to 20-30 with no error anywhere the principal could see.
+# `init: true` now prevents the zombies; this catches the next one of whatever
+# shape it takes.
+WATCHDOG_SRC="${SCRIPT_DIR}/ops/alfred-watchdog.sh"
+if [[ -f "${WATCHDOG_SRC}" ]]; then
+	install -m 0755 "${WATCHDOG_SRC}" /usr/local/bin/alfred-watchdog 2>/dev/null || true
+	if command -v crontab >/dev/null 2>&1; then
+		# Idempotent: drop any previous line, re-add exactly one.
+		{ crontab -l 2>/dev/null | grep -v 'alfred-watchdog' || true; \
+		  echo '*/5 * * * * /usr/local/bin/alfred-watchdog >/dev/null 2>&1'; } | crontab - 2>/dev/null \
+		  && green "Installed alfred-watchdog cron (every 5 min)." \
+		  || red "Could not install alfred-watchdog cron — add it by hand."
+	fi
+fi
+
 bold ""
 green "Bootstrap complete. Next:  docker compose up -d"
 green "(Tailscale is opt-in:      docker compose --profile tailscale up -d tailscale"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -263,10 +263,13 @@ if [[ -f "${WATCHDOG_SRC}" ]]; then
 	install -m 0755 "${WATCHDOG_SRC}" /usr/local/bin/alfred-watchdog 2>/dev/null || true
 	if command -v crontab >/dev/null 2>&1; then
 		# Idempotent: drop any previous line, re-add exactly one.
-		{ crontab -l 2>/dev/null | grep -v 'alfred-watchdog' || true; \
-		  echo '*/5 * * * * /usr/local/bin/alfred-watchdog >/dev/null 2>&1'; } | crontab - 2>/dev/null \
-		  && green "Installed alfred-watchdog cron (every 5 min)." \
-		  || red "Could not install alfred-watchdog cron — add it by hand."
+		if { crontab -l 2>/dev/null | grep -v 'alfred-watchdog' || true; \
+		     echo '*/5 * * * * /usr/local/bin/alfred-watchdog >/dev/null 2>&1'; } \
+		     | crontab - 2>/dev/null; then
+			green "Installed alfred-watchdog cron (every 5 min)."
+		else
+			red "Could not install alfred-watchdog cron — add it by hand."
+		fi
 	fi
 fi
 

--- a/scripts/ops/alfred-watchdog.sh
+++ b/scripts/ops/alfred-watchdog.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# alfred-watchdog — host-side cron, runs every 5 minutes.
+#
+# Two jobs, both born from the 2026-08-17 incidents:
+#
+#   1. SAMPLE. Record pids.current vs live thread count per container. This is
+#      the number that actually diagnoses a PID exhaustion, and the number we
+#      did NOT have when ctrl-api starved: its cgroup was destroyed with the
+#      container at 07:09:52 and took the evidence with it.
+#        pids >  threads  -> phantom/accounting leak (the caddy species)
+#        pids == threads  -> real processes piling up (unreaped children)
+#      Those two have different causes and different fixes, so this one column
+#      is what turns the next occurrence from archaeology into a diagnosis.
+#
+#   2. HEAL. Restart containers Docker has marked unhealthy. Docker detects
+#      this perfectly well and then does nothing with it — ctrl-api sat
+#      `unhealthy` for 2.5 days (19,482 failed probes) while vault writes
+#      silently degraded. A container stop tears down its cgroup scope
+#      ("docker-<id>.scope: Deactivated successfully"), which releases a leaked
+#      charge, so a restart is a real fix and not just a nudge.
+#
+# Deliberately boring: no new images, no docker socket exposed to a container,
+# no daemon. Root on the host already has docker access.
+
+set -uo pipefail
+
+LOG_DIR=/var/log/alfred
+STATE_DIR=/var/lib/alfred-watchdog
+RETAIN_DAYS=14
+# Only ever touch the managed stack. Anything else on the box (e.g. a
+# hand-run sidecar) is not ours to bounce — and at least one such container
+# runs healthy-but-unhealthy-flagged, which a blind heal would restart forever.
+NAME_PREFIX=alfred-black-
+# Don't re-restart the same container inside this window.
+COOLDOWN_SECONDS=1800
+# Hard stop per container per day. A container that needs more than this is
+# broken in a way a restart cannot fix, and hammering it is how you build the
+# restart loop we just spent a day removing.
+MAX_RESTARTS_PER_DAY=4
+
+mkdir -p "$LOG_DIR" "$STATE_DIR"
+today=$(date -u +%F)
+SAMPLE_LOG="$LOG_DIR/pids-$today.log"
+ACTION_LOG="$LOG_DIR/watchdog-actions.log"
+ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+command -v docker >/dev/null 2>&1 || exit 0
+
+# ── 1. sample ────────────────────────────────────────────────────────────────
+docker ps --format '{{.ID}} {{.Names}}' 2>/dev/null | while read -r cid cname; do
+    full=$(docker inspect -f '{{.Id}}' "$cid" 2>/dev/null) || continue
+    cg="/sys/fs/cgroup/system.slice/docker-${full}.scope"
+    [ -r "$cg/pids.current" ] || continue
+    cur=$(cat "$cg/pids.current" 2>/dev/null || echo -1)
+    max=$(cat "$cg/pids.max"     2>/dev/null || echo -1)
+    thr=$(wc -l < "$cg/cgroup.threads" 2>/dev/null || echo -1)
+    den=$(awk '/^max/{print $2}' "$cg/pids.events" 2>/dev/null || echo -1)
+    phantom=$(( cur - thr ))
+    printf '%s %s pids=%s/%s threads=%s phantom=%s denied=%s\n' \
+        "$ts" "$cname" "$cur" "$max" "$thr" "$phantom" "${den:-0}" >> "$SAMPLE_LOG"
+done
+
+# ── 2. heal ──────────────────────────────────────────────────────────────────
+docker ps --filter health=unhealthy --format '{{.Names}}' 2>/dev/null | while read -r name; do
+    [ -n "$name" ] || continue
+    case "$name" in
+        "$NAME_PREFIX"*) ;;
+        *) echo "$ts SKIP $name (not $NAME_PREFIX*)" >> "$ACTION_LOG"; continue ;;
+    esac
+
+    stamp="$STATE_DIR/${name}.last"
+    now=$(date -u +%s)
+    if [ -f "$stamp" ]; then
+        last=$(cat "$stamp" 2>/dev/null || echo 0)
+        if [ $(( now - last )) -lt "$COOLDOWN_SECONDS" ]; then
+            continue   # inside cooldown — stay quiet
+        fi
+    fi
+
+    todays=$(grep "^$today" "$ACTION_LOG" 2>/dev/null | grep -c "RESTART $name" || echo 0)
+    if [ "$todays" -ge "$MAX_RESTARTS_PER_DAY" ]; then
+        echo "$ts GIVEUP $name (already restarted ${todays}x today — needs a human)" >> "$ACTION_LOG"
+        continue
+    fi
+
+    # Capture the pids state at the moment of failure — this is the evidence.
+    full=$(docker inspect -f '{{.Id}}' "$name" 2>/dev/null)
+    cg="/sys/fs/cgroup/system.slice/docker-${full}.scope"
+    pre_cur=$(cat "$cg/pids.current" 2>/dev/null || echo ?)
+    pre_max=$(cat "$cg/pids.max" 2>/dev/null || echo ?)
+    pre_thr=$(wc -l < "$cg/cgroup.threads" 2>/dev/null || echo ?)
+    streak=$(docker inspect -f '{{if .State.Health}}{{.State.Health.FailingStreak}}{{end}}' "$name" 2>/dev/null)
+
+    if docker restart "$name" >/dev/null 2>&1; then
+        echo "$ts RESTART $name (unhealthy streak=$streak pids=$pre_cur/$pre_max threads=$pre_thr)" >> "$ACTION_LOG"
+        echo "$now" > "$stamp"
+    else
+        echo "$ts FAILED-RESTART $name" >> "$ACTION_LOG"
+    fi
+done
+
+# ── 3. prune ─────────────────────────────────────────────────────────────────
+find "$LOG_DIR" -name 'pids-*.log' -type f -mtime +$RETAIN_DAYS -delete 2>/dev/null || true
+exit 0


### PR DESCRIPTION
## What

1. `init: true` on `ctrl-api` — tini becomes PID 1 and reaps orphaned processes.
2. `scripts/ops/alfred-watchdog.sh` + a bootstrap-installed 5-minute cron — samples PID budgets per container and restarts containers Docker has flagged unhealthy.

## Why

ctrl-api was filling its 1024-PID budget with unreaped zombies and then **silently losing vault writes**.

**Mechanism.** Docker execs the healthcheck (`curl .../learning/status`) into the container. When it exits, its parent lives outside the container's PID namespace, so it reparents to PID 1 — and PID 1 is `node`, which has no reason to reap a child it never spawned. Each corpse holds a PID slot forever.

Once the budget is gone the container cannot fork, and that splits the API in half:

- vault **reads** are served in-process from the filesystem → keep working
- vault **writes** shell out to the vault daemon → die with `pthread_create failed: Resource temporarily unavailable`

**Impact.** On one tenant this ran from **2026-08-14 22:30 to 2026-08-17 07:09** — 19,482 failed probes. Docker had the container flagged `unhealthy` the entire time and does nothing with that signal, so nothing alerted. Vault writes fell from ~50/day to 20–30 while every read and dashboard looked healthy. It surfaced only because the assistant itself tried to write a record, failed, and reported it to its principal. A deploy that happened to recreate the container reset it by accident.

## Smoke evidence

**Zombie census across all 19 containers on a live tenant** — ctrl-api is the only one affected:

```
CONTAINER                        ZOMBIES  PID1        HEALTHCHECK
alfred-black-ctrl-api-1          14       node        yes      <-- and rising (8 -> 14 in 20 min)
alfred-black-hermes-1            0        tini        yes
alfred-black-caddy-1             0        caddy       no
alfred-black-vault-cli-1         0        node        yes
alfred-black-web-1               0        npm         yes
alfred-black-temporal-1          0        temporal    yes
... all others 0
```

`ps` inside ctrl-api showed them plainly — eight, then fourteen, all reparented to PID 1:

```
  PID  PPID STAT COMMAND
    1     0 Ssl  node
  435     1 Z    curl
 1629     1 Z    curl
 2087     1 Z    curl        (etc.)
```

**Phantom PIDs persisted, proving accumulation rather than in-flight work** — six consecutive samples, 12s apart:

```
pids=19 threads=11 phantom=8     (x6, never decayed)
```

**After `init: true`** on that tenant:

```
zombies BEFORE: 14
PID 1 now:      docker-init     (was: node)
init flag:      true
zombies AFTER:  0
pids=8 threads=8                (phantom gone)
health: healthy    API: 200
```

Two supporting observations: `hermes` already runs tini and has never accumulated zombies despite its own exec probe — precedent for the fix in our own stack. And `caddy` sits at 0 with a non-reaping PID 1 only because its probe was removed in #661, which confirms the probe is the corpse source.

**Watchdog** installed and sampling on every tenant; first run recorded all containers, and `phantom` immediately isolated ctrl-api as the sole outlier. Guarded so it cannot become the failure it exists to catch: only touches `alfred-black-*` (one healthy-but-unhealthy-flagged sidecar elsewhere on a host would otherwise be bounced forever), 30-minute per-container cooldown, hard stop after 4 restarts/day then it logs `GIVEUP` for a human, and every action is logged together with the pids state captured at the moment of failure.

**Validation:** `bash -n` clean on both scripts; `docker compose config` clean; 24 services intact; lane gate passed (phase0, 138 LOC, 3 files).

## Why not just remove the probe

That is what #661 did for caddy, and it removes the *symptom*. `init: true` removes the *cause*, and the probe is worth keeping here — it is the thing that would have told us, had anything been listening to it.

## Follow-up (not here)

ctrl-api's probe hits `/api/v1/learning/status`, heavier than every other service's probe and the likely reason its execs sometimes get killed on timeout rather than exiting cleanly. A cheaper endpoint would remove the trigger as well as the consequence. Also worth considering `init: true` prophylactically on the other non-reaping PID 1 containers — the watchdog will now show us if any of them start accumulating, so this can wait for evidence rather than being guessed at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)