### PR TITLE
feat(alfred-mac): the popover, and 01 · The Glance

### DIFF
--- a/packages/alfred-mac/Sources/AlfredBlack/App.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/App.swift
@@ -83,7 +83,23 @@ struct AlfredBlackMain {
       while !done && Date() < deadline { RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.05)) }
       exit(done ? 0 : 2)
     }
-        if CommandLine.arguments.contains("--tick") {
+    if let i = CommandLine.arguments.firstIndex(of: "--screen"), CommandLine.arguments.count > i + 2 {
+      let dir = URL(fileURLWithPath: CommandLine.arguments[i + 2]); try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+      _ = NSApplication.shared; AB.registerFonts(); NSApp.appearance = NSAppearance(named: .darkAqua)
+      var done = false
+      Task { @MainActor in
+        let st = AppState(); await st.tick(force: true)
+        switch CommandLine.arguments[i + 1] { default: st.screen = .glance }
+        let host = NSHostingView(rootView: PopoverView().environmentObject(st))
+        host.frame = NSRect(x: 0, y: 0, width: T.popoverWidth, height: host.fittingSize.height); host.layoutSubtreeIfNeeded()
+        if let rep = host.bitmapImageRepForCachingDisplay(in: host.bounds) { host.cacheDisplay(in: host.bounds, to: rep); try? rep.representation(using: .png, properties: [:])?.write(to: dir.appendingPathComponent("screen-\(CommandLine.arguments[i + 1]).png")) }
+        print("screen: \(CommandLine.arguments[i + 1]) \(Int(host.bounds.height))pt desk=\(st.desk.count) matters=\(st.matters.count) nar=\(st.narToday.map { String($0) } ?? "-")"); done = true
+      }
+      let deadline = Date().addingTimeInterval(120)
+      while !done && Date() < deadline { RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.05)) }
+      exit(done ? 0 : 2)
+    }
+    if CommandLine.arguments.contains("--tick") {
       var done = false
       Task { @MainActor in
         let st = AppState(); st.selfHeal(); await st.tick(force: true)
@@ -207,7 +223,9 @@ final class AppState: ObservableObject {
   @Published var deskTotal = 0
   @Published var matters: [Matter] = []
   @Published var narToday: Double? = nil
+  @Published var screen: Screen = .glance
   private var lastNar = Date.distantPast
+  func open(_ sc: Screen) { screen = sc }
   @Published var reply: (text: String, at: Date)? = nil
   @Published var asking = false
   @Published var brief: Brief? = nil
@@ -285,6 +303,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   let state = AppState()
   var statusItem: NSStatusItem!
   var window: NSWindow?
+  let popover: NSPopover = { let p = NSPopover(); p.behavior = .transient; p.animates = true; p.appearance = NSAppearance(named: .darkAqua); return p }()
   var timer: Timer?
 
   func applicationDidFinishLaunching(_ n: Notification) {
@@ -294,14 +313,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
     refreshPresence()
     statusItem.button?.toolTip = "Alfred Black"
-    statusItem.menu = buildMenu()
+    statusItem.button?.target = self; statusItem.button?.action = #selector(markClicked); statusItem.button?.sendAction(on: [.leftMouseUp, .rightMouseUp])
+    popover.contentViewController = NSHostingController(rootView: PopoverView().environmentObject(state))
     state.selfHeal()
     if state.pairing == nil || !Self.launchedAsLoginItem() { showWindow() }
     timer = Timer.scheduledTimer(withTimeInterval: 10, repeats: true) { [weak self] _ in
       guard let self else { return }
-      Task { @MainActor in await self.state.tick(); self.statusItem.menu = self.buildMenu(); self.refreshPresence() }
+      Task { @MainActor in await self.state.tick(); self.refreshPresence() }
     }
-    Task { @MainActor in await state.tick(force: true); statusItem.menu = buildMenu() }
+    Task { @MainActor in await state.tick(force: true); refreshPresence() }
   }
 
   /// Launched from a mounted disk image (or anywhere read-only), the app would
@@ -386,6 +406,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   static func ago(_ d: Date) -> String {
     let s = Int(Date().timeIntervalSince(d))
     if s < 60 { return "\(s)s ago" }; if s < 3600 { return "\(s/60)m ago" }; return "\(s/3600)h ago"
+  }
+
+  /// Left click: the popover. Right click: the utility menu.
+
+  @objc func markClicked() {
+
+    guard let button = statusItem.button else { return }
+
+    if NSApp.currentEvent?.type == .rightMouseUp || state.pairing == nil {
+
+      if state.pairing == nil { showWindow(); return }
+
+      statusItem.menu = buildMenu(); button.performClick(nil); statusItem.menu = nil; return
+
+    }
+
+    if popover.isShown { popover.performClose(nil) }
+
+    else { state.screen = .glance; popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY); popover.contentViewController?.view.window?.makeKey() }
+
   }
 
   @objc func openWindow() { showWindow() }

--- a/packages/alfred-mac/Sources/AlfredBlack/Popover.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Popover.swift
@@ -1,0 +1,54 @@
+// 01 · The Glance — click the mark. One popover that swaps content; the
+// silent state is the default state, and every screen renders meaningfully
+// with zero items.
+import SwiftUI
+import AppKit
+
+enum Screen { case glance, brief, matters, yourWord, ledger, vault, arrangement }
+
+struct PopoverView: View {
+  @EnvironmentObject var s: AppState
+  var body: some View {
+    ZStack { T.bg
+      switch s.screen {
+      default: GlanceView()
+      }
+    }
+    .frame(width: T.popoverWidth)
+    .animation(.easeInOut(duration: 0.15), value: s.screen)
+  }
+}
+
+struct GlanceView: View {
+  @EnvironmentObject var s: AppState
+  private var greeting: String {
+    let h = Calendar.current.component(.hour, from: Date())
+    return h < 12 ? "Good morning" : h < 18 ? "Good afternoon" : "Good evening"
+  }
+  private var line: String {
+    let n = max(s.deskTotal, s.desk.count)
+    if n == 0 { return "\(greeting), \(T.honorific). The desk is quiet — «nothing needs your word.»" }
+    if n == 1 { return "\(greeting), \(T.honorific). The desk is quiet — «one matter needs your word.»" }
+    return "\(greeting), \(T.honorific). «\(n) matters need your word.»"
+  }
+  private var returned: String {
+    guard let h = s.narToday else { return "Today · in hand" }
+    return h > 0.05 ? String(format: "Today · %.1f h returned", h) : String(format: "Today · net %.1f h", h)
+  }
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      Say(text: line).padding(.horizontal, 18).padding(.top, 20).padding(.bottom, 16)
+      ForEach(Array(s.desk.prefix(3))) { item in
+        PopRow(title: item.title, meta: "Your word", needsWord: true) { s.open(.yourWord) }
+      }
+      ForEach(Array(s.matters.prefix(max(0, 3 - min(3, s.desk.count))))) { m in
+        PopRow(title: m.glanceTitle, meta: m.state == "done" ? "Done" : "In hand")
+      }
+      HStack {
+        Meta(text: returned, tracking: 1.8)
+        Spacer()
+        Keycap(text: "⌘⇧A  ASK")
+      }.padding(.horizontal, 18).padding(.vertical, 11)
+    }
+  }
+}

