### PR TITLE
fix(vault): route pre-cutover types onto canonical ones; stop a 422 killing the curator

### DIFF
--- a/packages/alfred-vault/src/alfred/surveyor/labeler.py
+++ b/packages/alfred-vault/src/alfred/surveyor/labeler.py
@@ -116,11 +116,14 @@ def _first_balanced_span(text: str) -> str | None:
 # cluster contains one of these, its filename stem becomes a canonical
 # cluster tag so every member inherits the entity slug and downstream
 # consumers can match on `alfred_tags: [<entity-slug>]`.
-# bug #13: "matter" was listed here but is NOT a canonical vault KNOWN_TYPE
-# (see alfred.vault.schema.KNOWN_TYPES). If the cluster path ever fired on a
-# "matter"-typed record it would write `related_matters` links pointing at a
-# type the rest of the system rejects. Only canonical entity types belong here.
-ENTITY_RECORD_TYPES = frozenset({"person", "org", "project"})
+# bug #13 got this backwards, and the correction is the point of this comment.
+# It observed "matter" here, saw that schema.KNOWN_TYPES had no "matter", and
+# removed "matter" — keeping "project". The premise was the stale half: this
+# daemon's KNOWN_TYPES predated the four-store cutover, and `matter` is the
+# canonical type while `project` is the name it replaced. ctrl-api rejects
+# `project` with 422, so the cluster path was writing `related_project` links
+# at a type the rest of the system refuses. Reversed here.
+ENTITY_RECORD_TYPES = frozenset({"person", "org", "matter"})
 
 
 def _slug_from_rel_path(rel_path: str) -> str:

--- a/packages/alfred-vault/src/alfred/vault/ops.py
+++ b/packages/alfred-vault/src/alfred/vault/ops.py
@@ -12,10 +12,13 @@ from datetime import date
 from pathlib import Path
 
 import frontmatter
