### PR TITLE
fix(ctrl): a cowork chat is the owner's on first write; binding attributes earlier rows

### DIFF
--- a/packages/ctrl/src/db/alfredJournal.ts
+++ b/packages/ctrl/src/db/alfredJournal.ts
@@ -129,16 +129,39 @@ export function bindPrincipalChannel(
        (channel, chat_id, principal_id, added_at)
      VALUES (?, ?, ?, ?)`,
   ).run(channel, chatId, principalId, nowIso());
+  // A binding is a statement about the conversation, not about the moment it
+  // was made: rows written before it were this principal's too. The owner
+  // window filters on the stamped column, so attribute them now.
+  db.prepare(
+    `UPDATE alfred_journal SET principal_id = ?, updated_at = ?
+      WHERE channel = ? AND chat_id = ? AND principal_id IS NULL`,
+  ).run(principalId, nowIso(), channel, chatId);
+}
+
+/**
+ * Channels whose conversations are the owner's by construction: a Cowork
+ * session journals through this tenant's own authenticated tools, so an
+ * unknown chat there is a new session of the principal, not a stranger. Other
+ * channels (Telegram, Slack) can carry strangers and stay unbound until a
+ * deliberate bind.
+ */
+const AUTO_BIND_TO_OWNER = new Set(["cowork"]);
+
+function ownerPrincipalId(db: DatabaseSync): string | null {
+  const row = db
+    .prepare("SELECT id FROM alfred_principal WHERE is_owner = 1 LIMIT 1")
+    .get() as { id?: string } | undefined;
+  return row?.id ?? null;
 }
 
 /**
  * Append one entry. The shape is wide because every caller wants different
  * subsets — by-keyword args + a clear default for status.
  *
- * Auto-resolves principal_id from the (channel, chat_id) binding if the
- * caller didn't pass one explicitly — so every outbound on home auto-binds
- * chat_id=100000000 → 'owner' on first write, and later inbound lookups
- * find it.
+ * Resolves principal_id from the (channel, chat_id) binding if the caller
+ * didn't pass one explicitly. For channels in AUTO_BIND_TO_OWNER an unknown
+ * chat is bound to the owner on first write; every other channel stays
+ * unattributed until a deliberate bind (which then backfills).
  */
 export function appendJournal(
   db: DatabaseSync,
@@ -164,8 +187,15 @@ export function appendJournal(
 ): JournalEntry {
   const id = ulid();
   const ts = nowIso();
-  const principalId =
+  let principalId =
     fields.principal_id ?? resolvePrincipal(db, fields.channel, fields.chat_id);
+  if (!principalId && AUTO_BIND_TO_OWNER.has(fields.channel)) {
+    const owner = ownerPrincipalId(db);
+    if (owner) {
+      bindPrincipalChannel(db, fields.channel, fields.chat_id, owner);
+      principalId = owner;
+    }
+  }
   const metadataJson = fields.metadata ? JSON.stringify(fields.metadata) : null;
   // Normalise: only accept 0 or 1; anything else collapses to null so a
   // stale caller passing a truthy string cannot silently inflate the term.

--- a/packages/ctrl/tests/alfred-journal.test.ts
+++ b/packages/ctrl/tests/alfred-journal.test.ts
@@ -149,6 +149,37 @@ describe("appendJournal + resolvePrincipal", () => {
     db.close();
   });
 
+  it("appendJournal auto-binds an unknown cowork chat to the owner on first write", () => {
+    const db = makeDb();
+    const e = appendJournal(db, {
+      channel: "cowork", chat_id: "session_new", direction: "inbound", message: "hey alfred",
+    });
+    assert.equal(e.principal_id, "owner");
+    assert.equal(resolvePrincipal(db, "cowork", "session_new"), "owner");
+    const seen = queryRecentJournal(db, { principal_id: "owner" }, { limit: 10, within_hours: 1 });
+    assert.ok(seen.some((r) => r.id === e.id), "the owner window sees the row");
+  });
+
+  it("appendJournal leaves other channels unbound (no guessing who a stranger is)", () => {
+    const db = makeDb();
+    const e = appendJournal(db, {
+      channel: "telegram", chat_id: "999", direction: "inbound", message: "hello?",
+    });
+    assert.equal(e.principal_id, null);
+    assert.equal(resolvePrincipal(db, "telegram", "999"), null);
+  });
+
+  it("bindPrincipalChannel attributes rows written before the binding", () => {
+    const db = makeDb();
+    const before = appendJournal(db, {
+      channel: "telegram", chat_id: "424242", direction: "inbound", message: "earlier",
+    });
+    assert.equal(before.principal_id, null);
+    bindPrincipalChannel(db, "telegram", "424242", "owner");
+    const seen = queryRecentJournal(db, { principal_id: "owner" }, { limit: 10, within_hours: 1 });
+    assert.ok(seen.some((r) => r.id === before.id), "binding backfills the earlier row");
+  });
+
   it("appendJournal respects explicit principal_id over the binding", () => {
     const db = makeDb();
     bindPrincipalChannel(db, "telegram", "100000000", "owner");


### PR DESCRIPTION
## What

The owner's continuity window (`queryRecentJournal` by `principal_id`) filters on the row's **stamped** `principal_id`. A row written before its `(channel, chat_id)` was bound therefore stays invisible even after the binding. The first real Cowork session today journaled five turns through the tenant's own continuity tools (#721) and Hermes could see none of them.

- `appendJournal` binds an unknown **`cowork`** chat to the owner principal on first write — a Cowork session journals through this tenant's authenticated tools, so an unknown chat there is a new session of the principal, not a stranger. Telegram/Slack stay unbound until a deliberate bind.
- `bindPrincipalChannel` also attributes the pair's earlier NULL-principal rows, so re-posting a bind repairs history.
- The doc comment above `appendJournal` claimed an auto-bind that never existed; corrected.

Lane I. Test-first: three new tests in `tests/alfred-journal.test.ts` (red before, green after).

## Smoke evidence

- `tests/alfred-journal.test.ts` + `tests/journal-solicited.test.ts`: all pass locally (TAP summary in the PR checks).
- Full local `npm test`: 1535/1567 pass; the 10 failures are the HA WebSocket, phone-outbound and agent-profile suites, environment-dependent and untouched here — `test-ctrl` in CI is the arbiter.
- `npm run build` ok; local lane I gate passed.
- Tenant (hostname redacted): the five Cowork rows were attributed by hand via the bind route in the meantime; after deploy the same session's future turns stamp `owner` on write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)