### PR TITLE
feat(alfred-mac): Cowork plugin for sandboxed sessions — memory via the tools, Stop hook enforces journaling

### DIFF
--- a/packages/alfred-mac/README.md
+++ b/packages/alfred-mac/README.md
@@ -12,7 +12,7 @@ Slack, and the next turn on either side must already know about it.
 
 | | |
 |---|---|
-| **Pair** | Enter the tenant URL and the dashboard login. The app signs in, mints a dedicated API key (visible under *Study › API keys*, revocable there), stores it in the login Keychain, and forgets the password. |
+| **Pair** | Enter the tenant URL and the dashboard login. The app signs in, mints a dedicated API key (visible under *Study › API keys*, revocable there), stores it in a 0600 file of its own, and forgets the password. |
 | **Read side** | Every 30 s it renders the principal's recent journal (Slack, Telegram, Cowork, …) into `~/Alfred/continuity.md` as the same `[ALFRED-CONTINUITY — authoritative]` block the Hermes plugin injects. A Cowork plugin (staged by the app) reads that file on `SessionStart`, `UserPromptSubmit` and `PostCompact`. |
 | **Write side** | Every 60 s it mirrors new Cowork turns from the local session transcripts into the journal (`channel: cowork`), binding each new session to the owner. Only turns from the last 48 h are ever mirrored: the journal stamps `ts` server-side, so history mirrored late would land as "now". |
 | **Set up Cowork** | One action: registers the MCP server, exports the hooks plugin as `Alfred Continuity.plugin` into Downloads (a zip with `.claude-plugin/plugin.json` at its root — the file Claude Desktop's plugin upload accepts), selects it in Finder and opens Claude. Installing a plugin is Claude's own UI step; there is no deep link or CLI for it. |
@@ -72,11 +72,13 @@ Produces `dist/Alfred Black.app` and `dist/AlfredBlack-2026.09.03.dmg`.
 The build is **ad-hoc signed** (`codesign --sign -`). It runs on the Mac it
 was built on; on another Mac, Gatekeeper will refuse a double-click the
 first time — right-click › *Open* once, or clear the quarantine flag.
-Because each ad-hoc build has a new signature, an **updated** build asks once
-for access to the key the previous build stored in the Keychain — click *Always
-Allow*. Pairing from the installed app creates the item with that binary as its
-owner, so a first run never asks. A denied read is reported in the app, not
-mistaken for a network problem.
+The login Keychain's ACL trusts a code identity, and an ad-hoc signature is a
+new identity on every build — every update would re-ask, and for the background
+MCP server that Claude Desktop spawns the question is never shown: the process
+just blocks. So while the app is ad-hoc signed the key lives in a 0600 file in
+its support folder, and the Keychain is only read with user interaction
+disabled (to migrate a key an earlier build stored there). A Developer ID
+signature is what makes a Keychain-backed store viable.
 
 Proper distribution needs a Developer ID certificate and notarization;
 `build-app.sh` is the place to add them (`codesign --sign "Developer ID
@@ -92,9 +94,9 @@ Application: …"`, then `notarytool submit` + `stapler`).
 | `~/Library/Application Support/Alfred Black/state.json` | mirrored-turn ids, bound sessions, last run |
 | `~/Library/Application Support/Alfred Black/cowork-plugin/` | the staged Cowork plugin |
 | `~/Library/Application Support/Claude/claude_desktop_config.json` | `mcpServers.alfred-continuity` (other keys preserved) |
-| login Keychain, service `black.alfred.mac` | the API key |
+| `~/Library/Application Support/Alfred Black/.device-key` (0600) | the API key — see *Signing* for why not the Keychain yet |
 
-Sign out removes the pairing, the Keychain item and the MCP registration;
+Sign out removes the pairing, the key file and the MCP registration;
 the API key itself is revoked from *Study › API keys* on the tenant.
 
 ## Design

--- a/packages/alfred-mac/Sources/AlfredBlack/Resources/CoworkPlugin/hooks/continuity-context.sh
+++ b/packages/alfred-mac/Sources/AlfredBlack/Resources/CoworkPlugin/hooks/continuity-context.sh
@@ -1,21 +1,31 @@
 #!/bin/sh
-# Inject Alfred's cross-surface memory into this turn. The file is rendered
-# every 30s by Alfred Black for Mac from the tenant's journal; reading a local
-# file needs no network egress from the Cowork sandbox. Fail-soft: no file,
-# no context, never an error — the user's turn always goes through.
+# One Alfred, from inside a Cowork session.
+#
+# Cowork runs sessions in a sandbox that cannot see this Mac's files, but the
+# Alfred Black app's MCP tools (alfred_continuity_recent / _note / _bind) are
+# bridged into every session. So: when a rendered continuity file happens to be
+# reachable (a host-mode session), inject it verbatim; otherwise tell the model
+# exactly which tool to call. Fail-soft: never block the person's turn.
+in=$(cat 2>/dev/null)
+sid=$(printf '%s' "$in" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+ev=$(printf '%s' "$in" | sed -n 's/.*"hook_event_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+[ -n "$ev" ] || ev=SessionStart
 f="${ALFRED_CONTINUITY_FILE:-$HOME/Alfred/continuity.md}"
-[ -r "$f" ] || exit 0
-ctx=$(cat "$f")
-[ -n "$ctx" ] || exit 0
-# Hooks return additionalContext as JSON; escape via python if present, else a
-# conservative sed fallback so the hook works on a bare sandbox too.
-if command -v python3 >/dev/null 2>&1; then
-  python3 - "$f" <<'PY'
-import json, sys
-print(json.dumps({"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": open(sys.argv[1]).read()}}))
-PY
+[ -r "$f" ] || f="${CLAUDE_PROJECT_DIR:-.}/.alfred/continuity.md"
+
+rules="You are one Alfred across every surface; this Cowork session is one of them (session id: ${sid:-unknown}).
+Memory: if this session has not yet called alfred_continuity_recent, call it before answering — messages marked YOU -> principal there are things you said on other surfaces.
+Journal: for every exchange call alfred_continuity_note twice — direction inbound with the person's message verbatim, and direction outbound with your reply — using chat_id \"${sid:-unknown}\" and channel \"cowork\". A turn is not finished until both notes are written."
+
+if [ -r "$f" ] && [ -s "$f" ]; then
+  body=$(cat "$f"; printf '\n\n%s' "$rules")
 else
-  esc=$(printf '%s' "$ctx" | sed 's/\\/\\\\/g; s/"/\\"/g' | awk '{printf "%s\\n", $0}')
-  printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"%s"}}\n' "$esc"
+  body="$rules"
+fi
+if command -v python3 >/dev/null 2>&1; then
+  printf '%s' "$body" | python3 -c 'import json,sys; print(json.dumps({"hookSpecificOutput":{"hookEventName":sys.argv[1],"additionalContext":sys.stdin.read()}}))' "$ev"
+else
+  esc=$(printf '%s' "$body" | sed 's/\\/\\\\/g; s/"/\\"/g' | awk '{printf "%s\\n", $0}')
+  printf '{"hookSpecificOutput":{"hookEventName":"%s","additionalContext":"%s"}}\n' "$ev" "$esc"
 fi
 exit 0

