### PR TITLE
fix(learn): NAR recap folds same-day session chains into one conversation

### DIFF
--- a/packages/learn/src/activities/nar_data.py
+++ b/packages/learn/src/activities/nar_data.py
@@ -176,7 +176,7 @@ def _get_human_sessions(db: sqlite3.Connection, day: date) -> list[dict[str, Any
     try:
         rows = db.execute(
             """
-            SELECT id, source, started_at, ended_at
+            SELECT id, source, started_at, ended_at, parent_session_id
             FROM sessions
             WHERE source IN ({placeholders})
               AND started_at >= ?
@@ -211,12 +211,62 @@ def _get_human_sessions(db: sqlite3.Connection, day: date) -> list[dict[str, Any
             "source": row["source"],
             "started_at": row["started_at"],
             "ended_at": row["ended_at"],
+            "parent_session_id": row["parent_session_id"] if "parent_session_id" in row.keys() else None,
             "messages": [
                 {"role": m["role"], "content": m["content"], "ts": m["timestamp"]}
                 for m in msgs
             ],
         })
-    return sessions
+    return _fold_session_chains(sessions)
+
+
+def _fold_session_chains(sessions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Merge same-day continuation chains into one conversation per root.
+
+    Hermes context compression (end_reason=compression) and session resets
+    chain a continued human thread to its predecessor via parent_session_id.
+    Scored fragment by fragment, one long conversation becomes many sessions
+    that each look like "discussion only, nothing delivered": on a live tenant
+    a day with 11 real conversations appeared as 75 sessions (one chain was 40
+    fragments), every one scored bucket=none with 0 displaced while carrying
+    real engaged minutes — a -4.7h day that was actually productive.
+
+    Folding rule: a session whose parent is ALSO in this day's set is a
+    fragment; its messages join the root's, in timestamp order. The root keeps
+    its id/started_at/source, so dedup keys stay stable and the day's replace
+    write retires the fragment rows. A child whose parent started on another
+    day stays its own session for this day (bounded, rare — 7 of 142 live).
+    ``fragments`` records how many sessions were folded in (root counts as 1).
+    """
+    by_id = {s["id"]: s for s in sessions}
+    def root_of(sid: str) -> str:
+        seen = 0
+        cur = sid
+        while seen < 500:
+            parent = by_id[cur].get("parent_session_id")
+            if not parent or parent not in by_id:
+                return cur
+            cur = parent
+            seen += 1
+        return cur
+    merged: dict[str, dict[str, Any]] = {}
+    order: list[str] = []
+    for s in sessions:
+        r = root_of(s["id"])
+        if r not in merged:
+            root = dict(by_id[r])
+            root["messages"] = list(by_id[r]["messages"])
+            root["fragments"] = 1
+            merged[r] = root
+            order.append(r)
+        if r != s["id"]:
+            merged[r]["messages"].extend(s["messages"])
+            merged[r]["fragments"] += 1
+            if s.get("ended_at") and (not merged[r].get("ended_at") or s["ended_at"] > merged[r]["ended_at"]):
+                merged[r]["ended_at"] = s["ended_at"]
+    for r in order:
+        merged[r]["messages"].sort(key=lambda m: (m.get("ts") is None, m.get("ts") or 0))
+    return [merged[r] for r in order]
 
 
 # ---------------------------------------------------------------------------

--- a/packages/learn/tests/test_nar_recap.py
+++ b/packages/learn/tests/test_nar_recap.py
@@ -662,6 +662,40 @@ class TestGetHumanSessionsParentage:
         results = _get_human_sessions(db, self._day())
         assert [r["id"] for r in results] == ["s_continued"]
 
+    def test_same_day_chain_folds_into_root(self):
+        """Compression fragments of one conversation become ONE session: root id
+        kept, messages merged in timestamp order, fragments counted."""
+        t0 = self._ts(9)
+        db = _make_session_db(
+            sessions=[
+                {"id": "root", "source": "slack", "started_at": t0, "ended_at": t0 + 600, "parent_session_id": None},
+                {"id": "frag1", "source": "slack", "started_at": t0 + 600, "ended_at": t0 + 1200, "parent_session_id": "root"},
+                {"id": "frag2", "source": "slack", "started_at": t0 + 1200, "ended_at": t0 + 1800, "parent_session_id": "frag1"},
+            ],
+            messages=[
+                {"session_id": "frag2", "role": "user", "content": "c", "timestamp": t0 + 1300},
+                {"session_id": "root", "role": "user", "content": "a", "timestamp": t0 + 10},
+                {"session_id": "frag1", "role": "assistant", "content": "b", "timestamp": t0 + 700},
+            ],
+        )
+        results = _get_human_sessions(db, self._day())
+        assert [r["id"] for r in results] == ["root"]
+        assert results[0]["fragments"] == 3
+        assert [m["content"] for m in results[0]["messages"]] == ["a", "b", "c"]
+        assert results[0]["ended_at"] == t0 + 1800
+
+    def test_cross_day_child_stays_its_own_session(self):
+        """A fragment whose parent started on another day is not in today's
+        set — it stands alone for today rather than vanishing."""
+        t = self._ts(10)
+        db = _make_session_db([
+            {"id": "today_child", "source": "slack", "started_at": t, "ended_at": t + 60,
+             "parent_session_id": "yesterday_root_not_in_set"},
+        ])
+        results = _get_human_sessions(db, self._day())
+        assert [r["id"] for r in results] == ["today_child"]
+        assert results[0]["fragments"] == 1
+
     def test_spawned_session_turns_absent_from_results(self):
         """Turns belonging to an agent-spawned session must not appear in the
         returned session list, so their timestamps cannot reach cluster_bursts.


### PR DESCRIPTION
Follow-up to #719. Once continued threads were counted, compression fragmentation surfaced: one long conversation split into a chain of sessions, each scored in isolation as "nothing delivered" — on a live tenant, one day with 11 real conversations showed as 75 sessions (largest chain 40 fragments), all scored `none` with 0 displaced against 298 real engaged minutes; 13 July days went negative. Same-day chains now fold into their root before scoring; dedup keys stay stable and the day's replace-mode write retires fragment rows on the next run. Cross-day children stay their own session (bounded, 7 of 142 live).

## Smoke evidence

```
learn suite (py3.11): 2873 passed, 101 skipped, 0 failed
test_nar_recap.py:    79 passed (2 new: chain folds to root w/ ordered merge; cross-day child stands alone)
live shape (07-31):   sessions=75 roots=11 children=64 largest_chain=40 -> 75 rows unknown/none, 0m displaced, 298m engaged
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)