### PR TITLE
fix(web): Outlook onboarding must not require a Gmail connection (#758)

### DIFF
--- a/packages/web/src/dashboard/onboardingProviderCore.test.ts
+++ b/packages/web/src/dashboard/onboardingProviderCore.test.ts
@@ -16,6 +16,7 @@ import {
   connectRedirect,
   isActiveStatus,
   isProviderAvailable,
+  onboardingGates,
   parseConnectedMarker,
   providerOptions,
   toolkitForProvider,
@@ -81,4 +82,44 @@ test("active status is case-insensitive and null-safe", () => {
   assert.equal(isActiveStatus("INITIATED"), false);
   assert.equal(isActiveStatus(null), false);
   assert.equal(isActiveStatus(undefined), false);
+});
+
+// The startOnboarding gate decision — the regression for the bug where the
+// Gmail connection gate ran for an Outlook onboarding (issue #758 follow-up).
+test("Outlook onboarding does NOT require a Gmail connection", () => {
+  const g = onboardingGates("outlook", "composio");
+  assert.equal(g.requireGmailConnection, false); // the bug: this was true
+  assert.equal(g.requireOutlookConnection, true);
+  assert.equal(g.outlookNeedsComposio, false);
+  assert.equal(g.misconfigured, false);
+});
+
+test("Gmail onboarding requires the Gmail connection, not Outlook", () => {
+  const g = onboardingGates("gmail", "composio");
+  assert.equal(g.requireGmailConnection, true);
+  assert.equal(g.requireOutlookConnection, false);
+  assert.equal(g.outlookNeedsComposio, false);
+});
+
+test("Outlook without Composio is refused, not run as Gmail", () => {
+  const g = onboardingGates("outlook", "google");
+  assert.equal(g.outlookNeedsComposio, true);
+  assert.equal(g.requireGmailConnection, false); // never gate Gmail for Outlook
+  assert.equal(g.requireOutlookConnection, false);
+});
+
+test("no auth path configured is provider-neutral misconfigured", () => {
+  for (const p of ["gmail", "outlook"] as const) {
+    const g = onboardingGates(p, "none");
+    assert.equal(g.misconfigured, true);
+    assert.equal(g.requireGmailConnection, false);
+    assert.equal(g.requireOutlookConnection, false);
+  }
+});
+
+test("Gmail in google mode gates nothing here (legacy OAuthCredential path)", () => {
+  const g = onboardingGates("gmail", "google");
+  assert.equal(g.requireGmailConnection, false); // google mode uses the token check, not this gate
+  assert.equal(g.misconfigured, false);
+  assert.equal(g.outlookNeedsComposio, false);
 });

--- a/packages/web/src/dashboard/onboardingProviderCore.ts
+++ b/packages/web/src/dashboard/onboardingProviderCore.ts
@@ -135,3 +135,39 @@ export function connectErrorCopy(kind: ConnectErrorKind, provider: EmailProvider
 export function isActiveStatus(status: string | null | undefined): boolean {
   return String(status ?? "").toUpperCase() === "ACTIVE";
 }
+
+/**
+ * Which server-side gates `startOnboarding` must apply, decided purely from the
+ * selected provider and the resolved transport mode.
+ *
+ * The bug this exists to prevent (#758 follow-up): the Gmail connection gate
+ * must NOT run when Outlook is selected — otherwise an Outlook-only principal
+ * with no Gmail connection is rejected with "No Gmail connection found." Each
+ * gate is conditioned on the SELECTED provider, so the checks never bleed
+ * across providers. `startOnboarding` consumes this so the decision has one
+ * tested source of truth.
+ *
+ * Check order in the action: misconfigured → outlookNeedsComposio →
+ * requireGmailConnection → requireOutlookConnection.
+ */
+export interface OnboardingGates {
+  /** No auth path configured at all — fail fast, provider-neutral. */
+  misconfigured: boolean;
+  /** Gate on an ACTIVE Gmail connection (composio-Gmail path only). */
+  requireGmailConnection: boolean;
+  /** Gate on an ACTIVE Outlook connection + resolve its id. */
+  requireOutlookConnection: boolean;
+  /** Outlook selected without Composio — refuse (no direct Microsoft path). */
+  outlookNeedsComposio: boolean;
+}
+
+export function onboardingGates(provider: EmailProvider, mode: OnboardingMode): OnboardingGates {
+  const composio = mode === "composio";
+  return {
+    misconfigured: mode === "none",
+    requireGmailConnection: provider === "gmail" && composio,
+    requireOutlookConnection: provider === "outlook" && composio,
+    // google (or any non-composio, non-none) mode can't run Outlook.
+    outlookNeedsComposio: provider === "outlook" && !composio && mode !== "none",
+  };
+}

--- a/packages/web/src/dashboard/operations.ts
+++ b/packages/web/src/dashboard/operations.ts
@@ -41,6 +41,7 @@ import {
   checkGmailConnection,
   checkEmailProviderConnection,
 } from "../integrations/operations";
+import { onboardingGates } from "./onboardingProviderCore";
 import { pickTailnetHostnameForDashboard } from "./tailscaleCardCore";
 
 // ============================================================
@@ -1887,16 +1888,30 @@ export const startOnboarding: StartOnboarding<
   // ─────────────────────────────────────────────────────────────────────
   const gmailMode = resolveOnboardingGmailMode();
 
-  if (gmailMode === "none") {
+  // #758 follow-up: each gate is conditioned on the SELECTED provider, decided
+  // by one tested pure function. This is the fix for the bug where the Gmail
+  // connection gate ran whenever the deployment was in composio mode — even for
+  // an Outlook onboarding — rejecting an Outlook-only principal with "No Gmail
+  // connection found." The gates never bleed across providers.
+  const gates = onboardingGates(provider, gmailMode);
+
+  if (gates.misconfigured) {
     // No auth path is configured — fail fast rather than starting a
     // pipeline that can never fetch email and will stall.
     throw new HttpError(
       412,
-      "Gmail onboarding is not configured on this deployment — set COMPOSIO_API_KEY (recommended) or GOOGLE_CLIENT_ID + GOOGLE_CLIENT_SECRET.",
+      "Email onboarding is not configured on this deployment — set COMPOSIO_API_KEY (recommended) or GOOGLE_CLIENT_ID + GOOGLE_CLIENT_SECRET.",
     );
   }
 
-  if (gmailMode === "composio") {
+  if (gates.outlookNeedsComposio) {
+    throw new HttpError(
+      412,
+      "Outlook onboarding requires Composio (COMPOSIO_API_KEY) — there is no direct Microsoft OAuth path.",
+    );
+  }
+
+  if (gates.requireGmailConnection) {
     // Gate on the Composio Gmail connection — re-run the same check the
     // getGmailConnectionStatus query uses (shared helper), server-side, so
     // a client that calls startOnboarding without a real ACTIVE
@@ -1920,18 +1935,12 @@ export const startOnboarding: StartOnboarding<
     }
   }
 
-  // #758: Outlook onboarding. It needs Composio (no direct-Microsoft path) and
-  // an ACTIVE outlook connection on this tenant. We re-verify server-side and
-  // resolve the connection id from the tenant's own integration list — never
-  // trusting a client-supplied connected flag or arbitrary id (C-758-8).
+  // #758: Outlook onboarding gates on an ACTIVE outlook connection and resolves
+  // its id from the tenant's own integration list — never trusting a
+  // client-supplied connected flag or arbitrary id (C-758-8). Independent of
+  // the Gmail gate above, which does not run for an Outlook onboarding.
   let outlookConnectionId: string | null = null;
-  if (provider === "outlook") {
-    if (gmailMode !== "composio") {
-      throw new HttpError(
-        412,
-        "Outlook onboarding requires Composio (COMPOSIO_API_KEY) — there is no direct Microsoft OAuth path.",
-      );
-    }
+  if (gates.requireOutlookConnection) {
     let outlookConn: { connected: boolean; status: string | null; connectionId: string | null };
     try {
       outlookConn = await checkEmailProviderConnection(instance, "outlook");


### PR DESCRIPTION
Fixes the server-side blocker reported on #758: **Outlook onboarding wrongly required a Gmail connection.**

## The bug
In `startOnboarding`, the Gmail connection gate ran whenever `gmailMode === "composio"` — before the Outlook gate and regardless of the selected provider. So picking Outlook with an ACTIVE Outlook connection but **no Gmail connection** returned `412: "No Gmail connection found."`, and `checkEmailProviderConnection(instance, "outlook")` was never reached. The pure chooser tests didn't exercise the server action, so they missed it.

## The fix
Each gate is now conditioned on the **selected provider**, decided by one pure tested function `onboardingGates(provider, mode)`, which `startOnboarding` consumes:

| provider | mode | requireGmail | requireOutlook | outlookNeedsComposio |
|---|---|---|---|---|
| outlook | composio | **false** | true | false |
| gmail | composio | true | false | false |
| outlook | google | false | false | true (refused) |
| gmail | google | false | — | — (legacy token path) |
| any | none | — | — | misconfigured |

The gates never bleed across providers.

## Smoke evidence
```
$ npx tsx --test src/dashboard/onboardingProviderCore.test.ts
# tests 12 · pass 12 · fail 0
$ npx tsc --noEmit
(0 errors)
```
New regression tests encode the reporter's exact matrix: Outlook+composio requires the Outlook connection and **not** Gmail; Gmail+composio requires Gmail; Outlook without Composio is refused (never run as Gmail); `none` is a provider-neutral misconfigured. The `onboardingGates` function is the single source of truth the server action uses, so the check order can't silently drift back.

Lane III · net 114 LOC.
