### PR TITLE
feat(web): choose which weeks/months/quarters the Trends tab compares

### DIFF
--- a/packages/web/src/dashboard/AttentionPage.tsx
+++ b/packages/web/src/dashboard/AttentionPage.tsx
@@ -22,6 +22,8 @@ import {
   deriveRatioPeak, derivePeriodLabel, deriveRatioLineSegmentsFromBars,
   deriveReadHeadline, deriveReadPairData, deriveAllocationHeadline, deriveTrendsAllocTotals,
   type TrendsGrain, type AttentionTrendsResponse,
+  enumeratePeriodOptions, defaultTrendsWindow, clampTrendsWindow, periodBoundsClient,
+  type PeriodOption,
 } from "./attentionTrendsCore";
 
 const now = () => new Date().toISOString().slice(0, 10);
@@ -32,7 +34,6 @@ const dateParam = (key: string, fallback: string): string => {
   return v !== null && /^\d{4}-\d{2}-\d{2}$/.test(v) ? v : fallback;
 };
 const sevenAgo = () => { const d = new Date(); d.setDate(d.getDate() - 6); return d.toISOString().slice(0, 10); };
-const thirteenWeeksAgo = () => { const d = new Date(); d.setDate(d.getDate() - 91); return d.toISOString().slice(0, 10); };
 
 // ── Shared primitives ─────────────────────────────────────────────────────────
 
