### PR TITLE
feat(alfred-mac): 08 · The Ledger and 09 · The Vault

### DIFF
--- a/packages/alfred-mac/Sources/AlfredBlack/App.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/App.swift
@@ -281,6 +281,8 @@ final class AppState: ObservableObject {
   @Published var matters: [Matter] = []
   @Published var narToday: Double? = nil
   @Published var trust = 3
+  @Published var ledger: [LedgerLine] = []
+  @Published var vault: [String: Int] = [:]
   @Published var screen: Screen = .glance
   private var lastNar = Date.distantPast
   func open(_ sc: Screen) { screen = sc }
@@ -339,6 +341,8 @@ final class AppState: ObservableObject {
     if force || now.timeIntervalSince(lastNar) >= 300 {
       lastNar = now; if let h = try? await t.returnedToday() { narToday = h }
       if let c = try? await t.trustClass() { trust = c }
+      if let l = try? await t.activity() { ledger = l }
+      if let v = try? await t.vaultCounts() { vault = v }
     }
     if force || now.timeIntervalSince(lastBrief) >= 600 {
       lastBrief = now; if let b = try? await t.latestBrief() { brief = b }

--- a/packages/alfred-mac/Sources/AlfredBlack/Popover.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Popover.swift
@@ -14,6 +14,8 @@ struct PopoverView: View {
       case .brief: BriefView()
       case .matters: MattersView()
       case .yourWord: YourWordView()
+      case .ledger: LedgerView()
+      case .vault: VaultView()
       default: GlanceView()
       }
     }
@@ -159,6 +161,56 @@ struct YourWordView: View {
       } else {
         Say(text: "Nothing needs your word, \(T.honorific). «The desk is quiet.»").padding(.horizontal, 18).padding(.vertical, 18)
       }
+    }
+  }
+}
+
+/// 08 · The Ledger — history, append-only. No edit or delete affordance anywhere.
+struct LedgerView: View {
+  @EnvironmentObject var s: AppState
+  private func openAudit() { if let d = s.pairing?.domain, let u = URL(string: "https://\(d)/decisions") { NSWorkspace.shared.open(u) } }
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      HStack { Meta(text: "The Ledger · today", color: T.brass); Spacer(); Button(action: openAudit) { Meta(text: "Open ⌘F") }.buttonStyle(.plain) }
+        .padding(.horizontal, 18).padding(.top, 15).padding(.bottom, 13)
+      Rectangle().fill(T.hair).frame(height: 1)
+      if s.ledger.isEmpty { Say(text: "Nothing recorded yet today, \(T.honorific).").padding(.horizontal, 18).padding(.vertical, 18) }
+      ForEach(Array(s.ledger.sorted { (($0.mode ?? "live") == "live" ? 0 : 1) < (($1.mode ?? "live") == "live" ? 0 : 1) }.prefix(6))) { l in
+        let live = (l.mode ?? "live") == "live"
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+          Meta(text: l.time, color: T.dim, size: 8.5, tracking: 1.2).frame(width: 40, alignment: .leading)
+          Text(l.title).font(T.body(13.5)).foregroundColor(live ? T.ink : T.dim).lineLimit(2).frame(maxWidth: .infinity, alignment: .leading)
+          Meta(text: live ? (l.actor ?? "Alfred") : "Shadow", color: live ? T.brass : T.dim, size: 8.5, tracking: 1.4)
+        }.padding(.horizontal, 18).padding(.vertical, 11)
+        Rectangle().fill(T.hair).frame(height: 1)
+      }
+      Meta(text: "Every line traceable to its session", tracking: 1.8).padding(.horizontal, 18).padding(.vertical, 11)
+    }
+  }
+}
+
+/// 09 · The Vault — what Alfred holds. Credentials are sealed; never a count.
+struct VaultView: View {
+  @EnvironmentObject var s: AppState
+  private static let shelves: [(String, [String])] = [
+    ("Matters & commitments", ["matter", "commitment"]), ("Tasks & chores", ["task", "chore"]), ("People, orgs & places", ["person", "org", "place"]),
+    ("Notes & daybook", ["note", "daybook"]), ("Decisions & briefs", ["decision", "briefing"]), ("Instincts", ["instinct"]),
+  ]
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      HStack { Meta(text: "The Vault", color: T.brass); Spacer(); Meta(text: "Private by design") }
+        .padding(.horizontal, 18).padding(.top, 15).padding(.bottom, 13)
+      Rectangle().fill(T.hair).frame(height: 1)
+      ForEach(Self.shelves, id: \.0) { name, types in
+        let n = types.reduce(0) { $0 + (s.vault[$1] ?? 0) }
+        HStack { Text(name).font(T.body(14)).foregroundColor(T.ink); Spacer(); Meta(text: n == 0 ? "—" : String(n), size: 9, tracking: 1.4) }
+          .padding(.horizontal, 18).padding(.vertical, 12)
+        Rectangle().fill(T.hair).frame(height: 1)
+      }
+      HStack { Text("Credentials").font(T.body(14)).foregroundColor(T.ink); Spacer(); Meta(text: "Sealed", color: T.brass, size: 9, tracking: 1.4) }
+        .padding(.horizontal, 18).padding(.vertical, 12)
+      Rectangle().fill(T.hair).frame(height: 1)
+      Text("Nothing leaves this machine without your word, \(T.honorific).").font(T.say(13.5)).foregroundColor(T.dim).padding(.horizontal, 18).padding(.vertical, 14)
     }
   }
 }

