### PR TITLE
fix(hermes): hold the traversal bit so codex-builder and learn can reach their dirs

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -418,6 +418,14 @@ services:
     environment:
       - HERMES_API_SERVER_KEY=${HERMES_API_SERVER_KEY}
       - HERMES_HOME=/hermes-state
+      # hermes_cli.config._secure_dir() chmods HERMES_HOME on EVERY CLI
+      # invocation, defaulting to 0700. codex-builder runs as uid 10001,
+      # so a 0700 volume root means it cannot cd into its own profile:
+      # the gateway then crash-loops every ~5s and the supervisor
+      # eventually exits, restarting the whole container. 0711 grants
+      # traversal without exposing a directory listing. Container-wide so
+      # that `docker exec ... hermes` inherits it too.
+      - HERMES_HOME_MODE=0711
       # Opt a tenant out of the hermes-relay (:8767) + dashboard (:9119)
       # block in supervisor.sh. Documented there as the per-tenant switch
       # since it shipped, but never plumbed through compose — so setting it
@@ -1393,6 +1401,10 @@ services:
       - hermes
     environment:
       - HERMES_HOME=/hermes-state/profiles/main
+      # Same _secure_dir() tighten, one level down: without this the
+      # sidecar sets profiles/main to 0700 on each start and alfred-learn
+      # (uid 1000) silently reads zero sessions.
+      - HERMES_HOME_MODE=0711
     entrypoint: ["/bin/sh", "-lc"]
     # --skip-build: web_dist is baked into the image, so never shell out to
     # npm at runtime (the git-installed tree ships no bundle of its own).
@@ -1431,12 +1443,18 @@ services:
     user: "10000:10000"
     environment:
       - HERMES_HOME=/hermes-state/profiles/main
+      # Same _secure_dir() tighten, one level down: without this the
+      # sidecar sets profiles/main to 0700 on each start and alfred-learn
+      # (uid 1000) silently reads zero sessions.
+      - HERMES_HOME_MODE=0711
       # HOME must be writable by uid 10000 (task state lands in
       # $HOME/.hermes/hermes-live) but must NOT be the volume root: tools
       # that treat HOME as theirs tighten it to 0700, which removes the
       # traversal bit uid 10001 needs to reach its own profile and fails
-      # the init FS-isolation assert. A profile dir is the safe choice —
-      # patch_upstream_hermes_auth.py already stops those being chmod-ed.
+      # the init FS-isolation assert. A profile dir is the safe choice for
+      # HOME, but note it is NOT self-protecting: patch_upstream_hermes_auth
+      # guards secure_parent_dir() (the auth-save path), not
+      # _secure_dir(home), so HERMES_HOME_MODE above is what holds the mode.
       - HOME=/hermes-state/profiles/main
     entrypoint: ["/bin/sh", "-lc"]
     # The task store is single-owner and its lock outlives an unclean stop, so

--- a/packages/hermes/docker/supervisor.sh
+++ b/packages/hermes/docker/supervisor.sh
@@ -368,6 +368,48 @@ hermes profile use main 2>/dev/null || true
 # Same OAuth token, two file locations, one shared ChatGPT identity.
 # Survives `docker compose pull` because hermes_data is a named volume.
 HERMES_ROOT="${HERMES_HOME:-/hermes-state}"
