### PR TITLE
fix(surveyor): finish the project→matter change; these tests had never run

### DIFF
--- a/packages/alfred-vault/src/alfred/surveyor/daemon.py
+++ b/packages/alfred-vault/src/alfred/surveyor/daemon.py
@@ -324,7 +324,7 @@ class Daemon:
         # Stage 5: structured entity-link writeback. For each cluster whose
         # membership changed, walk non-entity members and add typed
         # frontmatter links (related_matters / related_persons / related_orgs
-        # / related_projects) to any entity member of the same cluster whose
+        # / related_matters) to any entity member of the same cluster whose
         # cosine similarity is above the configured threshold.
         self._link_entities_in_clusters(
             all_changed, cluster_members, records, paths, vectors,
@@ -384,7 +384,6 @@ class Daemon:
             "matter": self.writer.write_related_matters,
             "person": self.writer.write_related_persons,
             "org": self.writer.write_related_orgs,
-            "project": self.writer.write_related_projects,
         }
 
         threshold = self.cfg.entity_link.threshold
@@ -494,7 +493,6 @@ class Daemon:
             "matter": self.writer.write_related_matters,
             "person": self.writer.write_related_persons,
             "org": self.writer.write_related_orgs,
-            "project": self.writer.write_related_projects,
         }
 
         threshold = self.cfg.entity_link.threshold
@@ -586,7 +584,6 @@ class Daemon:
             "matter": self.writer.write_related_matters,
             "person": self.writer.write_related_persons,
             "org": self.writer.write_related_orgs,
-            "project": self.writer.write_related_projects,
         }
 
         threshold = self.cfg.entity_link.threshold

--- a/packages/alfred-vault/src/alfred/surveyor/writer.py
+++ b/packages/alfred-vault/src/alfred/surveyor/writer.py
@@ -149,17 +149,6 @@ class VaultWriter:
             rel_path, "related_orgs", org_paths, max_total
         )
 
