### PR TITLE
feat(hermes): bake Hermes 0.20.4 + the live-voice gateway into the image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -386,6 +386,11 @@ services:
     # the internet, and the gateway still requires the Bearer API_SERVER_KEY.
     ports:
       - "127.0.0.1:18789:18789"
+      # Live Voice dashboard (profile: live-voice). Published here because
+      # hermes-dashboard runs in THIS service's network namespace, so the port
+      # must be declared on the namespace owner. Loopback-only: reach it with
+      # `ssh -L 9121:127.0.0.1:9121 root@<host>`.
+      - "127.0.0.1:9121:9121"
     depends_on:
       init:
         condition: service_completed_successfully
@@ -1353,6 +1358,69 @@ services:
   # PR 2 lands the ctrl-api routes that drive `tailscale up / status /
   # logout / down` via `docker exec`; PR 3 the /connections card; PR 4
   # `tailscale cert` + `tailscale serve` for inbound from the tailnet.
+  # ---------------------------------------------------------------------------
+  # Live Voice (opt-in) — `docker compose --profile live-voice up -d`
+  #
+  # OFF by default. Both services need the `hermes-live` PLUGIN installed into
+  # the profile's plugins/ dir (it lives in the hermes_data volume, not the
+  # image) plus its config.env carrying the provider keys. A tenant without the
+  # plugin would restart-loop on a missing command, which is exactly what
+  # happened on the dev tenant on 2026-08-19 — so this stays behind a profile
+  # rather than defaulting on.
+  #
+  # Both share hermes' network namespace so they can reach the private gateway
+  # on 127.0.0.1:18789 and the live gateway on 127.0.0.1:8788 without either
+  # being published. The only exposed port is the dashboard, bound to loopback
+  # on the host — reach it from a laptop with `ssh -L 9121:127.0.0.1:9121`.
+  #
+  # Requires Hermes >= 0.20: the plugin registers its `hermes-live` command
+  # through the 0.20 plugin loader. On 0.19 the command does not exist.
+  hermes-dashboard:
+    profiles: ["live-voice"]
+    logging: *default-logging
+    image: ssdavidai00/alfred-black-hermes:latest
+    network_mode: "service:hermes"
+    volumes_from:
+      - hermes
+    environment:
+      - HERMES_HOME=/hermes-state/profiles/main
+    entrypoint: ["/bin/sh", "-lc"]
+    # --skip-build: web_dist is baked into the image, so never shell out to
+    # npm at runtime (the git-installed tree ships no bundle of its own).
+    command: exec hermes dashboard --host 0.0.0.0 --port 9121 --no-open --skip-build
+    depends_on:
+      hermes:
+        condition: service_started
+    restart: unless-stopped
+
+  hermes-live:
+    profiles: ["live-voice"]
+    logging: *default-logging
+    image: ssdavidai00/alfred-black-hermes:latest
+    network_mode: "service:hermes"
+    volumes_from:
+      - hermes
+    # uid 10000 is not a passwd user, it is the uid the init container chowns
+    # the whole hermes volume to (init/entrypoint.sh: `chown -R 10000:10000`).
+    # hermes-live REFUSES to read a config.env it does not own ("Managed config
+    # must be owned by the current user"), so running as root here silently
+    # loses every provider key. HOME must also point somewhere uid 10000 can
+    # write, or the CLI dies on `mkdir /.hermes`.
+    user: "10000:10000"
+    environment:
+      - HERMES_HOME=/hermes-state/profiles/main
+      - HOME=/hermes-state
+    entrypoint: ["/bin/sh", "-lc"]
+    # The task store is single-owner and its lock outlives an unclean stop, so
+    # a killed container would otherwise never start again. `tasks unlock`
+    # refuses to clear a lock held by a LIVE same-host process, so this is safe
+    # to run unconditionally on every start.
+    command: "hermes-live tasks unlock --confirm-no-gateway >/dev/null 2>&1 || true; exec hermes-live serve"
+    depends_on:
+      hermes:
+        condition: service_started
+    restart: unless-stopped
+
   tailscale:
     logging: *default-logging
     image: tailscale/tailscale:stable

