### PR TITLE
ci(fleet): one host list, daily drift detection, release-triggered rollout

### DIFF
--- a/.github/actions/fleet-ssh/action.yml
+++ b/.github/actions/fleet-ssh/action.yml
@@ -1,0 +1,38 @@
+# Write the fleet SSH key and a matching ssh_config. Used by every workflow
+# that reaches a tenant, so key handling lives in exactly one place.
+#
+# The key is an explicit input, not read from the caller's env: composite
+# actions do not reliably inherit the calling job's env into `${{ env.* }}`.
+name: fleet-ssh
+description: Configure SSH for alfred-black tenants
+inputs:
+  key:
+    description: Private half of ~/.ssh/alfred-black-verify (pass secrets.FLEET_SSH_KEY)
+    required: true
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        FLEET_SSH_KEY: ${{ inputs.key }}
+      run: |
+        set -euo pipefail
+        if [ -z "${FLEET_SSH_KEY:-}" ]; then
+          echo "FAIL: fleet-ssh needs the 'key' input (secrets.FLEET_SSH_KEY)." >&2
+          exit 1
+        fi
+        mkdir -p ~/.ssh
+        printf '%s\n' "$FLEET_SSH_KEY" > ~/.ssh/alfred-black-verify
+        chmod 600 ~/.ssh/alfred-black-verify
+        # accept-new rather than a pinned host key: tenant host keys rotate
+        # whenever a VM is reprovisioned.
+        {
+          echo "Host *.alfred.black"
+          echo "  User root"
+          echo "  IdentityFile ~/.ssh/alfred-black-verify"
+          echo "  IdentitiesOnly yes"
+          echo "  StrictHostKeyChecking accept-new"
+          echo "  ConnectTimeout 20"
+          echo "  ServerAliveInterval 15"
+        } > ~/.ssh/config
+        chmod 600 ~/.ssh/config

--- a/.github/fleet-hosts.txt
+++ b/.github/fleet-hosts.txt
@@ -1,0 +1,22 @@
+# The canonical alfred-black fleet. ONE list — every workflow that touches
+# tenants reads this file rather than carrying its own copy.
+#
+# Why this file exists: the tenant list used to be hard-coded separately in
+# each workflow. cratchit was added to none of them, so for a month it
+# received no image, compose, Caddyfile or .env.example update and drifted
+# far enough that bringing it current crash-looped a service. rami was in
+# the config-sync list but no image rollout reached it. A single list makes
+# "we forgot a tenant" a one-line diff instead of an invisible omission.
+#
+# One host per line, without the .alfred.black suffix. Blank lines and
+# lines starting with # are ignored.
+#
+# Adding a tenant here puts it in scope for: config sync (deploy-compose),
+# drift detection (fleet-drift), and release rollout (deploy-release).
+home
+rj
+joe
+zsolt
+miguel
+rami
+cratchit

--- a/.github/scripts/deploy-tenant.sh
+++ b/.github/scripts/deploy-tenant.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Deploy the current :latest images to one tenant and VERIFY it converged.
+#
+# Usage: deploy-tenant.sh <host.alfred.black>
+#
+# A deploy that reports success without checking is how a fleet ends up ten
+# days into a restart loop with nobody the wiser, so this runs the same
+# read-only drift check afterwards and fails if the tenant did not land clean.
+set -uo pipefail
+host="${1:?usage: deploy-tenant.sh <host>}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "═══ ${host}"
+
+if ! ssh -o BatchMode=yes "$host" 'echo ok' >/dev/null 2>&1; then
+  echo "  UNREACHABLE"
+  { echo "### :x: ${host} — unreachable"; } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+  exit 1
+fi
+
+ssh -o BatchMode=yes "$host" '
+  set -euo pipefail
+  cd /opt/alfred
+  # Validate before doing anything that restarts a container.
+  docker compose -p alfred-black config --quiet
+  docker compose -p alfred-black pull
+  docker compose -p alfred-black up -d
+' 2>&1 | grep -iE 'Pulled|Recreated|Started|Error|error' | sed 's/^/    /'
+rc=${PIPESTATUS[0]}
+
+if [ "$rc" -ne 0 ]; then
+  echo "  DEPLOY FAILED (rc=$rc)"
+  { echo "### :x: ${host} — deploy failed"; } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+  exit 1
+fi
+
+# Settle before verifying — containers need a moment to report healthy.
+sleep 30
+
+report=$(ssh -o BatchMode=yes "$host" 'bash -s' < "${here}/tenant-drift-check.sh" 2>&1)
+vrc=$?
+if [ "$vrc" -eq 0 ]; then
+  echo "  VERIFIED clean"
+  { echo "### :white_check_mark: ${host} — deployed and verified"; } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+else
+  echo "  DID NOT CONVERGE: ${report}"
+  {
+    echo "### :warning: ${host} — deployed but did not converge"
+    echo '```'; echo "$report"; echo '```'
+  } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+fi
+exit "$vrc"

