### PR TITLE
chore(gate): lane VIII (alfred-mac) — map lane-8/* in CI, accept VIII locally

### DIFF
--- a/.github/workflows/lane-gate.yml
+++ b/.github/workflows/lane-gate.yml
@@ -11,7 +11,7 @@
 #   lane-1/* → I (ctrl)          lane-5/* → V  (edges/infra)
 #   lane-2/* → II (learn)        lane-6/* → VI (voice-bridge)
 #   lane-3/* → III (web)         lane-7/* → VII (paperclip)
-#   lane-4/* → IV (alfred-vault)
+#   lane-4/* → IV (alfred-vault)  lane-8/* → VIII (alfred-mac)
 #   anything else → phase0 (operator branch; allow-all by design — the lane
 #   protocol constrains AGENT branches, and agents must use lane-N/ naming).
 #
@@ -45,6 +45,7 @@ jobs:
             lane-5/*) LANE=V ;;
             lane-6/*) LANE=VI ;;
             lane-7/*) LANE=VII ;;
+            lane-8/*) LANE=VIII ;;
             lane-*)   LANE=INVALID ;;
             *)        LANE=phase0 ;;
           esac
@@ -56,7 +57,7 @@ jobs:
         env:
           BRANCH: ${{ github.head_ref }}
         run: |
-          echo "::error::branch '$BRANCH' uses lane-* naming but maps to no lane (valid: lane-1 … lane-7). Rename the branch or use a non-lane branch for operator work."
+          echo "::error::branch '$BRANCH' uses lane-* naming but maps to no lane (valid: lane-1 … lane-8). Rename the branch or use a non-lane branch for operator work."
           exit 1
 
       - name: Replay the lane gate on the PR diff

--- a/docs/lane-protocol.md
+++ b/docs/lane-protocol.md
@@ -22,10 +22,11 @@ user-visible flow is the close gate.
 | **V** — edges/infra | `lane-5/` | `packages/{hermes,mcp-server,vault-init,setup}/**`, `scripts/**`, `caddy/**`, `docker-compose.yaml`, `.env.example`, `Makefile`, `docs/**` | `docker compose config -q` |
 | **VI** — voice-bridge | `lane-6/` | `packages/voice-bridge/**` | `cd packages/voice-bridge && npm test` |
 | **VII** — paperclip | `lane-7/` | `packages/paperclip/**` | `cd packages/paperclip/adapter && npm run typecheck && npm test` |
+| **VIII** — alfred-mac | `lane-8/` | `packages/alfred-mac/**` | `cd packages/alfred-mac && swift build -c release` |
 | phase0 — orchestrator | n/a (main checkout) | `**` (allow-all) | `true` |
 
 Branch naming: `lane-<arabic>/<issue>-<slug>` — the arabic digit maps to
-the roman lane ID (lane-1 = Lane I … lane-7 = Lane VII). These are the
+the roman lane ID (lane-1 = Lane I … lane-8 = Lane VIII). These are the
 ONLY valid lane IDs. If your work doesn't fit a lane, it's orchestrator
 (phase0) work — STOP and report; do not invent a lane name.
 
@@ -162,7 +163,7 @@ Inherit lane-worker.md. Your lane scope:
   {lane_scope}
 
 FIRST ACTION: write the .lane manifest — echo '{{"lane":"<ID>"}}' > .lane
-(valid IDs: I II III IV V VI VII — see docs/lane-protocol.md).
+(valid IDs: I II III IV V VI VII VIII — see docs/lane-protocol.md).
 
 Contracts at /tmp/orchestrator-{n}-contracts.md (read verbatim, don't drift).
 

--- a/scripts/hooks/check_lane.py
+++ b/scripts/hooks/check_lane.py
@@ -31,7 +31,7 @@ Hardening (2026-07-15, post-audit):
     the rules for the same commit. Falls back to the on-disk copy only when
     HEAD has no copy (fresh repo).
 
-`.lane` format:  {"lane": "II"}            # required: I|II|III|IV|V|VI|VII
+`.lane` format:  {"lane": "II"}            # required: I|II|III|IV|V|VI|VII|VIII
                  {"lane": "II", "verify": "cd packages/learn && python -m pytest tests/test_signals.py -q"}
                  {"lane": "II", "scope_limit": 350}   # only for a justified larger task
 
@@ -46,7 +46,7 @@ import sys
 
 RED, GREEN, YELLOW, RESET = "\033[31m", "\033[32m", "\033[33m", "\033[0m"
 
-ROMAN_LANES = ("I", "II", "III", "IV", "V", "VI", "VII")
+ROMAN_LANES = ("I", "II", "III", "IV", "V", "VI", "VII", "VIII")
 
 
 def run(*args):


### PR DESCRIPTION
## What

#722 added lane VIII (`packages/alfred-mac/**`) to `lanes.json` and the CLAUDE.md table, but the server-side replay maps branch names with a hard-coded `case` (lane-1 … lane-7) and `check_lane.py` lists the valid ids the same way — so #724, the first `lane-8/*` PR, was rejected as an unmapped lane. This maps `lane-8/*` → VIII, accepts VIII locally, and documents it in `docs/lane-protocol.md`. Phase0 (forbidden-zone files), orchestrator commit.

## Smoke evidence

- `python3 scripts/hooks/test_check_lane.py` → 17 tests OK (the lane-set test already expects VIII since #722).
- Local phase0 gate passed on the commit (verify ok).
- After merge: #724 rebased onto main so its `lane-gate` replays with the new mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)