### PR TITLE
feat(alfred-mac): ask Alfred from this Mac; the brief; the kit's components

### DIFF
--- a/packages/alfred-mac/Sources/AlfredBlack/App.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/App.swift
@@ -161,6 +161,24 @@ final class AppState: ObservableObject {
   }
 
 
+  /// One question, one reply, both remembered on every other surface.
+
+
+  func ask(_ text: String) async {
+
+
+    let q = text.trimmingCharacters(in: .whitespacesAndNewlines); guard !q.isEmpty, !asking, let t = tenant else { return }
+
+
+    asking = true; defer { asking = false }
+
+
+    do { reply = (try await t.ask(q, chatId: Store.deviceId()), Date()) } catch { record(error) }
+
+
+  }
+
+
   func signOut() {
     Keychain.delete("apikey"); Store.savePairing(nil); pairing = nil; online = nil
     try? Cowork.unregisterMCP(); cowork = Cowork.status()
@@ -172,6 +190,10 @@ final class AppState: ObservableObject {
   var lastReport = PushReport()
   @Published var activity = Activity.load()
   @Published var desk: [DeskItem] = []
+  @Published var reply: (text: String, at: Date)? = nil
+  @Published var asking = false
+  @Published var brief: Brief? = nil
+  private var lastBrief = Date.distantPast
   private var lastDesk = Date.distantPast
   var petState: PetState { Pet.isQuiet() ? .resting : (desk.isEmpty ? .present : .attending) }
 
@@ -204,6 +226,9 @@ final class AppState: ObservableObject {
         let n = try await Continuity.refresh(tenant: t, domain: p.domain)
         state.lastRenderAt = Date(); state.lastRenderEntries = n; online = true
       } catch { online = false; state.lastError = error.localizedDescription; state.lastErrorAt = Date() }
+    }
+    if force || now.timeIntervalSince(lastBrief) >= 600 {
+      lastBrief = now; if let b = try? await t.latestBrief() { brief = b }
     }
     if force || now.timeIntervalSince(lastDesk) >= 60 {
       lastDesk = now

--- a/packages/alfred-mac/Sources/AlfredBlack/Store.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Store.swift
@@ -51,6 +51,14 @@ enum Store {
     if let p, let d = try? enc.encode(p) { try? d.write(to: Paths.pairingFile, options: .atomic) }
     else { try? FileManager.default.removeItem(at: Paths.pairingFile) }
   }
+  /// A stable id for this Mac — the chat_id of its conversation with Alfred.
+  static func deviceId() -> String {
+    let f = Paths.support.appendingPathComponent("device-id")
+    if let s = try? String(contentsOf: f, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines), !s.isEmpty { return s }
+    let id = "mac-" + UUID().uuidString.lowercased().prefix(12)
+    try? FileManager.default.createDirectory(at: Paths.support, withIntermediateDirectories: true)
+    try? id.write(to: f, atomically: true, encoding: .utf8); return id
+  }
   static func loadState() -> RunState {
     guard let d = try? Data(contentsOf: Paths.stateFile), let s = try? dec.decode(RunState.self, from: d) else { return RunState() }
     return s

--- a/packages/alfred-mac/Sources/AlfredBlack/Surface.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Surface.swift
@@ -1,0 +1,67 @@
+// The kit's components, as SwiftUI: a mono status chip, one sparse ledger
+// line, the terminal prompt that is the hero of every Alfred surface, and
+// the reply in Alfred's own voice — serif, signed.
+import SwiftUI
+
+/// Mono uppercase status chip. Brass is filled (the one accent); the others are quiet outlines.
+struct Pill: View {
+  enum Tone { case brass, outline, muted, success, destructive }
+  let text: String; var tone: Tone = .outline
+  var body: some View {
+    Text(text.uppercased()).font(AB.mono(9, weight: .bold)).tracking(1.4)
+      .padding(.horizontal, 7).padding(.vertical, 3)
+      .foregroundColor(tone == .brass ? AB.paper : tone == .success ? AB.billiard : tone == .destructive ? AB.oxblood : tone == .muted ? AB.marginalia : AB.ink)
+      .background(tone == .brass ? AB.brass : Color.clear)
+      .overlay(Rectangle().stroke(tone == .muted ? Color.clear : tone == .brass ? AB.brass : tone == .success ? AB.billiard : tone == .destructive ? AB.oxblood : AB.rule, lineWidth: 1))
+  }
+}
+
+/// One line of a ledger: time · subject · state · next action, and nothing else.
+/// Divided by a hairline; washes 6% brass on hover and its rule brasses.
+struct LedgerRow<State: View>: View {
+  let time: String; let subject: String; var state: State; var action: (() -> Void)? = nil
+  @SwiftUI.State private var hover = false
+  var body: some View {
+    VStack(spacing: 0) {
+      Button(action: { action?() }) {
+        HStack(spacing: 12) {
+          Text(time).font(AB.mono(10)).foregroundColor(AB.marginalia).frame(width: 54, alignment: .leading)
+          Text(subject).font(AB.body(15)).foregroundColor(AB.ink).lineLimit(1).truncationMode(.tail)
+          Spacer(minLength: 8)
+          state
+        }.padding(.vertical, 8).padding(.horizontal, 6).contentShape(Rectangle())
+      }.buttonStyle(.plain).background(hover ? AB.brass.opacity(0.06) : Color.clear)
+      Rectangle().fill(hover ? AB.brass.opacity(0.7) : AB.rule).frame(height: 1)
+    }
+    .onHover { hover = $0 }
+    .animation(.easeOut(duration: 0.16), value: hover)
+  }
+}
+
+/// The terminal prompt — brass `alfred.black >`, a calm placeholder, mono throughout, a hairline frame.
+struct CommandField: View {
+  @Binding var text: String; var busy: Bool; var onSubmit: () -> Void
+  @FocusState private var focused: Bool
+  var body: some View {
+    HStack(spacing: 10) {
+      Text("alfred.black >").font(AB.mono(12, weight: .bold)).foregroundColor(AB.brass)
+      TextField("What shall Alfred handle?", text: $text).textFieldStyle(.plain).font(AB.mono(13)).foregroundColor(AB.ink)
+        .focused($focused).onSubmit(onSubmit).disabled(busy)
+      if busy { Text("…").font(AB.mono(12)).foregroundColor(AB.marginalia) }
+    }
+    .padding(.horizontal, 12).padding(.vertical, 10)
+    .overlay(Rectangle().stroke(focused ? AB.brass : AB.border, lineWidth: 1))
+    .animation(.easeOut(duration: 0.16), value: focused)
+  }
+}
+
+/// What Alfred says: serif, full sentences, signed.
+struct ReplyView: View {
+  let text: String
+  var body: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Text(text).font(AB.body(16)).foregroundColor(AB.ink).lineSpacing(3).fixedSize(horizontal: false, vertical: true).textSelection(.enabled)
+      Text("— Alfred.").font(AB.body(15, italic: true)).foregroundColor(AB.marginalia)
+    }
+  }
+}

--- a/packages/alfred-mac/Sources/AlfredBlack/Tenant.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Tenant.swift
@@ -32,7 +32,9 @@ struct Tenant {
     return URLSession(configuration: c)
   }
 
-  private func request(_ path: String, method: String = "GET", bearer: String?, body: [String: Any]? = nil, query: [String: String] = [:]) async throws -> (Int, Data) {
+  /// Asking Alfred can take a minute; everything else answers in seconds.
+  private static let slow: URLSession = { let c = URLSessionConfiguration.ephemeral; c.timeoutIntervalForRequest = 180; return URLSession(configuration: c) }()
+  private func request(_ path: String, method: String = "GET", bearer: String?, body: [String: Any]? = nil, query: [String: String] = [:], patient: Bool = false) async throws -> (Int, Data) {
     var comps = URLComponents(url: api.appendingPathComponent(path), resolvingAgainstBaseURL: false)!
     if !query.isEmpty { comps.queryItems = query.map { URLQueryItem(name: $0.key, value: $0.value) } }
     var r = URLRequest(url: comps.url!)
@@ -41,7 +43,7 @@ struct Tenant {
     r.setValue("application/json", forHTTPHeaderField: "Accept")
     if let bearer { r.setValue("Bearer \(bearer)", forHTTPHeaderField: "Authorization") }
     if let body { r.httpBody = try JSONSerialization.data(withJSONObject: body) }
-    let (data, resp) = try await session.data(for: r)
+    let (data, resp) = try await (patient ? Tenant.slow : session).data(for: r)
     return ((resp as? HTTPURLResponse)?.statusCode ?? 0, data)
   }
 
@@ -113,6 +115,29 @@ struct Tenant {
     return try JSONDecoder().decode(Page.self, from: data).records
   }
 
+  /// Ask Alfred from this Mac. ctrl-api journals both turns and puts his memory in front of him.
+  func ask(_ message: String, chatId: String) async throws -> String {
+    let (code, data) = try await request("api/v1/alfred/ask", method: "POST", bearer: apiKey, body: ["message": message, "chat_id": chatId, "channel": "mac"], patient: true)
+    let j = (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
+    guard code == 200, let reply = j["reply"] as? String, !reply.isEmpty else {
+      throw TenantError(message: code == 502 ? "Alfred could not be reached just now." : "The tenant did not answer (HTTP \(code)).")
+    }
+    return reply
+  }
+
+  /// The most recent brief: its slot, date, and a short excerpt of the body.
+  func latestBrief() async throws -> Brief? {
+    struct Item: Decodable { var slug_date: String; var slot: String; var date: String }
+    struct List: Decodable { var briefings: [Item] }
+    struct Detail: Decodable { var body: String }
+    let (code, data) = try await request("api/v1/briefings", bearer: apiKey)
+    guard code == 200, let latest = try JSONDecoder().decode(List.self, from: data).briefings.max(by: { $0.slug_date < $1.slug_date }) else { return nil }
+    let (c2, d2) = try await request("api/v1/briefings/\(latest.slug_date)", bearer: apiKey)
+    guard c2 == 200 else { return nil }
+    let body = try JSONDecoder().decode(Detail.self, from: d2).body
+    return Brief(slot: latest.slot, date: latest.date, excerpt: Brief.excerpt(of: body))
+  }
+
   static func domain(from raw: String) -> String? {
     var s = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     if !s.contains("://") { s = "https://" + s }
@@ -126,4 +151,17 @@ struct Tenant {
 struct DeskItem: Decodable, Identifiable {
   var id: String; var status: String?; var created: String?; var action_what: String?; var matter_ref: String?
   var title: String { (action_what ?? "").replacingOccurrences(of: "\n", with: " ").trimmingCharacters(in: .whitespaces) }
+}
+
+struct Brief {
+  var slot: String; var date: String; var excerpt: String
+  var title: String { "\(slot.prefix(1).uppercased() + slot.dropFirst()) brief · \(date)" }
+  /// First paragraph of prose after the heading, prose only, capped.
+  static func excerpt(of body: String) -> String {
+    let text = body.range(of: "\n---\n").map { String(body[$0.upperBound...]) } ?? body   // skip frontmatter if present
+    let para = text.components(separatedBy: "\n\n").map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      .first { !$0.isEmpty && !$0.hasPrefix("#") && !$0.hasPrefix("-") && !$0.hasPrefix("|") } ?? ""
+    let flat = para.replacingOccurrences(of: "**", with: "").replacingOccurrences(of: "\n", with: " ")
+    return flat.count > 260 ? String(flat.prefix(257)).trimmingCharacters(in: .whitespaces) + "…" : flat
+  }
 }


### PR DESCRIPTION
## What

Slice 3a of the desktop-app redesign — the tenant side and the kit's components; the surface that uses them follows in 3b.

- `Tenant.ask` posts to `POST /api/v1/alfred/ask` (#732) on a patient session (a reply can take a minute) with this Mac's stable device id as the chat, so the conversation continues turn to turn and every other surface remembers it. `Tenant.latestBrief` fetches the newest brief and keeps a prose excerpt.
- `Store.deviceId()` — a stable id for this Mac.
- `AppState.ask`, `reply`, `brief` (polled every 10 min).
- `Surface.swift`: `Pill` (mono status chip; brass filled only for the one accent), `LedgerRow` (time · subject · state; hairline-divided; 6 % brass wash and a brassed rule on hover), `CommandField` (brass `alfred.black >` prompt, calm placeholder, mono throughout, hairline frame), `ReplyView` (serif, signed "— Alfred.").

Lane VIII, 142 changed LOC.

## Smoke evidence

- `swift build -c release` ok; local lane VIII gate passed.
- Live, from the built app binary (`--ask`, added in 3b) against a tenant: a question about the most recent Slack exchange came back answered from memory — the ask route's journaled block reached the model, and both turns landed in the journal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)