### PR TITLE
feat(alfred-mac): command first — the surface: ask Alfred, the Desk, the brief, the ledger folded

### DIFF
--- a/packages/alfred-mac/README.md
+++ b/packages/alfred-mac/README.md
@@ -12,6 +12,8 @@ Slack, and the next turn on either side must already know about it.
 
 | | |
 |---|---|
+| **The surface** | Command first. `alfred.black >` asks Alfred anything; the reply comes back in serif, signed, and both turns are journaled (`POST /api/v1/alfred/ask`), so Slack, Telegram and Cowork remember the exchange. Below it: the Desk's matters awaiting judgment as ledger lines that open the Desk, the latest brief as a prose excerpt, and the machine-truth rows folded into a Ledger. |
+| **The Pet** | The menu-bar item is the design system's Pet (the Top Hat, 32 × 39 pixels): *Present* is still; *Attending* shows one brass dot when the Desk holds matters awaiting judgment, and the menu lists the first three; *Resting* dims the eyes through quiet hours (23:00–07:00 local) and never shows brass. It blinks perhaps once a minute, never under reduced motion. |
 | **Pair** | Enter the tenant URL and the dashboard login. The app signs in, mints a dedicated API key (visible under *Study › API keys*, revocable there), stores it in a 0600 file of its own, and forgets the password. |
 | **Read side** | Every 30 s it renders the principal's recent journal (Slack, Telegram, Cowork, …) into `~/Alfred/continuity.md` as the same `[ALFRED-CONTINUITY — authoritative]` block the Hermes plugin injects. A Cowork plugin (staged by the app) reads that file on `SessionStart`, `UserPromptSubmit` and `PostCompact`. |
 | **Write side** | Every 60 s it mirrors new Cowork turns from the local session transcripts into the journal (`channel: cowork`), binding each new session to the owner. Only turns from the last 48 h are ever mirrored: the journal stamps `ts` server-side, so history mirrored late would land as "now". |
@@ -32,7 +34,10 @@ packages/alfred-mac/
 ├── Sources/AlfredBlack/
 │   ├── App.swift                 entry point, AppState, menu bar, CLI modes
 │   ├── Views.swift               onboarding + status (SwiftUI)
-│   ├── Theme.swift               design-system tokens + font registration
+│   ├── Theme.swift               design-system tokens (paper by day, wool by night) + font registration
+│   ├── Brand.swift               the engraved icons, the marks, the seal, the grain
+│   ├── Surface.swift             Pill, LedgerRow, CommandField, ReplyView — the kit's components
+│   ├── Pet.swift                 the presence in the menu bar (Present / Attending / Resting)
 │   ├── Tenant.swift              login / API key / journal client
 │   ├── Continuity.swift          renders continuity.md + folder CLAUDE.md
 │   ├── Pusher.swift              transcript → journal mirror
@@ -41,6 +46,7 @@ packages/alfred-mac/
 │   ├── Store.swift / Keychain.swift
 │   └── Resources/
 │       ├── Fonts/                Playfair Display, EB Garamond, JetBrains Mono (OFL)
+│       ├── Brand/                icons.json (17 engraved icons), marks, seal, grain tiles
 │       └── CoworkPlugin/         the alfred-continuity plugin (hooks + skill)
 ├── Support/Info.plist, AppIcon.icns
 └── scripts/build-app.sh          → dist/Alfred Black.app + dist/AlfredBlack-<version>.dmg
@@ -64,7 +70,9 @@ Produces `dist/Alfred Black.app` and `dist/AlfredBlack-2026.09.03.dmg`.
 "dist/Alfred Black.app/Contents/MacOS/AlfredBlack" --tick       # one render + one mirror pass
 "dist/Alfred Black.app/Contents/MacOS/AlfredBlack" --status
 "dist/Alfred Black.app/Contents/MacOS/AlfredBlack" --export-plugin           # write ~/Downloads/Alfred Continuity.plugin
