### PR TITLE
feat(alfred-mac): 02 · The Brief — mornings, in the same popover, until read

### DIFF
--- a/packages/alfred-mac/Sources/AlfredBlack/App.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/App.swift
@@ -90,6 +90,7 @@ struct AlfredBlackMain {
       Task { @MainActor in
         let st = AppState(); await st.tick(force: true)
         let name = CommandLine.arguments[i + 1]
+        st.screen = ["brief": Screen.brief, "matters": .matters, "yourword": .yourWord, "ledger": .ledger, "vault": .vault, "arrangement": .arrangement][name] ?? .glance
         if let r = CommandLine.arguments.firstIndex(of: "--reply"), CommandLine.arguments.count > r + 1 { st.askReply = CommandLine.arguments[r + 1] }
         let host: NSHostingView<AnyView> = name == "ask" ? NSHostingView(rootView: AnyView(AskView().environmentObject(st))) : NSHostingView(rootView: AnyView(PopoverView().environmentObject(st)))
         let w: CGFloat = name == "ask" ? 620 : T.popoverWidth
@@ -282,6 +283,9 @@ final class AppState: ObservableObject {
   @Published var screen: Screen = .glance
   private var lastNar = Date.distantPast
   func open(_ sc: Screen) { screen = sc }
+  /// Priority when the popover opens: an unread brief of the day, else the Glance.
+  func popoverOpened() { screen = (brief.map { $0.isToday && state.briefReadSlug != $0.slug_date } ?? false) ? .brief : .glance }
+  func popoverClosed() { if screen == .brief, let b = brief { state.briefReadSlug = b.slug_date }; screen = .glance }
   @Published var reply: (text: String, at: Date)? = nil
   @Published var asking = false
   @Published var askReply: String? = nil
@@ -357,7 +361,8 @@ final class AppState: ObservableObject {
 }
 
 @MainActor
-final class AppDelegate: NSObject, NSApplicationDelegate {
+final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
+  func popoverDidClose(_ n: Notification) { state.popoverClosed() }
   let state = AppState()
   var statusItem: NSStatusItem!
   var window: NSWindow?
@@ -372,7 +377,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     refreshPresence()
     statusItem.button?.toolTip = "Alfred Black"
     statusItem.button?.target = self; statusItem.button?.action = #selector(markClicked); statusItem.button?.sendAction(on: [.leftMouseUp, .rightMouseUp])
-    popover.contentViewController = NSHostingController(rootView: PopoverView().environmentObject(state))
+    popover.contentViewController = NSHostingController(rootView: PopoverView().environmentObject(state)); popover.delegate = self
     state.selfHeal()
     HotKey.onPress = { [weak self] in self?.state.toggleAsk() }; HotKey.register()
     if state.pairing == nil || !Self.launchedAsLoginItem() { showWindow() }
@@ -484,7 +489,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     if popover.isShown { popover.performClose(nil) }
 
-    else { state.screen = .glance; popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY); popover.contentViewController?.view.window?.makeKey() }
+    else { state.popoverOpened(); popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY); popover.contentViewController?.view.window?.makeKey() }
 
   }
 

--- a/packages/alfred-mac/Sources/AlfredBlack/Popover.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Popover.swift
@@ -11,6 +11,7 @@ struct PopoverView: View {
   var body: some View {
     ZStack { T.bg
       switch s.screen {
+      case .brief: BriefView()
       default: GlanceView()
       }
     }
@@ -49,6 +50,32 @@ struct GlanceView: View {
         Spacer()
         Keycap(text: "⌘⇧A  ASK")
       }.padding(.horizontal, 18).padding(.vertical, 11)
+    }
+  }
+}
+
+/// 02 · The Brief — mornings, in the same popover, until read.
+struct BriefView: View {
+  @EnvironmentObject var s: AppState
+  private func openBrief() { if let d = s.pairing?.domain, let u = URL(string: "https://\(d)/brief") { NSWorkspace.shared.open(u) } }
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      HStack { Meta(text: s.brief?.header ?? "The Brief", color: T.brass); Spacer(); Meta(text: s.brief?.composedTime ?? "") }
+        .padding(.horizontal, 18).padding(.top, 15).padding(.bottom, 13)
+      Rectangle().fill(T.hair).frame(height: 1)
+      if let b = s.brief {
+        let items = b.items
+        Say(text: b.excerpt.isEmpty ? "Nothing pressing today, \(T.honorific). «Everything is in hand.»" : b.excerpt).padding(.horizontal, 18).padding(.top, 18).padding(.bottom, 16)
+        ForEach(Array(items.enumerated()), id: \.offset) { i, line in
+          let dl = Brief.deadline(in: line)
+          PopRow(title: line, meta: dl ?? (i == 0 ? "First" : "In hand"), needsWord: i == 0, metaBrass: dl != nil) { openBrief() }
+        }
+      } else {
+        Say(text: "No brief has been composed yet, \(T.honorific).").padding(.horizontal, 18).padding(.vertical, 18)
+      }
+      HStack { Meta(text: "Everything else is in hand", tracking: 1.8); Spacer()
+        Button(action: openBrief) { Keycap(text: "RETURN  OPEN") }.buttonStyle(.plain) }
+        .padding(.horizontal, 18).padding(.vertical, 11)
     }
   }
 }

