### PR TITLE
fix(alfred-mac): 'Cowork journaled' counts the tenant's window, not this app's tool calls

### DIFF
--- a/packages/alfred-mac/Sources/AlfredBlack/Continuity.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Continuity.swift
@@ -46,9 +46,15 @@ enum Continuity {
   """
 
   /// Fetch + write. Returns the number of entries rendered.
+  private static let isoFrac: ISO8601DateFormatter = { let f = ISO8601DateFormatter(); f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]; return f }()
+  private static let isoPlain = ISO8601DateFormatter()
+  static func parseTs(_ s: String) -> Date? { isoFrac.date(from: s) ?? isoPlain.date(from: s) }
+
   static func refresh(tenant: Tenant, domain: String) async throws -> Int {
     let entries = try await tenant.recent(limit: 50, withinHours: 48)
     try FileManager.default.createDirectory(at: Paths.alfredDir, withIntermediateDirectories: true)
+    let cw = entries.filter { $0.channel == "cowork" }
+    Activity.recordJournal(coworkCount: cw.count, last: cw.compactMap { Continuity.parseTs($0.ts) }.max())
     let block = render(entries, domain: domain)
     try block.write(to: Paths.continuity, atomically: true, encoding: .utf8)
     // Cowork sessions run in a sandbox that mounts only the space's folders, so the

--- a/packages/alfred-mac/Sources/AlfredBlack/MCPServer.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/MCPServer.swift
@@ -102,12 +102,33 @@ enum MCPServer {
 
 /// What the sandboxed sessions did through the tools — kept in a file of its
 /// own because the MCP server is a separate process from the menu-bar app.
-struct ActivityLog: Codable { var notes = 0; var recents = 0; var lastNoteAt: Date?; var lastRecentAt: Date? }
+struct ActivityLog: Codable {
+  var notes = 0; var recents = 0; var lastNoteAt: Date?; var lastRecentAt: Date?
+  var journalCowork = 0; var journalCoworkLast: Date?
+  init() {}
+  // Fields are added over time; an older file must still decode, not reset the counters.
+  init(from d: Decoder) throws {
+    let c = try d.container(keyedBy: CodingKeys.self)
+    notes = try c.decodeIfPresent(Int.self, forKey: .notes) ?? 0
+    recents = try c.decodeIfPresent(Int.self, forKey: .recents) ?? 0
+    lastNoteAt = try c.decodeIfPresent(Date.self, forKey: .lastNoteAt)
+    lastRecentAt = try c.decodeIfPresent(Date.self, forKey: .lastRecentAt)
+    journalCowork = try c.decodeIfPresent(Int.self, forKey: .journalCowork) ?? 0
+    journalCoworkLast = try c.decodeIfPresent(Date.self, forKey: .journalCoworkLast)
+  }
+}
 enum Activity {
   static var file: URL { Paths.support.appendingPathComponent("mcp-activity.json") }
   static func load() -> ActivityLog {
     guard let d = try? Data(contentsOf: file), let a = try? JSONDecoder().decode(ActivityLog.self, from: d) else { return ActivityLog() }
     return a
+  }
+  /// What the tenant's window says about Cowork — the truth regardless of which
+  /// tool path a session used (this app's server or the tenant's own).
+  static func recordJournal(coworkCount: Int, last: Date?) {
+    var a = load(); a.journalCowork = coworkCount; a.journalCoworkLast = last
+    try? FileManager.default.createDirectory(at: file.deletingLastPathComponent(), withIntermediateDirectories: true)
+    if let d = try? JSONEncoder().encode(a) { try? d.write(to: file, options: .atomic) }
   }
   static func record(note: Bool = false, recent: Bool = false) {
     var a = load()

--- a/packages/alfred-mac/Sources/AlfredBlack/Views.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Views.swift
@@ -84,7 +84,7 @@ struct StatusView: View {
       VStack(spacing: 0) {
         Row(k: "Tenant", v: s.online == true ? "connected" : (s.online == false ? "unreachable" : "checking"), ok: s.online)
         Row(k: "Memory file", v: s.state.lastRenderAt.map { "\(s.state.lastRenderEntries) entries · \(AppDelegate.ago($0))" } ?? "not yet", ok: s.state.lastRenderAt != nil)
-        Row(k: "Cowork journaled", v: s.activity.lastNoteAt.map { "\(s.activity.notes) notes via Claude · \(AppDelegate.ago($0))" } ?? "none yet — sessions journal through the tools", ok: s.activity.lastNoteAt != nil)
+        Row(k: "Cowork journaled", v: s.activity.journalCoworkLast.map { "\(s.activity.journalCowork) turns in the window · \(AppDelegate.ago($0))" } ?? "none in the window yet", ok: s.activity.journalCoworkLast != nil)
         Row(k: "Cowork mirrored", v: "\(s.state.totalPushed) turns · " + (s.state.lastPushAt.map { AppDelegate.ago($0) } ?? "not yet"), ok: s.state.lastPushAt != nil)
         Row(k: "Starts at login", v: s.loginItem ? "yes" : (SMAppService.mainApp.status == .requiresApproval ? "approve in System Settings › Login Items" : "no"), ok: s.loginItem)
       }.padding(.top, 6)


### PR DESCRIPTION
## What

A Cowork session may journal through the tenant's own continuity tools (#721) rather than this app's MCP server — the first real session did — so counting local tool calls said "1 note" while the tenant held five turns. The status row now reports the `cowork` rows in the rendered window (count and latest), whichever path wrote them. The activity file decodes older versions of itself instead of resetting the counters.

## Smoke evidence

```
tick: online=true rendered=32 pushed=0 …
activity: {"journalCowork":6,…,"journalCoworkLast":…}
```
Local lane VIII gate: verify ok. Reinstalled without touching the running `--mcp` processes (GUI killed by exact command line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)