### PR TITLE
feat(alfred-mac): a dictation engine that never leaves the Mac

### DIFF
--- a/packages/alfred-mac/Package.swift
+++ b/packages/alfred-mac/Package.swift
@@ -7,15 +7,25 @@ let package = Package(
   name: "AlfredBlack",
   platforms: [.macOS(.v13)],
   targets: [
+    // whisper.cpp, prebuilt by its own release pipeline (MIT). Dictation runs on this
+    // Mac against a bundled model; nothing is sent anywhere. Pinned by checksum.
+    .binaryTarget(
+      name: "whisper",
+      url: "https://github.com/ggml-org/whisper.cpp/releases/download/b4938/whisper-b4938-xcframework.zip",
+      checksum: "dcc6cdc6d6902d11893434ceda70c23a2a64450f65a1b570035c9908988dfedd"
+    ),
     .executableTarget(
       name: "AlfredBlack",
+      dependencies: ["whisper"],
       path: "Sources/AlfredBlack",
       resources: [
         .copy("Resources/Fonts"),
         .copy("Resources/CoworkPlugin"),
         .copy("Resources/Brand"),
       ],
-      swiftSettings: [.unsafeFlags(["-parse-as-library"])]
+      swiftSettings: [.unsafeFlags(["-parse-as-library"])],
+      // the framework lives in Contents/Frameworks inside the app (and beside the binary in .build)
+      linkerSettings: [.unsafeFlags(["-Xlinker", "-rpath", "-Xlinker", "@executable_path/../Frameworks"])]
     ),
   ]
 )

--- a/packages/alfred-mac/Sources/AlfredBlack/App.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/App.swift
@@ -60,6 +60,12 @@ struct AlfredBlackMain {
       do { let u = try Cowork.exportPlugin(); print("exported: \(u.path)"); exit(0) }
       catch { print("error: \((error as? TenantError)?.message ?? "\(error)")"); exit(1) }
     }
