### PR TITLE
feat(alfred-mac): 04 · Your Word — an escalation, one decision

### DIFF
--- a/packages/alfred-mac/Sources/AlfredBlack/App.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/App.swift
@@ -286,6 +286,16 @@ final class AppState: ObservableObject {
   func open(_ sc: Screen) { screen = sc }
   /// Priority when the popover opens: an unread brief of the day, else the Glance.
   func popoverOpened() { screen = (brief.map { $0.isToday && state.briefReadSlug != $0.slug_date } ?? false) ? .brief : .glance }
+  @Published var wordIndex = 0
+  @Published var deciding = false
+  /// The principal's word, then the next matter — or the Glance when none remain.
+  func decide(_ intent: String) async {
+    guard !deciding, let t = tenant, wordIndex < desk.count else { return }
+    let card = desk[wordIndex]; deciding = true; defer { deciding = false }
+    do { try await t.decide(card: card, intent: intent); desk.remove(at: wordIndex); deskTotal = max(0, deskTotal - 1) } catch { record(error) }
+    if wordIndex >= desk.count { wordIndex = max(0, desk.count - 1) }
+    if desk.isEmpty { screen = .glance }
+  }
   func popoverClosed() { if screen == .brief, let b = brief { state.briefReadSlug = b.slug_date }; screen = .glance }
   @Published var reply: (text: String, at: Date)? = nil
   @Published var asking = false

--- a/packages/alfred-mac/Sources/AlfredBlack/Popover.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Popover.swift
@@ -13,10 +13,12 @@ struct PopoverView: View {
       switch s.screen {
       case .brief: BriefView()
       case .matters: MattersView()
+      case .yourWord: YourWordView()
       default: GlanceView()
       }
     }
     .frame(width: T.popoverWidth)
+    .overlay(RoundedRectangle(cornerRadius: T.rPopover).stroke(T.brass.opacity(s.screen == .yourWord ? 0.5 : 0), lineWidth: 1))
     .animation(.easeInOut(duration: 0.15), value: s.screen)
   }
 }
@@ -122,6 +124,41 @@ struct MattersView: View {
       HStack { Meta(text: overdue == 0 ? "Nothing overdue" : "\(overdue) past due", color: overdue == 0 ? T.dim : T.brass, tracking: 1.8); Spacer()
         Button(action: { s.open(.ledger) }) { Keycap(text: "⌘L  LEDGER") }.buttonStyle(.plain) }
         .padding(.horizontal, 18).padding(.vertical, 11)
+    }
+  }
+}
+
+/// 04 · Your Word — an escalation, one decision. The border shifts to brass.
+struct YourWordView: View {
+  @EnvironmentObject var s: AppState
+  private var card: DeskItem? { s.wordIndex < s.desk.count ? s.desk[s.wordIndex] : nil }
+  private func when(_ ts: String?) -> String {
+    guard let ts, let d = ISO8601DateFormatter().date(from: ts) ?? { let f = ISO8601DateFormatter(); f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]; return f.date(from: ts) }() else { return "" }
+    let f = DateFormatter(); f.dateFormat = "d MMM"; return f.string(from: d)
+  }
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      HStack { Meta(text: "Your word, \(T.honorific)", color: T.brass); Spacer(); Meta(text: "\(min(s.wordIndex + 1, max(1, s.desk.count))) of \(max(s.desk.count, 1))") }
+        .padding(.horizontal, 18).padding(.top, 15).padding(.bottom, 13)
+      Rectangle().fill(T.hair).frame(height: 1)
+      if let c = card {
+        Say(text: c.title, size: 15.5).padding(.horizontal, 18).padding(.top, 18)
+        if !c.body.isEmpty && c.body != c.title {
+          Text(c.body).font(T.body(13.5)).foregroundColor(T.dim).lineSpacing(3).lineLimit(6).padding(.horizontal, 18).padding(.top, 10).fixedSize(horizontal: false, vertical: true)
+        }
+        HStack(spacing: 8) {
+          Meta(text: (c.target_kind ?? "matter"), size: 8.5, tracking: 1.4); Meta(text: "·", size: 8.5); Meta(text: when(c.created), size: 8.5, tracking: 1.4); Spacer()
+          Button(action: { if let d = s.pairing?.domain, let u = URL(string: "https://\(d)/desk") { NSWorkspace.shared.open(u) } }) { Meta(text: "Desk ⏎", color: T.brass, size: 8.5, tracking: 1.4) }.buttonStyle(.plain)
+        }.padding(.horizontal, 18).padding(.top, 14)
+        HStack(spacing: 8) {
+          Spacer()
+          Button("Hold") { Task { await s.decide("defer") } }.buttonStyle(PopButton()).keyboardShortcut(.escape, modifiers: [])
+          Button("Myself") { Task { await s.decide("take_mine") } }.buttonStyle(PopButton()).keyboardShortcut(.return, modifiers: [.command])
+          Button("So ordered") { Task { await s.decide("delegate") } }.buttonStyle(PopButton(primary: true)).keyboardShortcut(.return, modifiers: [])
+        }.padding(.horizontal, 18).padding(.vertical, 16).disabled(s.deciding)
+      } else {
+        Say(text: "Nothing needs your word, \(T.honorific). «The desk is quiet.»").padding(.horizontal, 18).padding(.vertical, 18)
+      }
     }
   }
 }

