### PR TITLE
fix(compose): live-voice commands were shlex-split into nothing

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1387,7 +1387,10 @@ services:
     entrypoint: ["/bin/sh", "-lc"]
     # --skip-build: web_dist is baked into the image, so never shell out to
     # npm at runtime (the git-installed tree ships no bundle of its own).
-    command: exec hermes dashboard --host 0.0.0.0 --port 9121 --no-open --skip-build
+    # MUST be a single-element list. A plain string here is shlex-split by
+    # compose, so `sh -lc` would receive only the first token as its script
+    # ("exec") and exit 0 immediately.
+    command: ["exec hermes dashboard --host 0.0.0.0 --port 9121 --no-open --skip-build"]
     depends_on:
       hermes:
         condition: service_started
@@ -1415,7 +1418,10 @@ services:
     # a killed container would otherwise never start again. `tasks unlock`
     # refuses to clear a lock held by a LIVE same-host process, so this is safe
     # to run unconditionally on every start.
-    command: "hermes-live tasks unlock --confirm-no-gateway >/dev/null 2>&1 || true; exec hermes-live serve"
+    # Single-element list for the same reason as the dashboard above: as a
+    # plain string compose splits it and everything from the redirect onward
+    # is lost, taking the `|| true` and the `exec ... serve` with it.
+    command: ["hermes-live tasks unlock --confirm-no-gateway >/dev/null 2>&1 || true; exec hermes-live serve"]
     depends_on:
       hermes:
         condition: service_started


### PR DESCRIPTION
`entrypoint: ["/bin/sh", "-lc"]` with a plain-string `command:` does not do what it looks like. Compose splits the string on whitespace, so `sh -lc` receives only the **first token** as its script and the rest as positional parameters.

| service | resulting `Cmd` | effect |
|---|---|---|
| `hermes-dashboard` | `["exec","hermes","dashboard",…]` | `sh -lc exec` runs the bare builtin → container **exits 0 with no log output at all** |
| `hermes-live` | `["hermes-live","tasks","unlock","--confirm-no-gateway"]` | truncated at the redirect, so `\|\| true` and `exec hermes-live serve` were silently dropped — taking the crash-lock recovery with them, leaving the gateway wedged on a stale lock from a previous container |

Both are now single-element lists, the only form that survives intact. Note the folded-scalar form (`command: >`) has the same problem — it also yields a string.

## Smoke evidence

Both sidecars recreated from the baked image on the staging box:

```
hermes-dashboard   Up (healthy)   :9121 -> 302 /login?next=%2F -> 200
                   log: "Skipping web UI build (--skip-build); using dist at
                         /usr/local/lib/hermes-agent/hermes_cli/web_dist"
hermes-live        Up (healthy)   /ready -> HTTP 200   status: ready
                   gateway ok=true  hermes ok=true  realtime ok=true  tasks ok=true
                   log: "hermes-live listening url=http://127.0.0.1:8788"

main gateway :18789 -> HTTP 200        (unaffected)
public dashboard    -> HTTP 200        (unaffected)
```

Lane V gate: passed — 10 LOC, 1 file, verify ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)