--- a/.github/scripts/tenant-drift-check.sh
+++ b/.github/scripts/tenant-drift-check.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Read-only drift check, run ON a tenant via `ssh <host> 'bash -s' < this`.
+#
+# Exits 0 and prints CLEAN when the tenant matches what the registry serves
+# and everything is running. Exits 1 and prints one line per problem
+# otherwise. Makes no changes: no pull, no up -d, no writes.
+set -uo pipefail
+drift=0
+
+# 1. Services that are not running. Catches the missing-env-key crash loops
+#    that bit two tenants on 2026-08-17 (mcp-server without TRUST_PROXY_HOPS,
+#    voice-bridge without VOICE_BRIDGE_INTERNAL_TOKEN).
+bad=$(docker compose -p alfred-black ps --format '{{.Service}} {{.State}}' 2>/dev/null \
+      | grep -v ' running' | awk '{print $1}' | tr '\n' ' ')
+if [ -n "$bad" ]; then echo "NOT RUNNING: $bad"; drift=1; fi
+
+# 2. Containers in a restart loop. A healthy container sits near 0; the
+#    hermes dashboard loop reached 5,747 over ten days without anyone
+#    noticing. 20 is comfortably clear of a legitimate flap.
+loops=$(for c in $(docker ps -q 2>/dev/null); do
+          n=$(docker inspect --format '{{.RestartCount}}' "$c" 2>/dev/null || echo 0)
+          if [ "$n" -gt 20 ]; then
+            echo "$(docker inspect --format '{{.Name}}' "$c" | tr -d /)=$n"
+          fi
+        done | tr '\n' ' ')
+if [ -n "$loops" ]; then echo "RESTART LOOP: $loops"; drift=1; fi
+
+# 3. Images behind what the registry serves.
+stale=""
+for img in alfred-learn alfred-worker alfred-ctrl-api alfred-black-hermes \
+           alfred-mcp-server alfred-web alfred-web-client alfred-vault-init \
+           alfred-black-paperclip alfred-voice-bridge alfred-init; do
+  full="ssdavidai00/${img}:latest"
+  rd=$(docker image inspect --format '{{if .RepoDigests}}{{index .RepoDigests 0}}{{end}}' "$full" 2>/dev/null \
+       | sed 's/.*@//' | cut -c8-19)
+  [ -z "$rd" ] && continue
+  tok=$(curl -fsS "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ssdavidai00/${img}:pull" 2>/dev/null \
+        | sed -E 's/.*"token":"([^"]+)".*/\1/')
+  [ -z "$tok" ] && continue
+  reg=$(curl -fsS -H "Authorization: Bearer ${tok}" \
+             -H "Accept: application/vnd.docker.distribution.manifest.v2+json,application/vnd.oci.image.index.v1+json" \
+             -I "https://registry-1.docker.io/v2/ssdavidai00/${img}/manifests/latest" 2>/dev/null \
+        | grep -i '^docker-content-digest' | tr -d '\r' | sed 's/.*sha256://' | cut -c1-12)
+  # A registry lookup that fails is not drift — say nothing rather than cry wolf.
+  [ -z "$reg" ] && continue
+  [ "$rd" != "$reg" ] && stale="${stale} ${img}"
+done
+if [ -n "$stale" ]; then echo "IMAGES BEHIND:$stale"; drift=1; fi
+
+[ "$drift" -eq 0 ] && echo "CLEAN"
+exit "$drift"

