### PR TITLE
fix(hermes): stop the retention cron registering itself twice per boot

### DIFF
--- a/packages/hermes/docker/supervisor.sh
+++ b/packages/hermes/docker/supervisor.sh
@@ -295,6 +295,25 @@ install_state_retention() {
 
         # Idempotent: re-registering every boot would stack duplicates, and an
         # operator who retuned the schedule must keep it.
+        #
+        # Read the store FILE, not `cron list`. This runs before the gateways
+        # are up, and at that point the CLI yields nothing usable — so a
+        # `cron list | grep` guard silently passed and registered a second
+        # copy on the very first boot after rollout (observed: two jobs, one
+        # 16:42 by hand, one 17:24:48 by this function). Every later boot would
+        # have added another. The file is plain JSON and is readable whether or
+        # not a gateway is running; the CLI check stays as a fallback.
+        if python3 - "${profile_dir}/cron/jobs.json" <<'PY' 2>/dev/null
+import json, sys
+try:
+    jobs = json.load(open(sys.argv[1])).get("jobs", [])
+except Exception:
+    sys.exit(1)                     # unreadable -> fall through to the CLI check
+sys.exit(0 if any(j.get("name") == "state-retention" for j in jobs) else 1)
+PY
+        then
+            continue
+        fi
         if hermes -p "${slug}" cron list 2>/dev/null | grep -q 'state-retention'; then
             continue
         fi


### PR DESCRIPTION
Follow-up to #699.

`install_state_retention` guarded on `hermes cron list | grep`. That function runs immediately after `wait_for_profiles`, **before any gateway is up**, and at that point the CLI yields nothing usable — so the guard silently passed and registered a second copy of the job.

Observed on the first boot after rollout — two jobs named `state-retention` on each of workers and heavy:

```
id=116a14187ecc created=2026-08-19T16:42:25Z   <- registered by hand
id=0aef7d3accfe created=2026-08-19T17:24:48Z   <- registered by the supervisor
supervisor log:  17:24:48Z [supervisor] registered state-retention cron on workers
```

Replaying the identical guard once the gateways were up **correctly skips** — which is precisely why it looked fine when I tested it by hand. Every subsequent boot would have stacked another copy.

### Fix

Guard on the store **file** instead. It is plain JSON, readable whether or not a gateway is running, and it is the same file the scheduler reads. The CLI check is kept as a fallback for a missing or unparseable file.

## Smoke evidence

Guard logic verified against all four states:

```
job present   -> exit 0   skip
job absent    -> exit 1   register
empty store   -> exit 1   register
missing file  -> exit 1   register (falls back to the CLI check)
```

Existing duplicates removed across all 7 tenants; every workers/heavy profile now carries exactly one `state-retention` job (14 total, verified per host).

Lane V gate: passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)