### PR TITLE
fix(alfred-mac): file-backed device key; MCP server auto-binds and records activity; memory block into space folders

### DIFF
--- a/packages/alfred-mac/Sources/AlfredBlack/App.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/App.swift
@@ -70,7 +70,7 @@ struct AlfredBlackMain {
     }
     if CommandLine.arguments.contains("--status") {
       let p = Store.loadPairing(); let st = Store.loadState(); let c = Cowork.status()
-      print("paired: \(p?.domain ?? "no") keyInKeychain: \(Keychain.get("apikey") != nil) loginItem: \(SMAppService.mainApp.status == .enabled)")
+      print("paired: \(p?.domain ?? "no") key: \(Keychain.get("apikey") != nil) loginItem: \(SMAppService.mainApp.status == .enabled)")
       print("render: \(st.lastRenderAt.map { ISO8601DateFormatter().string(from: $0) } ?? "never") entries=\(st.lastRenderEntries)  push: \(st.lastPushAt.map { ISO8601DateFormatter().string(from: $0) } ?? "never") total=\(st.totalPushed) lastError=\(st.lastError ?? "none")")
       print("cowork: folder=\(c.folderReady) mcp=\(c.mcpRegistered) plugin=\(c.pluginStaged) claude=\(c.claudeInstalled)")
       exit(0)
@@ -108,7 +108,7 @@ final class AppState: ObservableObject {
       let session = try await t.login(email: email, password: password)
       let name = "Alfred Black for Mac — \(Host.current().localizedName ?? "this Mac")"
       let key = try await t.createApiKey(session: session, name: name)
-      guard Keychain.set(key.key, account: "apikey") else { throw TenantError(message: "Could not store the device key in the Keychain.") }
+      guard Keychain.set(key.key, account: "apikey") else { throw TenantError(message: "Could not store the device key on this Mac.") }
       let p = Pairing(domain: domain, email: email, keyId: key.id, pairedAt: Date())
       Store.savePairing(p); pairing = p
       online = await Tenant(api: p.api, apiKey: key.key).check()
@@ -157,6 +157,7 @@ final class AppState: ObservableObject {
   private var lastRender = Date.distantPast
   private var lastPush = Date.distantPast
   var lastReport = PushReport()
+  @Published var activity = Activity.load()
 
   /// On every launch while paired: the app may have been moved (dist → /Applications),
   /// so the MCP registration and the login item must point at THIS bundle.
@@ -173,9 +174,10 @@ final class AppState: ObservableObject {
     cowork = Cowork.status()
   }
   func tick(force: Bool = false) async {
+    activity = Activity.load()
     // A denied Keychain prompt must not look like a network problem.
     if pairing != nil, Keychain.get("apikey") == nil {
-      state.lastError = "The key could not be read from the Keychain. Allow access when macOS asks, or sign out and pair again."
+      state.lastError = "The device key is missing on this Mac. Sign out and pair again."
       state.lastErrorAt = Date(); online = false; return
     }
     guard let t = tenant, let p = pairing else { return }

--- a/packages/alfred-mac/Sources/AlfredBlack/Continuity.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Continuity.swift
@@ -49,7 +49,20 @@ enum Continuity {
   static func refresh(tenant: Tenant, domain: String) async throws -> Int {
     let entries = try await tenant.recent(limit: 50, withinHours: 48)
     try FileManager.default.createDirectory(at: Paths.alfredDir, withIntermediateDirectories: true)
-    try render(entries, domain: domain).write(to: Paths.continuity, atomically: true, encoding: .utf8)
+    let block = render(entries, domain: domain)
+    try block.write(to: Paths.continuity, atomically: true, encoding: .utf8)
+    // Cowork sessions run in a sandbox that mounts only the space's folders, so the
+    // plugin's hook also looks for the block inside the project folder itself.
+    // The block is the principal's private memory: never into a folder that syncs
+    // elsewhere, and never into a repository's history.
+    for folder in Cowork.spaceFolders() where !Cowork.isSynced(folder) {
+      let dir = folder.appendingPathComponent(".alfred", isDirectory: true)
+      try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+      let file = dir.appendingPathComponent("continuity.md")
+      try? block.write(to: file, atomically: true, encoding: .utf8)
+      try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: file.path)
+      Cowork.excludeFromGit(folder, entry: ".alfred/")
+    }
     if !FileManager.default.fileExists(atPath: Paths.folderInstructions.path) {
       try folderInstructions.write(to: Paths.folderInstructions, atomically: true, encoding: .utf8)
     }

--- a/packages/alfred-mac/Sources/AlfredBlack/Cowork.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Cowork.swift
@@ -107,6 +107,45 @@ enum Cowork {
     guard size > 0, size < 4 * 1024 * 1024 else { throw TenantError(message: "Plugin file is \(size) bytes; Claude accepts up to 4 MB.") }
     return out
   }
+  /// The folders Cowork mounts into its sessions, from Claude Desktop's own
+  /// per-space records. Only folders that exist on this Mac.
+  static func spaceFolders() -> [URL] {
+    let root = Paths.coworkSessions
+    guard let accounts = try? FileManager.default.contentsOfDirectory(at: root, includingPropertiesForKeys: nil) else { return [] }
+    var out: [URL] = []
+    for account in accounts {
+      guard let spaces = try? FileManager.default.contentsOfDirectory(at: account, includingPropertiesForKeys: nil) else { continue }
+      for space in spaces {
+        let f = space.appendingPathComponent("spaces.json")
+        guard let d = try? Data(contentsOf: f), let j = try? JSONSerialization.jsonObject(with: d) as? [String: Any],
+              let list = j["spaces"] as? [[String: Any]] else { continue }
+        for sp in list {
+          for folder in (sp["folders"] as? [[String: Any]]) ?? [] {
+            if let path = folder["path"] as? String, FileManager.default.fileExists(atPath: path) { out.append(URL(fileURLWithPath: path)) }
+          }
+        }
+      }
+    }
+    return Array(Set(out.map { $0.path })).sorted().map { URL(fileURLWithPath: $0) }
+  }
+  /// Folders that replicate elsewhere are no place for private memory.
+  static func isSynced(_ folder: URL) -> Bool {
+    let p = folder.path
+    return ["/Syncthing/", "/Dropbox/", "/Mobile Documents/", "/Google Drive/", "/OneDrive/", "/Library/CloudStorage/"].contains { p.contains($0) }
+  }
+  /// If the folder is a git repository, keep `entry` out of its history via the
+  /// local exclude file (never touching tracked files). Idempotent.
+  static func excludeFromGit(_ folder: URL, entry: String) {
+    let git = folder.appendingPathComponent(".git")
+    guard FileManager.default.fileExists(atPath: git.path) else { return }
+    let info = git.appendingPathComponent("info", isDirectory: true)
+    let exclude = info.appendingPathComponent("exclude")
+    let existing = (try? String(contentsOf: exclude, encoding: .utf8)) ?? ""
+    if existing.split(separator: "\n").map(String.init).contains(entry) { return }
+    try? FileManager.default.createDirectory(at: info, withIntermediateDirectories: true)
+    let sep = existing.isEmpty || existing.hasSuffix("\n") ? "" : "\n"
+    try? (existing + sep + entry + "\n").write(to: exclude, atomically: true, encoding: .utf8)
+  }
   static func revealExport() { NSWorkspace.shared.activateFileViewerSelecting([exportedPlugin]) }
   static func revealAlfredFolder() { NSWorkspace.shared.activateFileViewerSelecting([Paths.continuity]) }
 }

--- a/packages/alfred-mac/Sources/AlfredBlack/Keychain.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Keychain.swift
@@ -1,38 +1,53 @@
-// Credentials live in the login Keychain, never on disk in plaintext.
+// The device key. Where it lives follows what the code signature can support:
+//
+// The legacy login-Keychain ACL trusts a *code identity*. An ad-hoc signature
+// is a new identity on every build, so every update re-asks — and for the
+// stdio MCP server that Claude Desktop spawns in the background, that question
+// is never shown: the process simply blocks inside SecItemCopyMatching. Until
+// the app ships with a Developer ID (a stable identity), the key is kept in a
+// 0600 file inside the app's own support folder — the protection a personal
+// credential file gets on this Mac — and the Keychain is only ever consulted
+// with user interaction disabled, so nothing can hang.
 import Foundation
 import Security
 
 enum Keychain {
   static let service = "black.alfred.mac"
+  static var fileURL: URL { Paths.support.appendingPathComponent(".device-key") }
 
   static func set(_ value: String, account: String) -> Bool {
-    let data = Data(value.utf8)
-    let q: [String: Any] = [kSecClass as String: kSecClassGenericPassword,
-                            kSecAttrService as String: service,
-                            kSecAttrAccount as String: account]
-    SecItemDelete(q as CFDictionary)
-    var add = q
-    add[kSecValueData as String] = data
-    add[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
-    return SecItemAdd(add as CFDictionary, nil) == errSecSuccess
+    do {
+      try FileManager.default.createDirectory(at: Paths.support, withIntermediateDirectories: true)
+      try Data(value.utf8).write(to: fileURL, options: .atomic)
+      try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
+      return true
+    } catch { return false }
   }
 
   static func get(_ account: String) -> String? {
-    let q: [String: Any] = [kSecClass as String: kSecClassGenericPassword,
-                            kSecAttrService as String: service,
-                            kSecAttrAccount as String: account,
-                            kSecReturnData as String: true,
-                            kSecMatchLimit as String: kSecMatchLimitOne]
-    var out: AnyObject?
-    guard SecItemCopyMatching(q as CFDictionary, &out) == errSecSuccess,
-          let d = out as? Data else { return nil }
-    return String(data: d, encoding: .utf8)
+    if let d = try? Data(contentsOf: fileURL), let s = String(data: d, encoding: .utf8), !s.isEmpty { return s }
+    // A key stored by an earlier build in the Keychain: read it without ever
+    // prompting, and move it to the file so the next read is local.
+    guard let s = keychainRead(account) else { return nil }
+    _ = set(s, account: account)
+    return s
   }
 
   static func delete(_ account: String) {
+    try? FileManager.default.removeItem(at: fileURL)
+    SecKeychainSetUserInteractionAllowed(false)
     let q: [String: Any] = [kSecClass as String: kSecClassGenericPassword,
-                            kSecAttrService as String: service,
-                            kSecAttrAccount as String: account]
+                            kSecAttrService as String: service, kSecAttrAccount as String: account]
     SecItemDelete(q as CFDictionary)
+  }
+
+  private static func keychainRead(_ account: String) -> String? {
+    SecKeychainSetUserInteractionAllowed(false)   // fail fast instead of waiting on a dialog nobody sees
+    let q: [String: Any] = [kSecClass as String: kSecClassGenericPassword,
+                            kSecAttrService as String: service, kSecAttrAccount as String: account,
+                            kSecReturnData as String: true, kSecMatchLimit as String: kSecMatchLimitOne]
+    var out: AnyObject?
+    guard SecItemCopyMatching(q as CFDictionary, &out) == errSecSuccess, let d = out as? Data else { return nil }
+    return String(data: d, encoding: .utf8)
   }
 }

--- a/packages/alfred-mac/Sources/AlfredBlack/MCPServer.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/MCPServer.swift
@@ -67,10 +67,20 @@ enum MCPServer {
             case "alfred_continuity_recent":
               let e = try await tenant.recent(limit: (args["limit"] as? Int) ?? 20, withinHours: (args["within_hours"] as? Double) ?? 24)
               out = text(Continuity.render(e, domain: domain))
+              Activity.record(recent: true)
             case "alfred_continuity_note":
-              try await tenant.append(channel: (args["channel"] as? String) ?? "cowork", chatId: args["chat_id"] as? String ?? "",
+              let channel = (args["channel"] as? String) ?? "cowork"
+              let chatId = (args["chat_id"] as? String).flatMap { $0.isEmpty ? nil : $0 } ?? "cowork-unknown"
+              // Bind on first sight, so the sandboxed session never has to.
+              var st = Store.loadState()
+              if !st.boundSessions.contains(chatId) {
+                try await tenant.bind(channel: channel, chatId: chatId)
+                st.boundSessions.insert(chatId); Store.saveState(st)
+              }
+              try await tenant.append(channel: channel, chatId: chatId,
                                       direction: args["direction"] as? String ?? "inbound", message: args["message"] as? String ?? "",
                                       sourceRef: UUID().uuidString, metadata: ["via": "alfred-black-mac-mcp"])
+              Activity.record(note: true)
               out = text("journaled")
             case "alfred_continuity_bind":
               try await tenant.bind(channel: (args["channel"] as? String) ?? "cowork", chatId: args["chat_id"] as? String ?? "")
@@ -86,5 +96,24 @@ enum MCPServer {
       }
     }
     exit(0)
+  }
+}
+
+
+/// What the sandboxed sessions did through the tools — kept in a file of its
+/// own because the MCP server is a separate process from the menu-bar app.
+struct ActivityLog: Codable { var notes = 0; var recents = 0; var lastNoteAt: Date?; var lastRecentAt: Date? }
+enum Activity {
+  static var file: URL { Paths.support.appendingPathComponent("mcp-activity.json") }
+  static func load() -> ActivityLog {
+    guard let d = try? Data(contentsOf: file), let a = try? JSONDecoder().decode(ActivityLog.self, from: d) else { return ActivityLog() }
+    return a
+  }
+  static func record(note: Bool = false, recent: Bool = false) {
+    var a = load()
+    if note { a.notes += 1; a.lastNoteAt = Date() }
+    if recent { a.recents += 1; a.lastRecentAt = Date() }
+    try? FileManager.default.createDirectory(at: file.deletingLastPathComponent(), withIntermediateDirectories: true)
+    if let d = try? JSONEncoder().encode(a) { try? d.write(to: file, options: .atomic) }
   }
 }

--- a/packages/alfred-mac/Sources/AlfredBlack/Views.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Views.swift
@@ -84,6 +84,7 @@ struct StatusView: View {
       VStack(spacing: 0) {
         Row(k: "Tenant", v: s.online == true ? "connected" : (s.online == false ? "unreachable" : "checking"), ok: s.online)
         Row(k: "Memory file", v: s.state.lastRenderAt.map { "\(s.state.lastRenderEntries) entries · \(AppDelegate.ago($0))" } ?? "not yet", ok: s.state.lastRenderAt != nil)
+        Row(k: "Cowork journaled", v: s.activity.lastNoteAt.map { "\(s.activity.notes) notes via Claude · \(AppDelegate.ago($0))" } ?? "none yet — sessions journal through the tools", ok: s.activity.lastNoteAt != nil)
         Row(k: "Cowork mirrored", v: "\(s.state.totalPushed) turns · " + (s.state.lastPushAt.map { AppDelegate.ago($0) } ?? "not yet"), ok: s.state.lastPushAt != nil)
         Row(k: "Starts at login", v: s.loginItem ? "yes" : (SMAppService.mainApp.status == .requiresApproval ? "approve in System Settings › Login Items" : "no"), ok: s.loginItem)
       }.padding(.top, 6)


### PR DESCRIPTION
## What

Companion to the sandboxed-sessions plugin PR.

- **Device key → 0600 file.** An ad-hoc signature is a new code identity on every build; the login-Keychain ACL re-asks, and for the background MCP server that Claude Desktop spawns the question is never shown — the process blocked inside `SecItemCopyMatching` (sampled). The key now lives in `~/Library/Application Support/Alfred Black/.device-key` (0600); the Keychain is read only with user interaction disabled, to migrate an existing key, so nothing can hang. A Developer ID signature is what makes a Keychain-backed store viable; README says so.
- **MCP server** binds a session on its first `alfred_continuity_note` and records activity in `mcp-activity.json`; the status view shows *Cowork journaled: N notes via Claude*.
- **Memory block into space folders**: rendered into each folder Cowork mounts (from Claude Desktop's `spaces.json`) as `.alfred/continuity.md`, 0600, synced folders skipped, `.alfred/` added to a repo's local git exclude — so the hook can inject it verbatim inside the sandbox.

## Smoke evidence

```
pair: ok domain=<tenant> online=true loginItem=true rendered=12 pushed=0 mcp=true plugin=true
key file perms: -rw-------
id 1 → ['instructions', 'capabilities', 'protocolVersion', 'serverInfo']
id 2 → journaled | isError: False
id 3 → [ALFRED-CONTINUITY — authoritative] The following are messages YOU (Alfred) sent … | isError: False
activity: {"recents":1,"notes":1,…}
```
- Tenant (hostname redacted): the self-test note present, `channel=cowork`, metadata `via: alfred-black-mac-mcp`, chat bound to the owner.
- `--tick` after the change: blocks rendered into three space folders, `-rw-------`.
- `--snapshot` left margin measured at 35 px with the new row.
- Local lane VIII gate: verify ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)