### PR TITLE
feat(ctrl): Outlook onboarding — provider-aware start, restricted consent, identity (#758)

### DIFF
--- a/packages/ctrl/src/api/routes/integrations.ts
+++ b/packages/ctrl/src/api/routes/integrations.ts
@@ -454,6 +454,11 @@ const RECOMMENDED_STREAMS: Record<string, {
   // openclaw runtime's ~15 KB tool-result cap doesn't truncate after one
   // message. See platform issue: openclaw runtime tool-result truncation.
   gmail:          { action: "GMAIL_FETCH_EMAILS",         name: "Gmail Emails",     interval: 300, args: { userId: "me", format: "metadata", maxResults: 50 } },
+  // Outlook / Microsoft 365 (#758). Read-only mail listing; one folder per
+  // call, so the recommended stream polls the Inbox (Sent Items is added by
+  // onboarding's own stream). Slug is the doubled-prefix one that exists on
+  // the project — the public docs' OUTLOOK_LIST_MESSAGES 404s.
+  outlook:        { action: "OUTLOOK_OUTLOOK_LIST_MESSAGES", name: "Outlook Mail",  interval: 300, args: { user_id: "me", folder: "Inbox", top: 50 } },
   // slack omitted: SLACK_FETCH_CONVERSATION_HISTORY requires a channel ID (per-tenant config)
   // GITHUB_LIST_NOTIFICATIONS was renamed by Composio in early 2026 to
   // GITHUB_LIST_NOTIFICATIONS_FOR_THE_AUTHENTICATED_USER. Same behavior;
@@ -470,6 +475,7 @@ const RECOMMENDED_STREAMS: Record<string, {
 const SYNC_MODE: Record<string, "snapshot" | "append" | "sync"> = {
   googlecalendar: "sync",
   gmail: "append",
+  outlook: "append",
   slack: "append",
   github: "append",
   notion: "snapshot",
@@ -487,6 +493,18 @@ const DEFAULT_ARGS: Record<string, Record<string, unknown>> = {
   GMAIL_LIST_THREADS: { userId: "me", format: "metadata", maxResults: 50 },
   GMAIL_SEND_EMAIL: { userId: "me" },
   GMAIL_LIST_LABELS: { userId: "me" },
+  // Outlook mail listing (#758) — read-only, one folder per call.
+  OUTLOOK_OUTLOOK_LIST_MESSAGES: { user_id: "me", folder: "Inbox", top: 50 },
+};
+
+// Managed-auth OAuth scopes to request when ctrl creates a Composio-managed
+// auth config for a toolkit on first connect (#758). Without this, a managed
+// config is created with Composio's full default scope set — for Outlook that
+// includes Mail.ReadWrite / Mail.Send / Calendars / Contacts. We ask for
+// read-only mail only. Verified live 2026-09-10: the Microsoft consent screen
+// then requests exactly `offline_access User.Read Mail.Read`.
+const MANAGED_AUTH_SCOPES: Record<string, string> = {
+  outlook: "offline_access,User.Read,Mail.Read",
 };
 
 // ---------------------------------------------------------------------------
@@ -1879,16 +1897,30 @@ export function registerIntegrationRoutes(): void {
 
       // If no auth_config exists, create one with Composio-managed OAuth
       if (!authConfigId) {
+        // #758: restrict the managed OAuth scopes for toolkits that would
+        // otherwise be created with a broad default set. Composio honours
+        // `credentials.scopes` on a managed config (verified live), so the
+        // consent screen asks for exactly what we list.
+        const managedScopes = MANAGED_AUTH_SCOPES[String(b.toolkit_slug).toLowerCase()];
+        const createConfigBody = managedScopes
+          ? {
+              toolkit: { slug: b.toolkit_slug },
+              auth_config: {
+                type: "use_composio_managed_auth",
+                credentials: { scopes: managedScopes },
+              },
+            }
+          : {
+              toolkit: { slug: b.toolkit_slug },
+              use_composio_auth: true,
+            };
         const createResp = await fetch(`${COMPOSIO_API_V3}/auth_configs`, {
           method: "POST",
           headers: {
             "x-api-key": apiKey,
             "Content-Type": "application/json",
           },
-          body: JSON.stringify({
-            toolkit: { slug: b.toolkit_slug },
-            use_composio_auth: true,
-          }),
+          body: JSON.stringify(createConfigBody),
         });
 
         if (!createResp.ok) {
@@ -3430,10 +3462,9 @@ export function registerIntegrationRoutes(): void {
   //           404 if the connection doesn't belong to this tenant,
   //           422 if identity couldn't be determined from Composio.
   // =========================================================================
-  addRoute("GET", "/api/v1/integrations/:id/google-identity", async ({ res, params }) => {
+  const resolveConnectionIdentity = async (res: any, connId: string): Promise<void> => {
     const apiKey = getComposioApiKey();
     const userId = getComposioUserId();
-    const connId = params.id;
 
     const conn = await assertConnectionOwnedByTenant(res, connId, userId, apiKey);
     if (!conn) return;
@@ -3469,12 +3500,15 @@ export function registerIntegrationRoutes(): void {
       return;
     }
 
-    // Live probe — run GMAIL_GET_PROFILE if the toolkit is Gmail, otherwise
-    // fail with 422 so SaaS knows it can't verify (and can make its own policy
-    // call — skip guard vs. fail closed — per Google-family toolkit).
+    // Live probe — Gmail runs GMAIL_GET_PROFILE, Outlook runs
+    // OUTLOOK_OUTLOOK_GET_PROFILE (#758, read-only under User.Read). Any other
+    // toolkit fails with 422 so the caller can make its own policy call
+    // (skip-guard vs. fail-closed).
     const toolkit = (conn as any).toolkit?.slug ?? "";
     const toolkitL = String(toolkit).toLowerCase().replace(/[-_\s]/g, "");
-    if (toolkitL !== "gmail" && toolkitL !== "googlemail") {
+    const isGmail = toolkitL === "gmail" || toolkitL === "googlemail";
+    const isOutlook = toolkitL === "outlook";
+    if (!isGmail && !isOutlook) {
       sendJson(res, 422, {
         error: "identity_unavailable",
         reason:
@@ -3482,6 +3516,36 @@ export function registerIntegrationRoutes(): void {
           "don't have a live-probe action for this toolkit.",
         toolkit,
       });
+      return;
+    }
+
+    if (isOutlook) {
+      try {
+        const parsed = await executeComposioAction({
+          apiKey,
+          userId,
+          actionSlug: "OUTLOOK_OUTLOOK_GET_PROFILE",
+          arguments: { user_id: "me" },
+          connectedAccountId: connId,
+        });
+        // The profile lands under data.response_data (Composio wrapper).
+        const outer = (parsed && typeof parsed === "object" ? (parsed as any).data ?? parsed : {}) as any;
+        const prof = (outer && typeof outer === "object" ? outer.response_data ?? outer : {}) as any;
+        const email = prof?.mail || prof?.userPrincipalName || null;
+        if (typeof email === "string" && email.includes("@")) {
+          sendJson(res, 200, { email, verified: true, source: "outlook_get_profile" });
+          return;
+        }
+        sendJson(res, 422, {
+          error: "identity_unavailable",
+          reason: "OUTLOOK_OUTLOOK_GET_PROFILE returned no email",
+        });
+      } catch (err: any) {
+        sendJson(res, 422, {
+          error: "identity_unavailable",
+          reason: `OUTLOOK_OUTLOOK_GET_PROFILE failed: ${String(err?.message ?? err).slice(0, 200)}`,
+        });
+      }
       return;
     }
 
@@ -3510,6 +3574,13 @@ export function registerIntegrationRoutes(): void {
         reason: `GMAIL_GET_PROFILE failed: ${String(err?.message ?? err).slice(0, 200)}`,
       });
     }
+  };
+  addRoute("GET", "/api/v1/integrations/:id/google-identity", async ({ res, params }) => {
+    await resolveConnectionIdentity(res, params.id);
+  });
+  // #758: provider-neutral alias — Gmail or Outlook identity.
+  addRoute("GET", "/api/v1/integrations/:id/identity", async ({ res, params }) => {
+    await resolveConnectionIdentity(res, params.id);
   });
 
   // =========================================================================

--- a/packages/ctrl/src/api/routes/workflows.ts
+++ b/packages/ctrl/src/api/routes/workflows.ts
@@ -141,13 +141,31 @@ export function registerWorkflowRoutes(): void {
     }
 
     const gmailMode = b.gmail_mode === "composio" ? "composio" : "google";
+
+    // #758: the email provider is a second axis alongside gmail_mode. Absent
+    // means gmail (every legacy caller); any other explicit value is rejected
+    // rather than silently treated as gmail.
+    const emailProvider = b.email_provider === undefined ? "gmail" : b.email_provider;
+    if (emailProvider !== "gmail" && emailProvider !== "outlook") {
+      throw new ValidationError(
+        `email_provider must be "gmail" or "outlook" (got ${JSON.stringify(emailProvider)})`,
+      );
+    }
+
     const onboardingInput: Record<string, unknown> = {
       user_id: b.user_id,
       stream_id: b.stream_id ?? "",
       gmail_mode: gmailMode,
+      email_provider: emailProvider,
     };
     if (gmailMode === "composio" && typeof b.composio_action === "string") {
       onboardingInput.composio_action = b.composio_action;
+    }
+    // The connection the principal chose (Composio connected_account id). The
+    // collectors pin it so, with both mailboxes connected, only the selected
+    // one is read.
+    if (typeof b.connection_id === "string" && b.connection_id) {
+      onboardingInput.connection_id = b.connection_id;
     }
 
     const workflowId = `onboarding-${b.user_id}-${Date.now()}`;
@@ -264,12 +282,20 @@ export function registerWorkflowRoutes(): void {
       const streamId = data.stream_id ?? "";
       const briefGmailMode =
         data.gmail_mode === "composio" ? "composio" : "google";
+      // #758: carry the provider + chosen connection forward off onboard.json
+      // (the learn pipeline persists them at first start) so the brief-stage
+      // resume stays on the same mailbox. Default to gmail for pre-#758 state.
+      const briefProvider = data.email_provider === "outlook" ? "outlook" : "gmail";
       if (userId) {
         const workflowId = `onboarding-${userId}-brief-${Date.now()}`;
         const briefInput: Record<string, unknown> = {
           user_id: userId,
           stream_id: streamId,
           gmail_mode: briefGmailMode,
+          email_provider: briefProvider,
+          ...(typeof data.connection_id === "string" && data.connection_id
+            ? { connection_id: data.connection_id }
+            : {}),
           // Carry the resume stage EXPLICITLY (#74). The brief stage runs
           // as a fresh OnboardingPipelineWorkflow; without this the
           // workflow re-derived its resume point from onboard.json and

--- a/packages/ctrl/tests/integrations-outlook.test.ts
+++ b/packages/ctrl/tests/integrations-outlook.test.ts
@@ -1,0 +1,128 @@
+// #758 — Outlook / Microsoft 365 support in ctrl integrations.
+//
+// Two things that matter for read-only onboarding:
+//   1. When ctrl creates a Composio-managed auth config for Outlook, it must
+//      request the restricted scope set (offline_access,User.Read,Mail.Read),
+//      not Composio's broad default. Gmail must keep the plain managed body.
+//   2. The provider-neutral /identity alias resolves an Outlook connection's
+//      mailbox address (from connection metadata, no live probe needed).
+
+import { mock, describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+const composioCalls: Array<{ method: string; url: string; body?: any }> = [];
+const realFetch = globalThis.fetch;
+
+globalThis.fetch = (async (url: any, init?: any) => {
+  const u = String(url);
+  const method = (init?.method ?? "GET").toUpperCase();
+  let body: any;
+  if (init?.body) { try { body = JSON.parse(init.body); } catch { /* ignore */ } }
+  composioCalls.push({ method, url: u, body });
+
+  // No existing auth config → force the create path.
+  if (method === "GET" && /\/api\/v3\/auth_configs(?:\?|$)/.test(u)) {
+    return new Response(JSON.stringify({ items: [] }), {
+      status: 200, headers: { "content-type": "application/json" },
+    });
+  }
+  if (method === "POST" && /\/api\/v3\/auth_configs$/.test(u)) {
+    return new Response(JSON.stringify({ auth_config: { id: "ac_out123" } }), {
+      status: 201, headers: { "content-type": "application/json" },
+    });
+  }
+  if (method === "POST" && /\/api\/v3\/connected_accounts$/.test(u)) {
+    return new Response(JSON.stringify({ id: "ca_out456", status: "INITIATED", redirect_url: "https://x/y" }), {
+      status: 200, headers: { "content-type": "application/json" },
+    });
+  }
+  // GET a specific connected account (ownership check + identity metadata).
+  const one = u.match(/\/api\/v3\/connected_accounts\/([^?/]+)$/);
+  if (method === "GET" && one) {
+    return new Response(JSON.stringify({
+      id: decodeURIComponent(one[1]),
+      user_id: "alfred-test-user",
+      toolkit: { slug: "outlook" },
+      state: { val: { profile: { email: "sir@corp.onmicrosoft.com" } } },
+    }), { status: 200, headers: { "content-type": "application/json" } });
+  }
+  return new Response(JSON.stringify({ error: "unmocked", url: u, method }), { status: 501 });
+}) as typeof globalThis.fetch;
+
+const fsMock = {
+  existsSync: mock.fn(() => false),
+  readFileSync: mock.fn(() => { const e = new Error("ENOENT") as any; e.code = "ENOENT"; throw e; }),
+  writeFileSync: mock.fn(), mkdirSync: mock.fn(), readdirSync: mock.fn(() => []),
+  statSync: mock.fn(() => ({ mtimeMs: 0, isDirectory: () => false, isFile: () => false })),
+  unlinkSync: mock.fn(), renameSync: mock.fn(), appendFileSync: mock.fn(), rmSync: mock.fn(),
+  chownSync: mock.fn(), openSync: mock.fn(() => 0), readSync: mock.fn(() => 0), closeSync: mock.fn(),
+  createReadStream: mock.fn(() => ({ pipe: mock.fn(), on: mock.fn() })),
+  Dirent: class Dirent { name = ""; isFile() { return true; } isDirectory() { return false; } },
+  promises: { mkdir: mock.fn(async () => undefined), writeFile: mock.fn(async () => undefined) },
+};
+mock.module("node:fs", { defaultExport: fsMock, namedExports: { ...fsMock } });
+
+process.env.COMPOSIO_API_KEY = "test-composio-key";
+process.env.COMPOSIO_USER_ID = "alfred-test-user";
+
+await import("../src/api/routes/integrations.js");
+const { createApiServer } = await import("../src/api/server.js");
+
+let server: http.Server;
+before(async () => {
+  server = createApiServer();
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+});
+after(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  globalThis.fetch = realFetch;
+});
+beforeEach(() => { composioCalls.length = 0; });
+
+async function req(method: string, pathname: string, body?: unknown): Promise<{ status: number; data: any }> {
+  const addr = server.address() as AddressInfo;
+  const payload = body !== undefined ? JSON.stringify(body) : undefined;
+  return new Promise((resolve, reject) => {
+    const r = http.request(
+      { hostname: "127.0.0.1", port: addr.port, path: pathname, method,
+        headers: { "content-type": "application/json", ...(payload ? { "content-length": Buffer.byteLength(payload) } : {}) } },
+      (resp) => {
+        let raw = "";
+        resp.on("data", (c) => (raw += c));
+        resp.on("end", () => { let d: any; try { d = JSON.parse(raw); } catch { d = raw; } resolve({ status: resp.statusCode ?? 0, data: d }); });
+      },
+    );
+    r.on("error", reject);
+    if (payload) r.write(payload);
+    r.end();
+  });
+}
+
+describe("#758 ctrl Outlook support", () => {
+  it("creates the Outlook managed auth config with restricted read-only scopes", async () => {
+    await req("POST", "/api/v1/integrations/connect", { toolkit_slug: "outlook" });
+    const create = composioCalls.find((c) => c.method === "POST" && /\/auth_configs$/.test(c.url));
+    assert.ok(create, "expected an auth_configs create call");
+    assert.equal(create!.body?.auth_config?.type, "use_composio_managed_auth");
+    assert.equal(create!.body?.auth_config?.credentials?.scopes, "offline_access,User.Read,Mail.Read");
+    // never the broad-default managed body
+    assert.equal(create!.body?.use_composio_auth, undefined);
+  });
+
+  it("leaves the Gmail managed auth config body unchanged", async () => {
+    await req("POST", "/api/v1/integrations/connect", { toolkit_slug: "gmail" });
+    const create = composioCalls.find((c) => c.method === "POST" && /\/auth_configs$/.test(c.url));
+    assert.ok(create, "expected an auth_configs create call");
+    assert.equal(create!.body?.use_composio_auth, true);
+    assert.equal(create!.body?.auth_config, undefined);
+  });
+
+  it("resolves an Outlook connection's mailbox via the /identity alias", async () => {
+    const { status, data } = await req("GET", "/api/v1/integrations/ca_out456/identity");
+    assert.equal(status, 200);
+    assert.equal(data.email, "sir@corp.onmicrosoft.com");
+    assert.equal(data.source, "composio_metadata");
+  });
+});

--- a/packages/ctrl/tests/workflows-onboarding-provider.test.ts
+++ b/packages/ctrl/tests/workflows-onboarding-provider.test.ts
@@ -1,0 +1,116 @@
+// #758 — POST /api/v1/workflows/onboarding/start carries the email provider.
+//
+// The workflow-start route stamps `email_provider` and the chosen
+// `connection_id` into OnboardingInput. Absent means gmail (every legacy
+// caller); an unsupported explicit value is rejected, never treated as gmail.
+
+import { mock, describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+// Capture the temporal CLI invocations so we can read back the --input JSON.
+const temporalCalls: string[][] = [];
+
+mock.module("../src/api/helpers.js", {
+  namedExports: {
+    HERMES_CONTAINER: "hermes",
+    HERMES_CMD: ["hermes"],
+    ALFRED_CMD: ["alfred"],
+    OPENCLAW_CMD: ["hermes"],
+    OPENCLAW_CONTAINER: "hermes",
+    COMPOSE_DIR: "/srv/alfred-black",
+    execAsync: async () => ({ stdout: "", stderr: "" }),
+    hostExec: async () => "",
+    sudoExec: async () => "",
+    parseJsonLines: (_raw: string) => [],
+    getQuery: (url: string) => new URLSearchParams(url.split("?")[1] || ""),
+    validateServiceName: (_name: string) => {},
+    dockerComposeCmd: async (_args: string[]) => "",
+    dockerExec: async (_container: string, command: string[]) => {
+      temporalCalls.push(command);
+      return JSON.stringify({ runId: "r1" });
+    },
+    dockerExecWithStdin: async () => "",
+  },
+});
+
+const fsMock = {
+  existsSync: mock.fn(() => false),
+  readFileSync: mock.fn(() => { const e = new Error("ENOENT") as any; e.code = "ENOENT"; throw e; }),
+  writeFileSync: mock.fn(), mkdirSync: mock.fn(), readdirSync: mock.fn(() => []),
+  statSync: mock.fn(() => ({ mtimeMs: 0, isDirectory: () => false, isFile: () => false })),
+  unlinkSync: mock.fn(), renameSync: mock.fn(), appendFileSync: mock.fn(), rmSync: mock.fn(),
+  chownSync: mock.fn(), openSync: mock.fn(() => 0), readSync: mock.fn(() => 0), closeSync: mock.fn(),
+  createReadStream: mock.fn(() => ({ pipe: mock.fn(), on: mock.fn() })),
+  Dirent: class Dirent { name = ""; isFile() { return true; } isDirectory() { return false; } },
+  promises: { mkdir: mock.fn(async () => undefined), writeFile: mock.fn(async () => undefined) },
+};
+mock.module("node:fs", { defaultExport: fsMock, namedExports: { ...fsMock } });
+
+await import("../src/api/routes/workflows.js");
+const { createApiServer } = await import("../src/api/server.js");
+
+let server: http.Server;
+before(async () => {
+  server = createApiServer();
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+});
+after(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+beforeEach(() => { temporalCalls.length = 0; });
+
+async function req(method: string, pathname: string, body?: unknown): Promise<{ status: number; data: any }> {
+  const addr = server.address() as AddressInfo;
+  const payload = body !== undefined ? JSON.stringify(body) : undefined;
+  return new Promise((resolve, reject) => {
+    const r = http.request(
+      { hostname: "127.0.0.1", port: addr.port, path: pathname, method,
+        headers: { "content-type": "application/json", ...(payload ? { "content-length": Buffer.byteLength(payload) } : {}) } },
+      (resp) => {
+        let raw = "";
+        resp.on("data", (c) => (raw += c));
+        resp.on("end", () => { let d: any; try { d = JSON.parse(raw); } catch { d = raw; } resolve({ status: resp.statusCode ?? 0, data: d }); });
+      },
+    );
+    r.on("error", reject);
+    if (payload) r.write(payload);
+    r.end();
+  });
+}
+
+function lastOnboardingInput(): any {
+  const start = temporalCalls.find((c) => c.includes("start") && c.includes("--input"));
+  assert.ok(start, "expected a temporal workflow start call");
+  const i = start!.indexOf("--input");
+  return JSON.parse(start![i + 1]);
+}
+
+describe("#758 onboarding/start provider", () => {
+  it("stamps email_provider=outlook and the chosen connection_id", async () => {
+    const { status } = await req("POST", "/api/v1/workflows/onboarding/start", {
+      user_id: "u1", stream_id: "s1", email_provider: "outlook", connection_id: "ca_out456",
+    });
+    assert.equal(status, 201);
+    const input = lastOnboardingInput();
+    assert.equal(input.email_provider, "outlook");
+    assert.equal(input.connection_id, "ca_out456");
+  });
+
+  it("defaults to gmail when no provider is given (legacy callers)", async () => {
+    const { status } = await req("POST", "/api/v1/workflows/onboarding/start", {
+      user_id: "u1", stream_id: "s1",
+    });
+    assert.equal(status, 201);
+    assert.equal(lastOnboardingInput().email_provider, "gmail");
+  });
+
+  it("rejects an unsupported provider rather than falling back to gmail", async () => {
+    const { status } = await req("POST", "/api/v1/workflows/onboarding/start", {
+      user_id: "u1", email_provider: "yahoo",
+    });
+    assert.equal(status, 400);
+    assert.equal(temporalCalls.length, 0, "no workflow should be started for a bad provider");
+  });
+});


### PR DESCRIPTION
Part of #758. The ctrl-api half: provider-aware onboarding start, read-only Outlook consent, and identity verification.

## What this does
- **Provider on the workflow-start contract.** `POST /api/v1/workflows/onboarding/start` stamps `email_provider` (`"gmail"|"outlook"`) and the chosen `connection_id` into `OnboardingInput`; the corrections/brief-resume route carries them forward off `onboard.json`. Absent → gmail (every legacy caller). An unsupported explicit value is **rejected (400)**, never silently gmail.
- **Read-only Outlook consent.** When ctrl creates a Composio-managed auth config for Outlook it now requests a restricted scope set (`offline_access,User.Read,Mail.Read`) via `MANAGED_AUTH_SCOPES`, instead of Composio's broad default (which for Outlook includes Mail.ReadWrite / Mail.Send / Calendars / Contacts). Gmail's body is unchanged.
- **Identity.** `/google-identity` is generalised to a provider-neutral `/identity` (old path kept as an alias). Metadata scan for both; Gmail keeps `GMAIL_GET_PROFILE`; Outlook falls back to `OUTLOOK_OUTLOOK_GET_PROFILE` (read-only, `User.Read`).
- **Lookup tables.** `RECOMMENDED_STREAMS` / `SYNC_MODE` / `DEFAULT_ARGS` gain `outlook` so the connections page, auto-config and skill-gen describe the same action.

## Verified live (read-only, on the shared Composio project, 2026-09-10)
Creating a managed Outlook config with `credentials.scopes = "offline_access,User.Read,Mail.Read"` and initiating a connection, the Microsoft authorization URL carried **exactly** `offline_access User.Read Mail.Read` — proving read-only consent works. The restricted config now exists on the project; ctrl reuses it and only creates one (restricted) if none exists.

## Smoke evidence
`npm run build` clean. New tests use the standard mocked-Composio + mocked-temporal harness — no live system.
```
$ node --test tests/integrations-outlook.test.ts tests/workflows-onboarding-provider.test.ts \
              tests/integrations-connect-api-key-authconfig.test.ts
# tests 7 · pass 7 · fail 0
```
Covers: Outlook managed config created with restricted scopes; Gmail managed body unchanged (regression guard); `/identity` resolving an Outlook mailbox from metadata; provider forwarding into OnboardingInput; gmail default for legacy callers; 400 + no workflow started for an unsupported provider. Full ctrl suite runs in CI (`test-ctrl`).

Lane I · net 361 LOC.
