### PR TITLE
feat(alfred-mac): command first on Today, and triage instead of an alarm

### DIFF
--- a/packages/alfred-mac/Sources/AlfredBlack/App.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/App.swift
@@ -323,7 +323,17 @@ final class AppState: ObservableObject {
     let body = a.written(into: rulesBody ?? "# Standing Rules\n")
     do { try await t.saveRules(body); rulesBody = body; arrangement = a } catch { record(error) }
   }
-  func popoverClosed() { if screen == .brief, let b = brief { state.briefReadSlug = b.slug_date }; screen = .glance }
+  /// Cards that arrived since the principal last looked at the desk (yesterday's midnight until they have).
+  var newSinceSeen: Int {
+    let since = state.deskSeenAt ?? Calendar.current.startOfDay(for: Date())
+    let f = ISO8601DateFormatter(); let g = ISO8601DateFormatter(); g.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return desk.filter { c in (c.created.flatMap { f.date(from: $0) ?? g.date(from: $0) } ?? .distantPast) > since }.count
+  }
+  func popoverClosed() {
+    if screen == .brief, let b = brief { state.briefReadSlug = b.slug_date }
+    if screen == .glance || screen == .yourWord { state.deskSeenAt = Date() }
+    screen = .glance
+  }
   @Published var reply: (text: String, at: Date)? = nil
   @Published var asking = false
   @Published var askReply: String? = nil
@@ -383,7 +393,7 @@ final class AppState: ObservableObject {
       lastDesk = now
       if let page = try? await t.deskPending() {
         let before = deskTotal
-        desk = page.items.filter { ($0.status ?? "pending") == "pending" }.sorted { ($0.created ?? "") > ($1.created ?? "") }; deskTotal = page.total   // newest first
+        desk = page.items.filter { ($0.status ?? "pending") == "pending" }.sorted { ($0.decay_score ?? 0, $0.created ?? "") > ($1.decay_score ?? 0, $1.created ?? "") }; deskTotal = page.total   // most pressing first
         if before > 0 || lastDeskSeen != nil, page.total > before, let newest = desk.first { Notify.yourWord(newest.title) }
         lastDeskSeen = now
       }

--- a/packages/alfred-mac/Sources/AlfredBlack/Popover.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Popover.swift
@@ -48,10 +48,10 @@ struct GlanceView: View {
     return h < 12 ? "Good morning" : h < 18 ? "Good afternoon" : "Good evening"
   }
   private var line: String {
-    let n = max(s.deskTotal, s.desk.count)
+    let n = max(s.deskTotal, s.desk.count); let new = s.newSinceSeen
     if n == 0 { return "\(greeting), \(T.honorific). The desk is quiet — «nothing needs your word.»" }
-    if n == 1 { return "\(greeting), \(T.honorific). The desk is quiet — «one thing needs your word.»" }
-    return "\(greeting), \(T.honorific). «\(n) things need your word.»"
+    if new == 0 { return "\(greeting), \(T.honorific). Nothing new since you looked — «\(n) waiting.»" }
+    return "\(greeting), \(T.honorific). «\(new == 1 ? "One thing is" : "\(new) things are") new» since you looked; \(n) waiting."
   }
   private var returned: String {
     guard let h = s.narToday else { return "Today · in hand" }
@@ -59,8 +59,9 @@ struct GlanceView: View {
   }
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
-      ScreenHeader(name: "Today", status: s.deskTotal == 0 ? "The desk is quiet" : "\(max(s.deskTotal, s.desk.count)) waiting", brass: s.deskTotal > 0)
-      Say(text: line).padding(.horizontal, 18).padding(.top, 18).padding(.bottom, 16)
+      ScreenHeader(name: "Today", status: s.deskTotal == 0 ? "The desk is quiet" : (s.newSinceSeen > 0 ? "\(s.newSinceSeen) new · \(max(s.deskTotal, s.desk.count)) waiting" : "\(max(s.deskTotal, s.desk.count)) waiting"), brass: s.newSinceSeen > 0)
+      AskInline().padding(.horizontal, 18).padding(.top, 16)
+      Say(text: line).padding(.horizontal, 18).padding(.top, 16).padding(.bottom, 14)
       ForEach(Array(s.desk.prefix(3))) { item in
         PopRow(title: item.title, meta: "Your word", needsWord: true) { s.open(.yourWord) }
       }
@@ -70,7 +71,7 @@ struct GlanceView: View {
       HStack {
         Meta(text: returned, tracking: 1.8)
         Spacer()
-        Button(action: { s.toggleAsk() }) { Keycap(text: "⌘⇧A  ASK ALFRED") }.buttonStyle(.plain).pointer()
+        if s.deskTotal > 3 { Button(action: { s.open(.yourWord) }) { Meta(text: "See all \(max(s.deskTotal, s.desk.count)) in Decisions →", color: T.brass, tracking: 1.4) }.buttonStyle(.plain).pointer() }
       }.padding(.horizontal, 18).padding(.vertical, 12)
     }
   }
@@ -271,9 +272,9 @@ struct NavStrip: View {
   var body: some View {
     VStack(spacing: 0) {
       Rectangle().fill(T.hair2).frame(height: 1)
-      HStack(spacing: 4) {
+      HStack(spacing: 1) {
         ForEach(items, id: \.0) { name, sc in NavItem(name: name, active: s.screen == sc) { s.open(sc) } }
-      }.frame(maxWidth: .infinity).padding(.horizontal, 6)
+      }.frame(maxWidth: .infinity).padding(.horizontal, 4)
     }.background(T.bg2.opacity(0.6))
   }
 }
@@ -283,10 +284,40 @@ struct NavItem: View {
   @State private var hover = false
   var body: some View {
     Button(action: action) {
-      Text(name.uppercased()).font(T.mono(9.5, weight: .heavy)).tracking(0.6)
+      Text(name.uppercased()).font(T.mono(9, weight: .heavy)).tracking(0.3)
         .foregroundColor(active ? T.brass : (hover ? T.ink : T.dim)).lineLimit(1).fixedSize()
-        .padding(.horizontal, 7).padding(.vertical, 11).contentShape(Rectangle())
+        .padding(.horizontal, 5).padding(.vertical, 11).contentShape(Rectangle())
         .background(RoundedRectangle(cornerRadius: T.rButton).fill(hover && !active ? T.bg3 : Color.clear))
     }.buttonStyle(.plain).onHover { hover = $0 }.pointer().accessibilityLabel(name)
+  }
+}
+
+/// The command line, in the popover: ask here, or ⌘⇧A anywhere. Alfred proposes before he acts.
+struct AskInline: View {
+  @EnvironmentObject var s: AppState
+  @State private var text = ""
+  @FocusState private var focused: Bool
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack(spacing: 10) {
+        Text("alfred.black >").font(T.mono(11, weight: .bold)).foregroundColor(T.brass)
+        TextField("What shall Alfred handle?", text: $text).textFieldStyle(.plain)
+          .font(T.say(15)).foregroundColor(T.ink).focused($focused).disabled(s.asking)
+          .onSubmit { if s.askReply != nil { s.soOrdered(withoutRead: NSEvent.modifierFlags.contains(.shift)) } else { let q = text; text = ""; Task { await s.propose(q) } } }
+        if s.asking { Meta(text: "reading your desk…", size: 8.5, tracking: 1.2) } else { Button(action: { s.toggleAsk() }) { Keycap(text: "⌘⇧A") }.buttonStyle(.plain).pointer().help("Ask from anywhere") }
+      }
+      .padding(.horizontal, 12).padding(.vertical, 9)
+      .overlay(RoundedRectangle(cornerRadius: T.rButton).stroke(focused ? T.brass : T.hair2, lineWidth: 1))
+      if let r = s.askReply {
+        Say(text: r, size: 14.5).padding(.top, 4)
+        HStack(spacing: 18) {
+          Button(action: { s.soOrdered(withoutRead: false) }) { Meta(text: "⏎ so ordered", color: T.brass, tracking: 1.6) }.buttonStyle(.plain).pointer()
+          Button(action: { s.soOrdered(withoutRead: true) }) { Meta(text: "⇧⏎ without read", tracking: 1.6) }.buttonStyle(.plain).pointer()
+          Button(action: { s.askReply = nil }) { Meta(text: "esc never mind", tracking: 1.6) }.buttonStyle(.plain).pointer().keyboardShortcut(.escape, modifiers: [])
+        }
+      } else if focused && text.isEmpty {
+        Meta(text: "⏎ to ask · Alfred proposes before he acts", size: 8.5, tracking: 1.2)
+      }
+    }
   }
 }

