### PR TITLE
feat(alfred-mac): export the Cowork plugin as a .plugin file; move to /Applications on first launch

### DIFF
--- a/packages/alfred-mac/README.md
+++ b/packages/alfred-mac/README.md
@@ -15,7 +15,9 @@ Slack, and the next turn on either side must already know about it.
 | **Pair** | Enter the tenant URL and the dashboard login. The app signs in, mints a dedicated API key (visible under *Study › API keys*, revocable there), stores it in the login Keychain, and forgets the password. |
 | **Read side** | Every 30 s it renders the principal's recent journal (Slack, Telegram, Cowork, …) into `~/Alfred/continuity.md` as the same `[ALFRED-CONTINUITY — authoritative]` block the Hermes plugin injects. A Cowork plugin (staged by the app) reads that file on `SessionStart`, `UserPromptSubmit` and `PostCompact`. |
 | **Write side** | Every 60 s it mirrors new Cowork turns from the local session transcripts into the journal (`channel: cowork`), binding each new session to the owner. Only turns from the last 48 h are ever mirrored: the journal stamps `ts` server-side, so history mirrored late would land as "now". |
+| **Set up Cowork** | One action: registers the MCP server, exports the hooks plugin as `Alfred Continuity.plugin` into Downloads (a zip with `.claude-plugin/plugin.json` at its root — the file Claude Desktop's plugin upload accepts), selects it in Finder and opens Claude. Installing a plugin is Claude's own UI step; there is no deep link or CLI for it. |
 | **MCP** | Registers itself in Claude Desktop (`mcpServers.alfred-continuity`, `--mcp`) exposing `alfred_continuity_recent` / `alfred_continuity_note` / `alfred_continuity_bind` — Cowork can read and write continuity directly, through the app, over a loopback stdio pipe. |
+| **First launch** | Opened from a mounted disk image, the app copies itself to `/Applications`, starts from there and lets the mounted copy quit — so the login item never points into `/Volumes`. A double-click on the running app opens the window; a login-item launch stays in the menu bar. |
 | **Always on** | Registers as a login item (`SMAppService`). Menu-bar only (`LSUIElement`), no Dock icon. On every launch it re-points the MCP registration and the login item at its current bundle path, so moving it to `/Applications` needs nothing. |
 
 Everything speaks to the tenant through the dashboard's own API proxy
@@ -61,7 +63,8 @@ Produces `dist/Alfred Black.app` and `dist/AlfredBlack-2026.09.03.dmg`.
 "dist/Alfred Black.app/Contents/MacOS/AlfredBlack" --pair https://<domain> <email> <password>
 "dist/Alfred Black.app/Contents/MacOS/AlfredBlack" --tick       # one render + one mirror pass
 "dist/Alfred Black.app/Contents/MacOS/AlfredBlack" --status
-"dist/Alfred Black.app/Contents/MacOS/AlfredBlack" --snapshot /path/out.png   # render the UI to a file
+"dist/Alfred Black.app/Contents/MacOS/AlfredBlack" --export-plugin           # write ~/Downloads/Alfred Continuity.plugin
+"dist/Alfred Black.app/Contents/MacOS/AlfredBlack" --snapshot /path/dir      # render both views to PNGs
 ```
 
 ## Signing and distribution
@@ -69,6 +72,12 @@ Produces `dist/Alfred Black.app` and `dist/AlfredBlack-2026.09.03.dmg`.
 The build is **ad-hoc signed** (`codesign --sign -`). It runs on the Mac it
 was built on; on another Mac, Gatekeeper will refuse a double-click the
 first time — right-click › *Open* once, or clear the quarantine flag.
+Because each ad-hoc build has a new signature, an **updated** build asks once
+for access to the key the previous build stored in the Keychain — click *Always
+Allow*. Pairing from the installed app creates the item with that binary as its
+owner, so a first run never asks. A denied read is reported in the app, not
+mistaken for a network problem.
+
 Proper distribution needs a Developer ID certificate and notarization;
 `build-app.sh` is the place to add them (`codesign --sign "Developer ID
 Application: …"`, then `notarytool submit` + `stapler`).

--- a/packages/alfred-mac/Sources/AlfredBlack/App.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/App.swift
@@ -37,7 +37,7 @@ struct AlfredBlackMain {
       _ = NSApplication.shared; AB.registerFonts()
       func write(_ view: some View, _ name: String) {
         let host = NSHostingView(rootView: view)
-        host.frame = NSRect(x: 0, y: 0, width: 520, height: 560)
+        host.frame = NSRect(x: 0, y: 0, width: 520, height: 640)
         host.layoutSubtreeIfNeeded()
         guard let rep = host.bitmapImageRepForCachingDisplay(in: host.bounds) else { return }
         host.cacheDisplay(in: host.bounds, to: rep)
@@ -51,6 +51,10 @@ struct AlfredBlackMain {
       if paired.pairing != nil { write(RootView().environmentObject(paired), "status.png") }
       print("snapshot: \(dir.path)")
       exit(0)
+    }
+    if CommandLine.arguments.contains("--export-plugin") {
+      do { let u = try Cowork.exportPlugin(); print("exported: \(u.path)"); exit(0) }
+      catch { print("error: \((error as? TenantError)?.message ?? "\(error)")"); exit(1) }
     }
     if CommandLine.arguments.contains("--tick") {
       var done = false
@@ -115,6 +119,35 @@ final class AppState: ObservableObject {
     } catch { message = error.localizedDescription }
   }
 
+  private func record(_ error: Error) {
+
+    state.lastError = (error as? TenantError)?.message ?? error.localizedDescription
+
+    state.lastErrorAt = Date()
+
+  }
+
+  /// Everything Cowork needs, in one action: the memory tools registered, the
+
+  /// plugin file in Downloads and selected in Finder, Claude opened.
+
+  func setUpCowork() {
+
+    do { try Cowork.registerMCP(); try Cowork.exportPlugin(); Cowork.revealExport(); Cowork.openClaude() } catch { record(error) }
+
+    cowork = Cowork.status()
+
+  }
+
+  func exportPlugin() {
+
+    do { try Cowork.exportPlugin(); Cowork.revealExport() } catch { record(error) }
+
+    cowork = Cowork.status()
+
+  }
+
+
   func signOut() {
     Keychain.delete("apikey"); Store.savePairing(nil); pairing = nil; online = nil
     try? Cowork.unregisterMCP(); cowork = Cowork.status()
@@ -140,6 +173,11 @@ final class AppState: ObservableObject {
     cowork = Cowork.status()
   }
   func tick(force: Bool = false) async {
+    // A denied Keychain prompt must not look like a network problem.
+    if pairing != nil, Keychain.get("apikey") == nil {
+      state.lastError = "The key could not be read from the Keychain. Allow access when macOS asks, or sign out and pair again."
+      state.lastErrorAt = Date(); online = false; return
+    }
     guard let t = tenant, let p = pairing else { return }
     let now = Date()
     if force || now.timeIntervalSince(lastRender) >= 30 {
@@ -181,6 +219,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   var timer: Timer?
 
   func applicationDidFinishLaunching(_ n: Notification) {
+
+    if Self.moveToApplicationsIfNeeded() { return }
     AB.registerFonts()
     statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
     statusItem.button?.image = Glyph.bowtie()
@@ -188,13 +228,67 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     statusItem.button?.toolTip = "Alfred Black"
     statusItem.menu = buildMenu()
     state.selfHeal()
-    if state.pairing == nil { showWindow() }
+    if state.pairing == nil || !Self.launchedAsLoginItem() { showWindow() }
     timer = Timer.scheduledTimer(withTimeInterval: 10, repeats: true) { [weak self] _ in
       guard let self else { return }
       Task { @MainActor in await self.state.tick(); self.statusItem.menu = self.buildMenu() }
     }
     Task { @MainActor in await state.tick(force: true); statusItem.menu = buildMenu() }
   }
+
+  /// Launched from a mounted disk image (or anywhere read-only), the app would
+
+  /// die on eject and its login item would point into /Volumes. Copy to
+
+  /// /Applications, start from there, and let this copy quit.
+
+  static func moveToApplicationsIfNeeded() -> Bool {
+
+    let here = URL(fileURLWithPath: Bundle.main.bundlePath)
+
+    guard here.path.hasPrefix("/Volumes/") else { return false }
+
+    let dest = URL(fileURLWithPath: "/Applications/Alfred Black.app")
+
+    do {
+
+      try? FileManager.default.removeItem(at: dest)
+
+      try FileManager.default.copyItem(at: here, to: dest)
+
+    } catch { return false }   // keep running from here rather than not at all
+
+    let cfg = NSWorkspace.OpenConfiguration(); cfg.createsNewApplicationInstance = true
+
+    NSWorkspace.shared.openApplication(at: dest, configuration: cfg) { _, _ in
+
+      DispatchQueue.main.async { NSApp.terminate(nil) }
+
+    }
+
+    return true
+
+  }
+
+
+  /// A login-item launch arrives as an open-application event tagged as such;
+
+  /// a person double-clicking the app does not, and expects to see the window.
+
+  static func launchedAsLoginItem() -> Bool {
+
+    let aevt: UInt32 = 0x61657674, oapp: UInt32 = 0x6F617070, prdt: UInt32 = 0x70726474, lgit: UInt32 = 0x6C676974
+
+    guard let ev = NSAppleEventManager.shared().currentAppleEvent, ev.eventClass == aevt, ev.eventID == oapp,
+
+          let prop = ev.paramDescriptor(forKeyword: prdt) else { return false }
+
+    return prop.enumCodeValue == lgit
+
+  }
+
+  func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows: Bool) -> Bool { showWindow(); return true }
+
 
   @MainActor func buildMenu() -> NSMenu {
     let m = NSMenu()
@@ -227,7 +321,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
   func showWindow() {
     if window == nil {
-      let w = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 520, height: 560),
+      let w = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 520, height: 640),
                        styleMask: [.titled, .closable, .miniaturizable], backing: .buffered, defer: false)
       w.title = "Alfred Black"
       w.titlebarAppearsTransparent = true

--- a/packages/alfred-mac/Sources/AlfredBlack/Cowork.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Cowork.swift
@@ -14,6 +14,7 @@ struct CoworkStatus {
   var folderReady = false
   var mcpRegistered = false
   var pluginStaged = false
+  var pluginExported = false
   var claudeInstalled = false
 }
 
@@ -25,6 +26,7 @@ enum Cowork {
     s.folderReady = FileManager.default.fileExists(atPath: Paths.folderInstructions.path)
     s.pluginStaged = FileManager.default.fileExists(atPath: Paths.coworkPlugin.appendingPathComponent(".claude-plugin/plugin.json").path)
     s.claudeInstalled = FileManager.default.fileExists(atPath: "/Applications/Claude.app")
+    s.pluginExported = FileManager.default.fileExists(atPath: exportedPlugin.path)
     if let d = try? Data(contentsOf: Paths.claudeDesktopConfig),
        let j = try? JSONSerialization.jsonObject(with: d) as? [String: Any],
        let servers = j["mcpServers"] as? [String: Any] {
@@ -75,5 +77,36 @@ enum Cowork {
     }
   }
   static func revealPlugin() { NSWorkspace.shared.activateFileViewerSelecting([Paths.coworkPlugin]) }
+
+  /// Claude Desktop installs a plugin from a `.plugin` file — a zip with
+  /// `.claude-plugin/plugin.json` at its root, under 4 MB — chosen in its own
+  /// Plugins UI. There is no deep link or CLI for that step, so the app makes
+  /// the file, selects it in Finder, and opens Claude.
+  static var exportedPlugin: URL {
+    let dl = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first
+      ?? FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Downloads")
+    return dl.appendingPathComponent("Alfred Continuity.plugin")
+  }
+
+  @discardableResult
+  static func exportPlugin() throws -> URL {
+    try stagePlugin()
+    let root = Paths.coworkPlugin
+    guard FileManager.default.fileExists(atPath: root.appendingPathComponent(".claude-plugin/plugin.json").path) else {
+      throw TenantError(message: "Plugin manifest missing from the staged copy.")
+    }
+    let out = exportedPlugin
+    try? FileManager.default.removeItem(at: out)
+    let zip = Process()
+    zip.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
+    zip.currentDirectoryURL = root
+    zip.arguments = ["-r", "-X", "-q", out.path, ".", "-x", "*.DS_Store", "-x", "__MACOSX/*"]
+    try zip.run(); zip.waitUntilExit()
+    guard zip.terminationStatus == 0 else { throw TenantError(message: "Could not build the plugin file (zip exited \(zip.terminationStatus)).") }
+    let size = (try? FileManager.default.attributesOfItem(atPath: out.path)[.size] as? Int) ?? 0
+    guard size > 0, size < 4 * 1024 * 1024 else { throw TenantError(message: "Plugin file is \(size) bytes; Claude accepts up to 4 MB.") }
+    return out
+  }
+  static func revealExport() { NSWorkspace.shared.activateFileViewerSelecting([exportedPlugin]) }
   static func revealAlfredFolder() { NSWorkspace.shared.activateFileViewerSelecting([Paths.continuity]) }
 }

--- a/packages/alfred-mac/Sources/AlfredBlack/Views.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Views.swift
@@ -7,7 +7,7 @@ struct RootView: View {
     ZStack { AB.paper.ignoresSafeArea()
       if s.pairing == nil { OnboardingView() } else { StatusView() }
     }
-    .frame(width: 520, height: 560)
+    .frame(width: 520, height: 640)
   }
 }
 
@@ -93,8 +93,12 @@ struct StatusView: View {
         Row(k: "Claude Desktop", v: s.cowork.claudeInstalled ? "installed" : "not found", ok: s.cowork.claudeInstalled)
         Row(k: "Alfred folder", v: s.cowork.folderReady ? "~/Alfred ready" : "pending", ok: s.cowork.folderReady)
         Row(k: "Memory tools", v: s.cowork.mcpRegistered ? "registered with Claude" : "not registered", ok: s.cowork.mcpRegistered)
-        Row(k: "Hooks plugin", v: s.cowork.pluginStaged ? "staged — install from Claude › Plugins" : "not staged", ok: s.cowork.pluginStaged)
+        Row(k: "Hooks plugin", v: s.cowork.pluginExported ? "exported to Downloads" : (s.cowork.pluginStaged ? "ready to export" : "not staged"), ok: s.cowork.pluginExported)
       }.padding(.top, 6)
+      if s.cowork.pluginExported {
+        Text("Alfred Continuity.plugin is in your Downloads, selected in Finder. In Claude, open Plugins and choose upload, then pick that file. Hooks load only through a plugin, and installing one is Claude's own step.")
+          .font(AB.body(14)).foregroundColor(AB.marginalia).lineSpacing(3).padding(.top, 12).frame(maxWidth: 448, alignment: .leading).fixedSize(horizontal: false, vertical: true)
+      }
 
       if let e = s.state.lastError, let at = s.state.lastErrorAt, Date().timeIntervalSince(at) < 600 {
         Text(e).font(AB.mono(10)).foregroundColor(AB.oxblood).padding(.top, 10).lineLimit(2)
@@ -102,8 +106,8 @@ struct StatusView: View {
       Spacer()
       Hairline(brass: true)
       HStack(spacing: 8) {
-        Button("Set up Cowork") { try? Cowork.stagePlugin(); try? Cowork.registerMCP(); s.cowork = Cowork.status(); Cowork.openClaude() }.buttonStyle(ABButton(primary: true))
-        Button("Plugin") { Cowork.revealPlugin() }.buttonStyle(ABButton())
+        Button("Set up Cowork") { s.setUpCowork() }.buttonStyle(ABButton(primary: true))
+        Button("Export") { s.exportPlugin() }.buttonStyle(ABButton())
         Button("Refresh") { Task { await s.tick(force: true) } }.buttonStyle(ABButton())
         Spacer()
         Button("Sign out") { s.signOut() }.buttonStyle(ABButton())


### PR DESCRIPTION
## What

Follow-up to #722, from the first real use:

- **Set up Cowork is now one action** — registers the MCP server, exports the hooks plugin as `~/Downloads/Alfred Continuity.plugin` (a zip with `.claude-plugin/plugin.json` at its root — the file Claude Desktop's plugin upload accepts), selects it in Finder and opens Claude. The status view tells the principal what to do next. An **Export** button repeats it. Claude Desktop has no deep link or CLI for installing a plugin, so the upload is the supported path.
- **First launch from a disk image moves the app to /Applications** and restarts from there — the login item never points into `/Volumes`.
- **Double-click opens the window** (`applicationShouldHandleReopen`); a login-item launch stays in the menu bar (detected from the launch Apple event).
- **A denied Keychain read is reported as such**, not mistaken for a network problem.
- Window 520×640; README updated.

## Smoke evidence

```
$ AlfredBlack --export-plugin
exported: /Users/<me>/Downloads/Alfred Continuity.plugin
$ unzip -l "Alfred Continuity.plugin"
  hooks/continuity-context.sh  hooks/hooks.json  .claude-plugin/plugin.json  skills/alfred-continuity/SKILL.md   (2756 bytes)
```

- Mounted the DMG, opened the app from the volume → running from `/Applications/Alfred Black.app`, volume ejected, 1 instance still up, `claude_desktop_config.json` command re-pointed to `/Applications`.
- `--snapshot` renders inspected; left margin measured from the PNG at 35 px (the button row had widened the column to 14 px before the fix).
- Local lane VIII gate: verify (`swift build -c release`) ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
