### PR TITLE
fix(omi): hand each device audio directory to the processor account

### DIFF
--- a/packages/ctrl/src/api/routes/omi.ts
+++ b/packages/ctrl/src/api/routes/omi.ts
@@ -9,6 +9,33 @@ const STREAMS_DIR = path.join(ALFRED_DATA_DIR, "streams");
 const OMI_AUDIO_DIR = path.join(STREAMS_DIR, "omi-audio");
 const STREAMS_META_PATH = path.join(STREAMS_DIR, "streams.json");
 
+const parseNumericId = (value: string | undefined, fallback: number): number => {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback;
+};
+
+// ctrl-api runs as root in the deployment while alfred-learn runs as uid/gid
+// 1000. A normal root-owned 0755 directory lets the processor read incoming
+// PCM chunks but not create its processed/ directory, permanently blocking
+// transcription. Hand each per-device directory to the processor account.
+// The writable fallback keeps local/non-root development usable when chown is
+// unavailable; the Docker volume is private to trusted stack services.
+export function ensureOmiUidDirectory(uid: string): string {
+  const uidDir = path.join(OMI_AUDIO_DIR, uid);
+  fs.mkdirSync(uidDir, { recursive: true });
+
+  const processorUid = parseNumericId(process.env.OMI_PROCESSOR_UID, 1000);
+  const processorGid = parseNumericId(process.env.OMI_PROCESSOR_GID, 1000);
+  try {
+    fs.chownSync(uidDir, processorUid, processorGid);
+    fs.chmodSync(uidDir, 0o770);
+  } catch {
+    fs.chmodSync(uidDir, 0o777);
+  }
+
+  return uidDir;
+}
+
 interface StreamMeta {
   id: string;
   source: string;
@@ -103,8 +130,7 @@ export function registerOmiRoutes(): void {
       }
 
       // Create directory for this uid
-      const uidDir = path.join(OMI_AUDIO_DIR, uid);
-      fs.mkdirSync(uidDir, { recursive: true });
+      const uidDir = ensureOmiUidDirectory(uid);
 
       // Write audio chunk and metadata
       const timestamp = Date.now();

--- a/packages/ctrl/tests/omi-directory-permissions.test.ts
+++ b/packages/ctrl/tests/omi-directory-permissions.test.ts
@@ -1,0 +1,32 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "omi-directory-permissions-"));
+process.env.ALFRED_DATA_DIR = tmp;
+process.env.OMI_PROCESSOR_UID = String(process.getuid?.() ?? 1000);
+process.env.OMI_PROCESSOR_GID = String(process.getgid?.() ?? 1000);
+
+const { ensureOmiUidDirectory } = await import("../src/api/routes/omi.js");
+
+describe("Omi audio directory permissions", () => {
+  it("repairs an existing 0755 device directory for the processor", () => {
+    const deviceDir = path.join(tmp, "streams", "omi-audio", "device-1");
+    fs.mkdirSync(deviceDir, { recursive: true, mode: 0o755 });
+    fs.chmodSync(deviceDir, 0o755);
+
+    const result = ensureOmiUidDirectory("device-1");
+    const stat = fs.statSync(result);
+
+    assert.equal(result, deviceDir);
+    assert.equal(stat.mode & 0o777, 0o770);
+    assert.equal(stat.uid, process.getuid?.() ?? 1000);
+    assert.equal(stat.gid, process.getgid?.() ?? 1000);
+
+    const processedDir = path.join(result, "processed");
+    fs.mkdirSync(processedDir);
+    assert.ok(fs.statSync(processedDir).isDirectory());
+  });
+});


### PR DESCRIPTION
The Omi audio webhook (ctrl-api, root) created device dirs root:root 0755; alfred-learn (uid 1000) could not create `processed/` inside them, so the audio processor failed every 10-minute tick and transcription was permanently blocked. `ensureOmiUidDirectory()` now chowns each device dir to the processor account (+0770, 0777 fallback for non-root dev) on every chunk — existing broken dirs self-repair on the next audio arrival, no tenant migration needed.

## Smoke evidence

```
live tenant:  manual chmod (the fix's equivalent) flipped
              OmiAudioProcessorWorkflow  Failed(09:00/09:10/09:20) -> Completed(09:30)
new test:     0755 device dir -> repaired to 0770 + processor ownership,
              processed/ creatable   (1 pass / 0 fail)
build:        packages/ctrl clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)