### PR TITLE
feat(alfred-mac): Decisions says what "So ordered" will do; keys on the buttons; ↑↓ between cards

### DIFF
--- a/packages/alfred-mac/Sources/AlfredBlack/App.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/App.swift
@@ -238,6 +238,15 @@ final class AppState: ObservableObject {
   func dismissAsk() { if asking { cancelAsk() }; askReply = nil; askPanel?.orderOut(nil) }
 
 
+  /// Open the Ask with a question already written — "what would you do about …?"
+
+
+  func askAbout(_ card: DeskItem) { askDraft = "What would you do about this: \(card.title)"; if askPanel?.isVisible != true { toggleAsk() } }
+
+
+  func nextCard(_ step: Int) { guard !desk.isEmpty else { return }; wordIndex = max(0, min(desk.count - 1, wordIndex + step)) }
+
+
   func toggleAsk() {
 
 
@@ -298,6 +307,7 @@ final class AppState: ObservableObject {
   @Published var notice: (text: String, at: Date, undo: (() -> Void)?)? = nil
   @Published var lastRefreshAt: Date? = nil
   @Published var askStartedAt: Date? = nil
+  @Published var askDraft: String = ""
   private var askTask: Task<String?, Never>? = nil
   func say(_ text: String, undo: (() -> Void)? = nil) {
     notice = (text, Date(), undo)

--- a/packages/alfred-mac/Sources/AlfredBlack/Ask.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Ask.swift
@@ -82,7 +82,8 @@ struct AskView: View {
     .frame(width: 700)
     .background(ZStack { Vibrancy(); RoundedRectangle(cornerRadius: 18).fill(T.bg.opacity(0.72)) })
     .overlay(RoundedRectangle(cornerRadius: 18).stroke(T.hair2, lineWidth: 1))
-    .onAppear { focused = true }
+    .onAppear { focused = true; if !s.askDraft.isEmpty { text = s.askDraft; s.askDraft = "" } }
+    .onChange(of: s.askDraft) { d in if !d.isEmpty { text = d; s.askDraft = ""; focused = true } }
     .onExitCommand { s.dismissAsk() }
     .animation(reduceMotion ? nil : .easeOut(duration: 0.15), value: s.askReply)
   }

--- a/packages/alfred-mac/Sources/AlfredBlack/Popover.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Popover.swift
@@ -161,7 +161,7 @@ struct YourWordView: View {
   }
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
-      ScreenHeader(name: "Decisions", status: s.desk.isEmpty ? "none waiting" : "\(min(s.wordIndex + 1, max(1, s.desk.count))) of \(max(s.deskTotal, s.desk.count, 1))", brass: !s.desk.isEmpty)
+      ScreenHeader(name: "Decisions", status: s.desk.isEmpty ? "none waiting" : "\(min(s.wordIndex + 1, max(1, s.desk.count))) of \(max(s.deskTotal, s.desk.count, 1))" + (s.newSinceSeen > 0 ? " · \(s.newSinceSeen) new" : "") + (s.desk.count > 1 ? " · ↑↓" : ""), brass: !s.desk.isEmpty)
       if let c = card {
         Say(text: c.title, size: 15.5).padding(.horizontal, 18).padding(.top, 18)
         if !c.body.isEmpty && c.body != c.title {
@@ -171,12 +171,21 @@ struct YourWordView: View {
           Meta(text: (c.target_kind ?? "matter"), size: 8.5, tracking: 1.4); Meta(text: "·", size: 8.5); Meta(text: when(c.created), size: 8.5, tracking: 1.4); Spacer()
           Button(action: { if let d = s.pairing?.domain, let u = URL(string: "https://\(d)/desk") { NSWorkspace.shared.open(u) } }) { Meta(text: "Desk ⏎", color: T.brass, size: 8.5, tracking: 1.4) }.buttonStyle(.plain)
         }.padding(.horizontal, 18).padding(.top, 14)
+        if let a = c.proposedAction {
+          HStack(alignment: .firstTextBaseline, spacing: 8) { Meta(text: "If so ordered", color: T.brass, size: 8.5, tracking: 1.4); Text(a).font(T.body(13)).foregroundColor(T.ink).lineLimit(2) }
+            .padding(.horizontal, 18).padding(.top, 12)
+        } else {
+          HStack(alignment: .firstTextBaseline, spacing: 8) { Meta(text: "No action proposed", size: 8.5, tracking: 1.4)
+            Button(action: { s.askAbout(c) }) { Meta(text: "Ask Alfred what he'd do →", color: T.brass, size: 8.5, tracking: 1.4) }.buttonStyle(.plain).pointer() }
+            .padding(.horizontal, 18).padding(.top, 12)
+        }
         HStack(spacing: 8) {
           Spacer()
-          Button("Hold") { Task { await s.decide("defer") } }.buttonStyle(PopButton()).keyboardShortcut(.escape, modifiers: [])
-          Button("Myself") { Task { await s.decide("take_mine") } }.buttonStyle(PopButton()).keyboardShortcut(.return, modifiers: [.command])
-          Button("So ordered") { Task { await s.decide("delegate") } }.buttonStyle(PopButton(primary: true)).keyboardShortcut(.return, modifiers: [])
+          Button(action: { Task { await s.decide("defer") } }) { HStack(spacing: 7) { Text("Hold"); Keycap(text: "ESC", color: T.ink) } }.buttonStyle(PopButton()).keyboardShortcut(.escape, modifiers: []).pointer()
+          Button(action: { Task { await s.decide("take_mine") } }) { HStack(spacing: 7) { Text("Myself"); Keycap(text: "⌘⏎", color: T.ink) } }.buttonStyle(PopButton()).keyboardShortcut(.return, modifiers: [.command]).pointer()
+          Button(action: { Task { await s.decide("delegate") } }) { HStack(spacing: 7) { Text("So ordered"); Keycap(text: "⏎", color: T.bg) } }.buttonStyle(PopButton(primary: true)).keyboardShortcut(.return, modifiers: []).pointer().disabled(c.proposedAction == nil)
         }.padding(.horizontal, 18).padding(.vertical, 16).disabled(s.deciding)
+        .background(Group { Button("") { s.nextCard(-1) }.keyboardShortcut(.upArrow, modifiers: []); Button("") { s.nextCard(1) }.keyboardShortcut(.downArrow, modifiers: []) }.opacity(0).frame(width: 0, height: 0))
       } else {
         Say(text: "Nothing needs your decision, \(T.honorific). «The desk is quiet.»").padding(.horizontal, 18).padding(.vertical, 18)
       }

--- a/packages/alfred-mac/Sources/AlfredBlack/Tenant.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Tenant.swift
@@ -254,6 +254,11 @@ struct DeskItem: Decodable, Identifiable {
     return id
   }
   var body: String { (display_body ?? body_preview ?? "").replacingOccurrences(of: "\n", with: " ").trimmingCharacters(in: .whitespaces) }
+  /// What Alfred would do if so ordered — the card's own action, when it names one distinct from the headline.
+  var proposedAction: String? {
+    guard let a = action_what?.replacingOccurrences(of: "\n", with: " ").trimmingCharacters(in: .whitespaces), !a.isEmpty, a != display_headline else { return nil }
+    return a.count > 90 ? String(a.prefix(89)) + "…" : a
+  }
 }
 
 struct Brief {

--- a/packages/alfred-mac/Sources/AlfredBlack/Tokens.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Tokens.swift
@@ -33,11 +33,11 @@ struct Meta: View {
 
 /// A keycap hint: mono 9px in a 1px hairline chip.
 struct Keycap: View {
-  let text: String
+  let text: String; var color: Color = T.dim
   var body: some View {
-    Text(text).font(T.mono(9, weight: .bold)).tracking(0.9).foregroundColor(T.dim)
+    Text(text).font(T.mono(9, weight: .bold)).tracking(0.9).foregroundColor(color).fixedSize()
       .padding(.horizontal, 6).padding(.vertical, 2)
-      .overlay(RoundedRectangle(cornerRadius: 4).stroke(T.hair2, lineWidth: 1))
+      .overlay(RoundedRectangle(cornerRadius: 4).stroke(color.opacity(0.45), lineWidth: 1))
   }
 }
 
@@ -99,7 +99,7 @@ struct PopRow: View {
 struct PopButton: ButtonStyle {
   var primary = false
   func makeBody(configuration: Configuration) -> some View {
-    configuration.label.font(T.mono(9, weight: .heavy)).tracking(1.8).textCase(.uppercase)
+    configuration.label.font(T.mono(9, weight: .heavy)).tracking(1.8).textCase(.uppercase).fixedSize()
       .padding(.horizontal, 16).padding(.vertical, 9)
       .foregroundColor(primary ? T.bg : T.ink)
       .background(RoundedRectangle(cornerRadius: T.rButton).fill(primary ? T.brass : Color.clear))


### PR DESCRIPTION
## What

Fourth slice of the usability pass — the decision itself.

- Before asking for a decision the screen states the consequence: "If so ordered — <the card's own action>". When the card names none, *So ordered* is disabled and "Ask Alfred what he'd do →" opens the Ask with the question already written.
- The keys sit on the buttons (Hold ESC · Myself ⌘⏎ · So ordered ⏎); ↑ and ↓ move between cards; the header counts the new ones. Keycaps take a colour so they read on brass.

Lane VIII, 43 changed LOC.

## Smoke evidence

- `swift build -c release` ok before and after the rebase; local lane VIII gate passed.
- `--screen yourword` rendered against a tenant: header "1 of 454 · 7 new · ↑↓", the proposed-action line, the three buttons with their keys, nothing wrapping at 400 (an earlier render had the labels breaking inside the buttons; fixed with fixed-size labels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)