### PR TITLE
feat(alfred-mac): 10 · The Arrangement — settings as a contract, not toggles

### DIFF
--- a/packages/alfred-mac/Sources/AlfredBlack/App.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/App.swift
@@ -93,7 +93,7 @@ struct AlfredBlackMain {
         st.screen = ["brief": Screen.brief, "matters": .matters, "yourword": .yourWord, "ledger": .ledger, "vault": .vault, "arrangement": .arrangement][name] ?? .glance
         if let r = CommandLine.arguments.firstIndex(of: "--reply"), CommandLine.arguments.count > r + 1 { st.askReply = CommandLine.arguments[r + 1] }
         let host: NSHostingView<AnyView> = name == "ask" ? NSHostingView(rootView: AnyView(AskView().environmentObject(st))) : NSHostingView(rootView: AnyView(PopoverView().environmentObject(st)))
-        let w: CGFloat = name == "ask" ? 620 : T.popoverWidth
+        let w: CGFloat = name == "ask" ? 620 : (name == "arrangement" ? 380 : T.popoverWidth)
         host.frame = NSRect(x: 0, y: 0, width: w, height: host.fittingSize.height); host.layoutSubtreeIfNeeded()
         if let rep = host.bitmapImageRepForCachingDisplay(in: host.bounds) { host.cacheDisplay(in: host.bounds, to: rep); try? rep.representation(using: .png, properties: [:])?.write(to: dir.appendingPathComponent("screen-\(CommandLine.arguments[i + 1]).png")) }
         print("screen: \(CommandLine.arguments[i + 1]) \(Int(host.bounds.height))pt desk=\(st.desk.count) matters=\(st.matters.count) nar=\(st.narToday.map { String($0) } ?? "-")"); done = true
@@ -283,6 +283,8 @@ final class AppState: ObservableObject {
   @Published var trust = 3
   @Published var ledger: [LedgerLine] = []
   @Published var vault: [String: Int] = [:]
+  @Published var rulesBody: String? = nil
+  @Published var arrangement = Arrangement()
   @Published var screen: Screen = .glance
   private var lastNar = Date.distantPast
   func open(_ sc: Screen) { screen = sc }
@@ -297,6 +299,15 @@ final class AppState: ObservableObject {
     do { try await t.decide(card: card, intent: intent); desk.remove(at: wordIndex); deskTotal = max(0, deskTotal - 1) } catch { record(error) }
     if wordIndex >= desk.count { wordIndex = max(0, desk.count - 1) }
     if desk.isEmpty { screen = .glance }
+  }
+  func chooseTrust(_ level: Int) {
+    let cal = Calendar.current; let midnight = cal.startOfDay(for: cal.date(byAdding: .day, value: 1, to: Date())!)
+    if level == trust { state.pendingTrust = nil; state.trustEffectiveAt = nil } else { state.pendingTrust = level; state.trustEffectiveAt = midnight }
+  }
+  func saveArrangement(_ a: Arrangement) async {
+    guard let t = tenant else { return }
+    let body = a.written(into: rulesBody ?? "# Standing Rules\n")
+    do { try await t.saveRules(body); rulesBody = body; arrangement = a } catch { record(error) }
   }
   func popoverClosed() { if screen == .brief, let b = brief { state.briefReadSlug = b.slug_date }; screen = .glance }
   @Published var reply: (text: String, at: Date)? = nil
@@ -343,6 +354,11 @@ final class AppState: ObservableObject {
       if let c = try? await t.trustClass() { trust = c }
       if let l = try? await t.activity() { ledger = l }
       if let v = try? await t.vaultCounts() { vault = v }
+      if let r = try? await t.rules() { rulesBody = r; arrangement = Arrangement.parse(r) }
+      // Deliberate friction: a chosen trust class takes effect at midnight, not now.
+      if let p = state.pendingTrust, let at = state.trustEffectiveAt, Date() >= at {
+        do { try await t.setTrust(p); state.pendingTrust = nil; state.trustEffectiveAt = nil; trust = p } catch { record(error) }
+      }
     }
     if force || now.timeIntervalSince(lastBrief) >= 600 {
       lastBrief = now; if let b = try? await t.latestBrief() { brief = b }
@@ -393,7 +409,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     refreshPresence()
     statusItem.button?.toolTip = "Alfred Black"
     statusItem.button?.target = self; statusItem.button?.action = #selector(markClicked); statusItem.button?.sendAction(on: [.leftMouseUp, .rightMouseUp])
-    popover.contentViewController = NSHostingController(rootView: PopoverView().environmentObject(state)); popover.delegate = self
+    let host = NSHostingController(rootView: PopoverView().environmentObject(state)); host.sizingOptions = .preferredContentSize; popover.contentViewController = host; popover.delegate = self
     state.selfHeal()
     HotKey.onPress = { [weak self] in self?.state.toggleAsk() }; HotKey.register()
     if state.pairing == nil || !Self.launchedAsLoginItem() { showWindow() }

--- a/packages/alfred-mac/Sources/AlfredBlack/Popover.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Popover.swift
@@ -16,10 +16,11 @@ struct PopoverView: View {
       case .yourWord: YourWordView()
       case .ledger: LedgerView()
       case .vault: VaultView()
+      case .arrangement: ArrangementView()
       default: GlanceView()
       }
     }
-    .frame(width: T.popoverWidth)
+    .frame(width: s.screen == .arrangement ? 380 : T.popoverWidth)
     .overlay(RoundedRectangle(cornerRadius: T.rPopover).stroke(T.brass.opacity(s.screen == .yourWord ? 0.5 : 0), lineWidth: 1))
     .animation(.easeInOut(duration: 0.15), value: s.screen)
   }
@@ -212,5 +213,52 @@ struct VaultView: View {
       Rectangle().fill(T.hair).frame(height: 1)
       Text("Nothing leaves this machine without your word, \(T.honorific).").font(T.say(13.5)).foregroundColor(T.dim).padding(.horizontal, 18).padding(.vertical, 14)
     }
+  }
+}
+
+/// 10 · The Arrangement — settings as a contract, not toggles. 380 pt.
+struct ArrangementView: View {
+  @EnvironmentObject var s: AppState
+  @State private var draft = Arrangement()
+  @State private var loaded = false
+  private var since: String {
+    guard let d = s.pairing?.pairedAt else { return "" }
+    let f = DateFormatter(); f.dateFormat = "MMM yyyy"; return "Since " + f.string(from: d)
+  }
+  private func field(_ label: String, _ text: Binding<String>) -> some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Meta(text: label, tracking: 1.8)
+      TextField("Not yet written", text: text).textFieldStyle(.plain).font(T.body(14)).foregroundColor(T.ink)
+    }.padding(.horizontal, 18).padding(.vertical, 12)
+  }
+  private func chip(_ level: Int, _ name: String) -> some View {
+    let active = (s.state.pendingTrust ?? s.trust) == level
+    return Button(action: { s.chooseTrust(level) }) {
+      Meta(text: name, color: active ? T.brass : T.dim, size: 8.5, tracking: 1.4).padding(.horizontal, 10).padding(.vertical, 7)
+        .background(RoundedRectangle(cornerRadius: T.rButton).fill(active ? T.brass.opacity(0.08) : Color.clear))
+        .overlay(RoundedRectangle(cornerRadius: T.rButton).stroke(active ? T.brass : T.hair2, lineWidth: 1))
+    }.buttonStyle(.plain)
+  }
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      HStack { Meta(text: "The Arrangement", color: T.brass); Spacer(); Meta(text: since) }
+        .padding(.horizontal, 18).padding(.top, 15).padding(.bottom, 13)
+      Rectangle().fill(T.hair).frame(height: 1)
+      field("Alfred may, without asking", $draft.may); Rectangle().fill(T.hair).frame(height: 1)
+      field("Alfred asks first", $draft.asksFirst); Rectangle().fill(T.hair).frame(height: 1)
+      field("Alfred never", $draft.never); Rectangle().fill(T.hair).frame(height: 1)
+      VStack(alignment: .leading, spacing: 10) {
+        Meta(text: "Trust class", tracking: 1.8)
+        HStack(spacing: 8) { chip(1, "L1 Watch"); chip(2, "L2 Propose"); chip(3, "L3 Act, then report") }
+      }.padding(.horizontal, 18).padding(.vertical, 14)
+      Rectangle().fill(T.hair).frame(height: 1)
+      HStack {
+        Meta(text: s.state.pendingTrust != nil ? "L\(s.state.pendingTrust!) takes effect at midnight" : "Changes take effect at midnight", color: s.state.pendingTrust != nil ? T.brass : T.dim, tracking: 1.8)
+        Spacer()
+        if draft != s.arrangement { Button(action: { Task { await s.saveArrangement(draft) } }) { Keycap(text: "SAVE ⏎") }.buttonStyle(.plain).keyboardShortcut(.return, modifiers: []) }
+      }.padding(.horizontal, 18).padding(.vertical, 11)
+    }
+    .onAppear { if !loaded { draft = s.arrangement; loaded = true } }
+    .onChange(of: s.arrangement) { a in if draft == Arrangement() { draft = a } }
   }
 }

