### PR TITLE
feat(alfred-mac): show what just happened — confirmations with Undo, a waiting state you can leave, "updated … ago"

### DIFF
--- a/packages/alfred-mac/Sources/AlfredBlack/App.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/App.swift
@@ -198,20 +198,14 @@ final class AppState: ObservableObject {
 
 
   func propose(_ text: String) async {
-
-
     let q = text.trimmingCharacters(in: .whitespacesAndNewlines); guard !q.isEmpty, !asking, let t = tenant else { return }
-
-
-    asking = true; defer { asking = false }
-
-
+    asking = true; askStartedAt = Date(); defer { asking = false; askStartedAt = nil }
     let framed = "\(T.honorific.capitalized) asks: «\(q)». Before acting, say in one short paragraph what you would do and any specifics you can see — then wait for his word. Do not act yet."
-
-
-    do { askReply = try await t.ask(framed, chatId: Store.deviceId()) } catch { record(error) }
-
-
+    let task = Task { () -> String? in try? await t.ask(framed, chatId: Store.deviceId()) }
+    askTask = task
+    let r = await task.value
+    if task.isCancelled { return }
+    if let r { askReply = r } else { say("Alfred could not be reached just now.") }
   }
 
 
@@ -219,17 +213,10 @@ final class AppState: ObservableObject {
 
 
   func soOrdered(withoutRead: Bool) {
-
-
     guard let t = tenant else { return }
-
-
     let word = withoutRead ? "So ordered — send without my read." : "So ordered."
-
-
-    dismissAsk(); Task { _ = try? await t.ask(word, chatId: Store.deviceId()) }
-
-
+    dismissAsk(); say(withoutRead ? "Ordered, without a read. Alfred is on it." : "Ordered. Alfred is on it — drafts for your read.")
+    Task { _ = try? await t.ask(word, chatId: Store.deviceId()) }
   }
 
 
@@ -245,7 +232,10 @@ final class AppState: ObservableObject {
   }
 
 
-  func dismissAsk() { askReply = nil; askPanel?.orderOut(nil) }
+  func cancelAsk() { askTask?.cancel(); askTask = nil; asking = false; askStartedAt = nil }
+
+
+  func dismissAsk() { if asking { cancelAsk() }; askReply = nil; askPanel?.orderOut(nil) }
 
 
   func toggleAsk() {
@@ -305,12 +295,28 @@ final class AppState: ObservableObject {
   /// Priority when the popover opens: an unread brief of the day, else the Glance.
   func popoverOpened() { screen = (brief.map { $0.isToday && state.briefReadSlug != $0.slug_date } ?? false) ? .brief : .glance }
   @Published var wordIndex = 0
+  @Published var notice: (text: String, at: Date, undo: (() -> Void)?)? = nil
+  @Published var lastRefreshAt: Date? = nil
+  @Published var askStartedAt: Date? = nil
+  private var askTask: Task<String?, Never>? = nil
+  func say(_ text: String, undo: (() -> Void)? = nil) {
+    notice = (text, Date(), undo)
+    DispatchQueue.main.asyncAfter(deadline: .now() + 8) { [weak self] in if let n = self?.notice, Date().timeIntervalSince(n.at) >= 7.9 { self?.notice = nil } }
+  }
   @Published var deciding = false
   /// The principal's word, then the next matter — or the Glance when none remain.
   func decide(_ intent: String) async {
     guard !deciding, let t = tenant, wordIndex < desk.count else { return }
     let card = desk[wordIndex]; deciding = true; defer { deciding = false }
-    do { try await t.decide(card: card, intent: intent); desk.remove(at: wordIndex); deskTotal = max(0, deskTotal - 1) } catch { record(error) }
+    do {
+      let id = try await t.decide(card: card, intent: intent)
+      let removed = desk.remove(at: wordIndex); deskTotal = max(0, deskTotal - 1)
+      let what = intent == "delegate" ? "Recorded. Alfred is on it." : intent == "defer" ? "Held for later." : "Recorded as yours."
+      say(what, undo: id.map { did in { [weak self] in
+        guard let self, let t = self.tenant else { return }
+        Task { do { try await t.reverse(decisionId: did); self.desk.insert(removed, at: 0); self.deskTotal += 1; self.notice = nil } catch { self.record(error) } }
+      } })
+    } catch { record(error) }
     if wordIndex >= desk.count { wordIndex = max(0, desk.count - 1) }
     if desk.isEmpty { screen = .glance }
   }
@@ -390,7 +396,7 @@ final class AppState: ObservableObject {
       lastBrief = now; if let b = try? await t.latestBrief() { brief = b }
     }
     if force || now.timeIntervalSince(lastDesk) >= 60 {
-      lastDesk = now
+      lastDesk = now; lastRefreshAt = now
       if let page = try? await t.deskPending() {
         let before = deskTotal
         desk = page.items.filter { ($0.status ?? "pending") == "pending" }.sorted { ($0.decay_score ?? 0, $0.created ?? "") > ($1.decay_score ?? 0, $1.created ?? "") }; deskTotal = page.total   // most pressing first

--- a/packages/alfred-mac/Sources/AlfredBlack/Ask.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Ask.swift
@@ -64,8 +64,11 @@ struct AskView: View {
         TextField("What can I take off your desk, \(T.honorific)?", text: $text).textFieldStyle(.plain)
           .font(T.say(21)).foregroundColor(T.ink).focused($focused).disabled(s.asking)
           .onSubmit { submit(withoutRead: NSEvent.modifierFlags.contains(.shift)) }
-        if s.asking { Meta(text: "one moment", color: T.dim) } else { Keycap(text: "ESC") }
+        if s.asking { Waiting() } else { Keycap(text: "ESC") }
       }.padding(.horizontal, 24).padding(.vertical, 22)
+      if s.askReply == nil && !s.asking {
+        Meta(text: "⏎ to ask · Alfred proposes before he acts", size: 8.5, tracking: 1.2).padding(.horizontal, 24).padding(.bottom, 14)
+      }
       if let r = s.askReply {
         Rectangle().fill(T.hair).frame(height: 1).padding(.horizontal, 24)
         Say(text: r, size: 17).padding(.horizontal, 24).padding(.top, 16)

--- a/packages/alfred-mac/Sources/AlfredBlack/Popover.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Popover.swift
@@ -22,9 +22,19 @@ struct PopoverView: View {
       default: GlanceView()
       }
       }
+      if let n = s.notice {
+        HStack(spacing: 12) {
+          Circle().fill(T.brass).frame(width: 5, height: 5)
+          Text(n.text).font(T.body(13)).foregroundColor(T.ink)
+          Spacer()
+          if let u = n.undo { Button(action: u) { Keycap(text: "UNDO") }.buttonStyle(.plain).pointer() }
+        }.padding(.horizontal, 18).padding(.vertical, 9).background(T.bg2)
+        .transition(.opacity)
+      }
       NavStrip()
       }
     }
+    .animation(.easeOut(duration: 0.2), value: s.notice?.at)
     .background(   // the screens' keys: ⌘G glance · ⌘B brief · ⌘M matters · ⌘L ledger · ⌘V vault · ⌘, arrangement
       Group {
         Button("") { s.open(.glance) }.keyboardShortcut("g", modifiers: [.command])
@@ -59,7 +69,7 @@ struct GlanceView: View {
   }
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
-      ScreenHeader(name: "Today", status: s.deskTotal == 0 ? "The desk is quiet" : (s.newSinceSeen > 0 ? "\(s.newSinceSeen) new · \(max(s.deskTotal, s.desk.count)) waiting" : "\(max(s.deskTotal, s.desk.count)) waiting"), brass: s.newSinceSeen > 0)
+      ScreenHeader(name: "Today", status: s.lastRefreshAt == nil ? "reading the desk…" : s.deskTotal == 0 ? "The desk is quiet" : (s.newSinceSeen > 0 ? "\(s.newSinceSeen) new · \(max(s.deskTotal, s.desk.count)) waiting" : "\(max(s.deskTotal, s.desk.count)) waiting"), brass: s.newSinceSeen > 0)
       AskInline().padding(.horizontal, 18).padding(.top, 16)
       Say(text: line).padding(.horizontal, 18).padding(.top, 16).padding(.bottom, 14)
       ForEach(Array(s.desk.prefix(3))) { item in
@@ -180,7 +190,7 @@ struct LedgerView: View {
   private func openAudit() { if let d = s.pairing?.domain, let u = URL(string: "https://\(d)/decisions") { NSWorkspace.shared.open(u) } }
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
-      ScreenHeader(name: "Activity", status: "today · every line traceable")
+      ScreenHeader(name: "Activity", status: s.lastRefreshAt.map { "updated \(AppDelegate.ago($0)) · every line traceable" } ?? "reading…")
       if s.ledger.isEmpty { Say(text: "Nothing recorded yet today, \(T.honorific).").padding(.horizontal, 18).padding(.vertical, 18) }
       ForEach(Array(s.ledger.sorted { (($0.mode ?? "live") == "live" ? 0 : 1) < (($1.mode ?? "live") == "live" ? 0 : 1) }.prefix(6))) { l in
         let live = (l.mode ?? "live") == "live"
@@ -304,7 +314,7 @@ struct AskInline: View {
         TextField("What shall Alfred handle?", text: $text).textFieldStyle(.plain)
           .font(T.say(15)).foregroundColor(T.ink).focused($focused).disabled(s.asking)
           .onSubmit { if s.askReply != nil { s.soOrdered(withoutRead: NSEvent.modifierFlags.contains(.shift)) } else { let q = text; text = ""; Task { await s.propose(q) } } }
-        if s.asking { Meta(text: "reading your desk…", size: 8.5, tracking: 1.2) } else { Button(action: { s.toggleAsk() }) { Keycap(text: "⌘⇧A") }.buttonStyle(.plain).pointer().help("Ask from anywhere") }
+        if s.asking { Waiting() } else { Button(action: { s.toggleAsk() }) { Keycap(text: "⌘⇧A") }.buttonStyle(.plain).pointer().help("Ask from anywhere") }
       }
       .padding(.horizontal, 12).padding(.vertical, 9)
       .overlay(RoundedRectangle(cornerRadius: T.rButton).stroke(focused ? T.brass : T.hair2, lineWidth: 1))
@@ -319,5 +329,19 @@ struct AskInline: View {
         Meta(text: "⏎ to ask · Alfred proposes before he acts", size: 8.5, tracking: 1.2)
       }
     }
+  }
+}
+
+/// While Alfred reads the desk: the seconds, and ESC to stop waiting.
+struct Waiting: View {
+  @EnvironmentObject var s: AppState
+  @State private var tick = 0
+  private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+  var body: some View {
+    let secs = Int(Date().timeIntervalSince(s.askStartedAt ?? Date())) + tick * 0
+    HStack(spacing: 8) {
+      Meta(text: "reading your desk · \(secs)s", size: 8.5, tracking: 1.2)
+      Button(action: { s.cancelAsk() }) { Keycap(text: "ESC") }.buttonStyle(.plain).pointer().keyboardShortcut(.escape, modifiers: [])
+    }.onReceive(timer) { _ in tick += 1 }
   }
 }

--- a/packages/alfred-mac/Sources/AlfredBlack/Tenant.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Tenant.swift
@@ -167,13 +167,18 @@ struct Tenant {
   }
 
   /// The principal's word on a Desk card: hold (defer), take it himself, or so ordered (delegate to Alfred).
-  func decide(card: DeskItem, intent: String) async throws {
+  @discardableResult
+  func decide(card: DeskItem, intent: String) async throws -> String? {
     let (code, data) = try await request("api/v1/decisions", method: "POST", bearer: apiKey,
       body: ["source": "needs_attention", "source_record": card.path ?? "needs_attention/\(card.id).md", "intent": intent, "origin": "mac"])
-    guard code == 200 || code == 201 else {
-      let msg = (try? JSONSerialization.jsonObject(with: data) as? [String: Any])?["error"] as? String
-      throw TenantError(message: msg ?? "The decision was not recorded (HTTP \(code)).")
-    }
+    let j = (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
+    guard code == 200 || code == 201 else { throw TenantError(message: (j["error"] as? String) ?? "The decision was not recorded (HTTP \(code)).") }
+    return (j["id"] as? String) ?? ((j["decision"] as? [String: Any])?["id"] as? String)
+  }
+  /// Undo: the route reverses a decision and restores the card.
+  func reverse(decisionId: String) async throws {
+    let (code, _) = try await request("api/v1/decisions/\(decisionId)/reverse", method: "POST", bearer: apiKey, body: [:])
+    guard code == 200 else { throw TenantError(message: "The decision could not be undone (HTTP \(code)).") }
   }
 
   /// The audit ledger — append-only, every line traceable to its session.


### PR DESCRIPTION
## What

Third slice of the usability pass — feedback.

- **A decision leaves a trace.** "Recorded. Alfred is on it." (or "Held for later." / "Recorded as yours.") for eight seconds with **UNDO**, which reverses the decision through `POST /api/v1/decisions/:id/reverse` and puts the card back. "So ordered" from the Ask says so on Today.
- **Waiting you can leave.** While Alfred reads the desk the field shows the seconds and ESC stops waiting (the request is cancelled client-side); before words, the hint "⏎ to ask · Alfred proposes before he acts".
- **Freshness.** Today's header says "reading the desk…" until the first fetch; Activity says when it was last updated.

Lane VIII, 104 changed LOC.

## Smoke evidence

- `swift build -c release` ok before and after the rebase; local lane VIII gate passed.
- `--screen ask` rendered: the hint under the field. The notice and Undo paths compile against the live route shapes (`id` from the decisions POST, the reverse route); no decision was posted during verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)