### PR TITLE
feat(alfred-mac): the presence in the menu bar — the Pet, with Present, Attending and Resting

### DIFF
--- a/packages/alfred-mac/Sources/AlfredBlack/App.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/App.swift
@@ -59,6 +59,16 @@ struct AlfredBlackMain {
       do { let u = try Cowork.exportPlugin(); print("exported: \(u.path)"); exit(0) }
       catch { print("error: \((error as? TenantError)?.message ?? "\(error)")"); exit(1) }
     }
+    if let i = CommandLine.arguments.firstIndex(of: "--pet"), CommandLine.arguments.count > i + 1 {
+      let dir = URL(fileURLWithPath: CommandLine.arguments[i + 1]); try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+      for (name, st) in [("present", PetState.present), ("attending", .attending), ("resting", .resting)] {
+        let img = Pet.image(st, scale: 8)
+        if let tiff = img.tiffRepresentation, let rep = NSBitmapImageRep(data: tiff), let png = rep.representation(using: .png, properties: [:]) {
+          try? png.write(to: dir.appendingPathComponent("pet-\(name).png"))
+        }
+      }
+      print("pet: \(dir.path)"); exit(0)
+    }
     if CommandLine.arguments.contains("--tick") {
       var done = false
       Task { @MainActor in
@@ -161,6 +171,9 @@ final class AppState: ObservableObject {
   private var lastPush = Date.distantPast
   var lastReport = PushReport()
   @Published var activity = Activity.load()
+  @Published var desk: [DeskItem] = []
+  private var lastDesk = Date.distantPast
+  var petState: PetState { Pet.isQuiet() ? .resting : (desk.isEmpty ? .present : .attending) }
 
   /// On every launch while paired: the app may have been moved (dist → /Applications),
   /// so the MCP registration and the login item must point at THIS bundle.
@@ -191,6 +204,10 @@ final class AppState: ObservableObject {
         let n = try await Continuity.refresh(tenant: t, domain: p.domain)
         state.lastRenderAt = Date(); state.lastRenderEntries = n; online = true
       } catch { online = false; state.lastError = error.localizedDescription; state.lastErrorAt = Date() }
+    }
+    if force || now.timeIntervalSince(lastDesk) >= 60 {
+      lastDesk = now
+      if let items = try? await t.deskPending() { desk = items.filter { ($0.status ?? "pending") == "pending" } }
     }
     if force || now.timeIntervalSince(lastPush) >= 60 {
       lastPush = now
@@ -228,15 +245,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     if Self.moveToApplicationsIfNeeded() { return }
     AB.registerFonts()
     statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-    statusItem.button?.image = Glyph.bowtie()
-    statusItem.button?.image?.isTemplate = true
+    statusItem.button?.image = Pet.image(state.petState)
+    scheduleBlink()
     statusItem.button?.toolTip = "Alfred Black"
     statusItem.menu = buildMenu()
     state.selfHeal()
     if state.pairing == nil || !Self.launchedAsLoginItem() { showWindow() }
     timer = Timer.scheduledTimer(withTimeInterval: 10, repeats: true) { [weak self] _ in
       guard let self else { return }
-      Task { @MainActor in await self.state.tick(); self.statusItem.menu = self.buildMenu() }
+      Task { @MainActor in await self.state.tick(); self.statusItem.menu = self.buildMenu(); self.statusItem.button?.image = Pet.image(self.state.petState) }
     }
     Task { @MainActor in await state.tick(force: true); statusItem.menu = buildMenu() }
   }
@@ -297,8 +314,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
   @MainActor func buildMenu() -> NSMenu {
     let m = NSMenu()
-    let title = state.pairing.map { "Paired with \($0.domain)" } ?? "Not paired"
+    let title = state.pairing.map { _ in Pet.line(state.petState, deskCount: state.desk.count) } ?? "Not paired"
     m.addItem(withTitle: title, action: nil, keyEquivalent: "")
+    for item in state.desk.prefix(3) where !item.title.isEmpty {
+      let t = item.title.count > 64 ? String(item.title.prefix(63)) + "…" : item.title
+      m.addItem(withTitle: "· " + t, action: #selector(openDesk), keyEquivalent: "").target = self
+    }
+    if state.pairing != nil { m.addItem(withTitle: "Open the Desk", action: #selector(openDesk), keyEquivalent: "d").target = self }
     if state.pairing != nil {
       let dot = state.online == true ? "connected" : (state.online == false ? "unreachable" : "checking")
       m.addItem(withTitle: "Tenant \(dot)", action: nil, keyEquivalent: "")
@@ -321,6 +343,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   }
 
   @objc func openWindow() { showWindow() }
+
+  @objc func openDesk() { if let d = state.pairing?.domain, let u = URL(string: "https://\(d)/desk") { NSWorkspace.shared.open(u) } }
+
+  /// Perhaps once a minute — unless the Mac asks for reduced motion, or the pet is resting.
+
+  func scheduleBlink() {
+
+    DispatchQueue.main.asyncAfter(deadline: .now() + Double.random(in: 45...90)) { [weak self] in
+
+      guard let self else { return }
+
+      if !NSWorkspace.shared.accessibilityDisplayShouldReduceMotion, self.state.petState != .resting {
+
+        self.statusItem.button?.image = Pet.image(self.state.petState, blink: true)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.16) { self.statusItem.button?.image = Pet.image(self.state.petState) }
+
+      }
+
+      self.scheduleBlink()
+
+    }
+
+  }
   @objc func revealFolder() { Cowork.revealAlfredFolder() }
   @objc func quit() { NSApp.terminate(nil) }
 

--- a/packages/alfred-mac/Sources/AlfredBlack/Pet.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Pet.swift
@@ -1,0 +1,66 @@
+// The presence in the menu bar — from the design system's "Alfred Pet"
+// exploration: a creature of few pixels, wool black with one brass accent,
+// a monocle instead of a cursor. It sits in a corner, never speaks first,
+// and brass appears only when something needs you. No badge counts, no
+// bubbles, no bouncing; it blinks perhaps once a minute.
+import AppKit
+
+enum PetState { case present, attending, resting }
+
+enum Pet {
+  // The exploration's palette: wool lifted to charcoal-taupe so the silhouette holds on any menu bar.
+  static let palette: [Character: NSColor] = [
+    "O": AB.hex(0x3B342A), "K": AB.hex(0x4A4236), "H": AB.hex(0x5A5143), "S": AB.hex(0x3F382E),
+    "T": AB.hex(0x26211B), "P": AB.hex(0xF2EDE1), "B": AB.hex(0xC69A55), "D": AB.hex(0x9A7440), "G": AB.hex(0x6E6558),
+  ]
+  /// 2A — the Top Hat at 32 × 39, the recommended form.
+  static let topHat: [String] = [
+    "..........OOOOOOOOOOOO..........", ".........OKKKKKKKKKKKKO.........", ".........OKHKKKKKKKKKKO.........",
+    ".........OKHKKKKKKKKKKO.........", ".........OKKKKKKKKKKKKO.........", ".........OBBBBBBBBBBBBO.........",
+    ".........ODDDDDDDDDDDDO.........", ".........OKKKKKKKKKKKKO.........", "...OKKKKKKKKKKKKKKKKKKKKKKKKO...",
+    "....OSSSSSSSSSSSSSSSSSSSSSSO....", "........OKKKKKKKKKKKKKKO........", ".......OKKKKKKKKKKKKKKKKO.......",
+    "......OKKKKKKKKKKKKKKKKKKO......", "......OKKTTTTTTTTTTTTTTKKO......", "......OKKTTTTTTTTTBBBTTKKO......",
+    "......OKKTTPPTTTTBTPTBTKKO......", "......OKKTTTTPPTTBTTTBTKKO......", "......OKKTTPPTTTTBTTTBTKKO......",
+    "......OKKTTTTTTTTTBBBTTKKO......", "......OKKTTTTTTTTTTTTDTKKO......", "......OKKTTTTTTTTTTTTTTKKO......",
+    ".......OKKKKKKKKKKKKKKDKO.......", "........OKKKKKKKKKKKKKKO........", "..........OKKKKKKKKKKO..........",
+    ".........OKPPKKKKKKPPKO.........", ".........OKKKBBDDBBKKKO.........", ".........OKKKBBDDBBKKKO.........",
+    ".......OKKKKKKKKKKKKKKKKO.......", ".....OKKKKKKKKKKKKKKKKKKKKO.....", ".....OKKKKKKKKKKKKKKKKKKKKO.....",
+    ".....OKKKKKKKKKKKKKKKKKKKKO.....", "......OKKKKKKKKKKKKKKKKKKO......", ".......OKKKKKKKKKKKKKKKKO.......",
+    "........OKKKKKKKKKKKKKKO........", ".........OKKKKO..OKKKKO.........", ".........OKKKKO..OKKKKO.........",
+    ".........OKKKKO..OKKKKO.........", "........OKKKKKO..OKKKKKO........", "........OOOOOOO..OOOOOOO........",
+  ]
+  static func cells(for state: PetState, blink: Bool) -> [[Character]] {
+    var m = topHat.map { Array($0) }
+    func set(_ r: Int, _ c: Int, _ ch: Character) { if r < m.count, c < m[r].count { m[r][c] = ch } }
+    if state == .resting || blink {                       // eyes to dim dashes (rows 15–17 hold the P cells)
+      for r in 15...17 { for c in 10...15 where m[r][c] == "P" { m[r][c] = state == .resting ? "G" : "T" } }
+    }
+    if state == .resting {                                // the monocle dims too
+      for r in 14...19 { for c in 16...22 where m[r][c] == "B" || m[r][c] == "D" { m[r][c] = "G" } }
+    }
+    if state == .attending {                              // one brass dot, top right; a glint in the monocle
+      for (r, row) in [".BB.", "BBBB", "BBBB", ".BB."].enumerated() { for (i, ch) in row.enumerated() where ch != "." { set(1 + r, 26 + i, ch) } }
+      set(16, 19, "P")
+    }
+    return m
+  }
+  /// The image for the status item; `scale` is points per cell (0.5 → 16 × 19.5 pt, crisp on Retina).
+  static func image(_ state: PetState, blink: Bool = false, scale: CGFloat = 0.5) -> NSImage {
+    let m = cells(for: state, blink: blink); let w = m[0].count, h = m.count
+    let img = NSImage(size: NSSize(width: CGFloat(w) * scale, height: CGFloat(h) * scale), flipped: true) { _ in
+      for (y, row) in m.enumerated() { for (x, ch) in row.enumerated() { guard let c = palette[ch] else { continue }
+        c.setFill(); NSRect(x: CGFloat(x) * scale, y: CGFloat(y) * scale, width: scale, height: scale).fill() } }
+      return true
+    }
+    img.isTemplate = false; return img
+  }
+  /// Quiet hours: the pet rests, and brass never appears. Local time, 23:00–07:00.
+  static func isQuiet(_ d: Date = Date()) -> Bool { let h = Calendar.current.component(.hour, from: d); return h >= 23 || h < 7 }
+  static func line(_ state: PetState, deskCount: Int) -> String {
+    switch state {
+    case .resting: return "Resting — quiet hours."
+    case .attending: return deskCount == 1 ? "Attending — one matter on the Desk." : "Attending — \(deskCount) matters on the Desk."
+    case .present: return "Present — no urgent action is required."
+    }
+  }
+}

--- a/packages/alfred-mac/Sources/AlfredBlack/Tenant.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Tenant.swift
@@ -105,6 +105,14 @@ struct Tenant {
   func check() async -> Bool { (try? await recent(limit: 1, withinHours: 1)) != nil }
 
   /// Turn whatever the person typed into the tenant domain.
+  /// The Desk: cards awaiting the principal's judgment.
+  func deskPending() async throws -> [DeskItem] {
+    struct Page: Decodable { var records: [DeskItem] }
+    let (code, data) = try await request("api/v1/admin/needs-attention", bearer: apiKey)
+    guard code == 200 else { throw TenantError(message: "Desk read failed (HTTP \(code)).") }
+    return try JSONDecoder().decode(Page.self, from: data).records
+  }
+
   static func domain(from raw: String) -> String? {
     var s = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     if !s.contains("://") { s = "https://" + s }
@@ -113,4 +121,9 @@ struct Tenant {
     for p in ["api.", "www."] where h.hasPrefix(p) { h = String(h.dropFirst(p.count)) }
     return h
   }
+}
+
+struct DeskItem: Decodable, Identifiable {
+  var id: String; var status: String?; var created: String?; var action_what: String?; var matter_ref: String?
+  var title: String { (action_what ?? "").replacingOccurrences(of: "\n", with: " ").trimmingCharacters(in: .whitespaces) }
 }


### PR DESCRIPTION
## What

Slice 2 of the desktop-app redesign. The menu-bar item becomes the design system's **Pet** ("Alfred Pet — Exploration", form 1C, the Top Hat at 32 × 39): a creature of few pixels, wool lifted so it holds on any menu bar, a monocle instead of a cursor.

- **Present** — still. **Attending** — one brass dot and a glint in the monocle when the Desk holds matters awaiting judgment (`GET /api/v1/admin/needs-attention`, polled each minute); the menu shows the first three, each opening the Desk, plus *Open the Desk* (⌘D). **Resting** — eyes and monocle dimmed through quiet hours (23:00–07:00 local), brass never appears.
- Blinks perhaps once a minute (45–90 s), never under reduced motion, never while resting. No badge counts, no bubbles, no bouncing.
- `--pet <dir>` renders the three states at 8× for inspection.

Lane VIII, 133 changed LOC.

## Smoke evidence

- `swift build -c release` ok (before and after the rebase onto main); local lane VIII gate passed.
- The three states rendered and inspected on paper and on wool: hat band and bow tie in brass, prompt-eyes, monocle; Attending's dot and glint; Resting's dimmed eyes and monocle.
- The Desk poll uses the same authenticated proxy as the journal (verified route shape `{records:[…]}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)