### PR TITLE
feat(alfred-mac): a Statement that explains its bars and turns its pages; notifications that land somewhere; README for the pass

### DIFF
--- a/packages/alfred-mac/README.md
+++ b/packages/alfred-mac/README.md
@@ -4,24 +4,25 @@ The principal's desk client for Alfred Black, built to the **Alfred for
 macOS** handoff. The core thesis: **there is no main window.** Alfred lives
 in the menu bar and a global command bar; the only true windows are the
 monthly Attention Statement and the first-run Placement. Everything else is
-one 344 pt popover that swaps its content. Silence when nothing needs the
-principal; one brass dot when something does.
+one 400 pt popover that swaps its content, with a strip of plain page names
+at its foot: Today · Brief · Matters · Decisions · Activity · Vault · Settings.
+Silence when nothing needs the principal; one brass dot when something does.
 
 | | |
 |---|---|
-| **00 · The Presence** | The white Alfred mark in the menu bar, 15 pt, and one brass dot to its right while at least one matter needs the principal's word. No dot is total silence — no badge counts, no animation. Left click opens the popover; right click the utility menu. |
-| **01 · The Glance** | Alfred's greeting with the clause that matters in brass; up to three rows — needs-you first (filled brass dot, *Your word*), then matters in flight (hollow, *In hand*); footer: today's hours returned after every cost, and `⌘⇧A ASK`. |
-| **02 · The Brief** | The tenant's latest brief: header in brass, its intro as Alfred's line, its first three bullets as rows. An unread brief of the day is what the popover opens on; closing it marks it read. |
-| **03 · Matters** | Work in flight, at most five: title, the living state as an italic subline, a meta (*Blocked on you* in brass when a Desk card points at it); trust class in the header; overdue count in the footer; ⌘L to the Ledger. |
-| **04 · Your Word** | An escalation, one decision, the border brassed: the Desk card's headline as Alfred's line, then Hold · Myself · So ordered (`POST /api/v1/decisions`), then the next. Only this screen may notify. |
-| **05/06 · The Ask** | ⌘⇧A anywhere: a floating 620 pt bar on any Space, one field, no modes. ⏎ asks Alfred what he would do (not yet acting); ⏎ again is *So ordered*, ⇧⏎ *send without read*, ESC never mind. Both turns journaled (`POST /api/v1/alfred/ask`), so every surface remembers. |
-| **07 · The Statement** | ⌘⇧S, the only real window: last month's hours returned in 54 pt brass and the three bars — displaced, your time (hatched), net — from the attention statement. ⌘E opens the print statement. |
-| **08 · The Ledger** | The audit ledger in plain words, append-only, actors in brass for what was done live; no edit or delete affordance. |
-| **09 · The Vault** | What Alfred holds, counted by record type onto six shelves; Credentials sealed, never a count. |
-| **10 · The Arrangement** | Settings as a contract: three sentences kept in `vault/RULES.md` (*Alfred may, without asking · asks first · never*), and the trust class (L1 · L2 · L3) mapped to the tenant's autonomy flags — applied at midnight, never at once. |
-| **11 · The Placement** | First run: the brass mark, "At your service.", Alfred's paragraph, the pairing fields, *The Terms* and *Begin the Watch*. One screen, then the app goes silent. |
+| **00 · The Presence** | The white Alfred mark in the menu bar, 15 pt, and one brass dot to its right while at least one thing needs the principal's word. No dot is total silence — no badge counts, no animation. Left click opens the popover; right click the utility menu. |
+| **01 · Today** | Alfred's greeting with the clause that matters in brass; a field to ask him inline; "N new since you last looked"; up to three rows — what needs the principal first (filled brass dot), then matters in flight (hollow); footer: today's hours returned after every cost and *See all N in Decisions*. An unread brief of the day opens first. |
+| **02 · Brief** | The tenant's latest brief: its intro as Alfred's line, its first three bullets as rows, *Read the full brief* below. Closing it marks it read. |
+| **03 · Matters** | Work in flight, at most five: the title, *Next: …* in the matter's own words as the subline, *changed <date>* as the meta — *Blocked on you* in brass when a Desk card points at it. A click opens the matter on the tenant; the header counts what is blocked on the principal. |
+| **04 · Decisions** | One Desk card at a time, the border brassed: the headline as Alfred's line, the body, then what *So ordered* will do (*If so ordered — …*, from the card's own action); when the card proposes nothing, *So ordered* is disabled and *Ask Alfred what he'd do* opens the Ask with the question written. Hold ESC · Myself ⌘⏎ · So ordered ⏎ (`POST /api/v1/decisions`); ↑↓ between cards; every decision confirms in a notice with UNDO for eight seconds. Only this screen may notify, and a click on the notification lands here. |
+| **05/06 · The Ask** | ⌘⇧A anywhere: the screen dims, a translucent 700 pt bar floats on any Space, one field, no modes. ⏎ asks Alfred what he would do (not yet acting); ⏎ again is *So ordered*, ⇧⏎ *send without read*, ESC never mind. Both turns journaled (`POST /api/v1/alfred/ask`), so every surface remembers. |
+| **07 · The Statement** | ⌘⇧S, the only real window: a month's hours returned in 54 pt brass and the three bars — displaced, your time (hatched), net — from the attention statement; ← → turn the months; every bar defines itself on hover. ⌘E opens the print statement. |
+| **08 · Activity** | The audit ledger in plain words, only the lines that touched the principal's things; workflow heartbeats and shadow checks are hidden and counted, the full log one click away. Append-only; no edit or delete affordance. |
+| **09 · Vault** | What Alfred holds, counted by record type onto six shelves, each opening the vault at that type; Credentials sealed, never a count. |
+| **10 · Settings** | Written as a contract, not toggles: three sentences kept in `vault/RULES.md` (*Alfred may, without asking · asks first · never*), each with a ghost example and a line on what it does; the trust class (L1 Watch · L2 Propose · L3 Act, then report) mapped to the tenant's autonomy flags — applied at midnight, never at once, and cancellable until then. A foot with Set up Cowork · Alfred folder · Sign out. |
+| **11 · The Placement** | First run: the brass mark, "At your service.", Alfred's paragraph, the pairing fields, *The terms* and *Begin the watch* — "Sign in and pair this Mac". One screen, then the app goes silent. |
 
