### PR TITLE
feat(alfred-mac): plain names, navigation between screens, and the Ask as an overlay

### DIFF
--- a/packages/alfred-mac/Sources/AlfredBlack/App.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/App.swift
@@ -93,7 +93,7 @@ struct AlfredBlackMain {
         st.screen = ["brief": Screen.brief, "matters": .matters, "yourword": .yourWord, "ledger": .ledger, "vault": .vault, "arrangement": .arrangement][name] ?? .glance
         if let r = CommandLine.arguments.firstIndex(of: "--reply"), CommandLine.arguments.count > r + 1 { st.askReply = CommandLine.arguments[r + 1] }
         let host: NSHostingView<AnyView> = name == "ask" ? NSHostingView(rootView: AnyView(AskView().environmentObject(st))) : name == "statement" ? NSHostingView(rootView: AnyView(StatementView().environmentObject(st))) : NSHostingView(rootView: AnyView(PopoverView().environmentObject(st)))
-        let w: CGFloat = name == "ask" ? 620 : name == "statement" ? 520 : (name == "arrangement" ? 380 : T.popoverWidth)
+        let w: CGFloat = name == "ask" ? 700 : name == "statement" ? 520 : (name == "arrangement" ? 380 : T.popoverWidth)
         host.frame = NSRect(x: 0, y: 0, width: w, height: host.fittingSize.height); host.layoutSubtreeIfNeeded()
         if let rep = host.bitmapImageRepForCachingDisplay(in: host.bounds) { host.cacheDisplay(in: host.bounds, to: rep); try? rep.representation(using: .png, properties: [:])?.write(to: dir.appendingPathComponent("screen-\(CommandLine.arguments[i + 1]).png")) }
         print("screen: \(CommandLine.arguments[i + 1]) \(Int(host.bounds.height))pt desk=\(st.desk.count) matters=\(st.matters.count) nar=\(st.narToday.map { String($0) } ?? "-")"); done = true

--- a/packages/alfred-mac/Sources/AlfredBlack/App.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/App.swift
@@ -513,12 +513,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
       m.addItem(withTitle: p, action: nil, keyEquivalent: "")
     }
     m.addItem(.separator())