+    if let i = CommandLine.arguments.firstIndex(of: "--transcribe"), CommandLine.arguments.count > i + 1 {   // the dictation engine on a file
+      let u = URL(fileURLWithPath: CommandLine.arguments[i + 1]); let t0 = Date()
+      guard Dictation.available else { print("no model in this build (\(Dictation.modelName))"); exit(2) }
+      guard let out = Dictation.transcribe(file: u) else { print("transcription failed"); exit(1) }
+      print(String(format: "transcribed in %.2fs", Date().timeIntervalSince(t0))); print(out); exit(0)
+    }
     if let i = CommandLine.arguments.firstIndex(of: "--presence"), CommandLine.arguments.count > i + 1 {
       let dir = URL(fileURLWithPath: CommandLine.arguments[i + 1]); try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
       for (name, need, dark) in [("silent-dark", false, true), ("attending-dark", true, true), ("attending-light", true, false)] {

--- a/packages/alfred-mac/Sources/AlfredBlack/Dictation.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Dictation.swift
@@ -1,0 +1,136 @@
+// Dictation — the Ask listens. Audio never leaves this Mac: whisper.cpp runs a
+// bundled model (ggml-base-q5_1, 57 MB, 99 languages) on the GPU while you speak,
+// and the field fills as the words settle. A pause ends the take; ⏎ sends it.
+import Foundation
+import AVFoundation
+import whisper
+
+final class Dictation: ObservableObject {
+  @Published var listening = false
+  @Published var text = ""            // the live transcript
+  @Published var level: Float = 0     // microphone level 0…1, for the pulse
+  @Published var finished = false     // the take ended; `text` is final
+  @Published var problem: String? = nil
+
+  static let modelName = "ggml-base-q5_1.bin"
+  static var modelURL: URL? { Bundle.main.resourceURL?.appendingPathComponent("Models/\(modelName)") }
+  static var available: Bool { modelURL.map { FileManager.default.fileExists(atPath: $0.path) } ?? false }
+  static let maxSeconds = 45.0, silence = 1.8, minSpeech = 0.6, voiceRMS: Float = 0.012
+
+  private let engine = AVAudioEngine()
+  private let lock = NSLock()
+  private var samples: [Float] = []   // 16 kHz mono, guarded by `lock`
+  private var lastVoiceAt: Date? = nil, startedAt: Date? = nil
+  private var ticker: Timer? = nil
+  private var pass: Task<Void, Never>? = nil
+
+  // One Whisper context per process. The first load compiles Metal shaders (seconds,
+  // cached by the system afterwards); later loads take ~0.1 s. Warm it at launch.
+  private static var ctx: OpaquePointer? = nil
+  private static let queue = DispatchQueue(label: "black.alfred.whisper", qos: .userInitiated)
+  static func warm() { queue.async { _ = context() } }
+  private static func context() -> OpaquePointer? {
+    if let c = ctx { return c }
+    guard let u = modelURL else { return nil }
+    var p = whisper_context_default_params(); p.use_gpu = true
+    ctx = whisper_init_from_file_with_params(u.path, p); return ctx
+  }
+
+  func start() {
+    guard !listening, Self.available else { return }
+    text = ""; finished = false; problem = nil; lastVoiceAt = nil; startedAt = Date()
+    lock.lock(); samples = []; lock.unlock()
+    AVCaptureDevice.requestAccess(for: .audio) { ok in
+      DispatchQueue.main.async {
+        guard ok else { self.problem = "The microphone is off for Alfred Black — System Settings › Privacy › Microphone."; return }
+        self.begin()
+      }
+    }
+  }
+  private func begin() {
+    let input = engine.inputNode; let native = input.outputFormat(forBus: 0)
+    guard native.sampleRate > 0,
+          let target = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 16000, channels: 1, interleaved: false),
+          let conv = AVAudioConverter(from: native, to: target) else { problem = "No microphone."; return }
+    input.installTap(onBus: 0, bufferSize: 4096, format: native) { [weak self] buf, _ in self?.ingest(buf, conv, target) }
+    do { engine.prepare(); try engine.start() } catch { problem = "The microphone could not start: \(error.localizedDescription)"; return }
+    listening = true; Self.warm()
+    ticker = Timer.scheduledTimer(withTimeInterval: 0.9, repeats: true) { [weak self] _ in self?.tick() }
+  }
+  /// On the audio thread: resample to 16 kHz mono, keep the samples, measure the level.
+  private func ingest(_ buf: AVAudioPCMBuffer, _ conv: AVAudioConverter, _ target: AVAudioFormat) {
+    let frames = AVAudioFrameCount(Double(buf.frameLength) * 16000 / buf.format.sampleRate) + 16
+    guard let out = AVAudioPCMBuffer(pcmFormat: target, frameCapacity: frames) else { return }
+    var fed = false
+    conv.convert(to: out, error: nil) { _, status in
+      if fed { status.pointee = .noDataNow; return nil }
+      fed = true; status.pointee = .haveData; return buf
+    }
+    guard let ch = out.floatChannelData?[0], out.frameLength > 0 else { return }
+    let n = Int(out.frameLength); var sum: Float = 0
+    for i in 0..<n { sum += ch[i] * ch[i] }
+    let rms = (sum / Float(n)).squareRoot()
+    lock.lock(); samples.append(contentsOf: UnsafeBufferPointer(start: ch, count: n)); lock.unlock()
+    DispatchQueue.main.async { self.level = min(1, rms * 12); if rms > Self.voiceRMS { self.lastVoiceAt = Date() } }
+  }
+  private func tick() {
+    guard listening else { return }
+    let now = Date()
+    if let v = lastVoiceAt, now.timeIntervalSince(v) > Self.silence { stop(); return }
+    if now.timeIntervalSince(startedAt ?? now) > Self.maxSeconds { stop(); return }
+    if lastVoiceAt != nil { transcribe(final: false) }
+  }
+  /// Ends the take; the final pass lands in `text` and sets `finished`.
+  func stop() {
+    guard listening else { return }
+    ticker?.invalidate(); ticker = nil
+    engine.inputNode.removeTap(onBus: 0); engine.stop(); listening = false; level = 0
+    if lastVoiceAt != nil { transcribe(final: true) } else { finished = true }
+  }
+  func cancel() { pass?.cancel(); pass = nil; if listening { stop() }; text = ""; finished = false }
+
+  private func transcribe(final: Bool) {
+    guard final || pass == nil else { return }          // one partial pass at a time
+    lock.lock(); let snap = samples; lock.unlock()
+    guard Double(snap.count) / 16000 >= Self.minSpeech else { if final { finished = true }; return }
+    pass = Task.detached(priority: .userInitiated) { [weak self] in
+      let out = Self.run(snap)
+      await MainActor.run { [weak self] in guard let self else { return }; if let out { self.text = out }; if final { self.finished = true }; self.pass = nil }
+    }
+  }
+  /// Whole-take decoding on the shared context; a 10 s take costs ~0.2 s on Apple silicon.
+  static func run(_ pcm: [Float]) -> String? {
+    var result: String? = nil
+    queue.sync {
+      guard let ctx = context() else { return }
+      var p = whisper_full_default_params(WHISPER_SAMPLING_GREEDY)
+      p.n_threads = Int32(max(2, min(6, ProcessInfo.processInfo.activeProcessorCount - 2)))
+      p.print_progress = false; p.print_realtime = false; p.print_timestamps = false; p.no_timestamps = true
+      p.suppress_blank = true; p.temperature_inc = 0
+      "auto".withCString { lang in
+        p.language = lang
+        guard whisper_full(ctx, p, pcm, Int32(pcm.count)) == 0 else { return }
+        var s = ""; for i in 0..<whisper_full_n_segments(ctx) { s += String(cString: whisper_full_get_segment_text(ctx, i)) }
+        result = clean(s)
+      }
+    }
+    return result
+  }
+  /// Whisper narrates silence as "[BLANK_AUDIO]" or "(music)"; those are not words.
+  static func clean(_ s: String) -> String {
+    let stripped = s.replacingOccurrences(of: #"\s*[\[\(][^\]\)]*[\]\)]"#, with: "", options: .regularExpression)
+    return stripped.replacingOccurrences(of: "  ", with: " ").trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+  /// Any audio file → the same pipeline (for `--transcribe`, the verifier).
+  static func transcribe(file: URL) -> String? {
+    guard let f = try? AVAudioFile(forReading: file),
+          let target = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 16000, channels: 1, interleaved: false),
+          let conv = AVAudioConverter(from: f.processingFormat, to: target),
+          let inBuf = AVAudioPCMBuffer(pcmFormat: f.processingFormat, frameCapacity: AVAudioFrameCount(f.length)),
+          let out = AVAudioPCMBuffer(pcmFormat: target, frameCapacity: AVAudioFrameCount(Double(f.length) * 16000 / f.processingFormat.sampleRate) + 64) else { return nil }
+    try? f.read(into: inBuf); var fed = false
+    conv.convert(to: out, error: nil) { _, status in if fed { status.pointee = .endOfStream; return nil }; fed = true; status.pointee = .haveData; return inBuf }
+    guard let ch = out.floatChannelData?[0] else { return nil }
+    return run(Array(UnsafeBufferPointer(start: ch, count: Int(out.frameLength))))
+  }
+}

--- a/packages/alfred-mac/scripts/build-app.sh
+++ b/packages/alfred-mac/scripts/build-app.sh
@@ -14,10 +14,21 @@ bundle=$(ls -d .build/release/AlfredBlack_AlfredBlack.bundle 2>/dev/null || true
 if [ -n "$bundle" ]; then cp -R "$bundle" "$APP/Contents/Resources/"; fi
 cp -R Sources/AlfredBlack/Resources/Fonts "$APP/Contents/Resources/Fonts"
 [ -f Support/AppIcon.icns ] && cp Support/AppIcon.icns "$APP/Contents/Resources/AppIcon.icns"
+# Dictation: whisper.cpp's framework (the SwiftPM binary target) and one bundled model,
+# fetched once into a cache and verified — never committed to the repo.
+MODEL=ggml-base-q5_1.bin; MODEL_SHA=422f1ae452ade6f30a004d7e5c6a43195e4433bc370bf23fac9cc591f01a8898
+CACHE="${ALFRED_MAC_MODEL_CACHE:-$HOME/Library/Caches/alfred-mac}"; mkdir -p "$CACHE"
+if [ ! -f "$CACHE/$MODEL" ] || [ "$(shasum -a 256 "$CACHE/$MODEL" | cut -c1-64)" != "$MODEL_SHA" ]; then
+  echo "fetching $MODEL"; curl -sSL -o "$CACHE/$MODEL" "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/$MODEL"
+  [ "$(shasum -a 256 "$CACHE/$MODEL" | cut -c1-64)" = "$MODEL_SHA" ] || { echo "model checksum mismatch"; exit 1; }
+fi
+mkdir -p "$APP/Contents/Resources/Models" "$APP/Contents/Frameworks"
+cp "$CACHE/$MODEL" "$APP/Contents/Resources/Models/$MODEL"
+cp -R .build/release/whisper.framework "$APP/Contents/Frameworks/whisper.framework"
 sed -e "s/__VERSION__/$VERSION/" -e "s/__BUILD__/$BUILD/" Support/Info.plist > "$APP/Contents/Info.plist"
 # Ad-hoc signature: runs on this Mac; other Macs need right-click → Open once
 # (or a Developer ID + notarization, which needs an Apple credential).
-codesign --force --deep --sign - --identifier black.alfred.mac "$APP"
+codesign --force --deep --sign - "$APP"   # identifiers come from each bundle's Info.plist
 codesign --verify --deep --strict "$APP" && echo "signed (ad-hoc)"
 hdiutil create -quiet -volname "Alfred Black" -srcfolder "$APP" -ov -format UDZO "dist/AlfredBlack-$VERSION.dmg"
 echo "built: $APP"; echo "dmg:   dist/AlfredBlack-$VERSION.dmg"


### PR DESCRIPTION
## What

The engine behind dictation in the Ask bar (the overlay wiring follows in the next PR).

- **whisper.cpp** arrives as its prebuilt xcframework — a SwiftPM binary target pinned by checksum (release b4938, MIT) — so the app still builds with the Command Line Tools alone. The build copies the framework into `Contents/Frameworks` and links with one rpath.
- **One bundled model**: `ggml-base-q5_1.bin` (57 MB, 99 languages). `build-app.sh` fetches it once into `~/Library/Caches/alfred-mac`, verifies a pinned SHA-256, and copies it into `Contents/Resources/Models`. It is never committed.
- **`Dictation`**: captures the microphone with `AVAudioEngine`, resamples to 16 kHz mono, keeps the take, and decodes the whole take on the GPU roughly once a second while you speak; a pause of 1.8 s ends the take; 45 s is the ceiling. Whisper's narration of silence ("[BLANK_AUDIO]") is stripped. One shared context per process, warmed off the main thread.
- **`--transcribe <file>`**: the same pipeline on any audio file — the verifier for this and every later change.

Lane VIII, 167 changed LOC. Why bundled rather than Apple's on-device recognizer: on this Mac the system recognizer is on-device for en-US only, and macOS 26's new transcriber covers nine languages without Hungarian; the bundled model covers both of the principal's languages, on every Mac the DMG lands on.

## Smoke evidence

- `swift build -c release` ok (downloads the 51 MB framework once); local lane VIII gate passed.
- Scratch benchmark of the same framework, four quantized models on a 9.5 s synthetic clip (Apple silicon, GPU): tiny 0.81 s, base.en 0.44 s, base 0.16 s, small 0.63 s; all four transcribed the sentence correctly, base.en/small with the apostrophe.
- Packaged app: `--transcribe` on a 16 kHz WAV and on the original AIFF (resampled by the pipeline) both returned the sentence verbatim; the first call took 16 s (one-time Metal shader compile, cached by the system), the second 0.42 s including model load.
- App bundle 70 MB, DMG 62 MB; the framework is signed ad-hoc with the app and verifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)