--- a/.github/workflows/deploy-compose.yml
+++ b/.github/workflows/deploy-compose.yml
@@ -48,28 +48,31 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # The tenant list lives in .github/fleet-hosts.txt — ONE list, read by every
+  # workflow that touches tenants. It used to be hard-coded here; cratchit was
+  # never added to it and silently received nothing for a month.
+  hosts:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.read.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: read
+        run: |
+          set -euo pipefail
+          matrix=$(grep -vE '^[[:space:]]*(#|$)' .github/fleet-hosts.txt \
+                   | sed 's/$/.alfred.black/' | jq -R . | jq -sc .)
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
   sync:
+    needs: hosts
     runs-on: ubuntu-latest
     strategy:
       # Don't abort the other tenants if one fails — partial rollout is
       # better than no rollout, and the summary makes the gap obvious.
       fail-fast: false
       matrix:
-        tenant:
-          - home.alfred.black
-          - rj.alfred.black
-          - joe.alfred.black
-          - zsolt.alfred.black
-          - miguel.alfred.black
-          - rami.alfred.black
-          # cratchit is its own VM, not a profile on joe (the `hermes-cratchit`
-          # container ON joe is a different thing). It was absent from every
-          # workflow until 2026-08-17, so it never received a compose, Caddyfile
-          # or .env.example update and silently fell behind on every merge —
-          # far enough that it was still running the caddy healthcheck #661
-          # removed, and its .env was missing TRUST_PROXY_HOPS, which crash-looped
-          # mcp-server the moment its images were brought current.
-          - cratchit.alfred.black
+        tenant: ${{ fromJSON(needs.hosts.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -1,0 +1,102 @@
+# Ship a published GitHub release to the ENTIRE fleet.
+#
+# Why this exists
+# ---------------
+# Day-to-day image rollout is deliberately narrow: deploy-fleet ships only to
+# the canary (ALFRED_FLEET_HOSTS, default `home`) so a bad merge cannot reach a
+# client tenant by itself. Nothing then moved the rest of the fleet, so client
+# tenants only advanced when somebody rolled them by hand — which, as of
+# 2026-08-17, nobody had for long enough that four of them were ten days into a
+# restart loop and one was a month behind on everything.
+#
+# A tagged release is the deliberate act that was missing. Cutting one means
+# "this is good enough for clients", so that is when the fleet moves.
+#
+# Order is canary-then-fleet, not all-at-once:
+#   1. home deploys and is verified. If home fails, NOTHING else is touched.
+#   2. the remaining tenants deploy serially, each verified before the next.
+# One failing tenant does not abort the others at that point — a partial
+# rollout with a loud summary beats a fleet frozen halfway.
+#
+# Each tenant is verified with the same read-only check fleet-drift runs, so a
+# deploy that silently fails to converge is reported rather than assumed good.
+name: deploy-release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      hosts:
+        description: 'Comma-separated hosts (default: the whole fleet)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  hosts:
+    runs-on: ubuntu-latest
+    outputs:
+      canary: ${{ steps.read.outputs.canary }}
+      rest: ${{ steps.read.outputs.rest }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: read
+        run: |
+          set -euo pipefail
+          if [ -n "${{ github.event.inputs.hosts }}" ]; then
+            all=$(echo "${{ github.event.inputs.hosts }}" | tr ',' '\n' | sed 's/[[:space:]]//g' | grep -v '^$')
+          else
+            all=$(grep -vE '^[[:space:]]*(#|$)' .github/fleet-hosts.txt)
+          fi
+          canary=$(echo "$all" | grep -x home || true)
+          rest=$(echo "$all" | grep -vx home || true)
+          echo "canary=${canary}" >> "$GITHUB_OUTPUT"
+          echo "rest=$(echo "$rest" | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Release rollout"
+            echo "- canary: \`${canary:-<none>}\`"
+            echo "- then: \`$(echo "$rest" | tr '\n' ' ')\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  canary:
+    needs: hosts
+    if: needs.hosts.outputs.canary != ''
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/fleet-ssh
+        with:
+          key: ${{ secrets.FLEET_SSH_KEY }}
+      - name: Deploy + verify the canary
+        run: .github/scripts/deploy-tenant.sh "${{ needs.hosts.outputs.canary }}.alfred.black"
+
+  fleet:
+    needs: [hosts, canary]
+    # Runs only if the canary was clean. If home cannot take the release,
+    # no client tenant should.
+    if: needs.hosts.outputs.rest != ''
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/fleet-ssh
+        with:
+          key: ${{ secrets.FLEET_SSH_KEY }}
+      - name: Deploy + verify the rest, serially
+        run: |
+          set -uo pipefail
+          failed=""
+          for h in ${{ needs.hosts.outputs.rest }}; do
+            if .github/scripts/deploy-tenant.sh "${h}.alfred.black"; then
+              echo "  OK $h"
+            else
+              echo "  FAILED $h"; failed="$failed $h"
+            fi
+          done
+          if [ -n "$failed" ]; then
+            echo "### :x: failed:$failed" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          echo "### :white_check_mark: whole fleet on the release" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/fleet-drift.yml
+++ b/.github/workflows/fleet-drift.yml
@@ -1,0 +1,91 @@
+# Detect fleet drift. REPORTS, never deploys.
+#
+# Why this exists
+# ---------------
+# Image rollout is deliberately narrow: deploy-fleet ships only to the canary
+# (ALFRED_FLEET_HOSTS, default `home`) so a bad merge cannot reach a client
+# tenant on its own. That is the right default. But narrow rollout with no
+# detection means every other tenant rots silently, and on 2026-08-17 we found
+# out how far it had gone:
+#
+#   * one tenant appeared in NO workflow and had received nothing for a month.
+#     Its compose still carried a caddy healthcheck removed weeks earlier,
+#     leaking one PID slot per probe.
+#   * another was in the config-sync list but no image rollout ever reached it.
+#   * four tenants had been restarting their hermes container every ~3 minutes
+#     for TEN DAYS — 4,600-5,700 restarts each — and nothing said a word.
+#
+# None of it was hard to find. Nothing was looking. This job looks, daily, and
+# fails loudly when a tenant has fallen behind; notify-telegram picks the
+# failure up, so drift reaches Sir instead of waiting to be stumbled over.
+#
+# Strictly read-only. Fixing drift stays a deliberate human act.
+name: fleet-drift
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  hosts:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.read.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: read
+        name: Read the canonical fleet list
+        run: |
+          set -euo pipefail
+          matrix=$(grep -vE '^[[:space:]]*(#|$)' .github/fleet-hosts.txt \
+                   | sed 's/$/.alfred.black/' | jq -R . | jq -sc .)
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "Fleet under check: \`$matrix\`" >> "$GITHUB_STEP_SUMMARY"
+
+  check:
+    needs: hosts
+    runs-on: ubuntu-latest
+    strategy:
+      # One drifted tenant must not hide the state of the others.
+      fail-fast: false
+      matrix:
+        tenant: ${{ fromJSON(needs.hosts.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/fleet-ssh
+        with:
+          key: ${{ secrets.FLEET_SSH_KEY }}
+
+      - name: Check ${{ matrix.tenant }}
+        run: |
+          set -uo pipefail
+          host='${{ matrix.tenant }}'
+
+          if ! ssh -o BatchMode=yes "$host" 'echo ok' >/dev/null 2>&1; then
+            echo "### :x: $host — UNREACHABLE" >> "$GITHUB_STEP_SUMMARY"
+            echo "$host unreachable" >&2
+            exit 1
+          fi
+
+          report=$(ssh -o BatchMode=yes "$host" 'bash -s' < .github/scripts/tenant-drift-check.sh 2>&1)
+          rc=$?
+
+          if [ "$rc" -eq 0 ]; then
+            echo "### :white_check_mark: $host — clean" >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "### :warning: $host — DRIFT"
+              echo '```'
+              echo "$report"
+              echo '```'
+              echo "Roll it with: \`ssh root@$host 'cd /opt/alfred && docker compose pull && docker compose up -d'\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          echo "$report"
+          exit "$rc"


### PR DESCRIPTION
## Why

Three related gaps, all surfaced together on 2026-08-17.

### 1. The tenant list was hard-coded per workflow

One tenant had been added to **none** of them. For a month it received no image, compose, Caddyfile or `.env.example` update. It drifted far enough that:

- its compose still carried the caddy healthcheck **#661 removed** — leaking a PID slot per probe
- its `.env` had never been given `TRUST_PROXY_HOPS`, so bringing its images current crash-looped mcp-server

A second tenant was in the config-sync list but no image rollout ever reached it.

**Now:** `.github/fleet-hosts.txt` is the single list, read by `deploy-compose`, `fleet-drift` and `deploy-release`. Forgetting a tenant becomes a one-line diff instead of an invisible omission.

### 2. Narrow rollout with no detection

Shipping images only to the canary is the right default — a bad merge must not reach a client tenant by itself. But nothing watched the tenants deliberately left behind, so four of them sat restarting hermes every ~3 minutes for **ten days** (4,600–5,700 restarts each) and nothing said a word.

`fleet-drift` runs daily, strictly read-only, and fails when a tenant has services down, a container in a restart loop, or images behind the registry. A failing run is picked up by `notify-telegram`, so drift arrives rather than waiting to be stumbled over.

### 3. Nothing ever moved the rest of the fleet

Client tenants only advanced when somebody rolled them by hand. A tagged release is the deliberate "good enough for clients" act that was missing.

`deploy-release` fires on `release: published` and ships to everyone — **canary first**. If home cannot take the release, nothing else is touched. The remaining tenants then go serially, each verified before the next; one failure does not abort the rest.

## Design notes

- **Every deploy verifies.** `deploy-tenant.sh` runs the same read-only check `fleet-drift` uses, after the deploy, so a deploy that silently fails to converge is reported rather than assumed good.
- **Shared SSH handling** is one composite action. The key is an explicit **input**, not read from the caller's env — composite actions do not reliably inherit `${{ env.* }}`.
- **A registry lookup that fails is not drift.** The check skips rather than crying wolf.
- **Restart-loop threshold is 20.** A healthy container sits near 0; the loop that went unnoticed reached 5,747.

## Smoke evidence

**Generated matrix is byte-identical to the static list it replaces:**
```
resolved: ['home.alfred.black','rj.alfred.black','joe.alfred.black','zsolt.alfred.black',
           'miguel.alfred.black','rami.alfred.black','cratchit.alfred.black']
identical to previous static list: True
```

**The drift check was run for real against live tenants** (read-only, no mutations):
```
home     -> exit=0  CLEAN
cratchit -> exit=0  CLEAN
```

**True positives:** these are the same three checks, run by hand earlier today, that found every problem above — `IMAGES BEHIND: alfred-black-hermes` on five tenants, `NOT RUNNING: mcp-server` on cratchit, and restart counts of 4,790 / 4,649 on two others. The logic is not speculative; it is what caught them.

All YAML parses; `bash -n` clean on both scripts.

**Gate:** phase0 (orchestrator) passed — 389 LOC, 7 files.

## Follow-up, deliberately not here

`deploy-fleet`'s `ALFRED_FLEET_HOSTS` still defaults to `home`, and that stays — per-merge rollout to clients is exactly what this PR argues against. Releases and manual rolls are the paths to the fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)