--- a/packages/alfred-mac/Sources/AlfredBlack/Tokens.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Tokens.swift
@@ -1,0 +1,88 @@
+// The macOS app's own language, from the "Alfred for macOS" handoff: a dark
+// wool ground, ivory ink, one brass accent, hairlines at 13–22% ivory; radii
+// 13 (popover) · 14 (command bar) · 12 (window) · 6 (button). Alfred speaks
+// in italic display serif; labels are mono, all caps, widely tracked.
+import SwiftUI
+import AppKit
+
+enum T {
+  static let bg    = Color(nsColor: AB.hex(0x1C1A17))   // oklch(0.17 0.005 60)
+  static let bg2   = Color(nsColor: AB.hex(0x262320))
+  static let bg3   = Color(nsColor: AB.hex(0x2F2B27))
+  static let ink   = Color(nsColor: AB.hex(0xF0EADE))   // oklch(0.94 0.012 80)
+  static let dim   = Color(nsColor: AB.hex(0xA49D8F))
+  static let brass = Color(nsColor: AB.hex(0xB08D57))   // oklch(0.62 0.09 75)
+  static let hair  = Color(nsColor: AB.hex(0xF0EADE, 0.13))
+  static let hair2 = Color(nsColor: AB.hex(0xF0EADE, 0.22))
+  static let popoverWidth: CGFloat = 344
+  static let rPopover: CGFloat = 13, rBar: CGFloat = 14, rWindow: CGFloat = 12, rButton: CGFloat = 6
+  static let honorific = "sir"   // a per-user setting later; keep the string in one place
+
+  /// Alfred's voice — display serif, italic.
+  static func say(_ size: CGFloat = 15.5) -> Font { Font.custom("PlayfairDisplay-Italic", size: size) }
+  static func title(_ size: CGFloat = 26) -> Font { Font.custom("PlayfairDisplayRoman-SemiBold", size: size) }
+  static func body(_ size: CGFloat = 14, italic: Bool = false) -> Font { Font.custom(italic ? "EBGaramond-Italic" : "EBGaramond-Regular", size: size) }
+  static func mono(_ size: CGFloat = 9, weight: Font.Weight = .bold) -> Font { Font.custom("JetBrains Mono", size: size).weight(weight) }
+}
+
+/// Mono microlabel: 9px w800, 0.24em tracking, uppercase.
+struct Meta: View {
+  let text: String; var color: Color = T.dim; var size: CGFloat = 9; var tracking: CGFloat = 2.2
+  var body: some View { Text(text.uppercased()).font(T.mono(size, weight: .heavy)).tracking(tracking).foregroundColor(color).lineLimit(1) }
+}
+
+/// A keycap hint: mono 9px in a 1px hairline chip.
+struct Keycap: View {
+  let text: String
+  var body: some View {
+    Text(text).font(T.mono(9, weight: .bold)).tracking(0.9).foregroundColor(T.dim)
+      .padding(.horizontal, 6).padding(.vertical, 2)
+      .overlay(RoundedRectangle(cornerRadius: 4).stroke(T.hair2, lineWidth: 1))
+  }
+}
+
+/// Alfred's line, with the clause that matters in brass. Mark the brass part with «…».
+struct Say: View {
+  let text: String; var size: CGFloat = 15.5
+  var body: some View {
+    let parts = text.components(separatedBy: "«")
+    var t = Text(parts[0]).foregroundColor(T.ink)
+    if parts.count > 1 {
+      let rest = parts[1].components(separatedBy: "»")
+      t = t + Text(rest[0]).foregroundColor(T.brass)
+      if rest.count > 1 { t = t + Text(rest[1]).foregroundColor(T.ink) }
+    }
+    return t.font(T.say(size)).lineSpacing(size * 0.45 - 4).fixedSize(horizontal: false, vertical: true)
+  }
+}
+
+/// One popover row: dot · title (body 14) · meta. Filled brass dot = needs the principal; hollow = in hand.
+struct PopRow: View {
+  let title: String; let meta: String; var needsWord = false; var metaBrass = false; var action: (() -> Void)? = nil
+  @State private var hover = false
+  var body: some View {
+    Button(action: { action?() }) {
+      HStack(alignment: .firstTextBaseline, spacing: 12) {
+        Circle().fill(needsWord ? T.brass : Color.clear).overlay(Circle().stroke(needsWord ? Color.clear : T.dim, lineWidth: 1)).frame(width: 6, height: 6).alignmentGuide(.firstTextBaseline) { d in d[VerticalAlignment.center] + 4 }
+        Text(title).font(T.body(14)).foregroundColor(T.ink).lineSpacing(3).fixedSize(horizontal: false, vertical: true).frame(maxWidth: .infinity, alignment: .leading)
+        Meta(text: meta, color: (needsWord || metaBrass) ? T.brass : T.dim, size: 8.5, tracking: 1.4)
+      }
+      .padding(.horizontal, 18).padding(.vertical, 12).contentShape(Rectangle())
+      .background(hover ? T.bg2 : Color.clear)
+    }.buttonStyle(.plain).onHover { hover = $0 }
+    Rectangle().fill(T.hair).frame(height: 1)
+  }
+}
+
+/// A ghost or brass button, mono 9px w800, 0.2em tracking, 6px radius.
+struct PopButton: ButtonStyle {
+  var primary = false
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label.font(T.mono(9, weight: .heavy)).tracking(1.8).textCase(.uppercase)
+      .padding(.horizontal, 16).padding(.vertical, 9)
+      .foregroundColor(primary ? T.bg : T.ink)
+      .background(RoundedRectangle(cornerRadius: T.rButton).fill(primary ? T.brass : Color.clear))
+      .overlay(RoundedRectangle(cornerRadius: T.rButton).stroke(primary ? T.brass : T.hair2, lineWidth: 1))
+      .opacity(configuration.isPressed ? 0.8 : 1)
+  }
+}