--- a/packages/hermes/Dockerfile
+++ b/packages/hermes/Dockerfile
@@ -291,6 +291,84 @@ RUN python3 /tmp/patch_upstream_hermes_channeldir.py \
  && rm /tmp/patch_upstream_hermes_channeldir.py
 
 # =============================================================================
+# Hermes 0.20.4 — the runtime the fleet actually executes.  (2026-08-19)
+# =============================================================================
+# 0.20.x is git-only: there is no PyPI wheel. So the pip install above stays as
+# the base layer (it resolves the Python dep tree and gives the patched
+# site-packages copy), and the vendor installer overlays 0.20.4 into
+# /usr/local/lib/hermes-agent — which ships its OWN venv and its OWN launchers
+# in /usr/local/bin. Every `hermes` invocation therefore runs the 0.20.x tree.
+#
+# Three consequences, each of which bit us on home before being handled here:
+#
+#  1. web_dist. The git tree ships no dashboard bundle — that is the original
+#     reason HERMES_VERSION was pinned to the wheel (see the note above). Left
+#     alone, `hermes dashboard` attempts an npm build on FIRST RUN, inside a
+#     container that may have no writable npm cache. Pre-build it exactly as
+#     `hermes dashboard --skip-build` documents: `cd web && npm run build`.
+#
+#  2. The upstream patches. The 0.20.x launcher execs its own venv with
+#     PYTHONPATH/PYTHONHOME unset, so the three site-packages patches above
+#     never reach the code that actually runs. They are re-applied to the
+#     0.20.x tree below. The tripwires are per-invocation, so a needle that
+#     moves in a future bump still fails the build loudly instead of silently
+#     no-op'ing. NB 0.20.4 has FOUR fd-open sites in utils.py, not the
+#     historical three — the channeldir patch warns and patches all of them.
+#
+#  3. hermes-live. The live-voice gateway is a SEPARATE npm package, not part
+#     of Hermes; the Hermes-side plugin only talks to it. The plugin half is
+#     tenant state (it lives in the hermes volume), but the `hermes-live`
+#     binary is an image artifact — so it vanishes on every container recreate
+#     unless it is baked. Pinned to the version matching the plugin (0.9.5).
+#
+# --skip-browser / --skip-computer-use: the installer would otherwise pull
+# ~620 MB of Playwright/Chromium that no fleet image has ever shipped (the base
+# image installs the playwright *library* only). Skipping keeps fleet parity
+# and keeps the image near 1 GB rather than 2.5 GB.
+ARG HERMES_GIT_COMMIT=13ce0c5c675e843af70d19c9e5144249cd51c8d1
+ARG HERMES_GIT_VERSION=0.20.4
+ARG HERMES_LIVE_VERSION=0.9.5
+RUN curl -fsSL https://hermes-agent.nousresearch.com/install.sh -o /tmp/hermes-install.sh \
+ && npm_config_nodedir=/usr npm_config_unsafe_perm=true \
+    bash /tmp/hermes-install.sh \
+        --commit "${HERMES_GIT_COMMIT}" \
+        --hermes-home /opt/data \
+        --skip-setup --non-interactive --skip-browser --skip-computer-use \
+ && rm -f /tmp/hermes-install.sh \
+ && hermes --version \
+ && hermes --version | grep -qF "v${HERMES_GIT_VERSION}"
+
+# Pre-build the dashboard SPA so first run never shells out to npm (see 1).
+RUN cd /usr/local/lib/hermes-agent/web \
+ && npm_config_nodedir=/usr npm_config_unsafe_perm=true npm install --no-audit --no-fund \
+ && npm run build \
+ && test -f /usr/local/lib/hermes-agent/hermes_cli/web_dist/index.html \
+ && npm cache clean --force
+
+# Re-apply the three upstream patches to the 0.20.x tree (see 2).
+COPY packages/hermes/patch_upstream_hermes_auth.py       /tmp/p_auth.py
+COPY packages/hermes/patch_upstream_hermes_channeldir.py /tmp/p_chan.py
+COPY packages/hermes/patch_openai_sdk.py                 /tmp/p_openai.py
+RUN HT=/usr/local/lib/hermes-agent \
+ && RESP="$(ls "$HT"/venv/lib/python*/site-packages/openai/lib/_parsing/_responses.py | head -1)" \
+ && python3 /tmp/p_auth.py   "$HT/hermes_constants.py" \
+ && python3 /tmp/p_chan.py   "$HT/utils.py" \
+ && python3 /tmp/p_openai.py "$RESP" \
+ && grep -qF "alfred-black: never chmod a Hermes profile dir" "$HT/hermes_constants.py" \
+ && grep -qF "alfred-black: fd-safe atomic write"             "$HT/utils.py" \
+ && grep -qF "_alfred_fdopen_or_close"                        "$HT/utils.py" \
+ && grep -qF "(response.output or [])"                        "$RESP" \
+ && "$HT/venv/bin/python" -m py_compile "$HT/hermes_constants.py" "$HT/utils.py" "$RESP" \
+ && rm -f /tmp/p_auth.py /tmp/p_chan.py /tmp/p_openai.py
+
+# The live-voice gateway binary (see 3). Off unless the live-voice compose
+# profile is enabled; baking it costs ~44 MB and removes the recreate cliff.
+RUN npm_config_nodedir=/usr npm_config_unsafe_perm=true \
+    npm install --global --no-audit --no-fund "hermes-live-voice@${HERMES_LIVE_VERSION}" \
+ && hermes-live --version | grep -qF "${HERMES_LIVE_VERSION}" \
+ && npm cache clean --force
+
+# =============================================================================
 # Bake the hermes-lcm plugin (lossless cross-session context engine).
 # =============================================================================
 # The `stephenschoettler/hermes-lcm` plugin enables Hermes' LCM context engine