--- a/packages/alfred-mac/Sources/AlfredBlack/Store.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Store.swift
@@ -15,6 +15,8 @@ struct RunState: Codable {
   var pushedUUIDs: Set<String> = []
   var boundSessions: Set<String> = []
   var briefReadSlug: String? = nil
+  var pendingTrust: Int? = nil
+  var trustEffectiveAt: Date? = nil
   var lastRenderAt: Date?
   var lastRenderEntries: Int = 0
   var lastPushAt: Date?

--- a/packages/alfred-mac/Sources/AlfredBlack/Tenant.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Tenant.swift
@@ -194,6 +194,26 @@ struct Tenant {
     return out
   }
 
+  /// The standing rules Alfred follows (vault/RULES.md), whole.
+  func rules() async throws -> String {
+    struct Rec: Decodable { var body: String }
+    let (code, data) = try await request("api/v1/vault/records/RULES.md", bearer: apiKey)
+    guard code == 200 else { throw TenantError(message: "Rules read failed (HTTP \(code)).") }
+    return try JSONDecoder().decode(Rec.self, from: data).body
+  }
+  func saveRules(_ body: String) async throws {
+    let (code, _) = try await request("api/v1/vault/records/RULES.md", method: "PATCH", bearer: apiKey, body: ["body_set": body])
+    guard code == 200 else { throw TenantError(message: "The arrangement was not saved (HTTP \(code)).") }
+  }
+  /// The trust class, applied: L3 acts (all live), L2 proposes (acts only through the principal), L1 watches.
+  func setTrust(_ level: Int) async throws {
+    let values = level >= 3 ? ["live", "live", "live"] : level == 2 ? ["shadow", "live", "live"] : ["shadow", "shadow", "shadow"]
+    for (k, v) in zip(["signal_action_mode", "state_mutator_mode", "auto_task_create_mode"], values) {
+      let (code, _) = try await request("api/v1/settings/\(k)", method: "PUT", bearer: apiKey, body: ["value": v])
+      guard code == 200 else { throw TenantError(message: "Trust class not applied (\(k): HTTP \(code)).") }
+    }
+  }
+
   static func domain(from raw: String) -> String? {
     var s = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     if !s.contains("://") { s = "https://" + s }
@@ -297,5 +317,32 @@ struct LedgerLine: Decodable, Identifiable {
     }
     t = t.replacingOccurrences(of: #"([a-z])([A-Z])"#, with: "$1 $2", options: .regularExpression).replacingOccurrences(of: " Workflow", with: "")
     return t.trimmingCharacters(in: .whitespaces)
+  }
+}
+
+/// The three sentences of the arrangement, kept in RULES.md under "## The arrangement".
+struct Arrangement: Equatable {
+  var may = "", asksFirst = "", never = ""
+  static let heading = "## The arrangement"
+  static let labels = ["Alfred may, without asking", "Alfred asks first", "Alfred never"]
+  static func parse(_ body: String) -> Arrangement {
+    var a = Arrangement()
+    guard let r = body.range(of: heading) else { return a }
+    let section = body[r.upperBound...].components(separatedBy: "\n## ").first ?? ""
+    for line in section.components(separatedBy: "\n") {
+      let l = line.trimmingCharacters(in: .whitespaces).replacingOccurrences(of: #"^[-*]\s*"#, with: "", options: .regularExpression)
+      for (i, label) in labels.enumerated() where l.lowercased().hasPrefix(label.lowercased() + ":") {
+        let v = l.dropFirst(label.count + 1).trimmingCharacters(in: .whitespaces)
+        if i == 0 { a.may = v } else if i == 1 { a.asksFirst = v } else { a.never = v }
+      }
+    }
+    return a
+  }
+  /// The body with this arrangement's section replaced, or appended.
+  func written(into body: String) -> String {
+    let block = "\(Self.heading)\n\n- \(Self.labels[0]): \(may)\n- \(Self.labels[1]): \(asksFirst)\n- \(Self.labels[2]): \(never)\n"
+    guard let r = body.range(of: Self.heading) else { return body.trimmingCharacters(in: .newlines) + "\n\n" + block }
+    let after = body[r.upperBound...]; let end = after.range(of: "\n## ").map { after.index($0.lowerBound, offsetBy: 1) } ?? after.endIndex
+    return String(body[..<r.lowerBound]) + block + (end < after.endIndex ? "\n" + String(after[end...]) : "")
   }
 }


### PR DESCRIPTION
## What

Eighth slice against the **Alfred for macOS** handoff.

- A 380 pt screen: "The Arrangement · since <month>"; three prose fields with mono microlabels — *Alfred may, without asking* · *Alfred asks first* · *Alfred never* — kept as a section of the standing rules Alfred already follows (`vault/RULES.md`, read and written back whole through the vault route with `body_set`), so what the principal writes here is what Alfred obeys.
- Trust class as segmented chips (L1 watch · L2 propose · L3 act, then report) mapped to the tenant's three autonomy flags; a chosen class is recorded and applied at midnight — deliberate friction, no instant changes. The popover sizes to the screen.

Lane VIII, 119 changed LOC.

## Smoke evidence

- `swift build -c release` ok before and after the rebase; local lane VIII gate passed.
- `--screen arrangement` rendered against a tenant: the three fields ("Not yet written" — no arrangement section exists yet), L3 active, the midnight footer.
- No trust class was changed and no rules were written during verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)