--- a/packages/alfred-mac/Sources/AlfredBlack/Tenant.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Tenant.swift
@@ -166,6 +166,16 @@ struct Tenant {
     return live.allSatisfy { $0 } ? 3 : (live[0] ? 2 : (live[1] || live[2] ? 2 : 1))
   }
 
+  /// The principal's word on a Desk card: hold (defer), take it himself, or so ordered (delegate to Alfred).
+  func decide(card: DeskItem, intent: String) async throws {
+    let (code, data) = try await request("api/v1/decisions", method: "POST", bearer: apiKey,
+      body: ["source": "needs_attention", "source_record": card.path ?? "needs_attention/\(card.id).md", "intent": intent, "origin": "mac"])
+    guard code == 200 || code == 201 else {
+      let msg = (try? JSONSerialization.jsonObject(with: data) as? [String: Any])?["error"] as? String
+      throw TenantError(message: msg ?? "The decision was not recorded (HTTP \(code)).")
+    }
+  }
+
   static func domain(from raw: String) -> String? {
     var s = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     if !s.contains("://") { s = "https://" + s }
@@ -178,7 +188,7 @@ struct Tenant {
 
 struct DeskItem: Decodable, Identifiable {
   var id: String; var status: String?; var created: String?; var action_what: String?; var matter_ref: String?
-  var display_headline: String?; var display_body: String?; var body_preview: String?; var target_path: String?; var target_kind: String?; var decay_score: Double?
+  var display_headline: String?; var display_body: String?; var body_preview: String?; var target_path: String?; var target_kind: String?; var decay_score: Double?; var path: String?
   /// The readable line: the card's headline, else what it asks, else its preview, else what it points at.
   var title: String {
     for c in [display_headline, action_what, body_preview, target_path] {


### PR DESCRIPTION
## What

Sixth slice against the **Alfred for macOS** handoff.

- The popover's border shifts to brass at 50 %. "Your word, sir" and "n of N"; the Desk card's headline as Alfred's line, its body beneath; a meta row (what it points at · when · Desk ⏎).
- Three buttons, right-aligned: **Hold** (defer, ESC) · **Myself** (take it, ⌘⏎) · **So ordered** (delegate to Alfred, ⏎) — recorded through `POST /api/v1/decisions` (`source: needs_attention`), then the next matter, or the Glance when none remain.
- The handoff names the counter-option concretely ("At the old rate"); the tenant's cards carry no named alternative yet, so the middle button is "Myself" until they do.

Lane VIII, 59 changed LOC.

## Smoke evidence

- `swift build -c release` ok before and after the rebase; local lane VIII gate passed.
- `--screen yourword` rendered against a tenant: header, count, a real card's headline and body, meta row, the three buttons, the brass border (holds personal data; not attached).
- No decision was posted during verification (that would act on the principal's Desk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)