### PR TITLE
fix(surveyor): load the Milvus collection — an existing one comes back released

### DIFF
--- a/packages/alfred-vault/src/alfred/surveyor/embedder.py
+++ b/packages/alfred-vault/src/alfred/surveyor/embedder.py
@@ -161,6 +161,14 @@ class Embedder:
                             log.warning("embedder.state_invalidate_failed", error=str(e))
                         break
             else:
+                # An existing collection comes back RELEASED after a restart:
+                # milvus-lite persists the data but not the loaded state, and
+                # any query then fails with
+                #   code=101 ... is in state 'released'; call load()
+                # create_collection() loads implicitly, so ONLY this path was
+                # affected — which is why the surveyor worked until the first
+                # restart and never again.
+                self._load_collection()
                 return
 
         schema = CollectionSchema(
@@ -187,7 +195,26 @@ class Embedder:
             collection_name=self.collection_name,
             index_params=index_params,
         )
+        # create_index does not load either; be explicit on both paths.
+        self._load_collection()
         log.info("embedder.collection_created", name=self.collection_name)
+
+    def _load_collection(self) -> None:
+        """Load the collection into memory. Required before any query/search.
+
+        Logged rather than raised: a failure here makes the surveyor useless
+        but should not take the whole worker down, and the query that follows
+        reports the real error anyway.
+        """
+        try:
+            self.milvus.load_collection(self.collection_name)
+            log.info("embedder.collection_loaded", name=self.collection_name)
+        except Exception as e:  # noqa: BLE001
+            log.warning(
+                "embedder.collection_load_failed",
+                name=self.collection_name,
+                error=str(e),
+            )
 
     async def _ensure_http(self) -> httpx.AsyncClient:
         """Lazily create and reuse a persistent HTTP client."""

--- a/packages/alfred-vault/tests/surveyor/test_embedder_collection_load.py
+++ b/packages/alfred-vault/tests/surveyor/test_embedder_collection_load.py
@@ -1,0 +1,66 @@
+"""An existing Milvus collection must be LOADED before it can be queried.
+
+milvus-lite persists the collection's data across restarts but not its loaded
+state. `create_collection()` loads implicitly, so a fresh deploy worked — and
+then every restart afterwards left the collection in state 'released', with
+every query failing:
+
+    MilvusException: (code=101, message=Collection 'vault_embeddings' is in
+    state 'released'; call load() first)
+
+_ensure_collection() returned early on the happy path (collection exists, dims
+match) without ever loading. These tests pin both paths.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from alfred.surveyor.embedder import Embedder
+
+
+def _embedder_with(milvus) -> Embedder:
+    e = Embedder.__new__(Embedder)          # bypass __init__ / real connections
+    e.milvus = milvus
+    e.collection_name = "vault_embeddings"
+    e.embedding_dims = 1024
+    e.state = MagicMock()
+    return e
+
+
+def _existing_collection_client(dim: int = 1024) -> MagicMock:
+    m = MagicMock()
+    m.has_collection.return_value = True
+    m.describe_collection.return_value = {
+        "fields": [{"name": "embedding", "params": {"dim": dim}}]
+    }
+    return m
+
+
+def test_existing_collection_is_loaded_not_just_returned():
+    """The regression. Dims match, so the method returns early — it must load
+    first, or every query after a restart fails."""
+    m = _existing_collection_client()
+    _embedder_with(m)._ensure_collection()
+    m.load_collection.assert_called_once_with("vault_embeddings")
+    m.create_collection.assert_not_called()
+
+
+def test_load_failure_is_logged_not_raised():
+    """A failed load makes the surveyor useless but must not take the worker
+    down; the query that follows reports the real error."""
+    m = _existing_collection_client()
+    m.load_collection.side_effect = RuntimeError("milvus down")
+    _embedder_with(m)._ensure_collection()   # must not raise
+
+
+def test_load_is_called_on_the_create_path_too():
+    """create_index() does not load either, so the fresh-collection path needs
+    it explicitly rather than relying on create_collection's implicit load."""
+    m = MagicMock()
+    m.has_collection.return_value = False
+    e = _embedder_with(m)
+    e._ensure_collection()
+    m.create_collection.assert_called_once()
+    m.load_collection.assert_called_once_with("vault_embeddings")


### PR DESCRIPTION
## The failure

Every surveyor pass on the dev tenant was dying:

```
MilvusException: (code=101, message=Collection 'vault_embeddings' is in
state 'released'; call load() first)
```

## Why it looked intermittent

`_ensure_collection()` has two paths:

| path | loads? |
|---|---|
| collection does not exist → `create_collection()` | ✅ implicitly |
| collection exists, dims match → **early `return`** | ❌ never |

milvus-lite persists a collection's *data* across restarts but not its *loaded state*. So a fresh deploy embeds fine — and then **every restart afterwards** leaves the collection released and every query fails. First run works, all subsequent runs don't.

## The fix

Both paths now load explicitly (`create_index()` doesn't load either, so the create path was relying on `create_collection`'s implicit load — made explicit rather than assumed).

A load failure is **logged, not raised**: it makes the surveyor useless but shouldn't take the whole worker down, and the query that follows reports the real error anyway.

## Smoke evidence

```
183 passed
```

**Verified red first** — with the load removed from the existing-collection path:
```
>  m.load_collection.assert_called_once_with("vault_embeddings")
FAILED tests/surveyor/test_embedder_collection_load.py::test_existing_collection_is_loaded_not_just_returned
1 failed, 2 passed
```

Three tests pin it: the existing-collection path loads, the create path loads, and a load failure is swallowed rather than fatal.

## Not related, for the record

The `ModuleNotFoundError: No module named 'faiss.swigfaiss_avx2'` in the same logs is **noise**, not a bug. faiss probes for CPU-optimised builds, falls back, and logs `Successfully loaded faiss` immediately after. I chased it before ruling it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)