### PR TITLE
fix(vault): vault_edit must not let a 422 kill the janitor sweep either

### DIFF
--- a/packages/alfred-vault/src/alfred/vault/ops.py
+++ b/packages/alfred-vault/src/alfred/vault/ops.py
@@ -522,7 +522,27 @@ def vault_edit(
                     merged_sets[k] = existing + [v]
                 else:
                     merged_sets[k] = [existing, v]
-        return ctrl_edit(rel_path, set_fields=merged_sets or None, body_append=body_append)
+        # Same reasoning as vault_create: ctrl answers 422 for any path outside
+        # the canonical 13, and that is PERMANENT. The janitor already handles a
+        # failed record by catching VaultError and moving on (12 call sites), so
+        # the only thing an escaping HTTPStatusError achieves is killing the
+        # sweep. It has been doing exactly that on the vault's pre-cutover
+        # records — `assumption/`, `synthesis/`, `constraint/`, `event/` — which
+        # the janitor keeps trying to annotate on every pass.
+        try:
+            return ctrl_edit(
+                rel_path, set_fields=merged_sets or None, body_append=body_append
+            )
+        except httpx.HTTPStatusError as exc:
+            detail = ""
+            try:
+                detail = exc.response.json().get("error", {}).get("message", "")
+            except Exception:  # noqa: BLE001
+                detail = (exc.response.text or "")[:200]
+            raise VaultError(
+                f"ctrl rejected edit of {rel_path}: "
+                f"HTTP {exc.response.status_code}. {detail}"
+            ) from exc
 
     file_path = _resolve_vault_path(vault_path, rel_path)
     if not file_path.exists():

--- a/packages/alfred-vault/tests/test_canonical_type_routing.py
+++ b/packages/alfred-vault/tests/test_canonical_type_routing.py
@@ -132,3 +132,31 @@ def test_project_is_routed_to_matter(monkeypatch, tmp_path):
     out = vault_create(tmp_path, "project", "MOSZ Discovery", set_fields={"status": "active"})
     assert seen["type"] == "matter", "project must be written as a matter"
     assert out["path"].startswith("matter/")
+
+
+# --- 3. the same guarantee on the edit path ------------------------------
+
+def test_edit_http_rejection_is_translated_to_vaulterror(monkeypatch, tmp_path):
+    """The janitor annotates existing records with vault_edit, and the vault is
+    full of pre-cutover ones (assumption/, synthesis/, constraint/, event/).
+    ctrl answers 422 for every such path. An escaping HTTPStatusError killed the
+    whole janitor sweep; the janitor already catches VaultError in a dozen
+    places, so translation is all that is needed."""
+    import alfred.ctrl_client as cc
+
+    def _boom(rel_path, set_fields=None, body_append=None):
+        raise httpx.HTTPStatusError(
+            "422", request=httpx.Request("PATCH", "http://ctrl/x"),
+            response=httpx.Response(
+                422,
+                json={"error": {"message": 'Path "assumption/x.md" is not canonical.'}},
+            ),
+        )
+
+    monkeypatch.setattr(cc, "ctrl_edit", _boom)
+    monkeypatch.setattr(cc, "via_ctrl_enabled", lambda: True)
+
+    from alfred.vault.ops import vault_edit
+    with pytest.raises(VaultError) as exc:
+        vault_edit(tmp_path, "assumption/x.md", set_fields={"janitor_note": "n"})
+    assert "422" in str(exc.value)


### PR DESCRIPTION
## Found by verifying, not by assuming

After #673 deployed I checked the dev tenant rather than declaring victory. The curator's crashes were gone — but **four 422 tracebacks remained in twenty minutes**. Different caller, different verb:

```
janitor/autofix.py:_flag_issue
  -> vault_edit                    (PATCH, not POST)
    -> ctrl_edit
      -> httpx.HTTPStatusError: 422
         .../vault/records/assumption/A%20narrow%20read-only%20live...
```

#673 fixed `vault_create` because that is where the curator failed. `vault_edit` has the identical shape and I had not covered it.

## Why it bites hard

The janitor annotates records it cannot auto-fix with a `janitor_note`. The vault is full of pre-cutover records, and ctrl answers 422 for every one of those paths:

| directory | records |
|---|---|
| `event/` | 1,468 |
| `assumption/` | 30 |
| `constraint/` | 25 |
| `synthesis/` | 24 |
| `contradiction/` | 17 |

So the sweep died on the first record it tried to flag — every pass.

## The fix

Identical to #673, and the caller contract is identical too: the janitor already catches `VaultError` in **twelve** places and skips the record. Only the escaping HTTP exception was stopping it.

The guarantee is now uniform across both verbs — no raw httpx error leaves the vault layer.

## Smoke evidence

```
176 passed
```

The new test discriminates by construction:
```
HTTPStatusError is a VaultError?  False
-> without the translation, pytest.raises(VaultError) cannot pass
```

I tried to demonstrate red-first by stripping the translation and my first two attempts silently failed to edit the file — the test passed both times for the wrong reason. Hence the structural argument above rather than a screenshot of a red run I did not actually produce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)