--- a/packages/hermes/patch_openai_sdk.py
+++ b/packages/hermes/patch_openai_sdk.py
@@ -46,7 +46,14 @@ SENTINEL = "(response.output or [])"
 
 
 def main() -> None:
-    p = pathlib.Path(RESPONSES_PY)
+    # Optional argv[1] target. The image installs Hermes twice: the pip wheel
+    # into site-packages, AND the pinned 0.20.x tree under
+    # /usr/local/lib/hermes-agent, which runs from its OWN venv with
+    # PYTHONPATH/PYTHONHOME unset — so a site-packages-only patch never
+    # reaches the code that actually runs. Both trees get patched; the
+    # default keeps existing callers unchanged.
+    target = sys.argv[1] if len(sys.argv) > 1 else RESPONSES_PY
+    p = pathlib.Path(target)
     src = p.read_text()
     if SENTINEL in src:
         print(f"openai/_parsing/_responses.py: already patched, skipping")

--- a/packages/hermes/patch_upstream_hermes_auth.py
+++ b/packages/hermes/patch_upstream_hermes_auth.py
@@ -64,14 +64,21 @@ REPLACEMENT = (
 
 
 def main() -> None:
-    p = pathlib.Path(TARGET)
+    # Optional argv[1] target. The image installs Hermes twice: the pip wheel
+    # into site-packages, AND the pinned 0.20.x tree under
+    # /usr/local/lib/hermes-agent, which runs from its OWN venv with
+    # PYTHONPATH/PYTHONHOME unset — so a site-packages-only patch never
+    # reaches the code that actually runs. Both trees get patched; the
+    # default keeps existing callers unchanged.
+    target = sys.argv[1] if len(sys.argv) > 1 else TARGET
+    p = pathlib.Path(target)
     src = p.read_text()
     if SENTINEL in src:
         print("secure_parent_dir: already patched, skipping")
         return
     if NEEDLE not in src:
         print(
-            f"secure_parent_dir: NEEDLE_NOT_FOUND in {TARGET} — upstream Hermes "
+            f"secure_parent_dir: NEEDLE_NOT_FOUND in {target} — upstream Hermes "
             f"may have moved this hunk; re-author the patch.",
             file=sys.stderr,
         )

--- a/packages/hermes/patch_upstream_hermes_channeldir.py
+++ b/packages/hermes/patch_upstream_hermes_channeldir.py
@@ -200,7 +200,13 @@ def patch_file(path: str, helper: str) -> None:
 
 
 def main() -> None:
-    patch_file(CHANNELDIR_PY, HELPER)
+    # Optional argv[1] target. The image installs Hermes twice: the pip wheel
+    # into site-packages, AND the pinned 0.20.x tree under
+    # /usr/local/lib/hermes-agent, which runs from its OWN venv with
+    # PYTHONPATH/PYTHONHOME unset — so a site-packages-only patch never
+    # reaches the code that actually runs. Both trees get patched; the
+    # default keeps existing callers unchanged.
+    patch_file(sys.argv[1] if len(sys.argv) > 1 else CHANNELDIR_PY, HELPER)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
0.20.x is git-only (no PyPI wheel), so the pip wheel stays as the base layer and the vendor installer — pinned to a commit, not a branch — overlays 0.20.4 into `/usr/local/lib/hermes-agent`. That tree ships **its own venv and its own launchers**, which is where the interesting failure modes live.

### What this fixes

1. **`web_dist`** — the git tree ships no dashboard bundle (the original reason `HERMES_VERSION` was pinned to the wheel). Left alone, `hermes dashboard` shells out to npm on first run. Now pre-built at image time, exactly as `--skip-build` documents.

2. **The upstream patches were silently bypassed.** The 0.20.x launcher execs its own venv with `PYTHONPATH`/`PYTHONHOME` unset, so the three site-packages patches never reached the code that actually runs — including the GH #222 fd-leak fix, whose absence wedges the gateway with "Too many open files". The patch scripts now take an optional target path (default unchanged) and are re-applied to the 0.20.x tree, tripwires intact. **0.20.4 has four fd-open sites in `utils.py`, not the historical three** — the patch warns and covers all of them.

3. **`hermes-live` is a separate npm package**, not part of Hermes. Its plugin half is tenant state in the volume, but the binary is an image artifact — so it vanished on every container recreate. Now pinned and baked.

`--skip-browser` / `--skip-computer-use` keep a ~620 MB Playwright/Chromium pull out; no fleet image has ever shipped those browsers.

### Compose

`hermes-dashboard` and `hermes-live` behind a `live-voice` profile, **off by default**. `hermes-live` runs as uid 10000 because it refuses to read a `config.env` it does not own, and the init container chowns the whole volume to that uid; `HOME` points into the volume so the CLI can write. Its task-store lock outlives an unclean stop, so start-up clears a crash-left lock first — that command refuses to touch a lock held by a live process.

## Smoke evidence

Verified end to end on the staging box before this commit:

```
hermes --version                     Hermes Agent v0.20.4 (2026.8.18)
utils.py loaded from                 /usr/local/lib/hermes-agent/utils.py
  fd-safe helper present             True
  profile-dir guard present          True
hermes-live /ready                   HTTP 200   status: ready
  gateway ok=True  hermes ok=True  realtime ok=True  tasks ok=True
  model_options: true, session_model_lock: true
hermes dashboard :9121               HTTP 200   (web_dist: 60 files, 3.1M)
docker compose config -q             OK
default profile                      0 of the two services
--profile live-voice                 hermes-dashboard, hermes-live
```

Lane V gate: passed — 174 LOC, 5 files, verify ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)