### PR TITLE
ci: run alfred-vault's tests — nothing did until now

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -182,6 +182,30 @@ jobs:
         if: steps.vb.outputs.changed != 'true'
         run: echo "voice-bridge unchanged in this PR — test not applicable, passing."
 
+  # packages/alfred-vault's 103 tests ran NOWHERE in CI until 2026-08-19. The
+  # lane gate's local pre-commit hook was the only thing executing them, on a
+  # developer's machine, and the worktree harness has historically disarmed it.
+  #
+  # That gap is how bug #13 shipped BACKWARDS: it removed `matter` from the
+  # surveyor's entity types (the canonical type) and kept `project` (the one
+  # ctrl-api rejects), with a test asserting the mistake. Nothing re-ran it.
+  pytest-alfred-vault:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install deps
+        working-directory: packages/alfred-vault
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e . || pip install -r requirements.txt || true
+          pip install pytest numpy
+      - name: pytest
+        working-directory: packages/alfred-vault
+        run: python -m pytest -q
+
   pytest-learn:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -198,10 +198,14 @@ jobs:
           python-version: "3.11"
       - name: Install deps
         working-directory: packages/alfred-vault
+        # Use the extras the package itself declares rather than a hand-picked
+        # list. `surveyor` pulls pymilvus/igraph/leidenalg/scikit-learn/numpy —
+        # without them those six test modules fail to import and pytest reports
+        # a collection error, which is the failure mode this job exists to
+        # catch rather than skip.
         run: |
           python -m pip install --upgrade pip
-          pip install -e . || pip install -r requirements.txt || true
-          pip install pytest numpy
+          pip install -e ".[surveyor,test]"
       - name: pytest
         working-directory: packages/alfred-vault
         run: python -m pytest -q


### PR DESCRIPTION
## The gap

`packages/alfred-vault` has **103 tests**. `ci-check` runs pytest for `packages/learn` only, so **none of them ran in CI**. The lane gate's local pre-commit hook was the only thing executing them — on a developer's machine, and the worktree harness has historically rewritten `core.hooksPath` and disarmed it for weeks at a time (CLAUDE.md §11.3).

## Why it matters, concretely

This is how **bug #13 shipped backwards**. It observed `matter` in the surveyor's `ENTITY_RECORD_TYPES`, found no `matter` in `KNOWN_TYPES`, and concluded matter was the phantom — removing the *canonical* type and keeping `project`, the one ctrl-api rejects with 422. It shipped **with a test asserting the mistake**, and nothing ever re-ran that test against reality.

Found while fixing the six-day curator outage (#673–#676).

## Note on numpy

Installed explicitly because the surveyor tests import it. Without it pytest **skips their collection** — the suite silently shrinks from 103 to 97 and reports green either way. A test job that quietly stops running six tests is worse than no job, because it looks like coverage.

## Smoke evidence

```
YAML OK; pytest jobs: ['pytest-alfred-vault', 'pytest-learn']
```

Locally, `python -m pytest -q` in `packages/alfred-vault` → `103 passed` with numpy present, `97 passed + 6 collection errors` without — which is exactly the failure mode this job is pinned against.

The job's real proof is this PR's own CI run: it either goes green on all 103, or it tells us something in that package has been broken for a while without anyone knowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)