### PR TITLE
feat(ctrl): a private chat reads its principal's cross-surface memory; rooms stay on their own

### DIFF
--- a/packages/ctrl/src/api/routes/alfredJournal.ts
+++ b/packages/ctrl/src/api/routes/alfredJournal.ts
@@ -26,6 +26,7 @@ import { getStateDb } from "../../db/state.js";
 import {
   appendJournal,
   bindPrincipalChannel,
+  queryRecentForChat,
   queryRecentJournal,
   type Direction,
   type Status,
@@ -153,17 +154,34 @@ export function registerAlfredJournalRoutes(): void {
     }
 
     const db = getStateDb();
-    const entries = principalId
-      ? queryRecentJournal(db, { principal_id: principalId }, {
-          limit,
-          within_hours: withinHours,
-          hermes_profile: hermesProfile,
-        })
-      : queryRecentJournal(
-          db,
-          { channel: channel as string, chat_id: chatId as string },
-          { limit, within_hours: withinHours, hermes_profile: hermesProfile },
-        );
+    // `scope=chat` pins a (channel, chat_id) request to that chat's own
+    // history; otherwise a bound private chat reads its principal's
+    // cross-surface window (rooms never do — see isPrivateChat).
+    const pinToChat = query.get("scope") === "chat";
+    let scope: "principal" | "chat" = "principal";
+    let entries;
+    if (principalId) {
+      entries = queryRecentJournal(db, { principal_id: principalId }, {
+        limit,
+        within_hours: withinHours,
+        hermes_profile: hermesProfile,
+      });
+    } else if (pinToChat) {
+      scope = "chat";
+      entries = queryRecentJournal(
+        db,
+        { channel: channel as string, chat_id: chatId as string },
+        { limit, within_hours: withinHours, hermes_profile: hermesProfile },
+      );
+    } else {
+      const r = queryRecentForChat(db, channel as string, chatId as string, {
+        limit,
+        within_hours: withinHours,
+        hermes_profile: hermesProfile,
+      });
+      scope = r.scope;
+      entries = r.entries;
+    }
 
     sendJson(res, 200, {
       entries,
@@ -171,6 +189,7 @@ export function registerAlfredJournalRoutes(): void {
       window: {
         limit,
         within_hours: withinHours,
+        scope,
         ...(profileParam !== null ? { profile: profileParam } : {}),
       },
     });

--- a/packages/ctrl/src/db/alfredJournal.ts
+++ b/packages/ctrl/src/db/alfredJournal.ts
@@ -235,6 +235,49 @@ export function appendJournal(
 }
 
 /**
+ * Is this chat the principal alone with Alfred, or a room with other people in
+ * it? The principal's cross-surface memory may be read into the former; never
+ * into the latter, where the model could repeat it to a client. Platform id
+ * shapes are the honest signal we have today: Slack DMs start with "D"
+ * (channels "C"/"G", names "#…"), Telegram private chats have positive ids
+ * (groups negative). Cowork, omi and voice are personal by construction.
+ * Unknown platforms are treated as rooms.
+ */
+export function isPrivateChat(channel: string, chatId: string): boolean {
+  switch (channel) {
+    case "cowork":
+    case "omi":
+    case "voice":
+      return true;
+    case "slack":
+      return /^D[A-Z0-9]+$/.test(chatId);
+    case "telegram":
+      return /^\d+$/.test(chatId);
+    default:
+      return false;
+  }
+}
+
+/**
+ * The window for a (channel, chat_id) as a surface asks for it: a private chat
+ * bound to a principal reads that principal's cross-surface window — so a
+ * Slack DM knows what was said in Cowork an hour ago — while a room, or an
+ * unbound chat, stays on its own history.
+ */
+export function queryRecentForChat(
+  db: DatabaseSync,
+  channel: string,
+  chatId: string,
+  opts: { limit?: number; within_hours?: number; hermes_profile?: string | null } = {},
+): { scope: "principal" | "chat"; entries: JournalEntry[] } {
+  const principal = isPrivateChat(channel, chatId) ? resolvePrincipal(db, channel, chatId) : null;
+  if (principal) {
+    return { scope: "principal", entries: queryRecentJournal(db, { principal_id: principal }, opts) };
+  }
+  return { scope: "chat", entries: queryRecentJournal(db, { channel, chat_id: chatId }, opts) };
+}
+
+/**
  * Window policy for the pre_gateway_dispatch hook: most-recent first, capped
  * by both N and a recency hours threshold. Both bounds matter — without N a
  * chatty user can blow main's context window; without `within_hours` an

--- a/packages/ctrl/tests/alfred-journal.test.ts
+++ b/packages/ctrl/tests/alfred-journal.test.ts
@@ -27,6 +27,8 @@ import { fileURLToPath } from "node:url";
 import {
   appendJournal,
   bindPrincipalChannel,
+  isPrivateChat,
+  queryRecentForChat,
   queryRecentJournal,
   resolvePrincipal,
 } from "../src/db/alfredJournal.js";
@@ -178,6 +180,46 @@ describe("appendJournal + resolvePrincipal", () => {
     bindPrincipalChannel(db, "telegram", "424242", "owner");
     const seen = queryRecentJournal(db, { principal_id: "owner" }, { limit: 10, within_hours: 1 });
     assert.ok(seen.some((r) => r.id === before.id), "binding backfills the earlier row");
+  });
+
+  it("isPrivateChat: DMs and personal surfaces are private, channels and groups are not", () => {
+    assert.equal(isPrivateChat("slack", "D0ABCDEF123"), true);
+    assert.equal(isPrivateChat("slack", "C0ABCDEF123"), false);
+    assert.equal(isPrivateChat("slack", "#general"), false);
+    assert.equal(isPrivateChat("telegram", "432094090"), true);
+    assert.equal(isPrivateChat("telegram", "-100987654321"), false);
+    for (const ch of ["cowork", "omi", "voice"]) assert.equal(isPrivateChat(ch, "anything"), true);
+    assert.equal(isPrivateChat("unknown-platform", "x"), false);
+  });
+
+  it("queryRecentForChat: a bound private chat reads the principal's cross-surface window", () => {
+    const db = makeDb();
+    bindPrincipalChannel(db, "slack", "D0DM", "owner");
+    appendJournal(db, { channel: "slack", chat_id: "D0DM", direction: "inbound", message: "ping" });
+    const cw = appendJournal(db, { channel: "cowork", chat_id: "session_x", direction: "inbound", message: "hey alfred" });
+    const seen = queryRecentForChat(db, "slack", "D0DM", { limit: 20, within_hours: 1 });
+    assert.equal(seen.scope, "principal");
+    assert.ok(seen.entries.some((r) => r.id === cw.id), "the DM sees the Cowork turn");
+  });
+
+  it("queryRecentForChat: a bound group channel stays on its own history", () => {
+    const db = makeDb();
+    bindPrincipalChannel(db, "slack", "C0CLIENT", "owner");
+    appendJournal(db, { channel: "slack", chat_id: "C0CLIENT", direction: "inbound", message: "hello team" });
+    const cw = appendJournal(db, { channel: "cowork", chat_id: "session_y", direction: "inbound", message: "private" });
+    const seen = queryRecentForChat(db, "slack", "C0CLIENT", { limit: 20, within_hours: 1 });
+    assert.equal(seen.scope, "chat");
+    assert.ok(!seen.entries.some((r) => r.id === cw.id), "no private memory in a group");
+    assert.equal(seen.entries.length, 1);
+  });
+
+  it("queryRecentForChat: an unbound private chat stays on its own history", () => {
+    const db = makeDb();
+    appendJournal(db, { channel: "slack", chat_id: "D0STRANGER", direction: "inbound", message: "hi" });
+    appendJournal(db, { channel: "cowork", chat_id: "session_z", direction: "inbound", message: "private" });
+    const seen = queryRecentForChat(db, "slack", "D0STRANGER", { limit: 20, within_hours: 1 });
+    assert.equal(seen.scope, "chat");
+    assert.equal(seen.entries.length, 1);
   });
 
   it("appendJournal respects explicit principal_id over the binding", () => {


### PR DESCRIPTION
## What

The Hermes one-alfred plugin asks `GET /api/v1/alfred-journal/recent` with the `(channel, chat_id)` of the turn, and that scope selected strictly `WHERE channel = ? AND chat_id = ?`. So a Slack DM's memory block held only Slack rows: the conversation the principal had in Cowork an hour earlier did not exist for it (verified on a tenant: 19 rows, all `slack`). One Alfred, but only per chat.

- `isPrivateChat(channel, chat_id)`: Slack DMs (`D…`), Telegram private chats (positive ids), and `cowork` / `omi` / `voice` are private; Slack channels/groups, Telegram groups and unknown platforms are rooms.
- `queryRecentForChat`: a **bound private** chat reads its principal's cross-surface window; a room or an unbound chat stays on its own history — the principal's private memory is never read into a context with other people in it (client channels are bound to the owner on live tenants).
- Route: `(channel, chat_id)` requests go through it; `scope=chat` pins to the pair; the response `window.scope` reports which applied. `principal_id` requests unchanged.

Lane I, test-first (4 new tests, red → green). No Hermes change needed: the plugin's existing query starts returning cross-surface memory for DMs on deploy.

## Smoke evidence

- `tests/alfred-journal.test.ts` green (DM sees the Cowork turn; group channel does not; unbound DM does not).
- Full local `npm test`: same 10 environment-dependent failures as before (HA WebSocket, phone, agent profiles), untouched; CI `test-ctrl` is the arbiter.
- `npm run build` ok, `tsc --noEmit` ok; local lane I gate passed.
- After deploy on the tenant: the plugin's exact DM query is expected to return `cowork` rows — will be verified and noted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)