-Keys inside the popover: ⌘G glance · ⌘B brief · ⌘M matters · ⌘W your word · ⌘L ledger · ⌘V vault · ⌘, arrangement.
+Keys inside the popover: ⌘G today · ⌘B brief · ⌘M matters · ⌘W decisions · ⌘L activity · ⌘V vault · ⌘, settings — and the strip at the foot for the mouse. Alfred's voice may be old-fashioned; the page names are plain.
 
 ## The continuity layer underneath
 
@@ -29,7 +30,7 @@ Keys inside the popover: ⌘G glance · ⌘B brief · ⌘M matters · ⌘W your 
 |---|---|
 | **Pair** | Enter the tenant URL and the dashboard login. The app signs in, mints a dedicated API key (visible under *Study › API keys*, revocable there), stores it in a 0600 file of its own, and forgets the password. |
 | **Read side** | Every 30 s it renders the principal's recent journal (Slack, Telegram, Cowork, …) into `~/Alfred/continuity.md` as the same `[ALFRED-CONTINUITY — authoritative]` block the Hermes plugin injects. A Cowork plugin (staged by the app) reads that file on `SessionStart`, `UserPromptSubmit` and `PostCompact`. |
-| **Write side** | Every 60 s it mirrors new Cowork turns from the local session transcripts into the journal (`channel: cowork`), binding each new session to the owner. Only turns from the last 48 h are ever mirrored: the journal stamps `ts` server-side, so history mirrored late would land as "now". |
+| **Write side** | Cowork sessions run in a VM and leave no transcript on the Mac, so they journal their own turns: the plugin's Stop hook holds the turn until it has been noted through the app's MCP server (`channel: cowork`, bound to the owner). Local Claude Code transcripts are still mirrored every 60 s; only turns from the last 48 h are ever mirrored, because the journal stamps `ts` server-side and history mirrored late would land as "now". |
 | **Set up Cowork** | One action: registers the MCP server, exports the hooks plugin as `Alfred Continuity.plugin` into Downloads (a zip with `.claude-plugin/plugin.json` at its root — the file Claude Desktop's plugin upload accepts), selects it in Finder and opens Claude. Installing a plugin is Claude's own UI step; there is no deep link or CLI for it. Upload it from **Cowork's** Plugins panel: a Cowork session loads only plugins installed there (an upload from the Code tab installs a local plugin that only Claude Code sessions see). The hooks act only inside Cowork sessions (`ALFRED_CONTINUITY_EVERYWHERE=1` opts others in). |
 | **MCP** | Registers itself in Claude Desktop (`mcpServers.alfred-continuity`, `--mcp`) exposing `alfred_continuity_recent` / `alfred_continuity_note` / `alfred_continuity_bind` — Cowork can read and write continuity directly, through the app, over a loopback stdio pipe. |
 | **First launch** | Opened from a mounted disk image, the app copies itself to `/Applications`, starts from there and lets the mounted copy quit — so the login item never points into `/Volumes`. A double-click on the running app opens the window; a login-item launch stays in the menu bar. |
@@ -45,12 +46,16 @@ remains the sole writer of the journal; the app is a client.
 packages/alfred-mac/
 ├── Package.swift                 SwiftPM, macOS 13+, no dependencies
 ├── Sources/AlfredBlack/
-│   ├── App.swift                 entry point, AppState, menu bar, CLI modes
-│   ├── Views.swift               onboarding + status (SwiftUI)
-│   ├── Theme.swift               design-system tokens (paper by day, wool by night) + font registration
+│   ├── App.swift                 entry point, AppState, menu bar, notifications, CLI modes
+│   ├── Popover.swift             the seven screens and the nav strip
+│   ├── Ask.swift                 the ⌘⇧A overlay: backdrop, vibrancy panel, hot keys
+│   ├── Statement.swift           the Attention Statement window
+│   ├── Presence.swift            the mark, and the brass dot
+│   ├── Tokens.swift              this app's tokens — wool ground, ivory ink, one brass, radii 13/14/12/6
+│   ├── Views.swift               the Placement (first run)
+│   ├── Notify.swift              "Your word" notifications — the only kind
+│   ├── Theme.swift, Surface.swift  the design-system kit (paper by day, wool by night) + font registration
 │   ├── Brand.swift               the engraved icons, the marks, the seal, the grain
-│   ├── Surface.swift             Pill, LedgerRow, CommandField, ReplyView — the kit's components
-│   ├── Pet.swift                 the presence in the menu bar (Present / Attending / Resting)
 │   ├── Tenant.swift              login / API key / journal client
 │   ├── Continuity.swift          renders continuity.md + folder CLAUDE.md
 │   ├── Pusher.swift              transcript → journal mirror
@@ -71,10 +76,10 @@ Command Line Tools are enough (no Xcode.app required).
 
 ```bash
 cd packages/alfred-mac
-scripts/build-app.sh 2026.09.03
+scripts/build-app.sh 2026.09.09
 ```
 
-Produces `dist/Alfred Black.app` and `dist/AlfredBlack-2026.09.03.dmg`.
+Produces `dist/Alfred Black.app` and `dist/AlfredBlack-2026.09.09.dmg`.
 
 ### Command-line modes (for verification and scripting)
 
@@ -85,7 +90,8 @@ Produces `dist/Alfred Black.app` and `dist/AlfredBlack-2026.09.03.dmg`.
 "dist/Alfred Black.app/Contents/MacOS/AlfredBlack" --export-plugin           # write ~/Downloads/Alfred Continuity.plugin
 "dist/Alfred Black.app/Contents/MacOS/AlfredBlack" --snapshot /path/dir [--light|--dark]   # render both views to PNGs
 "dist/Alfred Black.app/Contents/MacOS/AlfredBlack" --ask "what is on my plate today?"    # ask Alfred from a shell
-"dist/Alfred Black.app/Contents/MacOS/AlfredBlack" --pet /path/dir       # the Pet's three states at 8×
+"dist/Alfred Black.app/Contents/MacOS/AlfredBlack" --screen <glance|brief|matters|yourword|ledger|vault|arrangement|ask|statement> /path/dir [--reply "…"]   # one screen to PNG, live data
+"dist/Alfred Black.app/Contents/MacOS/AlfredBlack" --presence /path/dir   # the mark, with and without the dot
 ```
 
 ## Signing and distribution
@@ -122,8 +128,9 @@ the API key itself is revoked from *Study › API keys* on the tenant.
 
 ## Design
 
-Built on the Alfred Black design system (`design-system/`): paper by day and
-wool by night (brass holds, a step brighter on wool), ink, one brass accent,
-sharp corners, hairline rules, the engraved icon set, the seal at 7 % in the
-gutter, Playfair Display for display, EB Garamond for prose, JetBrains Mono
-for machine truth. No emoji. Calm copy. Entrances rise in; nothing bounces.
+Built to the Alfred for macOS handoff on top of the Alfred Black design
+system (`design-system/`): a wool ground, ivory ink, one brass accent that
+means *needs you* and otherwise stays silent, hairline rules, radii of
+13 / 14 / 12 / 6 pt (this app's own language; the web product's corners stay
+sharp), Playfair Display italic for what Alfred says, EB Garamond for prose,
+JetBrains Mono for machine truth. No emoji. Calm copy. Nothing bounces.

--- a/packages/alfred-mac/Sources/AlfredBlack/App.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/App.swift
@@ -5,6 +5,7 @@
 import SwiftUI
 import AppKit
 import ServiceManagement
+import UserNotifications
 
 @main
 struct AlfredBlackMain {
@@ -220,6 +221,21 @@ final class AppState: ObservableObject {
   }
 
 
+  func shiftStatement(_ by: Int) {
+
+
+    let n = max(1, statementMonthsBack + by); guard n != statementMonthsBack, let t = tenant else { return }
+
+
+    statementMonthsBack = n; statement = nil
+
+
+    Task { if let m = try? await t.statement(monthsBack: n) { statement = m } }
+
+
+  }
+
+
   func showStatement() {
 
 
@@ -297,6 +313,7 @@ final class AppState: ObservableObject {
   @Published var rulesBody: String? = nil
   @Published var arrangement = Arrangement()
   @Published var statement: MonthStatement? = nil
+  @Published var statementMonthsBack = 1
   var statementWindow: StatementWindow? = nil
   @Published var screen: Screen = .glance
   private var lastNar = Date.distantPast
@@ -398,7 +415,7 @@ final class AppState: ObservableObject {
       if let l = try? await t.activity() { ledger = l }
       if let v = try? await t.vaultCounts() { vault = v }
       if let r = try? await t.rules() { rulesBody = r; arrangement = Arrangement.parse(r) }
-      if let m = try? await t.statement() { statement = m }
+      if let m = try? await t.statement(monthsBack: statementMonthsBack) { statement = m }
       // Deliberate friction: a chosen trust class takes effect at midnight, not now.
       if let p = state.pendingTrust, let at = state.trustEffectiveAt, Date() >= at {
         do { try await t.setTrust(p); state.pendingTrust = nil; state.trustEffectiveAt = nil; trust = p } catch { record(error) }
@@ -442,7 +459,7 @@ final class AppState: ObservableObject {
 }
 
 @MainActor
-final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
+final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, UNUserNotificationCenterDelegate {
   func popoverDidClose(_ n: Notification) { state.popoverClosed() }
   let state = AppState()
   var statusItem: NSStatusItem!
@@ -454,6 +471,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     if Self.moveToApplicationsIfNeeded() { return }
     AB.registerFonts()
+    UNUserNotificationCenter.current().delegate = self
     statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
     refreshPresence()
     statusItem.button?.toolTip = "Alfred Black"
@@ -578,6 +596,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     else { state.popoverOpened(); popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY); popover.contentViewController?.view.window?.makeKey() }
 
   }
+
+  /// A click on "Your word" lands on Decisions; the banner shows even while the app is frontmost.
+
+  func userNotificationCenter(_ c: UNUserNotificationCenter, didReceive r: UNNotificationResponse, withCompletionHandler done: @escaping () -> Void) { showScreen(.yourWord); done() }
+
+  func userNotificationCenter(_ c: UNUserNotificationCenter, willPresent n: UNNotification, withCompletionHandler done: @escaping (UNNotificationPresentationOptions) -> Void) { done([.banner, .list]) }
 
   func showScreen(_ sc: Screen) {
 

--- a/packages/alfred-mac/Sources/AlfredBlack/Popover.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Popover.swift
@@ -147,6 +147,7 @@ struct MattersView: View {
             Meta(text: meta(m), color: b ? T.brass : T.dim, size: 8.5, tracking: 1.4)
           }.padding(.horizontal, 18).padding(.vertical, 12).contentShape(Rectangle())
           .onTapGesture { if let d = s.pairing?.domain, let u = URL(string: "https://\(d)/matters/\(m.id)") { NSWorkspace.shared.open(u) } }.pointer()
+          .accessibilityElement(children: .ignore).accessibilityLabel("\(m.title), \(meta(m))").accessibilityAddTraits(.isButton)
           Rectangle().fill(T.hair).frame(height: 1)
         }
       }
@@ -172,7 +173,7 @@ struct YourWordView: View {
         }
         HStack(spacing: 8) {
           Meta(text: (c.target_kind ?? "matter"), size: 8.5, tracking: 1.4); Meta(text: "·", size: 8.5); Meta(text: when(c.created), size: 8.5, tracking: 1.4); Spacer()
-          Button(action: { if let d = s.pairing?.domain, let u = URL(string: "https://\(d)/desk") { NSWorkspace.shared.open(u) } }) { Meta(text: "Desk ⏎", color: T.brass, size: 8.5, tracking: 1.4) }.buttonStyle(.plain)
+          Button(action: { if let d = s.pairing?.domain, let u = URL(string: "https://\(d)/desk") { NSWorkspace.shared.open(u) } }) { Meta(text: "Desk ⏎", color: T.dim, size: 8.5, tracking: 1.4) }.buttonStyle(.plain)
         }.padding(.horizontal, 18).padding(.top, 14)
         if let a = c.proposedAction {
           HStack(alignment: .firstTextBaseline, spacing: 8) { Meta(text: "If so ordered", color: T.brass, size: 8.5, tracking: 1.4); Text(a).font(T.body(13)).foregroundColor(T.ink).lineLimit(2) }
@@ -211,7 +212,7 @@ struct LedgerView: View {
           Meta(text: l.time, color: T.dim, size: 8.5, tracking: 1.2).frame(width: 40, alignment: .leading)
           Text(l.title).font(T.body(13.5)).foregroundColor(live ? T.ink : T.dim).lineLimit(2).frame(maxWidth: .infinity, alignment: .leading)
           Meta(text: live ? (l.actor ?? "Alfred") : "Shadow", color: live ? T.brass : T.dim, size: 8.5, tracking: 1.4)
-        }.padding(.horizontal, 18).padding(.vertical, 11)
+        }.padding(.horizontal, 18).padding(.vertical, 11).accessibilityElement(children: .combine)
         Rectangle().fill(T.hair).frame(height: 1)
       }
       HStack { Meta(text: "\(s.ledger.count - lines.count) machine lines hidden", size: 8.5, tracking: 1.2); Spacer()
@@ -232,13 +233,13 @@ struct VaultView: View {
       ScreenHeader(name: "Vault", status: "private by design")
       ForEach(Self.shelves, id: \.0) { name, types in
         let n = types.reduce(0) { $0 + (s.vault[$1] ?? 0) }
-        HStack { Text(name).font(T.body(14)).foregroundColor(T.ink); Spacer(); Meta(text: n == 0 ? "—" : String(n), size: 9, tracking: 1.4); Meta(text: "→", color: T.brass, size: 9) }
+        HStack { Text(name).font(T.body(14)).foregroundColor(T.ink); Spacer(); Meta(text: n == 0 ? "—" : String(n), size: 9, tracking: 1.4); Meta(text: "→", color: T.dim, size: 9) }
           .padding(.horizontal, 18).padding(.vertical, 12).contentShape(Rectangle())
           .onTapGesture { if let d = s.pairing?.domain, let u = URL(string: "https://\(d)/vault?type=\(types[0])") { NSWorkspace.shared.open(u) } }.pointer()
-          .accessibilityLabel("\(name), \(n) records")
+          .accessibilityLabel("\(name), \(n) records").accessibilityAddTraits(.isButton)
         Rectangle().fill(T.hair).frame(height: 1)
       }
-      HStack { Text("Credentials").font(T.body(14)).foregroundColor(T.ink); Spacer(); Meta(text: "Sealed", color: T.brass, size: 9, tracking: 1.4) }
+      HStack { Text("Credentials").font(T.body(14)).foregroundColor(T.ink); Spacer(); Meta(text: "Sealed", color: T.dim, size: 9, tracking: 1.4) }
         .padding(.horizontal, 18).padding(.vertical, 12)
         .help("Kept in the password vault on your tenant. Alfred can use them; he never shows or counts them here.")
       Rectangle().fill(T.hair).frame(height: 1)
@@ -299,6 +300,13 @@ struct ArrangementView: View {
         Spacer()
         if unsaved { Button(action: { Task { await s.saveArrangement(draft) } }) { Keycap(text: "SAVE ⏎", color: T.brass) }.buttonStyle(.plain).pointer() }
       }.padding(.horizontal, 18).padding(.vertical, 12)
+      Rectangle().fill(T.hair).frame(height: 1)
+      HStack(spacing: 16) {
+        Button(action: { s.setUpCowork() }) { Meta(text: "Set up Cowork", size: 8.5, tracking: 1.4) }.buttonStyle(.plain).pointer().help("Registers Alfred with Claude Desktop and exports the Cowork plugin")
+        Button(action: { Cowork.revealAlfredFolder() }) { Meta(text: "Alfred folder", size: 8.5, tracking: 1.4) }.buttonStyle(.plain).pointer().help("~/Alfred — what a Cowork session reads")
+        Spacer()
+        Button(action: { s.signOut() }) { Meta(text: "Sign out", size: 8.5, tracking: 1.4) }.buttonStyle(.plain).pointer().help("Forgets the pairing on this Mac; revoke the key under Study › API keys")
+      }.padding(.horizontal, 18).padding(.vertical, 10)
     }
     .onAppear { if !loaded { if let d = s.state.arrangementDraft, d.count == 3 { draft = Arrangement(may: d[0], asksFirst: d[1], never: d[2]) } else { draft = s.arrangement }; loaded = true } }
     .onChange(of: draft) { d in s.keepDraft(d) }

--- a/packages/alfred-mac/Sources/AlfredBlack/Statement.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Statement.swift
@@ -19,7 +19,7 @@ final class StatementWindow: NSWindow {
 struct StatementView: View {
   @EnvironmentObject var s: AppState
   private func openPDF() { if let d = s.pairing?.domain, let u = URL(string: "https://\(d)/attention") { NSWorkspace.shared.open(u) } }
-  private func bar(_ label: String, _ hours: Double, max: Double, hatched: Bool = false) -> some View {
+  private func bar(_ label: String, _ hours: Double, max: Double, hatched: Bool = false, help: String) -> some View {
     let h = max > 0 ? CGFloat(hours / max) * 120 : 0
     return VStack(spacing: 8) {
       ZStack(alignment: .bottom) {
@@ -31,21 +31,26 @@ struct StatementView: View {
       }
       Meta(text: label, size: 8, tracking: 1.4).fixedSize()
       Meta(text: String(format: "%.1f h", hours), color: T.ink, size: 8.5, tracking: 1.2).fixedSize()
-    }.frame(width: 64)
+    }.frame(width: 64).help(help)
   }
   var body: some View {
     let st = s.statement
     VStack(spacing: 0) {
-      Meta(text: "Attention statement · \(st?.month ?? "—")", color: T.brass, tracking: 2.6).padding(.top, 40)
+      HStack(spacing: 14) {
+        Button(action: { s.shiftStatement(+1) }) { Keycap(text: "←") }.buttonStyle(.plain).pointer().help("The month before").keyboardShortcut(.leftArrow, modifiers: [])
+        Meta(text: "Attention statement · \(st?.month ?? "—")", color: T.brass, tracking: 2.6)
+        Button(action: { s.shiftStatement(-1) }) { Keycap(text: "→") }.buttonStyle(.plain).pointer().help("The month after").keyboardShortcut(.rightArrow, modifiers: [])
+          .disabled(s.statementMonthsBack <= 1).opacity(s.statementMonthsBack <= 1 ? 0.35 : 1)
+      }.padding(.top, 40)
       HStack(alignment: .bottom, spacing: 16) {
         VStack(alignment: .leading, spacing: 8) {
           Text(st.map { String(format: "%.1f h", $0.returned) } ?? "—").font(T.title(54)).foregroundColor(T.brass).kerning(-1.1)
           Meta(text: "Returned · after every cost", size: 8.5, tracking: 1.3).fixedSize()
-        }.fixedSize()
+        }.fixedSize().help("Net hours returned to you this month: what Alfred absorbed, minus the time you spent on him")
         Spacer()
         if let st {
           let m = Swift.max(st.displaced, st.engaged, st.returned, 1)
-          HStack(alignment: .bottom, spacing: 6) { bar("Displaced", st.displaced, max: m); bar("Your time", st.engaged, max: m, hatched: true); bar("Net", st.returned, max: m) }
+          HStack(alignment: .bottom, spacing: 6) { bar("Displaced", st.displaced, max: m, help: "Hours of your attention Alfred absorbed — work that would otherwise have reached you"); bar("Your time", st.engaged, max: m, hatched: true, help: "Hours you spent with Alfred — reading, deciding, correcting"); bar("Net", st.returned, max: m, help: "Displaced minus your time — what was actually returned") }
         }
       }.padding(.horizontal, 44).padding(.top, 36)
       Spacer()

--- a/packages/alfred-mac/Sources/AlfredBlack/Tenant.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Tenant.swift
@@ -220,14 +220,15 @@ struct Tenant {
   }
 
   /// The last complete month's attention statement: returned, displaced, engaged (hours).
-  func statement() async throws -> MonthStatement? {
+  func statement(monthsBack: Int = 1) async throws -> MonthStatement? {
     struct Totals: Decodable { var nar_hours: Double?; var displaced_hours: Double?; var engaged_hours: Double? }
     struct Page: Decodable { var totals: Totals? }
     let cal = Calendar.current; let now = Date()
     guard let firstOfThis = cal.date(from: cal.dateComponents([.year, .month], from: now)),
-          let firstOfLast = cal.date(byAdding: .month, value: -1, to: firstOfThis),
-          let lastOfLast = cal.date(byAdding: .day, value: -1, to: firstOfThis) else { return nil }
-    let f = DateFormatter(); f.dateFormat = "yyyy-MM-dd"; let mf = DateFormatter(); mf.dateFormat = "MMMM"
+          let firstOfLast = cal.date(byAdding: .month, value: -monthsBack, to: firstOfThis),
+          let firstAfter = cal.date(byAdding: .month, value: 1, to: firstOfLast),
+          let lastOfLast = cal.date(byAdding: .day, value: -1, to: firstAfter) else { return nil }
+    let f = DateFormatter(); f.dateFormat = "yyyy-MM-dd"; let mf = DateFormatter(); mf.dateFormat = "MMMM yyyy"
     let (code, data) = try await request("api/v1/attention/statement", bearer: apiKey, query: ["from": f.string(from: firstOfLast), "to": f.string(from: lastOfLast)])
     guard code == 200, let t = try JSONDecoder().decode(Page.self, from: data).totals else { return nil }
     return MonthStatement(month: mf.string(from: firstOfLast), returned: t.nar_hours ?? 0, displaced: t.displaced_hours ?? 0, engaged: t.engaged_hours ?? 0)


### PR DESCRIPTION
## What

Last slice of the usability pass, plus the README.

- **Statement**: ← and → move between months (the label now carries the year); every bar, and the big number, defines itself on hover.
- **Notifications**: a click on a "Your word" notification opens the popover on Decisions; the banner shows even while the app is frontmost.
- **Settings foot**: the utility actions the right-click menu hid — Set up Cowork · Alfred folder · Sign out — with a hover line each.
- **Accessibility**: Matters and Vault rows are buttons to assistive tech; ledger rows read as one line.
- **Brass discipline**: brass comes off the small captions and arrows that did not mean "needs you" (the Desk link on Decisions, the Vault arrows, "Sealed").
- **README**: describes the app as it is after the pass — plain page names, the nav strip, the Ask overlay, what Decisions states before it asks, the source layout as it is, the render CLI modes, and the Cowork write side as it actually works.

Lane VIII, two commits (70 + 65 changed LOC).

## Smoke evidence

- `swift build -c release` ok on both commits; local lane VIII gate passed on each.
- `--screen statement` rendered against a tenant: ← and → around "Attention statement · August 2026", the → dimmed because there is no later complete month; the month maths for "months back" = 2 is July 1 → July 31 (checked by hand; the request carries `from`/`to` in `yyyy-MM-dd`).
- `--screen arrangement`, `vault`, `yourword`, `ledger` rendered: the Settings foot row under the midnight line; Vault arrows and "Sealed" in dim; "Desk ⏎" in dim on Decisions with "If so ordered" the only brass line; Activity unchanged.
- Notification click is wired through `UNUserNotificationCenterDelegate` on the app delegate (set in `applicationDidFinishLaunching`); it calls the same `showScreen(.yourWord)` the utility menu uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)