### PR TITLE
feat(alfred-mac): Matters that say what is next, an Activity worth reading, a Vault you can open

### DIFF
--- a/packages/alfred-mac/Sources/AlfredBlack/Popover.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Popover.swift
@@ -120,7 +120,8 @@ struct MattersView: View {
   }
   private func meta(_ m: Matter) -> String {
     if blocked(m) { return "Blocked on you" }
-    switch m.state ?? "" { case "done": return "Done"; case "waiting": return "Waiting"; case "dormant": return "Dormant"; default: return "In flight" }
+    if !m.when.isEmpty { return m.when }
+    switch m.state ?? "" { case "done": return "Done"; case "dormant": return "Dormant"; default: return "In flight" }
   }
   private var inFlight: [Matter] { s.matters.filter { ($0.state ?? "active") != "done" } }
   private var overdue: Int {
@@ -129,7 +130,7 @@ struct MattersView: View {
   }
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
-      ScreenHeader(name: "Matters", status: "\(inFlight.count) in flight · L\(s.trust) trust · " + (overdue == 0 ? "nothing overdue" : "\(overdue) past due"), brass: overdue > 0)
+      ScreenHeader(name: "Matters", status: "\(inFlight.count) in flight · L\(s.trust) trust" + (inFlight.filter(blocked).count > 0 ? " · \(inFlight.filter(blocked).count) blocked on you" : ""), brass: inFlight.contains(where: blocked))
       if inFlight.isEmpty {
         Say(text: "Nothing in flight, \(T.honorific). «The desk is clear.»").padding(.horizontal, 18).padding(.vertical, 18)
       }
@@ -140,10 +141,12 @@ struct MattersView: View {
             Circle().fill(b ? T.brass : Color.clear).overlay(Circle().stroke(b ? Color.clear : T.dim, lineWidth: 1)).frame(width: 6, height: 6).alignmentGuide(.firstTextBaseline) { d in d[VerticalAlignment.center] + 4 }
             VStack(alignment: .leading, spacing: 3) {
               Text(m.title).font(T.body(14)).foregroundColor(T.ink).lineLimit(1)
-              if !m.subline.isEmpty { Text(m.subline).font(T.body(11.5, italic: true)).foregroundColor(T.dim).lineLimit(2) }
+              if let n = m.nextAction { Text("Next: \(n)").font(T.body(11.5, italic: true)).foregroundColor(T.ink.opacity(0.85)).lineLimit(2) }
+              else if !m.subline.isEmpty { Text(m.subline).font(T.body(11.5, italic: true)).foregroundColor(T.dim).lineLimit(2) }
             }.frame(maxWidth: .infinity, alignment: .leading)
             Meta(text: meta(m), color: b ? T.brass : T.dim, size: 8.5, tracking: 1.4)
-          }.padding(.horizontal, 18).padding(.vertical, 12)
+          }.padding(.horizontal, 18).padding(.vertical, 12).contentShape(Rectangle())
+          .onTapGesture { if let d = s.pairing?.domain, let u = URL(string: "https://\(d)/matters/\(m.id)") { NSWorkspace.shared.open(u) } }.pointer()
           Rectangle().fill(T.hair).frame(height: 1)
         }
       }
@@ -200,8 +203,9 @@ struct LedgerView: View {
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
       ScreenHeader(name: "Activity", status: s.lastRefreshAt.map { "updated \(AppDelegate.ago($0)) · every line traceable" } ?? "reading…")
-      if s.ledger.isEmpty { Say(text: "Nothing recorded yet today, \(T.honorific).").padding(.horizontal, 18).padding(.vertical, 18) }
-      ForEach(Array(s.ledger.sorted { (($0.mode ?? "live") == "live" ? 0 : 1) < (($1.mode ?? "live") == "live" ? 0 : 1) }.prefix(6))) { l in
+      let lines = s.ledger.filter { $0.meaningful }
+      if lines.isEmpty { Say(text: "Nothing that touched your things today, \(T.honorific). «The machinery ran quietly.»").padding(.horizontal, 18).padding(.vertical, 18) }
+      ForEach(Array(lines.prefix(6))) { l in
         let live = (l.mode ?? "live") == "live"
         HStack(alignment: .firstTextBaseline, spacing: 12) {
           Meta(text: l.time, color: T.dim, size: 8.5, tracking: 1.2).frame(width: 40, alignment: .leading)
@@ -210,7 +214,8 @@ struct LedgerView: View {
         }.padding(.horizontal, 18).padding(.vertical, 11)
         Rectangle().fill(T.hair).frame(height: 1)
       }
-      Button(action: openAudit) { Meta(text: "Open the full log →", color: T.brass, tracking: 1.4) }.buttonStyle(.plain).pointer().padding(.horizontal, 18).padding(.vertical, 12)
+      HStack { Meta(text: "\(s.ledger.count - lines.count) machine lines hidden", size: 8.5, tracking: 1.2); Spacer()
+        Button(action: openAudit) { Meta(text: "Open the full log →", color: T.brass, tracking: 1.4) }.buttonStyle(.plain).pointer() }.padding(.horizontal, 18).padding(.vertical, 12)
     }
   }
 }
