### PR TITLE
feat(alfred-mac): ⌘⇧A listens — dictate to Alfred, transcribed on this Mac

### DIFF
--- a/packages/alfred-mac/README.md
+++ b/packages/alfred-mac/README.md
@@ -15,7 +15,7 @@ Silence when nothing needs the principal; one brass dot when something does.
 | **02 · Brief** | The tenant's latest brief: its intro as Alfred's line, its first three bullets as rows, *Read the full brief* below. Closing it marks it read. |
 | **03 · Matters** | Work in flight, at most five: the title, *Next: …* in the matter's own words as the subline, *changed <date>* as the meta — *Blocked on you* in brass when a Desk card points at it. A click opens the matter on the tenant; the header counts what is blocked on the principal. |
 | **04 · Decisions** | One Desk card at a time, the border brassed: the headline as Alfred's line, the body, then what *So ordered* will do (*If so ordered — …*, from the card's own action); when the card proposes nothing, *So ordered* is disabled and *Ask Alfred what he'd do* opens the Ask with the question written. Hold ESC · Myself ⌘⏎ · So ordered ⏎ (`POST /api/v1/decisions`); ↑↓ between cards; every decision confirms in a notice with UNDO for eight seconds. Only this screen may notify, and a click on the notification lands here. |
-| **05/06 · The Ask** | ⌘⇧A anywhere: the screen dims, a translucent 700 pt bar floats on any Space, one field, no modes. ⏎ asks Alfred what he would do (not yet acting); ⏎ again is *So ordered*, ⇧⏎ *send without read*, ESC never mind. Both turns journaled (`POST /api/v1/alfred/ask`), so every surface remembers. |
+| **05/06 · The Ask** | ⌘⇧A anywhere: the screen dims, a translucent 700 pt bar floats on any Space, one field, no modes — and it listens: speak, and the words settle into the field as you go; a pause ends the take, ⏎ asks (or ends the take and asks). Transcription is whisper.cpp with a bundled 57 MB model, on this Mac's GPU, in 99 languages; nothing is sent anywhere. The mark toggles listening; Settings switches it off. ⏎ asks Alfred what he would do (not yet acting); ⏎ again is *So ordered*, ⇧⏎ *send without read*, ESC never mind. Both turns journaled (`POST /api/v1/alfred/ask`), so every surface remembers. |
 | **07 · The Statement** | ⌘⇧S, the only real window: a month's hours returned in 54 pt brass and the three bars — displaced, your time (hatched), net — from the attention statement; ← → turn the months; every bar defines itself on hover. ⌘E opens the print statement. |
 | **08 · Activity** | The audit ledger in plain words, only the lines that touched the principal's things; workflow heartbeats and shadow checks are hidden and counted, the full log one click away. Append-only; no edit or delete affordance. |
 | **09 · Vault** | What Alfred holds, counted by record type onto six shelves, each opening the vault at that type; Credentials sealed, never a count. |
@@ -79,7 +79,8 @@ cd packages/alfred-mac
 scripts/build-app.sh 2026.09.09
 ```
 
-Produces `dist/Alfred Black.app` and `dist/AlfredBlack-2026.09.09.dmg`.
+Produces `dist/Alfred Black.app` and `dist/AlfredBlack-2026.09.09.dmg` (about 62 MB — the dictation model is most of it).
+The first build downloads whisper.cpp's prebuilt framework (a SwiftPM binary target, pinned by checksum) and the model (`ggml-base-q5_1.bin`, verified against a pinned digest, cached under `~/Library/Caches/alfred-mac`, never committed).
 
 ### Command-line modes (for verification and scripting)
 
@@ -92,6 +93,7 @@ Produces `dist/Alfred Black.app` and `dist/AlfredBlack-2026.09.09.dmg`.
 "dist/Alfred Black.app/Contents/MacOS/AlfredBlack" --ask "what is on my plate today?"    # ask Alfred from a shell
 "dist/Alfred Black.app/Contents/MacOS/AlfredBlack" --screen <glance|brief|matters|yourword|ledger|vault|arrangement|ask|statement> /path/dir [--reply "…"]   # one screen to PNG, live data
 "dist/Alfred Black.app/Contents/MacOS/AlfredBlack" --presence /path/dir   # the mark, with and without the dot
+"dist/Alfred Black.app/Contents/MacOS/AlfredBlack" --transcribe /path/clip.wav   # the dictation engine on any audio file
 ```
 
 ## Signing and distribution