-"dist/Alfred Black.app/Contents/MacOS/AlfredBlack" --snapshot /path/dir      # render both views to PNGs
+"dist/Alfred Black.app/Contents/MacOS/AlfredBlack" --snapshot /path/dir [--light|--dark]   # render both views to PNGs
+"dist/Alfred Black.app/Contents/MacOS/AlfredBlack" --ask "what is on my plate today?"    # ask Alfred from a shell
+"dist/Alfred Black.app/Contents/MacOS/AlfredBlack" --pet /path/dir       # the Pet's three states at 8×
 ```
 
 ## Signing and distribution
@@ -101,7 +109,8 @@ the API key itself is revoked from *Study › API keys* on the tenant.
 
 ## Design
 
-Built on the Alfred Black design system (`design-system/`): paper and wool,
-ink, one brass accent, sharp corners, hairline rules, Playfair Display for
-display, EB Garamond for prose, JetBrains Mono for machine truth. No emoji.
-Calm copy.
+Built on the Alfred Black design system (`design-system/`): paper by day and
+wool by night (brass holds, a step brighter on wool), ink, one brass accent,
+sharp corners, hairline rules, the engraved icon set, the seal at 7 % in the
+gutter, Playfair Display for display, EB Garamond for prose, JetBrains Mono
+for machine truth. No emoji. Calm copy. Entrances rise in; nothing bounces.

--- a/packages/alfred-mac/Sources/AlfredBlack/App.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/App.swift
@@ -69,12 +69,22 @@ struct AlfredBlackMain {
       }
       print("pet: \(dir.path)"); exit(0)
     }
+    if let i = CommandLine.arguments.firstIndex(of: "--ask"), CommandLine.arguments.count > i + 1 {   // ask Alfred from a shell
+      var done = false
+      Task { @MainActor in
+        let st = AppState(); await st.ask(CommandLine.arguments[i + 1])
+        print(st.reply.map { "Alfred: \($0.text)" } ?? "error: \(st.state.lastError ?? "no reply")"); done = true
+      }
+      let deadline = Date().addingTimeInterval(200)
+      while !done && Date() < deadline { RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.05)) }
+      exit(done ? 0 : 2)
+    }
     if CommandLine.arguments.contains("--tick") {
       var done = false
       Task { @MainActor in
         let st = AppState(); st.selfHeal(); await st.tick(force: true)
         let r = st.lastReport
-        print("tick: online=\(st.online.map(String.init) ?? "?") rendered=\(st.state.lastRenderEntries) pushed=\(r.pushed) skipped=\(r.skipped) tooOld=\(r.tooOld) bound=\(r.bound) failed=\(r.failed) total=\(st.state.totalPushed)")
+        print("tick: online=\(st.online.map(String.init) ?? "?") rendered=\(st.state.lastRenderEntries) pushed=\(r.pushed) skipped=\(r.skipped) tooOld=\(r.tooOld) bound=\(r.bound) failed=\(r.failed) total=\(st.state.totalPushed) desk=\(st.desk.count) brief=\(st.brief.map { $0.title } ?? "none")")
         done = true
       }
       let deadline = Date().addingTimeInterval(120)

--- a/packages/alfred-mac/Sources/AlfredBlack/Views.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Views.swift
@@ -70,42 +70,84 @@ struct Row: View {
   }
 }
 
+/// A single engraved icon in brass with reassuring copy — how the system rests.
+struct EmptyState: View {
+  let icon: String; let text: String
+  var body: some View {
+    HStack(spacing: 10) { ABIcon(icon, 18, color: AB.brass); Text(text).font(AB.body(15, italic: true)).foregroundColor(AB.marginalia) }
+      .padding(.vertical, 10)
+  }
+}
+
 struct StatusView: View {
   @EnvironmentObject var s: AppState
+  @State private var command = ""
+  @State private var ledgerOpen = false
+  private var reduceMotion: Bool { NSWorkspace.shared.accessibilityDisplayShouldReduceMotion }
+  private func openDesk() { if let d = s.pairing?.domain, let u = URL(string: "https://\(d)/desk") { NSWorkspace.shared.open(u) } }
+  private func openBrief() { if let d = s.pairing?.domain, let u = URL(string: "https://\(d)/brief") { NSWorkspace.shared.open(u) } }
+  private static let iso: ISO8601DateFormatter = { let f = ISO8601DateFormatter(); f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]; return f }()
+  private func when(_ ts: String?) -> String {
+    guard let ts, let d = Self.iso.date(from: ts) ?? ISO8601DateFormatter().date(from: ts) else { return "—" }
+    let f = DateFormatter(); f.dateFormat = Calendar.current.isDateInToday(d) ? "HH:mm" : "d MMM"; return f.string(from: d)
+  }
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
       HStack(alignment: .firstTextBaseline) { Label_(text: "For Mac"); Spacer(); Label_(text: s.pairing?.domain ?? "", color: AB.brass) }
       Wordmark().padding(.top, 6)
-      Text(s.online == false ? "The tenant cannot be reached at the moment." : "Everything important is in hand.")
+      Text(s.online == false ? "The tenant cannot be reached at the moment." : Pet.line(s.petState, deskCount: s.desk.count))
         .font(AB.body(19, italic: true)).foregroundColor(AB.marginalia).padding(.top, 4)
-      Hairline().padding(.vertical, 20)
+      Hairline().padding(.vertical, 16)
 
-      Label_(text: "Continuity")
-      VStack(spacing: 0) {
-        Row(k: "Tenant", v: s.online == true ? "connected" : (s.online == false ? "unreachable" : "checking"), ok: s.online)
-        Row(k: "Memory file", v: s.state.lastRenderAt.map { "\(s.state.lastRenderEntries) entries · \(AppDelegate.ago($0))" } ?? "not yet", ok: s.state.lastRenderAt != nil)
-        Row(k: "Cowork journaled", v: s.activity.journalCoworkLast.map { "\(s.activity.journalCowork) turns in the window · \(AppDelegate.ago($0))" } ?? "none in the window yet", ok: s.activity.journalCoworkLast != nil)
-        Row(k: "Cowork mirrored", v: "\(s.state.totalPushed) turns · " + (s.state.lastPushAt.map { AppDelegate.ago($0) } ?? "not yet"), ok: s.state.lastPushAt != nil)
-        Row(k: "Starts at login", v: s.loginItem ? "yes" : (SMAppService.mainApp.status == .requiresApproval ? "approve in System Settings › Login Items" : "no"), ok: s.loginItem)
-      }.padding(.top, 6)
+      CommandField(text: $command, busy: s.asking) { let q = command; command = ""; Task { await s.ask(q) } }
 
-      Label_(text: "Claude Cowork").padding(.top, 18)
-      VStack(spacing: 0) {
-        Row(k: "Claude Desktop", v: s.cowork.claudeInstalled ? "installed" : "not found", ok: s.cowork.claudeInstalled)
-        Row(k: "Alfred folder", v: s.cowork.folderReady ? "~/Alfred ready" : "pending", ok: s.cowork.folderReady)
-        Row(k: "Memory tools", v: s.cowork.mcpRegistered ? "registered with Claude" : "not registered", ok: s.cowork.mcpRegistered)
-        Row(k: "Hooks plugin", v: s.cowork.pluginExported ? "exported to Downloads" : (s.cowork.pluginStaged ? "ready to export" : "not staged"), ok: s.cowork.pluginExported)
-      }.padding(.top, 6)
-      if s.cowork.pluginExported {
-        Text("Alfred Continuity.plugin is in your Downloads, selected in Finder. In Claude, switch to Cowork, open its Plugins panel and upload that file there — a Cowork session loads only plugins installed from Cowork. Installing one is Claude's own step.")
-          .font(AB.body(14)).foregroundColor(AB.marginalia).lineSpacing(3).padding(.top, 12).frame(maxWidth: 448, alignment: .leading).fixedSize(horizontal: false, vertical: true)
+      ScrollView(.vertical, showsIndicators: false) {
+        VStack(alignment: .leading, spacing: 0) {
+          if let r = s.reply {
+            ReplyView(text: r.text).padding(.top, 14).id(r.at)
+              .transition(reduceMotion ? .opacity : .opacity.combined(with: .offset(y: 8)))
+          } else if s.asking {
+            Text("One moment.").font(AB.mono(11)).foregroundColor(AB.marginalia).padding(.top, 14)
+          }
+
+          HStack { Label_(text: "The Desk"); Spacer(); if !s.desk.isEmpty { Pill(text: "\(s.desk.count) awaiting", tone: .brass) } }.padding(.top, 22)
+          if s.desk.isEmpty { EmptyState(icon: "pocket_watch", text: "No urgent action is required.") }
+          else { ForEach(s.desk.prefix(4)) { item in LedgerRow(time: when(item.created), subject: item.title, state: Pill(text: "Awaiting")) { openDesk() } } }
+
+          Label_(text: "The Brief").padding(.top, 22)
+          if let b = s.brief, !b.excerpt.isEmpty {
+            Text(b.excerpt).font(AB.body(15)).foregroundColor(AB.ink).lineSpacing(3).padding(.top, 8).fixedSize(horizontal: false, vertical: true)
+            HStack { Text(b.title).font(AB.mono(10)).foregroundColor(AB.marginalia); Spacer()
+              Button("Read the brief →") { openBrief() }.buttonStyle(.plain).font(AB.mono(10, weight: .bold)).foregroundColor(AB.brass) }.padding(.top, 8)
+          } else { EmptyState(icon: "envelope", text: "No brief has been composed yet.") }
+
+          Button(action: { withAnimation(reduceMotion ? nil : .easeOut(duration: 0.3)) { ledgerOpen.toggle() } }) {
+            HStack(spacing: 8) { Label_(text: "Ledger"); Text(ledgerOpen ? "↓" : "→").font(AB.mono(10)).foregroundColor(AB.marginalia) }
+          }.buttonStyle(.plain).padding(.top, 22)
+          if ledgerOpen {
+            VStack(spacing: 0) {
+              Row(k: "Tenant", v: s.online == true ? "connected" : (s.online == false ? "unreachable" : "checking"), ok: s.online)
+              Row(k: "Memory file", v: s.state.lastRenderAt.map { "\(s.state.lastRenderEntries) entries · \(AppDelegate.ago($0))" } ?? "not yet", ok: s.state.lastRenderAt != nil)
+              Row(k: "Cowork journaled", v: s.activity.journalCoworkLast.map { "\(s.activity.journalCowork) turns in the window · \(AppDelegate.ago($0))" } ?? "none in the window yet", ok: s.activity.journalCoworkLast != nil)
+              Row(k: "Cowork mirrored", v: "\(s.state.totalPushed) turns · " + (s.state.lastPushAt.map { AppDelegate.ago($0) } ?? "not yet"), ok: s.state.lastPushAt != nil)
+              Row(k: "Starts at login", v: s.loginItem ? "yes" : (SMAppService.mainApp.status == .requiresApproval ? "approve in System Settings › Login Items" : "no"), ok: s.loginItem)
+              Row(k: "Claude Desktop", v: s.cowork.claudeInstalled ? "installed" : "not found", ok: s.cowork.claudeInstalled)
+              Row(k: "Memory tools", v: s.cowork.mcpRegistered ? "registered with Claude" : "not registered", ok: s.cowork.mcpRegistered)
+              Row(k: "Hooks plugin", v: s.cowork.pluginExported ? "exported to Downloads" : (s.cowork.pluginStaged ? "ready to export" : "not staged"), ok: s.cowork.pluginExported)
+            }.padding(.top, 6)
+            if s.cowork.pluginExported {
+              Text("Alfred Continuity.plugin is in your Downloads, selected in Finder. In Claude, switch to Cowork, open its Plugins panel and upload that file there — a Cowork session loads only plugins installed from Cowork. Installing one is Claude's own step.")
+                .font(AB.body(14)).foregroundColor(AB.marginalia).lineSpacing(3).padding(.top, 12).frame(maxWidth: 448, alignment: .leading).fixedSize(horizontal: false, vertical: true)
+            }
+          }
+        }
       }
+      .animation(reduceMotion ? nil : .easeOut(duration: 0.7), value: s.reply?.at)
 
       if let e = s.state.lastError, let at = s.state.lastErrorAt, Date().timeIntervalSince(at) < 600 {
-        Text(e).font(AB.mono(10)).foregroundColor(AB.oxblood).padding(.top, 10).lineLimit(2)
+        Text(e).font(AB.mono(10)).foregroundColor(AB.oxblood).padding(.top, 8).lineLimit(2)
       }
-      Spacer()
-      Hairline(brass: true)
+      Hairline(brass: true).padding(.top, 10)
       HStack(spacing: 8) {
         Button("Set up Cowork") { s.setUpCowork() }.buttonStyle(ABButton(primary: true))
         Button("Export") { s.exportPlugin() }.buttonStyle(ABButton())


### PR DESCRIPTION
## What

Slice 3b — the surface. The window is no longer a status panel.

- Under the wordmark and the Pet's line, the **command field** is the hero: a question to Alfred, his reply in serif signed "— Alfred.", remembered on every other surface (via #732 / #735).
- **The Desk**: matters awaiting judgment as ledger lines (time · subject · *Awaiting*) that open the Desk; a brass pill with the count.
- **The Brief**: the latest brief as a prose excerpt with *Read the brief →*.
- Each at rest behind a single engraved icon in brass and "No urgent action is required." / "No brief has been composed yet."
- The machine-truth rows (tenant, memory, Cowork, login item, Claude setup) fold into a **Ledger**.
- Entrances rise in unless the Mac asks for reduced motion. `--ask "…"` asks from a shell; `--tick` reports Desk and brief counts. README updated.

Lane VIII, ~120 changed LOC.

## Smoke evidence

- `swift build -c release` ok (before and after the rebase); local lane VIII gate passed.
- `--snapshot --light` and `--dark` rendered and inspected: command field, empty states with brass engravings, folded ledger, both palettes.
- Live from the built binary against a tenant:
  - `--ask "… what did I ask you about on Slack most recently?"` → `Alfred: You most recently asked me to turn on the office AC.` — memory reached the model; both turns journaled.
  - `--tick` → `desk=100 brief=Morning brief · 2026-09-09` — the Desk and the brief load through the authenticated proxy.
- Installed on the author's Mac from the DMG flow; the running `--mcp` servers were left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)