@@ -227,12 +232,15 @@ struct VaultView: View {
       ScreenHeader(name: "Vault", status: "private by design")
       ForEach(Self.shelves, id: \.0) { name, types in
         let n = types.reduce(0) { $0 + (s.vault[$1] ?? 0) }
-        HStack { Text(name).font(T.body(14)).foregroundColor(T.ink); Spacer(); Meta(text: n == 0 ? "—" : String(n), size: 9, tracking: 1.4) }
-          .padding(.horizontal, 18).padding(.vertical, 12)
+        HStack { Text(name).font(T.body(14)).foregroundColor(T.ink); Spacer(); Meta(text: n == 0 ? "—" : String(n), size: 9, tracking: 1.4); Meta(text: "→", color: T.brass, size: 9) }
+          .padding(.horizontal, 18).padding(.vertical, 12).contentShape(Rectangle())
+          .onTapGesture { if let d = s.pairing?.domain, let u = URL(string: "https://\(d)/vault?type=\(types[0])") { NSWorkspace.shared.open(u) } }.pointer()
+          .accessibilityLabel("\(name), \(n) records")
         Rectangle().fill(T.hair).frame(height: 1)
       }
       HStack { Text("Credentials").font(T.body(14)).foregroundColor(T.ink); Spacer(); Meta(text: "Sealed", color: T.brass, size: 9, tracking: 1.4) }
         .padding(.horizontal, 18).padding(.vertical, 12)
+        .help("Kept in the password vault on your tenant. Alfred can use them; he never shows or counts them here.")
       Rectangle().fill(T.hair).frame(height: 1)
       Text("Nothing leaves this machine without your word, \(T.honorific).").font(T.say(13.5)).foregroundColor(T.dim).padding(.horizontal, 18).padding(.vertical, 14)
     }

--- a/packages/alfred-mac/Sources/AlfredBlack/Tenant.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Tenant.swift
@@ -305,7 +305,16 @@ struct Brief {
 }
 
 struct Matter: Decodable, Identifiable {
-  var id: String; var name: String?; var summary: String?; var state: String?; var current_state: String?; var path: String?; var next: String?
+  var id: String; var name: String?; var summary: String?; var state: String?; var current_state: String?; var path: String?; var next: String?; var last: String?; var as_of: String?
+  /// The list gives `last` as "Wed Jul 29" and `next` as the next action in words.
+  var when: String {
+    guard let l = last, !l.isEmpty else { return "" }
+    var parts = l.split(separator: " ").map(String.init)
+    if let f = parts.first, f.count == 3, ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"].contains(f) { parts.removeFirst() }   // weekday
+    if parts.count > 2, parts.last?.count == 4 { parts.removeLast() }                                                    // year
+    return "changed " + parts.prefix(2).joined(separator: " ")
+  }
+  var nextAction: String? { guard let n = next?.trimmingCharacters(in: .whitespaces), !n.isEmpty else { return nil }; return n }
   /// The living state, first sentence only, for the subline.
   var subline: String {
     let st = (current_state ?? summary ?? "").replacingOccurrences(of: "\n", with: " ").trimmingCharacters(in: .whitespaces)
@@ -324,6 +333,13 @@ struct Matter: Decodable, Identifiable {
 
 struct LedgerLine: Decodable, Identifiable {
   var id: String; var ts: String?; var action_type: String?; var actor: String?; var summary: String?; var mode: String?; var target_path: String?
+  /// A machine heartbeat (a workflow starting or finishing, a shadow check) is not something a person needs to read.
+  var meaningful: Bool {
+    let t = (summary ?? "").lowercased()
+    if (mode ?? "live") != "live" { return false }
+    if target_path == nil && (t.hasSuffix(" completed") || t.hasSuffix(" started") || t.contains("workflow")) { return false }
+    return true
+  }
   var time: String {
     guard let ts, let d = ISO8601DateFormatter().date(from: ts) ?? { let f = ISO8601DateFormatter(); f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]; return f.date(from: ts) }() else { return "" }
     let f = DateFormatter(); f.dateFormat = Calendar.current.isDateInToday(d) ? "HH:mm" : "d MMM"; return f.string(from: d)


### PR DESCRIPTION
## What

Fifth slice of the usability pass — the three lists.

- **Matters**: the subline is the next action in words when the matter has one ("Next: …"); the meta is "changed <date>" from the list's own last-touched date (weekday and year dropped, whatever shape the API gives); clicking a row opens the matter on the tenant; the header counts what is blocked on the principal instead of guessing at overdue.
- **Activity**: only lines that touched the principal's things are shown; workflow heartbeats and shadow checks are hidden and counted ("N machine lines hidden"), with the full log one click away; an honest empty state when nothing qualifies.
- **Vault**: every shelf opens the vault at that type; "Sealed" explains itself on hover.

Lane VIII, 44 changed LOC.

## Smoke evidence

- `swift build -c release` ok before and after the rebase; local lane VIII gate passed.
- `--screen matters` rendered against a tenant: "CHANGED JUL 29"-style metas on every row, including one whose date came back with a weekday and a year (previously rendered verbatim); "Next: …" sublines from the matter's own next action; header "N in flight · L3 trust · k blocked on you".
- `--screen ledger` rendered: the tenant's last 30 audit lines were all machine lines, so the screen showed the empty state plus "30 machine lines hidden · Open the full log →" rather than a wall of heartbeats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)