### PR TITLE
feat(learn): Outlook provider edge + email source bucket (#758)

### DIFF
--- a/packages/learn/src/activities/email_providers.py
+++ b/packages/learn/src/activities/email_providers.py
@@ -1,0 +1,231 @@
+"""Provider-specific edges for email onboarding + sync (issue #758).
+
+Gmail and Outlook differ only at the collection boundary: the Composio action,
+its arguments, the response envelope, and the per-message field names. Every
+downstream stage — the behavioural profiler, the Opus fact/pattern/brief
+stages, the curator, the signal scorer — reads ONE normalised shape and never
+learns which mailbox the mail came from. Keeping that promise is what makes the
+provider a two-value axis rather than a second pipeline.
+
+The Gmail edge already lives in ``pull.py`` (``_composio_gmail_messages`` /
+``_composio_msg_to_email``) and is left byte-for-byte unchanged. This module is
+the Outlook mirror of that contract, written as pure functions so the Temporal
+activities stay thin and the mapping is unit-testable with no network.
+
+Two normalised shapes, matching the Gmail edge exactly:
+
+  * profiler shape  — ``{from, to, subject, date, snippet, domain}``; this is
+    what ``onboard.json["emails"]`` holds and the profiler + Opus stages read.
+  * flat ingest shape — a dict whose keys are the ones the existing
+    ``parsers.composio`` parser already reads (``id`` / ``from`` / ``to`` /
+    ``subject`` / ``date`` / ``snippet`` / ``threadId``), so Outlook backfill
+    events flow through that parser with NO parser change.
+
+Facts about Composio's Outlook toolkit, verified live against the project on
+2026-09-10 (the public docs are wrong — the documented ``OUTLOOK_LIST_MESSAGES``
+slug 404s):
+
+  * List action slug is ``OUTLOOK_OUTLOOK_LIST_MESSAGES`` (doubled prefix).
+  * It takes ONE folder per call (well-known names ``Inbox`` / ``SentItems``),
+    typed date filters (``received_date_time_ge`` / ``received_date_time_gt``,
+    ISO-8601 with a ``Z`` suffix, not a ``+00:00`` offset), ``top`` (1-1000),
+    ``skip`` for pagination, and ``orderby``. There is NO continuation token —
+    paging is ``skip``/``top`` and terminates on a short page.
+  * The page arrives at ``data.response_data.value`` (a list of Microsoft Graph
+    ``message`` resources). Composio surfaces a hard failure as
+    ``successful: false`` at the top level, exactly like Gmail.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Provider vocabulary (contract C-758-1)
+# ---------------------------------------------------------------------------
+
+EMAIL_PROVIDERS = ("gmail", "outlook")
+DEFAULT_EMAIL_PROVIDER = "gmail"
+
+
+def normalise_email_provider(provider: str | None) -> str:
+    """Return a supported provider id, defaulting an empty value to gmail.
+
+    Raises ``ValueError`` on a non-empty but unrecognised value — an unknown
+    provider is a caller bug (C-758-1: reject unsupported explicit values),
+    never a silent fall-back to Gmail.
+    """
+    p = (provider or "").strip().lower()
+    if not p:
+        return DEFAULT_EMAIL_PROVIDER
+    if p not in EMAIL_PROVIDERS:
+        raise ValueError(
+            f"unsupported email_provider {provider!r}; expected one of {EMAIL_PROVIDERS}"
+        )
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Outlook constants
+# ---------------------------------------------------------------------------
+
+OUTLOOK_LIST_ACTION = "OUTLOOK_OUTLOOK_LIST_MESSAGES"
+
+# The two folders that mirror Gmail's ``-in:drafts -in:spam -in:trash -in:chats``
+# exclusion: everything a person actually sent or received. Graph's
+# ``/me/messages`` would otherwise sweep Deleted Items and Junk too.
+OUTLOOK_ONBOARDING_FOLDERS = ("Inbox", "SentItems")
+
+# ``verbose:false`` has no Outlook analogue; instead we ask Graph for exactly
+# the fields the two normalised shapes need, which keeps each message small.
+OUTLOOK_SELECT_FIELDS = [
+    "id",
+    "subject",
+    "from",
+    "toRecipients",
+    "ccRecipients",
+    "receivedDateTime",
+    "sentDateTime",
+    "bodyPreview",
+    "conversationId",
+    "isRead",
+    "parentFolderId",
+]
+
+OUTLOOK_PAGE_SIZE = 250
+OUTLOOK_ORDER_BY = ["receivedDateTime desc"]
+
+
+def outlook_list_args(
+    folder: str,
+    *,
+    received_ge_iso: str | None = None,
+    received_gt_iso: str | None = None,
+    skip: int = 0,
+    top: int = OUTLOOK_PAGE_SIZE,
+    user_id: str = "me",
+) -> dict[str, Any]:
+    """Build the ``OUTLOOK_OUTLOOK_LIST_MESSAGES`` arguments for one page.
+
+    ``received_ge_iso`` (inclusive, used for a backfill window) and
+    ``received_gt_iso`` (exclusive, used for an incremental pull so the cursor
+    row is not re-fetched) are mutually exclusive; pass at most one.
+    """
+    args: dict[str, Any] = {
+        "user_id": user_id,
+        "folder": folder,
+        "top": top,
+        "skip": skip,
+        "orderby": OUTLOOK_ORDER_BY,
+        "select": OUTLOOK_SELECT_FIELDS,
+    }
+    if received_ge_iso:
+        args["received_date_time_ge"] = received_ge_iso
+    if received_gt_iso:
+        args["received_date_time_gt"] = received_gt_iso
+    return args
+
+
+def outlook_messages_from_response(
+    raw_response: dict[str, Any],
+) -> tuple[list[dict[str, Any]], str | None]:
+    """Extract ``(messages, error)`` from an ``OUTLOOK_OUTLOOK_LIST_MESSAGES`` response.
+
+    Mirrors ``_composio_gmail_messages``'s contract:
+      * ``error`` is ``None`` on success (including a legitimately empty page).
+      * ``error`` is a short string when Composio reports ``successful: false``,
+        so the caller can distinguish a transient failure from "no more mail"
+        and retry rather than terminating the backfill with zero results.
+
+    Composio nests the Graph payload under ``data`` / ``response_data`` at
+    varying depths; the list lives at ``…value``. We walk the known wrappers
+    the same way the Gmail extractor does.
+    """
+    if not isinstance(raw_response, dict):
+        return [], "non-dict response"
+
+    if raw_response.get("successful") is False:
+        err = raw_response.get("error")
+        if not err:
+            data = raw_response.get("data")
+            if isinstance(data, dict):
+                err = data.get("message") or data.get("error")
+        return [], str(err or "composio reported successful=false")[:300]
+
+    # Walk to the dict that holds ``value`` (the Graph message list).
+    payload: Any = raw_response
+    for _ in range(4):
+        if not isinstance(payload, dict):
+            break
+        if "value" in payload:
+            break
+        nxt = payload.get("data")
+        if nxt is None:
+            nxt = payload.get("response_data")
+        if nxt is None:
+            break
+        payload = nxt
+
+    if not isinstance(payload, dict):
+        return [], None
+    messages = payload.get("value")
+    if not isinstance(messages, list):
+        messages = []
+    return [m for m in messages if isinstance(m, dict)], None
+
+
+def _outlook_address(obj: Any) -> str:
+    """Flatten a Graph recipient/sender (``{emailAddress:{address,name}}``)."""
+    if isinstance(obj, dict):
+        ea = obj.get("emailAddress")
+        if isinstance(ea, dict):
+            return str(ea.get("address") or "").strip()
+        return str(obj.get("address") or "").strip()
+    return str(obj or "").strip()
+
+
+def _outlook_recipients(msg: dict[str, Any]) -> str:
+    to = msg.get("toRecipients")
+    if not isinstance(to, list):
+        return ""
+    addrs = [a for a in (_outlook_address(r) for r in to) if a]
+    return ", ".join(addrs)
+
+
+def outlook_msg_to_email(msg: dict[str, Any]) -> dict[str, Any]:
+    """Map one Graph message to the profiler shape used in onboard.json.
+
+    Identical key set to the direct-Gmail ``fetch_email_metadata`` and the
+    Composio ``_composio_msg_to_email`` output, so the behavioural profiler
+    (``src/profiler/features.py``) and the Opus stages stay provider-blind.
+    """
+    sender = _outlook_address(msg.get("from") or msg.get("sender"))
+    domain = sender.split("@")[-1].strip() if "@" in sender else "unknown"
+    return {
+        "from": sender,
+        "to": _outlook_recipients(msg),
+        "subject": str(msg.get("subject") or ""),
+        "date": str(msg.get("receivedDateTime") or msg.get("sentDateTime") or ""),
+        "snippet": str(msg.get("bodyPreview") or ""),
+        "domain": domain or "unknown",
+    }
+
+
+def outlook_msg_to_flat(msg: dict[str, Any]) -> dict[str, Any]:
+    """Map one Graph message to the flat shape the composio parser understands.
+
+    The existing ``parsers.composio`` parser reads ``id`` / ``from`` / ``to`` /
+    ``subject`` / ``date`` / ``snippet`` / ``threadId`` — so producing those
+    keys here means Outlook backfill events flow through that parser with no
+    parser change. Provider/mailbox provenance is stamped by the ingesting
+    activity (stream_type + metadata), not here.
+    """
+    return {
+        "id": str(msg.get("id") or ""),
+        "from": _outlook_address(msg.get("from") or msg.get("sender")),
+        "to": _outlook_recipients(msg),
+        "subject": str(msg.get("subject") or ""),
+        "date": str(msg.get("receivedDateTime") or msg.get("sentDateTime") or ""),
+        "snippet": str(msg.get("bodyPreview") or ""),
+        "threadId": str(msg.get("conversationId") or ""),
+    }

--- a/packages/learn/src/activities/noise.py
+++ b/packages/learn/src/activities/noise.py
@@ -117,7 +117,7 @@ def extract_log_line(event: dict[str, Any]) -> str:
     if not isinstance(raw, dict):
         raw = {}
 
-    if stream_type in ("gmail", "email"):
+    if stream_type in ("gmail", "email", "outlook"):
         return _log_line_email(raw)
     elif stream_type == "omi":
         return _log_line_omi(raw)

--- a/packages/learn/src/activities/noise_patterns.py
+++ b/packages/learn/src/activities/noise_patterns.py
@@ -125,7 +125,8 @@ def derive_signature(
     # on subject_keywords.
     if (
         source_type.startswith("composio-gmail")
-        or source_type in ("gmail", "email")
+        or source_type.startswith("composio-outlook")
+        or source_type in ("gmail", "email", "outlook")
     ):
         source_type = "gmail"
     elif source_type.startswith("composio-googlecalendar") or source_type == "gcal":

--- a/packages/learn/src/activities/signal_observations.py
+++ b/packages/learn/src/activities/signal_observations.py
@@ -60,6 +60,9 @@ def _normalise_source_type(raw: str) -> str:
     s = (raw or "").lower().strip()
     if s.startswith("composio-gmail") or s == "gmail":
         return "gmail"
+    # Outlook (#758) shares the email bucket — same priors, same noise gate.
+    if s.startswith("composio-outlook") or s == "outlook":
+        return "gmail"
     if s.startswith("composio-googlecalendar") or s in ("gcal", "googlecalendar"):
         return "gcal"
     if s.startswith("composio-slack") or s == "slack":
@@ -100,6 +103,8 @@ def _authoritative_source_type(event_fm: dict[str, Any], signal_source_type: str
     """
     source_ref = str(event_fm.get("source_ref") or "").strip().lower()
     if source_ref.startswith("gmail:"):
+        return "gmail"
+    if source_ref.startswith("outlook:"):
         return "gmail"
     if source_ref.startswith("gcal:") or source_ref.startswith("googlecalendar:"):
         return "gcal"

--- a/packages/learn/tests/test_email_providers.py
+++ b/packages/learn/tests/test_email_providers.py
@@ -1,0 +1,176 @@
+"""Unit tests for the Outlook provider edge (issue #758).
+
+Pure functions, no network: provider vocabulary, argument building, response
+extraction, and the two normalised message shapes. The round-trip test proves
+an Outlook message flattened by ``outlook_msg_to_flat`` is understood by the
+existing ``composio`` parser with no parser change.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from src.activities.email_providers import (  # noqa: E402
+    DEFAULT_EMAIL_PROVIDER,
+    OUTLOOK_LIST_ACTION,
+    OUTLOOK_ONBOARDING_FOLDERS,
+    normalise_email_provider,
+    outlook_list_args,
+    outlook_messages_from_response,
+    outlook_msg_to_email,
+    outlook_msg_to_flat,
+)
+from src.parsers import get_parser  # noqa: E402
+
+
+# --- provider vocabulary (C-758-1) -----------------------------------------
+
+def test_normalise_provider_defaults_empty_to_gmail() -> None:
+    assert normalise_email_provider("") == "gmail"
+    assert normalise_email_provider(None) == DEFAULT_EMAIL_PROVIDER
+
+
+def test_normalise_provider_accepts_supported() -> None:
+    assert normalise_email_provider("gmail") == "gmail"
+    assert normalise_email_provider("outlook") == "outlook"
+    assert normalise_email_provider("OUTLOOK") == "outlook"
+
+
+def test_normalise_provider_rejects_unknown() -> None:
+    with pytest.raises(ValueError):
+        normalise_email_provider("yahoo")
+
+
+# --- argument building ------------------------------------------------------
+
+def test_list_args_backfill_uses_ge_and_folder() -> None:
+    args = outlook_list_args("Inbox", received_ge_iso="2026-06-01T00:00:00Z")
+    assert args["folder"] == "Inbox"
+    assert args["received_date_time_ge"] == "2026-06-01T00:00:00Z"
+    assert "received_date_time_gt" not in args
+    assert args["orderby"] == ["receivedDateTime desc"]
+    assert "id" in args["select"] and "receivedDateTime" in args["select"]
+    assert args["user_id"] == "me"
+
+
+def test_list_args_paginates_by_skip() -> None:
+    args = outlook_list_args("SentItems", received_ge_iso="x", skip=250, top=250)
+    assert args["skip"] == 250
+    assert args["top"] == 250
+
+
+def test_list_action_and_folders_are_the_verified_ones() -> None:
+    # The doubled-prefix slug is the one that actually exists on the project.
+    assert OUTLOOK_LIST_ACTION == "OUTLOOK_OUTLOOK_LIST_MESSAGES"
+    assert OUTLOOK_ONBOARDING_FOLDERS == ("Inbox", "SentItems")
+
+
+# --- response extraction ----------------------------------------------------
+
+def _wrap(value):
+    return {"successful": True, "data": {"response_data": {"value": value}}}
+
+
+def test_messages_from_nested_response_data() -> None:
+    msgs, err = outlook_messages_from_response(_wrap([{"id": "1"}, {"id": "2"}]))
+    assert err is None
+    assert [m["id"] for m in msgs] == ["1", "2"]
+
+
+def test_messages_from_flat_value() -> None:
+    msgs, err = outlook_messages_from_response({"value": [{"id": "1"}]})
+    assert err is None and len(msgs) == 1
+
+
+def test_messages_empty_page_is_not_an_error() -> None:
+    msgs, err = outlook_messages_from_response(_wrap([]))
+    assert msgs == [] and err is None
+
+
+def test_messages_successful_false_surfaces_error() -> None:
+    msgs, err = outlook_messages_from_response(
+        {"successful": False, "error": "HTTP 429 throttled"}
+    )
+    assert msgs == []
+    assert err is not None and "429" in err
+
+
+def test_messages_non_dict_is_safe() -> None:
+    assert outlook_messages_from_response(None) == ([], "non-dict response")
+
+
+def test_messages_drops_non_dict_items() -> None:
+    msgs, err = outlook_messages_from_response(_wrap([{"id": "1"}, "junk", 5]))
+    assert err is None and [m["id"] for m in msgs] == ["1"]
+
+
+# --- profiler shape ---------------------------------------------------------
+
+def _graph_msg() -> dict:
+    return {
+        "id": "AAMk-xyz",
+        "subject": "Q3 numbers",
+        "from": {"emailAddress": {"address": "rob@neoterra.example", "name": "Rob"}},
+        "toRecipients": [
+            {"emailAddress": {"address": "me@corp.example"}},
+            {"emailAddress": {"address": "cc@corp.example"}},
+        ],
+        "receivedDateTime": "2026-08-01T09:15:00Z",
+        "bodyPreview": "Attaching the Q3 figures for review.",
+        "conversationId": "conv-77",
+        "isRead": True,
+    }
+
+
+def test_msg_to_email_maps_graph_shape() -> None:
+    e = outlook_msg_to_email(_graph_msg())
+    assert e == {
+        "from": "rob@neoterra.example",
+        "to": "me@corp.example, cc@corp.example",
+        "subject": "Q3 numbers",
+        "date": "2026-08-01T09:15:00Z",
+        "snippet": "Attaching the Q3 figures for review.",
+        "domain": "neoterra.example",
+    }
+
+
+def test_msg_to_email_missing_fields_default_empty() -> None:
+    e = outlook_msg_to_email({"id": "x"})
+    assert e["from"] == "" and e["to"] == "" and e["subject"] == ""
+    assert e["domain"] == "unknown"
+
+
+def test_msg_to_email_falls_back_to_sent_date() -> None:
+    e = outlook_msg_to_email({"from": {"emailAddress": {"address": "a@b.com"}},
+                              "sentDateTime": "2026-01-01T00:00:00Z"})
+    assert e["date"] == "2026-01-01T00:00:00Z"
+    assert e["domain"] == "b.com"
+
+
+# --- flat shape + parser round-trip ----------------------------------------
+
+def test_msg_to_flat_has_parser_keys() -> None:
+    f = outlook_msg_to_flat(_graph_msg())
+    assert f["id"] == "AAMk-xyz"
+    assert f["from"] == "rob@neoterra.example"
+    assert f["date"] == "2026-08-01T09:15:00Z"
+    assert f["snippet"].startswith("Attaching")
+    assert f["threadId"] == "conv-77"
+
+
+def test_flat_message_round_trips_through_composio_parser() -> None:
+    parser = get_parser("composio")
+    events = parser(outlook_msg_to_flat(_graph_msg()))
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.source_ref == "composio:AAMk-xyz"
+    assert "Q3 numbers" in ev.summary
+    # the email's real send time, not the fetch time
+    assert ev.received_at.startswith("2026-08-01")
+    # body preview survives into metadata
+    assert "Attaching" in (ev.metadata.get("body") or "")

--- a/packages/learn/tests/test_outlook_source_bucket.py
+++ b/packages/learn/tests/test_outlook_source_bucket.py
@@ -1,0 +1,70 @@
+"""Outlook events join the shared email bucket downstream (issue #758, C-758-10).
+
+Ongoing Outlook sync ingests events with ``stream_type: "outlook"``. These
+tests pin that the four source-type choke points collapse Outlook onto the same
+``gmail`` bucket Gmail uses, so priors, the noise gate and log lines treat an
+Outlook message exactly like a Gmail one.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from src.activities.signal_observations import (  # noqa: E402
+    _authoritative_source_type,
+    _normalise_source_type,
+)
+
+
+def test_normalise_maps_outlook_to_email_bucket() -> None:
+    assert _normalise_source_type("outlook") == "gmail"
+    assert _normalise_source_type("composio-outlook") == "gmail"
+
+
+def test_gmail_bucket_unchanged() -> None:
+    assert _normalise_source_type("gmail") == "gmail"
+    assert _normalise_source_type("composio-gmail-emails") == "gmail"
+
+
+def test_authoritative_source_type_reads_outlook_source_type() -> None:
+    # No gmail/gcal source_ref prefix and no email tag → falls through to the
+    # event's own source_type, which normalises Outlook onto the email bucket.
+    fm = {"source_ref": "composio:AAMk-1", "source_type": "outlook"}
+    assert _authoritative_source_type(fm, "outlook") == "gmail"
+
+
+def test_authoritative_source_type_outlook_prefix() -> None:
+    fm = {"source_ref": "outlook:AAMk-1"}
+    assert _authoritative_source_type(fm, "") == "gmail"
+
+
+def test_noise_log_line_handles_outlook_stream_type() -> None:
+    from src.activities.noise import extract_log_line
+
+    # An Outlook event takes the email log-line branch, not the generic one.
+    line = extract_log_line(
+        {
+            "stream_type": "outlook",
+            "raw": {"from": "rob@x.example", "subject": "Q3", "snippet": "hi"},
+        }
+    )
+    assert isinstance(line, str) and line != ""
+
+
+def test_noise_patterns_outlook_derives_a_sender_signature() -> None:
+    from src.activities.noise_patterns import derive_signature
+
+    # source_type "outlook" maps to the gmail branch → a real sender signature,
+    # never the "unknown" fallthrough that disables noise matching.
+    sig = derive_signature({"source_type": "outlook", "from": "rob@x.example"})
+    assert sig.get("kind") != "unknown"
+
+
+def test_noise_patterns_unknown_source_still_unknown() -> None:
+    from src.activities.noise_patterns import derive_signature
+
+    sig = derive_signature({"source_type": "mystery", "from": "rob@x.example"})
+    assert sig.get("kind") == "unknown"


### PR DESCRIPTION
Part of #758 (Gmail **or** Outlook / Microsoft 365 at Start Onboarding). First of the learn-lane PRs: the pure Outlook collection edge and the downstream email-bucket mapping. No workflow or activity wiring yet — that lands in the follow-up collectors PR.

## What this does
- Adds `email_providers.py`: the Microsoft 365 collection boundary as pure, network-free functions — the `OUTLOOK_OUTLOOK_LIST_MESSAGES` argument builder, response extraction (`data.response_data.value[]`, `successful:false` → error), and two normalised message shapes:
  - **profiler shape** `{from,to,subject,date,snippet,domain}` — identical to the Gmail path, so `onboard.json.emails` and every Opus stage stay provider-blind;
  - **flat-for-parser shape** — keys the existing `composio` parser already reads, so Outlook backfill events flow through it with **no parser change** (proven by a round-trip test).
- Maps Outlook onto the shared `gmail` source bucket at the four downstream choke points (`signal_observations` ×2, `noise`, `noise_patterns`), so ongoing Outlook events get the same priors and noise gate as Gmail (C-758-10).

## Verified live
Slugs, folders and field names were confirmed against the Composio project on 2026-09-10. The public docs' `OUTLOOK_LIST_MESSAGES` slug returns 404; the real action is the doubled-prefix `OUTLOOK_OUTLOOK_LIST_MESSAGES`.

## Smoke evidence
Pure functions — verified by unit tests, no live system needed.
```
$ python -m pytest tests/test_email_providers.py tests/test_outlook_source_bucket.py -q
........................                                                  [100%]
24 passed in 0.41s
```
Covers: provider vocabulary (default/accept/reject-unknown), arg building, response extraction (nested/flat/empty/error/non-dict/junk-items), profiler + flat mapping, the composio-parser round-trip, and the four downstream bucket mappings.

Lane II · net 487 LOC (mostly the new module + its tests).
