### PR TITLE
feat(ctrl): report the ledger's earliest entry in attention trends coverage

### DIFF
--- a/packages/ctrl/src/api/routes/attention.ts
+++ b/packages/ctrl/src/api/routes/attention.ts
@@ -1289,6 +1289,9 @@ export function registerAttentionRoutes(): void {
     const db=getStateDb();
     const cf=`${from}T00:00:00Z`, ct=`${to}T23:59:59.999Z`;
     const firstJ=(db.prepare(`SELECT MIN(DATE(ts)) AS d FROM alfred_journal WHERE direction='outbound' AND ts>=? AND ts<=?`).get(cf,ct) as {d:string|null}).d;
+    // Earliest ledger entry overall (not window-bound): the UI's period pickers
+    // need to know how far back a selectable week/month/quarter can reach.
+    const dataFrom=(db.prepare(`SELECT MIN(DATE(occurred_at)) AS d FROM nar_entry`).get() as {d:string|null}).d;
     const daysData=(db.prepare(`SELECT COUNT(DISTINCT DATE(occurred_at)) AS n FROM nar_entry WHERE occurred_at>=? AND occurred_at<=?`).get(cf,ct) as {n:number}).n;
 
     const periods=[];
@@ -1353,7 +1356,7 @@ export function registerAttentionRoutes(): void {
       } catch { /* malformed payload — treat as not generated */ }
     }
     sendJson(res,200,{grain,from,to,
-      coverage:{interruption_instrumented_from:firstJ??null,days_total:dates.length,days_with_data:daysData},
+      coverage:{interruption_instrumented_from:firstJ??null,days_total:dates.length,days_with_data:daysData,data_from:dataFrom??null},
       periods,read});
   });
 }

--- a/packages/ctrl/tests/attention-trends.test.ts
+++ b/packages/ctrl/tests/attention-trends.test.ts
@@ -92,6 +92,24 @@ describe("partial period",()=>{
 });
 
 // 3. return_ratio null when engaged=0
+describe("coverage.data_from",()=>{
+  it("reports the earliest ledger entry overall, not window-bound",async()=>{
+    clear();
+    nar({occurred_at:"2026-05-23T09:00:00Z"});           // earliest, outside window
+    nar({occurred_at:"2026-08-11T09:00:00Z"});
+    const {status,p}=await getTrends("grain=week&from=2026-08-10&to=2026-08-16");
+    assert.equal(status,200);
+    // The pickers need the floor of selectable periods; a window-bound MIN
+    // would hide history the user can legitimately compare against.
+    assert.equal(p.coverage.data_from,"2026-05-23");
+  });
+  it("null on an empty ledger — pickers fall back, never crash",async()=>{
+    clear();
+    const {p}=await getTrends("grain=week&from=2026-08-10&to=2026-08-16");
+    assert.equal(p.coverage.data_from,null);
+  });
+});
+
 describe("return_ratio",()=>{
   beforeEach(clear);
   it("null (not Infinity) when engaged_hours=0",async()=>{


### PR DESCRIPTION
The /attention Trends tab is gaining period pickers (select which weeks / months / quarters are being compared — consumer PR follows in lane III). The pickers need the floor of selectable history, so the trends response's `coverage` gains `data_from`: the earliest `nar_entry` date overall, deliberately not window-bound. Null on an empty ledger.

## Smoke evidence

```
attention-trends suite: 25 pass / 0 fail
  new: coverage.data_from reports earliest entry OVERALL (entry outside the
       queried window still sets the floor)
  new: empty ledger -> data_from null (pickers fall back, never crash)
packages/ctrl: npm run build clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)