### PR TITLE
feat(cowork): journal-destination webhooks + an installable Cowork bridge

### DIFF
--- a/packages/cowork-journal/README.md
+++ b/packages/cowork-journal/README.md
@@ -1,0 +1,81 @@
+# cowork-journal
+
+Mirrors your local **Claude Cowork** conversations into your Alfred's journal, so
+Alfred remembers what you discussed in Cowork the same way it remembers Slack
+and Telegram.
+
+## Why this exists
+
+When you talk to Alfred through Cowork, Alfred only ever sees isolated MCP tool
+calls — it has no thread, no history, no idea a conversation happened. Ask it
+something in Slack afterwards and it has amnesia, which breaks the "one Alfred"
+illusion (`docs/design/one-alfred.md`).
+
+This ships each Cowork turn into `alfred_journal`. The `one-alfred` Hermes
+plugin already re-injects recent journal context on every inbound message, so
+the continuity works with **no plugin change** — the read path exists, it was
+only ever missing the writer.
+
+## Install
+
+1. In your Alfred dashboard: **Connections → Custom Webhook → New**, set
+   destination **journal**, and copy the URL.
+2. Run:
+
+   ```bash
+   bash install.sh
+   ```
+
+It asks for the URL, verifies it can read your transcripts, offers to backfill
+existing history, then schedules itself every 5 minutes via `launchd`.
+
+```bash
+bash install.sh --uninstall     # stop and remove the timer
+```
+
+## What gets sent
+
+Only user and assistant **text** turns from local Cowork sessions:
+
+| field | value |
+|---|---|
+| `chat_id` | Cowork session id — one journal thread per conversation |
+| `direction` | `inbound` (you) / `outbound` (Alfred) |
+| `message` | the turn's text, truncated at 4000 chars |
+| `source_ref` | the turn's UUID — used for idempotency |
+
+Skipped: `<scheduled-task>` and `<system-reminder>` injections (machinery, not
+conversation), tool-call payloads, and attachments.
+
+## Guarantees
+
+- **Exactly once.** A per-file cursor of seen UUIDs lives in
+  `~/.alfred/cowork-journal/state.json`. Re-runs never duplicate.
+- **Fail-soft.** A failed POST leaves the cursor untouched, so the next run
+  retries rather than dropping turns.
+- **Least privilege.** The webhook token is the only credential. It can append
+  journal entries and nothing else — it is not your API key. Revoke it any time
+  with `DELETE /api/v1/webhooks/inbound/<token>` and this stops cleanly, with
+  no other access affected.
+- **Local only.** Transcripts are read from
+  `~/Library/Application Support/Claude/local-agent-mode-sessions/`. Nothing
+  else on your machine is read, and nothing is sent anywhere except your own
+  tenant.
+
+## Privacy
+
+Your Cowork conversations become journal entries in **your** vault and are
+embedded for semantic search there. Point this only at your own tenant. If a
+conversation shouldn't reach Alfred, don't backfill — choose "no" at the prompt
+and only new conversations are sent.
+
+## Troubleshooting
+
+```bash
+tail -20 ~/.alfred/cowork-journal/push.log      # what the timer is doing
+COWORK_DRY_RUN=1 python3 ~/.alfred/cowork-journal/push.py   # show, send nothing
+launchctl list | grep cowork-journal            # is it scheduled
+```
+
+`pushed=0 already_seen=N` means everything is already mirrored — the normal
+steady state.

