### PR TITLE
fix(hermes): install messaging adapters into the vendor venv, not site-packages

### DIFF
--- a/packages/hermes/Dockerfile
+++ b/packages/hermes/Dockerfile
@@ -361,6 +361,39 @@ RUN HT=/usr/local/lib/hermes-agent \
  && "$HT/venv/bin/python" -m py_compile "$HT/hermes_constants.py" "$HT/utils.py" "$RESP" \
  && rm -f /tmp/p_auth.py /tmp/p_chan.py /tmp/p_openai.py
 
+# The messaging adapters must live in the VENDOR VENV, not site-packages (see 2).
+# `hermes-agent[...,messaging,...]` above installs slack_bolt / slack_sdk /
+# python-telegram-bot / discord.py into /usr/local/lib/python3.12/site-packages.
+# But /usr/local/bin/hermes unsets PYTHONPATH/PYTHONHOME and execs the 0.20.x
+# venv (python3.11), which cannot see them. The adapter then fails to construct
+# and the platform goes silently unavailable — the gateway still starts, every
+# healthcheck still returns 200, and the only trace is three lines at boot:
+#   WARNING gateway.platform_registry: Platform 'Slack' requirements not met
+#   ERROR   gateway.run: Platform 'slack' is registered but adapter creation failed
+#   WARNING gateway.run: No adapter available for slack
+#
+# 2026-08-19 -> 2026-08-24: a tenant's Slack assistant was mute for five days on
+# exactly this. Its tokens were valid the whole time. Another tenant looked fine
+# only because it had been hand-patched nine seconds after its container came up
+# during the same rollout — an undocumented fix living in a container's writable
+# layer, one `up -d` from vanishing.
+#
+# Versions are pinned to whatever the `messaging` extra resolved above so the two
+# trees agree. The venv has no pip, no ensurepip, and uv is not on PATH, so these
+# go in via the 3.12 pip with --target; all four are pure-Python.
+#
+# When bumping HERMES_GIT_VERSION: re-check this. Same class as the patch block
+# above — anything site-packages needs, the vendor venv needs too.
+RUN HT=/usr/local/lib/hermes-agent \
+ && SP="$(ls -d "$HT"/venv/lib/python*/site-packages)" \
+ && python3 -m pip install --no-cache-dir --target "$SP" \
+        "slack_bolt==1.29.0" \
+        "slack_sdk==3.43.0" \
+        "python-telegram-bot==22.6" \
+        "discord.py==2.7.1" \
+ && "$HT/venv/bin/python" -c "import slack_bolt, slack_sdk, telegram, discord" \
+ && echo "messaging adapters importable in vendor venv"
+
 # The live-voice gateway binary (see 3). Off unless the live-voice compose
 # profile is enabled; baking it costs ~44 MB and removes the recreate cliff.
 RUN npm_config_nodedir=/usr npm_config_unsafe_perm=true \

--- a/packages/hermes/docker/supervisor.sh
+++ b/packages/hermes/docker/supervisor.sh
@@ -1005,6 +1005,37 @@ fi
 # =============================================================================
 # Supervise — restart any worker that exits while we are not shutting down.
 # =============================================================================
+# =============================================================================
+# Messaging-adapter preflight — fail LOUD, not silent.
+# =============================================================================
+# A configured platform whose Python dep is missing does not crash anything: the
+# gateway starts, healthchecks return 200, and the adapter is just absent. The
+# only trace is a WARNING at boot that nobody reads. In 2026-08 that pattern hid
+# a mute Slack assistant on a live tenant for five days, because the dep was
+# installed into site-packages while the runtime execs the vendor venv.
+#
+# So: if a token is configured but the module will not import in the interpreter
+# that actually runs, say so at ERROR with the fix. Never fatal — a broken chat
+# platform must not take the runtime down.
+MAIN_ENV="${PROFILES_DIR}/main/.env"
+if [[ -f "${MAIN_ENV}" ]]; then
+    VENV_PY="/usr/local/lib/hermes-agent/venv/bin/python"
+    [[ -x "${VENV_PY}" ]] || VENV_PY="$(command -v python3 || true)"
+    for pair in "SLACK_BOT_TOKEN:slack_bolt" "TELEGRAM_BOT_TOKEN:telegram" "DISCORD_BOT_TOKEN:discord"; do
+        tok_var="${pair%%:*}"; mod="${pair##*:}"
+        if grep -qE "^${tok_var}=.+" "${MAIN_ENV}" 2>/dev/null; then
+            if [[ -n "${VENV_PY}" ]] && ! "${VENV_PY}" -c "import ${mod}" >/dev/null 2>&1; then
+                log "ERROR: ${tok_var} is configured but '${mod}' will not import in ${VENV_PY}."
+                log "       That platform will be SILENTLY unavailable (gateway still healthy)."
+                log "       Fix: install ${mod} into the vendor venv's site-packages, not"
+                log "       /usr/local/lib/python3.12/site-packages — see packages/hermes/Dockerfile."
+            else
+                log "messaging preflight ok: ${tok_var} configured, '${mod}' importable"
+            fi
+        fi
+    done
+fi
+
 log "all gateway processes running — entering supervise loop"
 while true; do
     # Block until SOME child exits. `wait -n` returns that child's status.


