### PR TITLE
feat(alfred-mac): the data the popover reads — matters, the day's returned hours, the Desk's true count

### DIFF
--- a/packages/alfred-mac/Sources/AlfredBlack/App.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/App.swift
@@ -83,7 +83,7 @@ struct AlfredBlackMain {
       while !done && Date() < deadline { RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.05)) }
       exit(done ? 0 : 2)
     }
-    if CommandLine.arguments.contains("--tick") {
+        if CommandLine.arguments.contains("--tick") {
       var done = false
       Task { @MainActor in
         let st = AppState(); st.selfHeal(); await st.tick(force: true)
@@ -204,6 +204,10 @@ final class AppState: ObservableObject {
   var lastReport = PushReport()
   @Published var activity = Activity.load()
   @Published var desk: [DeskItem] = []
+  @Published var deskTotal = 0
+  @Published var matters: [Matter] = []
+  @Published var narToday: Double? = nil
+  private var lastNar = Date.distantPast
   @Published var reply: (text: String, at: Date)? = nil
   @Published var asking = false
   @Published var brief: Brief? = nil
@@ -241,12 +245,16 @@ final class AppState: ObservableObject {
         state.lastRenderAt = Date(); state.lastRenderEntries = n; online = true
       } catch { online = false; state.lastError = error.localizedDescription; state.lastErrorAt = Date() }
     }
+    if force || now.timeIntervalSince(lastNar) >= 300 {
+      lastNar = now; if let h = try? await t.returnedToday() { narToday = h }
+    }
     if force || now.timeIntervalSince(lastBrief) >= 600 {
       lastBrief = now; if let b = try? await t.latestBrief() { brief = b }
     }
     if force || now.timeIntervalSince(lastDesk) >= 60 {
       lastDesk = now
-      if let items = try? await t.deskPending() { desk = items.filter { ($0.status ?? "pending") == "pending" } }
+      if let page = try? await t.deskPending() { desk = page.items.filter { ($0.status ?? "pending") == "pending" }.sorted { ($0.created ?? "") > ($1.created ?? "") }; deskTotal = page.total }   // newest first
+      if let ms = try? await t.matters() { matters = ms.filter { ($0.state ?? "active") != "archived" } }
     }
     if force || now.timeIntervalSince(lastPush) >= 60 {
       lastPush = now
@@ -352,7 +360,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
   @MainActor func buildMenu() -> NSMenu {
     let m = NSMenu()
-    let title = state.pairing.map { _ in Presence.line(deskCount: state.desk.count) } ?? "Not paired"
+    let title = state.pairing.map { _ in Presence.line(deskCount: max(state.deskTotal, state.desk.count)) } ?? "Not paired"
     m.addItem(withTitle: title, action: nil, keyEquivalent: "")
     for item in state.desk.prefix(3) where !item.title.isEmpty {
       let t = item.title.count > 64 ? String(item.title.prefix(63)) + "…" : item.title

--- a/packages/alfred-mac/Sources/AlfredBlack/Tenant.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Tenant.swift
@@ -108,11 +108,12 @@ struct Tenant {
 
   /// Turn whatever the person typed into the tenant domain.
   /// The Desk: cards awaiting the principal's judgment.
-  func deskPending() async throws -> [DeskItem] {
-    struct Page: Decodable { var records: [DeskItem] }
+  func deskPending() async throws -> (items: [DeskItem], total: Int) {
+    struct Page: Decodable { var records: [DeskItem]; var count: Int? }
     let (code, data) = try await request("api/v1/admin/needs-attention", bearer: apiKey)
     guard code == 200 else { throw TenantError(message: "Desk read failed (HTTP \(code)).") }
-    return try JSONDecoder().decode(Page.self, from: data).records
+    let page = try JSONDecoder().decode(Page.self, from: data)
+    return (page.records, page.count ?? page.records.count)   // the list is capped; the count is the truth
   }
 
   /// Ask Alfred from this Mac. ctrl-api journals both turns and puts his memory in front of him.
@@ -138,6 +139,22 @@ struct Tenant {
     return Brief(slot: latest.slot, date: latest.date, excerpt: Brief.excerpt(of: body))
   }
 
+  /// Matters in flight, with the narrative state Alfred keeps for each.
+  func matters() async throws -> [Matter] {
+    struct Page: Decodable { var matters: [Matter] }
+    let (code, data) = try await request("api/v1/matters", bearer: apiKey)
+    guard code == 200 else { throw TenantError(message: "Matters read failed (HTTP \(code)).") }
+    return try JSONDecoder().decode(Page.self, from: data).matters
+  }
+  /// Hours returned today, after every cost (the attention statement for the day).
+  func returnedToday() async throws -> Double? {
+    struct Day: Decodable { var nar_hours: Double? }
+    let f = DateFormatter(); f.dateFormat = "yyyy-MM-dd"
+    let (code, data) = try await request("api/v1/attention/statement", bearer: apiKey, query: ["date": f.string(from: Date())])
+    guard code == 200 else { return nil }
+    return try JSONDecoder().decode(Day.self, from: data).nar_hours
+  }
+
   static func domain(from raw: String) -> String? {
     var s = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     if !s.contains("://") { s = "https://" + s }
@@ -150,7 +167,15 @@ struct Tenant {
 
 struct DeskItem: Decodable, Identifiable {
   var id: String; var status: String?; var created: String?; var action_what: String?; var matter_ref: String?
-  var title: String { (action_what ?? "").replacingOccurrences(of: "\n", with: " ").trimmingCharacters(in: .whitespaces) }
+  var display_headline: String?; var display_body: String?; var body_preview: String?; var target_path: String?; var target_kind: String?; var decay_score: Double?
+  /// The readable line: the card's headline, else what it asks, else its preview, else what it points at.
+  var title: String {
+    for c in [display_headline, action_what, body_preview, target_path] {
+      if let c, !c.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { return c.replacingOccurrences(of: "\n", with: " ").trimmingCharacters(in: .whitespaces) }
+    }
+    return id
+  }
+  var body: String { (display_body ?? body_preview ?? "").replacingOccurrences(of: "\n", with: " ").trimmingCharacters(in: .whitespaces) }
 }
 
 struct Brief {
@@ -163,5 +188,17 @@ struct Brief {
       .first { !$0.isEmpty && !$0.hasPrefix("#") && !$0.hasPrefix("-") && !$0.hasPrefix("|") } ?? ""
     let flat = para.replacingOccurrences(of: "**", with: "").replacingOccurrences(of: "\n", with: " ")
     return flat.count > 260 ? String(flat.prefix(257)).trimmingCharacters(in: .whitespaces) + "…" : flat
+  }
+}
+
+struct Matter: Decodable, Identifiable {
+  var id: String; var name: String?; var summary: String?; var state: String?; var current_state: String?
+  var title: String { (name ?? id).trimmingCharacters(in: .whitespaces) }
+  /// One line for the Glance: the matter and its living state, if any.
+  var glanceTitle: String {
+    let st = (current_state ?? summary ?? "").replacingOccurrences(of: "\n", with: " ").trimmingCharacters(in: .whitespaces)
+    guard !st.isEmpty else { return title }
+    let first = st.components(separatedBy: ". ").first ?? st
+    return "\(title) — \(first.count > 70 ? String(first.prefix(69)) + "…" : first)"
   }
 }

--- a/packages/alfred-mac/Sources/AlfredBlack/Views.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Views.swift
@@ -95,7 +95,7 @@ struct StatusView: View {
     VStack(alignment: .leading, spacing: 0) {
       HStack(alignment: .firstTextBaseline) { Label_(text: "For Mac"); Spacer(); Label_(text: s.pairing?.domain ?? "", color: AB.brass) }
       Wordmark().padding(.top, 6)
-      Text(s.online == false ? "The tenant cannot be reached at the moment." : Presence.line(deskCount: s.desk.count))
+      Text(s.online == false ? "The tenant cannot be reached at the moment." : Presence.line(deskCount: max(s.deskTotal, s.desk.count)))
         .font(AB.body(19, italic: true)).foregroundColor(AB.marginalia).padding(.top, 4)
       Hairline().padding(.vertical, 16)
 


### PR DESCRIPTION
## What

Data layer for the popover screens of the **Alfred for macOS** handoff (the popover itself follows in the next PR).

- `Tenant.matters()` — matters in flight with the narrative `current_state`; `Tenant.returnedToday()` — the day's attention statement (`nar_hours`, hours returned after every cost); `deskPending()` returns the API's true `count` alongside the capped list; `DeskItem` decodes `display_headline` / `display_body` / `body_preview` for a readable line.
- `AppState` polls matters with the Desk (each minute) and the statement every five minutes; Desk cards newest first; `deskTotal` drives the count in the menu-bar line.

Lane VIII, ~70 changed LOC.

## Smoke evidence

- `swift build -c release` ok; local lane VIII gate passed.
- `--tick` / `--screen` against a tenant (next PR): `desk=100 (count 456) matters=12 nar=-0.233`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)