+
+# ── Traversal bits: repair before ANY gateway launches ──────────────────────
+#
+# hermes_cli.config._secure_dir() chmods HERMES_HOME (and its standard
+# subdirs) on every CLI invocation, defaulting to 0700 unless
+# HERMES_HOME_MODE says otherwise. Two things then break, both silently:
+#
+#   - codex-builder runs as uid 10001, so a 0700 volume root means it cannot
+#     cd into its own profile. It exits 1, the supervisor restarts it every
+#     ~5s, and once the child restart budget is spent the supervisor exits and
+#     the whole container restarts — cold-starting main/workers/heavy with it.
+#   - alfred-learn runs as uid 1000 and reads profiles/main/state.db for the
+#     NAR recap. A 0700 profile dir makes that read fail as "no session db",
+#     which is logged as a skip, not an error, so the recap quietly books zero
+#     engaged minutes.
+#
+# The compose file now sets HERMES_HOME_MODE=0711 on the hermes service and on
+# both live-voice sidecars, which stops new drift at the source. This block is
+# the self-heal for volumes that have ALREADY drifted: it runs before the auth
+# propagation and before any gateway starts, so a tenant repairs itself on its
+# next restart with no operator action.
+#
+# 0711 is traverse-only — no directory listing, and file modes are untouched
+# (auth.json stays 0600, .env stays 0600). Verified on home 2026-08-28.
+assert_traversal_bits() {
+    local d mode
+    for d in "$HERMES_ROOT" "$HERMES_ROOT"/profiles/*/; do
+        [[ -d "$d" ]] || continue
+        mode=$(stat -c%a "$d" 2>/dev/null) || continue
+        # Only widen a too-tight owner-only dir; never touch anything an
+        # operator has deliberately opened further (0755 and friends).
+        if [[ "$mode" == "700" ]]; then
+            if chmod 0711 "$d" 2>/dev/null; then
+                log "traversal: $d was 0700 -> 0711 (uid 10001/1000 need to traverse)"
+            else
+                log "traversal: WARNING could not chmod $d (was $mode)"
+            fi
+        fi
+    done
+}
+assert_traversal_bits
+
 MAIN_AUTH="$HERMES_ROOT/profiles/main/auth.json"
 if [[ -f "$MAIN_AUTH" && -s "$MAIN_AUTH" ]]; then
     MAIN_SIZE=$(stat -c%s "$MAIN_AUTH" 2>/dev/null || echo 0)


### PR DESCRIPTION
Fixes a live incident on one tenant: the `codex-builder` gateway crash-looping every ~5s and taking the whole hermes container down with it every ~2 minutes, plus the NAR recap silently reading zero sessions. Same root cause, two symptoms.

## Root cause

`hermes_cli.config._secure_dir()` chmods `HERMES_HOME` and its standard subdirs on **every** CLI invocation, defaulting to `0700` unless `HERMES_HOME_MODE` says otherwise. Nothing set that outside the codex-builder profile `.env`, so:

- **The volume root drifted to 0700.** `codex-builder` runs as uid **10001** (the sealed-compartment profile, deliberately a different uid) and could no longer `cd` into its own profile. 109 failures in 10 minutes; once the child restart budget was spent the supervisor exited and the container restarted, cold-starting main/workers/heavy with it — ~80s of boot against ~40s of uptime on a 6 GB `state.db`.
- **`profiles/main` drifted to 0700** because both live-voice sidecars set `HERMES_HOME` to that profile dir. `alfred-learn` (uid 1000) then could not read `state.db`, which `_open_session_db()` logs as a *skip*, not an error — so the NAR recap booked zero engaged minutes with nothing in the logs to say so.

The compose comment claimed `patch_upstream_hermes_auth.py` already prevented this. **It does not** — that patch guards `secure_parent_dir()` (the auth-save path), not `_secure_dir(home)`, which is what actually fires. Comment corrected.

Note the deadlock: the thing that *maintained* `0711` was codex-builder’s own `HERMES_HOME_MODE`, applied at its startup. Once it could not start, nothing re-asserted the bit.

## Fix

- `HERMES_HOME_MODE=0711` on the `hermes` service and both live-voice sidecars — stops the drift at source, container-wide so `docker exec ... hermes` inherits it.
- `assert_traversal_bits()` in `supervisor.sh` — repairs an already-drifted volume before the auth propagation and before any gateway starts, so tenants self-heal on next restart with no operator action. Only widens `0700`; anything deliberately opened further is left alone.

`0711` is traverse-only: no directory listing, file modes untouched (`auth.json` and `.env` stay `0600`).

## Smoke evidence

Applied by hand on the affected tenant before the code change:

```
chmod 0711 /hermes-state      -> codex-builder up on :18793 within one supervisor
                                 retry, no container restart needed
chmod 0711 profiles/main      -> learn uid 1000: state.db NOT-READABLE -> READABLE
                                 .env still unreadable, directory still unlistable
stability                     -> RestartCount frozen at 46 over 150s (previously
                                 cycling ~2 min), 0 child restarts, 0 permission
                                 denials in 90s, all four gateways 200
```

Fleet: the other six tenants were unaffected (root `0755`, 0 restarts, up 2 days).

`assert_traversal_bits()` unit-tested on Linux against a temp tree — `0700` root/main/workers/codex-builder all → `0711` (4/4), a `0755` dir left untouched, second run logs nothing (idempotent). `bash -n` + `shellcheck -S error` clean, `docker compose config -q` OK, lane V gate passed (64 LOC).

## Rollout caution

Merging triggers `deploy-compose.yml`, which rsyncs and runs `up -d` **fleet-wide**. The changed `environment:` block means hermes is **recreated** on every tenant — ~80–100s cold start on the three tenants with large `state.db` (§15.16), and recreating hermes orphans the netns-sharing live-voice sidecars (§15.13), which must be recreated after it. Worth timing deliberately rather than merging blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)