### PR TITLE
feat(alfred-mac): 05/06 · The Ask — ⌘⇧A anywhere, one field, Alfred answers before you finish

### DIFF
--- a/packages/alfred-mac/Sources/AlfredBlack/App.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/App.swift
@@ -89,9 +89,11 @@ struct AlfredBlackMain {
       var done = false
       Task { @MainActor in
         let st = AppState(); await st.tick(force: true)
-        switch CommandLine.arguments[i + 1] { default: st.screen = .glance }
-        let host = NSHostingView(rootView: PopoverView().environmentObject(st))
-        host.frame = NSRect(x: 0, y: 0, width: T.popoverWidth, height: host.fittingSize.height); host.layoutSubtreeIfNeeded()
+        let name = CommandLine.arguments[i + 1]
+        if let r = CommandLine.arguments.firstIndex(of: "--reply"), CommandLine.arguments.count > r + 1 { st.askReply = CommandLine.arguments[r + 1] }
+        let host: NSHostingView<AnyView> = name == "ask" ? NSHostingView(rootView: AnyView(AskView().environmentObject(st))) : NSHostingView(rootView: AnyView(PopoverView().environmentObject(st)))
+        let w: CGFloat = name == "ask" ? 620 : T.popoverWidth
+        host.frame = NSRect(x: 0, y: 0, width: w, height: host.fittingSize.height); host.layoutSubtreeIfNeeded()
         if let rep = host.bitmapImageRepForCachingDisplay(in: host.bounds) { host.cacheDisplay(in: host.bounds, to: rep); try? rep.representation(using: .png, properties: [:])?.write(to: dir.appendingPathComponent("screen-\(CommandLine.arguments[i + 1]).png")) }
         print("screen: \(CommandLine.arguments[i + 1]) \(Int(host.bounds.height))pt desk=\(st.desk.count) matters=\(st.matters.count) nar=\(st.narToday.map { String($0) } ?? "-")"); done = true
       }
@@ -191,6 +193,60 @@ final class AppState: ObservableObject {
   }
 
 
+  /// The Ask, step one: Alfred says what he would do — before doing it.
+
+
+  func propose(_ text: String) async {
+
+
+    let q = text.trimmingCharacters(in: .whitespacesAndNewlines); guard !q.isEmpty, !asking, let t = tenant else { return }
+
+
+    asking = true; defer { asking = false }
+
+
+    let framed = "\(T.honorific.capitalized) asks: «\(q)». Before acting, say in one short paragraph what you would do and any specifics you can see — then wait for his word. Do not act yet."
+
+
+    do { askReply = try await t.ask(framed, chatId: Store.deviceId()) } catch { record(error) }
+
+
+  }
+
+
+  /// Step two: his word. The panel closes silently; the matter appears in flight.
+
+
+  func soOrdered(withoutRead: Bool) {
+
+
+    guard let t = tenant else { return }
+
+
+    let word = withoutRead ? "So ordered — send without my read." : "So ordered."
+
+
+    dismissAsk(); Task { _ = try? await t.ask(word, chatId: Store.deviceId()) }
+
+
+  }
+
+
+  func dismissAsk() { askReply = nil; askPanel?.orderOut(nil) }
+
+
+  func toggleAsk() {
+
+
+    if askPanel == nil { askPanel = AskPanel(state: self) }
+
+
+    if askPanel?.isVisible == true { dismissAsk() } else { askReply = nil; askPanel?.present() }
+
+
+  }
+
+
   /// One question, one reply, both remembered on every other surface.
 
 
@@ -228,6 +284,8 @@ final class AppState: ObservableObject {
   func open(_ sc: Screen) { screen = sc }
   @Published var reply: (text: String, at: Date)? = nil
   @Published var asking = false
+  @Published var askReply: String? = nil
+  var askPanel: AskPanel? = nil
   @Published var brief: Brief? = nil
   private var lastBrief = Date.distantPast
   private var lastDesk = Date.distantPast
@@ -316,6 +374,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     statusItem.button?.target = self; statusItem.button?.action = #selector(markClicked); statusItem.button?.sendAction(on: [.leftMouseUp, .rightMouseUp])
     popover.contentViewController = NSHostingController(rootView: PopoverView().environmentObject(state))
     state.selfHeal()
+    HotKey.onPress = { [weak self] in self?.state.toggleAsk() }; HotKey.register()
     if state.pairing == nil || !Self.launchedAsLoginItem() { showWindow() }
     timer = Timer.scheduledTimer(withTimeInterval: 10, repeats: true) { [weak self] _ in
       guard let self else { return }
@@ -396,6 +455,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       m.addItem(withTitle: p, action: nil, keyEquivalent: "")
     }
     m.addItem(.separator())
+    m.addItem(withTitle: "Ask Alfred…", action: #selector(askAlfred), keyEquivalent: "").target = self
     m.addItem(withTitle: "Open Alfred Black…", action: #selector(openWindow), keyEquivalent: "o").target = self
     m.addItem(withTitle: "Reveal Alfred folder", action: #selector(revealFolder), keyEquivalent: "").target = self
     m.addItem(.separator())
@@ -427,6 +487,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     else { state.screen = .glance; popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY); popover.contentViewController?.view.window?.makeKey() }
 
   }
+
+  @objc func askAlfred() { state.toggleAsk() }
 
   @objc func openWindow() { showWindow() }
 

--- a/packages/alfred-mac/Sources/AlfredBlack/Ask.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Ask.swift
@@ -1,0 +1,75 @@
+// 05 · The Ask — ⌘⇧A anywhere. One field, no tabs, no modes: Alfred sorts
+// intent. He answers beneath a hairline with what he will do; ⏎ is "so
+// ordered", ⇧⏎ sends without a read, ESC is never mind. On ⏎ the panel
+// closes silently and the matter appears among those in flight.
+import SwiftUI
+import AppKit
+import Carbon.HIToolbox
+
+final class AskPanel: NSPanel {
+  init(state: AppState) {
+    super.init(contentRect: NSRect(x: 0, y: 0, width: 620, height: 64), styleMask: [.borderless, .nonactivatingPanel], backing: .buffered, defer: false)
+    isFloatingPanel = true; level = .floating; collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+    backgroundColor = .clear; isOpaque = false; hasShadow = true; isMovableByWindowBackground = true
+    appearance = NSAppearance(named: .darkAqua); hidesOnDeactivate = false; isReleasedWhenClosed = false
+    contentViewController = NSHostingController(rootView: AskView().environmentObject(state))
+  }
+  override var canBecomeKey: Bool { true }
+  /// Upper third of the screen the mouse is on, centred.
+  func present() {
+    guard let screen = NSScreen.screens.first(where: { NSMouseInRect(NSEvent.mouseLocation, $0.frame, false) }) ?? NSScreen.main else { return }
+    let f = screen.visibleFrame; let h = contentView?.fittingSize.height ?? 64
+    setFrame(NSRect(x: f.midX - 310, y: f.minY + f.height * 0.62, width: 620, height: h), display: true)
+    makeKeyAndOrderFront(nil); NSApp.activate(ignoringOtherApps: true)
+  }
+}
+
+struct AskView: View {
+  @EnvironmentObject var s: AppState
+  @State private var text = ""
+  @FocusState private var focused: Bool
+  private var reduceMotion: Bool { NSWorkspace.shared.accessibilityDisplayShouldReduceMotion }
+  var body: some View {
+    VStack(spacing: 0) {
+      HStack(spacing: 14) {
+        if let m = Brand.image("logo-brass.svg") { Image(nsImage: m).resizable().aspectRatio(contentMode: .fit).frame(height: 22) }
+        TextField("What can I take off your desk, \(T.honorific)?", text: $text).textFieldStyle(.plain)
+          .font(T.say(19)).foregroundColor(T.ink).focused($focused).disabled(s.asking)
+          .onSubmit { submit(withoutRead: NSEvent.modifierFlags.contains(.shift)) }
+        if s.asking { Meta(text: "one moment", color: T.dim) } else { Keycap(text: "ESC") }
+      }.padding(.horizontal, 22).padding(.vertical, 18)
+      if let r = s.askReply {
+        Rectangle().fill(T.hair).frame(height: 1).padding(.horizontal, 22)
+        Say(text: r, size: 16).padding(.horizontal, 22).padding(.top, 16)
+        HStack(spacing: 22) {
+          Meta(text: "⏎ so ordered", color: T.brass, tracking: 1.8)
+          Meta(text: "⇧⏎ send without read", tracking: 1.8)
+          Meta(text: "esc never mind", tracking: 1.8)
+        }.padding(.horizontal, 22).padding(.top, 14).padding(.bottom, 18)
+      }
+    }
+    .frame(width: 620)
+    .background(RoundedRectangle(cornerRadius: T.rBar).fill(T.bg))
+    .overlay(RoundedRectangle(cornerRadius: T.rBar).stroke(T.hair2, lineWidth: 1))
+    .onAppear { focused = true }
+    .onExitCommand { s.dismissAsk() }
+    .animation(reduceMotion ? nil : .easeOut(duration: 0.15), value: s.askReply)
+  }
+  private func submit(withoutRead: Bool) {
+    if s.askReply != nil { s.soOrdered(withoutRead: withoutRead); return }   // ⏎ on the answer executes
+    let q = text; text = ""; guard !q.trimmingCharacters(in: .whitespaces).isEmpty else { return }
+    Task { await s.propose(q) }
+  }
+}
+
+/// ⌘⇧A, system-wide, without accessibility permission (Carbon hot keys).
+enum HotKey {
+  private static var ref: EventHotKeyRef?
+  static var onPress: (() -> Void)?
+  static func register() {
+    var id = EventHotKeyID(signature: OSType(0x414C4652), id: 1)   // "ALFR"
+    RegisterEventHotKey(UInt32(kVK_ANSI_A), UInt32(cmdKey | shiftKey), id, GetApplicationEventTarget(), 0, &ref)
+    var spec = EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed))
+    InstallEventHandler(GetApplicationEventTarget(), { _, _, _ in HotKey.onPress?(); return noErr }, 1, &spec, nil, nil)
+  }
+}


### PR DESCRIPTION
## What

Third slice against the **Alfred for macOS** handoff.

- A floating 620 pt panel on any Space (`NSPanel`, non-activating, floating, `canJoinAllSpaces`), summoned by a system-wide **⌘⇧A** — a Carbon hot key, so no accessibility permission — dismissed by ESC. The brass mark, "What can I take off your desk, sir?" in Alfred's italic, one field, no modes.
- **Two steps, so Alfred asks first.** ⏎ sends the request framed as *say what you would do — do not act yet*; his answer appears beneath a hairline with the clause that matters in brass, above `⏎ SO ORDERED · ⇧⏎ SEND WITHOUT READ · ESC NEVER MIND`. ⏎ again sends "So ordered." (⇧⏎ "send without my read") in the same per-device session and the panel closes silently; both turns are journaled, so every surface remembers.
- Also reachable from the utility menu. `--screen ask <dir> [--reply "…"]` renders the empty and the answered bar.

Lane VIII, 143 changed LOC.

## Smoke evidence

- `swift build -c release` ok before and after the rebase; local lane VIII gate passed.
- `--screen ask` renders inspected: the empty bar (mark, italic placeholder, ESC keycap) and the answered bar (hairline, brass clause, the three keys).
- The ask route itself was proven live from this binary earlier (`--ask` → an answer from memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)