### PR TITLE
feat(web): Outlook onboarding — provider core + provider-aware start (#758)

### DIFF
--- a/packages/web/main.wasp
+++ b/packages/web/main.wasp
@@ -1713,6 +1713,12 @@ query getGmailConnectionStatus {
   entities: [ComposioConnection]
 }
 
+// #758 — provider-aware connection status for the onboarding chooser (Gmail or Outlook).
+query getEmailProviderStatus {
+  fn: import { getEmailProviderStatus } from "@src/integrations/operations",
+  entities: [ComposioConnection]
+}
+
 query getIntegrationCapabilities {
   fn: import { getIntegrationCapabilities } from "@src/integrations/operations",
   entities: []

--- a/packages/web/src/dashboard/onboardingProviderCore.test.ts
+++ b/packages/web/src/dashboard/onboardingProviderCore.test.ts
@@ -1,0 +1,84 @@
+/**
+ * #758 — onboarding provider chooser core logic.
+ *
+ * Pure functions: provider availability by transport mode, marker/storage
+ * encode-decode, error copy, toolkit mapping, active-status. No React, no
+ * network.
+ *
+ * Run with:  cd packages/web && npx tsx --test src/dashboard/onboardingProviderCore.test.ts
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  CONNECTED_MARKER,
+  connectErrorCopy,
+  connectRedirect,
+  isActiveStatus,
+  isProviderAvailable,
+  parseConnectedMarker,
+  providerOptions,
+  toolkitForProvider,
+} from "./onboardingProviderCore";
+
+test("toolkit slug per provider", () => {
+  assert.equal(toolkitForProvider("gmail"), "gmail");
+  assert.equal(toolkitForProvider("outlook"), "outlook");
+});
+
+test("provider availability follows the transport mode", () => {
+  // composio: both available
+  let opts = providerOptions("composio");
+  assert.equal(opts.find((o) => o.id === "gmail")!.available, true);
+  assert.equal(opts.find((o) => o.id === "outlook")!.available, true);
+
+  // google: gmail available, outlook NOT (no direct Microsoft path)
+  opts = providerOptions("google");
+  assert.equal(opts.find((o) => o.id === "gmail")!.available, true);
+  assert.equal(opts.find((o) => o.id === "outlook")!.available, false);
+  assert.match(opts.find((o) => o.id === "outlook")!.reason!, /Composio/);
+
+  // none: neither
+  opts = providerOptions("none");
+  assert.equal(opts.find((o) => o.id === "gmail")!.available, false);
+  assert.equal(opts.find((o) => o.id === "outlook")!.available, false);
+});
+
+test("isProviderAvailable convenience", () => {
+  assert.equal(isProviderAvailable("outlook", "composio"), true);
+  assert.equal(isProviderAvailable("outlook", "google"), false);
+  assert.equal(isProviderAvailable("gmail", "google"), true);
+});
+
+test("connect redirect carries the marker and provider", () => {
+  const url = connectRedirect("https://home.example", "outlook");
+  assert.equal(url, `https://home.example/desk?onboarding=${CONNECTED_MARKER}&provider=outlook`);
+});
+
+test("parse marker round-trips", () => {
+  assert.deepEqual(
+    parseConnectedMarker("?onboarding=connected&provider=outlook"),
+    { marked: true, provider: "outlook" },
+  );
+  assert.deepEqual(
+    parseConnectedMarker("?onboarding=connected"),
+    { marked: true, provider: null },
+  );
+  assert.deepEqual(parseConnectedMarker("?foo=bar"), { marked: false, provider: null });
+  assert.deepEqual(parseConnectedMarker("?provider=yahoo"), { marked: false, provider: null });
+});
+
+test("error copy is provider-aware", () => {
+  assert.match(connectErrorCopy("admin_consent", "outlook"), /Microsoft 365 administrator/);
+  assert.match(connectErrorCopy("popup_blocked", "outlook"), /Microsoft/);
+  assert.match(connectErrorCopy("popup_blocked", "gmail"), /Google/);
+  assert.match(connectErrorCopy("cancelled", "outlook"), /didn't complete/);
+});
+
+test("active status is case-insensitive and null-safe", () => {
+  assert.equal(isActiveStatus("ACTIVE"), true);
+  assert.equal(isActiveStatus("active"), true);
+  assert.equal(isActiveStatus("INITIATED"), false);
+  assert.equal(isActiveStatus(null), false);
+  assert.equal(isActiveStatus(undefined), false);
+});

--- a/packages/web/src/dashboard/onboardingProviderCore.ts
+++ b/packages/web/src/dashboard/onboardingProviderCore.ts
@@ -1,0 +1,137 @@
+// Pure, network-free logic for the onboarding provider chooser (issue #758).
+//
+// The onboarding "connect your mailbox" step offers Gmail or Outlook /
+// Microsoft 365. All of the branching a component needs — which providers are
+// available in this deployment, what to label them, how the connected/marker
+// state is encoded, and what error copy to show — lives here so it can be unit
+// tested without React or a live tenant. DeskOnboardingGate.tsx consumes it.
+
+export type EmailProvider = "gmail" | "outlook";
+
+// The onboarding gmail-mode (transport) resolved server-side. Outlook is only
+// reachable when Composio is configured — there is no direct-Microsoft-OAuth
+// onboarding path, by design.
+export type OnboardingMode = "composio" | "google" | "none" | null;
+
+export interface ProviderOption {
+  id: EmailProvider;
+  label: string;
+  /** Short line under the label. */
+  hint: string;
+  /** Whether the principal can pick this provider on this deployment. */
+  available: boolean;
+  /** When not available, why (shown as a muted note). */
+  reason?: string;
+}
+
+export const CONNECTED_MARKER = "connected";
+
+/** The Composio toolkit slug for a provider. */
+export function toolkitForProvider(provider: EmailProvider): string {
+  return provider === "outlook" ? "outlook" : "gmail";
+}
+
+/**
+ * The two provider options, with availability decided by the transport mode.
+ *
+ * - Gmail is available in `google` and `composio` modes (its existing two
+ *   implementations); unavailable only in `none`.
+ * - Outlook requires `composio` — it has no direct-OAuth onboarding path. In
+ *   any other mode it is shown but disabled, with a reason, rather than hidden,
+ *   so the principal understands the option exists.
+ */
+export function providerOptions(mode: OnboardingMode): ProviderOption[] {
+  const composio = mode === "composio";
+  return [
+    {
+      id: "gmail",
+      label: "Gmail",
+      hint: "Google Workspace or personal Gmail",
+      available: mode === "composio" || mode === "google",
+      reason: mode === "none" ? "Email onboarding isn't configured on this instance." : undefined,
+    },
+    {
+      id: "outlook",
+      label: "Outlook / Microsoft 365",
+      hint: "Work or personal Microsoft mailbox",
+      available: composio,
+      reason: composio
+        ? undefined
+        : "Outlook onboarding needs Composio configured on this instance.",
+    },
+  ];
+}
+
+/** Is a provider selectable given the mode? */
+export function isProviderAvailable(provider: EmailProvider, mode: OnboardingMode): boolean {
+  return providerOptions(mode).find((o) => o.id === provider)?.available ?? false;
+}
+
+/** Per-viewer storage key so a reload keeps the chosen provider. */
+export const PROVIDER_STORAGE_KEY = "alfred.onboarding.provider";
+
+export function readStoredProvider(): EmailProvider | null {
+  try {
+    const v = window.localStorage.getItem(PROVIDER_STORAGE_KEY);
+    return v === "gmail" || v === "outlook" ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeStoredProvider(provider: EmailProvider | null): void {
+  try {
+    if (provider) window.localStorage.setItem(PROVIDER_STORAGE_KEY, provider);
+    else window.localStorage.removeItem(PROVIDER_STORAGE_KEY);
+  } catch {
+    /* private mode / blocked storage — the URL marker is the fallback */
+  }
+}
+
+/** The redirect URL carried back from a Composio consent round-trip. */
+export function connectRedirect(origin: string, provider: EmailProvider): string {
+  return `${origin}/desk?onboarding=${CONNECTED_MARKER}&provider=${provider}`;
+}
+
+/** Parse `?onboarding=connected&provider=outlook` off a URL search string. */
+export function parseConnectedMarker(search: string): { marked: boolean; provider: EmailProvider | null } {
+  try {
+    const q = new URLSearchParams(search);
+    const marked = q.get("onboarding") === CONNECTED_MARKER;
+    const p = q.get("provider");
+    return { marked, provider: p === "gmail" || p === "outlook" ? p : null };
+  } catch {
+    return { marked: false, provider: null };
+  }
+}
+
+/** Human-readable connect-step error copy, provider-aware. */
+export type ConnectErrorKind =
+  | "popup_blocked"
+  | "cancelled"
+  | "admin_consent"
+  | "mismatch"
+  | "generic";
+
+export function connectErrorCopy(kind: ConnectErrorKind, provider: EmailProvider): string {
+  const name = provider === "outlook" ? "Microsoft" : "Google";
+  switch (kind) {
+    case "popup_blocked":
+      return `Alfred couldn't open the ${name} sign-in window. Allow pop-ups and try again.`;
+    case "cancelled":
+      return "The connection didn't complete. Choose a mailbox to try again.";
+    case "admin_consent":
+      return provider === "outlook"
+        ? "Your Microsoft 365 administrator must approve Alfred before it can read this mailbox. Ask them to grant consent, then try again."
+        : "Your Google administrator must approve Alfred before it can read this mailbox.";
+    case "mismatch":
+      return "That account doesn't match this tenant's owner. Sign in with the owner's mailbox and try again.";
+    default:
+      return `Alfred couldn't start the ${name} connection. Please try again.`;
+  }
+}
+
+/** Map a connection status string to whether it is usable. */
+export function isActiveStatus(status: string | null | undefined): boolean {
+  return String(status ?? "").toUpperCase() === "ACTIVE";
+}

--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -37,7 +37,10 @@ import {
   resolveOnboardingGmailMode,
   type OnboardingGmailMode,
 } from "../server/onboardingGmailMode";
-import { checkGmailConnection } from "../integrations/operations";
+import {
+  checkGmailConnection,
+  checkEmailProviderConnection,
+} from "../integrations/operations";
 import { pickTailnetHostnameForDashboard } from "./tailscaleCardCore";
 
 // ============================================================
@@ -1854,12 +1857,17 @@ export const getFirstBrief: GetFirstBrief<void, any> = async (
 };
 
 export const startOnboarding: StartOnboarding<
-  { streamId?: string },
+  { streamId?: string; provider?: "gmail" | "outlook"; connectionId?: string },
   any
 > = async (_args, context) => {
   if (!context.user) throw new HttpError(401);
   const instance = await getUserInstance(context);
   const userId = context.user.id;
+
+  // #758: the email provider is a second axis. Absent → gmail (every legacy
+  // caller). Outlook has no direct-OAuth path, so it requires composio mode.
+  const provider: "gmail" | "outlook" =
+    _args?.provider === "outlook" ? "outlook" : "gmail";
 
   // ─────────────────────────────────────────────────────────────────────
   // Composio-managed Gmail onboarding (#69, P2). Resolve the Gmail mode
@@ -1912,6 +1920,44 @@ export const startOnboarding: StartOnboarding<
     }
   }
 
+  // #758: Outlook onboarding. It needs Composio (no direct-Microsoft path) and
+  // an ACTIVE outlook connection on this tenant. We re-verify server-side and
+  // resolve the connection id from the tenant's own integration list — never
+  // trusting a client-supplied connected flag or arbitrary id (C-758-8).
+  let outlookConnectionId: string | null = null;
+  if (provider === "outlook") {
+    if (gmailMode !== "composio") {
+      throw new HttpError(
+        412,
+        "Outlook onboarding requires Composio (COMPOSIO_API_KEY) — there is no direct Microsoft OAuth path.",
+      );
+    }
+    let outlookConn: { connected: boolean; status: string | null; connectionId: string | null };
+    try {
+      outlookConn = await checkEmailProviderConnection(instance, "outlook");
+    } catch (e: any) {
+      throw new HttpError(
+        502,
+        `Could not verify the Outlook connection with the tenant: ${e?.message ?? String(e)}`,
+      );
+    }
+    if (!outlookConn.connected || !outlookConn.connectionId) {
+      throw new HttpError(
+        412,
+        outlookConn.status
+          ? `The Outlook connection is not active (status: ${outlookConn.status}). Finish connecting Outlook before starting onboarding.`
+          : "No Outlook connection found. Connect Outlook before starting onboarding.",
+      );
+    }
+    outlookConnectionId = outlookConn.connectionId;
+  }
+
+  // Per-provider stream identity. The SaaS Stream `source` is unique per user,
+  // so a Gmail stream and an Outlook stream can coexist; the chooser decides
+  // which one onboarding reads.
+  const streamSource = provider === "outlook" ? "outlook" : "gmail";
+  const streamDisplayName = provider === "outlook" ? "Outlook" : "Gmail";
+
   // Track per-step outcomes so the dashboard can see which sub-steps
   // failed even if startOnboarding returns successfully overall (the
   // function intentionally returns "started" once the SaaS-side stream
@@ -1927,7 +1973,7 @@ export const startOnboarding: StartOnboarding<
 
   // Step 1: SaaS-DB Stream row (lazy-create on first call, idempotent).
   let gmailStream = await context.entities.Stream.findFirst({
-    where: { userId, source: "gmail" },
+    where: { userId, source: streamSource },
   });
 
   // The SaaS-DB Stream `config` blob — mode-specific. For `google` it is
@@ -1937,7 +1983,21 @@ export const startOnboarding: StartOnboarding<
   // intent — Composio holds the token, so there is no oauth2 auth block.
   // This blob is mirrored to the tenant by the Step 3 PATCH below.
   const streamConfig =
-    gmailMode === "composio"
+    provider === "outlook"
+      ? {
+          transport: "composio",
+          parser: "composio",
+          // #758: the onboarding stream row carries the Outlook list action,
+          // pinned to the chosen connection so only the selected mailbox is
+          // read. The learn collectors loop Inbox + Sent Items themselves.
+          composio: {
+            action: "OUTLOOK_OUTLOOK_LIST_MESSAGES",
+            toolkit: "outlook",
+            connection_id: outlookConnectionId,
+            args: { user_id: "me", folder: "Inbox", top: 250 },
+          },
+        }
+      : gmailMode === "composio"
       ? {
           transport: "composio",
           parser: "composio",
@@ -1987,9 +2047,9 @@ export const startOnboarding: StartOnboarding<
     gmailStream = await context.entities.Stream.create({
       data: {
         userId,
-        name: "Gmail",
+        name: streamDisplayName,
         type: "scheduled",
-        source: "gmail",
+        source: streamSource,
         config: streamConfig,
         webhookToken: crypto.randomBytes(24).toString("hex"),
       },
@@ -2021,9 +2081,9 @@ export const startOnboarding: StartOnboarding<
       path: "/api/v1/streams",
       body: {
         id: gmailStream.id,
-        name: "Gmail",
+        name: streamDisplayName,
         type: "scheduled",
-        source: "gmail",
+        source: streamSource,
         config: gmailStream.config,
         enabled: true,
       },
@@ -2049,7 +2109,19 @@ export const startOnboarding: StartOnboarding<
   //              stream-row contract P3's learn pipeline reads to drive
   //              the Composio fetch path.
   const streamPatchBody: Record<string, unknown> =
-    gmailMode === "composio"
+    provider === "outlook"
+      ? {
+          type: "composio",
+          parser: "composio",
+          // #758 — the Outlook onboarding stream row contract the learn
+          // pipeline reads. Pinned to the chosen connection.
+          composio_action: "OUTLOOK_OUTLOOK_LIST_MESSAGES",
+          composio_toolkit: "outlook",
+          composio_connection_id: outlookConnectionId,
+          composio_args: { user_id: "me", folder: "Inbox", top: 250 },
+          schedule_interval_seconds: 300,
+        }
+      : gmailMode === "composio"
       ? {
           type: "composio",
           parser: "composio",
@@ -2151,7 +2223,12 @@ export const startOnboarding: StartOnboarding<
         user_id: userId,
         stream_id: gmailStream.id,
         gmail_mode: gmailMode,
-        ...(gmailMode === "composio"
+        // #758 — provider axis + the pinned connection for Outlook.
+        email_provider: provider,
+        ...(provider === "outlook" && outlookConnectionId
+          ? { connection_id: outlookConnectionId }
+          : {}),
+        ...(provider !== "outlook" && gmailMode === "composio"
           ? { composio_action: "GMAIL_FETCH_EMAILS" }
           : {}),
       },

--- a/packages/web/src/integrations/operations.ts
+++ b/packages/web/src/integrations/operations.ts
@@ -21,6 +21,7 @@ import type {
   GetToolkitRequiredFields,
   GetConnectedIntegrations,
   GetGmailConnectionStatus,
+  GetEmailProviderStatus,
   GetIntegrationCapabilities,
   GetOpenclawReadiness,
   GetIntegrationScope,
@@ -320,27 +321,50 @@ export type GmailConnectionStatus = { connected: boolean; status: string | null 
  * the same check itself. Takes a resolved tenant `instance` so it is
  * callable from any server operation, not just a query with a `context`.
  */
+/** Provider-generalised connection status — adds the ACTIVE connection id so a
+ *  caller can pin exactly the mailbox the principal chose (#758). */
+export type EmailProviderConnectionStatus = {
+  connected: boolean;
+  status: string | null;
+  connectionId: string | null;
+};
+
+/**
+ * Core "is this email provider's toolkit connected?" check for gmail or
+ * outlook (#758). Reads the tenant's authoritative GET /api/v1/integrations
+ * list and reports whether an ACTIVE connection exists for the toolkit, plus
+ * that connection's id. Both the client-facing query and startOnboarding's
+ * server-side gate call this — the gate must never trust a client-supplied
+ * flag; it re-runs the same check.
+ */
+export async function checkEmailProviderConnection(
+  instance: Instance,
+  provider: "gmail" | "outlook",
+): Promise<EmailProviderConnectionStatus> {
+  const data = await proxyToTenant(instance, { path: "/api/v1/integrations" });
+  const list: any[] = Array.isArray(data?.integrations) ? data.integrations : [];
+  const toolkit = provider === "outlook" ? "outlook" : "gmail";
+  const conn = list.find(
+    (c) => String(c?.toolkit ?? "").toLowerCase() === toolkit,
+  );
+  if (!conn) {
+    return { connected: false, status: null, connectionId: null };
+  }
+  const status = String(conn.status ?? "").toUpperCase();
+  return {
+    connected: status === "ACTIVE",
+    status: status || null,
+    connectionId: conn.id ?? conn.connection_id ?? conn.connectionId ?? null,
+  };
+}
+
+// Backward-compatible Gmail helper — the existing callers (getGmailConnectionStatus
+// query, startOnboarding's Gmail gate) keep the narrower shape.
 export async function checkGmailConnection(
   instance: Instance,
 ): Promise<GmailConnectionStatus> {
-  const data = await proxyToTenant(instance, {
-    path: "/api/v1/integrations",
-  });
-  const list: any[] = Array.isArray(data?.integrations)
-    ? data.integrations
-    : [];
-
-  // The Gmail toolkit slug in Composio is `gmail` (confirmed against
-  // ctrl-api's RECOMMENDED_STREAMS + GMAIL_FETCH_EMAILS action mapping).
-  const gmail = list.find(
-    (c) => String(c?.toolkit ?? "").toLowerCase() === "gmail",
-  );
-  if (!gmail) {
-    return { connected: false, status: null };
-  }
-
-  const status = String(gmail.status ?? "").toUpperCase();
-  return { connected: status === "ACTIVE", status: status || null };
+  const { connected, status } = await checkEmailProviderConnection(instance, "gmail");
+  return { connected, status };
 }
 
 export const getGmailConnectionStatus: GetGmailConnectionStatus<
@@ -350,6 +374,18 @@ export const getGmailConnectionStatus: GetGmailConnectionStatus<
   requireUser(context);
   const instance = await getUserInstance(context);
   return checkGmailConnection(instance);
+};
+
+/** Provider-aware connection status — used by the chooser to know when the
+ *  selected mailbox has landed ACTIVE and to pin its connection id (#758). */
+export const getEmailProviderStatus: GetEmailProviderStatus<
+  { provider: "gmail" | "outlook" },
+  EmailProviderConnectionStatus
+> = async (args, context) => {
+  requireUser(context);
+  const provider = args?.provider === "outlook" ? "outlook" : "gmail";
+  const instance = await getUserInstance(context);
+  return checkEmailProviderConnection(instance, provider);
 };
 
 // =============================================================================


### PR DESCRIPTION
Part of #758. The web server + pure-logic half of the Gmail-or-Outlook chooser. The chooser UI itself lands in the follow-up.

## What this does
- **`onboardingProviderCore.ts`** — pure, tested logic the component consumes: provider availability by transport mode (Outlook needs `composio`; there is no direct-Microsoft onboarding path), marker/storage encode-decode, toolkit mapping, active-status, and provider-aware error copy (admin-consent, popup-blocked, cancelled, mismatch).
- **`checkEmailProviderConnection(instance, provider)`** generalises the Gmail check to `gmail|outlook` and returns the ACTIVE connection id. `checkGmailConnection` stays a thin wrapper. New **`getEmailProviderStatus`** query so the chooser can poll a provider's status + connection id.
- **`startOnboarding` is provider-aware.** Outlook re-verifies an ACTIVE outlook connection **server-side** and pins its connection id from the tenant's own integration list — never a client-supplied flag or id (C-758-8) — writes an `outlook`-source stream with the `OUTLOOK_OUTLOOK_LIST_MESSAGES` composio config, and posts `email_provider="outlook"` + `connection_id` to ctrl. The Gmail path is unchanged.

## Smoke evidence
```
$ npx tsx --test src/dashboard/onboardingProviderCore.test.ts
# tests 7 · pass 7 · fail 0
$ npx tsc --noEmit           # against the regenerated Wasp SDK
(0 errors)
```
Core tests cover: availability per mode (composio/google/none), the convenience check, redirect+marker round-trip, provider-aware error copy, active-status null-safety. Full web typecheck runs in CI (`wasp build`).

Lane III · net 394 LOC.