-    for (title, sel) in [("The Glance", #selector(showGlance)), ("The Brief", #selector(showBrief)), ("Matters", #selector(showMatters)), ("Your Word", #selector(showYourWord)), ("The Ledger", #selector(showLedger)), ("The Vault", #selector(showVault)), ("The Arrangement", #selector(showArrangement))] {
+    for (title, sel) in [("Today", #selector(showGlance)), ("Brief", #selector(showBrief)), ("Matters", #selector(showMatters)), ("Decisions", #selector(showYourWord)), ("Activity", #selector(showLedger)), ("Vault", #selector(showVault)), ("Settings", #selector(showArrangement))] {
       m.addItem(withTitle: title, action: sel, keyEquivalent: "").target = self
     }
     m.addItem(.separator())
     m.addItem(withTitle: "Ask Alfred…", action: #selector(askAlfred), keyEquivalent: "").target = self
-    m.addItem(withTitle: "The Statement…", action: #selector(showStatement), keyEquivalent: "").target = self
+    m.addItem(withTitle: "Attention statement…", action: #selector(showStatement), keyEquivalent: "").target = self
     m.addItem(withTitle: "Open Alfred Black…", action: #selector(openWindow), keyEquivalent: "o").target = self
     m.addItem(withTitle: "Reveal Alfred folder", action: #selector(revealFolder), keyEquivalent: "").target = self
     m.addItem(.separator())

--- a/packages/alfred-mac/Sources/AlfredBlack/Ask.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Ask.swift
@@ -6,22 +6,47 @@ import SwiftUI
 import AppKit
 import Carbon.HIToolbox
 
+/// The screen dims behind the bar; a click on the dimness is "never mind".
+final class Backdrop: NSWindow {
+  var onClick: (() -> Void)?
+  init() {
+    super.init(contentRect: .zero, styleMask: [.borderless], backing: .buffered, defer: false)
+    backgroundColor = NSColor.black.withAlphaComponent(0.42); isOpaque = false; hasShadow = false
+    level = .floating; collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]; ignoresMouseEvents = false; isReleasedWhenClosed = false
+  }
+  override func mouseDown(with event: NSEvent) { onClick?() }
+}
+
 final class AskPanel: NSPanel {
+  let backdrop = Backdrop()
   init(state: AppState) {
-    super.init(contentRect: NSRect(x: 0, y: 0, width: 620, height: 64), styleMask: [.borderless, .nonactivatingPanel], backing: .buffered, defer: false)
+    super.init(contentRect: NSRect(x: 0, y: 0, width: 700, height: 76), styleMask: [.borderless, .nonactivatingPanel], backing: .buffered, defer: false)
     isFloatingPanel = true; level = .floating; collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
     backgroundColor = .clear; isOpaque = false; hasShadow = true; isMovableByWindowBackground = true
     appearance = NSAppearance(named: .darkAqua); hidesOnDeactivate = false; isReleasedWhenClosed = false
     contentViewController = NSHostingController(rootView: AskView().environmentObject(state))
+    backdrop.onClick = { [weak state] in state?.dismissAsk() }
   }
   override var canBecomeKey: Bool { true }
-  /// Upper third of the screen the mouse is on, centred.
+  /// Over a dimmed screen — the one the mouse is on — centred, upper third.
   func present() {
     guard let screen = NSScreen.screens.first(where: { NSMouseInRect(NSEvent.mouseLocation, $0.frame, false) }) ?? NSScreen.main else { return }
-    let f = screen.visibleFrame; let h = contentView?.fittingSize.height ?? 64
-    setFrame(NSRect(x: f.midX - 310, y: f.minY + f.height * 0.62, width: 620, height: h), display: true)
-    makeKeyAndOrderFront(nil); NSApp.activate(ignoringOtherApps: true)
+    backdrop.setFrame(screen.frame, display: true); backdrop.alphaValue = 0; backdrop.orderFront(nil)
+    let f = screen.visibleFrame; let h = contentView?.fittingSize.height ?? 76
+    setFrame(NSRect(x: f.midX - 350, y: f.minY + f.height * 0.62, width: 700, height: h), display: true)
+    alphaValue = 0; makeKeyAndOrderFront(nil); NSApp.activate(ignoringOtherApps: true)
+    NSAnimationContext.runAnimationGroup { c in c.duration = 0.16; backdrop.animator().alphaValue = 1; animator().alphaValue = 1 }
   }
+  override func orderOut(_ sender: Any?) { backdrop.orderOut(sender); super.orderOut(sender) }
+}
+
+/// The bar's material — translucent over whatever is behind, like a system overlay.
+struct Vibrancy: NSViewRepresentable {
+  func makeNSView(context: Context) -> NSVisualEffectView {
+    let v = NSVisualEffectView(); v.material = .hudWindow; v.blendingMode = .behindWindow; v.state = .active
+    v.wantsLayer = true; v.layer?.cornerRadius = 18; v.layer?.masksToBounds = true; return v
+  }
+  func updateNSView(_ v: NSVisualEffectView, context: Context) {}
 }
 
 struct AskView: View {
@@ -31,16 +56,19 @@ struct AskView: View {
   private var reduceMotion: Bool { NSWorkspace.shared.accessibilityDisplayShouldReduceMotion }
   var body: some View {
     VStack(spacing: 0) {
-      HStack(spacing: 14) {
-        if let m = Brand.image("logo-brass.svg") { Image(nsImage: m).resizable().aspectRatio(contentMode: .fit).frame(height: 22) }
+      HStack(spacing: 16) {
+        if let m = Brand.image("logo-brass.svg") {
+          Image(nsImage: m).resizable().aspectRatio(contentMode: .fit).frame(height: 26)
+            .shadow(color: T.brass.opacity(0.55), radius: 10)   // the mark glows, faintly
+        }
         TextField("What can I take off your desk, \(T.honorific)?", text: $text).textFieldStyle(.plain)
-          .font(T.say(19)).foregroundColor(T.ink).focused($focused).disabled(s.asking)
+          .font(T.say(21)).foregroundColor(T.ink).focused($focused).disabled(s.asking)
           .onSubmit { submit(withoutRead: NSEvent.modifierFlags.contains(.shift)) }
         if s.asking { Meta(text: "one moment", color: T.dim) } else { Keycap(text: "ESC") }
-      }.padding(.horizontal, 22).padding(.vertical, 18)
+      }.padding(.horizontal, 24).padding(.vertical, 22)
       if let r = s.askReply {
-        Rectangle().fill(T.hair).frame(height: 1).padding(.horizontal, 22)
-        Say(text: r, size: 16).padding(.horizontal, 22).padding(.top, 16)
+        Rectangle().fill(T.hair).frame(height: 1).padding(.horizontal, 24)
+        Say(text: r, size: 17).padding(.horizontal, 24).padding(.top, 16)
         HStack(spacing: 22) {
           Meta(text: "⏎ so ordered", color: T.brass, tracking: 1.8)
           Meta(text: "⇧⏎ send without read", tracking: 1.8)
@@ -48,9 +76,9 @@ struct AskView: View {
         }.padding(.horizontal, 22).padding(.top, 14).padding(.bottom, 18)
       }
     }
-    .frame(width: 620)
-    .background(RoundedRectangle(cornerRadius: T.rBar).fill(T.bg))
-    .overlay(RoundedRectangle(cornerRadius: T.rBar).stroke(T.hair2, lineWidth: 1))
+    .frame(width: 700)
+    .background(ZStack { Vibrancy(); RoundedRectangle(cornerRadius: 18).fill(T.bg.opacity(0.72)) })
+    .overlay(RoundedRectangle(cornerRadius: 18).stroke(T.hair2, lineWidth: 1))
     .onAppear { focused = true }
     .onExitCommand { s.dismissAsk() }
     .animation(reduceMotion ? nil : .easeOut(duration: 0.15), value: s.askReply)

--- a/packages/alfred-mac/Sources/AlfredBlack/Popover.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Popover.swift
@@ -10,6 +10,8 @@ struct PopoverView: View {
   @EnvironmentObject var s: AppState
   var body: some View {
     ZStack { T.bg
+      VStack(spacing: 0) {
+      Group {
       switch s.screen {
       case .brief: BriefView()
       case .matters: MattersView()
@@ -18,6 +20,9 @@ struct PopoverView: View {
       case .vault: VaultView()
       case .arrangement: ArrangementView()
       default: GlanceView()
+      }
+      }
+      NavStrip()
       }
     }
     .background(   // the screens' keys: ⌘G glance · ⌘B brief · ⌘M matters · ⌘L ledger · ⌘V vault · ⌘, arrangement
@@ -45,8 +50,8 @@ struct GlanceView: View {
   private var line: String {
     let n = max(s.deskTotal, s.desk.count)
     if n == 0 { return "\(greeting), \(T.honorific). The desk is quiet — «nothing needs your word.»" }
-    if n == 1 { return "\(greeting), \(T.honorific). The desk is quiet — «one matter needs your word.»" }
-    return "\(greeting), \(T.honorific). «\(n) matters need your word.»"
+    if n == 1 { return "\(greeting), \(T.honorific). The desk is quiet — «one thing needs your word.»" }
+    return "\(greeting), \(T.honorific). «\(n) things need your word.»"
   }
   private var returned: String {
     guard let h = s.narToday else { return "Today · in hand" }
@@ -64,7 +69,7 @@ struct GlanceView: View {
       HStack {
         Meta(text: returned, tracking: 1.8)
         Spacer()
-        Keycap(text: "⌘⇧A  ASK")
+        Keycap(text: "⌘⇧A  ASK ALFRED")
       }.padding(.horizontal, 18).padding(.vertical, 11)
     }
   }
@@ -76,7 +81,7 @@ struct BriefView: View {
   private func openBrief() { if let d = s.pairing?.domain, let u = URL(string: "https://\(d)/brief") { NSWorkspace.shared.open(u) } }
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
-      HStack { Meta(text: s.brief?.header ?? "The Brief", color: T.brass); Spacer(); Meta(text: s.brief?.composedTime ?? "") }
+      HStack { Meta(text: s.brief?.header ?? "Brief", color: T.brass); Spacer(); Meta(text: s.brief?.composedTime ?? "") }
         .padding(.horizontal, 18).padding(.top, 15).padding(.bottom, 13)
       Rectangle().fill(T.hair).frame(height: 1)
       if let b = s.brief {
@@ -135,7 +140,7 @@ struct MattersView: View {
         }
       }
       HStack { Meta(text: overdue == 0 ? "Nothing overdue" : "\(overdue) past due", color: overdue == 0 ? T.dim : T.brass, tracking: 1.8); Spacer()
-        Button(action: { s.open(.ledger) }) { Keycap(text: "⌘L  LEDGER") }.buttonStyle(.plain) }
+        Button(action: { s.open(.ledger) }) { Keycap(text: "⌘L  ACTIVITY") }.buttonStyle(.plain) }
         .padding(.horizontal, 18).padding(.vertical, 11)
     }
   }
@@ -151,7 +156,7 @@ struct YourWordView: View {
   }
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
-      HStack { Meta(text: "Your word, \(T.honorific)", color: T.brass); Spacer(); Meta(text: "\(min(s.wordIndex + 1, max(1, s.desk.count))) of \(max(s.desk.count, 1))") }
+      HStack { Meta(text: "Decisions", color: T.brass); Spacer(); Meta(text: "\(min(s.wordIndex + 1, max(1, s.desk.count))) of \(max(s.deskTotal, s.desk.count, 1))") }
         .padding(.horizontal, 18).padding(.top, 15).padding(.bottom, 13)
       Rectangle().fill(T.hair).frame(height: 1)
       if let c = card {
@@ -170,7 +175,7 @@ struct YourWordView: View {
           Button("So ordered") { Task { await s.decide("delegate") } }.buttonStyle(PopButton(primary: true)).keyboardShortcut(.return, modifiers: [])
         }.padding(.horizontal, 18).padding(.vertical, 16).disabled(s.deciding)
       } else {
-        Say(text: "Nothing needs your word, \(T.honorific). «The desk is quiet.»").padding(.horizontal, 18).padding(.vertical, 18)
+        Say(text: "Nothing needs your decision, \(T.honorific). «The desk is quiet.»").padding(.horizontal, 18).padding(.vertical, 18)
       }
     }
   }
@@ -182,7 +187,7 @@ struct LedgerView: View {
   private func openAudit() { if let d = s.pairing?.domain, let u = URL(string: "https://\(d)/decisions") { NSWorkspace.shared.open(u) } }
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
-      HStack { Meta(text: "The Ledger · today", color: T.brass); Spacer(); Button(action: openAudit) { Meta(text: "Open ⌘F") }.buttonStyle(.plain) }
+      HStack { Meta(text: "Activity · today", color: T.brass); Spacer(); Button(action: openAudit) { Meta(text: "Open ⌘F") }.buttonStyle(.plain) }
         .padding(.horizontal, 18).padding(.top, 15).padding(.bottom, 13)
       Rectangle().fill(T.hair).frame(height: 1)
       if s.ledger.isEmpty { Say(text: "Nothing recorded yet today, \(T.honorific).").padding(.horizontal, 18).padding(.vertical, 18) }
@@ -209,7 +214,7 @@ struct VaultView: View {
   ]
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
-      HStack { Meta(text: "The Vault", color: T.brass); Spacer(); Meta(text: "Private by design") }
+      HStack { Meta(text: "Vault", color: T.brass); Spacer(); Meta(text: "Private by design") }
         .padding(.horizontal, 18).padding(.top, 15).padding(.bottom, 13)
       Rectangle().fill(T.hair).frame(height: 1)
       ForEach(Self.shelves, id: \.0) { name, types in
@@ -251,7 +256,7 @@ struct ArrangementView: View {
   }
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
-      HStack { Meta(text: "The Arrangement", color: T.brass); Spacer(); Meta(text: since) }
+      HStack { Meta(text: "Settings", color: T.brass); Spacer(); Meta(text: since) }
         .padding(.horizontal, 18).padding(.top, 15).padding(.bottom, 13)
       Rectangle().fill(T.hair).frame(height: 1)
       field("Alfred may, without asking", $draft.may); Rectangle().fill(T.hair).frame(height: 1)
@@ -270,5 +275,25 @@ struct ArrangementView: View {
     }
     .onAppear { if !loaded { draft = s.arrangement; loaded = true } }
     .onChange(of: s.arrangement) { a in if draft == Arrangement() { draft = a } }
+  }
+}
+
+/// Where the popover can go, in plain words; the screen you are on is brass.
+struct NavStrip: View {
+  @EnvironmentObject var s: AppState
+  private let items: [(String, Screen)] = [("Today", .glance), ("Brief", .brief), ("Matters", .matters), ("Decisions", .yourWord), ("Activity", .ledger), ("Vault", .vault), ("Settings", .arrangement)]
+  var body: some View {
+    VStack(spacing: 0) {
+      Rectangle().fill(T.hair2).frame(height: 1)
+      HStack(spacing: 11) {
+        ForEach(items, id: \.0) { name, sc in
+          Button(action: { s.open(sc) }) {
+            Text(name.uppercased()).font(T.mono(7.5, weight: .heavy)).tracking(0.8)
+              .foregroundColor(s.screen == sc ? T.brass : T.dim).lineLimit(1).fixedSize()
+              .padding(.vertical, 10).contentShape(Rectangle())
+          }.buttonStyle(.plain)
+        }
+      }.frame(maxWidth: .infinity)
+    }.background(T.bg2.opacity(0.6))
   }
 }

--- a/packages/alfred-mac/Sources/AlfredBlack/Presence.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Presence.swift
@@ -28,6 +28,6 @@ enum Presence {
     img.isTemplate = false; return img
   }
   static func line(deskCount: Int) -> String {
-    deskCount == 0 ? "The desk is quiet." : deskCount == 1 ? "One matter needs your word." : "\(deskCount) matters need your word."
+    deskCount == 0 ? "The desk is quiet." : deskCount == 1 ? "One thing needs your word." : "\(deskCount) things need your word."
   }
 }

--- a/packages/alfred-mac/Sources/AlfredBlack/Statement.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Statement.swift
@@ -9,7 +9,7 @@ struct MonthStatement { var month: String; var returned: Double; var displaced: 
 final class StatementWindow: NSWindow {
   init(state: AppState) {
     super.init(contentRect: NSRect(x: 0, y: 0, width: 520, height: 420), styleMask: [.titled, .closable, .miniaturizable, .fullSizeContentView], backing: .buffered, defer: false)
-    title = "Attention Statement"; titlebarAppearsTransparent = true; titleVisibility = .hidden
+    title = "Attention statement"; titlebarAppearsTransparent = true; titleVisibility = .hidden
     appearance = NSAppearance(named: .darkAqua); backgroundColor = AB.hex(0x1C1A17); isReleasedWhenClosed = false
     contentViewController = NSHostingController(rootView: StatementView().environmentObject(state))
     center()

--- a/packages/alfred-mac/Sources/AlfredBlack/Tenant.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Tenant.swift
@@ -257,7 +257,7 @@ struct Brief {
   /// "THE BRIEF · TUE 9 SEP" and the time it was composed.
   var header: String {
     let f = DateFormatter(); f.dateFormat = "yyyy-MM-dd"; let o = DateFormatter(); o.dateFormat = "EEE d MMM"
-    return "The Brief · " + (f.date(from: date).map { o.string(from: $0) } ?? date)
+    return "Brief · " + (f.date(from: date).map { o.string(from: $0) } ?? date)
   }
   var composedTime: String {
     guard let c = composed_at, let d = ISO8601DateFormatter().date(from: c) ?? { let f = ISO8601DateFormatter(); f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]; return f.date(from: c) }() else { return slot == "morning" ? "07:00" : "19:00" }


### PR DESCRIPTION
## What

From the principal's first use of the redesigned app:

- **Plain names.** The screens say what they are — Today · Brief · Matters · Decisions · Activity · Vault · Settings — in the popover headers, the utility menu, and a **navigation strip** along the bottom of the popover (the current screen in brass). What needs the principal's word are "things", never "matters", since Matters is a screen of its own; the Decisions header counts the Desk's true total.
- **The Ask as an overlay.** ⌘⇧A dims the screen the mouse is on (42 % black; a click on the dimness is *never mind*), and the bar — 700 pt, 18 pt corners — is translucent over what lies behind, the brass mark glowing faintly, the question at 21 pt; both fade in over 160 ms.

Lane VIII, two commits, 113 changed LOC.

## Smoke evidence

- `swift build -c release` ok; local lane VIII gate passed on both commits.
- `--screen glance` / `yourword` rendered against a tenant: "453 things need your word", the strip with seven evenly spaced names, Decisions "1 of 453".
- `--screen ask --reply …` rendered: the wider bar, the glowing mark, the brass clause (the dimmed backdrop and translucency show only live).
- Installed on the author's Mac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)