+import httpx
 import yaml
 
 from . import obsidian
 from .schema import (
+    CANONICAL_VAULT_TYPES,
+    TYPE_ALIASES,
     KNOWN_TYPES,
     LIST_FIELDS,
     NAME_FIELD_BY_TYPE,
@@ -387,6 +390,10 @@ def vault_create(
     body: str | None = None,
 ) -> dict:
     """Create a new vault record. Returns {path, warnings}."""
+    # Pre-cutover name -> canonical, before anything downstream sees the type.
+    # The curator's extraction skill still emits `project` and `location`.
+    record_type = TYPE_ALIASES.get(record_type, record_type)
+
     _validate_type(record_type)
     set_fields = set_fields or {}
 
@@ -395,8 +402,36 @@ def vault_create(
     # contract/index/signal.
     from alfred.ctrl_client import ctrl_create, via_ctrl_enabled
     if via_ctrl_enabled():
+        # ctrl accepts only the canonical 13. A type outside that set is a
+        # PERMANENT rejection, not a transient one — retrying cannot help. Fail
+        # as VaultError so callers that already skip-and-continue on VaultError
+        # (curator._resolve_entities) drop the one entity instead of losing the
+        # whole pipeline run to an escaping httpx exception.
+        if record_type not in CANONICAL_VAULT_TYPES:
+            raise VaultError(
+                f"Type '{record_type}' is not a canonical vault type and cannot "
+                f"be written to the vault. Canonical: "
+                f"{', '.join(sorted(CANONICAL_VAULT_TYPES))}. "
+                "Demoted types belong in alfred-state.db via ctrl-api's state "
+                "routes, not in the principal's vault."
+            )
         rendered = _render_new_record(vault_path, record_type, name, set_fields, body)
-        out = ctrl_create(record_type, name, rendered)
+        try:
+            out = ctrl_create(record_type, name, rendered)
+        except httpx.HTTPStatusError as exc:
+            # Never let a raw HTTP error escape the vault layer: callers catch
+            # VaultError, so an HTTPStatusError kills whatever pipeline is
+            # running. This is exactly how one rejected entity took down every
+            # curator run for six days.
+            detail = ""
+            try:
+                detail = exc.response.json().get("error", {}).get("message", "")
+            except Exception:  # noqa: BLE001
+                detail = (exc.response.text or "")[:200]
+            raise VaultError(
+                f"ctrl rejected create of {record_type}/{name}: "
+                f"HTTP {exc.response.status_code}. {detail}"
+            ) from exc
         return {"path": out["path"], "warnings": []}
 
     # Determine directory and path

--- a/packages/alfred-vault/src/alfred/vault/schema.py
+++ b/packages/alfred-vault/src/alfred/vault/schema.py
@@ -4,6 +4,28 @@ from __future__ import annotations
 
 # --- Known record types and their valid statuses ---
 
+# The ONLY record types ctrl-api will accept on POST /api/v1/vault/records.
+# MUST stay identical to the allowed list in
+# packages/ctrl/src/db/promotionContract.ts — ctrl is the enforcing side, and a
+# type that is in KNOWN_TYPES but not here fails at the network boundary with a
+# 422, not locally.
+CANONICAL_VAULT_TYPES: set[str] = {
+    "matter", "task", "note", "person", "org", "place", "asset",
+    "chore", "instinct", "decision", "briefing", "daybook", "commitment",
+}
+
+# Pre-cutover names and the canonical types that replaced them.
+#
+# This daemon's vocabulary predates the four-store cutover. `project` is what a
+# `matter` used to be called and `location` is what a `place` used to be called;
+# the curator's extraction skill still teaches the old names, so every extracted
+# project was POSTed as type `project` and rejected. Applied in vault_create
+# before anything downstream sees the type.
+TYPE_ALIASES: dict[str, str] = {
+    "project": "matter",
+    "location": "place",
+}
+
 KNOWN_TYPES: set[str] = {
     "project", "task", "session", "input", "person", "org",
     "location", "note", "decision", "process", "run", "event",
@@ -16,6 +38,10 @@ KNOWN_TYPES: set[str] = {
     # and where it is in its lifecycle. The unit the commitment register
     # reconciles against.
     "commitment",
+    # Canonical types the pre-cutover vocabulary had no name for. Without these
+    # the daemon cannot create the vault's central record at all: there was no
+    # `matter` in KNOWN_TYPES, so nothing here could author one.
+    "matter", "place", "chore", "briefing", "daybook",
 }
 
 LEARN_TYPES: set[str] = {
@@ -61,6 +87,13 @@ STATUS_BY_TYPE: dict[str, set[str]] = {
     # daemon has no business enforcing that state machine, so `status` stays
     # the same four-value rollup every other reader already understands.
     "commitment": {"todo", "active", "blocked", "done"},
+    # Matter's principal-facing lifecycle. Deliberately NOT project's old set:
+    # `paused`/`abandoned`/`proposed` are not states a matter can be in.
+    "matter": {"active", "dormant", "completed", "archived"},
+    "place": {"active", "inactive"},
+    "chore": set(),      # schedule state lives in Temporal, not frontmatter
+    "briefing": set(),
+    "daybook": set(),
 }
 
 # Type → expected top-level directory
@@ -84,6 +117,11 @@ TYPE_DIRECTORY: dict[str, str] = {
     "synthesis": "synthesis",
     "instinct": "instinct",
     "commitment": "commitment",
+    "matter": "matter",
+    "place": "place",
+    "chore": "chore",
+    "briefing": "briefing",
+    "daybook": "daybook",
     # session, input have flexible placement
 }
 

--- a/packages/alfred-vault/tests/test_canonical_type_routing.py
+++ b/packages/alfred-vault/tests/test_canonical_type_routing.py
@@ -1,0 +1,134 @@
+"""The curator died for six days on a type ctrl-api will never accept.
+
+`_resolve_entities` extracted an entity of type `project`, `vault_create`
+POSTed it, ctrl-api answered 422 PROMOTION_CONTRACT_VIOLATION, and httpx raised
+`HTTPStatusError`. The caller catches `VaultError`, so the HTTP exception blew
+straight past the skip-and-continue handler and killed the whole pipeline run —
+after the file had already been moved into inbox/processed/, so it was never
+retried and the failure was invisible.
+
+Two independent defects, one per class of test below:
+  1. the daemon's vocabulary disagreed with ctrl's (project/location vs
+     matter/place), and had no name for `matter` at all;
+  2. a permanent, non-retryable rejection escaped the vault layer as an HTTP
+     exception instead of a VaultError.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import httpx
+import pytest
+
+from alfred.vault.ops import VaultError, vault_create
+from alfred.vault.schema import (
+    CANONICAL_VAULT_TYPES,
+    KNOWN_TYPES,
+    TYPE_ALIASES,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CTRL_CONTRACT = REPO_ROOT / "packages/ctrl/src/db/promotionContract.ts"
+
+
+# --- 1. the two vocabularies must agree -----------------------------------
+
+def test_canonical_set_matches_ctrl_api_exactly():
+    """The seam that broke. ctrl-api is the enforcing side; if this daemon's
+    idea of canonical drifts from ctrl's, every write of the drifted type
+    fails at the network boundary rather than locally."""
+    if not CTRL_CONTRACT.exists():
+        pytest.skip("ctrl package not present (alfred-vault installed standalone)")
+    src = CTRL_CONTRACT.read_text()
+    block = re.search(
+        r"export const CANONICAL_RECORD_TYPES = \[(.*?)\]", src, re.S
+    )
+    assert block, "could not find CANONICAL_RECORD_TYPES in ctrl's promotionContract.ts"
+    ctrl_types = set(re.findall(r'"([a-z_]+)"', block.group(1)))
+    assert ctrl_types == CANONICAL_VAULT_TYPES, (
+        "alfred-vault and ctrl-api disagree about the canonical vault types.\n"
+        f"  only in ctrl:         {sorted(ctrl_types - CANONICAL_VAULT_TYPES)}\n"
+        f"  only in alfred-vault: {sorted(CANONICAL_VAULT_TYPES - ctrl_types)}"
+    )
+
+
+def test_every_canonical_type_is_nameable_by_this_daemon():
+    """`matter` was absent from KNOWN_TYPES, so the daemon could not author the
+    vault's central record type at all."""
+    assert CANONICAL_VAULT_TYPES <= KNOWN_TYPES, (
+        f"canonical types this daemon cannot name: "
+        f"{sorted(CANONICAL_VAULT_TYPES - KNOWN_TYPES)}"
+    )
+
+
+def test_aliases_map_pre_cutover_names_onto_canonical_ones():
+    assert TYPE_ALIASES["project"] == "matter"
+    assert TYPE_ALIASES["location"] == "place"
+    for old, new in TYPE_ALIASES.items():
+        assert new in CANONICAL_VAULT_TYPES, f"{old} aliases to non-canonical {new}"
+        assert old not in CANONICAL_VAULT_TYPES, f"{old} is canonical; do not alias it"
+
+
+# --- 2. a permanent rejection must not escape as an HTTP exception --------
+
+class _FakeResponse:
+    status_code = 422
+
+    @staticmethod
+    def json():
+        return {"error": {"message": 'Record type "project" is not a canonical vault type.'}}
+
+    text = "422"
+
+
+def test_http_rejection_is_translated_to_vaulterror(monkeypatch, tmp_path):
+    """An HTTPStatusError escaping vault_create is what killed the pipeline:
+    callers catch VaultError, so the raw httpx error bypassed their handler."""
+    import alfred.ctrl_client as cc
+
+    def _boom(record_type, name, content):
+        raise httpx.HTTPStatusError(
+            "422", request=httpx.Request("POST", "http://ctrl/x"),
+            response=httpx.Response(422, json=_FakeResponse.json()),
+        )
+
+    monkeypatch.setattr(cc, "ctrl_create", _boom)
+    monkeypatch.setattr(cc, "via_ctrl_enabled", lambda: True)
+
+    with pytest.raises(VaultError) as exc:
+        vault_create(tmp_path, "matter", "Some Matter")
+    assert "422" in str(exc.value)
+
+
+def test_non_canonical_type_raises_vaulterror_not_http(monkeypatch, tmp_path):
+    """A demoted type is a permanent rejection. It must surface as VaultError so
+    the curator drops that one entity and keeps processing the file."""
+    import alfred.ctrl_client as cc
+
+    def _must_not_be_called(*a, **k):  # pragma: no cover
+        raise AssertionError("non-canonical type should never reach the network")
+
+    monkeypatch.setattr(cc, "ctrl_create", _must_not_be_called)
+    monkeypatch.setattr(cc, "via_ctrl_enabled", lambda: True)
+
+    with pytest.raises(VaultError) as exc:
+        vault_create(tmp_path, "assumption", "Some Assumption")
+    assert "not a canonical vault type" in str(exc.value)
+
+
+def test_project_is_routed_to_matter(monkeypatch, tmp_path):
+    """The exact failure: an extracted `project` entity now lands as a matter."""
+    import alfred.ctrl_client as cc
+    seen: dict = {}
+
+    def _capture(record_type, name, content):
+        seen["type"] = record_type
+        return {"path": f"{record_type}/{name}.md"}
+
+    monkeypatch.setattr(cc, "ctrl_create", _capture)
+    monkeypatch.setattr(cc, "via_ctrl_enabled", lambda: True)
+
+    out = vault_create(tmp_path, "project", "MOSZ Discovery", set_fields={"status": "active"})
+    assert seen["type"] == "matter", "project must be written as a matter"
+    assert out["path"].startswith("matter/")

--- a/packages/alfred-vault/tests/test_surveyor_entity_types.py
+++ b/packages/alfred-vault/tests/test_surveyor_entity_types.py
@@ -1,8 +1,13 @@
 """Bug #13 — surveyor `matter` phantom type.
 
-`labeler.ENTITY_RECORD_TYPES` listed "matter", but vault/schema.py KNOWN_TYPES
-has no "matter". If that path fired it would write `related_matters` links
-pointing at a type the rest of the system rejects (dead/poison code).
+Originally filed the wrong way round, and corrected here. Bug #13 saw "matter"
+in `labeler.ENTITY_RECORD_TYPES`, found no "matter" in vault/schema.py
+KNOWN_TYPES, and removed "matter" — keeping "project". But KNOWN_TYPES was the
+stale half: it predated the four-store cutover, where `matter` is the canonical
+type and `project` is the name it replaced. ctrl-api rejects `project` with 422
+PROMOTION_CONTRACT_VIOLATION, so the cluster path was writing `related_project`
+links at a type the system refuses — the very poison-link failure this test set
+out to prevent.
 
 NOTE on import strategy: `alfred.surveyor.labeler` imports `structlog` at
 module top — a heavy runtime dep that may not be in a minimal test env. We
@@ -16,19 +21,25 @@ from __future__ import annotations
 from alfred.vault.schema import KNOWN_TYPES
 
 # Expected value of labeler.ENTITY_RECORD_TYPES AFTER the fix (matter removed).
-EXPECTED_ENTITY_RECORD_TYPES = frozenset({"person", "org", "project"})
+EXPECTED_ENTITY_RECORD_TYPES = frozenset({"person", "org", "matter"})
 
 
 def test_entity_record_types_are_all_known_types():
-    """Every surveyor entity type must be a canonical KNOWN_TYPE, else any
-    `related_<type>` link it writes points at a type the system rejects."""
+    """Every surveyor entity type must be one ctrl-api will accept, else any
+    `related_<type>` link it writes points at a type the system rejects.
+    KNOWN_TYPES is too weak a bar — it still contains pre-cutover names."""
+    from alfred.vault.schema import CANONICAL_VAULT_TYPES
     assert EXPECTED_ENTITY_RECORD_TYPES <= KNOWN_TYPES
+    assert EXPECTED_ENTITY_RECORD_TYPES <= CANONICAL_VAULT_TYPES
 
 
-def test_matter_is_not_an_entity_record_type():
-    assert "matter" not in EXPECTED_ENTITY_RECORD_TYPES
-    # And the reason it must go: `matter` is not a canonical vault type.
-    assert "matter" not in KNOWN_TYPES
+def test_project_is_not_an_entity_record_type():
+    """`project` is the pre-cutover name. ctrl-api answers 422 for it, so a
+    `related_project` link is exactly the poison link bug #13 meant to stop."""
+    from alfred.vault.schema import CANONICAL_VAULT_TYPES
+    assert "project" not in EXPECTED_ENTITY_RECORD_TYPES
+    assert "project" not in CANONICAL_VAULT_TYPES
+    assert "matter" in CANONICAL_VAULT_TYPES
 
 
 def test_labeler_constant_matches_expected():


### PR DESCRIPTION
## The outage

The curator had been dead for **six days**, on every inbox file. Live on the dev tenant:

```
File "/app/src/alfred/curator/pipeline.py", line 506, in _resolve_entities
  result = vault_create(...)
File "/app/src/alfred/ctrl_client.py", line 81, in ctrl_create
  resp.raise_for_status()
httpx.HTTPStatusError: Client error '422 Unprocessable Entity'
  for url 'http://ctrl-api:3100/api/v1/vault/records'
```

`entity_type = 'project'`. ctrl-api answers:

```
PROMOTION_CONTRACT_VIOLATION
Record type "project" is not a canonical vault type.
Allowed: matter, task, note, person, org, place, asset, chore,
         instinct, decision, briefing, daybook, commitment
```

196 of these in the current container's lifetime.

## Two independent defects

**1. The vocabularies disagreed.** This daemon's `KNOWN_TYPES` predates the four-store cutover. `project` is what a `matter` used to be called, `location` what a `place` used to be called — and **`matter` was absent entirely**, so the daemon could not author the vault's central record type at all. Of the types it knows, 13 are not canonical.

**2. A permanent rejection escaped as an HTTP exception.** `curator._resolve_entities` already handles a failed entity correctly — it catches `VaultError`, logs, and moves on. It never got the chance: `HTTPStatusError` is not a `VaultError`, so the exception blew past the handler and killed the whole run — *after* the file had been moved into `inbox/processed/`, so it was never retried and the failure was silent.

Now: aliases applied before anything downstream sees the type; a non-canonical type refused **before the network** (a contract rejection is permanent — retrying cannot help); any 4xx translated to `VaultError`. One unusable entity costs one entity.

## Bug #13 was fixed backwards

It saw `matter` in `labeler.ENTITY_RECORD_TYPES`, found no `matter` in `KNOWN_TYPES`, and removed **`matter`** — keeping `project`. The premise was the stale half. Since that fix the cluster path has written `related_project` links at a type ctrl-api refuses — precisely the poison-link failure #13 set out to prevent. Reversed, along with the test that encoded it.

## Smoke evidence

**Verified red first.** With `TYPE_ALIASES` disabled, the new test fails on the exact production error:
```
E  VaultError: Type 'project' is not a canonical vault type...
FAILED tests/test_canonical_type_routing.py::test_project_is_routed_to_matter
1 failed, 5 passed
```

**Green with the fix:** `103 passed`.

**Reproduced the contract live** before writing anything (probe record deleted afterwards):
```
POST type=project -> 422 PROMOTION_CONTRACT_VIOLATION
POST type=matter  -> 201 {"path":"matter/…"}
```

## The test that matters

`test_canonical_set_matches_ctrl_api_exactly` parses `CANONICAL_RECORD_TYPES` out of ctrl's `promotionContract.ts` and asserts this daemon's set is identical. Both sides were individually correct and internally tested; **nothing checked that they agreed**, which is the entire reason this shipped. It skips cleanly when ctrl is absent so alfred-vault stays installable standalone.

## Two things reviewers should know

- **CI does not run these tests.** `ci-check` runs pytest for `packages/learn` only; alfred-vault's 103 tests run nowhere in CI. That is how the backwards #13 fix survived. Fixing that is a separate phase0 PR — worth doing before trusting this lane again.
- **The skill packs still teach `project`.** The type map means the model's `project` output now lands as a `matter`, so the curator works. Retraining the packs is a follow-up PR (it is ~980 LOC of renames, over the lane's CI cap in one go).

🤖 Generated with [Claude Code](https://claude.com/claude-code)