### PR TITLE
feat(mcp-server): continuity tools — read, note, bind the one-Alfred journal

### DIFF
--- a/packages/mcp-server/src/tools/alfred.ts
+++ b/packages/mcp-server/src/tools/alfred.ts
@@ -31,6 +31,7 @@
 import { z } from "zod";
 import type { ToolDef } from "./types.js";
 import { ALL_ATTENTION_TOOLS } from "./attention.js";
+import { ALL_CONTINUITY_TOOLS } from "./continuity.js";
 
 // ─── shared schema fragments ────────────────────────────────────────────────
 
@@ -771,4 +772,5 @@ export const ALL_ALFRED_TOOLS: ToolDef[] = [
   ...dispositionTools,
   ...channelTools,
   ...ALL_ATTENTION_TOOLS,
+  ...ALL_CONTINUITY_TOOLS,
 ];

--- a/packages/mcp-server/src/tools/continuity.test.ts
+++ b/packages/mcp-server/src/tools/continuity.test.ts
@@ -1,0 +1,44 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { continuityRecent, continuityNote, continuityBind, ALL_CONTINUITY_TOOLS } from "./continuity.js";
+
+test("continuity_recent reads the owner's cross-channel window", () => {
+  const r = continuityRecent.buildRequest({ limit: 30, within_hours: 48 });
+  assert.equal(r.method, "GET");
+  assert.equal(r.path, "/api/v1/alfred-journal/recent");
+  assert.deepEqual(r.query, { principal_id: "owner", limit: 30, within_hours: 48 });
+});
+
+test("continuity_recent omits unset window params so server defaults apply", () => {
+  const r = continuityRecent.buildRequest({});
+  assert.equal((r.query as Record<string, unknown>).limit, undefined);
+  assert.equal((r.query as Record<string, unknown>).principal_id, "owner");
+});
+
+test("continuity_note maps direction to the journal's status vocabulary", () => {
+  const inb = continuityNote.buildRequest({ channel: "cowork", chat_id: "s1", direction: "inbound", message: "hi" });
+  const out = continuityNote.buildRequest({ channel: "cowork", chat_id: "s1", direction: "outbound", message: "hello" });
+  assert.equal(inb.method, "POST");
+  assert.equal(inb.path, "/api/v1/alfred-journal");
+  assert.equal((inb.body as { status: string }).status, "received");
+  assert.equal((out.body as { status: string }).status, "delivered");
+  assert.equal((out.body as { source_kind: string }).source_kind, "cowork");
+});
+
+test("continuity_bind always binds to the owner principal", () => {
+  const r = continuityBind.buildRequest({ channel: "cowork", chat_id: "abc" });
+  assert.equal(r.path, "/api/v1/alfred-journal/principal/bind");
+  assert.deepEqual(r.body, { channel: "cowork", chat_id: "abc", principal_id: "owner" });
+});
+
+test("schemas reject a bad channel slug and an empty message", () => {
+  assert.equal(continuityNote.inputSchema.safeParse({ channel: "Bad Channel", chat_id: "x", direction: "inbound", message: "m" }).success, false);
+  assert.equal(continuityNote.inputSchema.safeParse({ channel: "cowork", chat_id: "x", direction: "inbound", message: "" }).success, false);
+  assert.equal(continuityRecent.inputSchema.safeParse({ limit: 51 }).success, false);
+});
+
+test("all three are exported in the catalogue with unique names", () => {
+  const names = ALL_CONTINUITY_TOOLS.map((t) => t.name);
+  assert.deepEqual(names, ["alfred_continuity_recent", "alfred_continuity_note", "alfred_continuity_bind"]);
+  assert.equal(new Set(names).size, 3);
+});

