### PR TITLE
feat(alfred-mac): 03 · Matters — work in flight

### DIFF
--- a/packages/alfred-mac/Sources/AlfredBlack/App.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/App.swift
@@ -280,6 +280,7 @@ final class AppState: ObservableObject {
   @Published var deskTotal = 0
   @Published var matters: [Matter] = []
   @Published var narToday: Double? = nil
+  @Published var trust = 3
   @Published var screen: Screen = .glance
   private var lastNar = Date.distantPast
   func open(_ sc: Screen) { screen = sc }
@@ -327,6 +328,7 @@ final class AppState: ObservableObject {
     }
     if force || now.timeIntervalSince(lastNar) >= 300 {
       lastNar = now; if let h = try? await t.returnedToday() { narToday = h }
+      if let c = try? await t.trustClass() { trust = c }
     }
     if force || now.timeIntervalSince(lastBrief) >= 600 {
       lastBrief = now; if let b = try? await t.latestBrief() { brief = b }

--- a/packages/alfred-mac/Sources/AlfredBlack/Popover.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Popover.swift
@@ -12,6 +12,7 @@ struct PopoverView: View {
     ZStack { T.bg
       switch s.screen {
       case .brief: BriefView()
+      case .matters: MattersView()
       default: GlanceView()
       }
     }
@@ -75,6 +76,51 @@ struct BriefView: View {
       }
       HStack { Meta(text: "Everything else is in hand", tracking: 1.8); Spacer()
         Button(action: openBrief) { Keycap(text: "RETURN  OPEN") }.buttonStyle(.plain) }
+        .padding(.horizontal, 18).padding(.vertical, 11)
+    }
+  }
+}
+
+/// 03 · Matters — work in flight. At most five; older matters live in the Ledger.
+struct MattersView: View {
+  @EnvironmentObject var s: AppState
+  private func blocked(_ m: Matter) -> Bool {
+    let refs = Set(s.desk.compactMap { $0.matter_ref })
+    return refs.contains(where: { $0.contains(m.id) || (m.path.map { $0.contains(m.id) } ?? false) && $0 == m.path })
+  }
+  private func meta(_ m: Matter) -> String {
+    if blocked(m) { return "Blocked on you" }
+    switch m.state ?? "" { case "done": return "Done"; case "waiting": return "Waiting"; case "dormant": return "Dormant"; default: return "In flight" }
+  }
+  private var inFlight: [Matter] { s.matters.filter { ($0.state ?? "active") != "done" } }
+  private var overdue: Int {
+    let f = DateFormatter(); f.dateFormat = "yyyy-MM-dd"; let today = f.string(from: Date())
+    return inFlight.filter { ($0.next ?? "").count >= 10 && String($0.next!.prefix(10)) < today }.count
+  }
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      HStack { Meta(text: "Matters · \(inFlight.count) in flight", color: T.brass); Spacer(); Meta(text: "L\(s.trust) trust") }
+        .padding(.horizontal, 18).padding(.top, 15).padding(.bottom, 13)
+      Rectangle().fill(T.hair).frame(height: 1)
+      if inFlight.isEmpty {
+        Say(text: "Nothing in flight, \(T.honorific). «The desk is clear.»").padding(.horizontal, 18).padding(.vertical, 18)
+      }
+      ForEach(Array(inFlight.prefix(5))) { m in
+        let b = blocked(m)
+        VStack(alignment: .leading, spacing: 0) {
+          HStack(alignment: .firstTextBaseline, spacing: 12) {
+            Circle().fill(b ? T.brass : Color.clear).overlay(Circle().stroke(b ? Color.clear : T.dim, lineWidth: 1)).frame(width: 6, height: 6).alignmentGuide(.firstTextBaseline) { d in d[VerticalAlignment.center] + 4 }
+            VStack(alignment: .leading, spacing: 3) {
+              Text(m.title).font(T.body(14)).foregroundColor(T.ink).lineLimit(1)
+              if !m.subline.isEmpty { Text(m.subline).font(T.body(11.5, italic: true)).foregroundColor(T.dim).lineLimit(2) }
+            }.frame(maxWidth: .infinity, alignment: .leading)
+            Meta(text: meta(m), color: b ? T.brass : T.dim, size: 8.5, tracking: 1.4)
+          }.padding(.horizontal, 18).padding(.vertical, 12)
+          Rectangle().fill(T.hair).frame(height: 1)
+        }
+      }
+      HStack { Meta(text: overdue == 0 ? "Nothing overdue" : "\(overdue) past due", color: overdue == 0 ? T.dim : T.brass, tracking: 1.8); Spacer()
+        Button(action: { s.open(.ledger) }) { Keycap(text: "⌘L  LEDGER") }.buttonStyle(.plain) }
         .padding(.horizontal, 18).padding(.vertical, 11)
     }
   }

