### PR TITLE
docs(#758): C-758 contracts, Outlook onboarding spec + operator note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -856,6 +856,16 @@ the repo when they change (those aren't in any image).
 Sequential ritual at `/awaken → … → /first-brief → /desk`. Behind the
 scenes:
 
+0. **Provider chooser** (#758) — *Start Onboarding* opens a Gmail /
+   Outlook·Microsoft 365 chooser (`DeskOnboardingGate.tsx` +
+   `onboardingProviderCore.ts`) before any authorization. Gmail keeps the
+   google/composio flow; Outlook runs the Composio `outlook` connect (managed
+   read-only consent: `offline_access,User.Read,Mail.Read`) and reads the
+   mailbox through `OUTLOOK_OUTLOOK_LIST_MESSAGES`. The choice rides an
+   explicit `email_provider` axis (separate from `gmail_mode`) from the browser
+   through ctrl to `OnboardingInput`; everything downstream of the collectors
+   is provider-blind. Absent `email_provider` = gmail. Frozen contracts: C-758
+   in `docs/FIX-CONTRACTS.md`; design in `docs/specs/758-outlook-onboarding.md`.
 1. **Gmail OAuth + Composio account creation** (steps `/composing` /
    `/preparing`) — backfilled via `alfred-learn` activities.
 2. **Stream pull** — `composio_pull` activity pulls ~100 days of email

--- a/docs/FIX-CONTRACTS.md
+++ b/docs/FIX-CONTRACTS.md
@@ -398,6 +398,56 @@ One-line registrations; the cited files are the frozen source of truth:
 
 ---
 
+## C-758 — Gmail-or-Outlook onboarding (email provider axis)
+
+Frozen for #758. The email provider is a second axis alongside `gmail_mode`
+(the Gmail transport). Full design + blast radius in
+`docs/specs/758-outlook-onboarding.md`.
+
+- **C-758-1** — provider vocabulary. `email_provider ∈ {"gmail","outlook"}`.
+  Absent means `gmail` at every layer (web default, ctrl default, learn
+  `OnboardingInput` default), so all historical inputs and in-flight workflows
+  keep the Gmail path. Any other explicit value is rejected — web 400, ctrl
+  `ValidationError`, learn non-retryable `ApplicationError`. `gmail_mode` keeps
+  its meaning and is never overloaded. *(III → I → II)*
+- **C-758-2** — workflow-start body (`packages/ctrl/src/api/routes/workflows.ts`,
+  `POST /api/v1/workflows/onboarding/start`) carries `email_provider` and
+  `connection_id`; the corrections/brief-resume route reads them back off
+  `onboard.json`. *(III → I → II)*
+- **C-758-3** — `OnboardingInput` (`packages/learn/src/workflows/onboarding_pipeline.py`)
+  gains `email_provider="gmail"` + `connection_id=""` (additive, replay-safe).
+  `persist_onboarding_provider` writes both to `onboard.json`; its call is gated
+  with `workflow.patched("758-onboarding-provider")`. *(II internal)*
+- **C-758-4/5/7** — the Outlook stream + collection contract
+  (`packages/learn/src/activities/email_providers.py`, `pull.py`): action slug
+  **`OUTLOOK_OUTLOOK_LIST_MESSAGES`** (the doubled-prefix slug that exists on the
+  Composio project; the docs' `OUTLOOK_LIST_MESSAGES` 404s), Inbox + Sent Items
+  folders, `skip`/`top` pagination (no continuation token), page at
+  `data.response_data.value[]`, ISO-`Z` date filters, `SYNC_CONFIGS` append-mode
+  entry with `{backfill_iso_z}`/`{last_pull_iso_z}`. *(II internal; I mirrors the
+  tables)*
+- **C-758-6/10** — normalisation + provenance. Outlook messages map to the SAME
+  profiler shape `{from,to,subject,date,snippet,domain}` and the flat shape the
+  existing `composio` parser reads (no parser change). Ingest events carry
+  `stream_type:"outlook"` + `metadata.provider:"outlook"`; four source-bucket
+  choke points (`signals`/`signal_observations`/`noise`/`noise_patterns`)
+  collapse Outlook onto the shared email bucket. *(II internal)*
+- **C-758-8** — server-side verification. `startOnboarding`
+  (`packages/web/src/dashboard/operations.ts`) and the ctrl connect path re-verify
+  the chosen connection is ACTIVE for the provider's toolkit and belongs to the
+  tenant, resolving the connection id from the tenant's own integration list —
+  never a client-supplied flag or id. *(III + I)*
+- **C-758-8b** — read-only consent. ctrl's connect route creates a Composio-managed
+  Outlook auth config with `MANAGED_AUTH_SCOPES.outlook =
+  "offline_access,User.Read,Mail.Read"`. Verified live 2026-09-10: the Microsoft
+  authorize URL then carries exactly those three scopes. *(I)*
+- **C-758-9** — identity. `GET /api/v1/integrations/:id/identity` (with
+  `/google-identity` kept as an alias): metadata scan for both providers, Gmail's
+  `GMAIL_GET_PROFILE` fallback unchanged, Outlook falls back to
+  `OUTLOOK_OUTLOOK_GET_PROFILE` (read-only, `User.Read`). *(I → III guard)*
+
+---
+
 ## Open items (2026-07-15 verification)
 
 - **TODO(C15):** the `SAAS_INTERNAL_URL` → `/api/internal/twilio/*` leg

--- a/docs/operators/outlook-onboarding.md
+++ b/docs/operators/outlook-onboarding.md
@@ -1,0 +1,47 @@
+# Operator note — Outlook / Microsoft 365 onboarding (#758)
+
+What an operator needs to know to offer Outlook onboarding on a tenant.
+
+## Prerequisites
+
+1. **Composio is configured.** `COMPOSIO_API_KEY` must be set (the tenant is in
+   `composio` onboarding mode). Outlook has no direct-Microsoft-OAuth path; in
+   `google` or `none` mode the chooser shows Outlook disabled with a reason.
+
+2. **An Outlook auth config exists on the Composio project** (created once, then
+   reused for every tenant on that project). ctrl creates one automatically on
+   first connect if none exists, with restricted read-only scopes
+   (`offline_access,User.Read,Mail.Read`). If you pre-create it by hand, use the
+   same restricted scopes — otherwise Composio's broad managed default
+   (`Mail.ReadWrite`, `Mail.Send`, calendars, contacts) is requested at consent.
+
+3. **Microsoft admin consent** may be required on locked-down Microsoft 365
+   tenants. The principal (or their IT admin) grants it in the Microsoft consent
+   screen; if the org requires admin approval, the connection reports a consent
+   error and the chooser surfaces a retryable "administrator must approve"
+   message. This is a customer-side step, not a code change.
+
+## What the principal sees
+
+*Start Onboarding* → a chooser (Gmail · Outlook / Microsoft 365) → pick Outlook →
+a Microsoft sign-in popup asking for **read-only mail** access → onboarding runs
+exactly as Gmail does (reading the room → facts → First Brief).
+
+The consent screen names Composio's Microsoft application. This is expected for
+all deployments.
+
+## Verifying
+
+- The Microsoft authorize URL requests exactly `offline_access User.Read
+  Mail.Read` (read-only).
+- After connect, `onboard.json` carries `email_provider: "outlook"` and the
+  chosen `connection_id`, and the tenant Stream row has `source: "outlook"` with
+  `composio_action: OUTLOOK_OUTLOOK_LIST_MESSAGES`.
+- The First Brief is generated from the Outlook corpus like any Gmail onboarding.
+
+## Notes
+
+- Gmail is unchanged. A tenant can have both a Gmail and an Outlook stream; the
+  chooser decides which mailbox onboarding reads.
+- Ongoing sync uses append mode (a received-time window), mirroring Gmail.
+- No new environment variable is introduced.

--- a/docs/specs/758-outlook-onboarding.md
+++ b/docs/specs/758-outlook-onboarding.md
@@ -1,0 +1,138 @@
+# #758 — Gmail or Outlook / Microsoft 365 at Start Onboarding
+
+Offer Outlook / Microsoft 365 as a **second** onboarding provider alongside
+Gmail, without replacing Gmail, without a new store, and without touching the
+analysis pipeline. The provider is a second axis (`email_provider`) next to the
+existing Gmail transport (`gmail_mode`).
+
+## In one sentence
+
+When the principal clicks *Start Onboarding*, show a two-option chooser; carry
+the choice as an explicit `email_provider` from the browser through the web
+server, ctrl-api and the Temporal workflow to the collectors, so an Outlook
+mailbox flows through the same reading-the-room, facts, patterns,
+personalisation, verification, First Brief and packs stages as Gmail does.
+
+## Why it's a wire-to-existing, not a second pipeline
+
+Most of the plumbing is already provider-agnostic:
+
+- **Connection lifecycle** — `initiateConnect(toolkit_slug)` →
+  `POST /api/v1/integrations/connect` opens Composio consent for any toolkit.
+- **Stream archetype** — a tenant stream row carrying
+  `composio_action`/`composio_toolkit`/`composio_args` is pulled by the same
+  `StreamPullerWorkflow` branch regardless of toolkit; incremental args come
+  from the `SYNC_CONFIGS` table keyed by action slug.
+- **Downstream** — the profiler, the Opus fact/pattern/brief stages, the
+  curator and the signal scorer read `onboard.json` and the ingest tables, never
+  a mailbox. They never learn a provider name.
+
+What was Gmail-bound: the onboarding **start path** (gate → server action →
+ctrl route → workflow input) and the **collectors** (query syntax + response
+field names). Those are what this feature generalises.
+
+## Verified against the live Composio project (2026-09-10)
+
+The public docs are wrong for this project. The documented `OUTLOOK_LIST_MESSAGES`
+slug returns 404. The real read-only tools carry a doubled prefix:
+
+| Purpose | Slug |
+|---|---|
+| List messages (one folder, skip/top paging) | `OUTLOOK_OUTLOOK_LIST_MESSAGES` |
+| Get one message | `OUTLOOK_OUTLOOK_GET_MESSAGE` |
+| Profile (identity) | `OUTLOOK_OUTLOOK_GET_PROFILE` |
+| List folders | `OUTLOOK_OUTLOOK_LIST_MAIL_FOLDERS` |
+| Delta sync (future v2) | `OUTLOOK_GET_MAIL_DELTA` |
+
+`OUTLOOK_OUTLOOK_LIST_MESSAGES` takes one `folder` per call (well-known names
+`Inbox` / `SentItems`), typed date filters (`received_date_time_ge` /
+`received_date_time_gt`, ISO-8601 **with a `Z` suffix**, not a `+00:00`
+offset), `top` (1–1000), `skip` for pagination (**no continuation token**), and
+`orderby`. The page arrives at `data.response_data.value[]`.
+
+**Read-only consent works.** Creating a Composio-managed Outlook auth config
+with `credentials.scopes = "offline_access,User.Read,Mail.Read"` and initiating
+a connection, the Microsoft authorize URL carried exactly those three scopes.
+The consent screen names Composio's Microsoft app — accepted for all
+deployments.
+
+## The provider × transport matrix
+
+| `email_provider` | `gmail_mode` | metadata activity | backfill activity |
+|---|---|---|---|
+| gmail | google | `fetch_email_metadata` | `backfill_gmail_as_events` |
+| gmail | composio | `composio_fetch_email_metadata` | `composio_backfill_gmail_as_events` |
+| outlook | composio | `composio_fetch_email_metadata_outlook` | `composio_backfill_outlook_as_events` |
+| outlook | google / none | refused at start (412) — Outlook needs Composio | — |
+
+Never a silent fallback from Outlook to Gmail.
+
+## The layers
+
+**Web** — `DeskOnboardingGate.tsx` opens the chooser (`onboardingProviderCore.ts`
+holds the pure logic). Outlook is disabled with a reason when the deployment
+isn't in composio mode. `startOnboarding` is provider-aware: it re-verifies an
+ACTIVE outlook connection server-side, pins its connection id from the tenant's
+own list (never a client flag), writes an `outlook`-source stream, and posts
+`email_provider` + `connection_id` to ctrl.
+
+**ctrl** — `/api/v1/workflows/onboarding/start` stamps `email_provider` +
+`connection_id` into `OnboardingInput` (rejects an unsupported value);
+corrections/brief-resume carries them forward. The connect route creates the
+Outlook managed config with restricted read-only scopes
+(`MANAGED_AUTH_SCOPES`). The identity route is provider-neutral
+(`/identity`, with `/google-identity` as an alias) with an Outlook profile
+fallback. `RECOMMENDED_STREAMS` / `SYNC_MODE` / `DEFAULT_ARGS` gain outlook rows.
+
+**learn** — `email_providers.py` is the Outlook edge (arg building, response
+extraction, the two normalised message shapes). `pull.py` adds the two Outlook
+activities (mirroring the Gmail collectors: 100-day window, 5000-message cap,
+per-page retry with quota-aware heartbeated backoff, connection pinning) and the
+`SYNC_CONFIGS` append-mode entry. `onboarding_pipeline.py` selects the Outlook
+collectors when `email_provider=="outlook"` and persists the provider via a
+`workflow.patched`-gated activity (replay safety).
+
+## Replay safety
+
+Adding a `workflow.execute_activity()` call to an existing `@workflow.run` is a
+non-additive change (see `packages/learn/CLAUDE.md`). The new
+`persist_onboarding_provider` call is gated with
+`workflow.patched("758-onboarding-provider")`, so pre-#758 in-flight histories
+replay without it. The metadata/backfill selection is safe unguarded: an
+in-flight run defaults to gmail and re-selects the identical Gmail activity on
+replay; only post-deploy runs can be Outlook.
+
+## Blast radius
+
+Touched: the onboarding start path in three packages; the Composio collector
+edge and its parser mapping (additive — no parser change); four source-bucket
+normalisers (one branch each); three ctrl lookup tables + one route alias; one
+Wasp query; two new `onboard.json` keys.
+
+Untouched by construction: `alfred-state.db`, `ingest.db`, migrations,
+`schema.sql`, `server.ts`; the promotion contract and every vault record type;
+profiler / facts / patterns / personalisation / verification / brief / packs /
+chores; the Hermes image, profiles and MCP servers; compose / Caddy / bootstrap
+(no new env var); every existing Gmail test and the legacy direct-Gmail path.
+
+Existing tenants see no change until someone clicks *Start Onboarding* on a
+tenant that has never onboarded. Completed and in-flight Gmail onboardings keep
+their state — nothing is reset, reconnected or migrated.
+
+## Non-goals
+
+Replacing Gmail; merging multiple mailboxes into one onboarding; resetting
+existing tenants; changing the analysis/personality pipeline; Microsoft
+calendar / contacts / Teams. Shared-mailbox support is out of scope.
+
+## Follow-ups
+
+- Ongoing Outlook sync uses append mode (mirrors Gmail). A later phase can move
+  it to `OUTLOOK_GET_MAIL_DELTA` (`@odata.deltaLink`) under the `sync` pull
+  mode once a token is extracted from the link.
+- Outlook owner-email mismatch guard at auto-config time (the Gmail-family
+  tenant-email guard's Outlook analogue). `startOnboarding` already rejects an
+  inactive/mismatched/foreign connection; this would add the wrong-account
+  belt-and-suspenders at connect time.
+- The downstream LightswitchOS / Nova port is tracked separately; merging Alfred
+  source is not evidence a deployed Nova instance has the feature.


### PR DESCRIPTION
Part of #758. The documentation + frozen contracts (phase0 — touches CLAUDE.md and FIX-CONTRACTS.md, orchestrator-owned).

## What this adds
- **`docs/FIX-CONTRACTS.md`** — C-758-1…9: provider vocabulary, workflow-start body, OnboardingInput, the Outlook stream/collection contract (the live-verified slugs), normalisation + source buckets, server-side verification, read-only consent, identity.
- **`CLAUDE.md` §14** — the provider chooser as onboarding step 0.
- **`docs/specs/758-outlook-onboarding.md`** — full design: the live-verified Composio slugs (the doubled-prefix ones; the public docs' `OUTLOOK_LIST_MESSAGES` 404s), the provider × transport matrix, replay safety, blast radius, follow-ups.
- **`docs/operators/outlook-onboarding.md`** — prerequisites (Composio mode, restricted managed scopes, Microsoft admin consent) and how to verify.

## Smoke evidence
N/A — docs-only change. No code paths touched.