--- a/packages/mcp-server/src/tools/continuity.ts
+++ b/packages/mcp-server/src/tools/continuity.ts
@@ -1,0 +1,91 @@
+// One Alfred — continuity tools.
+//
+// The alfred_journal in alfred-state.db is the single memory every surface
+// reads before speaking and writes after: Hermes' main profile (via the
+// one-alfred plugin), Telegram, Slack, voice, omi, and — with these tools —
+// any MCP client such as Claude Cowork. A surface that only writes is an
+// answering machine; one that only reads is eavesdropping. These give an MCP
+// client both directions without depending on hooks it may not have.
+//
+// Read-side framing matters and was learned the hard way (one-alfred,
+// 2026-05-25): presented as advisory context the model defers to its own
+// empty session history and says "I don't remember sending that". The
+// description below therefore instructs the model to treat entries as its
+// own authoritative memory. Docs: docs/design/one-alfred.md.
+//
+// All three map 1:1 onto existing ctrl-api routes; nothing new server-side.
+
+import { z } from "zod";
+import type { ToolDef } from "./types.js";
+
+const Channel = z
+  .string()
+  .regex(/^[a-z][a-z0-9_-]{1,31}$/, "channel: lowercase slug, e.g. cowork")
+  .describe("Surface name. Use `cowork` from Claude Cowork.");
+
+export const continuityRecent: ToolDef = {
+  name: "alfred_continuity_recent",
+  description:
+    "Recall what Alfred and the principal said to each other recently across EVERY surface — Slack, Telegram, voice, Cowork, the dashboard — " +
+    "not just this session. Call this BEFORE answering anything that might refer to an earlier exchange (\"the reminder you sent\", \"what we discussed\", \"hm?\").\n\n" +
+    "AUTHORITATIVE: entries with direction=outbound are messages YOU (Alfred) sent; direction=inbound are messages the principal sent you. " +
+    "They happened even if they are not in this session's history. Never say you don't remember something this returns.\n\n" +
+    "Newest first. `limit` is capped at 50 by the server; `within_hours` defaults to 24.",
+  inputSchema: z.object({
+    limit: z.number().int().min(1).max(50).optional().describe("Max entries (server cap 50). Default 20."),
+    within_hours: z.number().min(0.1).max(720).optional().describe("Recency window in hours. Default 24."),
+  }),
+  buildRequest: (args) => ({
+    method: "GET",
+    path: "/api/v1/alfred-journal/recent",
+    query: {
+      principal_id: "owner",
+      limit: args.limit,
+      within_hours: args.within_hours,
+    },
+  }),
+};
+
+export const continuityNote: ToolDef = {
+  name: "alfred_continuity_note",
+  description:
+    "Write one turn into Alfred's cross-surface journal so every other surface remembers it. " +
+    "Use it when this surface has no automatic journaling: record the principal's message (direction=inbound) and your reply (direction=outbound) as they happen. " +
+    "Keep `message` to the actual words, not a summary, so the other surfaces see what was really said.",
+  inputSchema: z.object({
+    channel: Channel,
+    chat_id: z.string().min(1).max(200).describe("Stable id for this conversation on this surface (e.g. the Cowork session id)."),
+    direction: z.enum(["inbound", "outbound"]).describe("inbound = the principal said it; outbound = Alfred said it."),
+    message: z.string().min(1).max(8000),
+  }),
+  buildRequest: (args) => ({
+    method: "POST",
+    path: "/api/v1/alfred-journal",
+    body: {
+      channel: args.channel,
+      chat_id: args.chat_id,
+      direction: args.direction,
+      message: args.message,
+      source_kind: args.channel,
+      status: args.direction === "inbound" ? "received" : "delivered",
+    },
+  }),
+};
+
+export const continuityBind: ToolDef = {
+  name: "alfred_continuity_bind",
+  description:
+    "Bind a conversation on a surface to the principal, so its entries join the cross-surface memory that every other surface reads. " +
+    "Idempotent. Call once per new conversation id before the first alfred_continuity_note.",
+  inputSchema: z.object({
+    channel: Channel,
+    chat_id: z.string().min(1).max(200),
+  }),
+  buildRequest: (args) => ({
+    method: "POST",
+    path: "/api/v1/alfred-journal/principal/bind",
+    body: { channel: args.channel, chat_id: args.chat_id, principal_id: "owner" },
+  }),
+};
+
+export const ALL_CONTINUITY_TOOLS: ToolDef[] = [continuityRecent, continuityNote, continuityBind];


### PR DESCRIPTION
The `alfred_journal` in alfred-state.db is the single memory every surface reads before speaking and writes after. Hermes main gets both directions from the `one-alfred` plugin; Telegram, Slack, voice and omi write through their ctrl-api routes. An MCP client — **Claude Cowork** above all — had neither direction, so a conversation there was invisible to every other surface, and vice versa.

Three declarative tools, each mapping 1:1 onto an existing ctrl-api route — nothing new server-side:

| tool | route |
|---|---|
| `alfred_continuity_recent` | `GET /api/v1/alfred-journal/recent?principal_id=owner` |
| `alfred_continuity_note` | `POST /api/v1/alfred-journal` |
| `alfred_continuity_bind` | `POST /api/v1/alfred-journal/principal/bind` |

The read tool's description presents entries as the model's **own authoritative memory**, not advisory context. Framed the soft way, the model defers to its empty session history and says "I don't remember sending that" — learned on the Hermes side on 2026-05-25 and written into the one-alfred plugin; the same lesson applies here.

## Smoke evidence

```
tsc --noEmit            clean
continuity.test.ts      6/6  (request shapes, status vocabulary, owner binding,
                              schema rejections, catalogue membership)
full suite              244/244
alfred catalogue        34 tools · 3 continuity · 0 duplicate names
```

Lane V gate: passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)