### PR DESCRIPTION
## What

1. `packages/hermes/Dockerfile` — install `slack_bolt` / `slack_sdk` / `python-telegram-bot` / `discord.py` into the **vendor venv's** site-packages, with an import assertion so the build fails rather than shipping a mute platform.
2. `packages/hermes/docker/supervisor.sh` — boot-time preflight: if a platform token is configured but its module won't import in the interpreter that actually runs, log ERROR with the fix. Never fatal.

## Why

**A tenant's Slack assistant was mute for five days** (2026-08-19 → 08-24), with valid tokens and every healthcheck green.

`hermes-agent[...,messaging,...]` installs the adapters into `/usr/local/lib/python3.12/site-packages`. But `/usr/local/bin/hermes` is a wrapper that does:

```bash
unset PYTHONPATH
unset PYTHONHOME
exec "/usr/local/lib/hermes-agent/venv/bin/python" "/usr/local/lib/hermes-agent/hermes" "$@"
```

…and that venv is **python3.11**, which cannot see the 3.12 site-packages. Confirmed against a pristine image — all four import under 3.12, none under the venv:

```
                venv(3.11)   site-packages(3.12)
slack_bolt      MISSING      present
slack_sdk       MISSING      present
telegram        MISSING      present
discord         MISSING      present
```

**Nothing fails loudly.** The gateway starts, all three profiles return 200 on `/health`, the tokens are fine, and the platform is simply absent. The whole trace is three lines at boot:

```
WARNING gateway.platform_registry: Platform 'Slack' requirements not met
ERROR   gateway.run: Platform 'slack' is registered but adapter creation failed
WARNING gateway.run: No adapter available for slack
```

A second tenant looked healthy only because it had been hand-patched **nine seconds** after its container started during the same rollout (`slack_bolt` mtime 17:37:05 vs container start 17:36:56) — an undocumented fix living in a container's writable layer, one `up -d` from vanishing. That is why this presented as *"the image is broken, so how is it working over there?"*

## Smoke evidence

**Root cause isolated** — the gateway process runs the venv interpreter, not the one holding the package:

```
pid=46  exe: /usr/bin/python3.11
cmd: /usr/local/lib/hermes-agent/venv/bin/python /usr/local/lib/hermes-agent/hermes -p main gateway run

python3.11 slack_bolt: ModuleNotFoundError   <- the interpreter that matters
python3.12 slack_bolt: 1.29.0                <- installed, never loaded
```

**Both affected tenants ran the identical image** (`f50423450d63`, built 2026-08-19T17:34:15), same venv, same python 3.11.2 — so this was never an image-vs-image difference.

**Install mechanism verified in a pristine container before writing it** (the venv has no `pip`, no `ensurepip`, and `uv` is not on PATH):

```
venv import after install: OK slack_bolt 1.30.0 slack_sdk 3.43.0
```

**Versions pinned to what the `messaging` extra already resolved**, so both trees agree: slack_bolt 1.29.0, slack_sdk 3.43.0, python-telegram-bot 22.6, discord.py 2.7.1.

**Live confirmation of the diagnosis:** applying the same install by hand to the affected tenant and restarting its main gateway brought Slack straight back —

```
slack_bolt.AsyncApp: ...                                  <- adapter built
hermes_plugins.slack_platform.adapter: [Slack] ... workspace <redacted>
"No adapter available for slack" since restart: 0
gateways 18789/18790/18791: 200
```

That hot-patch is exactly what this PR makes durable; it does not survive a container recreate.

**Validation:** `bash -n` clean; `shellcheck -S error` clean; lane gate passed (phase0, 64 LOC, 2 files). The Dockerfile change carries its own build-time assertion (`import slack_bolt, slack_sdk, telegram, discord` in the venv).

## Deploy note

Needs `build-hermes` + a `docker compose pull hermes` per tenant — `deploy-compose` runs `up -d` **without** a pull, so images do not advance on their own. Until then the two Slack tenants are running on hand-patched containers and will go mute again on any recreate.

## Related

Same class as the patch block directly above it in the Dockerfile (the GH #222 fd-leak fix, which silently stopped applying for the same reason). The rule the comment now states explicitly: **anything site-packages needs, the vendor venv needs too — re-check on every version bump.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)