### PR TITLE
fix(hermes): bake the Slack adapter deps into the 0.20.x venv

### DIFF
--- a/packages/hermes/Dockerfile
+++ b/packages/hermes/Dockerfile
@@ -299,7 +299,7 @@ RUN python3 /tmp/patch_upstream_hermes_channeldir.py \
 # /usr/local/lib/hermes-agent — which ships its OWN venv and its OWN launchers
 # in /usr/local/bin. Every `hermes` invocation therefore runs the 0.20.x tree.
 #
-# Three consequences, each of which bit us on home before being handled here:
+# Four consequences, each of which bit us on a tenant before being handled here:
 #
 #  1. web_dist. The git tree ships no dashboard bundle — that is the original
 #     reason HERMES_VERSION was pinned to the wheel (see the note above). Left
@@ -320,6 +320,15 @@ RUN python3 /tmp/patch_upstream_hermes_channeldir.py \
 #     tenant state (it lives in the hermes volume), but the `hermes-live`
 #     binary is an image artifact — so it vanishes on every container recreate
 #     unless it is baked. Pinned to the version matching the plugin (0.9.5).
+#
+#  4. Slack platform deps. The base wheel's [messaging] extra puts slack-bolt
+#     in SITE-PACKAGES — the tree that does not run (see 2). The 0.20.x venv
+#     is uv-built with no pip/ensurepip and no slack deps vendored, so the
+#     gateway re-resolves them at EVERY boot via a uv bootstrap (astral.sh +
+#     pypi at boot time). When that per-boot install fails, the Slack adapter
+#     dies with "requirements not met" — a tenant's Slack went dark exactly
+#     this way on 2026-08-28 after a fleet recreate. Baked below so the
+#     adapter has no boot-time network dependency.
 #
 # --skip-browser / --skip-computer-use: the installer would otherwise pull
 # ~620 MB of Playwright/Chromium that no fleet image has ever shipped (the base
@@ -360,6 +369,21 @@ RUN HT=/usr/local/lib/hermes-agent \
  && grep -qF "(response.output or [])"                        "$RESP" \
  && "$HT/venv/bin/python" -m py_compile "$HT/hermes_constants.py" "$HT/utils.py" "$RESP" \
  && rm -f /tmp/p_auth.py /tmp/p_chan.py /tmp/p_openai.py
+
+# Slack adapter deps for the 0.20.x venv (see 4). Pure-python wheels pinned to
+# what uv resolved on the golden home box; installed with the SYSTEM pip
+# --target into the venv's site-packages because the uv-built venv has no pip.
+# --no-deps on purpose: everything transitive (aiohttp etc.) is already in the
+# venv — uv confirmed this live ("Installed 2 packages"). The import runs with
+# the venv's OWN interpreter, so the build fails loudly if the bake ever stops
+# reaching the tree that actually runs.
+ARG SLACK_BOLT_VERSION=1.30.0
+ARG SLACK_SDK_VERSION=3.43.0
+RUN VSP="$(/usr/local/lib/hermes-agent/venv/bin/python -c 'import site; print(site.getsitepackages()[0])')" \
+ && pip install --no-cache-dir --no-deps --target "$VSP" \
+        "slack-bolt==${SLACK_BOLT_VERSION}" "slack-sdk==${SLACK_SDK_VERSION}" \
+ && /usr/local/lib/hermes-agent/venv/bin/python -c "import slack_bolt, slack_sdk" \
+ && echo "slack deps baked into the 0.20.x venv"
 
 # The live-voice gateway binary (see 3). Off unless the live-voice compose
 # profile is enabled; baking it costs ~44 MB and removes the recreate cliff.


### PR DESCRIPTION
One tenant's Slack went dark after the 2026-08-28 06:20 fleet recreate while another tenant on the **same image** kept working. Root cause: Hermes does not ship its Slack dependencies — the 0.20.x venv (uv-built, no pip) gets `slack-bolt`/`slack-sdk` re-installed at **every boot** by a uv bootstrap that needs astral.sh + pypi at boot time. When that roll of the dice fails, the adapter dies with `Platform 'Slack' requirements not met` and stays dead until the next lucky boot.

The base wheel's `[messaging]` extra is a decoy: it installs slack-bolt into site-packages — the tree that does not run (CLAUDE.md §9.0). This is the same two-trees trap as the upstream patches, one dependency further down.

## Fix

Bake the two wheels into the venv at build time:

- `slack-bolt==1.30.0` + `slack-sdk==3.43.0` — exactly what uv resolved on the golden box
- system `pip --target` into the venv's own site-packages (the venv has no pip); pure-python wheels so the interpreter split is irrelevant
- `--no-deps`: everything transitive is already in the venv (uv confirmed live: "Installed 2 packages")
- the import assert runs with the venv's **own** interpreter — the build fails loudly if a future bump moves the venv and the bake stops reaching the tree that runs

## Smoke evidence

Live equivalent verified on the affected tenant today: the same two pinned wheels installed into the same venv path restored the adapter — connected to the workspace, error gone, gateways 200 — and survived a fs-preserving restart. The build-time assert is the identical import that failed before the fix. `docker compose config -q` clean; the real build runs in CI `build-hermes` on merge.

## Rollout

Merge only builds a new `:latest` — no auto-deploy, no tenant restarts. Tenants pick it up on their next image roll; the two tenants currently carrying the runtime install keep working either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)