@@ -653,9 +654,13 @@ function RangeView({ stats }: { stats: AttentionStatsResponse }) {
 
 // ── Trends view (#584 — canonical 4-panel report) ────────────────────────────
 
-function TrendsView({ data, grain, setGrain, interpretingRead, onGenerateRead, readTimedOut, onRetry }: {
+function TrendsView({ data, grain, setGrain, interpretingRead, onGenerateRead, readTimedOut, onRetry,
+  periodOptions, windowFrom, windowTo, onPickPeriod, isCustomWindow, onResetWindow }: {
   data: AttentionTrendsResponse; grain: TrendsGrain; setGrain: (g: TrendsGrain) => void;
   interpretingRead: boolean; onGenerateRead: () => void; readTimedOut: boolean; onRetry: () => void;
+  periodOptions: PeriodOption[]; windowFrom: string; windowTo: string;
+  onPickPeriod: (edge: "from" | "to", startDate: string) => void;
+  isCustomWindow: boolean; onResetWindow: () => void;
 }) {
   const ps = trimEmptyEdgePeriods(data.periods ?? []);
   if (!ps.length) return <p className="font-mono text-xs opacity-40 mt-12">No data for this period.</p>;
@@ -765,15 +770,50 @@ function TrendsView({ data, grain, setGrain, interpretingRead, onGenerateRead, r
         Attention Trends.
       </h1>
 
-      {/* Grain selector */}
-      <div className="flex gap-4 mb-10">
-        {(["week", "month", "quarter"] as TrendsGrain[]).map(g => (
-          <button key={g} type="button" onClick={() => setGrain(g)}
-            className="font-mono text-[10px] uppercase tracking-[0.22em] pb-1 transition-colors"
-            style={{ color: grain === g ? "var(--brass)" : "var(--marginalia)", borderBottom: grain === g ? "1px solid var(--brass)" : "1px solid transparent" }}>
-            {g === "week" ? "Weekly" : g === "month" ? "Monthly" : "Quarterly"}
-          </button>
-        ))}
+      {/* Grain selector + comparison window (which periods are compared) */}
+      <div className="flex flex-wrap items-end gap-x-6 gap-y-3 mb-10">
+        <div className="flex gap-4">
+          {(["week", "month", "quarter"] as TrendsGrain[]).map(g => (
+            <button key={g} type="button" onClick={() => setGrain(g)}
+              className="font-mono text-[10px] uppercase tracking-[0.22em] pb-1 transition-colors"
+              style={{ color: grain === g ? "var(--brass)" : "var(--marginalia)", borderBottom: grain === g ? "1px solid var(--brass)" : "1px solid transparent" }}>
+              {g === "week" ? "Weekly" : g === "month" ? "Monthly" : "Quarterly"}
+            </button>
+          ))}
+        </div>
+        <div className="flex items-center gap-2 ml-auto">
+          {(["from", "to"] as const).map((edge) => {
+            // The selected option is the period CONTAINING the window edge —
+            // a clamped edge (partial current period) still highlights right.
+            const sel = periodOptions.find(o => edge === "from"
+              ? (windowFrom >= o.start && windowFrom <= o.end)
+              : (windowTo >= o.start && windowTo <= o.end));
+            return (
+              <span key={edge} className="flex items-center gap-2">
+                {edge === "to" && <span className="font-mono text-[9px] tracking-[0.2em]" style={{ color: "var(--marginalia)" }}>{"—"}</span>}
+                <select
+                  value={sel?.start ?? ""}
+                  onChange={(e) => onPickPeriod(edge, e.target.value)}
+                  aria-label={edge === "from" ? "Compare from period" : "Compare to period"}
+                  className="font-mono text-[10px] uppercase tracking-[0.14em] bg-transparent border px-2 py-1 focus:outline-none transition-colors"
+                  style={{ color: "var(--ink)", borderColor: "var(--rule)" }}>
+                  {periodOptions.map(o => (
+                    <option key={o.key + o.start} value={o.start}>{o.label}</option>
+                  ))}
+                </select>
+              </span>
+            );
+          })}
+          {isCustomWindow && (
+            <button type="button" onClick={onResetWindow}
+              className="font-mono text-[9px] uppercase tracking-[0.2em] pb-0.5 transition-colors"
+              style={{ color: "var(--marginalia)", borderBottom: "1px solid transparent" }}
+              onMouseEnter={(e) => { (e.target as HTMLElement).style.color = "var(--brass)"; }}
+              onMouseLeave={(e) => { (e.target as HTMLElement).style.color = "var(--marginalia)"; }}>
+              Reset
+            </button>
+          )}
+        </div>
       </div>
 
       {/* 01 NET RETURNED — mirrored chart: GIVEN BACK above axis, YOUR TIME below */}
@@ -993,9 +1033,16 @@ export default function AttentionPage() {
   const [from, setFrom] = useState(dateParam("from", sevenAgo()));
   const [to, setTo] = useState(dateParam("to", now()));
   const [running, setRunning] = useState(false);
-  const [grain, setGrain] = useState<TrendsGrain>("week");
-  const [trendsFrom] = useState(thirteenWeeksAgo);
-  const [trendsTo] = useState(now);
+  const [grain, setGrainRaw] = useState<TrendsGrain>("week");
+  // Custom comparison window per grain (null = the grain's default). Switching
+  // grain returns to that grain's default — predictable, never a stale window
+  // measured in another grain's units.
+  const [customWin, setCustomWin] = useState<{ from: string; to: string } | null>(null);
+  const setGrain = (g: TrendsGrain) => { setGrainRaw(g); setCustomWin(null); };
+  const today = now();
+  const defWin = defaultTrendsWindow(grain, today);
+  const trendsFrom = customWin?.from ?? defWin.from;
+  const trendsTo = customWin?.to ?? defWin.to;
   const [interpretingRead, setInterpretingRead] = useState(false);
   const [readTimedOut, setReadTimedOut] = useState(false);
   // Timestamp recorded when polling starts; compared against POLL_GIVE_UP_MS in the interval.
@@ -1005,6 +1052,18 @@ export default function AttentionPage() {
   const trendsQ = useQuery(getAttentionTrends, { grain, from: trendsFrom, to: trendsTo }, { enabled: tab === "trends" });
   const recompute = useAction(recomputeAttention);
   const interpretTrends = useAction(interpretAttentionTrends);
+
+  // Period pickers: which weeks/months/quarters are being compared. Options
+  // reach from the ledger's first entry (coverage.data_from) to today.
+  const dataFrom = (trendsQ.data as AttentionTrendsResponse | undefined)?.coverage?.data_from ?? null;
+  const periodOptions = enumeratePeriodOptions(dataFrom, today, grain);
+  const pickPeriod = (edge: "from" | "to", startDate: string) => {
+    const period = periodBoundsClient(grain, startDate);
+    const next = edge === "from"
+      ? { from: period.start, to: trendsTo }
+      : { from: trendsFrom, to: period.end };
+    setCustomWin(clampTrendsWindow(next.from, next.to, today, grain));
+  };
 
   // Poll for the read every 15 s while it is being generated; give up after POLL_GIVE_UP_MS.
   // Interval is cleared on unmount and when the read arrives (see effect below).
@@ -1085,7 +1144,7 @@ export default function AttentionPage() {
               : statsQ.data ? <RangeView stats={statsQ.data as AttentionStatsResponse} /> : null
             : trendsQ.isLoading ? <p className="font-mono text-xs opacity-40">Loading…</p>
               : trendsQ.error ? <p className="font-mono text-xs" style={{ color: "oklch(0.42 0.12 30)" }}>{String((trendsQ.error as any)?.message ?? "Failed.")}</p>
-              : trendsQ.data ? <TrendsView data={trendsQ.data as AttentionTrendsResponse} grain={grain} setGrain={setGrain} interpretingRead={interpretingRead} onGenerateRead={handleGenerateRead} readTimedOut={readTimedOut} onRetry={handleGenerateRead} /> : null}
+              : trendsQ.data ? <TrendsView data={trendsQ.data as AttentionTrendsResponse} grain={grain} setGrain={setGrain} interpretingRead={interpretingRead} onGenerateRead={handleGenerateRead} readTimedOut={readTimedOut} onRetry={handleGenerateRead} periodOptions={periodOptions} windowFrom={trendsFrom} windowTo={trendsTo} onPickPeriod={pickPeriod} isCustomWindow={customWin != null} onResetWindow={() => setCustomWin(null)} /> : null}
 
       </section>
     </Frame>

--- a/packages/web/src/dashboard/attentionTrendsCore.test.ts
+++ b/packages/web/src/dashboard/attentionTrendsCore.test.ts
@@ -16,6 +16,8 @@ import {
   f1, dir, deriveNarHeadline, deriveRatioHeadline, deriveRatioPeak,
   deriveRatioLineSegmentsFromBars, deriveReadHeadline, deriveAllocationHeadline,
   type TrendsPeriod, type ReadHeadlineParams, type RatioBar,
+  periodBoundsClient, enumeratePeriodOptions, defaultTrendsWindow, clampTrendsWindow,
+  TRENDS_MAX_DAYS,
 } from "./attentionTrendsCore";
 
 // ── Fixture factory ───────────────────────────────────────────────────────────
@@ -403,4 +405,64 @@ test("AttentionPage computes the ratio peak via deriveRatioPeak, not inline", ()
   // periods, which ignores the engagement floor.
   assert.doesNotMatch(src, /rb\.reduce\(/,
     "unfiltered peak scan over rb is back; it ignores the engagement floor");
+});
+
+
+test("period pickers: periodBoundsClient matches ctrl conventions (ISO week, month, quarter)", () => {
+  // Same fixtures as ctrl's periodKeyBounds tests — the two implementations
+  // must never disagree on a boundary.
+  const w = periodBoundsClient("week", "2026-08-10"); // a Monday
+  assert.equal(w.key, "2026-W33"); assert.equal(w.start, "2026-08-10"); assert.equal(w.end, "2026-08-16");
+  const m = periodBoundsClient("month", "2026-02-15");
+  assert.equal(m.key, "2026-02"); assert.equal(m.start, "2026-02-01"); assert.equal(m.end, "2026-02-28");
+  const q = periodBoundsClient("quarter", "2026-08-01");
+  assert.equal(q.key, "2026-Q3"); assert.equal(q.start, "2026-07-01"); assert.equal(q.end, "2026-09-30");
+});
+
+test("period pickers: ISO week-year edge: Jan 1 belonging to the previous year's W53", () => {
+  // 2027-01-01 is a Friday; its ISO week is 2026-W53 (Thursday anchor 2026-12-31).
+  const w = periodBoundsClient("week", "2027-01-01");
+  assert.equal(w.key, "2026-W53");
+  assert.equal(w.start, "2026-12-28"); assert.equal(w.end, "2027-01-03");
+});
+
+test("period pickers: enumeratePeriodOptions spans floor → today, ascending, no gaps", () => {
+  const opts = enumeratePeriodOptions("2026-05-23", "2026-09-02", "week");
+  assert.equal(opts[0].key, "2026-W21");            // week containing May 23
+  assert.equal(opts[opts.length - 1].key, "2026-W36"); // week containing Sep 2
+  for (let i = 1; i < opts.length; i++) {
+    const prevEndPlus1 = new Date(`${opts[i - 1].end}T00:00:00Z`);
+    prevEndPlus1.setUTCDate(prevEndPlus1.getUTCDate() + 1);
+    assert.equal(opts[i].start, prevEndPlus1.toISOString().slice(0, 10), "gap between periods");
+  }
+  const months = enumeratePeriodOptions("2026-05-23", "2026-09-02", "month");
+  assert.deepEqual(months.map(o => o.key), ["2026-05", "2026-06", "2026-07", "2026-08", "2026-09"]);
+  const quarters = enumeratePeriodOptions("2026-05-23", "2026-09-02", "quarter");
+  assert.deepEqual(quarters.map(o => o.key), ["2026-Q2", "2026-Q3"]);
+});
+
+test("period pickers: enumeratePeriodOptions falls back to a year of history when data_from is absent", () => {
+  const opts = enumeratePeriodOptions(null, "2026-09-02", "quarter");
+  assert.equal(opts[0].key, "2025-Q3"); // period containing 2025-09-02
+  assert.equal(opts[opts.length - 1].key, "2026-Q3");
+});
+
+test("period pickers: defaultTrendsWindow yields 13 weeks / 6 months / 4 quarters ending today", () => {
+  const w = defaultTrendsWindow("week", "2026-09-02");
+  assert.equal(w.to, "2026-09-02");
+  assert.equal(w.from, "2026-06-08"); // Monday of W24, 13 ISO weeks incl. current
+  const mo = defaultTrendsWindow("month", "2026-09-02");
+  assert.equal(mo.from, "2026-04-01");
+  const q = defaultTrendsWindow("quarter", "2026-09-02");
+  assert.equal(q.from, "2025-10-01");
+});
+
+test("period pickers: clampTrendsWindow: future end snaps to today; inverted range recovers; 400-day cap holds", () => {
+  const fut = clampTrendsWindow("2026-08-01", "2026-12-31", "2026-09-02", "month");
+  assert.equal(fut.to, "2026-09-02");
+  const inv = clampTrendsWindow("2026-08-01", "2026-06-30", "2026-09-02", "month");
+  assert.ok(inv.from <= inv.to, "inverted range must recover");
+  const wide = clampTrendsWindow("2024-01-01", "2026-09-02", "2026-09-02", "month");
+  const span = Math.round((Date.parse(`${wide.to}T00:00:00Z`) - Date.parse(`${wide.from}T00:00:00Z`)) / 86400000) + 1;
+  assert.ok(span <= TRENDS_MAX_DAYS, `span ${span} exceeds the server cap`);
 });

--- a/packages/web/src/dashboard/attentionTrendsCore.ts
+++ b/packages/web/src/dashboard/attentionTrendsCore.ts
@@ -17,7 +17,7 @@ export interface TrendsPeriod {
   outcomes: { delivered: number; failed: number; unknown: number };
   sessions: number;
 }
-export interface TrendsCoverage { interruption_instrumented_from: string | null; days_total: number; days_with_data: number }
+export interface TrendsCoverage { interruption_instrumented_from: string | null; days_total: number; days_with_data: number; data_from?: string | null }
 export interface TrendsObservation { headline: string; detail: string; evidence: string }
 export interface TrendsRead { generated_at: string; observations: TrendsObservation[] }
 export interface AttentionTrendsResponse {
@@ -41,6 +41,93 @@ export function derivePeriodLabel(key: string, grain: TrendsGrain): string {
 export const GRAIN_FULL_DAYS: Record<TrendsGrain, number> = { week: 7, month: 28, quarter: 84 };
 export function isPartialPeriod(period: Pick<TrendsPeriod, "days">, grain: TrendsGrain): boolean {
   return (period.days ?? 0) < GRAIN_FULL_DAYS[grain];
+}
+
+// ── Period pickers (#trends-window) ──────────────────────────────────────────
+// The Trends tab lets the principal choose WHICH weeks/months/quarters are
+// compared. These helpers enumerate selectable periods and derive/clamp the
+// window. Boundary conventions MUST match ctrl's periodKeyBounds
+// (packages/ctrl/src/api/routes/attention.ts): ISO weeks Mon–Sun with the
+// Thursday anchor, calendar months, calendar quarters.
+
+export interface PeriodOption { key: string; label: string; start: string; end: string }
+
+/** Mirror of ctrl periodKeyBounds — pure, UTC, no Date.now(). */
+export function periodBoundsClient(grain: TrendsGrain, dateStr: string): PeriodOption {
+  if (grain === "week") {
+    const d = new Date(`${dateStr}T00:00:00Z`); const dow = d.getUTCDay() || 7;
+    const mon = new Date(d); mon.setUTCDate(d.getUTCDate() - dow + 1);
+    const sun = new Date(mon); sun.setUTCDate(mon.getUTCDate() + 6);
+    const thu = new Date(d); thu.setUTCDate(d.getUTCDate() - dow + 4);
+    const wn = Math.ceil(((thu.getTime() - Date.UTC(thu.getUTCFullYear(), 0, 1)) / 86400000 + 1) / 7);
+    const key = `${thu.getUTCFullYear()}-W${String(wn).padStart(2, "0")}`;
+    const start = mon.toISOString().slice(0, 10);
+    const mm = MONTH_ABBR[mon.getUTCMonth()]; const dd = mon.getUTCDate();
+    return { key, label: `W${String(wn).padStart(2, "0")} · ${mm} ${dd}`, start, end: sun.toISOString().slice(0, 10) };
+  }
+  const [y, mo] = dateStr.slice(0, 7).split("-").map(Number);
+  if (grain === "month") {
+    const start = `${y}-${String(mo).padStart(2, "0")}-01`;
+    return { key: dateStr.slice(0, 7), label: `${MONTH_ABBR[mo - 1]} ${y}`, start,
+      end: new Date(Date.UTC(y, mo, 0)).toISOString().slice(0, 10) };
+  }
+  const q = Math.ceil(mo / 3); const qm1 = (q - 1) * 3 + 1;
+  return { key: `${y}-Q${q}`, label: `Q${q} ${y}`, start: `${y}-${String(qm1).padStart(2, "0")}-01`,
+    end: new Date(Date.UTC(y, q * 3, 0)).toISOString().slice(0, 10) };
+}
+
+/** Hard cap mirrored from the ctrl route — a wider request is a 400. */
+export const TRENDS_MAX_DAYS = 400;
+const DAY = 86400000;
+function addDaysIso(dateStr: string, n: number): string {
+  const d = new Date(`${dateStr}T00:00:00Z`); d.setUTCDate(d.getUTCDate() + n);
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Every selectable period from the ledger's first entry (or a one-year
+ * fallback when the API predates data_from) through today. Ascending.
+ */
+export function enumeratePeriodOptions(dataFrom: string | null | undefined, today: string, grain: TrendsGrain): PeriodOption[] {
+  const floor = dataFrom && /^\d{4}-\d{2}-\d{2}$/.test(dataFrom) ? dataFrom : addDaysIso(today, -365);
+  const out: PeriodOption[] = [];
+  let cur = periodBoundsClient(grain, floor);
+  const stop = new Date(`${today}T00:00:00Z`).getTime();
+  // ≤400-day windows over a few years of grain periods — bounded, but belt it.
+  for (let i = 0; i < 400; i++) {
+    out.push(cur);
+    const nextStart = addDaysIso(cur.end, 1);
+    if (new Date(`${nextStart}T00:00:00Z`).getTime() > stop) break;
+    cur = periodBoundsClient(grain, nextStart);
+  }
+  return out;
+}
+
+/** Default comparison window per grain: last 13 weeks / 6 months / 4 quarters. */
+export const GRAIN_DEFAULT_PERIODS: Record<TrendsGrain, number> = { week: 13, month: 6, quarter: 4 };
+export function defaultTrendsWindow(grain: TrendsGrain, today: string): { from: string; to: string } {
+  const n = GRAIN_DEFAULT_PERIODS[grain];
+  const latest = periodBoundsClient(grain, today);
+  // Walk back n-1 periods from the current one.
+  let start = latest;
+  for (let i = 1; i < n; i++) start = periodBoundsClient(grain, addDaysIso(start.start, -1));
+  return { from: start.start, to: today };
+}
+
+/**
+ * Clamp a picked window: future end snaps to today, inverted ranges snap the
+ * `to` up to the `from` period's end, and a span over the server's 400-day cap
+ * pulls `from` forward to the start of the period containing (to − 399d).
+ */
+export function clampTrendsWindow(fromStart: string, toEnd: string, today: string, grain: TrendsGrain): { from: string; to: string } {
+  let from = fromStart;
+  let to = toEnd > today ? today : toEnd;
+  if (from > to) to = periodBoundsClient(grain, from).end > today ? today : periodBoundsClient(grain, from).end;
+  const span = Math.round((new Date(`${to}T00:00:00Z`).getTime() - new Date(`${from}T00:00:00Z`).getTime()) / DAY) + 1;
+  if (span > TRENDS_MAX_DAYS) from = periodBoundsClient(grain, addDaysIso(to, -(TRENDS_MAX_DAYS - 1))).start;
+  // A from pulled forward into a partial period must not precede the cap window.
+  if (from < addDaysIso(to, -(TRENDS_MAX_DAYS - 1))) from = addDaysIso(to, -(TRENDS_MAX_DAYS - 1));
+  return { from, to };
 }
 
 // ── NAR chart ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Consumer half of #716. The /attention Trends window was hardcoded to 13-weeks-back for every grain; it now has From — To period selects (options span the ledger's first entry through today, labelled per grain), a Reset when custom, per-grain defaults on grain switch, and the interpreted read follows the chosen window. Boundary math is pure, tested, and mirrors ctrl's periodKeyBounds conventions exactly; the server's 400-day cap is enforced client-side so a picked window can never 400.

## Smoke evidence

```
attentionTrendsCore: 50 pass / 0 fail  (6 new picker tests, incl. ISO
  week-year W53 edge and ctrl-parity fixtures)
wasp compile && npx tsc --noEmit  -> exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)