@@ -105,7 +107,8 @@ MCP server that Claude Desktop spawns the question is never shown: the process
 just blocks. So while the app is ad-hoc signed the key lives in a 0600 file in
 its support folder, and the Keychain is only read with user interaction
 disabled (to migrate a key an earlier build stored there). A Developer ID
-signature is what makes a Keychain-backed store viable.
+signature is what makes a Keychain-backed store viable. The same applies to the
+microphone: macOS asks once per code identity, so every rebuild asks again.
 
 Proper distribution needs a Developer ID certificate and notarization;
 `build-app.sh` is the place to add them (`codesign --sign "Developer ID

--- a/packages/alfred-mac/Sources/AlfredBlack/App.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/App.swift
@@ -60,6 +60,17 @@ struct AlfredBlackMain {
       do { let u = try Cowork.exportPlugin(); print("exported: \(u.path)"); exit(0) }
       catch { print("error: \((error as? TenantError)?.message ?? "\(error)")"); exit(1) }
     }
+    if let i = CommandLine.arguments.firstIndex(of: "--listen"), CommandLine.arguments.count > i + 1 {   // live microphone for N seconds
+      let secs = Double(CommandLine.arguments[i + 1]) ?? 10; let d = Dictation(); var shown = ""; var peak: Float = 0
+      if let f = CommandLine.arguments.firstIndex(of: "--file"), CommandLine.arguments.count > f + 1 { d.rehearse(file: URL(fileURLWithPath: CommandLine.arguments[f + 1])) } else { d.start() }
+      let end = Date().addingTimeInterval(secs)
+      while Date() < end, d.problem == nil, !(d.finished && !d.listening) {
+        RunLoop.main.run(until: Date().addingTimeInterval(0.25))
+        peak = max(peak, d.level); if d.text != shown { shown = d.text; print("partial: \(shown)") }
+      }
+      if d.listening { d.stop(); while !d.finished { RunLoop.main.run(until: Date().addingTimeInterval(0.1)) } }
+      print(d.problem ?? "final: \(d.text)"); print(String(format: "peak level %.2f", peak)); exit(d.problem == nil ? 0 : 1)
+    }
     if let i = CommandLine.arguments.firstIndex(of: "--transcribe"), CommandLine.arguments.count > i + 1 {   // the dictation engine on a file
       let u = URL(fileURLWithPath: CommandLine.arguments[i + 1]); let t0 = Date()
       guard Dictation.available else { print("no model in this build (\(Dictation.modelName))"); exit(2) }
@@ -99,7 +110,8 @@ struct AlfredBlackMain {
         let name = CommandLine.arguments[i + 1]
         st.screen = ["brief": Screen.brief, "matters": .matters, "yourword": .yourWord, "ledger": .ledger, "vault": .vault, "arrangement": .arrangement][name] ?? .glance
         if let r = CommandLine.arguments.firstIndex(of: "--reply"), CommandLine.arguments.count > r + 1 { st.askReply = CommandLine.arguments[r + 1] }
-        let host: NSHostingView<AnyView> = name == "ask" ? NSHostingView(rootView: AnyView(AskView().environmentObject(st))) : name == "statement" ? NSHostingView(rootView: AnyView(StatementView().environmentObject(st))) : NSHostingView(rootView: AnyView(PopoverView().environmentObject(st)))
+        if name == "ask", CommandLine.arguments.contains("--listening") { st.dictation.listening = true; st.dictation.level = 0.6; st.dictation.text = "Move the painter\'s quote to next week and tell the client we need two more days on the" }
+        let host: NSHostingView<AnyView> = name == "ask" ? NSHostingView(rootView: AnyView(AskView().environmentObject(st).environmentObject(st.dictation))) : name == "statement" ? NSHostingView(rootView: AnyView(StatementView().environmentObject(st))) : NSHostingView(rootView: AnyView(PopoverView().environmentObject(st)))
         let w: CGFloat = name == "ask" ? 700 : name == "statement" ? 520 : T.popoverWidth
         host.frame = NSRect(x: 0, y: 0, width: w, height: host.fittingSize.height); host.layoutSubtreeIfNeeded()
         if let rep = host.bitmapImageRepForCachingDisplay(in: host.bounds) { host.cacheDisplay(in: host.bounds, to: rep); try? rep.representation(using: .png, properties: [:])?.write(to: dir.appendingPathComponent("screen-\(CommandLine.arguments[i + 1]).png")) }
@@ -257,7 +269,8 @@ final class AppState: ObservableObject {
   func cancelAsk() { askTask?.cancel(); askTask = nil; asking = false; askStartedAt = nil }
 
 
-  func dismissAsk() { if asking { cancelAsk() }; askReply = nil; askPanel?.orderOut(nil) }
+  func dismissAsk() { dictation.cancel(); if asking { cancelAsk() }; askReply = nil; askPanel?.orderOut(nil) }
+  func setDictation(_ on: Bool) { state.dictation = on; Store.saveState(state); if !on { dictation.cancel() } }
 
 
   /// Open the Ask with a question already written — "what would you do about …?"
@@ -275,7 +288,7 @@ final class AppState: ObservableObject {
     if askPanel == nil { askPanel = AskPanel(state: self) }
 
 
-    if askPanel?.isVisible == true { dismissAsk() } else { askReply = nil; askPanel?.present() }
+    if askPanel?.isVisible == true { dismissAsk() } else { askReply = nil; askPanel?.present(); if state.dictation && Dictation.available && askDraft.isEmpty { dictation.start() } }
 
 
   }
@@ -379,6 +392,7 @@ final class AppState: ObservableObject {
   @Published var asking = false
   @Published var askReply: String? = nil
   var askPanel: AskPanel? = nil
+  let dictation = Dictation()
   @Published var brief: Brief? = nil
   private var lastBrief = Date.distantPast
   private var lastDesk = Date.distantPast
@@ -485,6 +499,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, UNU
     let host = NSHostingController(rootView: PopoverView().environmentObject(state)); host.sizingOptions = .preferredContentSize; popover.contentViewController = host; popover.delegate = self
     state.selfHeal()
     HotKey.onPress = { [weak self] in self?.state.toggleAsk() }; HotKey.onStatement = { [weak self] in self?.state.showStatement() }; HotKey.register()
+    if state.state.dictation && Dictation.available { Dictation.warm() }   // the first load compiles shaders; not on his time
     if state.pairing == nil || !Self.launchedAsLoginItem() { showWindow() }
     timer = Timer.scheduledTimer(withTimeInterval: 10, repeats: true) { [weak self] _ in
       guard let self else { return }

--- a/packages/alfred-mac/Sources/AlfredBlack/Ask.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Ask.swift
@@ -24,7 +24,7 @@ final class AskPanel: NSPanel {
     isFloatingPanel = true; level = .floating; collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
     backgroundColor = .clear; isOpaque = false; hasShadow = true; isMovableByWindowBackground = true
     appearance = NSAppearance(named: .darkAqua); hidesOnDeactivate = false; isReleasedWhenClosed = false
-    contentViewController = NSHostingController(rootView: AskView().environmentObject(state))
+    contentViewController = NSHostingController(rootView: AskView().environmentObject(state).environmentObject(state.dictation))
     backdrop.onClick = { [weak state] in state?.dismissAsk() }
   }
   override var canBecomeKey: Bool { true }
@@ -51,23 +51,30 @@ struct Vibrancy: NSViewRepresentable {
 
 struct AskView: View {
   @EnvironmentObject var s: AppState
+  @EnvironmentObject var d: Dictation
   @State private var text = ""
+  @State private var sendWhenFinal = false
   @FocusState private var focused: Bool
   private var reduceMotion: Bool { NSWorkspace.shared.accessibilityDisplayShouldReduceMotion }
   var body: some View {
     VStack(spacing: 0) {
       HStack(spacing: 16) {
-        if let m = Brand.image("logo-brass.svg") {
-          Image(nsImage: m).resizable().aspectRatio(contentMode: .fit).frame(height: 26)
-            .shadow(color: T.brass.opacity(0.55), radius: 10)   // the mark glows, faintly
+        if let m = Brand.image("logo-brass.svg") {   // the mark glows faintly; while listening it breathes with your voice
+          Button(action: { d.listening ? d.stop() : d.start() }) {
+            Image(nsImage: m).resizable().aspectRatio(contentMode: .fit).frame(height: 26)
+              .shadow(color: T.brass.opacity(d.listening ? 0.6 + Double(d.level) * 0.4 : 0.55), radius: d.listening ? 10 + CGFloat(d.level) * 16 : 10)
+          }.buttonStyle(.plain).pointer().disabled(!Dictation.available).help(d.listening ? "Stop listening" : "Dictate")
         }
         TextField("What can I take off your desk, \(T.honorific)?", text: $text).textFieldStyle(.plain)
           .font(T.say(21)).foregroundColor(T.ink).focused($focused).disabled(s.asking)
           .onSubmit { submit(withoutRead: NSEvent.modifierFlags.contains(.shift)) }
-        if s.asking { Waiting() } else { Keycap(text: "ESC") }
+        if s.asking { Waiting() } else if d.listening { Listening() } else { Keycap(text: "ESC") }
       }.padding(.horizontal, 24).padding(.vertical, 22)
       if s.askReply == nil && !s.asking {
-        Meta(text: "⏎ to ask · Alfred proposes before he acts", size: 8.5, tracking: 1.2).padding(.horizontal, 24).padding(.bottom, 14)
+        Meta(text: d.listening ? "Speak · a pause ends the take · ⏎ asks · esc never mind" : d.finished && !text.isEmpty ? "⏎ to ask · click the mark to dictate again" : "⏎ to ask · Alfred proposes before he acts", size: 8.5, tracking: 1.2).padding(.horizontal, 24).padding(.bottom, 14)
+      }
+      if let e = d.problem {
+        Text(e).font(T.body(12.5)).foregroundColor(Color(nsColor: AB.hex(0xD9776C))).padding(.horizontal, 24).padding(.bottom, 14)
       }
       if let r = s.askReply {
         Rectangle().fill(T.hair).frame(height: 1).padding(.horizontal, 24)
@@ -82,15 +89,29 @@ struct AskView: View {
     .frame(width: 700)
     .background(ZStack { Vibrancy(); RoundedRectangle(cornerRadius: 18).fill(T.bg.opacity(0.72)) })
     .overlay(RoundedRectangle(cornerRadius: 18).stroke(T.hair2, lineWidth: 1))
-    .onAppear { focused = true; if !s.askDraft.isEmpty { text = s.askDraft; s.askDraft = "" } }
+    .onAppear { focused = true; if !s.askDraft.isEmpty { text = s.askDraft; s.askDraft = "" } else if d.listening || d.finished { text = d.text } }
     .onChange(of: s.askDraft) { d in if !d.isEmpty { text = d; s.askDraft = ""; focused = true } }
+    .onChange(of: d.text) { t in if d.listening || d.finished { text = t } }
+    .onChange(of: d.finished) { f in guard f else { return }; focused = true; if sendWhenFinal { sendWhenFinal = false; submit(withoutRead: false) } }
     .onExitCommand { s.dismissAsk() }
     .animation(reduceMotion ? nil : .easeOut(duration: 0.15), value: s.askReply)
   }
   private func submit(withoutRead: Bool) {
     if s.askReply != nil { s.soOrdered(withoutRead: withoutRead); return }   // ⏎ on the answer executes
+    if d.listening { sendWhenFinal = true; d.stop(); return }                  // ⏎ mid-take: finish, then ask
     let q = text; text = ""; guard !q.trimmingCharacters(in: .whitespaces).isEmpty else { return }
     Task { await s.propose(q) }
+  }
+}
+
+/// A brass point that swells with the voice, and the word for what is happening.
+struct Listening: View {
+  @EnvironmentObject var d: Dictation
+  var body: some View {
+    HStack(spacing: 10) {
+      Circle().fill(T.brass).frame(width: 7, height: 7).scaleEffect(1 + CGFloat(d.level) * 1.6).animation(.easeOut(duration: 0.12), value: d.level)
+      Meta(text: "Listening", color: T.brass, size: 8.5, tracking: 1.6)
+    }.fixedSize().accessibilityLabel("Listening")
   }
 }
 

--- a/packages/alfred-mac/Sources/AlfredBlack/Dictation.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Dictation.swift
@@ -32,8 +32,11 @@ final class Dictation: ObservableObject {
   private static func context() -> OpaquePointer? {
     if let c = ctx { return c }
     guard let u = modelURL else { return nil }
+    whisper_log_set({ _, _, _ in }, nil)                       // its narration is not for the principal
     var p = whisper_context_default_params(); p.use_gpu = true
-    ctx = whisper_init_from_file_with_params(u.path, p); return ctx
+    ctx = whisper_init_from_file_with_params(u.path, p)
+    atexit { Dictation.queue.sync { if let c = Dictation.ctx { whisper_free(c); Dictation.ctx = nil } } }   // before ggml's static destructors
+    return ctx
   }
 
   func start() {
@@ -47,20 +50,34 @@ final class Dictation: ObservableObject {
       }
     }
   }
+  private static let target = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 16000, channels: 1, interleaved: false)!
+  private var usingEngine = false
   private func begin() {
     let input = engine.inputNode; let native = input.outputFormat(forBus: 0)
-    guard native.sampleRate > 0,
-          let target = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 16000, channels: 1, interleaved: false),
-          let conv = AVAudioConverter(from: native, to: target) else { problem = "No microphone."; return }
-    input.installTap(onBus: 0, bufferSize: 4096, format: native) { [weak self] buf, _ in self?.ingest(buf, conv, target) }
+    guard native.sampleRate > 0, let conv = AVAudioConverter(from: native, to: Self.target) else { problem = "No microphone."; return }
+    input.installTap(onBus: 0, bufferSize: 4096, format: native) { [weak self] buf, _ in self?.ingest(buf, conv) }
     do { engine.prepare(); try engine.start() } catch { problem = "The microphone could not start: \(error.localizedDescription)"; return }
+    usingEngine = true; arm()
+  }
+  private func arm() {
     listening = true; Self.warm()
     ticker = Timer.scheduledTimer(withTimeInterval: 0.9, repeats: true) { [weak self] _ in self?.tick() }
   }
+  /// A file plays the microphone's part, in real time, through the same path (for `--listen --file`).
+  func rehearse(file: URL) {
+    guard !listening, Self.available, let f = try? AVAudioFile(forReading: file), let conv = AVAudioConverter(from: f.processingFormat, to: Self.target) else { problem = "Cannot read \(file.lastPathComponent)"; return }
+    text = ""; finished = false; problem = nil; lastVoiceAt = nil; startedAt = Date(); lock.lock(); samples = []; lock.unlock(); arm()
+    Thread.detachNewThread { [weak self] in
+      let chunk: AVAudioFrameCount = 4096
+      while let self, self.listening, let buf = AVAudioPCMBuffer(pcmFormat: f.processingFormat, frameCapacity: chunk), (try? f.read(into: buf, frameCount: chunk)) != nil, buf.frameLength > 0 {
+        self.ingest(buf, conv); Thread.sleep(forTimeInterval: Double(buf.frameLength) / f.processingFormat.sampleRate)
+      }
+    }
+  }
   /// On the audio thread: resample to 16 kHz mono, keep the samples, measure the level.
-  private func ingest(_ buf: AVAudioPCMBuffer, _ conv: AVAudioConverter, _ target: AVAudioFormat) {
+  private func ingest(_ buf: AVAudioPCMBuffer, _ conv: AVAudioConverter) {
     let frames = AVAudioFrameCount(Double(buf.frameLength) * 16000 / buf.format.sampleRate) + 16
-    guard let out = AVAudioPCMBuffer(pcmFormat: target, frameCapacity: frames) else { return }
+    guard let out = AVAudioPCMBuffer(pcmFormat: Self.target, frameCapacity: frames) else { return }
     var fed = false
     conv.convert(to: out, error: nil) { _, status in
       if fed { status.pointee = .noDataNow; return nil }
@@ -84,7 +101,8 @@ final class Dictation: ObservableObject {
   func stop() {
     guard listening else { return }
     ticker?.invalidate(); ticker = nil
-    engine.inputNode.removeTap(onBus: 0); engine.stop(); listening = false; level = 0
+    if usingEngine { engine.inputNode.removeTap(onBus: 0); engine.stop(); usingEngine = false }
+    listening = false; level = 0
     if lastVoiceAt != nil { transcribe(final: true) } else { finished = true }
   }
   func cancel() { pass?.cancel(); pass = nil; if listening { stop() }; text = ""; finished = false }

--- a/packages/alfred-mac/Sources/AlfredBlack/Popover.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Popover.swift
@@ -293,6 +293,14 @@ struct ArrangementView: View {
       }.padding(.horizontal, 18).padding(.vertical, 14)
       Rectangle().fill(T.hair).frame(height: 1)
       HStack {
+        Meta(text: "Dictation on ⌘⇧A", tracking: 1.8); Spacer()
+        ForEach([true, false], id: \.self) { on in
+          Button(action: { s.setDictation(on) }) { Keycap(text: on ? "ON" : "OFF", color: s.state.dictation == on ? T.brass : T.dim) }.buttonStyle(.plain).pointer()
+        }
+      }.padding(.horizontal, 18).padding(.top, 12).padding(.bottom, 4)
+      Text(Dictation.available ? "Transcribed on this Mac by a bundled model; nothing is sent anywhere." : "This build carries no dictation model.").font(T.body(11.5, italic: true)).foregroundColor(T.dim).padding(.horizontal, 18).padding(.bottom, 12)
+      Rectangle().fill(T.hair).frame(height: 1)
+      HStack {
         if let p = s.state.pendingTrust {
           Meta(text: "L\(p) takes effect at midnight", tracking: 1.8)
           Button(action: { s.cancelTrustChange() }) { Keycap(text: "CANCEL") }.buttonStyle(.plain).pointer()

--- a/packages/alfred-mac/Sources/AlfredBlack/Store.swift
+++ b/packages/alfred-mac/Sources/AlfredBlack/Store.swift
@@ -19,6 +19,7 @@ struct RunState: Codable {
   var trustEffectiveAt: Date? = nil
   var deskSeenAt: Date? = nil
   var arrangementDraft: [String]? = nil   // an unsaved sentence survives the popover closing
+  var dictation: Bool = true               // ⌘⇧A listens
   var lastRenderAt: Date?
   var lastRenderEntries: Int = 0
   var lastPushAt: Date?

--- a/packages/alfred-mac/Support/Info.plist
+++ b/packages/alfred-mac/Support/Info.plist
@@ -15,6 +15,7 @@
   <key>NSHighResolutionCapable</key> <true/>
   <key>NSHumanReadableCopyright</key><string>Alfred Black. Service is the standard.</string>
   <key>ATSApplicationFontsPath</key> <string>Fonts</string>
+  <key>NSMicrophoneUsageDescription</key><string>Alfred listens only while the Ask bar is open. Speech is transcribed on this Mac and never leaves it.</string>
   <key>NSAppTransportSecurity</key>
   <dict><key>NSAllowsArbitraryLoads</key><false/></dict>
 </dict>


### PR DESCRIPTION
## What

The overlay side of dictation, on top of #759.

- **⌘⇧A listens** as the bar opens (unless a question was pre-written for it): the mark breathes with the voice, a brass point and the word *Listening* replace the ESC keycap, and the words settle into the field as the take goes on. A pause of 1.8 s ends the take and hands the field back for edits; ⏎ mid-take finishes the take and then asks; ESC is still never mind. The mark toggles listening.
- **Settings**: a *Dictation on ⌘⇧A* switch, with what happens to the audio written under it ("Transcribed on this Mac by a bundled model; nothing is sent anywhere").
- **Info.plist** carries the microphone usage string; the engine is warmed at launch so the first ⌘⇧A does not pay for the shader compile.
- **Engine fixes found while verifying**: the Whisper context is freed at exit (ggml asserts in a static destructor otherwise — every CLI run and every Quit would have crashed), and whisper's own log narration is kept off the console.
- **`--listen <seconds> [--file clip]`**: rehearses the whole capture path — a file plays the microphone's part in real time through the same resampler, level meter, silence detection and partial passes — so the path can be verified without a voice.
- README: the Ask row, build notes (model fetched and verified, never committed; 62 MB DMG), the new verifiers, and the note that ad-hoc signing makes macOS re-ask for the microphone after each rebuild.

Lane VIII, 109 changed LOC.

## Smoke evidence

- `swift build -c release` ok before and after the rebase; local lane VIII gate passed.
- `--listen 30 --file <9.5 s clip at 22 kHz>` from the packaged app: eleven partials arriving roughly once a second ("Alfred." → "Alfred, please move the painter" → … → the full sentence), the take ended on the pause after the clip, the final text matched the clip verbatim, peak level 1.00, exit 0, nothing on stderr.
- `--transcribe` now exits 0 with an empty stderr (before this PR it printed whisper's load log and aborted in `ggml_metal_device_free` at exit).
- `--screen ask --listening` rendered: the mark with the wider glow, the transcript in the field, the brass point and "LISTENING" on the right, the hint "Speak · a pause ends the take · ⏎ asks · esc never mind".
- `--screen arrangement` rendered the Dictation row with its ON/OFF keycaps and the explanation under it, nothing wrapping at 400.
- A live microphone run was attempted but this Mac's default input and output are the same AirPods, so a clip played aloud never reached a microphone; the rehearsal mode exists for exactly that reason. The real-microphone path differs only in the `AVAudioEngine` tap that hands buffers to the same `ingest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)