### PR TITLE
feat(alfred-mac): 07 · The Statement — the only real window (⌘⇧S)

### DIFF
--- a/packages/alfred-mac/Sources/AlfredBlack/App.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/App.swift
@@ -92,8 +92,8 @@ struct AlfredBlackMain {
         let name = CommandLine.arguments[i + 1]
         st.screen = ["brief": Screen.brief, "matters": .matters, "yourword": .yourWord, "ledger": .ledger, "vault": .vault, "arrangement": .arrangement][name] ?? .glance
         if let r = CommandLine.arguments.firstIndex(of: "--reply"), CommandLine.arguments.count > r + 1 { st.askReply = CommandLine.arguments[r + 1] }
-        let host: NSHostingView<AnyView> = name == "ask" ? NSHostingView(rootView: AnyView(AskView().environmentObject(st))) : NSHostingView(rootView: AnyView(PopoverView().environmentObject(st)))
-        let w: CGFloat = name == "ask" ? 620 : (name == "arrangement" ? 380 : T.popoverWidth)
+        let host: NSHostingView<AnyView> = name == "ask" ? NSHostingView(rootView: AnyView(AskView().environmentObject(st))) : name == "statement" ? NSHostingView(rootView: AnyView(StatementView().environmentObject(st))) : NSHostingView(rootView: AnyView(PopoverView().environmentObject(st)))
+        let w: CGFloat = name == "ask" ? 620 : name == "statement" ? 520 : (name == "arrangement" ? 380 : T.popoverWidth)
         host.frame = NSRect(x: 0, y: 0, width: w, height: host.fittingSize.height); host.layoutSubtreeIfNeeded()
         if let rep = host.bitmapImageRepForCachingDisplay(in: host.bounds) { host.cacheDisplay(in: host.bounds, to: rep); try? rep.representation(using: .png, properties: [:])?.write(to: dir.appendingPathComponent("screen-\(CommandLine.arguments[i + 1]).png")) }
         print("screen: \(CommandLine.arguments[i + 1]) \(Int(host.bounds.height))pt desk=\(st.desk.count) matters=\(st.matters.count) nar=\(st.narToday.map { String($0) } ?? "-")"); done = true
@@ -233,6 +233,18 @@ final class AppState: ObservableObject {
   }
 
 
+  func showStatement() {
+
+
+    if statementWindow == nil { statementWindow = StatementWindow(state: self) }
+
+
+    statementWindow?.makeKeyAndOrderFront(nil); NSApp.activate(ignoringOtherApps: true)
+
+
+  }
+
+
   func dismissAsk() { askReply = nil; askPanel?.orderOut(nil) }
 
 
@@ -285,6 +297,8 @@ final class AppState: ObservableObject {
   @Published var vault: [String: Int] = [:]
   @Published var rulesBody: String? = nil
   @Published var arrangement = Arrangement()
+  @Published var statement: MonthStatement? = nil
+  var statementWindow: StatementWindow? = nil
   @Published var screen: Screen = .glance
   private var lastNar = Date.distantPast
   func open(_ sc: Screen) { screen = sc }
@@ -355,6 +369,7 @@ final class AppState: ObservableObject {
       if let l = try? await t.activity() { ledger = l }
       if let v = try? await t.vaultCounts() { vault = v }
       if let r = try? await t.rules() { rulesBody = r; arrangement = Arrangement.parse(r) }
+      if let m = try? await t.statement() { statement = m }
       // Deliberate friction: a chosen trust class takes effect at midnight, not now.
       if let p = state.pendingTrust, let at = state.trustEffectiveAt, Date() >= at {
         do { try await t.setTrust(p); state.pendingTrust = nil; state.trustEffectiveAt = nil; trust = p } catch { record(error) }
@@ -411,7 +426,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     statusItem.button?.target = self; statusItem.button?.action = #selector(markClicked); statusItem.button?.sendAction(on: [.leftMouseUp, .rightMouseUp])
     let host = NSHostingController(rootView: PopoverView().environmentObject(state)); host.sizingOptions = .preferredContentSize; popover.contentViewController = host; popover.delegate = self
     state.selfHeal()
-    HotKey.onPress = { [weak self] in self?.state.toggleAsk() }; HotKey.register()
+    HotKey.onPress = { [weak self] in self?.state.toggleAsk() }; HotKey.onStatement = { [weak self] in self?.state.showStatement() }; HotKey.register()
     if state.pairing == nil || !Self.launchedAsLoginItem() { showWindow() }
     timer = Timer.scheduledTimer(withTimeInterval: 10, repeats: true) { [weak self] _ in
       guard let self else { return }
@@ -493,6 +508,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     }
     m.addItem(.separator())
     m.addItem(withTitle: "Ask Alfred…", action: #selector(askAlfred), keyEquivalent: "").target = self
+    m.addItem(withTitle: "The Statement…", action: #selector(showStatement), keyEquivalent: "").target = self
     m.addItem(withTitle: "Open Alfred Black…", action: #selector(openWindow), keyEquivalent: "o").target = self
     m.addItem(withTitle: "Reveal Alfred folder", action: #selector(revealFolder), keyEquivalent: "").target = self
     m.addItem(.separator())
@@ -526,6 +542,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
   }
 
   @objc func askAlfred() { state.toggleAsk() }
+
+  @objc func showStatement() { state.showStatement() }
 
   @objc func openWindow() { showWindow() }
 

--- a/packages/alfred-mac/Sources/AlfredBlack/Ask.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Ask.swift
@@ -64,12 +64,18 @@ struct AskView: View {
 
 /// ⌘⇧A, system-wide, without accessibility permission (Carbon hot keys).
 enum HotKey {
-  private static var ref: EventHotKeyRef?
-  static var onPress: (() -> Void)?
+  private static var refs: [EventHotKeyRef?] = [nil, nil]
+  static var onPress: (() -> Void)?          // ⌘⇧A
+  static var onStatement: (() -> Void)?      // ⌘⇧S
   static func register() {
-    var id = EventHotKeyID(signature: OSType(0x414C4652), id: 1)   // "ALFR"
-    RegisterEventHotKey(UInt32(kVK_ANSI_A), UInt32(cmdKey | shiftKey), id, GetApplicationEventTarget(), 0, &ref)
+    var a = EventHotKeyID(signature: OSType(0x414C4652), id: 1)   // "ALFR"
+    var b = EventHotKeyID(signature: OSType(0x414C4652), id: 2)
+    RegisterEventHotKey(UInt32(kVK_ANSI_A), UInt32(cmdKey | shiftKey), a, GetApplicationEventTarget(), 0, &refs[0])
+    RegisterEventHotKey(UInt32(kVK_ANSI_S), UInt32(cmdKey | shiftKey), b, GetApplicationEventTarget(), 0, &refs[1])
     var spec = EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed))
-    InstallEventHandler(GetApplicationEventTarget(), { _, _, _ in HotKey.onPress?(); return noErr }, 1, &spec, nil, nil)
+    InstallEventHandler(GetApplicationEventTarget(), { _, event, _ in
+      var id = EventHotKeyID(); GetEventParameter(event, EventParamName(kEventParamDirectObject), EventParamType(typeEventHotKeyID), nil, MemoryLayout<EventHotKeyID>.size, nil, &id)
+      if id.id == 2 { HotKey.onStatement?() } else { HotKey.onPress?() }; return noErr
+    }, 1, &spec, nil, nil)
   }
 }

--- a/packages/alfred-mac/Sources/AlfredBlack/Statement.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Statement.swift
@@ -1,0 +1,72 @@
+// 07 · The Statement — the only real window (⌘⇧S). A month of attention,
+// after every cost: hours returned in brass, and the three bars — displaced,
+// your time, net. "Read it sceptically, sir — every line is traceable."
+import SwiftUI
+import AppKit
+
+struct MonthStatement { var month: String; var returned: Double; var displaced: Double; var engaged: Double }
+
+final class StatementWindow: NSWindow {
+  init(state: AppState) {
+    super.init(contentRect: NSRect(x: 0, y: 0, width: 520, height: 420), styleMask: [.titled, .closable, .miniaturizable, .fullSizeContentView], backing: .buffered, defer: false)
+    title = "Attention Statement"; titlebarAppearsTransparent = true; titleVisibility = .hidden
+    appearance = NSAppearance(named: .darkAqua); backgroundColor = AB.hex(0x1C1A17); isReleasedWhenClosed = false
+    contentViewController = NSHostingController(rootView: StatementView().environmentObject(state))
+    center()
+  }
+}
+
+struct StatementView: View {
+  @EnvironmentObject var s: AppState
+  private func openPDF() { if let d = s.pairing?.domain, let u = URL(string: "https://\(d)/attention") { NSWorkspace.shared.open(u) } }
+  private func bar(_ label: String, _ hours: Double, max: Double, hatched: Bool = false) -> some View {
+    let h = max > 0 ? CGFloat(hours / max) * 120 : 0
+    return VStack(spacing: 8) {
+      ZStack(alignment: .bottom) {
+        Rectangle().fill(Color.clear).frame(width: 40, height: 120)
+        if hatched {
+          Rectangle().fill(T.ink.opacity(0.18)).frame(width: 40, height: h)
+            .overlay(HatchOverlay().clipped().frame(width: 40, height: h))
+        } else { Rectangle().fill(T.brass).frame(width: 40, height: h) }
+      }
+      Meta(text: label, size: 8, tracking: 1.4).fixedSize()
+      Meta(text: String(format: "%.1f h", hours), color: T.ink, size: 8.5, tracking: 1.2).fixedSize()
+    }.frame(width: 64)
+  }
+  var body: some View {
+    let st = s.statement
+    VStack(spacing: 0) {
+      Meta(text: "Attention statement · \(st?.month ?? "—")", color: T.brass, tracking: 2.6).padding(.top, 40)
+      HStack(alignment: .bottom, spacing: 16) {
+        VStack(alignment: .leading, spacing: 8) {
+          Text(st.map { String(format: "%.1f h", $0.returned) } ?? "—").font(T.title(54)).foregroundColor(T.brass).kerning(-1.1)
+          Meta(text: "Returned · after every cost", size: 8.5, tracking: 1.3).fixedSize()
+        }.fixedSize()
+        Spacer()
+        if let st {
+          let m = Swift.max(st.displaced, st.engaged, st.returned, 1)
+          HStack(alignment: .bottom, spacing: 6) { bar("Displaced", st.displaced, max: m); bar("Your time", st.engaged, max: m, hatched: true); bar("Net", st.returned, max: m) }
+        }
+      }.padding(.horizontal, 44).padding(.top, 36)
+      Spacer()
+      Rectangle().fill(T.hair).frame(height: 1).padding(.horizontal, 44)
+      HStack {
+        Say(text: "Read it sceptically, \(T.honorific) — «every line is traceable.»", size: 14.5)
+        Spacer()
+        Button(action: openPDF) { Keycap(text: "⌘E  PDF") }.buttonStyle(.plain).keyboardShortcut("e", modifiers: [.command])
+      }.padding(.horizontal, 44).padding(.vertical, 22)
+    }
+    .frame(width: 520, height: 420).background(T.bg)
+  }
+}
+
+/// Diagonal ivory hatching — "your time", drawn, not filled.
+struct HatchOverlay: View {
+  var body: some View {
+    Canvas { ctx, size in
+      var p = Path(); var x: CGFloat = -size.height
+      while x < size.width { p.move(to: CGPoint(x: x, y: size.height)); p.addLine(to: CGPoint(x: x + size.height, y: 0)); x += 6 }
+      ctx.stroke(p, with: .color(Color(nsColor: AB.hex(0xF0EADE, 0.55))), lineWidth: 1)
+    }
+  }
+}

--- a/packages/alfred-mac/Sources/AlfredBlack/Tenant.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Tenant.swift
@@ -214,6 +214,20 @@ struct Tenant {
     }
   }
 
+  /// The last complete month's attention statement: returned, displaced, engaged (hours).
+  func statement() async throws -> MonthStatement? {
+    struct Totals: Decodable { var nar_hours: Double?; var displaced_hours: Double?; var engaged_hours: Double? }
+    struct Page: Decodable { var totals: Totals? }
+    let cal = Calendar.current; let now = Date()
+    guard let firstOfThis = cal.date(from: cal.dateComponents([.year, .month], from: now)),
+          let firstOfLast = cal.date(byAdding: .month, value: -1, to: firstOfThis),
+          let lastOfLast = cal.date(byAdding: .day, value: -1, to: firstOfThis) else { return nil }
+    let f = DateFormatter(); f.dateFormat = "yyyy-MM-dd"; let mf = DateFormatter(); mf.dateFormat = "MMMM"
+    let (code, data) = try await request("api/v1/attention/statement", bearer: apiKey, query: ["from": f.string(from: firstOfLast), "to": f.string(from: lastOfLast)])
+    guard code == 200, let t = try JSONDecoder().decode(Page.self, from: data).totals else { return nil }
+    return MonthStatement(month: mf.string(from: firstOfLast), returned: t.nar_hours ?? 0, displaced: t.displaced_hours ?? 0, engaged: t.engaged_hours ?? 0)
+  }
+
   static func domain(from raw: String) -> String? {
     var s = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     if !s.contains("://") { s = "https://" + s }


### PR DESCRIPTION
## What

Ninth slice against the **Alfred for macOS** handoff.

- A 520 pt window: "Attention statement · <month>" centred in mono; the last complete month's hours returned after every cost in 54 pt brass serif; the three bars — displaced in brass, your time in ivory hatching, net in brass — from `GET /api/v1/attention/statement?from&to`; Alfred's line, "Read it sceptically, sir — every line is traceable."; ⌘E opens the print statement.
- A second system-wide hot key, **⌘⇧S**, and a utility-menu item. `--screen statement <dir>` renders it.

Lane VIII, ~130 changed LOC.

## Smoke evidence

- `swift build -c release` ok before and after the rebase; local lane VIII gate passed.
- `--screen statement` rendered against a tenant with August's real totals (101.6 h returned · 134.8 displaced · 29.4 your time) and inspected: nothing truncates at 520.

🤖 Generated with [Claude Code](https://claude.com/claude-code)