--- a/packages/alfred-mac/Sources/AlfredBlack/Store.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Store.swift
@@ -17,6 +17,7 @@ struct RunState: Codable {
   var briefReadSlug: String? = nil
   var pendingTrust: Int? = nil
   var trustEffectiveAt: Date? = nil
+  var deskSeenAt: Date? = nil
   var lastRenderAt: Date?
   var lastRenderEntries: Int = 0
   var lastPushAt: Date?


### PR DESCRIPTION
## What

Second slice of the usability pass.

- **Command first.** The command line sits at the top of Today — ask here, or ⌘⇧A anywhere — with the hint "⏎ to ask · Alfred proposes before he acts" while it waits for words, and the so-ordered / without-read / never-mind keys under the answer.
- **Triage, not an alarm.** "7 things are new since you looked; 454 waiting"; the header says "7 new · 454 waiting"; cards come most pressing first by the API's decay score; "See all in Decisions →" takes the rest. The desk counts as looked at when Today or Decisions closes (`deskSeenAt` in state.json).

Lane VIII, 66 changed LOC.

## Smoke evidence

- `swift build -c release` ok before and after the rebase; local lane VIII gate passed.
- `--screen glance` rendered against a tenant: the field with the brass prompt, "7 new · 454 waiting", the triage line, three cards most pressing first, the see-all link (holds personal data; not attached).

🤖 Generated with [Claude Code](https://claude.com/claude-code)