### PR TITLE
feat(ctrl): POST /api/v1/alfred/ask — a surface asks Alfred, both turns journaled, memory in front of the model

### DIFF
--- a/packages/ctrl/src/api/askAlfred.ts
+++ b/packages/ctrl/src/api/askAlfred.ts
@@ -1,0 +1,100 @@
+// A surface asks Alfred. ctrl-api owns continuity (migration 0002), so the
+// exchange is journaled here — inbound before the call, outbound after — and
+// the principal's recent cross-surface memory is put in front of the model
+// the way the Hermes plugin does for gateway turns. /v1/responses calls do
+// not pass through that hook, so without this a Mac menu bar would talk to
+// an Alfred with amnesia.
+import fs from "node:fs";
+import type { DatabaseSync } from "node:sqlite";
+import { appendJournal, queryRecentJournal, type JournalEntry } from "../db/alfredJournal.js";
+
+const HERMES_HOME = process.env.HERMES_HOME ?? "/hermes-state";
+const HERMES_CONFIG_DIR = process.env.HERMES_CONFIG_DIR ?? `${HERMES_HOME}/profiles`;
+const HERMES_MAIN_URL = process.env.HERMES_GATEWAY_URL ?? "http://hermes:18789";
+const HERMES_TIMEOUT_MS = 120_000;
+const MEMORY_LIMIT = 20;
+const MEMORY_HOURS = 24;
+
+export type HermesCall = (input: string, sessionKey: string) => Promise<unknown>;
+
+/** Walk a /v1/responses body and concatenate the assistant text. */
+export function extractHermesText(resp: unknown): string {
+  if (typeof resp !== "object" || resp === null) return "";
+  const r = resp as Record<string, unknown>;
+  if (typeof r.output_text === "string") return r.output_text;
+  const out = r.output;
+  if (typeof out === "string") return out;
+  const items = Array.isArray(out) ? out : out && typeof out === "object" ? [out] : [];
+  const acc: string[] = [];
+  for (const item of items) {
+    const parts = (item as Record<string, unknown>)?.content;
+    if (typeof parts === "string") { acc.push(parts); continue; }
+    if (!Array.isArray(parts)) continue;
+    for (const p of parts) {
+      if (typeof p === "string") acc.push(p);
+      else if (p && typeof p === "object" && typeof (p as any).text === "string") acc.push((p as any).text);
+    }
+  }
+  return acc.filter((s) => s.length > 0).join("\n");
+}
+
+/** The same block the Hermes plugin injects on gateway turns (newest-in → oldest-first). */
+export function formatContinuityBlock(entries: JournalEntry[]): string {
+  if (entries.length === 0) return "";
+  const lines = [...entries].reverse().map((e) => {
+    const who = e.direction === "outbound" ? "YOU → principal" : "principal → YOU";
+    const msg = e.message.replace(/\s+/g, " ").trim();
+    return `  [${e.ts.slice(0, 19)}] ${who} on ${e.channel}: ${msg.length > 400 ? msg.slice(0, 397) + "…" : msg}`;
+  });
+  return [
+    "[ALFRED-CONTINUITY — authoritative]",
+    "The following are messages YOU (Alfred) sent to the principal, and messages the principal sent you, across surfaces — including ones delivered outside this session. These DID happen. Treat them as your own memory.",
+    ...lines,
+    "[/ALFRED-CONTINUITY]",
+  ].join("\n");
+}
+
+function readMainApiKey(): string | null {
+  try {
+    const env = fs.readFileSync(`${HERMES_CONFIG_DIR}/main/.env`, "utf8");
+    const m = env.match(/^API_SERVER_KEY=(.+)$/m);
+    return m ? m[1].trim().replace(/^["']|["']$/g, "") : null;
+  } catch { return null; }
+}
+
+const defaultCall: HermesCall = async (input, sessionKey) => {
+  const key = readMainApiKey();
+  const headers: Record<string, string> = { "Content-Type": "application/json", "X-Hermes-Session-Key": sessionKey };
+  if (key) headers.Authorization = `Bearer ${key}`;
+  const resp = await fetch(`${HERMES_MAIN_URL}/v1/responses`, {
+    method: "POST", headers, body: JSON.stringify({ input }), signal: AbortSignal.timeout(HERMES_TIMEOUT_MS),
+  });
+  if (!resp.ok) throw new Error(`Hermes returned HTTP ${resp.status}`);
+  return resp.json();
+};
+
+export async function askAlfred(
+  db: DatabaseSync,
+  args: { message: string; channel: string; chat_id: string; memory?: boolean },
+  deps: { callHermes?: HermesCall } = {},
+): Promise<{ reply: string; inbound_id: string; outbound_id: string }> {
+  const inbound = appendJournal(db, {
+    channel: args.channel, chat_id: args.chat_id, direction: "inbound", message: args.message,
+    source_kind: args.channel, status: "received",
+  });
+  let input = args.message;
+  if (args.memory !== false && inbound.principal_id) {
+    const recent = queryRecentJournal(db, { principal_id: inbound.principal_id }, { limit: MEMORY_LIMIT, within_hours: MEMORY_HOURS })
+      .filter((e) => e.id !== inbound.id);
+    const block = formatContinuityBlock(recent);
+    if (block) input = `${block}\n\n${args.message}`;
+  }
+  const raw = await (deps.callHermes ?? defaultCall)(input, `${args.channel}:${args.chat_id}`);
+  const reply = extractHermesText(raw).trim();
+  if (!reply) throw new Error("Alfred gave no reply (empty /v1/responses output)");
+  const outbound = appendJournal(db, {
+    channel: args.channel, chat_id: args.chat_id, direction: "outbound", message: reply,
+    source_kind: "reply", status: "delivered", solicited: 1, metadata: { via: "alfred-ask" },
+  });
+  return { reply, inbound_id: inbound.id, outbound_id: outbound.id };
+}

--- a/packages/ctrl/src/api/routes/alfredJournal.ts
+++ b/packages/ctrl/src/api/routes/alfredJournal.ts
@@ -32,6 +32,7 @@ import {
   type Status,
 } from "../../db/alfredJournal.js";
 import { reconcileCronOutbounds } from "../../db/hermesCronJournal.js";
+import { askAlfred } from "../askAlfred.js";
 
 const VALID_DIRECTIONS: ReadonlySet<Direction> = new Set([
   "outbound",
@@ -205,6 +206,21 @@ export function registerAlfredJournalRoutes(): void {
     const db = getStateDb();
     const r = reconcileCronOutbounds(db, undefined, profile);
     sendJson(res, 200, { ok: true, ...r });
+  });
+
+  // POST /api/v1/alfred/ask — a surface asks Alfred; both turns journaled,
+  // memory in front of the model, reply returned. {message, chat_id, channel?="mac"}
+  addRoute("POST", "/api/v1/alfred/ask", async ({ res, body }) => {
+    const b = (body ?? {}) as Record<string, unknown>;
+    const message = asString(b.message, "message");
+    const chatId = asString(b.chat_id, "chat_id");
+    const channel = typeof b.channel === "string" && b.channel ? b.channel : "mac";
+    if (!/^[a-z][a-z0-9_-]{1,31}$/.test(channel)) throw new ValidationError("channel must be a short lowercase slug");
+    try {
+      sendJson(res, 200, await askAlfred(getStateDb(), { message, channel, chat_id: chatId, memory: b.memory !== false }));
+    } catch (err) {
+      sendJson(res, 502, { error: "ALFRED_UNAVAILABLE", detail: err instanceof Error ? err.message : String(err) });
+    }
   });
 
   // POST /api/v1/alfred-journal/principal/bind — idempotent (channel, chat_id) → principal_id.

--- a/packages/ctrl/src/db/alfredJournal.ts
+++ b/packages/ctrl/src/db/alfredJournal.ts
@@ -145,7 +145,7 @@ export function bindPrincipalChannel(
  * channels (Telegram, Slack) can carry strangers and stay unbound until a
  * deliberate bind.
  */
-const AUTO_BIND_TO_OWNER = new Set(["cowork"]);
+const AUTO_BIND_TO_OWNER = new Set(["cowork", "mac"]);
 
 function ownerPrincipalId(db: DatabaseSync): string | null {
   const row = db
@@ -246,6 +246,7 @@ export function appendJournal(
 export function isPrivateChat(channel: string, chatId: string): boolean {
   switch (channel) {
     case "cowork":
+    case "mac":
     case "omi":
     case "voice":
       return true;

--- a/packages/ctrl/tests/ask-alfred.test.ts
+++ b/packages/ctrl/tests/ask-alfred.test.ts
@@ -1,0 +1,62 @@
+// A surface asks Alfred through ctrl-api: both turns are journaled, the
+// principal's cross-surface memory is put in front of the model, and the
+// reply comes back — one Alfred, from a Mac menu bar as from Slack.
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import schema from "../src/db/schema.sql";
+import { runMigrations } from "../src/db/migrate.js";
+import { appendJournal, bindPrincipalChannel, resolvePrincipal } from "../src/db/alfredJournal.js";
+import { askAlfred, extractHermesText, formatContinuityBlock } from "../src/api/askAlfred.js";
+
+function makeDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:"); db.exec(schema); runMigrations(db); return db;
+}
+
+describe("askAlfred", () => {
+  it("journals both turns on a private surface bound to the owner and hands memory to the model", async () => {
+    const db = makeDb();
+    bindPrincipalChannel(db, "slack", "D0DM", "owner");
+    appendJournal(db, { channel: "slack", chat_id: "D0DM", direction: "outbound", message: "The office is cooling to 21°C." });
+    const seen: { input: string; sessionKey: string }[] = [];
+    const r = await askAlfred(db, { message: "what did you set the AC to?", channel: "mac", chat_id: "device-1" }, {
+      callHermes: async (input, sessionKey) => { seen.push({ input, sessionKey }); return { output: [{ type: "message", role: "assistant", content: [{ type: "output_text", text: "21°C, Sir." }] }] }; },
+    });
+    assert.equal(r.reply, "21°C, Sir.");
+    assert.equal(seen[0].sessionKey, "mac:device-1");
+    assert.ok(seen[0].input.includes("[ALFRED-CONTINUITY"), "memory block precedes the question");
+    assert.ok(seen[0].input.includes("cooling to 21°C"), "the Slack turn is in the block");
+    assert.ok(seen[0].input.trimEnd().endsWith("what did you set the AC to?"));
+    assert.equal(resolvePrincipal(db, "mac", "device-1"), "owner");
+    const rows = db.prepare("SELECT direction, message, principal_id FROM alfred_journal WHERE channel='mac' ORDER BY ts").all() as any[];
+    assert.deepEqual(rows.map((x) => [x.direction, x.principal_id]), [["inbound", "owner"], ["outbound", "owner"]]);
+    assert.equal(rows[1].message, "21°C, Sir.");
+  });
+
+  it("keeps the question journaled and reports the failure when Hermes gives nothing back", async () => {
+    const db = makeDb();
+    await assert.rejects(
+      askAlfred(db, { message: "hello?", channel: "mac", chat_id: "device-2" }, { callHermes: async () => ({ output: [] }) }),
+      /no reply/,
+    );
+    const rows = db.prepare("SELECT direction FROM alfred_journal WHERE channel='mac'").all() as any[];
+    assert.deepEqual(rows.map((x) => x.direction), ["inbound"]);
+  });
+
+  it("extractHermesText tolerates the shapes Hermes has used", () => {
+    assert.equal(extractHermesText({ output_text: "plain" }), "plain");
+    assert.equal(extractHermesText({ output: "str" }), "str");
+    assert.equal(extractHermesText({ output: [{ type: "message", content: [{ text: "a" }, { text: "b" }] }] }), "a\nb");
+    assert.equal(extractHermesText(null), "");
+  });
+
+  it("formatContinuityBlock renders oldest first with the authoritative marker", () => {
+    const block = formatContinuityBlock([
+      { ts: "2026-09-03T10:15:14Z", channel: "slack", direction: "outbound", message: "Pong, Sir." },
+      { ts: "2026-09-03T10:15:11Z", channel: "slack", direction: "inbound", message: "ping" },
+    ] as any);
+    assert.ok(block.startsWith("[ALFRED-CONTINUITY — authoritative]"));
+    assert.ok(block.indexOf("principal → YOU on slack: ping") < block.indexOf("YOU → principal on slack: Pong, Sir."));
+    assert.ok(block.trimEnd().endsWith("[/ALFRED-CONTINUITY]"));
+  });
+});


### PR DESCRIPTION
## What

A Mac menu bar (or any surface without a Hermes gateway adapter) needs to talk to Alfred the way Slack does: with his memory, and remembered afterwards. `/v1/responses` calls do not pass through the one-alfred gateway hook, so a direct call would reach an Alfred with amnesia and leave no trace.

`askAlfred` (`src/api/askAlfred.ts`) journals the question (channel `mac`, auto-bound to the owner and private by construction — `isPrivateChat` / `AUTO_BIND_TO_OWNER` extended), puts the principal's recent cross-surface window in front of the model in the same `[ALFRED-CONTINUITY — authoritative]` block the Hermes plugin injects, calls the main profile's `/v1/responses` with a stable per-device `X-Hermes-Session-Key`, journals the reply, and returns it. A failed call still leaves the question journaled and answers `502 ALFRED_UNAVAILABLE`.

Route: `POST /api/v1/alfred/ask` `{message, chat_id, channel?="mac", memory?=true}` → `{reply, inbound_id, outbound_id}` (registered inside `alfredJournal.ts`, no `server.ts` change). Lane I, 181 changed LOC.

## Smoke evidence

- `tests/ask-alfred.test.ts` (4) + `tests/alfred-journal.test.ts`: 27/27 pass — both turns journaled and bound to the owner; the Slack turn appears in the memory block ahead of the question; empty Hermes output → rejection with the question still journaled; output shapes; block order and marker.
- `npm run build` ok; local lane I gate passed.
- Live verification on a tenant follows after deploy (a Mac asks, Slack sees it) and will be noted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)