### PR TITLE
fix(bootstrap): generate the two keys that crash services on a fresh deploy

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -151,6 +151,7 @@ AUTO_SECRETS=(
 	SURE_API_KEY
 	PAPERCLIP_BETTER_AUTH_SECRET
 	PAPERCLIP_HEARTBEAT_SECRET
+	VOICE_BRIDGE_INTERNAL_TOKEN
 	# PAPERCLIP_API_KEY is NOT auto-generated — Paperclip's better-auth
 	# issues API keys through its own UI flow (signup → settings → keys),
 	# and the value must be one Paperclip itself recognises. Leave the
@@ -217,6 +218,27 @@ if [[ -z "${existing_uid}" || "${existing_uid}" == "default" ]]; then
 fi
 
 green "Auto-secrets: ${GENERATED} generated, ${KEPT} kept (already set)."
+
+# ── TRUST_PROXY_HOPS ────────────────────────────────────────────────
+# Not a secret — the number of reverse proxies in front of mcp-server, used
+# to pick the right client IP out of X-Forwarded-For. mcp-server REFUSES TO
+# START in production without it (`TRUST_PROXY_HOPS must be set in
+# production`), so an unset value is not a soft default: it is a crash loop
+# on a fresh deploy. Found 2026-08-17 on a tenant that had never been through
+# this script. The stack puts exactly one proxy in front — Caddy — so 1 is
+# correct for every standard deploy; raise it only if you front Caddy with
+# another proxy or a CDN that appends its own hop.
+existing_hops="$(trim "$(env_get TRUST_PROXY_HOPS)")"
+if [[ -z "${existing_hops}" ]]; then
+	if grep -qE "^#?TRUST_PROXY_HOPS=" "${ENV_FILE}" 2>/dev/null; then
+		tmp="$(mktemp)"
+		awk '$0 ~ "^#?TRUST_PROXY_HOPS=" && !d { print "TRUST_PROXY_HOPS=1"; d=1; next } { print }' "${ENV_FILE}" > "${tmp}"
+		mv "${tmp}" "${ENV_FILE}"
+	else
+		printf 'TRUST_PROXY_HOPS=1\n' >> "${ENV_FILE}"
+	fi
+	green "Set TRUST_PROXY_HOPS=1 (one proxy in front: Caddy)."
+fi
 
 # ── 4. TAILSCALE_HOSTNAME_PREFIX (issue #109 PR 1) ──────────────────
 # The Tailscale sidecar runs only with `--profile tailscale` and is OFF on


### PR DESCRIPTION
## What

`bootstrap.sh` never generated `VOICE_BRIDGE_INTERNAL_TOKEN` or `TRUST_PROXY_HOPS`, but voice-bridge and mcp-server both refuse to start in production without them. A fresh deploy following the README came up with **two services in a crash loop**.

Not hypothetical — this is what happened on 2026-08-17 when two tenants had their images brought current:

```
Error: VOICE_BRIDGE_INTERNAL_TOKEN env var is required
    at required (file:///app/dist/config.js:5:15)     -> voice-bridge, restarts=9

Error: TRUST_PROXY_HOPS must be set in production
    at parseTrustProxyHops (file:///app/dist/trustProxy.js:5:19)  -> mcp-server, restarts=12
```

Documenting them in `.env.example` (#663) made them discoverable. It did not make them exist.

## Approach

| key | treatment | why |
|---|---|---|
| `VOICE_BRIDGE_INTERNAL_TOKEN` | joins `AUTO_SECRETS`, gets `openssl rand -hex 32` | genuine shared secret between ctrl-api and voice-bridge |
| `TRUST_PROXY_HOPS` | own defaults block, value `1` | not a secret — a proxy-hop count for X-Forwarded-For. The stack puts exactly one proxy in front (Caddy) |

The `TRUST_PROXY_HOPS` block is modelled on the existing `COMPOSIO_USER_ID` / `TAILSCALE_HOSTNAME_PREFIX` sections, and both follow the established re-run-stable pattern: existing non-blank value kept, commented placeholder replaced in place, otherwise appended.

## Smoke evidence

The `TRUST_PROXY_HOPS` block was extracted and exercised against fixtures covering every path. **The first version of this patch failed case 2** — a shell-quoting error left a malformed awk program that silently did nothing to a commented placeholder. Caught by this test, then fixed:

```
case1 append (key absent):        TRUST_PROXY_HOPS=1
case2 replace-commented:          TRUST_PROXY_HOPS=1   (lines=1, other keys intact=1)
case3 preserve existing value 2:  TRUST_PROXY_HOPS=2   <- not clobbered
case4 idempotent re-run:          1 line (expect 1)
```

`bash -n scripts/bootstrap.sh` clean.

**Gate:** lane V passed, verify `bash -n scripts/bootstrap.sh` ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)