### PR TITLE
fix(hermes): keep the traversal bit on the hermes volume root

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1412,7 +1412,13 @@ services:
     user: "10000:10000"
     environment:
       - HERMES_HOME=/hermes-state/profiles/main
-      - HOME=/hermes-state
+      # HOME must be writable by uid 10000 (task state lands in
+      # $HOME/.hermes/hermes-live) but must NOT be the volume root: tools
+      # that treat HOME as theirs tighten it to 0700, which removes the
+      # traversal bit uid 10001 needs to reach its own profile and fails
+      # the init FS-isolation assert. A profile dir is the safe choice —
+      # patch_upstream_hermes_auth.py already stops those being chmod-ed.
+      - HOME=/hermes-state/profiles/main
     entrypoint: ["/bin/sh", "-lc"]
     # The task store is single-owner and its lock outlives an unclean stop, so
     # a killed container would otherwise never start again. `tasks unlock`

--- a/packages/hermes/init/entrypoint.sh
+++ b/packages/hermes/init/entrypoint.sh
@@ -661,6 +661,14 @@ fi
 chown -R 10000:10000 "$HERMES_DATA_DIR" 2>/dev/null || true
 chown -R 10000:10000 /vault 2>/dev/null || true
 
+# The data dir's own mode is a precondition for §7b below: uid 10001 has to
+# TRAVERSE it to reach its profile. Anything that treats this directory as a
+# HOME can tighten it to 0700 (Hermes' own _secure_dir does exactly that),
+# and the isolation assert then fails with the confusing "cannot read its own
+# .env" — the .env is fine, the path to it is not. Re-assert the traversal
+# bit every boot so that failure mode self-heals instead of wedging deploys.
+chmod 0755 "$HERMES_DATA_DIR" 2>/dev/null || true
+
 # =============================================================================
 # 7b. codex-builder profile FS isolation (PR 4 of
 #     docs/codex-builder-runtime.md §6).


### PR DESCRIPTION
The init container asserts that uid 10001 (codex-builder) can read its own profile `.env`. That assert started failing with *"cannot read its own .env"* — but the `.env` was fine, at `0644 10001:10001`. The **path** to it was not: the volume root had gone `0755` → `0700`, so uid 10001 could no longer traverse it. The error names the wrong thing, which is what made it interesting.

**Cause.** The live-voice sidecar was given `HOME=/hermes-state`, and a tool that treats a directory as its HOME tightens it to `0700` (Hermes' own `_secure_dir` does exactly this). `patch_upstream_hermes_auth.py` already prevents that happening to a *profile* dir — but the volume root is not a profile dir.

**Two changes**, so it cannot recur and repairs itself if it somehow does:

- `HOME` for the live-voice gateway moves to the main profile dir. It still needs a writable HOME (task state lands in `$HOME/.hermes/hermes-live`), and a profile dir is already protected by the auth patch.
- `init` re-asserts `chmod 0755` on the data dir, next to the `chown` it already does. That mode is a precondition for the FS-isolation assert directly below it, so a boot that finds it wrong now heals instead of wedging every `deploy-compose` run.

Untouched tenants all carry `drwxr-xr-x` here, so this restores the norm rather than inventing one.

## Smoke evidence

Staging box, before → after:

```
volume root     drwx------ 10000:10000   ->  drwxr-xr-x 10000:10000
uid 10001 read  READ DENIED              ->  READ OK
init            Exited (71) FS isolation ->  Exited (0) "=== Init complete ==="
                assertion failed
hermes-live     Up (healthy)  /ready -> HTTP 200
task state      /hermes-state/profiles/main/.hermes/hermes-live/
```

Lane V gate: passed — 16 LOC, 2 files, verify ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)