--- a/packages/alfred-mac/Sources/AlfredBlack/Resources/CoworkPlugin/hooks/continuity-stop.sh
+++ b/packages/alfred-mac/Sources/AlfredBlack/Resources/CoworkPlugin/hooks/continuity-stop.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# A turn is not over until it is journaled. On Stop, look at the transcript
+# since the person's last message: if alfred_continuity_note was called, allow;
+# otherwise block once with the exact instruction. stop_hook_active means we
+# already blocked this turn — never loop. Unreadable transcript: allow (soft).
+in=$(cat 2>/dev/null)
+case "$in" in *'"stop_hook_active"'*'true'*) exit 0 ;; esac
+sid=$(printf '%s' "$in" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+tp=$(printf '%s' "$in" | sed -n 's/.*"transcript_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+[ -n "$tp" ] && [ -r "$tp" ] || exit 0
+journaled=$(awk '
+  /"type":[[:space:]]*"user"/ && !/tool_result/ { seen = 0; next }   # the person spoke: start counting afresh
+  /alfred_continuity_note/ && /tool_use/ { seen = 1 }
+  END { print seen + 0 }' "$tp")
+[ "$journaled" = "1" ] && exit 0
+reason="This exchange is not journaled yet. Call alfred_continuity_note twice — direction inbound with the person's last message verbatim, direction outbound with the reply you are giving — with chat_id \"${sid:-unknown}\" and channel \"cowork\". If this session has not called alfred_continuity_recent yet, call it too. Then finish."
+if command -v python3 >/dev/null 2>&1; then
+  printf '%s' "$reason" | python3 -c 'import json,sys; print(json.dumps({"decision":"block","reason":sys.stdin.read()}))'
+else
+  esc=$(printf '%s' "$reason" | sed 's/\\/\\\\/g; s/"/\\"/g')
+  printf '{"decision":"block","reason":"%s"}\n' "$esc"
+fi
+exit 0

--- a/packages/alfred-mac/Sources/AlfredBlack/Resources/CoworkPlugin/hooks/hooks.json
+++ b/packages/alfred-mac/Sources/AlfredBlack/Resources/CoworkPlugin/hooks/hooks.json
@@ -8,6 +8,9 @@
     ],
     "PostCompact": [
       { "hooks": [ { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/continuity-context.sh", "timeout": 10 } ] }
+    ],
+    "Stop": [
+      { "hooks": [ { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/continuity-stop.sh", "timeout": 10 } ] }
     ]
   }
 }

--- a/packages/alfred-mac/Sources/AlfredBlack/Resources/CoworkPlugin/skills/alfred-continuity/SKILL.md
+++ b/packages/alfred-mac/Sources/AlfredBlack/Resources/CoworkPlugin/skills/alfred-continuity/SKILL.md
@@ -6,7 +6,9 @@ description: You are one Alfred across every surface. Before answering anything 
 # One Alfred
 
 The person is talking to one Alfred. Which surface they used does not matter — a phone
-call and a face-to-face conversation draw on the same memory.
+call and a face-to-face conversation draw on the same memory. In Cowork the memory is
+reached through three tools bridged from Alfred Black for Mac: `alfred_continuity_recent`,
+`alfred_continuity_note`, `alfred_continuity_bind`.
 
 ## Before you answer
 
@@ -14,18 +16,17 @@ call and a face-to-face conversation draw on the same memory.
   memory**. Messages marked `YOU → principal` are things you said, on any surface, even
   if this session's history does not show them. Never say you don't remember something
   that block contains.
-- If no block is present and the question might refer to an earlier exchange, call
-  `alfred_continuity_recent` first.
+- If no block is present, call `alfred_continuity_recent` once at the start of the
+  session, and again whenever the person refers to something you cannot see here.
 
 ## As you converse
 
-- On the first turn of a new session, call `alfred_continuity_bind` with
-  `channel: "cowork"` and this session's id, once.
-- After each exchange, call `alfred_continuity_note` twice: the person's message as
-  `inbound`, your reply as `outbound`. Record the actual words, not a summary.
-- If Alfred Black for Mac is running, it journals this surface automatically; the notes
-  are then harmless duplicates that the server de-duplicates by `source_ref`.
+- After each exchange call `alfred_continuity_note` twice: the person's message as
+  `inbound`, your reply as `outbound`. Record the actual words, not a summary. Use this
+  session's id as `chat_id` (the hook context states it) and `channel: "cowork"`.
+- A turn is not finished until both notes are written; the plugin's Stop hook will ask
+  you to write them if they are missing. Binding to the principal happens automatically.
 
 ## Voice
 
-Plain, calm, brief. No exclamation marks. "No urgent action is required." is the register.
+Alfred's voice does not change between surfaces: calm, exact, no exclamation marks.


### PR DESCRIPTION
## What

From the first real Cowork session with the plugin installed: **0 turns**. Cowork now runs sessions in a local VM (`claudevm.bundle`, gVisor) that cannot see this Mac's files, so the hook found no memory file and nothing was journaled. The channel that reaches the host from inside a session is the app's MCP server (Claude Desktop spawns it), so the plugin now drives that:

- **Hooks** (`SessionStart` / `UserPromptSubmit` / `PostCompact`) inject the memory block when a rendered file is reachable (`~/Alfred/continuity.md`, or the space folder's `.alfred/continuity.md`, which the app renders — companion PR) and otherwise the exact tools to call, with the session id.
- **Stop hook** refuses to end a turn until `alfred_continuity_note` was called for it: blocks once with the instruction; `stop_hook_active` prevents loops; an unreadable transcript allows (soft).
- SKILL.md and README updated for the sandboxed model. Plugin is re-exported by the app (*Export*) and re-uploaded in Claude › Plugins.

Companion: the app-side PR (file-backed key, auto-bind, activity, space-folder render).

## Smoke evidence

Hook scripts against synthetic transcripts (POSIX sh + awk only, as in the sandbox):
```
context (no file): UserPromptSubmit | You are one Alfred across every surface; this Cowork session is one of them (session id: a…
stop, unjournaled turn → block | This exchange is not journaled yet. Call alfred_continuity_n…
stop, journaled turn → allowed (no output)
stop, already blocked once → allowed (no output)
stop, unreadable transcript → allowed (soft)
```
Local lane VIII gate: verify ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)