--- a/packages/alfred-mac/Sources/AlfredBlack/Tenant.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Tenant.swift
@@ -155,6 +155,17 @@ struct Tenant {
     return try JSONDecoder().decode(Day.self, from: data).nar_hours
   }
 
+  /// The tenant's autonomy flags, read as a trust class: L1 watches (all
+  /// shadow), L2 proposes (acts only through the principal), L3 acts, then reports.
+  func trustClass() async throws -> Int {
+    let (code, data) = try await request("api/v1/settings", bearer: apiKey)
+    guard code == 200, let j = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return 3 }
+    let bag = (j["settings"] as? [String: Any]) ?? j
+    func mode(_ k: String) -> String { ((bag[k] as? [String: Any])?["value"] as? String) ?? (bag[k] as? String) ?? "live" }
+    let live = ["signal_action_mode", "state_mutator_mode", "auto_task_create_mode"].map { mode($0) == "live" }
+    return live.allSatisfy { $0 } ? 3 : (live[0] ? 2 : (live[1] || live[2] ? 2 : 1))
+  }
+
   static func domain(from raw: String) -> String? {
     var s = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     if !s.contains("://") { s = "https://" + s }
@@ -222,7 +233,13 @@ struct Brief {
 }
 
 struct Matter: Decodable, Identifiable {
-  var id: String; var name: String?; var summary: String?; var state: String?; var current_state: String?
+  var id: String; var name: String?; var summary: String?; var state: String?; var current_state: String?; var path: String?; var next: String?
+  /// The living state, first sentence only, for the subline.
+  var subline: String {
+    let st = (current_state ?? summary ?? "").replacingOccurrences(of: "\n", with: " ").trimmingCharacters(in: .whitespaces)
+    let first = st.components(separatedBy: ". ").first ?? st
+    return first.count > 90 ? String(first.prefix(89)) + "…" : first
+  }
   var title: String { (name ?? id).trimmingCharacters(in: .whitespaces) }
   /// One line for the Glance: the matter and its living state, if any.
   var glanceTitle: String {


### PR DESCRIPTION
## What

Fifth slice against the **Alfred for macOS** handoff.

- "Matters · N in flight" in brass and the trust class read from the tenant's three autonomy flags (L1 watches, L2 proposes, L3 acts, then reports); at most five matters — title, the living state Alfred keeps as an italic subline, and a meta: "Blocked on you" in brass when a Desk card points at the matter, else the roll-up state; footer "Nothing overdue" (or the count past due) and ⌘L to the Ledger. Never paginated.
- `Tenant.trustClass()`; `Matter.subline`; `--screen matters <dir>`.

Lane VIII, 67 changed LOC.

## Smoke evidence

- `swift build -c release` ok before and after the rebase; local lane VIII gate passed.
- `--screen matters` rendered against a tenant: 12 in flight, L3 trust, five matters with their sublines, "Nothing overdue" (holds personal data; not attached).

🤖 Generated with [Claude Code](https://claude.com/claude-code)