-    def write_related_projects(
-        self,
-        rel_path: str,
-        project_paths: list[str],
-        max_total: int | None = None,
-    ) -> int:
-        """Append project vault paths to `related_projects` frontmatter."""
-        return self._append_to_list_field(
-            rel_path, "related_projects", project_paths, max_total
-        )
-
     def write_relationships(self, rel_path: str, new_rels: list[dict]) -> None:
         """Append machine-generated relationships (only those with confidence < 1.0).
 

--- a/packages/alfred-vault/tests/surveyor/test_cli_entity_linking_scan.py
+++ b/packages/alfred-vault/tests/surveyor/test_cli_entity_linking_scan.py
@@ -27,7 +27,7 @@ def test_counts_related_fields_across_types(tmp_path):
     _w(vault, "event/a.md",
        "---\ntype: event\nrelated_matters: [matter/m.md]\nrelated_persons: [person/p.md]\n---\nbody\n")
     _w(vault, "event/b.md",
-       "---\ntype: event\nrelated_orgs: [org/o.md]\nrelated_projects: [project/x.md]\n---\nbody\n")
+       "---\ntype: event\nrelated_orgs: [org/o.md]\n---\nbody\n")
     _w(vault, "matter/m.md", "---\ntype: matter\n---\nbody\n")
 
     r = _scan_entity_linking_coverage(vault)
@@ -35,7 +35,6 @@ def test_counts_related_fields_across_types(tmp_path):
     assert r["records_with_related_matters"] == 1
     assert r["records_with_related_persons"] == 1
     assert r["records_with_related_orgs"] == 1
-    assert r["records_with_related_projects"] == 1
     assert r["records_with_any_related"] == 2  # two events touched
 
 

--- a/packages/alfred-vault/tests/surveyor/test_daemon_backfill.py
+++ b/packages/alfred-vault/tests/surveyor/test_daemon_backfill.py
@@ -169,14 +169,13 @@ def test_backfill_respects_threshold(daemon_and_vault):
     assert "related_matters" not in frontmatter.load(vault / "event/e.md").metadata
 
 
-def test_backfill_all_four_entity_types(daemon_and_vault):
+def test_backfill_all_three_entity_types(daemon_and_vault):
     """Each entity type gets written to its own field."""
     daemon, vault = daemon_and_vault
     for rel, rt in [
         ("matter/m.md", "matter"),
         ("person/p.md", "person"),
         ("org/o.md", "org"),
-        ("project/x.md", "project"),
         ("event/e.md", "event"),
     ]:
         _write(vault, rel, rt)
@@ -184,7 +183,6 @@ def test_backfill_all_four_entity_types(daemon_and_vault):
         ("matter/m.md", "matter"),
         ("person/p.md", "person"),
         ("org/o.md", "org"),
-        ("project/x.md", "project"),
         ("event/e.md", "event"),
     ]}
     v = _norm([1.0, 0.0])
@@ -192,7 +190,7 @@ def test_backfill_all_four_entity_types(daemon_and_vault):
     vectors = np.asarray([v] * 5, dtype=np.float32)
 
     daemon._backfill_new_entities(
-        new_entity_paths=["matter/m.md", "person/p.md", "org/o.md", "project/x.md"],
+        new_entity_paths=["matter/m.md", "person/p.md", "org/o.md"],
         records=records,
         all_paths=paths,
         all_vectors=vectors,
@@ -202,7 +200,6 @@ def test_backfill_all_four_entity_types(daemon_and_vault):
     assert md["related_matters"] == ["matter/m.md"]
     assert md["related_persons"] == ["person/p.md"]
     assert md["related_orgs"] == ["org/o.md"]
-    assert md["related_projects"] == ["project/x.md"]
 
 
 def test_backfill_caps_max_per_record(tmp_path):

--- a/packages/alfred-vault/tests/surveyor/test_daemon_entity_link.py
+++ b/packages/alfred-vault/tests/surveyor/test_daemon_entity_link.py
@@ -127,16 +127,14 @@ def test_separates_entity_types_into_own_fields(daemon_and_vault):
     _write(vault, "matter/m.md", "matter")
     _write(vault, "person/p.md", "person")
     _write(vault, "org/o.md", "org")
-    _write(vault, "project/x.md", "project")
     _write(vault, "event/e.md", "event")
-    for p in ["matter/m.md", "person/p.md", "org/o.md", "project/x.md", "event/e.md"]:
+    for p in ["matter/m.md", "person/p.md", "org/o.md", "event/e.md"]:
         daemon.state.update_file(p, "h")
 
     records = {
         "matter/m.md": _record("matter/m.md", "matter"),
         "person/p.md": _record("person/p.md", "person"),
         "org/o.md": _record("org/o.md", "org"),
-        "project/x.md": _record("project/x.md", "project"),
         "event/e.md": _record("event/e.md", "event"),
     }
     # All 5 same vector so all sims = 1.0
@@ -157,7 +155,6 @@ def test_separates_entity_types_into_own_fields(daemon_and_vault):
     assert e_md.get("related_matters") == ["matter/m.md"]
     assert e_md.get("related_persons") == ["person/p.md"]
     assert e_md.get("related_orgs") == ["org/o.md"]
-    assert e_md.get("related_projects") == ["project/x.md"]
 
 
 def test_cluster_without_entities_noop(daemon_and_vault):

--- a/packages/alfred-vault/tests/surveyor/test_daemon_noise_linking.py
+++ b/packages/alfred-vault/tests/surveyor/test_daemon_noise_linking.py
@@ -131,14 +131,13 @@ def test_noise_event_below_threshold_not_linked(daemon_and_vault):
     assert "related_matters" not in md
 
 
-def test_noise_point_all_four_entity_types(daemon_and_vault):
+def test_noise_point_all_three_entity_types(daemon_and_vault):
     """One noise event linked to each entity type in one pass."""
     daemon, vault = daemon_and_vault
     for rel, rt in [
         ("matter/m.md", "matter"),
         ("person/p.md", "person"),
         ("org/o.md", "org"),
-        ("project/x.md", "project"),
         ("event/e.md", "event"),
     ]:
         _write(vault, rel, rt)
@@ -146,7 +145,6 @@ def test_noise_point_all_four_entity_types(daemon_and_vault):
         ("matter/m.md", "matter"),
         ("person/p.md", "person"),
         ("org/o.md", "org"),
-        ("project/x.md", "project"),
         ("event/e.md", "event"),
     ]}
 
@@ -166,7 +164,6 @@ def test_noise_point_all_four_entity_types(daemon_and_vault):
     assert md.get("related_matters") == ["matter/m.md"]
     assert md.get("related_persons") == ["person/p.md"]
     assert md.get("related_orgs") == ["org/o.md"]
-    assert md.get("related_projects") == ["project/x.md"]
 
 
 def test_noise_entity_source_skips_same_type_targets(daemon_and_vault):

--- a/packages/alfred-vault/tests/surveyor/test_labeler.py
+++ b/packages/alfred-vault/tests/surveyor/test_labeler.py
@@ -41,7 +41,7 @@ def test_slug_from_rel_path_no_extension():
 def test_entity_record_types_snapshot():
     # Bug #13 removed "matter" — it is not a canonical vault KNOWN_TYPE.
     # Lock the entity set so accidental changes require a test update.
-    assert ENTITY_RECORD_TYPES == {"person", "org", "project"}
+    assert ENTITY_RECORD_TYPES == {"person", "org", "matter"}
 
 
 def _make_labeler(llm_response: str | None) -> Labeler:
@@ -85,9 +85,10 @@ async def test_label_cluster_includes_entity_slug_first():
 
 @pytest.mark.asyncio
 async def test_label_cluster_includes_multiple_entity_slugs():
-    # "person" and "org" are canonical entity types; "matter" is not (bug #13).
-    # The "matter" record below is present as a non-entity member — its slug
-    # does NOT appear as a canonical tag.
+    # person, org and matter are the three canonical entity types. Bug #13 had
+    # this backwards — it treated `matter` as the phantom and kept `project`,
+    # the type ctrl-api actually rejects — so this test used to assert that the
+    # matter slug must NOT appear. It should, and now does.
     labeler = _make_labeler(llm_response='["makerspace"]')
     records = {
         "matter/erste-makerspace.md": _record("matter/erste-makerspace.md", "matter"),
@@ -100,13 +101,13 @@ async def test_label_cluster_includes_multiple_entity_slugs():
         member_paths=list(records.keys()),
         records=records,
     )
-    entity_slugs = {"jazmin-rapali", "erste-bank"}
+    entity_slugs = {"jazmin-rapali", "erste-bank", "erste-makerspace"}
     assert entity_slugs.issubset(set(tags))
     # Entity slugs should come first (before LLM tags)
     assert set(tags[: len(entity_slugs)]) == entity_slugs
     assert "makerspace" in tags
-    # "matter" is not an entity type — its slug must NOT appear
-    assert "erste-makerspace" not in tags
+    # `matter` IS an entity type, so its slug is a canonical tag.
+    assert "erste-makerspace" in tags
 
 
 @pytest.mark.asyncio

--- a/packages/alfred-vault/tests/surveyor/test_writer_entity_links.py
+++ b/packages/alfred-vault/tests/surveyor/test_writer_entity_links.py
@@ -83,13 +83,11 @@ def test_write_related_persons_separate_field(vault_with_record):
     assert md["related_persons"] == ["person/b.md"]
 
 
-def test_write_related_orgs_and_projects_separate_fields(vault_with_record):
+def test_write_related_orgs_and_matters_separate_fields(vault_with_record):
     _, _, writer, rel = vault_with_record
     writer.write_related_orgs(rel, ["org/x.md"])
-    writer.write_related_projects(rel, ["project/y.md"])
     md = _read_metadata(writer.vault_path, rel)
     assert md["related_orgs"] == ["org/x.md"]
-    assert md["related_projects"] == ["project/y.md"]
 
 
 def test_empty_list_is_noop(vault_with_record):
@@ -126,14 +124,12 @@ def test_existing_scalar_value_handled(vault_with_record):
 
 
 def test_multiple_fields_independent(vault_with_record):
-    """All four fields can coexist on the same record without interference."""
+    """All three fields can coexist on the same record without interference."""
     _, _, writer, rel = vault_with_record
     writer.write_related_matters(rel, ["matter/a.md"])
     writer.write_related_persons(rel, ["person/p.md"])
     writer.write_related_orgs(rel, ["org/o.md"])
-    writer.write_related_projects(rel, ["project/x.md"])
     md = _read_metadata(writer.vault_path, rel)
     assert md["related_matters"] == ["matter/a.md"]
     assert md["related_persons"] == ["person/p.md"]
     assert md["related_orgs"] == ["org/o.md"]
-    assert md["related_projects"] == ["project/x.md"]


### PR DESCRIPTION
## What happened

The canonical-type work (#673, #674) left the surveyor half-converted. Nothing caught it, because **`packages/alfred-vault`'s surveyor tests run nowhere**:

- **not locally** — they need `igraph`/`pymilvus`, absent from a plain env, so pytest skips their collection and *still reports green*
- **not in CI** — `ci-check` runs pytest for `packages/learn` only

The new `pytest-alfred-vault` job (#677) caught this on its first real run. That is exactly why it exists.

## What was wrong

| | |
|---|---|
| `daemon.py` | dispatched entity writes on record type carrying **both** `"matter" → write_related_matters` and `"project" → write_related_projects`. With `ENTITY_RECORD_TYPES` corrected to `{person, org, matter}`, the `"project"` key can never match — dead weight. Removed, with the now-unreachable `write_related_projects` |
| the tests | asserted `related_projects` and `project/x.md` throughout — they pinned the pre-cutover behaviour |
| `test_labeler` | asserted the matter slug must **not** appear as a canonical tag, encoding bug #13's inversion directly |

**Third instance of the same seam defect:** `packages/learn` already reads `related_matters`. The surveyor was writing `related_projects` — a field nothing consumed.

## On the rework

The tests covered **four** entity types where there are now three. They are reworked, not renamed: a blanket `project`→`matter` substitution turned the project case into a *duplicate* matter case, which passed for the wrong reason. Caught by actually running them:

```
assert md["related_matters"] == ["matter/a.md"]
E  AssertionError: assert ['matter/a.md', 'matter/x.md'] == ['matter/a.md']
```

## Smoke evidence

Full suite, surveyor included, in a venv with the package's declared extras:

```
175 passed in 1.83s
```

**That is the first time all of them have run.** The lane gate's local verify still excludes `tests/surveyor` (the deps cannot be installed under PEP 668 on the dev machine), so #677 is what keeps this honest from here.

Merge #677 after this so its job goes green on a tree that is actually correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)