--- a/packages/alfred-mac/Sources/AlfredBlack/Store.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Store.swift
@@ -14,6 +14,7 @@ struct Pairing: Codable, Equatable {
 struct RunState: Codable {
   var pushedUUIDs: Set<String> = []
   var boundSessions: Set<String> = []
+  var briefReadSlug: String? = nil
   var lastRenderAt: Date?
   var lastRenderEntries: Int = 0
   var lastPushAt: Date?

--- a/packages/alfred-mac/Sources/AlfredBlack/Tenant.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Tenant.swift
@@ -128,7 +128,7 @@ struct Tenant {
 
   /// The most recent brief: its slot, date, and a short excerpt of the body.
   func latestBrief() async throws -> Brief? {
-    struct Item: Decodable { var slug_date: String; var slot: String; var date: String }
+    struct Item: Decodable { var slug_date: String; var slot: String; var date: String; var composed_at: String? }
     struct List: Decodable { var briefings: [Item] }
     struct Detail: Decodable { var body: String }
     let (code, data) = try await request("api/v1/briefings", bearer: apiKey)
@@ -136,7 +136,7 @@ struct Tenant {
     let (c2, d2) = try await request("api/v1/briefings/\(latest.slug_date)", bearer: apiKey)
     guard c2 == 200 else { return nil }
     let body = try JSONDecoder().decode(Detail.self, from: d2).body
-    return Brief(slot: latest.slot, date: latest.date, excerpt: Brief.excerpt(of: body))
+    return Brief(slot: latest.slot, date: latest.date, slug_date: latest.slug_date, composed_at: latest.composed_at, excerpt: Brief.excerpt(of: body), items: Brief.items(of: body))
   }
 
   /// Matters in flight, with the narrative state Alfred keeps for each.
@@ -179,8 +179,38 @@ struct DeskItem: Decodable, Identifiable {
 }
 
 struct Brief {
-  var slot: String; var date: String; var excerpt: String
+  var slot: String; var date: String; var slug_date: String = ""; var composed_at: String? = nil; var excerpt: String; var items: [String] = []
   var title: String { "\(slot.prefix(1).uppercased() + slot.dropFirst()) brief · \(date)" }
+  /// "THE BRIEF · TUE 9 SEP" and the time it was composed.
+  var header: String {
+    let f = DateFormatter(); f.dateFormat = "yyyy-MM-dd"; let o = DateFormatter(); o.dateFormat = "EEE d MMM"
+    return "The Brief · " + (f.date(from: date).map { o.string(from: $0) } ?? date)
+  }
+  var composedTime: String {
+    guard let c = composed_at, let d = ISO8601DateFormatter().date(from: c) ?? { let f = ISO8601DateFormatter(); f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]; return f.date(from: c) }() else { return slot == "morning" ? "07:00" : "19:00" }
+    let t = DateFormatter(); t.dateFormat = "HH:mm"; return t.string(from: d)
+  }
+  var isToday: Bool { let f = DateFormatter(); f.dateFormat = "yyyy-MM-dd"; return f.string(from: Date()) == date }
+  /// The brief's bullet lines, markdown stripped, at most three.
+  static func items(of body: String) -> [String] {
+    let text = body.range(of: "\n---\n").map { String(body[$0.upperBound...]) } ?? body
+    var out: [String] = []
+    for raw in text.components(separatedBy: "\n") {
+      let line = raw.trimmingCharacters(in: .whitespaces)
+      guard line.hasPrefix("- ") || line.hasPrefix("* ") || line.hasPrefix("• ") else { continue }
+      var t = String(line.dropFirst(2)).replacingOccurrences(of: "**", with: "")
+      t = t.replacingOccurrences(of: #"\[([^\]]+)\]\([^)]*\)"#, with: "$1", options: .regularExpression)
+      if !t.isEmpty && !out.contains(t) { out.append(t) }
+      if out.count == 3 { break }
+    }
+    return out
+  }
+  /// A deadline the line names, as its meta — else nothing.
+  static func deadline(in line: String) -> String? {
+    let re = try! NSRegularExpression(pattern: #"\b(noon|tonight|today|tomorrow|this (?:morning|evening|week)|by (?:mon|tue|wed|thu|fri|sat|sun)\w*|\d{1,2}:\d{2})\b"#, options: .caseInsensitive)
+    guard let m = re.firstMatch(in: line, range: NSRange(line.startIndex..., in: line)), let r = Range(m.range, in: line) else { return nil }
+    return String(line[r])
+  }
   /// First paragraph of prose after the heading, prose only, capped.
   static func excerpt(of body: String) -> String {
     let text = body.range(of: "\n---\n").map { String(body[$0.upperBound...]) } ?? body   // skip frontmatter if present


### PR DESCRIPTION
## What

Fourth slice against the **Alfred for macOS** handoff.

- The tenant's latest brief in the popover: header in brass ("The Brief · Wed 9 Sep") with the time composed; its intro paragraph as Alfred's line; its first three bullets as rows — the first with the brass dot, a deadline the line names as its meta, the rest in hand; footer "Everything else is in hand" + a keycap that opens the brief.
- An unread brief of the day is what the popover opens on; closing it marks it read (per brief, in `state.json`) and the Glance returns. `--screen brief <dir>` renders it.

Lane VIII, 75 changed LOC.

## Smoke evidence

- `swift build -c release` ok before and after the rebase; local lane VIII gate passed.
- `--screen brief` rendered against a tenant with this morning's real brief and inspected (holds personal data; not attached).

🤖 Generated with [Claude Code](https://claude.com/claude-code)