### PR TITLE
fix(ctrl_client): send structured values via json_set, not set

### DIFF
--- a/packages/alfred-vault/src/alfred/ctrl_client.py
+++ b/packages/alfred-vault/src/alfred/ctrl_client.py
@@ -52,10 +52,37 @@ def ctrl_edit(
     set_fields: dict[str, Any] | None = None,
     body_append: str | None = None,
 ) -> dict:
-    """PATCH a vault record through ctrl-api (§15.1 wrapped body shape)."""
+    """PATCH a vault record through ctrl-api (§15.1 wrapped body shape).
+
+    `set` and `json_set` are NOT interchangeable, and picking the wrong one
+    fails loudly at the far end:
+
+        set:      scalars only. ctrl stringifies each value for the vault
+                  CLI's --set flag.
+        json_set: lists, dicts, bools, numbers. Merged into frontmatter as
+                  native YAML, shape preserved.
+
+    Sending a list through `set` produced the JavaScript coercion `[object
+    Object]` in the CLI argument, and the vault daemon rejected it with
+    "Field 'relationships' must be a list, got str" — HTTP 500. On the dev
+    tenant that was ~150 failed writes per 20 minutes, every one of them a
+    surveyor entity-link update, which is exactly the payload most likely to
+    be a list.
+
+    So the split is made here rather than left to the caller: every value is
+    routed by its own type.
+    """
     payload: dict[str, Any] = {}
     if set_fields:
-        payload["set"] = set_fields
+        scalars = {
+            k: v for k, v in set_fields.items()
+            if v is None or isinstance(v, (str, int, float, bool))
+        }
+        structured = {k: v for k, v in set_fields.items() if k not in scalars}
+        if scalars:
+            payload["set"] = scalars
+        if structured:
+            payload["json_set"] = structured
     if body_append:
         payload["body_append"] = body_append
     if not payload:

--- a/packages/alfred-vault/tests/test_ctrl_edit_json_set.py
+++ b/packages/alfred-vault/tests/test_ctrl_edit_json_set.py
@@ -1,0 +1,95 @@
+"""`set` and `json_set` are not interchangeable, and the failure is remote.
+
+ctrl-api's PATCH contract:
+
+    set:      scalars only — each value is stringified for the vault CLI's
+              --set flag.
+    json_set: lists, dicts, bools, numbers — merged as native YAML.
+
+Sending a list through `set` made ctrl build the CLI argument
+`--set relationships=[object Object]` (JavaScript coercing an object to a
+string), and the vault daemon rejected it:
+
+    {"error": "Field 'relationships' must be a list, got str"}   -> HTTP 500
+
+~150 failed writes per 20 minutes on the dev tenant, every one a surveyor
+entity-link update — the payload most likely to be a list.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import alfred.ctrl_client as cc
+
+
+def _capture(monkeypatch) -> dict:
+    seen: dict = {}
+
+    class _Resp:
+        @staticmethod
+        def raise_for_status(): return None
+        @staticmethod
+        def json(): return {"path": "p"}
+
+    class _C:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def patch(self, url, json=None):
+            seen["url"] = url
+            seen["payload"] = json
+            return _Resp()
+
+    monkeypatch.setattr(cc, "_client", lambda: _C())
+    return seen
+
+
+def test_lists_go_to_json_set_not_set(monkeypatch):
+    """The regression. A list in `set` becomes [object Object] at the far end."""
+    seen = _capture(monkeypatch)
+    cc.ctrl_edit("task/x.md", set_fields={"relationships": ["a", "b"]})
+    assert seen["payload"].get("json_set") == {"relationships": ["a", "b"]}
+    assert "relationships" not in seen["payload"].get("set", {})
+
+
+def test_dicts_go_to_json_set(monkeypatch):
+    seen = _capture(monkeypatch)
+    cc.ctrl_edit("task/x.md", set_fields={"undo_recipe": {"evidence": [1]}})
+    assert seen["payload"].get("json_set") == {"undo_recipe": {"evidence": [1]}}
+
+
+def test_scalars_still_go_to_set(monkeypatch):
+    """Scalars must keep using `set` — json_set bypasses the CLI entirely and
+    with it the validation the CLI performs."""
+    seen = _capture(monkeypatch)
+    cc.ctrl_edit("task/x.md", set_fields={"status": "done", "count": 3, "ok": True})
+    assert seen["payload"]["set"] == {"status": "done", "count": 3, "ok": True}
+    assert "json_set" not in seen["payload"]
+
+
+def test_mixed_payload_is_split_by_value_type(monkeypatch):
+    seen = _capture(monkeypatch)
+    cc.ctrl_edit(
+        "task/x.md",
+        set_fields={"status": "active", "related_matters": ["matter/a.md"]},
+    )
+    assert seen["payload"]["set"] == {"status": "active"}
+    assert seen["payload"]["json_set"] == {"related_matters": ["matter/a.md"]}
+
+
+def test_none_is_a_scalar(monkeypatch):
+    """Clearing a field must still go through the CLI path."""
+    seen = _capture(monkeypatch)
+    cc.ctrl_edit("task/x.md", set_fields={"closure_predicate": None})
+    assert seen["payload"]["set"] == {"closure_predicate": None}
+    assert "json_set" not in seen["payload"]
+
+
+def test_fields_changed_still_reports_every_key(monkeypatch):
+    """Splitting the payload must not lose keys from the caller's receipt."""
+    _capture(monkeypatch)
+    out = cc.ctrl_edit(
+        "task/x.md", set_fields={"status": "active", "related_matters": ["m.md"]}
+    )
+    assert out["fields_changed"] == ["related_matters", "status"]


### PR DESCRIPTION
## Found by fixing the previous bug

#681 unblocked the surveyor into a **second failure the crash had been masking**. Its entity-link writes came back HTTP 500:

```
args:   alfred vault edit task/… --set relationships=[object Object]
stdout: {"error": "Field 'relationships' must be a list, got str"}
```

`[object Object]` is JavaScript coercing an object to a string.

## It's caller misuse, not a ctrl bug

ctrl-api's PATCH contract is explicit:

| key | accepts |
|---|---|
| `set` | **scalars only** — stringified for the vault CLI's `--set` |
| `json_set` | lists, dicts, bools, numbers — merged as native YAML, shape preserved (#838 Phase 2) |

`ctrl_edit` put everything in `set` regardless of type, so any list arrived as that literal string.

## Why it hid

PATCH overall was healthy — **2,982 × 200**. Only the structured writes failed:

```
2982 x 200
 179 x 422   promotion contract (the event/ records — separate, #682)
 150 x 500   this bug
 142 x 403   different cause again, not fixed here
```

~150 failed writes per 20 minutes, every one a surveyor entity-link update — the payload most likely to be a list.

## Design notes

- **The split is made in `ctrl_edit`**, not left to callers. Otherwise every caller that ever sets a list has to remember the distinction, and the failure is remote and unobvious when they don't.
- **Scalars deliberately keep using `set`.** `json_set` bypasses the CLI entirely, and with it the validation the CLI performs — so it should carry only what `set` genuinely cannot.
- **`None` is treated as a scalar** — clearing a field must still go through the CLI path.

## Smoke evidence

```
193 passed
```

**Verified red first** — with the type split removed:
```
FAILED test_lists_go_to_json_set_not_set
FAILED test_dicts_go_to_json_set
FAILED test_mixed_payload_is_split_by_value_type
3 failed, 3 passed
```

The three that still pass are the scalar cases — so the tests discriminate the change rather than just the file being edited.

## Flagged, not fixed

The same PATCH stream shows **142 HTTP 403s**. Different cause; I haven't chased it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)