### PR TITLE
fix(distiller): the manifest file was written where this process cannot read it

### DIFF
--- a/packages/alfred-vault/src/alfred/curator/pipeline.py
+++ b/packages/alfred-vault/src/alfred/curator/pipeline.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from alfred.vault.mutation_log import log_mutation
+from alfred.shared_paths import manifest_paths
 from alfred.vault.ops import VaultError, vault_create, vault_edit, vault_read
 
 import time
@@ -317,11 +318,10 @@ async def _stage1_analyze(
     if not template:
         return "", []
 
-    # Generate a unique manifest file path for the LLM to write to.
-    # Use /alfred-data/ (shared volume between alfred and openclaw-workers
-    # containers) instead of /tmp (separate tmpfs per container).
-    manifest_id = uuid.uuid4().hex[:12]
-    manifest_path = f"/alfred-data/alfred-curator-{manifest_id}-manifest.json"
+    # The LLM writes in the hermes container; we read here. Same volume,
+    # different mount points. manifest_paths() hands back both views so the
+    # prompt gets the LLM's path and the read gets ours. See alfred.shared_paths.
+    manifest_path, manifest_local = manifest_paths("curator")
 
     prompt = template.format(
         vault_cli_reference=VAULT_CLI_REFERENCE,
@@ -363,18 +363,11 @@ async def _stage1_analyze(
                     )
                 note_path = suppressed
 
-        # Try to read the entity manifest from the temp file first.
-        # The manifest_path uses /alfred-data/ (openclaw-workers mount point),
-        # but the alfred container mounts the same volume at /app/data/.
-        # Try both paths.
+        # Read the manifest the LLM wrote. `manifest_local` is that same file
+        # as this container sees it — no path guessing, no always-missing
+        # primary read to fall back from.
         try:
-            manifest_file = Path(manifest_path)
-            if not manifest_file.exists():
-                # Translate /alfred-data/ → /app/data/ for cross-container access
-                alt_path = manifest_path.replace("/alfred-data/", "/app/data/")
-                alt_file = Path(alt_path)
-                if alt_file.exists():
-                    manifest_file = alt_file
+            manifest_file = manifest_local
             if manifest_file.exists():
                 raw_json = manifest_file.read_text(encoding="utf-8").strip()
                 data = json.loads(raw_json)
@@ -388,12 +381,11 @@ async def _stage1_analyze(
         except (json.JSONDecodeError, OSError, KeyError) as e:
             log.warning("pipeline.manifest_file_read_failed", path=manifest_path, error=str(e))
         finally:
-            # Clean up the temp manifest file (try both possible paths)
-            for p in [manifest_path, manifest_path.replace("/alfred-data/", "/app/data/")]:
-                try:
-                    Path(p).unlink(missing_ok=True)
-                except OSError:
-                    pass
+            # Clean up the temp manifest file.
+            try:
+                manifest_local.unlink(missing_ok=True)
+            except OSError:
+                pass
 
         # Fallback: parse entity manifest from stdout if file method failed
         if not manifest:

--- a/packages/alfred-vault/src/alfred/distiller/pipeline.py
+++ b/packages/alfred-vault/src/alfred/distiller/pipeline.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from alfred.vault.mutation_log import log_mutation, read_mutations
+from alfred.shared_paths import manifest_paths
 from alfred.vault.ops import VaultError, vault_edit
 from alfred.vault.schema import DISTILLER_CREATABLE_TYPES
 
@@ -366,7 +367,11 @@ async def _stage1_extract(
     # Generate a unique temp file path for the manifest output.
     # The LLM will write its JSON manifest here instead of relying on stdout,
     # which is polluted by OpenClaw's agent conversation/reasoning output.
-    manifest_path = f"/tmp/alfred-distiller-{uuid.uuid4().hex[:12]}-manifest.json"
+    # /tmp is a separate tmpfs per container, so the file the LLM writes there
+    # is unreachable from this process — the primary read could never succeed.
+    # manifest_paths() returns the LLM-visible path for the prompt and the
+    # locally-openable path for the read. See alfred.shared_paths.
+    manifest_path, manifest_local = manifest_paths("distiller")
 
     prompt = template.format(
         learn_type_schemas=_load_learn_type_schemas(),
@@ -403,7 +408,7 @@ async def _stage1_extract(
 
         # Primary: read manifest from the temp file the LLM was instructed to write
         try:
-            manifest_text = Path(manifest_path).read_text(encoding="utf-8")
+            manifest_text = manifest_local.read_text(encoding="utf-8")
             manifest = _parse_extraction_manifest(manifest_text)
             if manifest:
                 log.info(
@@ -420,7 +425,7 @@ async def _stage1_extract(
         finally:
             # Clean up temp file
             try:
-                os.unlink(manifest_path)
+                os.unlink(manifest_local)
             except OSError:
                 pass
 

--- a/packages/alfred-vault/src/alfred/shared_paths.py
+++ b/packages/alfred-vault/src/alfred/shared_paths.py
@@ -1,0 +1,53 @@
+"""Paths on the volume shared between this daemon and the LLM's container.
+
+The LLM does not run here. It runs in the hermes container, and the two
+containers mount the SAME docker volume at DIFFERENT places:
+
+    alfred-black_alfred_data  ->  /alfred-data   (hermes: where the LLM writes)
+                              ->  /app/data      (this daemon: where we read)
+
+So a path handed to the LLM in a prompt is not a path this process can open,
+and vice versa. Getting that wrong is silent: the write succeeds, the read
+raises FileNotFoundError, and the pipeline falls back to scraping stdout.
+
+The distiller got it wrong in a way no fallback could rescue — it used /tmp,
+which is a separate tmpfs per container, so the file the LLM wrote was never
+reachable from here at all. Its "primary" read path could not succeed even in
+principle; every run depended on the stdout fallback, and a well-behaved model
+that wrote the file and printed a short acknowledgement produced nothing to
+scrape. The better the model behaved, the worse the outcome.
+
+Use manifest_paths() rather than composing either path by hand.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+# How the LLM's container sees the shared volume.
+LLM_SHARED_DIR = "/alfred-data"
+# How this container sees the same volume.
+LOCAL_SHARED_DIR = "/app/data"
+
+
+def to_local(llm_path: str) -> Path:
+    """Translate a path as the LLM sees it into one this process can open."""
+    if llm_path.startswith(LLM_SHARED_DIR + "/"):
+        return Path(llm_path.replace(LLM_SHARED_DIR, LOCAL_SHARED_DIR, 1))
+    return Path(llm_path)
+
+
+def manifest_paths(prefix: str) -> tuple[str, Path]:
+    """Allocate a manifest file on the shared volume.
+
+    Returns (llm_path, local_path):
+      * llm_path   — put THIS in the prompt; it is what the LLM can write to.
+      * local_path — read THIS here; it is the same file, seen from this
+                     container.
+
+    They are deliberately different types so the two cannot be swapped by
+    accident: the prompt wants a str, the reader wants a Path.
+    """
+    llm_path = f"{LLM_SHARED_DIR}/alfred-{prefix}-{uuid.uuid4().hex[:12]}-manifest.json"
+    return llm_path, to_local(llm_path)

--- a/packages/alfred-vault/tests/test_shared_manifest_paths.py
+++ b/packages/alfred-vault/tests/test_shared_manifest_paths.py
@@ -1,0 +1,59 @@
+"""The LLM writes in a different container than the one that reads.
+
+alfred-black_alfred_data is mounted at /alfred-data in hermes (where the LLM
+runs) and /app/data here. A path handed to the LLM is therefore NOT a path this
+process can open.
+
+The distiller used /tmp, which is a separate tmpfs per container. Its primary
+read could not succeed even in principle — every run silently depended on
+scraping stdout, and a well-behaved model that wrote the file and printed a
+short acknowledgement produced nothing to scrape.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from alfred.shared_paths import (
+    LLM_SHARED_DIR,
+    LOCAL_SHARED_DIR,
+    manifest_paths,
+    to_local,
+)
+
+SRC = Path(__file__).resolve().parents[1] / "src" / "alfred"
+
+
+def test_llm_path_and_local_path_are_the_same_file_seen_differently():
+    llm, local = manifest_paths("distiller")
+    assert llm.startswith(LLM_SHARED_DIR + "/")
+    assert str(local).startswith(LOCAL_SHARED_DIR + "/")
+    assert Path(llm).name == local.name
+
+
+def test_the_two_paths_are_different_types_so_they_cannot_be_swapped():
+    """The prompt wants a str, the reader wants a Path. Mixing them up is the
+    original bug, so make it a type error rather than a silent miss."""
+    llm, local = manifest_paths("curator")
+    assert isinstance(llm, str)
+    assert isinstance(local, Path)
+
+
+def test_to_local_is_a_no_op_for_paths_already_local():
+    assert to_local("/app/data/x.json") == Path("/app/data/x.json")
+    assert to_local("/vault/x.md") == Path("/vault/x.md")
+
+
+def test_no_pipeline_asks_the_llm_to_write_to_tmp():
+    """/tmp is per-container. A manifest written there by the LLM is
+    unreachable from here — which is exactly how the distiller's primary path
+    came to be dead for its whole life."""
+    offenders = []
+    for f in SRC.rglob("pipeline.py"):
+        for i, line in enumerate(f.read_text().splitlines(), 1):
+            if re.search(r'["\']/tmp/[^"\']*manifest', line):
+                offenders.append(f"{f.relative_to(SRC)}:{i}: {line.strip()}")
+    assert not offenders, (
+        "manifest files must live on the shared volume, not /tmp:\n  "
+        + "\n  ".join(offenders)
+    )


### PR DESCRIPTION
## The bug

The LLM does not run in this container. It runs in **hermes**, and the two mount the **same volume at different paths** — verified on the dev tenant:

```
alfred-black_alfred_data -> /alfred-data   in hermes        (the LLM writes here)
                         -> /app/data      in this daemon   (we read here)
```

The distiller asked the LLM to write its manifest to **`/tmp`**. `/tmp` is a separate tmpfs per container, so the file landed in hermes's tmpfs while this process looked in its own. **The primary read could not succeed even in principle** — it has been dead for the life of the code.

Proven on the box:
```
worker CANNOT see hermes /tmp — confirmed separate
worker:/app/data IS hermes:/alfred-data — YES
```

## Why it's worse than a fallback papering over it

Every distiller run depended on the stdout fallback, and **the failure mode is inverted**: a model that behaves *well* — writes the file, prints a short acknowledgement — leaves nothing to scrape. So the run burns all three retries and extracts nothing. Live on the dev tenant: `stdout_len=97` followed by `manifest_parse_failed`.

The better the model behaves, the worse the outcome.

## The curator survived the same confusion by accident

It hands the LLM `/alfred-data` (right for hermes), then fails its own read of that path (no such directory here), then falls back to a hand-written `/alfred-data` → `/app/data` string replace. **That fallback has been doing the work on every single run**, while the primary read logged a miss each time. Hence the `s1_manifest_file_missing` noise in the logs that started this investigation.

## The fix

`alfred.shared_paths.manifest_paths()` returns both views — the LLM's path for the prompt, the local path for the read — deliberately as a `str` and a `Path` so they cannot be swapped by accident. Both pipelines use it. The curator's alt-path dance and always-missing primary read are gone.

## Smoke evidence

```
180 passed
```

The guard test greps every pipeline for a `/tmp` manifest path and fails naming the offending line. **Verified red against the previous code:**

```
E  distiller/pipeline.py:369: manifest_path = f"/tmp/alfred-distiller-{uuid...}-manifest.json"
```

## Scope note

This is the manifest-parse failure I flagged after the curator work — separate defect, same investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)