--- a/packages/cowork-journal/install.sh
+++ b/packages/cowork-journal/install.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# cowork-journal installer — mirrors local Claude Cowork conversations into
+# your Alfred's journal, so Alfred remembers what you discussed in Cowork.
+#
+#   bash install.sh            interactive
+#   bash install.sh --uninstall
+set -euo pipefail
+
+DEST="$HOME/.alfred/cowork-journal"
+PLIST="$HOME/Library/LaunchAgents/com.alfred.cowork-journal.plist"
+LABEL="com.alfred.cowork-journal"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ "${1:-}" == "--uninstall" ]]; then
+  launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || launchctl unload "$PLIST" 2>/dev/null || true
+  rm -f "$PLIST"
+  echo "Uninstalled. Your data in $DEST was left in place; delete it if you want."
+  exit 0
+fi
+
+command -v python3 >/dev/null || { echo "python3 is required"; exit 1; }
+
+echo
+echo "  Connect Claude Cowork to your Alfred"
+echo "  ------------------------------------"
+echo "  Alfred will remember your Cowork conversations the same way it"
+echo "  remembers Slack and Telegram."
+echo
+
+# 1. the webhook URL (contains the token)
+if [[ -n "${ALFRED_WEBHOOK_URL:-}" ]]; then
+  URL="$ALFRED_WEBHOOK_URL"
+else
+  echo "  In your Alfred dashboard: Connections -> Custom Webhook -> New,"
+  echo "  choose destination 'journal', and copy the URL it gives you."
+  echo
+  read -r -p "  Webhook URL: " URL
+fi
+case "$URL" in
+  https://*/api/v1/webhooks/in/*) ;;
+  *) echo "  That does not look like a webhook ingest URL."; exit 1 ;;
+esac
+
+mkdir -p "$DEST"
+install -m 0755 "$HERE/push.py" "$DEST/push.py"
+umask 077
+printf 'ALFRED_WEBHOOK_URL=%s\n' "$URL" > "$DEST/env"
+chmod 600 "$DEST/env"
+
+# 2. prove it works before scheduling anything
+echo
+echo "  Testing..."
+set -a; . "$DEST/env"; set +a
+if ! COWORK_DRY_RUN=1 python3 "$DEST/push.py" >/dev/null 2>&1; then
+  echo "  Could not read local Cowork transcripts. Nothing installed."; exit 1
+fi
+COUNT="$(COWORK_DRY_RUN=1 python3 "$DEST/push.py" 2>/dev/null | tail -1)"
+echo "  $COUNT"
+
+echo
+read -r -p "  Send existing history now? [y/N] " BACKFILL
+if [[ "${BACKFILL:-n}" =~ ^[Yy]$ ]]; then
+  python3 "$DEST/push.py" || { echo "  Push failed — check the URL. Nothing scheduled."; exit 1; }
+else
+  # Mark everything seen so only NEW conversations are sent from here on.
+  python3 - "$DEST" <<'PY'
+import json, sys, os, pathlib
+sys.path.insert(0, sys.argv[1])
+os.environ["COWORK_DRY_RUN"] = "1"
+import importlib.util
+spec = importlib.util.spec_from_file_location("push", os.path.join(sys.argv[1], "push.py"))
+m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+state = {}
+for path in m.transcripts():
+    uuids = []
+    for line in open(path, errors="replace"):
+        try: e = json.loads(line)
+        except Exception: continue
+        if e.get("type") in ("user", "assistant") and e.get("uuid"):
+            uuids.append(e["uuid"])
+    if uuids: state[str(path)] = {"uuids": uuids[-5000:]}
+m.save_state(state)
+print("  Existing history marked as seen; only new conversations will be sent.")
+PY
+fi
+
+# 3. schedule it
+mkdir -p "$HOME/Library/LaunchAgents"
+cat > "$PLIST" <<PLIST_EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key><string>$LABEL</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string><string>-lc</string>
+    <string>set -a; . "$DEST/env"; set +a; exec /usr/bin/python3 "$DEST/push.py"</string>
+  </array>
+  <key>StartInterval</key><integer>300</integer>
+  <key>RunAtLoad</key><true/>
+  <key>StandardOutPath</key><string>$DEST/push.log</string>
+  <key>StandardErrorPath</key><string>$DEST/push.log</string>
+</dict></plist>
+PLIST_EOF
+
+launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$PLIST" 2>/dev/null || launchctl load "$PLIST"
+
+echo
+echo "  Done. Runs every 5 minutes."
+echo "    log:       $DEST/push.log"
+echo "    uninstall: bash install.sh --uninstall"
+echo

--- a/packages/cowork-journal/install.sh
+++ b/packages/cowork-journal/install.sh
@@ -42,7 +42,17 @@ case "$URL" in
 esac
 
 mkdir -p "$DEST"