--- a/packages/alfred-mac/Sources/AlfredBlack/Tenant.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Tenant.swift
@@ -176,6 +176,24 @@ struct Tenant {
     }
   }
 
+  /// The audit ledger — append-only, every line traceable to its session.
+  func activity(limit: Int = 30) async throws -> [LedgerLine] {
+    struct Page: Decodable { var items: [LedgerLine] }
+    let (code, data) = try await request("api/v1/admin/activity", bearer: apiKey, query: ["limit": String(limit)])
+    guard code == 200 else { throw TenantError(message: "Ledger read failed (HTTP \(code)).") }
+    return try JSONDecoder().decode(Page.self, from: data).items
+  }
+  /// What the vault holds, counted by record type from the index.
+  func vaultCounts() async throws -> [String: Int] {
+    let (code, data) = try await request("api/v1/vault/index", bearer: apiKey)
+    struct Entry: Decodable { var type: String?; var slug: String? }
+    struct Index: Decodable { var titles: [Entry] }
+    guard code == 200, let idx = try? JSONDecoder().decode(Index.self, from: data) else { return [:] }
+    var out: [String: Int] = [:]
+    for e in idx.titles { let t = e.type ?? String(e.slug?.split(separator: "/").first ?? ""); if !t.isEmpty { out[t, default: 0] += 1 } }
+    return out
+  }
+
   static func domain(from raw: String) -> String? {
     var s = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     if !s.contains("://") { s = "https://" + s }
@@ -257,5 +275,27 @@ struct Matter: Decodable, Identifiable {
     guard !st.isEmpty else { return title }
     let first = st.components(separatedBy: ". ").first ?? st
     return "\(title) — \(first.count > 70 ? String(first.prefix(69)) + "…" : first)"
+  }
+}
+
+struct LedgerLine: Decodable, Identifiable {
+  var id: String; var ts: String?; var action_type: String?; var actor: String?; var summary: String?; var mode: String?; var target_path: String?
+  var time: String {
+    guard let ts, let d = ISO8601DateFormatter().date(from: ts) ?? { let f = ISO8601DateFormatter(); f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]; return f.date(from: ts) }() else { return "" }
+    let f = DateFormatter(); f.dateFormat = Calendar.current.isDateInToday(d) ? "HH:mm" : "d MMM"; return f.string(from: d)
+  }
+  /// The line in plain words: slugs become titles, workflows become their names.
+  var title: String {
+    var t = (summary ?? action_type ?? id).replacingOccurrences(of: "\n", with: " ")
+    for prefix in ["steward-action: ", "signal-action: ", "desk-action: "] { if t.hasPrefix(prefix) { t = String(t.dropFirst(prefix.count)) } }
+    if let r = t.range(of: " (conf=") { t = String(t[..<r.lowerBound]) }
+    if let r = t.range(of: #"^(\w+) on (task|matter|note|chore|instinct)/(.+?)\.md$"#, options: .regularExpression) {
+      let parts = String(t[r]).components(separatedBy: " on "); let verb = parts[0].replacingOccurrences(of: "_", with: " ")
+      var name = parts[1].components(separatedBy: "/").last ?? parts[1]; name = name.replacingOccurrences(of: ".md", with: "")
+      name = name.replacingOccurrences(of: #"^[0-9a-f]{8}-"#, with: "", options: .regularExpression).replacingOccurrences(of: "-", with: " ")
+      t = "\(verb.prefix(1).uppercased() + verb.dropFirst()) — \(name)"
+    }
+    t = t.replacingOccurrences(of: #"([a-z])([A-Z])"#, with: "$1 $2", options: .regularExpression).replacingOccurrences(of: " Workflow", with: "")
+    return t.trimmingCharacters(in: .whitespaces)
   }
 }


### PR DESCRIPTION
## What

Seventh slice against the **Alfred for macOS** handoff.

- **08 · The Ledger** — the tenant's audit ledger (`GET /api/v1/admin/activity`), append-only, in plain words (slugs become titles, workflows their names): time on the left, the actor in brass for what was done live, shadow checks dimmed and last; no edit or delete affordance; "Every line traceable to its session". The handoff's minutes-credited column has no backing yet; the actor stands in its place.
- **09 · The Vault** — what Alfred holds, counted by record type from the vault index onto six shelves; Credentials are sealed, never a count; Alfred's closing line, dim.

Lane VIII, 96 changed LOC.

## Smoke evidence

- `swift build -c release` ok before and after the rebase; local lane VIII gate passed.
- `--screen ledger` and `--screen vault` rendered against a tenant: six ledger lines in plain words with actors; shelves with real counts and Credentials sealed (hold personal data; not attached).

🤖 Generated with [Claude Code](https://claude.com/claude-code)