### PR DESCRIPTION
## What

Second slice against the **Alfred for macOS** handoff (data layer in #739).

- **No main window.** Left click on the mark opens one 344 pt `NSPopover` (dark appearance, transient) whose content swaps by screen; right click shows the utility menu.
- **Tokens** (`Tokens.swift`): the app's own language — `--bg/bg2/bg3/ink/dim/brass/hair/hair2`, radii 13/14/12/6, Alfred's voice in italic display serif, mono metas; components `Say` (brass clause), `PopRow` (filled brass dot = needs your word, hollow = in hand), `Meta`, `Keycap`, `PopButton`.
- **01 · The Glance**: greeting by time of day, the Desk's true count, up to three rows — needs-you first (newest cards, readable headline), then matters in flight — and the footer: `TODAY · X.X H RETURNED` from the day's attention statement (`NET −X.X H` while the day has not turned) + `⌘⇧A ASK`.
- `--screen glance <dir>` renders the screen with live data.

Lane VIII, 190 changed LOC.

## Smoke evidence

- `swift build -c release` ok before and after the rebase; local lane VIII gate passed.
- `--screen glance` rendered against a tenant and inspected: three real cards with headlines and brass dots, the net footer, the keycap (holds personal data; not attached).
- Installed on the author's Mac: the mark, the dot, the popover on click, the utility menu on right click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)