-install -m 0755 "$HERE/push.py" "$DEST/push.py"
+# Work whether run from a clone or fetched standalone with curl.
+RAW="https://raw.githubusercontent.com/ssdavidai/alfred/main/packages/cowork-journal/push.py"
+if [[ -f "$HERE/push.py" ]]; then
+  install -m 0755 "$HERE/push.py" "$DEST/push.py"
+else
+  echo "  Fetching push.py..."
+  curl -fsSL "$RAW" -o "$DEST/push.py" || { echo "  Could not download push.py"; exit 1; }
+  chmod 0755 "$DEST/push.py"
+fi
+python3 -c "import ast,sys;ast.parse(open(sys.argv[1]).read())" "$DEST/push.py" \
+  || { echo "  push.py failed to parse — aborting"; exit 1; }
 umask 077
 printf 'ALFRED_WEBHOOK_URL=%s\n' "$URL" > "$DEST/env"
 chmod 600 "$DEST/env"

--- a/packages/cowork-journal/push.py
+++ b/packages/cowork-journal/push.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""cowork-journal-push — mirror local Claude Cowork / local-agent-mode chat turns
+into Alfred's alfred_journal, so Alfred has continuity of conversations that did
+not happen over a Hermes channel.
+
+Runs on a timer (launchd). Stateful + idempotent: it records a per-file cursor,
+so each turn is pushed exactly once. Fail-soft: on any network error the cursor
+is NOT advanced, so the next run retries.
+
+  channel   = "cowork"
+  chat_id   = the session id (stable per conversation)
+  direction = inbound  (user turns)  /  outbound (assistant turns)
+
+Config (env, written by install.sh into ~/.alfred/cowork-journal/env):
+  ALFRED_WEBHOOK_URL   full public ingest URL incl. token, e.g.
+                       https://zsolt.alfred.black/api/v1/webhooks/in/<token>
+  COWORK_DRY_RUN=1     print what would be sent, send nothing
+  COWORK_MAX_CHARS     per-message truncation (default 4000)
+
+The token is the only credential and it is scoped to this one webhook: it can
+append journal entries and nothing else. Revoke it from the tenant at any time
+(DELETE /api/v1/webhooks/inbound/<token>) and this stops, with no other access
+affected.
+"""
+import json, os, sys, time, urllib.request, urllib.error
+from pathlib import Path
+
+ROOT   = Path.home() / "Library/Application Support/Claude"
+STATE  = Path.home() / ".alfred/cowork-journal/state.json"
+URL    = os.environ.get("ALFRED_JOURNAL_URL", "").rstrip("/")
+
+KEY    = os.environ.get("ALFRED_API_KEY", "")
+DRY    = os.environ.get("COWORK_DRY_RUN") == "1"
+MAXC   = int(os.environ.get("COWORK_MAX_CHARS", "4000"))
+
+def transcripts():
+    """Every local conversation transcript we know how to read."""
+    yield from (ROOT / "local-agent-mode-sessions").rglob(".claude/projects/**/*.jsonl")
+
+def load_state():
+    try: return json.loads(STATE.read_text())
+    except Exception: return {}
+
+def seen_uuids(state):
+    """Turn UUIDs are globally unique, and the SAME turn appears in more than
+    one transcript file (Cowork copies a session's log into per-run project
+    dirs). Dedupe must therefore be global — a per-file cursor re-sends every
+    duplicated turn under each new file key and never converges."""
+    s = set(state.get("_seen", []))
+    # Migrate legacy per-file cursors written before this was fixed.
+    for k, v in state.items():
+        if k != "_seen" and isinstance(v, dict):
+            s.update(v.get("uuids", []))
+    return s
+
+def save_state(s):
+    STATE.parent.mkdir(parents=True, exist_ok=True)
+    tmp = STATE.with_suffix(".tmp")
+    tmp.write_text(json.dumps(s, indent=2))
+    tmp.replace(STATE)
+
+def text_of(entry):
+    m = entry.get("message") or {}
+    c = m.get("content")
+    if isinstance(c, str):
+        return c.strip()
+    if isinstance(c, list):
+        return " ".join(
+            b.get("text", "") for b in c
+            if isinstance(b, dict) and b.get("type") == "text"
+        ).strip()
+    return ""
+
+def post(entry_payload):
+    req = urllib.request.Request(
+        URL,
+        data=json.dumps(entry_payload).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=15) as r:
+        return r.status
+
+def main():
+    if not DRY and not URL:
+        print("ALFRED_WEBHOOK_URL unset — run install.sh", file=sys.stderr)
+        return 2
+    state = load_state()
+    seen_all = seen_uuids(state)
+    newly_seen = []
+    pushed = skipped = failed = 0
+
+    for path in sorted(transcripts()):
+        key = str(path)
+        seen = seen_all
+        session = path.stem
+        new_uuids = []
+        try:
+            lines = path.read_text(errors="replace").splitlines()
+        except Exception:
+            continue
+
+        for line in lines:
+            try: e = json.loads(line)
+            except Exception: continue
+            if e.get("type") not in ("user", "assistant"):
+                continue
+            uid = e.get("uuid")
+            if not uid or uid in seen:
+                skipped += 1
+                continue
+            body = text_of(e)
+            if not body:
+                continue
+            # Scheduled-task and system-injected turns are not conversation.
+            if body.startswith("<scheduled-task") or body.startswith("<system-reminder"):
+                continue
+
+            payload = {
+                "chat_id":     e.get("sessionId") or session,
+                "direction":   "inbound" if e["type"] == "user" else "outbound",
+                "message":     body[:MAXC],
+                "source_ref":  uid,
+                "metadata": {
+                    "entry_uuid": uid,
+                    "timestamp":  e.get("timestamp"),
+                    "cwd":        e.get("cwd"),
+                    "transcript": key,
+                },
+            }
+            if DRY:
+                print(f"  [{payload['direction']:8}] {str(e.get('timestamp'))[:19]} "
+                      f"{payload['chat_id'][:8]} {body[:80]!r}")
+                pushed += 1
+                new_uuids.append(uid)
+                continue
+            try:
+                post(payload)
+                pushed += 1
+                new_uuids.append(uid)
+            except Exception as ex:
+                failed += 1
+                print(f"  POST failed ({ex}) — cursor not advanced", file=sys.stderr)
+                break   # stop this file; retry next run
+
+        if new_uuids:
+            newly_seen.extend(new_uuids)
+            seen_all.update(new_uuids)
+
+    if not DRY:
+        merged = sorted(set(state.get("_seen", [])) | set(newly_seen) | seen_all)
+        save_state({"_seen": merged[-50000:],
+                    "last_run": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())})
+    print(f"cowork-journal: pushed={pushed} already_seen={skipped} failed={failed}"
+          f"{' (DRY RUN)' if DRY else ''}")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/ctrl/src/api/routes/webhooksInbound.ts
+++ b/packages/ctrl/src/api/routes/webhooksInbound.ts
@@ -13,6 +13,26 @@
  *   - GET    /api/v1/webhooks/inbound          — list registered webhooks
  *   - DELETE /api/v1/webhooks/inbound/:id      — delete (id = bare token or "webhook:<token>")
  *   - POST   /api/v1/webhooks/in/:token        — PUBLIC ingest; emits stream_event
+ *                                                 (or an alfred_journal entry when
+ *                                                  the webhook's destination is
+ *                                                  "journal" — see below)
+ *
+ * DESTINATIONS. A webhook routes to one of two places:
+ *   "stream"  (default) — emits a stream_event, the normal curator path.
+ *   "journal" — appends to alfred_journal instead. This exists so a surface
+ *               that talks to Alfred OUTSIDE a Hermes channel (Claude Cowork
+ *               via MCP, a desktop client, a script) can give Alfred
+ *               continuity of that conversation. The one-alfred plugin's
+ *               pre_gateway_dispatch hook already re-injects journal context
+ *               on every inbound message, so a journalled Cowork exchange is
+ *               remembered on the principal's next Slack/Telegram message with
+ *               no plugin change. See docs/design/one-alfred.md.
+ *
+ *               Why a webhook token rather than exposing /api/v1/alfred-journal:
+ *               ctrl-api is deliberately NOT public (Caddy proxies only a small
+ *               allowlist), and the alternative — handing a laptop the master
+ *               AAS_API_KEY — grants full ctrl-api access. A webhook token is
+ *               scoped, per-device and revocable.
  *
  * The ingest path is registered in server.ts's `isPublic` whitelist; the
  * other three CRUD routes go through the normal AAS_API_KEY auth path.
@@ -23,6 +43,8 @@ import crypto from "node:crypto";
 import { addRoute } from "../server.js";
 import { sendJson, ValidationError, NotFoundError } from "../errors.js";
 import { getIngestDb } from "../../db/ingest.js";
+import { getStateDb } from "../../db/state.js";
+import { appendJournal } from "../../db/alfredJournal.js";
 import { ulid } from "../../db/ulid.js";
 
 const VAULT_ROOT = process.env.VAULT_PATH ?? "/vault";
@@ -41,6 +63,8 @@ export function composeInboundWebhookUrl(token: string): string {
   return base ? `${base.replace(/\/$/, "")}${rel}` : rel;
 }
 
+type WebhookDestination = "stream" | "journal";
+
 interface WebhookFrontmatter {
   type: "webhook_endpoint";
   token: string;
@@ -48,6 +72,12 @@ interface WebhookFrontmatter {
   created_at: string;
   event_count: number;
   last_event_at: string | null;
+  // Omitted on every webhook created before this shipped — readWebhookRecord
+  // defaults it to "stream", so existing tokens keep their behaviour exactly.
+  destination?: WebhookDestination;
+  // Journal destination only: the channel name journal rows are written under
+  // (e.g. "cowork"). Defaults to the label, slugified.
+  journal_channel?: string;
 }
 
 function ensureDirs(): void {
@@ -126,6 +156,8 @@ function readWebhookRecord(token: string): WebhookFrontmatter | null {
     label: String(fm.label ?? "Custom Webhook"),
     created_at: String(fm.created_at ?? ""),
     event_count: typeof fm.event_count === "number" ? fm.event_count : 0,
+    destination: fm.destination === "journal" ? "journal" : "stream",
+    journal_channel: typeof fm.journal_channel === "string" ? fm.journal_channel : undefined,
     last_event_at: fm.last_event_at == null
       ? null
       : String(fm.last_event_at),
@@ -140,8 +172,22 @@ function writeWebhookRecord(fm: WebhookFrontmatter): void {
     created_at: fm.created_at,
     event_count: fm.event_count,
     last_event_at: fm.last_event_at,
+    ...(fm.destination ? { destination: fm.destination } : {}),
+    ...(fm.journal_channel ? { journal_channel: fm.journal_channel } : {}),
   });
   fs.writeFileSync(recordPath(fm.token), body, "utf-8");
+}
+
+// Best-effort counter bump, shared by both destinations. Never throws: a
+// bookkeeping failure must not fail an accepted delivery.
+function bumpWebhookCounters(fm: WebhookFrontmatter, iso: string): void {
+  try {
+    writeWebhookRecord({
+      ...fm,
+      event_count: (fm.event_count || 0) + 1,
+      last_event_at: iso,
+    });
+  } catch { /* ignore */ }
 }
 
 // Sanitise a token-ish identifier (filename-safe component) — used so that
@@ -160,6 +206,19 @@ export function registerInboundWebhookRoutes(): void {
       throw new ValidationError("label (non-empty string) is required");
     }
     const label = b.label.trim().slice(0, 120);
+
+    const destRaw = typeof b.destination === "string" ? b.destination.trim() : "stream";
+    if (destRaw !== "stream" && destRaw !== "journal") {
+      throw new ValidationError(`destination must be "stream" or "journal" (got ${JSON.stringify(destRaw)})`);
+    }
+    const destination = destRaw as WebhookDestination;
+    const journalChannel =
+      destination === "journal"
+        ? (typeof b.journal_channel === "string" && b.journal_channel.trim()
+            ? b.journal_channel.trim().toLowerCase().replace(/[^a-z0-9_-]/g, "-").slice(0, 40)
+            : safeIdent(label).toLowerCase())
+        : undefined;
+
     ensureDirs();
     const token = crypto.randomBytes(16).toString("hex");
     const createdAt = new Date().toISOString();
@@ -170,11 +229,15 @@ export function registerInboundWebhookRoutes(): void {
       created_at: createdAt,
       event_count: 0,
       last_event_at: null,
+      destination,
+      journal_channel: journalChannel,
     });
     sendJson(res, 201, {
       id: `webhook:${token}`,
       token,
       label,
+      destination,
+      journal_channel: journalChannel ?? null,
       url: composeInboundWebhookUrl(token),
       created_at: createdAt,
     });
@@ -248,6 +311,72 @@ export function registerInboundWebhookRoutes(): void {
     const iso = now.toISOString();
     const ts = iso.replace(/[:.]/g, "-");
     const shortUuid = crypto.randomBytes(4).toString("hex");
+
+    // ── destination: journal ─────────────────────────────────────────────
+    // Continuity path (Cowork/desktop/scripts). Writes straight to
+    // alfred_journal; nothing enters the signal pipeline, because a
+    // conversation the principal already had is not a new inbound signal to
+    // triage — it is history Alfred should simply remember.
+    if ((fm.destination ?? "stream") === "journal") {
+      const jb = (body ?? {}) as Record<string, unknown>;
+
+      const direction = String(jb.direction ?? "").trim();
+      if (direction !== "inbound" && direction !== "outbound") {
+        throw new ValidationError(
+          `direction must be "inbound" or "outbound" (got ${JSON.stringify(jb.direction)})`,
+        );
+      }
+      const message = typeof jb.message === "string" ? jb.message : "";
+      if (!message.trim()) throw new ValidationError("message (non-empty string) is required");
+
+      // chat_id keys continuity. A caller that omits it collapses every
+      // exchange into one thread, which is worse than useless, so require it.
+      const chatId = typeof jb.chat_id === "string" && jb.chat_id.trim()
+        ? jb.chat_id.trim().slice(0, 200)
+        : "";
+      if (!chatId) throw new ValidationError("chat_id (non-empty string) is required");
+
+      const channel = fm.journal_channel || safeIdent(fm.label).toLowerCase();
+
+      let entry;
+      try {
+        entry = appendJournal(getStateDb(), {
+          channel,
+          chat_id: chatId,
+          direction: direction as "inbound" | "outbound",
+          message: message.slice(0, 20000),
+          source_kind: channel,
+          source_ref: typeof jb.source_ref === "string" ? jb.source_ref.slice(0, 200) : null,
+          hermes_session_id: null,
+          hermes_profile: null,
+          status: direction === "inbound" ? "received" : "delivered",
+          delivery_error: null,
+          metadata:
+            jb.metadata && typeof jb.metadata === "object"
+              ? (jb.metadata as Record<string, unknown>)
+              : null,
+          principal_id: typeof jb.principal_id === "string" ? jb.principal_id : null,
+          // Journalled history is a record of something that already happened,
+          // never a prompt Alfred should answer.
+          solicited: 0,
+        });
+      } catch (e) {
+        // Fail loudly to the caller (it retries) but never leave the webhook
+        // counter half-updated.
+        throw e;
+      }
+
+      bumpWebhookCounters(fm, iso);
+      sendJson(res, 201, {
+        ok: true,
+        destination: "journal",
+        channel,
+        chat_id: chatId,
+        journal_id: (entry as any)?.id ?? null,
+      });
+      return;
+    }
+
 
     // Pretty-print the inbound payload as text so the curator (which scans
     // markdown bodies) sees the structured content; opaque JSON in
@@ -330,13 +459,7 @@ export function registerInboundWebhookRoutes(): void {
     }
 
     // ── 3. BEST-EFFORT: webhook_endpoint counter bump ────────────────────
-    try {
-      writeWebhookRecord({
-        ...fm,
-        event_count: (fm.event_count || 0) + 1,
-        last_event_at: iso,
-      });
-    } catch { /* ignore */ }
+    bumpWebhookCounters(fm, iso);
 
     sendJson(res, 202, { status: "accepted" });
   });


### PR DESCRIPTION
## What

1. **ctrl-api** — inbound webhooks gain a `destination`: `"stream"` (default, unchanged) or `"journal"`, which appends to `alfred_journal` instead of emitting a `stream_event`.
2. **`packages/cowork-journal/`** — an installable client (`push.py` + `install.sh` + `README.md`) that mirrors local Claude Cowork conversations into a tenant's journal.

## Why

When a principal talks to Alfred through Cowork, Alfred sees isolated MCP tool calls — no thread, no history, no record the conversation happened. Ask it something in Slack afterwards and it has amnesia. That is exactly the failure `docs/design/one-alfred.md` was written to prevent:

> *"main's actual session never records that the exchange happened. Sir replies later, main has amnesia, the illusion of one Alfred breaks."*

**The read side already worked.** `one-alfred`'s `pre_gateway_dispatch` hook queries `alfred_journal` on every inbound message and rewrites the user message with that context. The only missing piece was a writer — so this adds one, with **no plugin change and no Hermes change**.

## Design notes

**Why a webhook token rather than exposing `/api/v1/alfred-journal`.** ctrl-api is deliberately not publicly routable: `api.<domain>` proxies to the Wasp app, and Caddy forwards only a small allowlist (omi streams, a few webhooks, email inbound, paperclip, HA, composio) to ctrl-api. The alternative — handing a laptop the master `AAS_API_KEY` — grants full ctrl-api access. A webhook token is scoped to one destination, per-device, and revocable with a single DELETE.

**Why the journal branch bypasses the pipeline.** A conversation the principal already had is history to remember, not a new inbound signal to triage. It writes `solicited=0` and never enters `ingest.db`.

**Backwards compatible.** `readWebhookRecord` defaults `destination` to `"stream"`, so every token created before this keeps its exact behaviour; the field is simply absent from their frontmatter.

## Smoke evidence

**End-to-end against a live tenant** — 359 turns extracted from real local transcripts and journalled:

```
# remote: ok=359 fail=0
cowork-journal: pushed=359 already_seen=0 failed=0
```

**A real bug caught by testing, not review.** Successive runs pushed 359, then 30, then 11 — never converging. Cause: dedupe was per-file, but Cowork copies a session's log into more than one project dir, so the same turn UUID lives in several files and each re-sends it under its own cursor. Fixed to global UUID dedupe, which converges immediately:

```
run 1: pushed=0 already_seen=359 failed=0
run 2: pushed=0 already_seen=359 failed=0
```

`load_state` migrates legacy per-file cursors in place, so an already-installed client self-heals rather than re-sending its whole history.

**Build:** `npm run build` clean (`dist/api.mjs`); `tsc --noEmit` reports no error in `webhooksInbound.ts` (33 pre-existing errors elsewhere in the package are untouched by this change). `bash -n install.sh` clean. Lane gate passed (phase0, 490 LOC, 4 files).

## Client behaviour

Sends only user/assistant **text** turns; skips `<scheduled-task>` / `<system-reminder>` injections, tool payloads and attachments. Truncates at 4000 chars. Fail-soft — a failed POST leaves the cursor unadvanced so the next run retries rather than dropping turns. Installer offers backfill or "new conversations only", and schedules a 5-minute `launchd` job.

## Deploy note

The ctrl-api half needs `build-ctrl-api` + a `docker compose pull ctrl-api` per tenant — `deploy-compose` runs `up -d` **without** a pull, so images do not advance on their own. Until it lands, a tenant can still be populated over SSH (`docker exec` into ctrl-api), which is how the 359-turn verification above was done.

## Not in scope

Real-time push. Cowork exposes no local lifecycle hook that fires per turn, so this is a 5-minute sweep. If sub-minute latency is ever wanted, Cowork's OpenTelemetry export (Team/Enterprise) is the supported deterministic path and would feed the same webhook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)