### PR TITLE
fix(janitor): stop attempting writes ctrl-api will always refuse

### DIFF
--- a/packages/alfred-vault/src/alfred/janitor/autofix.py
+++ b/packages/alfred-vault/src/alfred/janitor/autofix.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from alfred.vault.mutation_log import log_mutation
 from alfred.vault.ops import VaultError, vault_edit, vault_read
+from alfred.vault.schema import is_writable_vault_path
 from alfred.vault.schema import (
     KNOWN_TYPES,
     LIST_FIELDS,
@@ -182,6 +183,26 @@ def autofix_issues(
     by_file: dict[str, list[Issue]] = {}
     for issue in issues:
         by_file.setdefault(issue.file, []).append(issue)
+
+    # Records ctrl-api will never accept a write to — the vault's pre-cutover
+    # directories (event/, assumption/, constraint/, synthesis/, ...). Every
+    # fix and every flag on one of these is a guaranteed 422, so attempting
+    # them costs a round-trip each and buys nothing. On the dev tenant that was
+    # 2,866 rejected calls per sweep against event/ alone, crowding out the
+    # records the janitor CAN act on.
+    #
+    # Counted and reported once, not skipped silently: a sweep that quietly
+    # ignores a thousand records looks identical to a clean one.
+    unwritable = [p for p in by_file if not is_writable_vault_path(p)]
+    if unwritable:
+        by_file = {p: v for p, v in by_file.items() if is_writable_vault_path(p)}
+        heads = sorted({p.split("/", 1)[0] for p in unwritable})
+        log.info(
+            "autofix.skipped_unwritable",
+            records=len(unwritable),
+            directories=heads,
+            reason="not a canonical vault path; ctrl-api rejects any write",
+        )
 
     for rel_path, file_issues in by_file.items():
         file_fixed = False

--- a/packages/alfred-vault/src/alfred/vault/schema.py
+++ b/packages/alfred-vault/src/alfred/vault/schema.py
@@ -14,6 +14,32 @@ CANONICAL_VAULT_TYPES: set[str] = {
     "chore", "instinct", "decision", "briefing", "daybook", "commitment",
 }
 
+# Vault paths ctrl-api accepts that are NOT record-type directories. Mirrors
+# CANONICAL_NON_RECORD_DIRS / CANONICAL_TOP_LEVEL_FILES in ctrl's
+# promotionContract.ts — the seam test asserts they stay identical.
+CANONICAL_NON_RECORD_DIRS: set[str] = {"_templates", "needs_attention"}
+CANONICAL_TOP_LEVEL_FILES: set[str] = {"SOUL.md", "RULES.md"}
+
+
+def is_writable_vault_path(rel_path: str) -> bool:
+    """True if ctrl-api will accept a write to this vault path.
+
+    Anything else is a permanent 422 — the pre-cutover directories the vault
+    still holds (event/, assumption/, constraint/, synthesis/, ...). Callers
+    that sweep the whole vault should consult this BEFORE attempting a write,
+    rather than discovering it one rejected HTTP round-trip at a time: on the
+    dev tenant the janitor was making 2,866 such calls per sweep against
+    event/ alone.
+    """
+    rel = rel_path.strip("/")
+    if not rel:
+        return False
+    head, _, tail = rel.partition("/")
+    if not tail:
+        return head in CANONICAL_TOP_LEVEL_FILES
+    return head in CANONICAL_VAULT_TYPES or head in CANONICAL_NON_RECORD_DIRS
+
+
 # Pre-cutover names and the canonical types that replaced them.
 #
 # This daemon's vocabulary predates the four-store cutover. `project` is what a

--- a/packages/alfred-vault/tests/test_canonical_type_routing.py
+++ b/packages/alfred-vault/tests/test_canonical_type_routing.py
@@ -160,3 +160,59 @@ def test_edit_http_rejection_is_translated_to_vaulterror(monkeypatch, tmp_path):
     with pytest.raises(VaultError) as exc:
         vault_edit(tmp_path, "assumption/x.md", set_fields={"janitor_note": "n"})
     assert "422" in str(exc.value)
+
+
+# --- 4. don't attempt writes ctrl will refuse -----------------------------
+
+def test_writable_path_predicate_matches_ctrl_exemptions():
+    """Seam test, same shape as the type one: ctrl exempts _templates/,
+    needs_attention/, SOUL.md and RULES.md from the promotion contract. If this
+    daemon's idea of writable drifts, the janitor either skips records it could
+    have fixed or hammers ones it never can."""
+    from alfred.vault.schema import (
+        CANONICAL_NON_RECORD_DIRS,
+        CANONICAL_TOP_LEVEL_FILES,
+    )
+    if not CTRL_CONTRACT.exists():
+        pytest.skip("ctrl package not present")
+    src = CTRL_CONTRACT.read_text()
+    dirs = set(re.findall(r'"([a-z_]+)"', re.search(
+        r"CANONICAL_NON_RECORD_DIRS = new Set<string>\(\[(.*?)\]", src, re.S).group(1)))
+    files = set(re.findall(r'"([A-Za-z.]+\.md)"', re.search(
+        r"CANONICAL_TOP_LEVEL_FILES = new Set<string>\(\[(.*?)\]", src, re.S).group(1)))
+    assert dirs == CANONICAL_NON_RECORD_DIRS, (dirs, CANONICAL_NON_RECORD_DIRS)
+    assert files == CANONICAL_TOP_LEVEL_FILES, (files, CANONICAL_TOP_LEVEL_FILES)
+
+
+def test_pre_cutover_directories_are_not_writable():
+    """These are what the janitor was hammering — 2,866 rejected writes per
+    sweep against event/ alone."""
+    from alfred.vault.schema import is_writable_vault_path
+    for demoted in ("event", "assumption", "constraint", "synthesis",
+                    "contradiction", "project", "session", "account"):
+        assert not is_writable_vault_path(f"{demoted}/x.md"), demoted
+
+
+def test_canonical_and_exempt_paths_stay_writable():
+    from alfred.vault.schema import is_writable_vault_path
+    for ok in ("matter/x.md", "task/x.md", "note/x.md", "person/x.md",
+               "needs_attention/card.md", "_templates/t.md", "SOUL.md", "RULES.md"):
+        assert is_writable_vault_path(ok), ok
+
+
+def test_janitor_skips_unwritable_records_without_attempting_a_write(monkeypatch):
+    """The behaviour, not just the predicate: autofix must not call through to
+    vault_edit for a record ctrl will refuse."""
+    import alfred.janitor.autofix as af
+
+    def _must_not_run(*a, **k):  # pragma: no cover
+        raise AssertionError("attempted a write to an unwritable record")
+
+    monkeypatch.setattr(af, "_apply_fix", _must_not_run)
+
+    class _Issue:
+        file = "event/some-old-record.md"
+        code = type("C", (), {"value": "FM002"})()
+        message = "stale"
+
+    af.autofix_issues([_Issue()], Path("/vault"), "session/x.md")


### PR DESCRIPTION
## What making the 422 non-fatal revealed

#679 stopped the janitor dying on rejected writes. It also showed the scale of what it had been dying on — fifteen minutes on the dev tenant:

```
2,906 rejected writes across 1,501 distinct records
  2,866  event/
     14  contradiction/
     12  constraint/
```

Those are the vault's **pre-cutover directories**. ctrl-api rejects every write to them, permanently. Each attempt is a wasted round-trip, and the sweep spends itself on records it can never touch instead of the ones it can.

## The fix

`schema.is_writable_vault_path()` answers the question **before** the call. It mirrors ctrl's `promotionContract.ts`, including the exemptions that are not record types but are still legitimate writes:

| writable | not writable |
|---|---|
| the canonical 13 | `event/` `assumption/` `constraint/` `synthesis/` `contradiction/` `project/` `session/` `account/` … |
| `_templates/`, `needs_attention/` | |
| `SOUL.md`, `RULES.md` | |

A **seam test** asserts this daemon's exemptions stay identical to ctrl's — same shape as the type-set test in #673. The absence of exactly that check is what caused this entire thread of bugs.

## Counted, not silent

The skip is logged once per sweep with the directories involved:

```
autofix.skipped_unwritable  records=1501  directories=[...]
  reason="not a canonical vault path; ctrl-api rejects any write"
```

A sweep that quietly ignores fifteen hundred records looks identical to a clean one — and every bug in this thread has been something that failed while appearing to succeed.

## What this deliberately does not do

**It does not decide where those records should live.** That's a real design question — the promotion contract says `alfred-state.db` — and it isn't answered by making the janitor stop shouting. The 1,468 `event/` records still need a home; this just stops them consuming every sweep.

## Smoke evidence

```
184 passed
```

**Verified red first** — with the skip removed:
```
E  AssertionError: attempted a write to an unwritable record
```

The behaviour test patches `_apply_fix` to explode, so it proves the janitor never reaches the write — not merely that the predicate returns False.

🤖 Generated with [Claude Code](https://claude.com/claude-code)